### PR TITLE
[cherry-pick] [branch-2.2] [Enhancement] Optimize the memory usage of rows between unbounded preceding and current row (#5883)

### DIFF
--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -36,7 +36,8 @@ private:
 
     Status _get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
     Status _get_next_for_unbounded_preceding_range_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
-    Status _get_next_for_unbounded_preceding_rows_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+    Status _get_next_for_rows_between_unbounded_preceding_and_current_row(RuntimeState* state, ChunkPtr* chunk,
+                                                                          bool* eos);
     Status _get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
     Status (AnalyticNode::*_get_next)(RuntimeState* state, ChunkPtr* chunk, bool* eos) = nullptr;
 


### PR DESCRIPTION
No need to read all the partition data and add to buffer, we will read only one chunk and then output for rows between unbounded preceding and current row.

for sql

```
select count(lo_orderkey), count(lo_partkey), count(lo_custkey), count(lo_suppkey), count(lo_quantity), count(lo_discount), count(lo_shipmode), count(_num) from 
(select lo_orderkey, lo_partkey, lo_custkey, lo_suppkey, lo_quantity, lo_discount, lo_shipmode, row_number() over(order by lo_partkey) as _num from lineorder) t1;
```

parallel = 4

before opt: TheLastFragment PeakMem(4.55G), time(25.257s)

```
    Fragment 0:
      Instance a570aad6-d009-11ec-8733-66660a909346 (host=TNetworkAddress(hostname:172.26.92.195, port:10061)):(Active: 25s247ms[25247329630ns], % non-child: 0.00%)
         - AverageThreadTokens: 4607182418800017400.00
         - MemoryLimit: 18.63 GB
         - PeakMemoryUsage: 4.55 GB
         - RowsProduced: 1
 ```

after opt: TheLastFragment PeakMem(782.66M), time(24.614s)

```
      Instance ab4b09fe-d008-11ec-8733-66660a909346 (host=TNetworkAddress(hostname:172.26.92.195, port:10061)):(Active: 24s602ms[24602663842ns], % non-child: 0.00%)
         - AverageThreadTokens: 4607182418800017400.00
         - MemoryLimit: 18.63 GB
         - PeakMemoryUsage: 782.66 MB
         - RowsProduced: 1
```