### PR TITLE
[Bugfix] Fix primary index and pending rowset inconsistency when doin…

### DIFF
--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -1195,6 +1195,11 @@ Status TabletMetaManager::delete_pending_rowset(DataDir* store, WriteBatch* batc
     return to_status(batch->Delete(h, pkey));
 }
 
+Status TabletMetaManager::delete_pending_rowset(DataDir* store, TTabletId tablet_id, int64_t version) {
+    auto pkey = encode_meta_pending_rowset_key(tablet_id, version);
+    return store->get_meta()->remove(META_COLUMN_FAMILY_INDEX, pkey);
+}
+
 Status TabletMetaManager::clear_pending_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id) {
     auto lower = encode_meta_pending_rowset_key(tablet_id, 0);
     auto upper = encode_meta_pending_rowset_key(tablet_id, INT64_MAX);

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -167,6 +167,8 @@ public:
 
     static Status delete_pending_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id, int64_t version);
 
+    static Status delete_pending_rowset(DataDir* store, TTabletId tablet_id, int64_t version);
+
     // Unlike `rowset_delete`, this method will NOT clear delete vectors.
     static Status clear_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
 

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -263,6 +263,11 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
         LOG(WARNING) << "load RowsetUpdateState error: " << st << " tablet: " << tablet->tablet_id();
         _update_state_cache.remove(state_entry);
     }
+    if (tablet->tablet_state() == TABLET_NOTREADY) {
+        // tablet in initial schema change phase, this rowset will not be applied until schemachange finishes
+        // so don't load primary index
+        return Status::OK();
+    }
     if (st.ok()) {
         auto index_entry = _index_cache.get_or_create(tablet->tablet_id());
         st = index_entry->value().load(tablet);


### PR DESCRIPTION
…g tablet schemachange

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/5878
CherryPick https://github.com/StarRocks/starrocks/pull/5937

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When doing schema change, if a new write txn comes, it will pre-load the primary index at the commit stage, even if it's empty, and when schema change's converting is done and start to apply pending rowsets, it doesn't reload the index, causing inconsistency, so this PR fixes this.
