### PR TITLE
[Bugfix] support splitting chunk into multiple TFetchDataResults to avoid failures of thrift serialization(#5865)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -203,8 +203,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         if (_use_pass_through) {
             size_t chunk_size = serde::ProtobufChunkSerde::max_serialized_size(*chunk);
             // -1 means disable pipeline level shuffle
-            _pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
-                                               _parent->_is_pipeline_level_shuffle ? driver_sequence : -1);
+            TRY_CATCH_BAD_ALLOC(
+                    _pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
+                                                       _parent->_is_pipeline_level_shuffle ? driver_sequence : -1));
             _current_request_bytes += chunk_size;
             COUNTER_UPDATE(_parent->_bytes_pass_through_counter, chunk_size);
         } else {
@@ -212,7 +213,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
                 _chunk_request->add_driver_sequences(driver_sequence);
             }
             auto pchunk = _chunk_request->add_chunks();
-            RETURN_IF_ERROR(_parent->serialize_chunk(chunk, pchunk, &_is_first_chunk));
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_parent->serialize_chunk(chunk, pchunk, &_is_first_chunk)));
             _current_request_bytes += pchunk->data().size();
         }
     }
@@ -413,7 +414,8 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
             // 1. create a new chunk PB to serialize
             ChunkPB* pchunk = _chunk_request->add_chunks();
             // 2. serialize input chunk to pchunk
-            RETURN_IF_ERROR(serialize_chunk(chunk.get(), pchunk, &_is_first_chunk, _channels.size()));
+            TRY_CATCH_BAD_ALLOC(
+                    RETURN_IF_ERROR(serialize_chunk(chunk.get(), pchunk, &_is_first_chunk, _channels.size())));
             _current_request_bytes += pchunk->data().size();
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > _request_bytes_threshold) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -91,10 +91,14 @@ Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
         runtime_filter_hub()->set_collector(_plan_node_id, std::make_unique<RuntimeFilterCollector>(
                                                                    std::move(in_filters), std::move(bloom_filters)));
     }
