### PR TITLE
[Enhancement][UDF][stage-2] ASM codegen for Scalar UDF

### DIFF
--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -58,11 +58,13 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     RETURN_IF_ERROR(add_method("destroy", udaf_ctx->udaf_class.clazz(), &udaf_ctx->destory));
 
     RETURN_IF_ERROR(add_method("update", udaf_ctx->udaf_class.clazz(), &udaf_ctx->update));
-    const char* stub_clazz_name = "com.starrocks.udf.gen.CallStub";
-    const char* batch_update_method = "batchCallV";
-    ASSIGN_OR_RETURN(auto update_stub_clazz, udf_classloader->genCallStub(stub_clazz_name, udaf_ctx->udaf_class.clazz(),
-                                                                          udaf_ctx->update->method.handle()));
-    ASSIGN_OR_RETURN(auto method, analyzer->get_method_object(update_stub_clazz.clazz(), batch_update_method));
+    const char* stub_clazz_name = AggBatchCallStub::stub_clazz_name;
+    const char* stub_method_name = AggBatchCallStub::batch_update_method_name;
+    jclass udaf_clazz = udaf_ctx->udaf_class.clazz();
+    jobject update_method = udaf_ctx->update->method.handle();
+    ASSIGN_OR_RETURN(auto update_stub_clazz, udf_classloader->genCallStub(stub_clazz_name, udaf_clazz, update_method,
+                                                                          ClassLoader::BATCH_SINGLE_UPDATE));
+    ASSIGN_OR_RETURN(auto method, analyzer->get_method_object(update_stub_clazz.clazz(), stub_method_name));
     udaf_ctx->update_batch_call_stub = std::make_unique<AggBatchCallStub>(
             context, udaf_ctx->handle.handle(), std::move(update_stub_clazz), JavaGlobalRef(std::move(method)));
 

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/CallStubGenerator.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/CallStubGenerator.java
@@ -11,9 +11,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
 import static org.objectweb.asm.Opcodes.AALOAD;
+import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ANEWARRAY;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASTORE;
 import static org.objectweb.asm.Opcodes.F_APPEND;
 import static org.objectweb.asm.Opcodes.F_CHOP;
 import static org.objectweb.asm.Opcodes.GOTO;
