### PR TITLE
[BugFix] Do not use ColumnViewer::size for regex_match

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -240,7 +240,7 @@ bool ColumnHelper::is_all_const(const Columns& columns) {
     return std::all_of(std::begin(columns), std::end(columns), [](const ColumnPtr& col) { return col->is_constant(); });
 }
 
-pair<bool, size_t> ColumnHelper::num_packed_rows(const Columns& columns) {
+std::pair<bool, size_t> ColumnHelper::num_packed_rows(const Columns& columns) {
     if (columns.empty()) {
         return {false, 0};
     }

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -240,6 +240,19 @@ bool ColumnHelper::is_all_const(const Columns& columns) {
     return std::all_of(std::begin(columns), std::end(columns), [](const ColumnPtr& col) { return col->is_constant(); });
 }
 
+pair<bool, size_t> ColumnHelper::num_packed_rows(const Columns& columns) {
+    if (columns.empty()) {
+        return {false, 0};
+    }
+
+    bool all_const = is_all_const(columns);
+    if (!all_const) {
+        return {all_const, columns[0]->size()};
+    }
+
+    return {all_const, 1};
+}
+
 using ColumnsConstIterator = Columns::const_iterator;
 bool ColumnHelper::is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end) {
     for (auto it = begin; it < end; ++it) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -265,6 +265,13 @@ public:
 
     static bool is_all_const(const Columns& columns);
 
+    // Returns
+    //  1. whether all the columns are constant.
+    //  2. the number of the packed rows. If all the columns are constant, it will be 1,
+    //     which could reduce unnecessary calculations.
+    //     Don't forget to resize the result constant columns if necessary.
+    static pair<bool, size_t> num_packed_rows(const Columns& columns);
+
     using ColumnsConstIterator = Columns::const_iterator;
     static bool is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);
     static size_t compute_bytes_size(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -270,7 +270,7 @@ public:
     //  2. the number of the packed rows. If all the columns are constant, it will be 1,
     //     which could reduce unnecessary calculations.
     //     Don't forget to resize the result constant columns if necessary.
-    static pair<bool, size_t> num_packed_rows(const Columns& columns);
+    static std::pair<bool, size_t> num_packed_rows(const Columns& columns);
 
     using ColumnsConstIterator = Columns::const_iterator;
     static bool is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -1571,15 +1571,11 @@ ColumnPtr TimeFunctions::datetime_format(FunctionContext* context, const Columns
     if (fc != nullptr && fc->is_valid) {
         return do_format<TYPE_DATETIME>(fc, columns);
     } else {
-        bool all_const = ColumnHelper::is_all_const(columns);
+        auto [all_const, num_rows] = ColumnHelper::num_packed_rows(columns);
         ColumnViewer<TYPE_DATETIME> viewer_date(columns[0]);
         ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
 
-        // all_const was true viewer_date.size() will return 1
-        // which could reduce unnecessary calculations
-        size_t num_rows = all_const ? viewer_date.size() : columns[0]->size();
-
-        ColumnBuilder<TYPE_VARCHAR> builder(columns[0]->size());
+        ColumnBuilder<TYPE_VARCHAR> builder(num_rows);
         for (int i = 0; i < num_rows; ++i) {
             if (viewer_date.is_null(i)) {
                 builder.append_null();

--- a/be/test/exprs/vectorized/like_test.cpp
+++ b/be/test/exprs/vectorized/like_test.cpp
@@ -471,5 +471,81 @@ TEST_F(LikeTest, rowsPatternRegex) {
                         .ok());
 }
 
+TEST_F(LikeTest, constValueLike) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+
+    const int num_rows = 10;
+
+    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", 1);
+    auto pattern_col = BinaryColumn::create();
+    pattern_col->append("abc");
+    pattern_col->append("abc%");
+    pattern_col->append("abc_");
+    pattern_col->append("%abc");
+    pattern_col->append("_abc");
+    pattern_col->append("a%d");
+    pattern_col->append("ab_d");
+    pattern_col->append("abcd");
+    pattern_col->append("abcm");
+    pattern_col->append("abcd_");
+
+    bool expected[num_rows] = {false, true, true, true, true, true, true, true, false, false};
+
+    Columns columns;
+    columns.emplace_back(std::move(value_col));
+    columns.emplace_back(std::move(pattern_col));
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns);
+    ASSERT_TRUE(result->is_numeric());
+    ASSERT_EQ(num_rows, result->size());
+
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+    for (int i = 0; i < num_rows; ++i) {
+        ASSERT_EQ(expected[i], v->get_data()[i]);
+    }
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, constValueRegexp) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+
+    const int num_rows = 4;
+
+    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", 1);
+    auto pattern_col = BinaryColumn::create();
+    pattern_col->append("abc");
+    pattern_col->append("ab.*");
+    pattern_col->append("abcd");
+    pattern_col->append("abcm");
+
+    bool expected[num_rows] = {true, true, true, false};
+
+    Columns columns;
+    columns.emplace_back(std::move(value_col));
+    columns.emplace_back(std::move(pattern_col));
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::regex(context, columns);
+    ASSERT_TRUE(result->is_numeric());
+    ASSERT_EQ(num_rows, result->size());
+
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+    for (int i = 0; i < num_rows; ++i) {
+        ASSERT_EQ(expected[i], v->get_data()[i]);
+    }
+
+    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
 } // namespace vectorized
 } // namespace starrocks

--- a/be/test/exprs/vectorized/like_test.cpp
+++ b/be/test/exprs/vectorized/like_test.cpp
@@ -477,7 +477,7 @@ TEST_F(LikeTest, constValueLike) {
 
     const int num_rows = 10;
 
-    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", 1);
+    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", num_rows);
     auto pattern_col = BinaryColumn::create();
     pattern_col->append("abc");
     pattern_col->append("abc%");
@@ -518,7 +518,7 @@ TEST_F(LikeTest, constValueRegexp) {
 
     const int num_rows = 4;
 
-    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", 1);
+    auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", num_rows);
     auto pattern_col = BinaryColumn::create();
     pattern_col->append("abc");
     pattern_col->append("ab.*");

--- a/be/test/exprs/vectorized/like_test.cpp
+++ b/be/test/exprs/vectorized/like_test.cpp
@@ -480,10 +480,10 @@ TEST_F(LikeTest, constValueLike) {
     auto value_col = ColumnHelper::create_const_column<TYPE_VARCHAR>("abcd", num_rows);
     auto pattern_col = BinaryColumn::create();
     pattern_col->append("abc");
-    pattern_col->append("abc%");
+    pattern_col->append("ab%");
     pattern_col->append("abc_");
-    pattern_col->append("%abc");
-    pattern_col->append("_abc");
+    pattern_col->append("%cd");
+    pattern_col->append("_bcd");
     pattern_col->append("a%d");
     pattern_col->append("ab_d");
     pattern_col->append("abcd");


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5983.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`regex_match_{partial,full}` uses `ColumnViewer.size` as the number of rows. However, when the column is a constant column, `ColumnViewer.size` returns the size of inner data column size (which is 1) not the logic size.

```C++
ColumnViewer<TYPE_VARCHAR> value_viewer(columns[0]);
for (int row = 0; row < value_viewer.size(); ++row) {
    // ...
}
```

Therefore, don't use `ColumnViewer.size()` for regex_match.
