### PR TITLE
[Enhancement]PrivTable list->map to speed up matching

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -65,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -445,30 +446,36 @@ public class Auth implements Writable {
      * This method will check the given privilege levels
      */
     public boolean checkHasPriv(ConnectContext ctx, PrivPredicate priv, PrivLevel... levels) {
-        return checkHasPrivInternal(ctx.getRemoteIP(), ctx.getQualifiedUser(), priv, levels);
+        // currentUser referred to the account that determines user's access privileges.
+        return checkHasPrivInternal(ctx.getCurrentUserIdentity(), priv, levels);
     }
 
-    private boolean checkHasPrivInternal(String host, String user, PrivPredicate priv, PrivLevel... levels) {
-        for (PrivLevel privLevel : levels) {
-            switch (privLevel) {
-                case GLOBAL:
-                    if (userPrivTable.hasPriv(host, user, priv)) {
-                        return true;
-                    }
-                    break;
-                case DATABASE:
-                    if (dbPrivTable.hasPriv(host, user, priv)) {
-                        return true;
-                    }
-                    break;
-                case TABLE:
-                    if (tablePrivTable.hasPriv(host, user, priv)) {
-                        return true;
-                    }
-                    break;
-                default:
-                    break;
+    private boolean checkHasPrivInternal(UserIdentity currentUser, PrivPredicate priv, PrivLevel... levels) {
+        readLock();
+        try {
+            for (PrivLevel privLevel : levels) {
+                switch (privLevel) {
+                    case GLOBAL:
+                        if (userPrivTable.hasPriv(currentUser, priv)) {
+                            return true;
+                        }
+                        break;
+                    case DATABASE:
+                        if (dbPrivTable.hasPriv(currentUser, priv)) {
+                            return true;
+                        }
+                        break;
+                    case TABLE:
+                        if (tablePrivTable.hasPriv(currentUser, priv)) {
+                            return true;
+                        }
+                        break;
+                    default:
+                        break;
+                }
             }
+        } finally {
+            readUnlock();
         }
         return false;
     }
@@ -1246,11 +1253,11 @@ public class Auth implements Writable {
         List<DbPrivEntry> dbPrivs = Lists.newArrayList();
         readLock();
         try {
-            for (PrivEntry entry : dbPrivTable.entries) {
-                if (!entry.match(userIdent, true /* exact match */)) {
-                    continue;
+            List<PrivEntry> entryList = dbPrivTable.map.get(userIdent);
+            if (entryList != null) {
+                for (PrivEntry entry : entryList) {
+                    dbPrivs.add((DbPrivEntry) entry);
                 }
-                dbPrivs.add((DbPrivEntry) entry);
             }
         } finally {
             readUnlock();
@@ -1262,11 +1269,11 @@ public class Auth implements Writable {
         List<TablePrivEntry> tablePrivs = Lists.newArrayList();
         readLock();
         try {
-            for (PrivEntry entry : tablePrivTable.entries) {
-                if (!entry.match(userIdent, true /* exact match */)) {
-                    continue;
+            List<PrivEntry> entryList = tablePrivTable.map.get(userIdent);
+            if (entryList != null) {
+                for (PrivEntry entry : entryList) {
+                    tablePrivs.add((TablePrivEntry) entry);
                 }
-                tablePrivs.add((TablePrivEntry) entry);
             }
         } finally {
             readUnlock();
@@ -1312,47 +1319,51 @@ public class Auth implements Writable {
         return userAuthInfos;
     }
 
+    /**
+     * TODO: This function is much too long and obscure. I'll refactor it in another PR.
+     */
     private void getUserAuthInfo(List<List<String>> userAuthInfos, UserIdentity userIdent) {
         List<String> userAuthInfo = Lists.newArrayList();
 
         // global
-        for (PrivEntry entry : userPrivTable.entries) {
-            if (!entry.match(userIdent, true /* exact match */)) {
-                continue;
-            }
-            GlobalPrivEntry gEntry = (GlobalPrivEntry) entry;
-            userAuthInfo.add(userIdent.toString());
-            Password password = gEntry.getPassword();
-            //Password
-            if (userIdent.isDomain()) {
-                // for domain user ident, password is saved in property manager
-                userAuthInfo.add(propertyMgr.doesUserHasPassword(userIdent) ? "No" : "Yes");
-            } else {
-                userAuthInfo.add((password == null || password.getPassword().length == 0) ? "No" : "Yes");
-            }
-            //AuthPlugin and UserForAuthPlugin
-            if (password == null) {
-                userAuthInfo.add(FeConstants.null_string);
-                userAuthInfo.add(FeConstants.null_string);
-            } else {
-                if (password.getAuthPlugin() == null) {
+        List<PrivEntry> userPrivEntries = userPrivTable.map.get(userIdent);
+        if (userPrivEntries != null) {
+            for (PrivEntry entry : userPrivEntries) {
+                GlobalPrivEntry gEntry = (GlobalPrivEntry) entry;
+                userAuthInfo.add(userIdent.toString());
+                Password password = gEntry.getPassword();
+                //Password
+                if (userIdent.isDomain()) {
+                    // for domain user ident, password is saved in property manager
+                    userAuthInfo.add(propertyMgr.doesUserHasPassword(userIdent) ? "No" : "Yes");
+                } else {
+                    userAuthInfo.add((password == null || password.getPassword().length == 0) ? "No" : "Yes");
+                }
+                //AuthPlugin and UserForAuthPlugin
+                if (password == null) {
+                    userAuthInfo.add(FeConstants.null_string);
                     userAuthInfo.add(FeConstants.null_string);
                 } else {
-                    userAuthInfo.add(password.getAuthPlugin().name());
-                }
+                    if (password.getAuthPlugin() == null) {
+                        userAuthInfo.add(FeConstants.null_string);
+                    } else {
+                        userAuthInfo.add(password.getAuthPlugin().name());
+                    }
 
-                if (Strings.isNullOrEmpty(password.getUserForAuthPlugin())) {
-                    userAuthInfo.add(FeConstants.null_string);
-                } else {
-                    userAuthInfo.add(password.getUserForAuthPlugin());
+                    if (Strings.isNullOrEmpty(password.getUserForAuthPlugin())) {
+                        userAuthInfo.add(FeConstants.null_string);
+                    } else {
+                        userAuthInfo.add(password.getUserForAuthPlugin());
+                    }
                 }
+                //GlobalPrivs
+                userAuthInfo.add(gEntry.getPrivSet().toString() + " (" + gEntry.isSetByDomainResolver() + ")");
+                break;
             }
-            //GlobalPrivs
-            userAuthInfo.add(gEntry.getPrivSet().toString() + " (" + gEntry.isSetByDomainResolver() + ")");
-            break;
-        }
-
-        if (userAuthInfo.isEmpty()) {
+        } else {
+            // user not in user priv table
+            // TODO I cannot think of any occation that would lead to this branch.
+            //   I'll try to figure out and clean this up in another PR
             if (!userIdent.isDomain()) {
                 // If this is not a domain user identity, it must have global priv entry.
                 // TODO(cmy): I don't know why previous comment said:
@@ -1376,51 +1387,45 @@ public class Auth implements Writable {
 
         // db
         List<String> dbPrivs = Lists.newArrayList();
-        for (PrivEntry entry : dbPrivTable.entries) {
-            if (!entry.match(userIdent, true /* exact match */)) {
-                continue;
+        List<PrivEntry> dbPrivEntries = dbPrivTable.map.get(userIdent);
+        if (dbPrivEntries != null) {
+            for (PrivEntry entry : dbPrivEntries) {
+                DbPrivEntry dEntry = (DbPrivEntry) entry;
+                dbPrivs.add(dEntry.getOrigDb() + ": " + dEntry.getPrivSet().toString()
+                        + " (" + entry.isSetByDomainResolver() + ")");
             }
-            DbPrivEntry dEntry = (DbPrivEntry) entry;
-            dbPrivs.add(dEntry.getOrigDb() + ": " + dEntry.getPrivSet().toString()
-                    + " (" + entry.isSetByDomainResolver() + ")");
-        }
-        if (dbPrivs.isEmpty()) {
-            userAuthInfo.add(FeConstants.null_string);
-        } else {
             userAuthInfo.add(Joiner.on("; ").join(dbPrivs));
+        } else {
+            userAuthInfo.add(FeConstants.null_string);
         }
 
         // tbl
         List<String> tblPrivs = Lists.newArrayList();
-        for (PrivEntry entry : tablePrivTable.entries) {
-            if (!entry.match(userIdent, true /* exact match */)) {
-                continue;
+        List<PrivEntry> tblPrivEntries = tablePrivTable.map.get(userIdent);
+        if (tblPrivEntries != null) {
+            for (PrivEntry entry : tblPrivEntries) {
+                TablePrivEntry tEntry = (TablePrivEntry) entry;
+                tblPrivs.add(tEntry.getOrigDb() + "." + tEntry.getOrigTbl() + ": "
+                        + tEntry.getPrivSet().toString()
+                        + " (" + entry.isSetByDomainResolver() + ")");
             }
-            TablePrivEntry tEntry = (TablePrivEntry) entry;
-            tblPrivs.add(tEntry.getOrigDb() + "." + tEntry.getOrigTbl() + ": "
-                    + tEntry.getPrivSet().toString()
-                    + " (" + entry.isSetByDomainResolver() + ")");
-        }
-        if (tblPrivs.isEmpty()) {
-            userAuthInfo.add(FeConstants.null_string);
-        } else {
             userAuthInfo.add(Joiner.on("; ").join(tblPrivs));
+        } else {
+            userAuthInfo.add(FeConstants.null_string);
         }
 
         // resource
         List<String> resourcePrivs = Lists.newArrayList();
-        for (PrivEntry entry : resourcePrivTable.entries) {
-            if (!entry.match(userIdent, true /* exact match */)) {
-                continue;
+        List<PrivEntry> resourcePrivEntries = resourcePrivTable.map.get(userIdent);
+        if (resourcePrivEntries != null) {
+            for (PrivEntry entry : resourcePrivEntries) {
+                ResourcePrivEntry rEntry = (ResourcePrivEntry) entry;
+                resourcePrivs.add(rEntry.getOrigResource() + ": " + rEntry.getPrivSet().toString()
+                        + " (" + entry.isSetByDomainResolver() + ")");
             }
-            ResourcePrivEntry rEntry = (ResourcePrivEntry) entry;
-            resourcePrivs.add(rEntry.getOrigResource() + ": " + rEntry.getPrivSet().toString()
-                    + " (" + entry.isSetByDomainResolver() + ")");
-        }
-        if (resourcePrivs.isEmpty()) {
-            userAuthInfo.add(FeConstants.null_string);
-        } else {
             userAuthInfo.add(Joiner.on("; ").join(resourcePrivs));
+        } else {
+            userAuthInfo.add(FeConstants.null_string);
         }
 
         userAuthInfos.add(userAuthInfo);
@@ -1428,30 +1433,22 @@ public class Auth implements Writable {
 
     private Set<UserIdentity> getAllUserIdents(boolean includeEntrySetByResolver) {
         Set<UserIdentity> userIdents = Sets.newHashSet();
-        for (PrivEntry entry : userPrivTable.entries) {
-            if (!includeEntrySetByResolver && entry.isSetByDomainResolver()) {
-                continue;
+        List<PrivTable> allTables = Arrays.asList(userPrivTable, dbPrivTable, tablePrivTable, resourcePrivTable);
+        for (PrivTable table : allTables) {
+            if (includeEntrySetByResolver) {
+                userIdents.addAll(table.map.keySet());
+            } else {
+                for (Map.Entry<UserIdentity, List<PrivEntry>> mapEntry : table.map.entrySet()) {
+                    for (PrivEntry privEntry : mapEntry.getValue()) {
+                        if (!privEntry.isSetByDomainResolver) {
+                            userIdents.add(mapEntry.getKey());
+                            break;
+                        }
+                    } // for privEntry in privEntryList
+                } // for userIdentity, privEntryList in table map
             }
-            userIdents.add(entry.getUserIdent());
-        }
-        for (PrivEntry entry : dbPrivTable.entries) {
-            if (!includeEntrySetByResolver && entry.isSetByDomainResolver()) {
-                continue;
-            }
-            userIdents.add(entry.getUserIdent());
-        }
-        for (PrivEntry entry : tablePrivTable.entries) {
-            if (!includeEntrySetByResolver && entry.isSetByDomainResolver()) {
-                continue;
-            }
-            userIdents.add(entry.getUserIdent());
-        }
-        for (PrivEntry entry : resourcePrivTable.entries) {
-            if (!includeEntrySetByResolver && entry.isSetByDomainResolver()) {
-                continue;
-            }
-            userIdents.add(entry.getUserIdent());
-        }
+        } // for table in all tables
+
         return userIdents;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
@@ -145,6 +145,7 @@ public class DbPrivEntry extends PrivEntry {
         isClassNameWrote = false;
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivTable.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 
 /*
  * DbPrivTable saves all database level privs
@@ -41,13 +43,14 @@ public class DbPrivTable extends PrivTable {
      * saved in 'savedPrivs'.
      */
     public void getPrivs(UserIdentity currentUser, String db, PrivBitSet savedPrivs) {
-        DbPrivEntry matchedEntry = null;
-        for (PrivEntry entry : entries) {
-            DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return;
+        }
 
-            if (!dbPrivEntry.match(currentUser, true)) {
-                continue;
-            }
+        DbPrivEntry matchedEntry = null;
+        for (PrivEntry entry : userPrivEntryList) {
+            DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
 
             // check db
             if (!dbPrivEntry.isAnyDb() && !dbPrivEntry.getDbPattern().match(db)) {
@@ -67,17 +70,14 @@ public class DbPrivTable extends PrivTable {
     /*
      * Check if user@host has specified privilege on any database
      */
-    public boolean hasPriv(String host, String user, PrivPredicate wanted) {
-        for (PrivEntry entry : entries) {
+    public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return false;
+        }
+
+        for (PrivEntry entry : userPrivEntryList) {
             DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
-            // check host
-            if (!dbPrivEntry.isAnyHost() && !dbPrivEntry.getHostPattern().match(host)) {
-                continue;
-            }
-            // check user
-            if (!dbPrivEntry.isAnyUser() && !dbPrivEntry.getUserPattern().match(user)) {
-                continue;
-            }
             // check priv
             if (dbPrivEntry.privSet.satisfy(wanted)) {
                 return true;
@@ -87,8 +87,9 @@ public class DbPrivTable extends PrivTable {
     }
 
     public boolean hasClusterPriv(ConnectContext ctx, String clusterName) {
-        for (PrivEntry entry : entries) {
-            DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
+        Iterator<PrivEntry> iter = this.getFullIterator();
+        while (iter.hasNext()) {
+            DbPrivEntry dbPrivEntry = (DbPrivEntry) iter.next();
             if (dbPrivEntry.getOrigDb().startsWith(clusterName)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivTable.java
@@ -68,16 +68,12 @@ public class DbPrivTable extends PrivTable {
     }
 
     /*
-     * Check if user@host has specified privilege on any database
+     * Check if current user has specified privilege on any database
      */
     public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
-        List<PrivEntry> userPrivEntryList = map.get(currentUser);
-        if (userPrivEntryList == null) {
-            return false;
-        }
-
-        for (PrivEntry entry : userPrivEntryList) {
-            DbPrivEntry dbPrivEntry = (DbPrivEntry) entry;
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            DbPrivEntry dbPrivEntry = (DbPrivEntry) iter.next();
             // check priv
             if (dbPrivEntry.privSet.satisfy(wanted)) {
                 return true;
@@ -87,7 +83,7 @@ public class DbPrivTable extends PrivTable {
     }
 
     public boolean hasClusterPriv(ConnectContext ctx, String clusterName) {
-        Iterator<PrivEntry> iter = this.getFullIterator();
+        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
         while (iter.hasNext()) {
             DbPrivEntry dbPrivEntry = (DbPrivEntry) iter.next();
             if (dbPrivEntry.getOrigDb().startsWith(clusterName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
@@ -130,14 +130,6 @@ public abstract class PrivEntry implements Comparable<PrivEntry>, Writable {
         return userIdentity;
     }
 
-    public boolean match(UserIdentity userIdent, boolean exactMatch) {
-        if (exactMatch) {
-            return origUser.equals(userIdent.getQualifiedUser()) && origHost.equals(userIdent.getHost());
-        } else {
-            return origUser.equals(userIdent.getQualifiedUser()) && hostPattern.match(userIdent.getHost());
-        }
-    }
-
     public abstract boolean keyMatch(PrivEntry other);
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivTable.java
@@ -66,8 +66,6 @@ public abstract class PrivTable implements Writable {
                 map.put(newEntry.getUserIdent(), new ArrayList<>());
             }
             map.get(newUser).add(newEntry);
-            // entries.add(newEntry);
-            // Collections.sort(entries);
             LOG.debug("add priv entry: {}", newEntry);
             return newEntry;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivTable.java
@@ -50,11 +50,11 @@ public abstract class PrivTable implements Writable {
     protected Map<UserIdentity, List<PrivEntry>> map = new TreeMap<>(new Comparator<UserIdentity>() {
         @Override
         public int compare(UserIdentity o1, UserIdentity o2) {
-            int compareByUser = o1.getQualifiedUser().compareTo(o2.getQualifiedUser());
-            if (compareByUser != 0) {
-                return - compareByUser;
+            int compareByHost = o1.getHost().compareTo(o2.getHost());
+            if (compareByHost != 0) {
+                return - compareByHost;
             }
-            return - o1.getHost().compareTo(o2.getHost());
+            return - o1.getQualifiedUser().compareTo(o2.getQualifiedUser());
         }
     });
 
@@ -101,7 +101,7 @@ public abstract class PrivTable implements Writable {
 
     public void dropEntry(PrivEntry entry) {
         UserIdentity userIdentity = entry.getUserIdent();
-        List<PrivEntry> userPrivEntryList = map.get(entry.getUserIdent());
+        List<PrivEntry> userPrivEntryList = map.get(userIdentity);
         if (userPrivEntryList == null) {
             return;
         }
@@ -281,8 +281,8 @@ public abstract class PrivTable implements Writable {
 
             @Override
             public PrivEntry next() {
-                if (privEntryIterator == null || ! privEntryIterator.hasNext()) {
-                    if (! mapIterator.hasNext()) {
+                if (privEntryIterator == null || !privEntryIterator.hasNext()) {
+                    if (!mapIterator.hasNext()) {
                         return null;
                     }
                     Map.Entry<UserIdentity, List<PrivEntry>> next = mapIterator.next();

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivTable.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 /*
  * ResourcePrivTable saves all resources privs
@@ -40,13 +41,14 @@ public class ResourcePrivTable extends PrivTable {
      * saved in 'savedPrivs'.
      */
     public void getPrivs(UserIdentity currentUser, String resourceName, PrivBitSet savedPrivs) {
-        ResourcePrivEntry matchedEntry = null;
-        for (PrivEntry entry : entries) {
-            ResourcePrivEntry resourcePrivEntry = (ResourcePrivEntry) entry;
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return;
+        }
 
-            if (!resourcePrivEntry.match(currentUser, true)) {
-                continue;
-            }
+        ResourcePrivEntry matchedEntry = null;
+        for (PrivEntry entry : userPrivEntryList) {
+            ResourcePrivEntry resourcePrivEntry = (ResourcePrivEntry) entry;
 
             // check resource
             if (!resourcePrivEntry.getResourcePattern().match(resourceName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivTable.java
@@ -77,12 +77,9 @@ public class TablePrivTable extends PrivTable {
      *      I will try to remove this in another PR.
      */
     public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
-        List<PrivEntry> userPrivEntryList = map.get(currentUser);
-        if (userPrivEntryList == null) {
-            return false;
-        }
-        for (PrivEntry entry : userPrivEntryList) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             // check priv
             if (tblPrivEntry.privSet.satisfy(wanted)) {
                 return true;
@@ -92,12 +89,9 @@ public class TablePrivTable extends PrivTable {
     }
 
     public boolean hasPrivsOfDb(UserIdentity currentUser, String db) {
-        List<PrivEntry> userPrivEntryList = map.get(currentUser);
-        if (userPrivEntryList == null) {
-            return false;
-        }
-        for (PrivEntry entry : userPrivEntryList) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             // check db
             Preconditions.checkState(!tblPrivEntry.isAnyDb());
             if (!tblPrivEntry.getDbPattern().match(db)) {
@@ -121,7 +115,7 @@ public class TablePrivTable extends PrivTable {
     }
 
     public boolean hasClusterPriv(ConnectContext ctx, String clusterName) {
-        Iterator<PrivEntry> iter = this.getFullIterator();
+        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
         while (iter.hasNext()) {
             TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             if (tblPrivEntry.getOrigDb().startsWith(clusterName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
@@ -85,7 +85,7 @@ public class UserPrivTable extends PrivTable {
     }
 
     /*
-     * Check if user@host has specified privilege
+     * Check if current user has specified privilege
      */
     public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
         List<PrivEntry> userPrivEntryList = map.get(currentUser);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -437,7 +437,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     priv -> {
                         boolean isGrantable =
                                 Privilege.NODE_PRIV != priv // NODE_PRIV counld not be granted event with GRANT_PRIV
-                                        && userPrivTable.hasPriv(userIdent.getHost(), userIdent.getQualifiedUser(),
+                                        && userPrivTable.hasPriv(userIdent,
                                         PrivPredicate.GRANT);
                         TUserPrivDesc privDesc = new TUserPrivDesc();
                         privDesc.setIs_grantable(isGrantable);


### PR DESCRIPTION
This commit changes the data structure of PrivTable from List to Map, using UserIdentity as the key because after
identification of the UserIdentity of the context is definitely an existing entry and requires no fuzzy matching.
The authorization time will significantly improve with this map.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5944 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR implements Plan 1 of #5944.
I added a test case to see the performance change. Assuming there are 500 users who each have the privilege of 250 tables, the time of authorization speed up to nearly 100 times(10min+ -> 7s) after this PR.