### PR TITLE
[BugFix] Fix const expression with in subquery bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +102,7 @@ public class Utils {
 
     public static List<ColumnRefOperator> extractColumnRef(ScalarOperator root) {
         if (null == root || !root.isVariable()) {
-            return Collections.emptyList();
+            return new LinkedList<>();
         }
 
         LinkedList<ColumnRefOperator> list = new LinkedList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -163,4 +163,13 @@ public class SubqueryTest extends PlanTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     partitions=0/1");
     }
+
+    @Test
+    public void testCorrelatedComplexInSubQuery() throws Exception {
+        String sql = "SELECT v4  FROM t1\n" +
+                "WHERE ( (\"1969-12-09 14:18:03\") IN (\n" +
+                "          SELECT t2.v8 FROM t2 WHERE (t1.v5) = (t2.v9))\n" +
+                "    ) IS NULL\n";
+        Assert.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6093

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
SELECT subt1.c_1_0 FROM t1 subt1
WHERE (("1969-12-09 14:18:03") IN (
          SELECT t2.c_2_0 
          FROM t2 
          WHERE (subt1.c_1_12) = (t2.c_2_6)
      )) IS NULL;
```

InSubquery predicate `("1969-12-09 14:18:03") IN (....)`, the left child is a constant columns, Utils.extractColumnRef will return unmodify list(emptyList()), then outer code add column to the list