### PR TITLE
[Bugfix]cancel fragment_ctx when query is expired

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -62,7 +62,8 @@ void PipelineDriverPoller::run_internal() {
                 // The state of driver shouldn't be changed.
                 LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
                              << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
-                driver->fragment_ctx()->cancel(Status::TimedOut("query timeout"));
+                driver->fragment_ctx()->cancel(Status::TimedOut(fmt::format(
+                        "Query exceeded time limit of {} seconds", driver->query_ctx()->get_expire_seconds())));
                 driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -62,6 +62,7 @@ void PipelineDriverPoller::run_internal() {
                 // The state of driver shouldn't be changed.
                 LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
                              << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
+                driver->fragment_ctx()->cancel(Status::TimedOut("query timeout"));
                 driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -42,7 +42,7 @@ public:
     bool has_no_active_instances() { return _num_active_fragments.load() == 0; }
 
     void set_expire_seconds(int expire_seconds) { _expire_seconds = seconds(expire_seconds); }
-
+    inline int get_expire_seconds() { return _expire_seconds.count(); }
     // now time point pass by deadline point.
     bool is_expired() {
         auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -48,7 +48,6 @@ public class ResultReceiver {
     private boolean isCancel = false;
     private long packetIdx = 0;
     private final long timeoutTs;
-    private final int expireSeconds;
     private final TNetworkAddress address;
     private final PUniqueId finstId;
     private final Long backendId;
@@ -61,7 +60,6 @@ public class ResultReceiver {
         this.backendId = backendId;
         this.address = address;
         this.timeoutTs = System.currentTimeMillis() + timeoutMs;
-        this.expireSeconds = timeoutMs / 1000;
     }
 
     public RowBatch getNext(Status status) throws TException {
@@ -128,14 +126,16 @@ public class ResultReceiver {
             if (e.getMessage().contains("time out")) {
                 // if timeout, we set error code to TIMEOUT, and it will not retry querying.
                 status.setStatus(new Status(TStatusCode.TIMEOUT,
-                        String.format("Query exceeded time limit of %d seconds", expireSeconds)));
+                        String.format("Query exceeded time limit of %d seconds",
+                                ConnectContext.get().getSessionVariable().getQueryTimeoutS())));
             } else {
                 status.setRpcStatus(e.getMessage());
                 SimpleScheduler.addToBlacklist(backendId);
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", finstId, e);
-            status.setStatus(String.format("Query exceeded time limit of %d seconds", expireSeconds));
+            status.setStatus(String.format("Query exceeded time limit of %d seconds",
+                    ConnectContext.get().getSessionVariable().getQueryTimeoutS()));
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -48,6 +48,7 @@ public class ResultReceiver {
     private boolean isCancel = false;
     private long packetIdx = 0;
     private final long timeoutTs;
+    private final int expireSeconds;
     private final TNetworkAddress address;
     private final PUniqueId finstId;
     private final Long backendId;
@@ -60,6 +61,7 @@ public class ResultReceiver {
         this.backendId = backendId;
         this.address = address;
         this.timeoutTs = System.currentTimeMillis() + timeoutMs;
+        this.expireSeconds = timeoutMs / 1000;
     }
 
     public RowBatch getNext(Status status) throws TException {
@@ -125,14 +127,15 @@ public class ResultReceiver {
             LOG.warn("fetch result execution exception, finstId={}", finstId, e);
             if (e.getMessage().contains("time out")) {
                 // if timeout, we set error code to TIMEOUT, and it will not retry querying.
-                status.setStatus(new Status(TStatusCode.TIMEOUT, "query timeout"));
+                status.setStatus(new Status(TStatusCode.TIMEOUT,
+                        String.format("Query exceeded time limit of %d seconds", expireSeconds)));
             } else {
                 status.setRpcStatus(e.getMessage());
                 SimpleScheduler.addToBlacklist(backendId);
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", finstId, e);
-            status.setStatus("query timeout");
+            status.setStatus(String.format("Query exceeded time limit of %d seconds", expireSeconds));
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -125,7 +125,7 @@ public class ResultReceiver {
             LOG.warn("fetch result execution exception, finstId={}", finstId, e);
             if (e.getMessage().contains("time out")) {
                 // if timeout, we set error code to TIMEOUT, and it will not retry querying.
-                status.setStatus(new Status(TStatusCode.TIMEOUT, e.getMessage()));
+                status.setStatus(new Status(TStatusCode.TIMEOUT, "query timeout"));
             } else {
                 status.setRpcStatus(e.getMessage());
                 SimpleScheduler.addToBlacklist(backendId);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5814

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If query is expired, PipelineDriverPoller will cancel operators directly without setting a timeout status and the BufferControlBlock will close with Status::OK(). 
When the fetch_data request arrived and the BufferControlBlock is closed, it will get an empty result.

In addition, if the fetch_data rpc times out, FE may return such an error to user: `ERROR 1064 (HY000): Ocurrs time out with specfied time 1986 MILLISECONDS`. The number in error message may not equal to the query_timeout setting by user, I think this might be misleading, so I change it to a more friendly pattern