-
-    for (auto& read_only_join_prober : _read_only_join_probers) {
-        read_only_join_prober->reference_hash_table(_join_builder.get());
+    {
+        TRY_CATCH_ALLOC_SCOPE_START()
+        for (auto& read_only_join_prober : _read_only_join_probers) {
+            read_only_join_prober->reference_hash_table(_join_builder.get());
+        }
+        TRY_CATCH_ALLOC_SCOPE_END()
     }
+
     _join_builder->enter_probe_phase();
     for (auto& read_only_join_prober : _read_only_join_probers) {
         read_only_join_prober->enter_probe_phase();

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -74,7 +74,7 @@ bool ResultSinkOperator::need_input() const {
     if (is_finished()) {
         return false;
     }
-    if (!_fetch_data_result) {
+    if (_fetch_data_result.empty()) {
         return true;
     }
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
@@ -91,9 +91,9 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::Chu
     if (!_last_error.ok()) {
         return _last_error;
     }
-    DCHECK(!_fetch_data_result);
+    DCHECK(_fetch_data_result.empty());
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
-    auto status = mysql_writer->process_chunk(chunk.get());
+    auto status = mysql_writer->process_chunk_for_pipeline(chunk.get());
     if (status.ok()) {
         _fetch_data_result = std::move(status.value());
         return mysql_writer->try_add_batch(_fetch_data_result).status();

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -41,7 +41,7 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished && !_fetch_data_result; }
+    bool is_finished() const override { return _is_finished && _fetch_data_result.empty(); }
 
     Status set_finishing(RuntimeState* state) override {
         _is_finished = true;
@@ -63,7 +63,7 @@ private:
     std::atomic<int64_t>& _num_written_rows;
 
     std::shared_ptr<ResultWriter> _writer;
-    mutable TFetchDataResultPtr _fetch_data_result;
+    mutable TFetchDataResultPtrs _fetch_data_result;
 
     std::unique_ptr<RuntimeProfile> _profile = nullptr;
 

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -67,9 +67,14 @@ public:
     ~BufferControlBlock();
 
     Status init();
+    // In order not to affect the current implementation of the non-pipeline engine,
+    // this method is reserved and is only used in the non-pipeline engine
     Status add_batch(TFetchDataResult* result);
+    Status add_batch(std::unique_ptr<TFetchDataResult>& result);
+
     // non-blocking version of add_batch
-    StatusOr<bool> try_add_batch(TFetchDataResult* result);
+    StatusOr<bool> try_add_batch(std::unique_ptr<TFetchDataResult>& result);
+    StatusOr<bool> try_add_batch(std::vector<std::unique_ptr<TFetchDataResult>>& results);
 
     // get result from batch, use timeout?
     Status get_batch(TFetchDataResult* result);
@@ -98,6 +103,8 @@ public:
     }
 
 private:
+    void _process_batch_without_lock(std::unique_ptr<TFetchDataResult>& result);
+
     typedef std::list<TFetchDataResult*> ResultQueue;
 
     // result's query id

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -29,6 +29,7 @@
 #include "exprs/expr.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/buffer_control_block.h"
+#include "runtime/current_thread.h"
 #include "runtime/primitive_type.h"
 #include "util/date_func.h"
 #include "util/mysql_row_buffer.h"
@@ -134,25 +135,85 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::process_chunk(vectorized::Chunk
     return result;
 }
 
-StatusOr<bool> MysqlResultWriter::try_add_batch(TFetchDataResultPtr& result) {
-    SCOPED_TIMER(_result_send_timer);
-    auto* fetch_data = result.release();
-    auto num_rows = fetch_data->result_batch.rows.size();
-    auto status = _sinker->try_add_batch(fetch_data);
+StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk_for_pipeline(vectorized::Chunk* chunk) {
+    SCOPED_TIMER(_append_chunk_timer);
+    int num_rows = chunk->num_rows();
+    std::vector<TFetchDataResultPtr> results;
 
+    vectorized::Columns result_columns;
+    // Step 1: compute expr
+    int num_columns = _output_expr_ctxs.size();
+    result_columns.reserve(num_columns);
+
+    for (int i = 0; i < num_columns; ++i) {
+        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
+        column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
+                         ? vectorized::ColumnHelper::convert_time_column_from_double_to_str(column)
+                         : column;
+        result_columns.emplace_back(std::move(column));
+    }
+
+    // Step 2: convert chunk to mysql row format row by row
+    {
+        TRY_CATCH_ALLOC_SCOPE_START()
+        _row_buffer->reserve(128);
+        size_t current_bytes = 0;
+        int current_rows = 0;
+        SCOPED_TIMER(_convert_tuple_timer);
+        auto result = std::make_unique<TFetchDataResult>();
+        auto& result_rows = result->result_batch.rows;
+        result_rows.resize(num_rows);
+
+        for (int i = 0; i < num_rows; ++i) {
+            DCHECK_EQ(0, _row_buffer->length());
+            for (auto& result_column : result_columns) {
+                result_column->put_mysql_row_buffer(_row_buffer, i);
+            }
+            size_t len = _row_buffer->length();
+
+            if (UNLIKELY(current_bytes + len >= _max_row_buffer_size)) {
+                result_rows.resize(current_rows);
+                results.emplace_back(std::move(result));
+
+                result = std::make_unique<TFetchDataResult>();
+                result_rows = result->result_batch.rows;
+                result_rows.resize(num_rows - i);
+
+                current_bytes = 0;
+                current_rows = 0;
+            }
+            _row_buffer->move_content(&result_rows[current_rows]);
+            _row_buffer->reserve(len * 1.1);
+
+            current_bytes += len;
+            current_rows += 1;
+        }
+        if (current_rows > 0) {
+            result_rows.resize(current_rows);
+            results.emplace_back(std::move(result));
+        }
+        TRY_CATCH_ALLOC_SCOPE_END()
+    }
+    return results;
+}
+
+StatusOr<bool> MysqlResultWriter::try_add_batch(TFetchDataResultPtrs& results) {
+    SCOPED_TIMER(_result_send_timer);
+    size_t num_rows = 0;
+    for (auto& result : results) {
+        num_rows += result->result_batch.rows.size();
+    }
+
+    auto status = _sinker->try_add_batch(results);
     if (status.ok()) {
         // success in add result to ResultQueue of _sinker
         if (status.value()) {
             _written_rows += num_rows;
-        } else {
-            // the result is given back to chunk
-            result.reset(fetch_data);
+            results.clear();
         }
     } else {
-        delete fetch_data;
-        if (!status.ok()) {
-            LOG(WARNING) << "Append result batch to sink failed: status=" << status.status().to_string();
-        }
+        results.clear();
+        LOG(WARNING) << "Append result batch to sink failed: status=" << status.status().to_string();
     }
     return status;
 }

--- a/be/src/runtime/mysql_result_writer.h
+++ b/be/src/runtime/mysql_result_writer.h
@@ -32,6 +32,7 @@ class MysqlRowBuffer;
 class BufferControlBlock;
 class RuntimeProfile;
 using TFetchDataResultPtr = std::unique_ptr<TFetchDataResult>;
+using TFetchDataResultPtrs = std::vector<TFetchDataResultPtr>;
 // convert the row batch to mysql protocol row
 class MysqlResultWriter final : public ResultWriter {
 public:
@@ -50,10 +51,15 @@ public:
     // the former transform input chunk into TFetchDataResult, the latter add TFetchDataResult
     // to queue whose consumers are rpc threads that invoke fetch_data rpc.
     StatusOr<TFetchDataResultPtr> process_chunk(vectorized::Chunk* chunk);
+    // because the mem buffer used by thrift serialization is limited, we should control the size of single TFetchDataResult,
+    // we may split a chunk into multiple TFetchDataResults
+    // In order not to affect the current implementation of the non-pipeline engine,
+    // we only implement it for the pipeline engine
+    StatusOr<TFetchDataResultPtrs> process_chunk_for_pipeline(vectorized::Chunk* chunk);
 
     // try to add result into _sinker if ResultQueue is not full and this operation is
     // non-blocking. return true on success, false in case of that ResultQueue is full.
-    StatusOr<bool> try_add_batch(TFetchDataResultPtr& result);
+    StatusOr<bool> try_add_batch(TFetchDataResultPtrs& results);
 
 private:
     void _init_profile();
@@ -71,6 +77,8 @@ private:
     RuntimeProfile::Counter* _result_send_timer = nullptr;
     // number of sent rows
     RuntimeProfile::Counter* _sent_rows_counter = nullptr;
+
+    const size_t _max_row_buffer_size = 1024 * 1024 * 1024;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/vectorized/statistic_result_writer.h
+++ b/be/src/runtime/vectorized/statistic_result_writer.h
@@ -30,10 +30,10 @@ public:
 private:
     void _init_profile();
 
-    void _fill_statistic_data_v1(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
-                                 TFetchDataResult* result);
-    void _fill_dict_statistic_data(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
+    Status _fill_statistic_data_v1(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
                                    TFetchDataResult* result);
+    Status _fill_dict_statistic_data(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
+                                     TFetchDataResult* result);
 
 private:
     BufferControlBlock* _sinker;

--- a/be/test/runtime/buffer_control_block_test.cpp
+++ b/be/test/runtime/buffer_control_block_test.cpp
@@ -48,7 +48,7 @@ TEST_F(BufferControlBlockTest, add_one_get_one) {
     BufferControlBlock control_block(TUniqueId(), 1024);
     ASSERT_TRUE(control_block.init().ok());
 
-    TFetchDataResult* add_result = new TFetchDataResult();
+    std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
     add_result->result_batch.rows.push_back("hello test");
     ASSERT_TRUE(control_block.add_batch(add_result).ok());
 
@@ -74,10 +74,9 @@ TEST_F(BufferControlBlockTest, get_add_after_cancel) {
     ASSERT_TRUE(control_block.init().ok());
 
     ASSERT_TRUE(control_block.cancel().ok());
-    TFetchDataResult* add_result = new TFetchDataResult();
+    std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
     add_result->result_batch.rows.push_back("hello test");
     ASSERT_FALSE(control_block.add_batch(add_result).ok());
-    delete add_result;
 
     TFetchDataResult get_result;
     ASSERT_FALSE(control_block.get_batch(&get_result).ok());
@@ -99,17 +98,16 @@ TEST_F(BufferControlBlockTest, add_then_cancel) {
     pthread_create(&id, NULL, cancel_thread, &control_block);
 
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         ASSERT_TRUE(control_block.add_batch(add_result).ok());
     }
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         ASSERT_FALSE(control_block.add_batch(add_result).ok());
-        delete add_result;
     }
 
     TFetchDataResult get_result;
@@ -136,7 +134,7 @@ void* add_thread(void* param) {
     BufferControlBlock* control_block = static_cast<BufferControlBlock*>(param);
     sleep(1);
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         control_block->add_batch(add_result);


### PR DESCRIPTION


1. support split chunk into multiple TFetchDataResults to avoid failures during serialization
2. try to catch std::bad_alloc in different operators

(cherry picked from commit 0d1bf366012906e5354407595ef94e90b51cf222)

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
