### PR TITLE
[Enhancement] Disable enable_exchange_pass_through default to false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -192,6 +192,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
+    public static final String ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE = "enable_exchange_pass_through_expire";
 
     public static final String SINGLE_NODE_EXEC_PLAN = "single_node_exec_plan";
 
@@ -478,9 +479,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test,
     // and it will cause memory statistics problem of fragment instance,
     // It also which will introduce the problem of cross-thread memory allocate and release,
-    // So i temporarily disable the enable_exchange_pass_throuth.
+    // So i temporarily disable the enable_exchange_pass_through.
     // I will turn on int after all the above problems are solved.
-    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH)
+    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE, alias = ENABLE_EXCHANGE_PASS_THROUGH,
+            show = ENABLE_EXCHANGE_PASS_THROUGH)
     private boolean enableExchangePassThrough = false;
 
     // The following variables are deprecated and invisible //

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -475,8 +475,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_COLUMN_EXPR_PREDICATE)
     private boolean enableColumnExprPredicate = false;
 
+    // Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test,
+    // and it will cause memory statistics problem of fragment instance,
+    // It also which will introduce the problem of cross-thread memory allocate and release,
+    // So i temporarily disable the enable_exchange_pass_throuth.
+    // I will turn on int after all the above problems are solved.
     @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH)
-    private boolean enableExchangePassThrough = true;
+    private boolean enableExchangePassThrough = false;
 
     // The following variables are deprecated and invisible //
     // ----------------------------------------------------------------------------//


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6054 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test, and it will cause memory statistics problem of fragment instance, It also will introduce the problem of cross-thread memory allocate and release. So i temporarily disable the enable_exchange_pass_throuth. I will turn on it after all the above problems are solved.
