### PR TITLE
[BugFix] add `es_index_max_result_window` config value to limit fetch batch size

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -505,6 +505,11 @@ CONF_String(es_scroll_keepalive, "5m");
 // HTTP connection timeout for es.
 CONF_Int32(es_http_timeout_ms, "5000");
 
+// es index max result window, and this value affects batch size.
+// if request batch size exceeds this value, ES will return bad request(400)
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html
+CONF_Int32(es_index_max_result_window, "10000");
+
 // The max client cache number per each host.
 // There are variety of client cache in BE, but currently we use the
 // same cache size configuration.

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -168,7 +168,8 @@ Status ESDataSource::_create_scanner() {
         _properties[ESScanReader::KEY_TYPE] = es_scan_range.type;
     }
     _properties[ESScanReader::KEY_SHARD] = std::to_string(es_scan_range.shard_id);
-    _properties[ESScanReader::KEY_BATCH_SIZE] = std::to_string(_runtime_state->chunk_size());
+    _properties[ESScanReader::KEY_BATCH_SIZE] =
+            std::to_string(std::min(config::es_index_max_result_window, _runtime_state->chunk_size()));
     _properties[ESScanReader::KEY_HOST_PORT] = get_host_port(es_scan_range.es_hosts);
     // push down limit to Elasticsearch
     if (_read_limit != -1 && _read_limit <= _runtime_state->chunk_size()) {


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5994

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

if request batch size exceeds `index.max_result_window`, ES will return bad request(400)

see also https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html
