### PR TITLE
[Bug] Fix limit error when setting select_sql_limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -92,7 +92,8 @@ class QueryTransformer {
 
         // Add project operator to prune order by columns
         if (!orderByColumns.isEmpty() && !outputColumns.containsAll(orderByColumns)) {
-            builder = project(builder, queryBlock.getOutputExpr(), queryBlock.getLimit().getLimit());
+            long limit = queryBlock.hasLimit() ? queryBlock.getLimit().getLimit() : -1;
+            builder = project(builder, queryBlock.getOutputExpr(), limit);
         }
 
         return new LogicalPlan(builder, outputColumns, correlation);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -92,7 +92,7 @@ class QueryTransformer {
 
         // Add project operator to prune order by columns
         if (!orderByColumns.isEmpty() && !outputColumns.containsAll(orderByColumns)) {
-            builder = project(builder, queryBlock.getOutputExpr());
+            builder = project(builder, queryBlock.getOutputExpr(), queryBlock.getLimit().getLimit());
         }
 
         return new LogicalPlan(builder, outputColumns, correlation);
@@ -159,6 +159,10 @@ class QueryTransformer {
     }
 
     private OptExprBuilder project(OptExprBuilder subOpt, Iterable<Expr> expressions) {
+        return project(subOpt, expressions, -1);
+    }
+
+    private OptExprBuilder project(OptExprBuilder subOpt, Iterable<Expr> expressions, long limit) {
         ExpressionMapping outputTranslations = new ExpressionMapping(subOpt.getScope(), subOpt.getFieldMappings());
 
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
@@ -171,7 +175,7 @@ class QueryTransformer {
             outputTranslations.put(expression, columnRef);
         }
 
-        LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections);
+        LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections, limit);
         return new OptExprBuilder(projectOperator, Lists.newArrayList(subOpt), outputTranslations);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -119,8 +119,18 @@ public class OrderByTest extends PlanTestBase {
     public void testSqlSelectLimit() throws Exception {
         connectContext.getSessionVariable().setSqlSelectLimit(200);
         // test order by with project
-        String sql = "select L_QUANTITY from lineitem order by L_QUANTITY, L_PARTKEY limit 10";
-        String plan = getFragmentPlan(sql);
+        String sql;
+        String plan;
+
+        sql = "select L_QUANTITY from lineitem order by L_QUANTITY, L_PARTKEY";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:TOP-N\n" +
+                "  |  order by: <slot 5> 5: L_QUANTITY ASC, <slot 2> 2: L_PARTKEY ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 200");
+
+        sql = sql + " limit 10";
+        plan = getFragmentPlan(sql);
         assertContains(plan, "  1:TOP-N\n" +
                 "  |  order by: <slot 5> 5: L_QUANTITY ASC, <slot 2> 2: L_PARTKEY ASC\n" +
                 "  |  offset: 0\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import mockit.Mock;
@@ -112,5 +113,18 @@ public class OrderByTest extends PlanTestBase {
             connectContext.getSessionVariable().setPipelineDop(pipelineDop);
         }
 
+    }
+
+    @Test
+    public void testSqlSelectLimit() throws Exception {
+        connectContext.getSessionVariable().setSqlSelectLimit(200);
+        // test order by with project
+        String sql = "select L_QUANTITY from lineitem order by L_QUANTITY, L_PARTKEY limit 10";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:TOP-N\n" +
+                "  |  order by: <slot 5> 5: L_QUANTITY ASC, <slot 2> 2: L_PARTKEY ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 10");
+        connectContext.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

close #5966 

## detail infomation

It was because we will use root LogicPlan to check whether we have add a limit for SQLs. But when we build logic plan from relation, TopN logic won't pass limit to project which will make `transformWithSelectLimit` think the SQL has no limit for the query.
