### PR TITLE
[Enhancement] PrivTable list->map to speed up matching (#5945)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
@@ -145,6 +145,7 @@ public class DbPrivEntry extends PrivEntry {
         isClassNameWrote = false;
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
@@ -130,14 +130,6 @@ public abstract class PrivEntry implements Comparable<PrivEntry>, Writable {
         return userIdentity;
     }
 
-    public boolean match(UserIdentity userIdent, boolean exactMatch) {
-        if (exactMatch) {
-            return origUser.equals(userIdent.getQualifiedUser()) && origHost.equals(userIdent.getHost());
-        } else {
-            return origUser.equals(userIdent.getQualifiedUser()) && hostPattern.match(userIdent.getHost());
-        }
-    }
-
     public abstract boolean keyMatch(PrivEntry other);
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivTable.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 /*
  * ResourcePrivTable saves all resources privs
@@ -40,13 +41,14 @@ public class ResourcePrivTable extends PrivTable {
      * saved in 'savedPrivs'.
      */
     public void getPrivs(UserIdentity currentUser, String resourceName, PrivBitSet savedPrivs) {
-        ResourcePrivEntry matchedEntry = null;
-        for (PrivEntry entry : entries) {
-            ResourcePrivEntry resourcePrivEntry = (ResourcePrivEntry) entry;
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return;
+        }
 
-            if (!resourcePrivEntry.match(currentUser, true)) {
-                continue;
-            }
+        ResourcePrivEntry matchedEntry = null;
+        for (PrivEntry entry : userPrivEntryList) {
+            ResourcePrivEntry resourcePrivEntry = (ResourcePrivEntry) entry;
 
             // check resource
             if (!resourcePrivEntry.getResourcePattern().match(resourceName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivTable.java
@@ -28,6 +28,8 @@ import com.starrocks.qe.ConnectContext;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 
 /*
  * TablePrivTable saves all table level privs
@@ -35,17 +37,18 @@ import java.io.IOException;
 public class TablePrivTable extends PrivTable {
 
     /*
-     * Return first priv which match the user@host on db.tbl The returned priv will
+     * Return first priv which match current user on db.tbl The returned priv will
      * be saved in 'savedPrivs'.
      */
     public void getPrivs(UserIdentity currentUser, String db, String tbl, PrivBitSet savedPrivs) {
-        TablePrivEntry matchedEntry = null;
-        for (PrivEntry entry : entries) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
-            if (!tblPrivEntry.match(currentUser, true)) {
-                continue;
-            }
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return;
+        }
 
+        TablePrivEntry matchedEntry = null;
+        for (PrivEntry entry : userPrivEntryList) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
             // check db
             Preconditions.checkState(!tblPrivEntry.isAnyDb());
             if (!tblPrivEntry.getDbPattern().match(db)) {
@@ -68,19 +71,15 @@ public class TablePrivTable extends PrivTable {
     }
 
     /*
-     * Check if user@host has specified privilege on any table
+     * Check if user has specified privilege on any table
+     * TODO I can't think of any occasion that requires the privilege of ANY table,
+     *      nor can I find such usage through all codes.
+     *      I will try to remove this in another PR.
      */
-    public boolean hasPriv(String host, String user, PrivPredicate wanted) {
-        for (PrivEntry entry : entries) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
-            // check host
-            if (!tblPrivEntry.isAnyHost() && !tblPrivEntry.getHostPattern().match(host)) {
-                continue;
-            }
-            // check user
-            if (!tblPrivEntry.isAnyUser() && !tblPrivEntry.getUserPattern().match(user)) {
-                continue;
-            }
+    public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             // check priv
             if (tblPrivEntry.privSet.satisfy(wanted)) {
                 return true;
@@ -90,13 +89,9 @@ public class TablePrivTable extends PrivTable {
     }
 
     public boolean hasPrivsOfDb(UserIdentity currentUser, String db) {
-        for (PrivEntry entry : entries) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
-
-            if (!tblPrivEntry.match(currentUser, true)) {
-                continue;
-            }
-
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             // check db
             Preconditions.checkState(!tblPrivEntry.isAnyDb());
             if (!tblPrivEntry.getDbPattern().match(db)) {
@@ -120,8 +115,9 @@ public class TablePrivTable extends PrivTable {
     }
 
     public boolean hasClusterPriv(ConnectContext ctx, String clusterName) {
-        for (PrivEntry entry : entries) {
-            TablePrivEntry tblPrivEntry = (TablePrivEntry) entry;
+        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
+        while (iter.hasNext()) {
+            TablePrivEntry tblPrivEntry = (TablePrivEntry) iter.next();
             if (tblPrivEntry.getOrigDb().startsWith(clusterName)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 
 /*
@@ -40,35 +41,27 @@ public class UserPrivTable extends PrivTable {
     public UserPrivTable() {
     }
 
+    /**
+     * get privileges of specific user
+     */
     public void getPrivs(UserIdentity currentUser, PrivBitSet savedPrivs) {
-        GlobalPrivEntry matchedEntry = null;
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-
-            if (!globalPrivEntry.match(currentUser, true)) {
-                continue;
-            }
-
-            matchedEntry = globalPrivEntry;
-            break;
-        }
-        if (matchedEntry == null) {
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
             return;
         }
-
-        savedPrivs.or(matchedEntry.getPrivSet());
+        savedPrivs.or(userPrivEntryList.get(0).getPrivSet());
     }
 
+    /**
+     * get password of specific user
+     */
     public Password getPassword(UserIdentity currentUser) {
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-
-            if (globalPrivEntry.match(currentUser, true)) {
-                return globalPrivEntry.getPassword();
-            }
+        List<PrivEntry> userPrivEntryList = map.get(currentUser);
+        if (userPrivEntryList == null) {
+            return null;
         }
-
-        return null;
+        GlobalPrivEntry entry = (GlobalPrivEntry) userPrivEntryList.get(0);
+        return entry.getPassword();
     }
 
     /**
@@ -77,39 +70,21 @@ public class UserPrivTable extends PrivTable {
      * before {@link Auth#checkPassword}. for sending handshake request.
      */
     public Password getPasswordByApproximate(String remoteUser, String remoteHost) {
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-
-            // check host
-            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(remoteHost)) {
-                continue;
-            }
-
-            // check user
-            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(remoteUser)) {
-                continue;
-            }
-
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(remoteUser, remoteHost);
+        while (iter.hasNext()) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) iter.next();
             return globalPrivEntry.getPassword();
         }
-
         return null;
     }
 
     /*
-     * Check if user@host has specified privilege
+     * Check if current user has specified privilege
      */
-    public boolean hasPriv(String host, String user, PrivPredicate wanted) {
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-            // check host
-            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(host)) {
-                continue;
-            }
-            // check user
-            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(user)) {
-                continue;
-            }
+    public boolean hasPriv(UserIdentity currentUser, PrivPredicate wanted) {
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(currentUser);
+        while (iter.hasNext()) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) iter.next();
             if (globalPrivEntry.getPrivSet().satisfy(wanted)) {
                 return true;
             }
@@ -119,26 +94,15 @@ public class UserPrivTable extends PrivTable {
 
     // validate the connection by host, user and password.
     // return true if this connection is valid, and 'savedPrivs' save all global privs got from user table.
-    // if currentUser is not null, save the current user identity
+    // if currentUser is not null, save ALL matching user identity
     public boolean checkPassword(String remoteUser, String remoteHost, byte[] remotePasswd, byte[] randomString,
                                  List<UserIdentity> currentUser) {
         LOG.debug("check password for user: {} from {}, password: {}, random string: {}",
                 remoteUser, remoteHost, remotePasswd, randomString);
 
-        // TODO(cmy): for now, we check user table from first entry to last,
-        // This may not efficient, but works.
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-
-            // check host
-            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(remoteHost)) {
-                continue;
-            }
-
-            // check user
-            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(remoteUser)) {
-                continue;
-            }
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(remoteUser, remoteHost);
+        while (iter.hasNext()) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) iter.next();
 
             Password password = globalPrivEntry.getPassword();
             if (password == null) {
@@ -166,18 +130,9 @@ public class UserPrivTable extends PrivTable {
 
     public boolean checkPlainPassword(String remoteUser, String remoteHost, String remotePasswd,
                                       List<UserIdentity> currentUser) {
-        for (PrivEntry entry : entries) {
-            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
-
-            // check host
-            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(remoteHost)) {
-                continue;
-            }
-
-            // check user
-            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(remoteUser)) {
-                continue;
-            }
+        Iterator<PrivEntry> iter = getReadOnlyIteratorByUser(remoteUser, remoteHost);
+        while (iter.hasNext()) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) iter.next();
 
             Password password = globalPrivEntry.getPassword();
             if (password == null) {
@@ -209,8 +164,11 @@ public class UserPrivTable extends PrivTable {
     // return true only if user exist and not set by domain
     // user set by domain should be checked in property manager
     public boolean doesUserExist(UserIdentity userIdent) {
-        for (PrivEntry privEntry : entries) {
-            if (privEntry.match(userIdent, true /* exact match */) && !privEntry.isSetByDomainResolver()) {
+        if (!map.containsKey(userIdent)) {
+            return false;
+        }
+        for (PrivEntry privEntry : map.get(userIdent)) {
+            if (!privEntry.isSetByDomainResolver()) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -431,7 +431,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     priv -> {
                         boolean isGrantable =
                                 Privilege.NODE_PRIV != priv // NODE_PRIV counld not be granted event with GRANT_PRIV
-                                        && userPrivTable.hasPriv(userIdent.getHost(), userIdent.getQualifiedUser(),
+                                        && userPrivTable.hasPriv(userIdent,
                                         PrivPredicate.GRANT);
                         TUserPrivDesc privDesc = new TUserPrivDesc();
                         privDesc.setIs_grantable(isGrantable);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -49,12 +49,19 @@ import com.starrocks.qe.QueryState;
 import com.starrocks.system.SystemInfoService;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -1223,6 +1230,7 @@ public class AuthTest {
             e.printStackTrace();
             Assert.fail();
         }
+        Assert.assertEquals(1, auth.getAuthInfo(userIdentity).size());
         Assert.assertTrue(auth.checkResourcePriv(userIdentity, resourceName, PrivPredicate.USAGE));
         Assert.assertFalse(auth.checkGlobalPriv(userIdentity, PrivPredicate.USAGE));
 
@@ -1697,4 +1705,269 @@ public class AuthTest {
                 auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", new byte[0], seed,
                         currentUser));
     }
-}
+
+    private static final Logger LOG = LogManager.getLogger(AuthTest.class);
+    @Test
+    public void testManyUsersAndTables() throws Exception {
+        int BIG_NUMBER = 500;
+        int BIG_NUMBER2 = BIG_NUMBER / 2;
+        int LOG_INTERVAL = BIG_NUMBER / 50;
+        String DB = SystemInfoService.DEFAULT_CLUSTER  + ":db1";
+        LOG.info("before add privilege: table {} entries, user {} entries",
+                auth.getTablePrivTable().size(), auth.getUserPrivTable().size());
+        Assert.assertEquals(1, auth.getAuthInfo(null).size());
+
+        // 1. create N user with select privilege to N/2 table
+        // 1.1 create user
+        for (int i = 0; i != BIG_NUMBER; i++) {
+            String userName = String.format("user_%d_of_%d", i, BIG_NUMBER);
+            UserIdentity userIdentity = new UserIdentity(userName, "%");
+            userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+            UserDesc userDesc = new UserDesc(userIdentity, "12345", true);
+            CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
+            createUserStmt.analyze(analyzer);
+            auth.createUser(createUserStmt);
+        }
+        Assert.assertEquals(1 + BIG_NUMBER, auth.getAuthInfo(null).size());
+
+        // check the last user
+        String lastUserName = String.format("user_%d_of_%d", BIG_NUMBER - 1, BIG_NUMBER);
+        UserIdentity lastUserIdentity = new UserIdentity(lastUserName, "%");
+        lastUserIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        // information_schema
+        Assert.assertEquals(1, auth.getDBPrivEntries(lastUserIdentity).size());
+        int infomationSchemaTableCnt = auth.getTablePrivEntries(lastUserIdentity).size();
+        Assert.assertEquals(1, auth.getAuthInfo(lastUserIdentity).size());
+
+        // 1.2 grant N/2 table privilege
+        long start = System.currentTimeMillis();
+        for (int i = 0; i != BIG_NUMBER; i++) {
+            if (i % LOG_INTERVAL == 0) {
+                LOG.info("added {} user..", i);
+            }
+            String userName = String.format("user_%d_of_%d", i, BIG_NUMBER);
+            UserIdentity userIdentity = new UserIdentity(userName, "%");
+            userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+            for (int j = 0; j != BIG_NUMBER2; j++) {
+                String tableName = String.format("table_%d_of_%d", j, BIG_NUMBER2);
+                TablePattern tablePattern = new TablePattern("db1", tableName);
+                tablePattern.analyze(SystemInfoService.DEFAULT_CLUSTER);
+                PrivBitSet privileges = AccessPrivilege.SELECT_PRIV.toPrivilege();
+                auth.grantPrivs(userIdentity, tablePattern, privileges, false);
+            }
+        }
+        long end = System.currentTimeMillis();
+        LOG.info("add privilege: {} entries, total {} ms",  auth.getTablePrivTable().size(), end - start);
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i != BIG_NUMBER; i++) {
+            // 1.1 create user
+            String userName = String.format("user_%d_of_%d", i, BIG_NUMBER);
+            UserIdentity userIdentity = new UserIdentity(userName, "%");
+            userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+            for (int j = 0; j != BIG_NUMBER2; j++) {
+                String tableName = String.format("table_%d_of_%d", j, BIG_NUMBER2);
+                Assert.assertTrue(auth.checkTblPriv(
+                        userIdentity, DB, tableName, PrivPredicate.SELECT));
+            }
+        }
+        end = System.currentTimeMillis();
+        LOG.info("check privilege: total {} ms", end - start);
+
+        // check the last user
+        // infomation_schema
+        Assert.assertEquals(1, auth.getDBPrivEntries(lastUserIdentity).size());
+        Assert.assertEquals(BIG_NUMBER / 2 + infomationSchemaTableCnt, auth.getTablePrivEntries(lastUserIdentity).size());
+        Assert.assertEquals(1, auth.getAuthInfo(lastUserIdentity).size());
+    }
+
+    @Test
+    public void checkDefaultRootPrivilege() throws Exception {
+        Assert.assertTrue(auth.checkHasPriv(ctx, PrivPredicate.ADMIN, Auth.PrivLevel.GLOBAL));
+        Assert.assertTrue(auth.checkHasPriv(ctx, PrivPredicate.GRANT, Auth.PrivLevel.GLOBAL));
+        Assert.assertFalse(auth.checkHasPriv(ctx, PrivPredicate.ADMIN, Auth.PrivLevel.DATABASE));
+        Assert.assertFalse(auth.checkHasPriv(ctx, PrivPredicate.ADMIN, Auth.PrivLevel.TABLE));
+    }
+
+    @Test
+    public void testCanEnterCluster() throws Exception {
+        UserIdentity userIdentity = new UserIdentity("test_user", "%");
+        userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        UserDesc userDesc = new UserDesc(userIdentity, "12345", true);
+        CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt.analyze(analyzer);
+        auth.createUser(createUserStmt);
+
+        new Expectations(ctx) {
+            {
+                ctx.getCurrentUserIdentity();
+                minTimes = 0;
+                result = userIdentity;
+            }
+        };
+        String newCluster = "another_cluster";
+        Assert.assertFalse(auth.checkCanEnterCluster(ctx, newCluster));
+
+        TablePattern tablePattern = new TablePattern("db1", "test_table");
+        tablePattern.analyze(newCluster);
+        PrivBitSet privileges = AccessPrivilege.SELECT_PRIV.toPrivilege();
+        auth.grantPrivs(userIdentity, tablePattern, privileges, false);
+        Assert.assertTrue(auth.checkCanEnterCluster(ctx, newCluster));
+
+        auth.revokePrivs(userIdentity, tablePattern, privileges, false);
+        Assert.assertFalse(auth.checkCanEnterCluster(ctx, newCluster));
+    }
+
+    @Test
+    public void testGetPasswordByApproximate() throws Exception {
+        UserIdentity userIdentity = new UserIdentity("test_user", "%");
+        userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        UserDesc userDesc = new UserDesc(userIdentity, "12345", true);
+        CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt.analyze(analyzer);
+        auth.createUser(createUserStmt);
+
+        Assert.assertNull(auth.getUserPrivTable().getPasswordByApproximate(
+                SystemInfoService.DEFAULT_CLUSTER + ":unknown_user", "10.1.1.1"));
+        Assert.assertNotNull(auth.getUserPrivTable().getPasswordByApproximate(
+                SystemInfoService.DEFAULT_CLUSTER + ":test_user", "10.1.1.1"));
+        Assert.assertNotNull(auth.getUserPrivTable().getPasswordByApproximate(
+                SystemInfoService.DEFAULT_CLUSTER + ":test_user", "localhost"));
+    }
+
+    /**
+     * TODO I think this case should in UserPrivTableTest instead of AuthTest
+     *    Unfortunately the two classes are highly coupled.
+     */
+    @Test
+    public void testMultiUserMatch() throws Exception {
+        Assert.assertEquals(1, auth.getUserPrivTable().size());
+        String PASSWORD_STR = "12345";
+
+        // create four entries
+        String userHostPatterns[][] = {
+                {"user_1", "10.1.1.1"},
+                {"user_1", "%"},
+                {"user_zzz", "%"},
+                {"user_zzz", "10.1.1.1"},
+        };
+        for (String[] userHost: userHostPatterns) {
+            UserIdentity userIdentity = new UserIdentity(userHost[0], userHost[1]);
+            userIdentity.analyze(SystemInfoService.DEFAULT_CLUSTER);
+            UserDesc userDesc = new UserDesc(userIdentity, PASSWORD_STR, true);
+            CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
+            createUserStmt.analyze(analyzer);
+            auth.createUser(createUserStmt);
+        }
+        Assert.assertEquals(5, auth.getUserPrivTable().size());
+
+        // check if login match
+        // remote_user, remote_ip, expect_user_identity
+        String userHostAndMatchedUserHosts[][] = {
+                // login as user_1 from 10.1.1.1, expected identified as user_1@10.1.1.1
+                {"user_1", "10.1.1.1", "user_1", "10.1.1.1"},
+                // login as user_1 from 10.1.1.2, expected identified as user_1@%, fuzzy matching
+                {"user_1", "10.1.1.2", "user_1", "%"},
+                {"user_zzz", "10.1.1.1", "user_zzz", "10.1.1.1"},
+                {"user_zzz", "10.1.1.2", "user_zzz", "%"},
+
+        };
+        for (String[] userHostAndMatchedUserHost : userHostAndMatchedUserHosts) {
+            List<UserIdentity> identities = new ArrayList<>();
+            String remoteUser = SystemInfoService.DEFAULT_CLUSTER + ":" + userHostAndMatchedUserHost[0];
+            String remoteIp = userHostAndMatchedUserHost[1];
+            String expectQualifiedUser = SystemInfoService.DEFAULT_CLUSTER + ":" + userHostAndMatchedUserHost[2];
+            String expectHost = userHostAndMatchedUserHost[3];
+
+            auth.checkPlainPassword(remoteUser, remoteIp, PASSWORD_STR, identities);
+            Assert.assertEquals(1, identities.size());
+            Assert.assertEquals(expectQualifiedUser, identities.get(0).getQualifiedUser());
+            Assert.assertEquals(expectHost, identities.get(0).getHost());
+
+            identities.clear();
+            byte[] seed = "dJSH\\]mcwKJlLH[bYunm".getBytes("utf-8");
+            byte[] scramble = MysqlPassword.scramble(seed, PASSWORD_STR);
+            auth.checkPassword(remoteUser, remoteIp, scramble, seed, identities);
+            Assert.assertEquals(1, identities.size());
+            Assert.assertEquals(expectQualifiedUser, identities.get(0).getQualifiedUser());
+            Assert.assertEquals(expectHost, identities.get(0).getHost());
+        }
+
+        // test iterator
+        // full iterator
+        Iterator<PrivEntry> iter = auth.getUserPrivTable().getFullReadOnlyIterator();
+        List<String> userHostResult = new ArrayList<>();
+        while(iter.hasNext()) {
+            PrivEntry entry = iter.next();
+            if (entry.getOrigUser() != "root") {
+                userHostResult.add(String.format("%s@%s", entry.getOrigUser(), entry.getOrigHost()));
+            }
+        }
+        Assert.assertEquals(4, userHostResult.size());
+        List<String> expect = new ArrayList<>();
+        for (String[] userHost : userHostPatterns) {
+            expect.add(String.format("default_cluster:%s@%s", userHost[0], userHost[1]));
+        }
+        Collections.sort(expect);
+        Collections.sort(userHostResult);
+        Assert.assertEquals(expect, userHostResult);
+
+        UserIdentity user = new UserIdentity("user_1", "10.1.1.1");
+        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        iter = auth.getUserPrivTable().getReadOnlyIteratorByUser(user);
+        userHostResult.clear();
+        while(iter.hasNext()) {
+            PrivEntry entry = iter.next();
+            userHostResult.add(String.format("%s@%s", entry.getOrigUser(), entry.getOrigHost()));
+        }
+        // expect match 2: user_1@10.1.1.1 & user_1@%
+        Assert.assertEquals(2, userHostResult.size());
+        Assert.assertTrue(userHostResult.contains("default_cluster:user_1@10.1.1.1"));
+        Assert.assertTrue(userHostResult.contains("default_cluster:user_1@%"));
+
+
+        // test grant
+        // GRANT select_priv on db1.table1 to user_1@%
+        // GRANT select_priv on db1.table2 to user_1@10.1.1.2
+        // see if user_1@10.1.1.1 can see two table
+        // and user_1@10.1.1.2 can see one table
+
+        // GRANT select_priv on db1.table1 to user_1@%
+        TablePattern tablePattern = new TablePattern("db1", "table1");
+        tablePattern.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        PrivBitSet privileges = AccessPrivilege.SELECT_PRIV.toPrivilege();
+        user = new UserIdentity("user_1", "%");
+        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        auth.grantPrivs(user, tablePattern, privileges, false);
+
+        // GRANT select_priv on db1.table2 to user_1@10.1.1.1
+        tablePattern = new TablePattern("db1", "table2");
+        tablePattern.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        privileges = AccessPrivilege.SELECT_PRIV.toPrivilege();
+        user = new UserIdentity("user_1", "10.1.1.1");
+        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        auth.grantPrivs(user, tablePattern, privileges, false);
+
+        // check if user_1@10.1.1.1 can see two table
+        List<UserIdentity> identities = new ArrayList<>();
+        auth.checkPlainPassword(
+                SystemInfoService.DEFAULT_CLUSTER + ":user_1", "10.1.1.1", PASSWORD_STR, identities);
+        Assert.assertEquals(1, identities.size());
+        user = identities.get(0);
+        Assert.assertEquals("10.1.1.1", user.getHost());
+        String db = SystemInfoService.DEFAULT_CLUSTER + ":db1";
+        // TODO: this is a legacy bug, I will fix it in another PR
+        // Assert.assertTrue(auth.checkTblPriv(user, db, "table1", PrivPredicate.SELECT));
+        Assert.assertTrue(auth.checkTblPriv(user, db, "table2", PrivPredicate.SELECT));
+
+        // check if user_1@10.1.1.2 can see one table
+        identities.clear();
+        auth.checkPlainPassword(
+                SystemInfoService.DEFAULT_CLUSTER + ":user_1", "10.1.1.2", PASSWORD_STR, identities);
+        Assert.assertEquals(1, identities.size());
+        user = identities.get(0);
+        Assert.assertEquals("%", user.getHost());
+        Assert.assertTrue(auth.checkTblPriv(user, db, "table1", PrivPredicate.SELECT));
+        Assert.assertFalse(auth.checkTblPriv(user, db, "table2", PrivPredicate.SELECT));
+     }
+ }


### PR DESCRIPTION
This PR implements Plan 1 of #5944.

This commit changes the data structure of PrivTable from List to Map, using UserIdentity as the key because after
identification of the UserIdentity of the context is an existing entry and requires no fuzzy matching.
The authorization time will significantly improve with this map.

I added a test case to see the performance change. Assuming there are 500 users who each have the privilege of 250 tables, the time of authorization speed up to nearly 100 times(10min+ -> 7s) after this PR.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5944

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
