### PR TITLE
[cherry-pick] [branch-2.1] [enhancement] Opt the binary search of find partition end in Analytor(#5864)

### DIFF
--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -427,10 +427,10 @@ void Analytor::find_partition_end() {
         return;
     }
 
-    _found_partition_end = _partition_columns[0]->size();
-    for (size_t i = 0; i < _partition_columns.size(); ++i) {
-        vectorized::Column* column = _partition_columns[i].get();
-        _found_partition_end = _find_first_not_equal(column, _partition_end, _found_partition_end);
+    int64_t start = _found_partition_end;
+    _found_partition_end = static_cast<int64_t>(_partition_columns[0]->size());
+    for (auto& column : _partition_columns) {
+        _found_partition_end = _find_first_not_equal(column.get(), _partition_end, start, _found_partition_end);
     }
 }
 
@@ -444,9 +444,8 @@ void Analytor::find_peer_group_end() {
     _peer_group_end = _partition_end;
     DCHECK(!_order_columns.empty());
 
-    for (size_t i = 0; i < _order_columns.size(); ++i) {
-        vectorized::Column* column = _order_columns[i].get();
-        _peer_group_end = _find_first_not_equal(column, _peer_group_start, _peer_group_end);
+    for (auto& column : _order_columns) {
+        _peer_group_end = _find_first_not_equal(column.get(), _peer_group_start, _peer_group_start, _peer_group_end);
     }
 }
 
@@ -517,8 +516,7 @@ void Analytor::_update_window_batch_normal(int64_t peer_group_start, int64_t pee
     }
 }
 
-int64_t Analytor::_find_first_not_equal(vectorized::Column* column, int64_t start, int64_t end) {
-    int64_t target = start;
+int64_t Analytor::_find_first_not_equal(vectorized::Column* column, int64_t target, int64_t start, int64_t end) {
     while (start + 1 < end) {
         int64_t mid = start + (end - start) / 2;
         if (column->compare_at(target, mid, *column, 1) == 0) {

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -208,7 +208,7 @@ private:
     void _update_window_batch_lead_lag(int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                        int64_t frame_end);
 
-    int64_t _find_first_not_equal(vectorized::Column* column, int64_t start, int64_t end);
+    static int64_t _find_first_not_equal(vectorized::Column* column, int64_t target, int64_t start, int64_t end);
 };
 
 // Helper class that properly invokes destructor when state goes out of scope.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(EXEC_FILES
         ./exec/vectorized/hdfs_scanner_test.cpp
         ./exec/vectorized/orc_scanner_adapter_test.cpp
         ./exec/vectorized/table_function_node_test.cpp
+        ./exec/vectorized/analytor_test.cpp
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/parquet/parquet_schema_test.cpp

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -1,0 +1,63 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include <gtest/gtest.h>
+
+#include "exec/vectorized/analytor.h"
+
+namespace starrocks::vectorized {
+class AnalytorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        config::vector_chunk_size = 1024;
+    }
+};
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_partition_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    auto c2 = Int32Column::create();
+    v = 3;
+    c2->append_value_multiple_times(&v, 5);
+    v = 4;
+    c2->append_value_multiple_times(&v, 15);
+
+    analytor.update_input_rows(20);
+    analytor._partition_columns.emplace_back(c1);
+    analytor._partition_columns.emplace_back(c2);
+
+    analytor.find_partition_end();
+    ASSERT_EQ(analytor.found_partition_end(), 5);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_peer_group_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    analytor.update_input_rows(20);
+    analytor._order_columns.emplace_back(c1);
+    analytor._partition_end = 20;
+
+    analytor.find_peer_group_end();
+    ASSERT_EQ(analytor.peer_group_end(), 10);
+}
+
+}


### PR DESCRIPTION
In the past, every time a new Chunk was read, the start pos of the binary search was PartitionStart. Currently, we execute binary search from the last pos, to reduce the frequency of compare.

This is not the main point that affects the calculation performance of the window function. The actual test has no effect on the performance. The main purpose is to release the memory earlier of the PartitionColumn in advance later.