### PR TITLE
[Enhancement] opt the memory usage of rows between unbounded preceding and current row for pipeline engine

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -63,7 +63,6 @@ StatusOr<vectorized::ChunkPtr> AnalyticSinkOperator::pull_chunk(RuntimeState* st
 }
 
 Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    std::cout<<"PUSH"<<std::endl;
     _analytor->input_chunk_first_row_positions().emplace_back(_analytor->input_rows());
     size_t chunk_size = chunk->num_rows();
     _analytor->update_input_rows(chunk_size);

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -152,7 +152,6 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary_for_rows_between
 
     _process_by_partition_for_rows_between_unbounded_preceding_and_current_row(chunk_size);
 
-    // Chunk may contains multiply partitions, so the chunk need to be reprocessed
     vectorized::ChunkPtr chunk;
     RETURN_IF_ERROR(_analytor->output_result_chunk(&chunk));
     _analytor->offer_chunk_to_buffer(chunk);

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -29,10 +29,13 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    Status _process_by_partition_if_necessary();
+    Status _process_by_partition_if_necessary_for_other();
+    Status _process_by_partition_if_necessary_for_rows_between_unbounded_preceding_and_following();
+    Status (AnalyticSinkOperator::*_process_by_partition_if_necessary)() = nullptr;
+
     void _process_by_partition_for_unbounded_frame(size_t chunk_size, bool is_new_partition);
     void _process_by_partition_for_unbounded_preceding_range_frame(size_t chunk_size, bool is_new_partition);
-    void _process_by_partition_for_unbounded_preceding_rows_frame(size_t chunk_size, bool is_new_partition);
+    void _process_by_partition_for_rows_between_unbounded_preceding_and_current_row(size_t chunk_size);
     void _process_by_partition_for_sliding_frame(size_t chunk_size, bool is_new_partition);
     void (AnalyticSinkOperator::*_process_by_partition)(size_t chunk_size, bool is_new_partition) = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5829 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

for sql

```
select count(lo_orderkey), count(lo_partkey), count(lo_custkey), count(lo_suppkey), count(lo_quantity), count(lo_discount), count(lo_shipmode), count(_num) from 
(select lo_orderkey, lo_partkey, lo_custkey, lo_suppkey, lo_quantity, lo_discount, lo_shipmode, row_number() over(order by lo_partkey) as _num from lineorder) t1;
```

pipeline_dop = 4

before optimization

```
  Execution Profile cd6f9224-d2b4-11ec-8457-66660a909341:
     - ExecutionTotalTime: 39s610ms
    Fragment 0:
       - BackendNum: 1
       - InstanceNum: 1
       - MemoryLimit: 74.51 GB
       - PeakMemoryUsage: 4.18 GB
```

after optimization

```
  Execution Profile 629809f0-d2b4-11ec-8457-66660a909341:
     - ExecutionTotalTime: 35s658ms
    Fragment 0:
       - BackendNum: 1
       - InstanceNum: 1
       - MemoryLimit: 74.51 GB    
       - PeakMemoryUsage: 774.14 MB
```

Note: the performance is less then non-pipeline (24.6s), may the the scheduler implement problem