### PR TITLE
[BugFix] fix concurrency safety of workgroup queue

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -209,10 +209,12 @@ void DriverQueueWithWorkGroup::close() {
 }
 
 void DriverQueueWithWorkGroup::put_back(const DriverRawPtr driver) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
     _put_back<false>(driver);
 }
 
 void DriverQueueWithWorkGroup::put_back(const std::vector<DriverRawPtr>& drivers) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
     for (const auto driver : drivers) {
         _put_back<false>(driver);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5980
Fixes #6008 
Fixed #5989


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`DriverQueueWithWorkGroup::put_back` does not take a lock, which is not safe.