@@ -127,15 +131,6 @@ public class CallStubGenerator {
             // define local variables
             final Label l5 = new Label();
             batchCall.visitLabel(l5);
-            batchCall.visitLocalVariable("i", "I", null, l1, l2, iIdx);
-            batchCall.visitLocalVariable("rows", "I", null, l1, l5, 0);
-            batchCall.visitLocalVariable("obj", "L" + Type.getInternalName(udafClazz) + ";", null, l0, l5, 1);
-            int padding = 2;
-            for (int i = 0; i < parameters.length; ++i) {
-                final Class<?> type = parameters[i].getType();
-                batchCall.visitLocalVariable("var" + i, "L" + Type.getInternalName(type) + ";", null, l1, l5,
-                        i + padding);
-            }
             int callStubInputParameters = 3 + parameters.length;
             batchCall.visitMaxs(callStubInputParameters, callStubInputParameters + 1);
             batchCall.visitEnd();
@@ -157,4 +152,139 @@ public class CallStubGenerator {
         generator.finish();
         return generator.getByteCode();
     }
+
+
+//    public class CallStub {
+//        public static void batchCallV(int rows, UDF obj, TYPE[] var1, Integer[] var2) throws Exception {
+//            for(int var = 0; var < rows; ++var) {
+//                obj.update(var0, var1[var8], var2[var8]);
+//            }
+//        }
+//    }
+    private static class BatchCallEvaluateGenerator {
+        BatchCallEvaluateGenerator(Class<?> clazz, Method update) {
+            this.UDFClazz = clazz;
+            this.UDFEvaluate = update;
+        }
+
+        private final ClassWriter writer = new ClassWriter(0);
+
+        private void declareCallStubClazz() {
+            writer.visit(V1_8, ACC_PUBLIC, CLAZZ_NAME, null, "java/lang/Object", null);
+        }
+
+        private void genBatchUpdateSingle() {
+            final Parameter[] parameters = UDFEvaluate.getParameters();
+            StringBuilder desc = new StringBuilder("(");
+            desc.append("I");
+            desc.append(Type.getDescriptor(UDFClazz));
+            for (Parameter parameter : parameters) {
+                final Class<?> type = parameter.getType();
+                if (type.isPrimitive()) {
+                    throw new UnsupportedOperationException("Unsupported Primitive Type:" + type.getTypeName());
+                }
+                desc.append("[");
+                desc.append(Type.getDescriptor(type));
+            }
+
+            final Class<?> returnType = UDFEvaluate.getReturnType();
+            if (returnType.isPrimitive()) {
+                throw new UnsupportedOperationException("Unsupported return Type:" + returnType.getTypeName());
+            }
+            desc.append(")");
+            desc.append("[").append(Type.getDescriptor(returnType));
+
+            final MethodVisitor batchCall =
+                    writer.visitMethod(ACC_PUBLIC + ACC_STATIC, "batchCallV", desc.toString(), null,
+                            new String[] {"java/lang/Exception"});
+
+            batchCall.visitCode();
+
+            // local var1: rows
+            // local var2: UDAF handle
+            // local var3...varn: left paramters
+
+            // RET_TYPE[] res;
+            int resIndex = 2 + parameters.length;
+            // int i;
+            int iIndex = resIndex + 1;
+
+            final Label l0 = new Label();
+            batchCall.visitLabel(l0);
+            // RETURN_TYPE[] = new RETURN_TYPE[num_rows]
+            batchCall.visitVarInsn(ILOAD, 0);
+            batchCall.visitTypeInsn(ANEWARRAY, Type.getInternalName(returnType));
+            batchCall.visitVarInsn(ASTORE, resIndex);
+
+            // PUSH FRAME
+            final Label l1 = new Label();
+            batchCall.visitLabel(l1);
+            batchCall.visitInsn(ICONST_0);
+            batchCall.visitVarInsn(ISTORE, iIndex);
+
+            final Label l2 = new Label();
+            batchCall.visitLabel(l2);
+            batchCall.visitFrame(F_APPEND, 2, new Object[] {"[" + Type.getDescriptor(returnType), INTEGER}, 0, null);
+            batchCall.visitVarInsn(ILOAD, iIndex);
+            batchCall.visitVarInsn(ILOAD, 0);
+
+            final Label l3 = new Label();
+            batchCall.visitJumpInsn(IF_ICMPGE, l3);
+
+            final Label l4 = new Label();
+            batchCall.visitLabel(l4);
+            // load res[i]
+            batchCall.visitVarInsn(ALOAD, resIndex);
+            batchCall.visitVarInsn(ILOAD, iIndex);
+            // load obj
+            batchCall.visitVarInsn(ALOAD, 1);
+            int padding = 2;
+            for (int i = 0; i < parameters.length; i++) {
+                batchCall.visitVarInsn(ALOAD, i + padding);
+                batchCall.visitVarInsn(ILOAD, iIndex);
+                batchCall.visitInsn(AALOAD);
+            }
+
+            batchCall.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(UDFClazz), UDFEvaluate.getName(),
+                    Type.getMethodDescriptor(UDFEvaluate), false);
+            batchCall.visitInsn(AASTORE);
+
+            final Label l5 = new Label();
+            batchCall.visitLabel(l5);
+            batchCall.visitIincInsn(iIndex, 1);
+            batchCall.visitJumpInsn(GOTO, l2);
+
+            batchCall.visitLabel(l3);
+            batchCall.visitFrame(F_CHOP, 1, new Object[] {INTEGER}, 0, null);
+            batchCall.visitVarInsn(ALOAD, resIndex);
+            batchCall.visitInsn(ARETURN);
+
+            final Label l6 = new Label();
+            batchCall.visitLabel(l6);
+            batchCall.visitLocalVariable("i", "I", null, l2, l3, iIndex);
+            batchCall.visitLocalVariable("res", Type.getDescriptor(returnType), null, l1, l6, resIndex);
+            batchCall.visitMaxs(iIndex +1 ,iIndex + 1);
+            batchCall.visitEnd();
+        }
+
+        private void finish() {
+            writer.visitEnd();
+        }
+
+        private byte[] getByteCode() {
+            return writer.toByteArray();
+        }
+
+        private final Class<?> UDFClazz;
+        private final Method UDFEvaluate;
+    }
+
+    public static byte[] generateScalarCallStub(Class<?> clazz, Method method) {
+        final BatchCallEvaluateGenerator generator = new BatchCallEvaluateGenerator(clazz, method);
+        generator.declareCallStubClazz();
+        generator.genBatchUpdateSingle();
+        generator.finish();
+        return generator.getByteCode();
+    }
+
 }

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFClassLoader.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFClassLoader.java
@@ -17,6 +17,8 @@ import java.util.Map;
 public class UDFClassLoader extends URLClassLoader {
 
     private Map<String, Class<?>> genClazzMap = new HashMap<>();
+    private static final int SINGLE_BATCH_UPDATE = 1;
+    private static final int BATCH_EVALUATE = 2; 
 
     public UDFClassLoader(String udfPath) throws IOException {
         super(new URL[] {new URL("file://" + udfPath)});
@@ -31,14 +33,21 @@ public class UDFClassLoader extends URLClassLoader {
         return super.findClass(clazzName);
     }
 
-    // (Boxed[]...)V update
-    public Class<?> generateCallStubV(String name, Class<?> clazz, Method method) {
+
+    public Class<?> generateCallStubV(String name, Class<?> clazz, Method method, int genType) {
         String clazzName = name.replace("/", ".");
         if (!clazzName.startsWith(CallStubGenerator.GEN_KEYWORD)) {
             throw new UnsupportedOperationException(
                     "generate class name should start with " + CallStubGenerator.GEN_KEYWORD);
         }
-        final byte[] bytes = CallStubGenerator.generateCallStubV(clazz, method);
+        byte[] bytes = null;
+        if (genType == SINGLE_BATCH_UPDATE) {
+            bytes = CallStubGenerator.generateCallStubV(clazz, method);
+        } else if (genType == BATCH_EVALUATE) {
+            bytes = CallStubGenerator.generateScalarCallStub(clazz, method);
+        } else {
+            throw new UnsupportedOperationException("Unsupported generate stub type:" + genType);
+        }
         final Class<?> genClazz = defineClass(clazzName, bytes, 0, bytes.length);
         genClazzMap.put(name, genClazz);
         return genClazz;

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -323,6 +323,7 @@ public class UDFHelper {
     public static Object[] createBoxedIntegerArray(int numRows, ByteBuffer nullBuffer, ByteBuffer dataBuffer) {
         int[] dataArr = new int[numRows];
         dataBuffer.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().get(dataArr);
+        dataBuffer.asIntBuffer().get(dataArr);
         if (nullBuffer != null) {
             byte[] nullArr = getNullData(nullBuffer, numRows);
             Integer[] result = new Integer[numRows];
@@ -333,7 +334,11 @@ public class UDFHelper {
             }
             return result;
         } else {
-            return Arrays.stream(dataArr).boxed().toArray();
+            Integer[] result = new Integer[numRows];
+            for (int i = 0; i < numRows; ++i) {
+                result[i] = dataArr[i];
+            }
+            return result;
         }
     }
 
@@ -417,7 +422,7 @@ public class UDFHelper {
             }
             return res;
         } else {
-            return Arrays.stream(dataArr).boxed().toArray();
+            return Arrays.stream(dataArr).boxed().toArray(Long[]::new);
         }
     }
 
@@ -456,7 +461,7 @@ public class UDFHelper {
             }
             return res;
         } else {
-            return Arrays.stream(dataArr).boxed().toArray();
+            return Arrays.stream(dataArr).boxed().toArray(Double[]::new);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
#5803

## Problem Summary(Required) ：
support codegen for scalar UDF


here was my performance test:
```
 select count(udf_add(lo_orderdate,lo_orderkey)) from lineorder;
```
1FE 3BE parallel=16
baseline: 1.16 sec
patched: 0.67 sec

