### PR TITLE
[Feature] Add deduplication and fixed mode for window_funnel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -7,6 +7,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.FunctionParams;
+import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateFunction;
@@ -157,6 +158,19 @@ public class FunctionAnalyzer {
                 throw new SemanticException("retention only support Array<BOOLEAN>");
             }
             // For Array<BOOLEAN> that have different size, we just extend result array to Compatible with it
+        }
+
+        if (fnName.getFunction().equals(FunctionSet.WINDOW_FUNNEL)) {
+            Expr modeArg = functionCallExpr.getChild(2);
+            if (modeArg instanceof IntLiteral) {
+                IntLiteral modeIntLiteral = (IntLiteral) modeArg;
+                long modeValue = modeIntLiteral.getValue();
+                if (modeValue < 0 || modeValue > 3) {
+                    throw new SemanticException("mode argument's range must be [0-3]");
+                }
+            } else {
+                throw new SemanticException("mode argument must be numerical type");
+            }
         }
 
         // SUM and AVG cannot be applied to non-numeric types

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -731,6 +731,28 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testWindowFunnel() throws Exception {
+       FeConstants.runningUnitTest = true;
+       String sql = "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 0, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
+       String plan = getFragmentPlan(sql);
+       assertContains(plan, "window_funnel(1800, 11: L_SHIPDATE, 0, 18: expr)");
+
+       sql = "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 1, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
+       plan = getFragmentPlan(sql);
+       assertContains(plan, "window_funnel(1800, 11: L_SHIPDATE, 1, 18: expr)");
+
+       sql = "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 2, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
+       plan = getFragmentPlan(sql);
+       assertContains(plan, "window_funnel(1800, 11: L_SHIPDATE, 2, 18: expr)");
+
+       sql = "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 3, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
+       plan = getFragmentPlan(sql);
+       assertContains(plan, "window_funnel(1800, 11: L_SHIPDATE, 3, 18: expr)");
+
+       FeConstants.runningUnitTest = false;
+    }
+
+    @Test
     public void testLocalAggregateWithMultiStage() throws Exception {
         FeConstants.runningUnitTest = true;
         connectContext.getSessionVariable().setNewPlanerAggStage(2);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We add two modes for window_funnel
- deduplication: If ordered sequence is A-B-C-B-D, the result only could be A-B-C(3 level).
- fixed: if ordered sequence is A-B-D, the result could be A-B(2 level).
