### PR TITLE
[cherry-pick] [branch-2.2] [Enhancement] Disable enable_exchange_pass_through default to false (#6055)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -189,6 +189,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
+    public static final String ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE = "enable_exchange_pass_through_expire";
 
     public static final String SINGLE_NODE_EXEC_PLAN = "single_node_exec_plan";
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
@@ -464,8 +465,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_COLUMN_EXPR_PREDICATE)
     private boolean enableColumnExprPredicate = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH)
-    private boolean enableExchangePassThrough = true;
+    // Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test,
+    // and it will cause memory statistics problem of fragment instance,
+    // It also which will introduce the problem of cross-thread memory allocate and release,
+    // So i temporarily disable the enable_exchange_pass_through.
+    // I will turn on int after all the above problems are solved.
+    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE, alias = ENABLE_EXCHANGE_PASS_THROUGH,
+            show = ENABLE_EXCHANGE_PASS_THROUGH)
+    private boolean enableExchangePassThrough = false;
 
     // The following variables are deprecated and invisible //
     // ----------------------------------------------------------------------------//


### PR DESCRIPTION
Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test, and it will cause memory statistics problem of fragment instance, It also will introduce the problem of cross-thread memory allocate and release. So i temporarily disable the enable_exchange_pass_throuth. I will turn on it after all the above problems are solved.