### PR TITLE
[cherry-pick] [branch-2.1] [enhancement] Add some interface for rows frame between unbouned preceding and current row (#5869)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -85,7 +85,7 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
         _analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column);
     }
 
-    _analytor->input_chunks().emplace_back(std::move(chunk));
+    _analytor->input_chunks().emplace_back(chunk);
 
     return _process_by_partition_if_necessary();
 }
@@ -102,12 +102,12 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             return Status::OK();
         }
 
-        size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
+        auto chunk_size = static_cast<int64_t>(_analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows());
         _analytor->create_agg_result_columns(chunk_size);
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         (this->*_process_by_partition)(chunk_size, is_new_partition);

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -125,7 +125,7 @@ Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -168,7 +168,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState*
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -217,7 +217,7 @@ Status AnalyticNode::_get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* 
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -257,7 +257,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -8,8 +8,7 @@
 #include "exprs/expr.h"
 #include "runtime/descriptors.h"
 
-namespace starrocks {
-namespace vectorized {
+namespace starrocks::vectorized {
 
 class AnalyticNode final : public ExecNode {
 public:
@@ -44,5 +43,4 @@ private:
     Status _fetch_next_chunk(RuntimeState* state);
     Status _try_fetch_next_partition_data(RuntimeState* state);
 };
-} // namespace vectorized
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -434,6 +434,20 @@ void Analytor::find_partition_end() {
     }
 }
 
+bool Analytor::find_and_check_partition_end() {
+    if (_partition_columns.empty() || _input_rows == 0) {
+        _found_partition_end = _input_rows;
+        return false;
+    }
+
+    int64_t start = _found_partition_end;
+    _found_partition_end = static_cast<int64_t>(_partition_columns[0]->size());
+    for (auto& column : _partition_columns) {
+        _found_partition_end = _find_first_not_equal(column.get(), _partition_end, start, _found_partition_end);
+    }
+    return _found_partition_end != static_cast<int64_t>(_partition_columns[0]->size());
+}
+
 void Analytor::find_peer_group_end() {
     // current peer group data don't output finished
     if (_current_row_position < _peer_group_end) {
@@ -449,9 +463,17 @@ void Analytor::find_peer_group_end() {
     }
 }
 
-void Analytor::reset_state_for_new_partition() {
+void Analytor::reset_state_for_cur_partition() {
     _partition_start = _partition_end;
     _partition_end = _found_partition_end;
+    _current_row_position = _partition_start;
+    reset_window_state();
+    DCHECK_GE(_current_row_position, 0);
+}
+
+void Analytor::reset_state_for_next_partition() {
+    _partition_end = _found_partition_end;
+    _partition_start = _partition_end;
     _current_row_position = _partition_start;
     reset_window_state();
     DCHECK_GE(_current_row_position, 0);
@@ -485,6 +507,7 @@ void Analytor::remove_unused_buffer_values(RuntimeState* state) {
     _removed_from_buffer_rows += remove_count;
     _partition_start -= remove_count;
     _partition_end -= remove_count;
+    _found_partition_end -= remove_count;
     _current_row_position -= remove_count;
     _peer_group_start -= remove_count;
     _peer_group_end -= remove_count;
@@ -509,7 +532,9 @@ void Analytor::_update_window_batch_normal(int64_t peer_group_start, int64_t pee
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         const vectorized::Column* agg_column = _agg_intput_columns[i][0].get();
         frame_start = std::max<int64_t>(frame_start, _partition_start);
-        frame_end = std::min<int64_t>(frame_end, _partition_end);
+        // for rows betweend unbounded preceding and current row, we have not found the partition end, for others,
+        // _found_partition_end = _partition_end, so we use _found_partition_end instead of _partition_end
+        frame_end = std::min<int64_t>(frame_end, _found_partition_end);
         _agg_functions[i]->update_batch_single_state(
                 _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], &agg_column,
                 peer_group_start, peer_group_end, frame_start, frame_end);

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -109,8 +109,10 @@ public:
     bool is_new_partition();
     int64_t get_total_position(int64_t local_position);
     void find_partition_end();
+    bool find_and_check_partition_end();
     void find_peer_group_end();
-    void reset_state_for_new_partition();
+    void reset_state_for_cur_partition();
+    void reset_state_for_next_partition();
 
     void remove_unused_buffer_values(RuntimeState* state);
 

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -60,4 +60,90 @@ TEST_F(AnalytorTest, find_peer_group_end) {
     ASSERT_EQ(analytor.peer_group_end(), 10);
 }
 
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, reset_state_for_cur_partition) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    analytor._partition_start = 3;
+    analytor._partition_end = 10;
+    analytor._found_partition_end = 20;
+    analytor.reset_state_for_cur_partition();
+    ASSERT_EQ(analytor.partition_start(), 10);
+    ASSERT_EQ(analytor.partition_end(), 20);
+    ASSERT_EQ(analytor.current_row_position(), 10);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, reset_state_for_next_partition) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    analytor._partition_start = 10;
+    analytor._partition_end = 10;
+    analytor._found_partition_end = 20;
+    analytor.reset_state_for_next_partition();
+    ASSERT_EQ(analytor.partition_start(), 20);
+    ASSERT_EQ(analytor.partition_end(), 20);
+    ASSERT_EQ(analytor.current_row_position(), 20);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_and_check_partition_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor1(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    auto c2 = Int32Column::create();
+    v = 3;
+    c2->append_value_multiple_times(&v, 5);
+    v = 4;
+    c2->append_value_multiple_times(&v, 15);
+
+    analytor1.update_input_rows(20);
+    analytor1._partition_columns.emplace_back(c1);
+    analytor1._partition_columns.emplace_back(c2);
+
+    bool end = analytor1.find_and_check_partition_end();
+    ASSERT_TRUE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 5);
+
+    analytor1.reset_state_for_cur_partition();
+
+    end = analytor1.find_and_check_partition_end();
+    ASSERT_TRUE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 10);
+
+    analytor1.reset_state_for_cur_partition();
+
+    end = analytor1.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 20);
+
+    // partition columns is empty
+    Analytor analytor2(plan_node, row_desc, nullptr);
+    analytor2.update_input_rows(20);
+
+    end = analytor2.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor2.found_partition_end(), 20);
+
+    // input rows = 0
+    Analytor analytor3(plan_node, row_desc, nullptr);
+    analytor3.update_input_rows(0);
+
+    end = analytor3.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor3.found_partition_end(), 0);
+}
+
 }


### PR DESCRIPTION
Add some interface for rows betweend unbounded preceding and current row

* reset_state_for_next_partition: for `rows betweend unbounded preceding and current row`, we no need to find the bound of cur partition, so we will reset the state of next partition, when we reach the bound of cur partition.
* find_and_check_partition_end: get one chunk and search the bound, if found return true
* For rows betweend unbounded preceding and current row, we have not found the partition end, for others, _found_partition_end = _partition_end, so we use _found_partition_end instead of _partition_end as frame end
* add `found_partition_end` to `remove_unused_buffer_values`
