### PR TITLE
[Enhancement] rank window function optimization, add partition topn (2)

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -147,6 +147,9 @@ set(EXEC_FILES
     pipeline/crossjoin/cross_join_right_sink_operator.cpp
     pipeline/crossjoin/cross_join_left_operator.cpp
     pipeline/sort/partition_sort_sink_operator.cpp
+    pipeline/sort/local_partition_topn_sink.cpp
+    pipeline/sort/local_partition_topn_source.cpp
+    pipeline/sort/local_partition_topn_context.cpp
     pipeline/sort/local_merge_sort_source_operator.cpp
     pipeline/sort/sort_context.cpp
     pipeline/pipeline_driver_executor.cpp

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -1,0 +1,124 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/sort/local_partition_topn_context.h"
+
+#include <exec/vectorized/partition/chunks_partitioner.h>
+
+#include "exec/vectorized/chunks_sorter_topn.h"
+
+namespace starrocks::pipeline {
+
+LocalPartitionTopnContext::LocalPartitionTopnContext(
+        const std::vector<TExpr>& t_partition_exprs, SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order,
+        std::vector<bool> is_null_first, const std::string& sort_keys, int64_t offset, int64_t limit,
+        const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
+        const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc)
+        : _t_partition_exprs(t_partition_exprs),
+          _sort_exec_exprs(sort_exec_exprs),
+          _is_asc_order(is_asc_order),
+          _is_null_first(is_null_first),
+          _sort_keys(sort_keys),
+          _offset(offset),
+          _limit(limit),
+          _order_by_types(order_by_types),
+          _materialized_tuple_desc(materialized_tuple_desc),
+          _parent_node_row_desc(parent_node_row_desc),
+          _parent_node_child_row_desc(parent_node_child_row_desc) {}
+
+Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_partition_exprs, &_partition_exprs));
+    auto partition_size = _t_partition_exprs.size();
+    _partition_types.resize(partition_size);
+    for (auto i = 0; i < partition_size; ++i) {
+        TExprNode expr = _t_partition_exprs[i].nodes[0];
+        _partition_types[i].result_type = TypeDescriptor::from_thrift(expr.type);
+        _partition_types[i].is_nullable = expr.is_nullable;
+        _has_nullable_key = _has_nullable_key || _partition_types[i].is_nullable;
+    }
+
+    _chunks_partitioner =
+            std::make_unique<vectorized::ChunksPartitioner>(_has_nullable_key, _partition_exprs, _partition_types);
+    return _chunks_partitioner->prepare(state);
+}
+
+Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(const vectorized::ChunkPtr& chunk) {
+    return _chunks_partitioner->offer(chunk);
+}
+
+void LocalPartitionTopnContext::sink_complete() {
+    _is_sink_complete = true;
+}
+
+Status LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorters(RuntimeState* state) {
+    const auto num_partitions = _chunks_partitioner->num_partitions();
+    _chunks_sorters.resize(num_partitions);
+    for (int i = 0; i < num_partitions; ++i) {
+        _chunks_sorters[i] = std::make_shared<vectorized::ChunksSorterTopn>(
+                state, &_sort_exec_exprs.lhs_ordering_expr_ctxs(), &_is_asc_order, &_is_null_first, _sort_keys, _offset,
+                _limit, vectorized::ChunksSorterTopn::tunning_buffered_chunks(_limit));
+    }
+    RETURN_IF_ERROR(
+            _chunks_partitioner->accept([this, state](int32_t partition_idx, const vectorized::ChunkPtr& chunk) {
+                _chunks_sorters[partition_idx]->update(state, chunk);
+                return true;
+            }));
+
+    for (auto& chunks_sorter : _chunks_sorters) {
+        RETURN_IF_ERROR(chunks_sorter->done(state));
+    }
+
+    return Status::OK();
+}
+
+bool LocalPartitionTopnContext::has_output() {
+    return _is_sink_complete && _sorter_index < _chunks_sorters.size();
+}
+
+bool LocalPartitionTopnContext::is_finished() {
+    if (!_is_sink_complete) {
+        return false;
+    }
+    return !has_output();
+}
+
+StatusOr<vectorized::ChunkPtr> LocalPartitionTopnContext::pull_one_chunk_from_sorters() {
+    auto& chunks_sorter = _chunks_sorters[_sorter_index];
+    vectorized::ChunkPtr chunk;
+    if (chunks_sorter->pull_chunk(&chunk)) {
+        // Current sorter has no output, try to get chunk from next sorter
+        _sorter_index++;
+    }
+    return chunk;
+}
+
+LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
+        const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
+        SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
+        const std::string& sort_keys, int64_t offset, int64_t limit, const std::vector<OrderByType>& order_by_types,
+        TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
+        const RowDescriptor& parent_node_child_row_desc)
+        : _ctxs(degree_of_parallelism),
+          _t_partition_exprs(t_partition_exprs),
+          _sort_exec_exprs(sort_exec_exprs),
+          _is_asc_order(is_asc_order),
+          _is_null_first(is_null_first),
+          _sort_keys(sort_keys),
+          _offset(offset),
+          _limit(limit),
+          _order_by_types(order_by_types),
+          _materialized_tuple_desc(materialized_tuple_desc),
+          _parent_node_row_desc(parent_node_row_desc),
+          _parent_node_child_row_desc(parent_node_child_row_desc) {}
+
+LocalPartitionTopnContext* LocalPartitionTopnContextFactory::create(int32_t driver_sequence) {
+    DCHECK_LT(driver_sequence, _ctxs.size());
+
+    if (_ctxs[driver_sequence] == nullptr) {
+        _ctxs[driver_sequence] = std::make_shared<LocalPartitionTopnContext>(
+                _t_partition_exprs, _sort_exec_exprs, _is_asc_order, _is_null_first, _sort_keys, _offset, _limit,
+                _order_by_types, _materialized_tuple_desc, _parent_node_row_desc, _parent_node_child_row_desc);
+    }
+
+    return _ctxs[driver_sequence].get();
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -1,0 +1,113 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/vectorized/chunks_sorter.h"
+#include "exec/vectorized/partition/chunks_partitioner.h"
+
+namespace starrocks::pipeline {
+
+class LocalPartitionTopnContext;
+class LocalPartitionTopnContextFactory;
+
+using LocalPartitionTopnContextPtr = std::shared_ptr<LocalPartitionTopnContext>;
+using LocalPartitionTopnContextFactoryPtr = std::shared_ptr<LocalPartitionTopnContextFactory>;
+
+// LocalPartitionTopnContext is the bridge of each pair of LocalPartitionTopn{Sink/Source}Operators
+// The purpose of LocalPartitionTopn{Sink/Source}Operator is to reduce the amount of data,
+// so the output chunks are still remain unordered
+//                                   ┌────► topn─────┐
+//                                   │               │
+// (unordered)                       │               │                  (unordered)
+// inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
+//                                   │               │
+//                                   │               │
+//                                   └────► topn ────┘
+class LocalPartitionTopnContext {
+public:
+    LocalPartitionTopnContext(const std::vector<TExpr>& t_partition_exprs, SortExecExprs& sort_exec_exprs,
+                              std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
+                              const std::string& sort_keys, int64_t offset, int64_t limit,
+                              const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
+                              const RowDescriptor& parent_node_row_desc,
+                              const RowDescriptor& parent_node_child_row_desc);
+
+    Status prepare(RuntimeState* state);
+
+    // Add one chunk to partitioner
+    Status push_one_chunk_to_partitioner(const vectorized::ChunkPtr& chunk);
+
+    // Notify that there is no further input for partitiner
+    void sink_complete();
+
+    // Pull chunks form partitioner of each partition to correspondent sorter
+    Status transfer_all_chunks_from_partitioner_to_sorters(RuntimeState* state);
+
+    // Return true if at least one of the sorters has remaining data
+    bool has_output();
+
+    // Return true if sink completed and all the data in the chunks_sorters has been pulled out
+    bool is_finished();
+
+    // Pull one chunk from one of the sorters
+    // The output chunk stream is unordered
+    StatusOr<vectorized::ChunkPtr> pull_one_chunk_from_sorters();
+
+private:
+    const std::vector<TExpr>& _t_partition_exprs;
+    std::vector<ExprContext*> _partition_exprs;
+    std::vector<vectorized::PartitionColumnType> _partition_types;
+    bool _has_nullable_key = false;
+
+    bool _is_sink_complete = false;
+
+    vectorized::ChunksPartitionerPtr _chunks_partitioner;
+
+    // Every partition holds a chunks_sorter
+    vectorized::ChunksSorters _chunks_sorters;
+    SortExecExprs _sort_exec_exprs;
+    std::vector<bool> _is_asc_order;
+    std::vector<bool> _is_null_first;
+    const std::string _sort_keys;
+    int64_t _offset;
+    int64_t _limit;
+    const std::vector<OrderByType>& _order_by_types;
+    TupleDescriptor* _materialized_tuple_desc;
+    const RowDescriptor& _parent_node_row_desc;
+    const RowDescriptor& _parent_node_child_row_desc;
+
+    int32_t _sorter_index = 0;
+};
+
+using LocalPartitionTopnContextPtr = std::shared_ptr<LocalPartitionTopnContext>;
+
+class LocalPartitionTopnContextFactory {
+public:
+    LocalPartitionTopnContextFactory(const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
+                                     SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order,
+                                     std::vector<bool> is_null_first, const std::string& sort_keys, int64_t offset,
+                                     int64_t limit, const std::vector<OrderByType>& order_by_types,
+                                     TupleDescriptor* materialized_tuple_desc,
+                                     const RowDescriptor& parent_node_row_desc,
+                                     const RowDescriptor& parent_node_child_row_desc);
+
+    LocalPartitionTopnContext* create(int32_t driver_sequence);
+
+private:
+    std::vector<LocalPartitionTopnContextPtr> _ctxs;
+
+    const std::vector<TExpr>& _t_partition_exprs;
+
+    vectorized::ChunksSorters _chunks_sorters;
+    SortExecExprs _sort_exec_exprs;
+    std::vector<bool> _is_asc_order;
+    std::vector<bool> _is_null_first;
+    const std::string _sort_keys;
+    int64_t _offset;
+    int64_t _limit;
+    const std::vector<OrderByType>& _order_by_types;
+    TupleDescriptor* _materialized_tuple_desc;
+    const RowDescriptor& _parent_node_row_desc;
+    const RowDescriptor& _parent_node_child_row_desc;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
@@ -1,0 +1,41 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/sort/local_partition_topn_sink.h"
+
+namespace starrocks::pipeline {
+
+LocalPartitionTopnSinkOperator::LocalPartitionTopnSinkOperator(OperatorFactory* factory, int32_t id,
+                                                               int32_t plan_node_id, int32_t driver_sequence,
+                                                               LocalPartitionTopnContext* partition_topn_ctx)
+        : Operator(factory, id, "local_partition_topn_sink", plan_node_id, driver_sequence),
+          _partition_topn_ctx(partition_topn_ctx) {}
+
+Status LocalPartitionTopnSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    return _partition_topn_ctx->prepare(state);
+}
+
+StatusOr<vectorized::ChunkPtr> LocalPartitionTopnSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't call pull_chunk from local partition topn sink operator.");
+}
+
+Status LocalPartitionTopnSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    return _partition_topn_ctx->push_one_chunk_to_partitioner(chunk);
+}
+
+Status LocalPartitionTopnSinkOperator::set_finishing(RuntimeState* state) {
+    RETURN_IF_ERROR(_partition_topn_ctx->transfer_all_chunks_from_partitioner_to_sorters(state));
+    _partition_topn_ctx->sink_complete();
+    _is_finished = true;
+    return Status::OK();
+}
+
+LocalPartitionTopnSinkOperatorFactory::LocalPartitionTopnSinkOperatorFactory(
+        int32_t id, int32_t plan_node_id, const LocalPartitionTopnContextFactoryPtr& partition_topn_ctx_factory)
+        : OperatorFactory(id, "local_partition_topn_sink", plan_node_id),
+          _partition_topn_ctx_factory(partition_topn_ctx_factory) {}
+OperatorPtr LocalPartitionTopnSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<LocalPartitionTopnSinkOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                            _partition_topn_ctx_factory->create(driver_sequence));
+}
+}; // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.h
@@ -1,0 +1,58 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/sort/local_partition_topn_context.h"
+
+namespace starrocks::pipeline {
+
+// The purpose of LocalPartitionTopn{Sink/Source}Operator is to reduce the amount of data,
+// so the output chunks are still remain unordered
+//                                   ┌────► topn─────┐
+//                                   │               │
+// (unordered)                       │               │                  (unordered)
+// inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
+//                                   │               │
+//                                   │               │
+//                                   └────► topn ────┘
+class LocalPartitionTopnSinkOperator : public Operator {
+public:
+    LocalPartitionTopnSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                                   LocalPartitionTopnContext* partition_topn_ctx);
+
+    ~LocalPartitionTopnSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    bool has_output() const override { return false; }
+
+    bool need_input() const override { return true; }
+
+    bool is_finished() const override { return _is_finished; }
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+    Status set_finishing(RuntimeState* state) override;
+
+private:
+    bool _is_finished = false;
+
+    LocalPartitionTopnContext* _partition_topn_ctx;
+};
+
+class LocalPartitionTopnSinkOperatorFactory final : public OperatorFactory {
+public:
+    LocalPartitionTopnSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                          const LocalPartitionTopnContextFactoryPtr& partition_topn_ctx_factory);
+
+    ~LocalPartitionTopnSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    LocalPartitionTopnContextFactoryPtr _partition_topn_ctx_factory;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_source.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_source.cpp
@@ -1,0 +1,33 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/sort/local_partition_topn_source.h"
+
+namespace starrocks::pipeline {
+
+LocalPartitionTopnSourceOperator::LocalPartitionTopnSourceOperator(OperatorFactory* factory, int32_t id,
+                                                                   int32_t plan_node_id, int32_t driver_sequence,
+                                                                   LocalPartitionTopnContext* partition_topn_ctx)
+        : SourceOperator(factory, id, "local_partition_topn_source", plan_node_id, driver_sequence),
+          _partition_topn_ctx(partition_topn_ctx) {}
+
+bool LocalPartitionTopnSourceOperator::has_output() const {
+    return _partition_topn_ctx->has_output();
+}
+
+bool LocalPartitionTopnSourceOperator::is_finished() const {
+    return _partition_topn_ctx->is_finished();
+}
+
+StatusOr<vectorized::ChunkPtr> LocalPartitionTopnSourceOperator::pull_chunk(RuntimeState* state) {
+    return _partition_topn_ctx->pull_one_chunk_from_sorters();
+}
+
+LocalPartitionTopnSourceOperatorFactory::LocalPartitionTopnSourceOperatorFactory(
+        int32_t id, int32_t plan_node_id, const LocalPartitionTopnContextFactoryPtr& partition_topn_ctx_factory)
+        : SourceOperatorFactory(id, "local_partition_topn_source", plan_node_id),
+          _partition_topn_ctx_factory(partition_topn_ctx_factory) {}
+OperatorPtr LocalPartitionTopnSourceOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<LocalPartitionTopnSourceOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                              _partition_topn_ctx_factory->create(driver_sequence));
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_source.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_source.h
@@ -1,0 +1,48 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/sort/local_partition_topn_context.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+
+// The purpose of LocalPartitionTopn{Sink/Source}Operator is to reduce the amount of data,
+// so the output chunks are still remain unordered
+//                                   ┌────► topn─────┐
+//                                   │               │
+// (unordered)                       │               │                  (unordered)
+// inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
+//                                   │               │
+//                                   │               │
+//                                   └────► topn ────┘
+class LocalPartitionTopnSourceOperator : public SourceOperator {
+public:
+    LocalPartitionTopnSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                     int32_t driver_sequence, LocalPartitionTopnContext* partition_topn_ctx);
+
+    ~LocalPartitionTopnSourceOperator() override = default;
+
+    bool has_output() const override;
+
+    bool is_finished() const override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+private:
+    LocalPartitionTopnContext* _partition_topn_ctx;
+};
+
+class LocalPartitionTopnSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    LocalPartitionTopnSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                            const LocalPartitionTopnContextFactoryPtr& partition_topn_ctx_factory);
+
+    ~LocalPartitionTopnSourceOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    LocalPartitionTopnContextFactoryPtr _partition_topn_ctx_factory;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -19,18 +19,19 @@ static void get_compare_results_colwise(size_t row_to_sort, Columns& order_by_co
                                         std::vector<DataSegment>& data_segments,
                                         const std::vector<int>& sort_order_flags,
                                         const std::vector<int>& null_first_flags) {
-    for (size_t i = 0; i < data_segments.size(); ++i) {
+    size_t dats_segment_size = data_segments.size();
+
+    for (size_t i = 0; i < dats_segment_size; ++i) {
         size_t rows = data_segments[i].chunk->num_rows();
         compare_results_array[i].resize(rows, 0);
     }
 
-    size_t dats_segment_size = data_segments.size();
-    size_t size = order_by_columns.size();
+    size_t order_by_column_size = order_by_columns.size();
 
     for (size_t i = 0; i < dats_segment_size; i++) {
         std::vector<Datum> rhs_values;
         auto& segment = data_segments[i];
-        for (size_t col_idx = 0; col_idx < size; col_idx++) {
+        for (size_t col_idx = 0; col_idx < order_by_column_size; col_idx++) {
             rhs_values.push_back(order_by_columns[col_idx]->get(row_to_sort));
         }
         compare_columns(segment.order_by_columns, compare_results_array[i], rhs_values, sort_order_flags,

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -72,6 +72,9 @@ struct DataSegment {
 using DataSegments = std::vector<DataSegment>;
 
 class SortedRuns;
+class ChunksSorter;
+using ChunksSorterPtr = std::shared_ptr<ChunksSorter>;
+using ChunksSorters = std::vector<ChunksSorterPtr>;
 
 // Sort Chunks in memory with specified order by rules.
 class ChunksSorter {
@@ -80,13 +83,14 @@ public:
 
     /**
      * Constructor.
-     * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
-     * @param is_asc         Orders on each column.
-     * @param is_null_first  NULL values should at the head or tail.
-     * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
+     * @param sort_exprs            The order-by columns or columns with expression. This sorter will use but not own the object.
+     * @param is_asc_order          Orders on each column.
+     * @param is_null_first         NULL values should at the head or tail.
+     * @param size_of_chunk_batch   In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
-    ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                 const std::vector<bool>* is_null_first, const std::string& sort_keys, const bool is_topn);
+    ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                 const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
+                 const std::string& sort_keys, const bool is_topn);
     virtual ~ChunksSorter();
 
     static StatusOr<vectorized::ChunkPtr> materialize_chunk_before_sort(vectorized::Chunk* chunk,
@@ -113,7 +117,8 @@ public:
 
     bool sink_complete();
 
-    // pull_chunk for pipeline.
+    // Pull chunk version for pipeline.
+    // Return false if there is no more chunks
     virtual bool pull_chunk(ChunkPtr* chunk) = 0;
 
     virtual int64_t mem_usage() const = 0;

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -12,9 +12,9 @@
 namespace starrocks::vectorized {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
-                                           const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                                           const std::string& sort_keys)
-        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, false) {}
+                                           const std::vector<bool>* is_asc_order,
+                                           const std::vector<bool>* is_null_first, const std::string& sort_keys)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
 

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -21,7 +21,7 @@ public:
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
-                         const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                         const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
                          const std::string& sort_keys);
     ~ChunksSorterFullSort() override;
 

--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.h
@@ -213,9 +213,11 @@ class ChunksSorterHeapSort final : public ChunksSorter {
 public:
     using DataSegmentPtr = std::shared_ptr<DataSegment>;
     ChunksSorterHeapSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
-                         const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                         const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
                          const std::string& sort_keys, size_t offset, size_t limit)
-            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true), _offset(offset), _limit(limit) {}
+            : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, true),
+              _offset(offset),
+              _limit(limit) {}
     ~ChunksSorterHeapSort() = default;
 
     Status update(RuntimeState* state, const ChunkPtr& chunk) override;

--- a/be/src/exec/vectorized/partition/chunks_partitioner.cpp
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.cpp
@@ -4,7 +4,6 @@
 
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
-#include "runtime/current_thread.h"
 
 namespace starrocks::vectorized {
 
@@ -79,33 +78,6 @@ Status ChunksPartitioner::offer(const ChunkPtr& chunk) {
 
 int32_t ChunksPartitioner::num_partitions() {
     return _hash_map_variant.size();
-}
-
-template <typename Consumer>
-Status ChunksPartitioner::accept(Consumer&& consumer) {
-    // First, fetch chunks from hash map
-    if (false) {
-    }
-#define HASH_MAP_METHOD(NAME)                                                                           \
-    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                           \
-        TRY_CATCH_BAD_ALLOC(fetch_chunks_from_hash_map<decltype(_hash_map_variant.NAME)::element_type>( \
-                *_hash_map_variant.NAME, consumer));                                                    \
-    }
-    APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
-#undef HASH_MAP_METHOD
-
-    // Second, fetch chunks from null_key_value if any
-    if (false) {
-    }
-#define HASH_MAP_METHOD(NAME)                                                                                 \
-    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                                 \
-        TRY_CATCH_BAD_ALLOC(fetch_chunks_from_null_key_value<decltype(_hash_map_variant.NAME)::element_type>( \
-                *_hash_map_variant.NAME, consumer));                                                          \
-    }
-    APPLY_FOR_PARTITION_VARIANT_NULL(HASH_MAP_METHOD)
-#undef HASH_MAP_METHOD
-
-    return Status::OK();
 }
 
 bool ChunksPartitioner::_is_partition_columns_fixed_size(const std::vector<ExprContext*>& partition_expr_ctxs,

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1095,7 +1095,7 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             for (auto j = 1; j < profiles.size(); j++) {
                 auto* profile = profiles[j];
                 if (i >= profile->num_children()) {
-                    LOG(WARNING) << "find non-isomorphic children, profile_name" << profile0->name()
+                    LOG(WARNING) << "find non-isomorphic children, profile_name=" << profile0->name()
                                  << ", another profile_name=" << profile->name();
                     return;
                 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5885

## Enhancement

```sql
select * from (
    select *, rank() over (partition by v2 order by v3) as rk from t0
) sub_t0
where rk < 5;
```

For rank window function, including `rank`、`dense_rank`、`row_number`, if it has a related predicate (`rk < 5`), then it can be optimized by inserting a `PartitionTopN` operator before the `Sort` operator of window function. 

**The main purpose of `PartitionTopN` is to filter data, and it's output still remain unordered. It consists of three components:**

* `partitioner`：Divide the input chunk based on the partition exprs
* `sorter(topn)`：Each partition has an instance of sorter and is sorted independently
* `gather`：fetch chunks from all sorters into one data stream, so the data is still unordered after gahtering. Moreover, gather is a only logical concetp, not an actual component

```


                                   ┌────► topn─────┐
                                   │               │
 (unordered)                       │               │                  (unordered)
 inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
                                   │               │
                                   │               │
                                   └────► topn ────┘
```

**The implementation on the optimizer and the executor is a little different:**

* In optimizer, for simplicity, we do not define a new pair of `{Logical/Physical}PartitionTopNOperator`  but reuse the existing `{Logical/Physical}TopNOperator` by adding a new field `partitionByExprs` to record the partition by information. Besides, we need to pay attentation to the following things: 
    * Make sure that we cannot derive sort property from PartitionTopN
    * Make sure that ExchangeNode not set limit if PartitionTopN
* In executor, we define a new pair of `LocalPartitionTopN{Sink/Source}Operator`, and we may use different implementation based on the field `partitionByExprs`
    * if `partitionByExprs` is unset or empty, then the original pair of `PartitionSortSinkOperator/LocalMergeSortSourceOperator` is used
    * if `partitionByExprs` is not empty, then pair of `LocalPartitionTopN{Sink/Source}Operator` is used

## Tasks

- [x] Support component partitioner
    * only support one partition expr right now
- [x] **Support PartitionTopN(this pr)**
- [ ] Support `row_number`
- [ ] Support `rank`
    * by supporting TopN limit by rank
- [ ] Support `dense_rank`
    * by supporting TopN limit by dense_rank
- [ ] Support multi partition exprs
