### PR TITLE
[cherry-pick] [branch-2.2] [Enhancement] opt the memory usage of rows between unbounded preceding and current row for pipeline engine (#6036)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -17,8 +17,10 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
     TAnalyticWindow window = _tnode.analytic_node.window;
 
     if (!_tnode.analytic_node.__isset.window) {
+        _process_by_partition_if_necessary = &AnalyticSinkOperator::_process_by_partition_if_necessary_for_other;
         _process_by_partition = &AnalyticSinkOperator::_process_by_partition_for_unbounded_frame;
     } else if (window.type == TAnalyticWindowType::RANGE) {
+        _process_by_partition_if_necessary = &AnalyticSinkOperator::_process_by_partition_if_necessary_for_other;
         // RANGE windows must have UNBOUNDED PRECEDING
         // RANGE window end bound must be CURRENT ROW or UNBOUNDED FOLLOWING
         if (!window.__isset.window_end) {
@@ -28,10 +30,14 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
         }
     } else {
         if (!window.__isset.window_start && !window.__isset.window_end) {
+            _process_by_partition_if_necessary = &AnalyticSinkOperator::_process_by_partition_if_necessary_for_other;
             _process_by_partition = &AnalyticSinkOperator::_process_by_partition_for_unbounded_frame;
         } else if (!window.__isset.window_start && window.window_end.type == TAnalyticWindowBoundaryType::CURRENT_ROW) {
-            _process_by_partition = &AnalyticSinkOperator::_process_by_partition_for_unbounded_preceding_rows_frame;
+            _process_by_partition_if_necessary =
+                    &AnalyticSinkOperator::
+                            _process_by_partition_if_necessary_for_rows_between_unbounded_preceding_and_following;
         } else {
+            _process_by_partition_if_necessary = &AnalyticSinkOperator::_process_by_partition_if_necessary_for_other;
             _process_by_partition = &AnalyticSinkOperator::_process_by_partition_for_sliding_frame;
         }
     }
@@ -47,7 +53,7 @@ void AnalyticSinkOperator::close(RuntimeState* state) {
 Status AnalyticSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
     _analytor->input_eos() = true;
-    RETURN_IF_ERROR(_process_by_partition_if_necessary());
+    RETURN_IF_ERROR((this->*_process_by_partition_if_necessary)());
     _analytor->sink_complete();
     return Status::OK();
 }
@@ -90,10 +96,10 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
     _analytor->input_chunks().emplace_back(chunk);
 
-    return _process_by_partition_if_necessary();
+    return (this->*_process_by_partition_if_necessary)();
 }
 
-Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
+Status AnalyticSinkOperator::_process_by_partition_if_necessary_for_other() {
     while (_analytor->has_output()) {
         if (_analytor->reached_limit()) {
             return Status::OK();
@@ -123,6 +129,33 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             _analytor->offer_chunk_to_buffer(chunk);
         }
     }
+    return Status::OK();
+}
+
+Status AnalyticSinkOperator::_process_by_partition_if_necessary_for_rows_between_unbounded_preceding_and_following() {
+    // When set_finishing(), the has_output() may be false, so add the check
+    if (!_analytor->has_output()) {
+        return Status::OK();
+    }
+
+    if (_analytor->reached_limit()) {
+        return Status::OK();
+    }
+
+    // reset state for the first partition
+    if (_analytor->current_row_position() == 0) {
+        _analytor->reset_window_state();
+    }
+
+    auto chunk_size = static_cast<int64_t>(_analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows());
+    _analytor->create_agg_result_columns(chunk_size);
+
+    _process_by_partition_for_rows_between_unbounded_preceding_and_current_row(chunk_size);
+
+    vectorized::ChunkPtr chunk;
+    RETURN_IF_ERROR(_analytor->output_result_chunk(&chunk));
+    _analytor->offer_chunk_to_buffer(chunk);
+
     return Status::OK();
 }
 
@@ -170,21 +203,28 @@ void AnalyticSinkOperator::_process_by_partition_for_unbounded_preceding_range_f
     }
 }
 
