### PR TITLE
[BugFix ] Fix bad variant access

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -378,7 +378,7 @@ void Aggregator::compute_single_agg_state(size_t chunk_size) {
             _agg_functions[i]->update_batch_single_state(_agg_fn_ctxs[i], chunk_size, _agg_input_raw_columns[i].data(),
                                                          _single_agg_state + _agg_states_offsets[i]);
         } else {
-            DCHECK_EQ(_agg_intput_columns[i].size(), 1);
+            DCHECK_GE(_agg_intput_columns[i].size(), 1);
             _agg_functions[i]->merge_batch_single_state(_agg_fn_ctxs[i], chunk_size, _agg_intput_columns[i][0].get(),
                                                         _single_agg_state + _agg_states_offsets[i]);
         }

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -72,7 +72,7 @@ struct WindowFunnelState {
         bool other_sorted = (uint8_t)datum_array[1].get_int64();
 
         for (size_t i = 2; i < datum_array.size() - 1; i += 2) {
-            typename TimeType::type timestamp = (typename TimeType::type)datum_array[i].get_int64();
+            typename TimeType::type timestamp = datum_array[i].get_int64();
             int64_t event_level = datum_array[i + 1].get_int64();
             other_list.emplace_back(std::make_pair(timestamp, uint8_t(event_level)));
         }
@@ -105,7 +105,7 @@ struct WindowFunnelState {
             array.emplace_back((int64_t)events_size);
             array.emplace_back((int64_t)sorted);
             for (int i = 0; i < size; i++) {
-                array.emplace_back(events_list[i].first);
+                array.emplace_back((int64_t)events_list[i].first);
                 array.emplace_back((int64_t)events_list[i].second);
             }
             array_column->append_datum(array);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/5976, https://github.com/StarRocks/starrocks/issues/5956, https://github.com/StarRocks/starrocks/issues/5951, https://github.com/StarRocks/starrocks/issues/5935

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should use int64_t as array element for all timestampe(date/datetime ). Because date's type is int32_t, so we can't put  it in array, just transfer to int64_t.