### PR TITLE
[BugFix] Fix setting wrong major/minor version when saving meta

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2331,7 +2331,7 @@ void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
             compaction_pb->add_outputs(cp->output);
             auto svpb = compaction_pb->mutable_start_version();
             svpb->set_major(cp->start_version.major());
-            svpb->set_major(cp->start_version.minor());
+            svpb->set_minor(cp->start_version.minor());
         }
         // rowsetid_add is only useful in meta log, and it's a bit harder to construct it
         // so do not set it here


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix setting the wrong major&minor version when save meta.