### PR TITLE
[cherry-pick] [branch-2.1][BugFix] Restart fe failed with InsufficientLogException (#5685)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -241,6 +241,12 @@ public class BDBEnvironment {
         restore.execute(insufficientLogEx, config);
     }
 
+    public void refreshAndSetup(InsufficientLogException insufficientLogEx) {
+        refreshLog(insufficientLogEx);
+        close();
+        setup();
+    }
+
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
         return this.replicationGroupAdmin;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5642

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When fe has been stopped for a long time, the logs in bdb will be too far behind. On this case, bdb will throw the InsufficientLogException. We should catch this exception and refresh the log from master.