-void AnalyticSinkOperator::_process_by_partition_for_unbounded_preceding_rows_frame(size_t chunk_size,
-                                                                                    bool is_new_partition) {
-    while (_analytor->current_row_position() < _analytor->partition_end() &&
-           _analytor->window_result_position() < chunk_size) {
-        _analytor->update_window_batch(_analytor->partition_start(), _analytor->partition_end(),
-                                       _analytor->current_row_position(), _analytor->current_row_position() + 1);
+void AnalyticSinkOperator::_process_by_partition_for_rows_between_unbounded_preceding_and_current_row(
+        size_t chunk_size) {
+    do {
+        bool end = _analytor->find_and_check_partition_end();
 
-        _analytor->update_window_result_position(1);
-        int64_t frame_start = _analytor->get_total_position(_analytor->current_row_position()) -
-                              _analytor->input_chunk_first_row_positions()[_analytor->output_chunk_index()];
+        while (_analytor->current_row_position() < _analytor->found_partition_end()) {
+            _analytor->update_window_batch(_analytor->partition_start(), _analytor->found_partition_end(),
+                                           _analytor->current_row_position(), _analytor->current_row_position() + 1);
 
-        DCHECK_GE(frame_start, 0);
-        _analytor->get_window_function_result(frame_start, _analytor->window_result_position());
-        _analytor->update_current_row_position(1);
-    }
+            _analytor->update_window_result_position(1);
+            int64_t frame_start = _analytor->get_total_position(_analytor->current_row_position()) -
+                                  _analytor->input_chunk_first_row_positions()[_analytor->output_chunk_index()];
+
+            DCHECK_GE(frame_start, 0);
+            _analytor->get_window_function_result(frame_start, _analytor->window_result_position());
+            _analytor->update_current_row_position(1);
+        }
+
+        if (end) {
+            _analytor->reset_state_for_next_partition();
+        }
+    } while (_analytor->window_result_position() < chunk_size);
 }
 
 void AnalyticSinkOperator::_process_by_partition_for_sliding_frame(size_t chunk_size, bool is_new_partition) {

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -27,10 +27,13 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    Status _process_by_partition_if_necessary();
+    Status _process_by_partition_if_necessary_for_other();
+    Status _process_by_partition_if_necessary_for_rows_between_unbounded_preceding_and_following();
+    Status (AnalyticSinkOperator::*_process_by_partition_if_necessary)() = nullptr;
+
     void _process_by_partition_for_unbounded_frame(size_t chunk_size, bool is_new_partition);
     void _process_by_partition_for_unbounded_preceding_range_frame(size_t chunk_size, bool is_new_partition);
-    void _process_by_partition_for_unbounded_preceding_rows_frame(size_t chunk_size, bool is_new_partition);
+    void _process_by_partition_for_rows_between_unbounded_preceding_and_current_row(size_t chunk_size);
     void _process_by_partition_for_sliding_frame(size_t chunk_size, bool is_new_partition);
     void (AnalyticSinkOperator::*_process_by_partition)(size_t chunk_size, bool is_new_partition) = nullptr;
 


### PR DESCRIPTION
for sql

```
select count(lo_orderkey), count(lo_partkey), count(lo_custkey), count(lo_suppkey), count(lo_quantity), count(lo_discount), count(lo_shipmode), count(_num) from 
(select lo_orderkey, lo_partkey, lo_custkey, lo_suppkey, lo_quantity, lo_discount, lo_shipmode, row_number() over(order by lo_partkey) as _num from lineorder) t1;
```

pipeline_dop = 4

before optimization

```
  Execution Profile cd6f9224-d2b4-11ec-8457-66660a909341:
     - ExecutionTotalTime: 39s610ms
    Fragment 0:
       - BackendNum: 1
       - InstanceNum: 1
       - MemoryLimit: 74.51 GB
       - PeakMemoryUsage: 4.18 GB
```

after optimization

```
  Execution Profile 629809f0-d2b4-11ec-8457-66660a909341:
     - ExecutionTotalTime: 35s658ms
    Fragment 0:
       - BackendNum: 1
       - InstanceNum: 1
       - MemoryLimit: 74.51 GB    
       - PeakMemoryUsage: 774.14 MB
```

Note: the performance is less then non-pipeline (24.6s), may the the scheduler implement problem