### PR TITLE
[BugFix] Fix CTE exchange deserialize error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SortInfo;
-import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
@@ -102,20 +101,6 @@ public class ExchangeNode extends PlanNode {
                         DistributionSpec.DistributionType type) {
         this(id, inputNode, copyConjuncts);
         distributionType = type;
-    }
-
-    public ExchangeNode(PlanNodeId id, PlanNode inputNode, boolean copyConjuncts,
-                        DistributionSpec.DistributionType type, TupleDescriptor tuple) {
-        this(id, inputNode, copyConjuncts, type);
-        tupleIds.add(tuple.getId());
-        nullableTupleIds.add(tuple.getId());
-        receiveColumns = Lists.newArrayList();
-        tuple.getSlots().forEach(s -> receiveColumns.add(s.getId().asInt()));
-    }
-
-    // For Test
-    public ExchangeNode(PlanNodeId id, PlanNode inputNode) {
-        super(id, inputNode, "EXCHANGE");
     }
 
     public void setPartitionType(TPartitionType type) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2280,24 +2280,8 @@ public class PlanFragmentBuilder {
             int cteId = consume.getCteId();
 
             MultiCastPlanFragment cteFragment = (MultiCastPlanFragment) context.getCteProduceFragments().get(cteId);
-
-            // create new tuple, don't use CTE-Produce tuple
-            TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
-
-            for (ColumnRefOperator cteProduceColumnRef : consume.getCteOutputColumnRefMap().values()) {
-                SlotId slotId = new SlotId(cteProduceColumnRef.getId());
-                SlotDescriptor cteProduceDesc = context.getDescTbl().getSlotDesc(slotId);
-
-                SlotDescriptor slotDescriptor = context.getDescTbl().addSlotDescriptor(tupleDescriptor, slotId);
-                slotDescriptor.setIsNullable(cteProduceDesc.getIsNullable());
-                slotDescriptor.setIsMaterialized(true);
-                slotDescriptor.setType(cteProduceDesc.getType());
-                context.getColRefToExpr()
-                        .put(cteProduceColumnRef, new SlotRef(cteProduceColumnRef.toString(), slotDescriptor));
-            }
-
-            ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(), cteFragment.getPlanRoot(), false,
-                    DistributionSpec.DistributionType.SHUFFLE, tupleDescriptor);
+            ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(),
+                    cteFragment.getPlanRoot(), false, DistributionSpec.DistributionType.SHUFFLE);
 
             exchangeNode.setNumInstances(cteFragment.getPlanRoot().getNumInstances());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -318,4 +318,22 @@ public class CTEPlanTest extends PlanTestBase {
 
         getFragmentPlan(sql2);
     }
+
+    @Test
+    public void testCTEConsumeTuple() throws Exception {
+        String sql = "WITH w_t0 as (SELECT * FROM t0) \n" +
+                "SELECT x0.v1, x1.v2 FROM  w_t0 x0, w_t0 x1";
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MultiCastDataSinks\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    RANDOM");
+
+        String thrift = getThriftPlan(sql);
+        assertNotContains(thrift, "tuple_id:3");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


For SQL:
```
MySQL td> set enable_exchange_pass_through=false;
Query OK, 0 rows affected
MySQL td> with xx as (select * from t0) select * from (select v1 from xx) x1 join (select v2 from xx) x2;
(1064, 'build chunk meta error')
```

Each CTEConsume will create new tuples because each CETConsume output columns may be different, but when the output has same column, will produce two tuple and the slot id is same.

ExchangeNode will deserialize column by tuple descipter when sender send columns by network way, then exchange node will find two slotId and report error
