### PR TITLE
[BugFix] Do not use ColumnViewer::size for regex_match (#6021)

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -245,6 +245,19 @@ bool ColumnHelper::is_all_const(const Columns& columns) {
     return std::all_of(std::begin(columns), std::end(columns), [](const ColumnPtr& col) { return col->is_constant(); });
 }
 
+std::pair<bool, size_t> ColumnHelper::num_packed_rows(const Columns& columns) {
+    if (columns.empty()) {
+        return {false, 0};
+    }
+
+    bool all_const = is_all_const(columns);
+    if (!all_const) {
+        return {all_const, columns[0]->size()};
+    }
+
+    return {all_const, 1};
+}
+
 using ColumnsConstIterator = Columns::const_iterator;
 bool ColumnHelper::is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end) {
     for (auto it = begin; it < end; ++it) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -249,6 +249,13 @@ public:
 
     static bool is_all_const(const Columns& columns);
 
+    // Returns
+    //  1. whether all the columns are constant.
+    //  2. the number of the packed rows. If all the columns are constant, it will be 1,
+    //     which could reduce unnecessary calculations.
+    //     Don't forget to resize the result constant columns if necessary.
+    static std::pair<bool, size_t> num_packed_rows(const Columns& columns);
+
     using ColumnsConstIterator = Columns::const_iterator;
     static bool is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);
     static size_t compute_bytes_size(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -1462,15 +1462,11 @@ ColumnPtr TimeFunctions::datetime_format(FunctionContext* context, const Columns
     if (fc != nullptr && fc->is_valid) {
         return do_format<TYPE_DATETIME>(fc, columns);
     } else {
-        bool all_const = ColumnHelper::is_all_const(columns);
+        auto [all_const, num_rows] = ColumnHelper::num_packed_rows(columns);
         ColumnViewer<TYPE_DATETIME> viewer_date(columns[0]);
         ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
 
-        // all_const was true viewer_date.size() will return 1
-        // which could reduce unnecessary calculations
-        size_t num_rows = all_const ? viewer_date.size() : columns[0]->size();
-
-        ColumnBuilder<TYPE_VARCHAR> builder(columns[0]->size());
+        ColumnBuilder<TYPE_VARCHAR> builder(num_rows);
         for (int i = 0; i < num_rows; ++i) {
             if (viewer_date.is_null(i)) {
                 builder.append_null();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5983.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from #6021.
