### PR TITLE
[Enhancement][UDF] optimize UDAF group by performance

### DIFF
--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -73,6 +73,11 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     RETURN_IF_ERROR(add_method("serialize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->serialize));
     RETURN_IF_ERROR(add_method("serializeLength", udaf_ctx->udaf_state_class.clazz(), &udaf_ctx->serialize_size));
 
+    auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
+    ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
+    ASSIGN_OR_RETURN(auto get_func, analyzer->get_method_object(state_clazz.clazz(), "get"));
+    ASSIGN_OR_RETURN(auto add_func, analyzer->get_method_object(state_clazz.clazz(), "add"));
+    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), std::move(get_func), std::move(add_func));
     udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
 
     return Status::OK();

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -19,7 +19,7 @@ void assign_jvalue(MethodTypeDescriptor method_type_desc, Column* col, int row_n
 class JavaWindowFunction final : public JavaUDAFAggregateFunction<true> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        ctx->impl()->udaf_ctxs()->_func->reset(data(state).handle());
+        ctx->impl()->udaf_ctxs()->_func->reset(data(state).handle);
     }
 
     std::string get_name() const override { return "java_window"; }
@@ -40,7 +40,7 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         JNIEnv* env = helper.getEnv();
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_args, num_rows, &args);
-        ctx->impl()->udaf_ctxs()->_func->window_update_batch(data(state).handle(), peer_group_start, peer_group_end,
+        ctx->impl()->udaf_ctxs()->_func->window_update_batch(data(state).handle, peer_group_start, peer_group_end,
                                                              frame_start, frame_end, num_args, args.data());
         // release input cols
         for (int i = 0; i < num_args; ++i) {
@@ -51,7 +51,7 @@ public:
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        jvalue val = ctx->impl()->udaf_ctxs()->_func->finalize(this->data(state).handle());
+        jvalue val = ctx->impl()->udaf_ctxs()->_func->finalize(this->data(state).handle);
         // insert values to column
         JNIEnv* env = helper.getEnv();
         MethodTypeDescriptor desc = {(PrimitiveType)ctx->get_return_type().type, true};

--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -11,11 +11,10 @@
 
 namespace starrocks::vectorized {
 struct JavaUDAFState {
-    JavaUDAFState(JavaGlobalRef&& handle) : _handle(std::move(handle)){};
+    JavaUDAFState(int handle_) : handle(std::move(handle_)) {}
     ~JavaUDAFState() = default;
-    jobject handle() const { return _handle.handle(); }
     // UDAF State
-    JavaGlobalRef _handle;
+    int handle;
 };
 // Column to DirectByteBuffer, which could avoid some memory copy,
 // directly access the C++ address space in Java
@@ -52,7 +51,8 @@ private:
 
 class JavaDataTypeConverter {
 public:
-    static jobject convert_to_object_array(uint8_t** data, size_t offset, int num_rows);
+    static jobject convert_to_states(uint8_t** data, size_t offset, int num_rows);
+    static jobject convert_to_states_with_filter(uint8_t** data, size_t offset, const uint8_t* filter, int num_rows);
 
     static void convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
                                        const Column** columns, int num_cols, int num_rows, std::vector<jobject>* res);

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -19,6 +19,7 @@
 #include "runtime/primitive_type.h"
 #include "udf/java/java_native_method.h"
 #include "udf/udf.h"
+#include "udf/udf_internal.h"
 #include "util/defer_op.h"
 
 // find a jclass and return a global jclass ref
@@ -69,6 +70,11 @@ JVMFunctionHelper& JVMFunctionHelper::getInstance() {
     }
     static JVMFunctionHelper helper;
     return helper;
+}
+
+std::pair<JNIEnv*, JVMFunctionHelper&> JVMFunctionHelper::getInstanceWithEnv() {
+    auto& instance = getInstance();
+    return {instance.getEnv(), instance};
 }
 
 void JVMFunctionHelper::_init() {
@@ -122,13 +128,20 @@ void JVMFunctionHelper::_init() {
     _create_boxed_array = _env->GetStaticMethodID(_udf_helper_class, "createBoxedArray",
                                                   "(IIZ[Ljava/nio/ByteBuffer;)[Ljava/lang/Object;");
 
-    _batch_update = _env->GetStaticMethodID(_udf_helper_class, "batchUpdate",
-                                            "(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)V");
+    _batch_update = _env->GetStaticMethodID(
+            _udf_helper_class, "batchUpdate",
+            "(Ljava/lang/Object;Ljava/lang/reflect/Method;Lcom/starrocks/udf/FunctionStates;[I[Ljava/lang/Object;)V");
     _batch_call = _env->GetStaticMethodID(
             _udf_helper_class, "batchCall",
             "(Ljava/lang/Object;Ljava/lang/reflect/Method;I[Ljava/lang/Object;)[Ljava/lang/Object;");
     _batch_call_no_args = _env->GetStaticMethodID(_udf_helper_class, "batchCall",
                                                   "(Ljava/lang/Object;Ljava/lang/reflect/Method;I)[Ljava/lang/Object;");
+    _batch_update_state = _env->GetStaticMethodID(_udf_helper_class, "batchUpdateState",
+                                                  "(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)V");
+    _batch_update_if_not_null = _env->GetStaticMethodID(
+            _udf_helper_class, "batchUpdateIfNotNull",
+            "(Ljava/lang/Object;Ljava/lang/reflect/Method;Lcom/starrocks/udf/FunctionStates;[I[Ljava/lang/Object;)V");
+
     _int_batch_call = _env->GetStaticMethodID(_udf_helper_class, "batchCall",
                                               "([Ljava/lang/Object;Ljava/lang/reflect/Method;I)[I");
     _get_boxed_result =
@@ -137,6 +150,8 @@ void JVMFunctionHelper::_init() {
     _direct_buffer_clear = _env->GetMethodID(_direct_buffer_class, "clear", "()Ljava/nio/Buffer;");
     DCHECK(_batch_call);
     DCHECK(_batch_call_no_args);
+    DCHECK(_batch_update_state);
+    DCHECK(_batch_update_if_not_null);
     DCHECK(_get_boxed_result);
     DCHECK(_direct_buffer_clear);
 
@@ -144,6 +159,10 @@ void JVMFunctionHelper::_init() {
     DCHECK(_list_get != nullptr);
     _list_size = _env->GetMethodID(_list_class, "size", "()I");
     DCHECK(_list_size != nullptr);
+
+    name = JVMFunctionHelper::to_jni_class_name(UDAFStateList::clazz_name);
+    jclass loaded_clazz = JNI_FIND_CLASS(name.c_str());
+    _function_states_clazz = std::make_unique<JVMClass>(std::move(loaded_clazz));
 }
 
 // https://stackoverflow.com/questions/45232522/how-to-set-classpath-of-a-running-jvm-in-cjni
@@ -184,6 +203,10 @@ jobjectArray JVMFunctionHelper::_build_object_array(jclass clazz, jobject* arr, 
         _env->SetObjectArrayElement(res_arr, i, arr[i]);
     }
     return res_arr;
+}
+
+JVMClass& JVMFunctionHelper::function_state_clazz() {
+    return *_function_states_clazz;
 }
 
 #define CHECK_FUNCTION_EXCEPTION(_env, name)                  \
@@ -292,14 +315,35 @@ jobject JVMFunctionHelper::create_object_array(jobject o, int num_rows) {
     return res_arr;
 }
 
-void JVMFunctionHelper::batch_update_single(AggBatchCallStub* stub, jobject state, jobject* input, int cols, int rows) {
-    stub->batch_update_single(rows, state, input, cols);
+void JVMFunctionHelper::batch_update_single(AggBatchCallStub* stub, int state, jobject* input, int cols, int rows) {
+    auto obj = convert_handle_to_jobject(stub->ctx(), state);
+    LOCAL_REF_GUARD(obj);
+    stub->batch_update_single(rows, obj, input, cols);
 }
 
-void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject update, jobject* input, int cols) {
+void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject update, jobject states, jobject* input,
+                                     int cols) {
     jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
     LOCAL_REF_GUARD(input_arr);
-    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, input_arr);
+    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update,
+                               ctx->impl()->udaf_ctxs()->states->handle(), states, input_arr);
+    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+}
+
+void JVMFunctionHelper::batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input,
+                                           int cols) {
+    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    LOCAL_REF_GUARD(input_arr);
+    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_state, udaf, update, input_arr);
+    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+}
+
+void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject udaf, jobject update, jobject states,
+                                                 jobject* input, int cols) {
+    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    LOCAL_REF_GUARD(input_arr);
+    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update,
+                               ctx->impl()->udaf_ctxs()->states->handle(), states, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
 }
 
