### PR TITLE
[BugFix] Fix onPredicate change itself at rule transform phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
@@ -85,7 +85,7 @@ public class PushDownJoinOnExpressionToChildProject extends TransformationRule {
 
         Rewriter leftRewriter = new Rewriter(leftProjectMaps);
         Rewriter rightRewriter = new Rewriter(rightProjectMaps);
-        ScalarOperator newJoinOnPredicate = onPredicate.accept(leftRewriter, null).accept(rightRewriter, null);
+        ScalarOperator newJoinOnPredicate = onPredicate.clone().accept(leftRewriter, null).accept(rightRewriter, null);
 
         OptExpression newJoinOpt = OptExpression.create(new LogicalJoinOperator.Builder().withOperator(joinOperator)
                 .setOnPredicate(newJoinOnPredicate)


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5970, #5971 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The onPredicate will be changed in the rule transform, change the origin groupExression, which will result in can not find in MEMO