### PR TITLE
[Enhancement] Optimization for primary key tablet when rowset is empty

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -164,6 +164,7 @@ public:
     bool delete_flag() const { return rowset_meta()->delete_flag(); }
     int64_t num_segments() const { return rowset_meta()->num_segments(); }
     uint32_t num_delete_files() const { return rowset_meta()->get_num_delete_files(); }
+    bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0; }
 
     // remove all files in this rowset
     // TODO should we rename the method to remove_files() to be more specific?

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -460,7 +460,7 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
             LOG(INFO) << "commit rowset tablet:" << _tablet.tablet_id() << " version:" << version
                       << " txn:" << rowset->txn_id() << " " << rowset->rowset_id().to_string()
                       << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id() << " #seg:" << rowset->num_segments()
-                      << " #row:" << rowset->num_rows()
+                      << " #delfile:" << rowset->num_delete_files() << " #row:" << rowset->num_rows()
                       << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
                       << " #pending:" << _pending_commits.size();
             _try_commit_pendings_unlocked();
@@ -718,11 +718,23 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     auto index_entry = manager->index_cache().get_or_create(tablet_id);
     index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
     auto& index = index_entry->value();
-    st = index.load(&_tablet);
-    manager->index_cache().update_object_size(index_entry, index.memory_usage());
+    // empty rowset does not need to load in-memory primary index, so skip it
+    if (rowset->has_data_files() || enable_persistent_index) {
+        auto st = index.load(&_tablet);
+        manager->index_cache().update_object_size(index_entry, index.memory_usage());
+        if (!st.ok()) {
+            manager->index_cache().remove(index_entry);
+            std::string msg = Substitute("_apply_rowset_commit error: load primary index failed: $0 $1", st.to_string(),
+                                         debug_string());
+            LOG(ERROR) << msg;
+            _set_error(msg);
+            return;
+        }
+    }
+    st = index.prepare(version);
     if (!st.ok()) {
         manager->index_cache().remove(index_entry);
-        std::string msg = Substitute("_apply_rowset_commit error: load primary index failed: $0 $1", st.to_string(),
+        std::string msg = Substitute("_apply_rowset_commit error: primary index prepare failed: $0 $1", st.to_string(),
                                      debug_string());
         LOG(ERROR) << msg;
         _set_error(msg);
@@ -750,7 +762,6 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     for (uint32_t i = 0; i < rowset->num_segments(); i++) {
         new_deletes[rowset_id + i] = {};
     }
-    index.prepare(version);
     auto& upserts = state.upserts();
     for (uint32_t i = 0; i < upserts.size(); i++) {
         if (upserts[i] != nullptr) {
@@ -765,12 +776,14 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     }
 
     PersistentIndexMetaPB index_meta;
-    st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), tablet_id, &index_meta);
-    if (!st.ok() && !st.is_not_found()) {
-        std::string msg = Substitute("get persistent index meta failed: $0", st.to_string());
-        LOG(ERROR) << msg;
-        _set_error(msg);
-        return;
+    if (enable_persistent_index) {
+        st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), tablet_id, &index_meta);
+        if (!st.ok() && !st.is_not_found()) {
+            std::string msg = Substitute("get persistent index meta failed: $0", st.to_string());
+            LOG(ERROR) << msg;
+            _set_error(msg);
+            return;
+        }
     }
     st = index.commit(&index_meta);
     if (!st.ok()) {

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -201,8 +201,8 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
         txn_tablet_map[key][tablet_info] = load_info;
         _insert_txn_partition_map_unlocked(transaction_id, partition_id);
         LOG(INFO) << "Commit txn successfully. "
-                  << " tablet: " << tablet_id << ", txn_id: " << key.second
-                  << ", rowsetid: " << rowset_ptr->rowset_id();
+                  << " tablet: " << tablet_id << ", txn_id: " << key.second << ", rowsetid: " << rowset_ptr->rowset_id()
+                  << " #segment:" << rowset_ptr->num_segments() << " #delfile:" << rowset_ptr->num_delete_files();
     }
     return Status::OK();
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4770

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For real-time ingestion with a lot of buckets, most of the bucket is empty, but it still goes through the whole commit and apply process, we should optimize the code path for empty rowsets.