### PR TITLE
[BugFix]fix UserResource serialization compatibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserResource.java
@@ -49,8 +49,8 @@ public class UserResource {
 
     public static void write(DataOutput out) throws IOException {
         // Num resources
-        out.write(0);
+        out.writeInt(0);
         // Num groups
-        out.write(0);
+        out.writeInt(0);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Serialization should use `writeInt` instead of write a byte.