@@ -333,6 +377,12 @@ jobject JVMFunctionHelper::list_get(jobject obj, int idx) {
 
 int JVMFunctionHelper::list_size(jobject obj) {
     return static_cast<int>(_env->CallIntMethod(obj, _list_size));
+}
+
+// convert UDAF ctx to jobject
+jobject JVMFunctionHelper::convert_handle_to_jobject(FunctionContext* ctx, int state) {
+    auto* states = ctx->impl()->udaf_ctxs()->states.get();
+    return states->get_state(ctx, _env, state);
 }
 
 DEFINE_NEW_BOX(boolean, uint8_t, Boolean, Boolean);
@@ -422,7 +472,27 @@ StatusOr<JavaGlobalRef> JVMClass::newInstance() const {
         return Status::InternalError("couldn't found default constructor for Java Object");
     }
     auto local_ref = env->NewObject((jclass)_clazz.handle(), constructor);
+    LOCAL_REF_GUARD(local_ref);
     return env->NewGlobalRef(local_ref);
+}
+
+UDAFStateList::UDAFStateList(JavaGlobalRef&& handle, JavaGlobalRef&& get, JavaGlobalRef&& add)
+        : _handle(std::move(handle)), _get_method(std::move(get)), _add_method(std::move(add)) {
+    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    _get_method_id = env->FromReflectedMethod(_get_method.handle());
+    _add_method_id = env->FromReflectedMethod(_add_method.handle());
+}
+
+jobject UDAFStateList::get_state(FunctionContext* ctx, JNIEnv* env, int state_handle) {
+    auto obj = env->CallObjectMethod(_handle.handle(), _get_method_id, state_handle);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
+    return obj;
+}
+
+int UDAFStateList::add_state(FunctionContext* ctx, JNIEnv* env, jobject state) {
+    auto res = env->CallIntMethod(_handle.handle(), _add_method_id, state);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
+    return res;
 }
 
 ClassLoader::~ClassLoader() {
@@ -707,31 +777,33 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
 
 JavaUDFContext::~JavaUDFContext() = default;
 
-JavaGlobalRef UDAFFunction::create() {
-    JNIEnv* env = getJNIEnv();
+int UDAFFunction::create() {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     jmethodID create = _ctx->create->get_method_id();
     auto obj = env->CallObjectMethod(_udaf_handle, create);
     LOCAL_REF_GUARD(obj);
-
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
-    auto res = env->NewGlobalRef(obj);
-    return JavaGlobalRef(std::move(res));
+    return _ctx->states->add_state(_function_context, env, obj);
 }
 
-void UDAFFunction::destroy(JavaGlobalRef& state) {
-    JNIEnv* env = getJNIEnv();
+void UDAFFunction::destroy(int state) {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
     jmethodID destory = _ctx->destory->get_method_id();
-    env->CallVoidMethod(_udaf_handle, destory, state.handle());
+    // call destroy
+    env->CallVoidMethod(_udaf_handle, destory, obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
-    state.clear();
 }
 
-jvalue UDAFFunction::finalize(jobject state) {
+jvalue UDAFFunction::finalize(int state) {
     auto& helper = JVMFunctionHelper::getInstance();
     JNIEnv* env = helper.getEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
     jmethodID finalize = _ctx->finalize->get_method_id();
     jvalue res;
-    res.l = env->CallObjectMethod(_udaf_handle, finalize, state);
+    res.l = env->CallObjectMethod(_udaf_handle, finalize, obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
     return res;
 }
@@ -764,48 +836,58 @@ jobject BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input, int cols
 }
 
 void UDAFFunction::update(jvalue* val) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     jmethodID update = _ctx->update->get_method_id();
     env->CallVoidMethodA(_udaf_handle, update, val);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
-void UDAFFunction::merge(jobject state, jobject buffer) {
-    JNIEnv* env = getJNIEnv();
+void UDAFFunction::merge(int state, jobject buffer) {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
     jmethodID merge = _ctx->merge->get_method_id();
-    env->CallVoidMethod(_udaf_handle, merge, state, buffer);
+    env->CallVoidMethod(_udaf_handle, merge, obj, buffer);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
-void UDAFFunction::serialize(jobject state, jobject buffer) {
-    JNIEnv* env = getJNIEnv();
-    jmethodID merge = _ctx->serialize->get_method_id();
-    env->CallVoidMethod(_udaf_handle, merge, state, buffer);
+void UDAFFunction::serialize(int state, jobject buffer) {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
+    jmethodID serialize = _ctx->serialize->get_method_id();
+    env->CallVoidMethod(_udaf_handle, serialize, obj, buffer);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
-int UDAFFunction::serialize_size(jobject state) {
-    JNIEnv* env = getJNIEnv();
+int UDAFFunction::serialize_size(int state) {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
     jmethodID serialize_size = _ctx->serialize_size->get_method_id();
-    int sz = env->CallIntMethod(state, serialize_size);
+    int sz = env->CallIntMethod(obj, serialize_size);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
     return sz;
 }
 
-void UDAFFunction::reset(jobject state) {
-    JNIEnv* env = getJNIEnv();
+void UDAFFunction::reset(int state) {
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
     jmethodID reset = _ctx->reset->get_method_id();
     env->CallVoidMethod(_udaf_handle, reset, state);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
-jobject UDAFFunction::window_update_batch(jobject state, int peer_group_start, int peer_group_end, int frame_start,
+jobject UDAFFunction::window_update_batch(int state, int peer_group_start, int peer_group_end, int frame_start,
                                           int frame_end, int col_sz, jobject* cols) {
-    JNIEnv* env = getJNIEnv();
+    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto obj = helper.convert_handle_to_jobject(_function_context, state);
+    LOCAL_REF_GUARD(obj);
+
     jmethodID window_update = _ctx->window_update->get_method_id();
     jvalue jvalues[5 + col_sz];
-    jvalues[0].l = state;
+    jvalues[0].l = obj;
     jvalues[1].j = peer_group_start;
     jvalues[2].j = peer_group_end;
     jvalues[3].j = frame_start;

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/FunctionStates.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/FunctionStates.java
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.udf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FunctionStates<T> {
+    public List<T> states = new ArrayList<>();
+
+    public T get(int idx) {
+        return states.get(idx);
+    }
+
+    public int add(T state) throws Exception {
+        states.add(state);
+        return states.size() - 1;
+    }
+
+}

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -499,7 +499,25 @@ public class UDFHelper {
     }
 
     // batch call void(Object...)
-    public static void batchUpdate(Object o, Method method, Object[] column)
+    public static void batchUpdate(Object o, Method method, FunctionStates ctx, int[] states, Object[] column)
+            throws Throwable {
+        Object[][] inputs = (Object[][]) column;
+        Object[] parameter = new Object[inputs.length + 1];
+        int numRows = states.length;
+        try {
+            for (int i = 0; i < numRows; ++i) {
+                parameter[0] = ctx.get(states[i]);
+                for (int j = 0; j < column.length; ++j) {
+                    parameter[j + 1] = inputs[j][i];
+                }
+                method.invoke(o, parameter);
+            }
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+
+    public static void batchUpdateState(Object o, Method method, Object[] column)
             throws Throwable {
         Object[][] inputs = (Object[][]) column;
         Object[] parameter = new Object[inputs.length];
@@ -514,7 +532,26 @@ public class UDFHelper {
         } catch (InvocationTargetException e) {
             throw e.getTargetException();
         }
+    }
 
+    public static void batchUpdateIfNotNull(Object o, Method method, FunctionStates ctx, int[] states, Object[] column)
+            throws Throwable {
+        Object[][] inputs = (Object[][]) column;
+        Object[] parameter = new Object[inputs.length + 1];
+        int numRows = states.length;
+        try {
+            for (int i = 0; i < numRows; ++i) {
+                if (states[i] != -1) {
+                    parameter[0] = ctx.get(states[i]);
+                    for (int j = 0; j < column.length; ++j) {
+                        parameter[j + 1] = inputs[j][i];
+                    }
+                    method.invoke(o, parameter);
+                }
+            }
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
     }
 
     // batch call Object(Object...)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

#5803

## Problem Summary(Required) ：

In the past, we used to hold a global ref directly for the State of the aggregation function. But this has led to some problems:
1. it is easier to trigger GC
2. need to call the SetObjectArray method before executing batch_update, which causes a lot of JNI overhead

this PR uses an optimization like this
Instead of holding a global ref handle directly, each aggregate function holds a FunctionStates (a list), and the UDAF State uses an int to represent a handle. (This imposes some restrictions, such as the number of group by keys cannot exceed int32, but in the old implementation framework it is usually almost impossible to execute when hundreds of thousands of global refs exist at the same time)