### PR TITLE
[Enhancement] window function optimization, support rank (5)

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -13,8 +13,9 @@ const int32_t LocalPartitionTopnContext::MAX_PARTITION_NUM = 4096;
 LocalPartitionTopnContext::LocalPartitionTopnContext(
         const std::vector<TExpr>& t_partition_exprs, SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order,
         std::vector<bool> is_null_first, const std::string& sort_keys, int64_t offset, int64_t partition_limit,
-        const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-        const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc)
+        const TTopNType::type topn_type, const std::vector<OrderByType>& order_by_types,
+        TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
+        const RowDescriptor& parent_node_child_row_desc)
         : _t_partition_exprs(t_partition_exprs),
           _sort_exec_exprs(sort_exec_exprs),
           _is_asc_order(is_asc_order),
@@ -22,6 +23,7 @@ LocalPartitionTopnContext::LocalPartitionTopnContext(
           _sort_keys(sort_keys),
           _offset(offset),
           _partition_limit(partition_limit),
+          _topn_type(topn_type),
           _order_by_types(order_by_types),
           _materialized_tuple_desc(materialized_tuple_desc),
           _parent_node_row_desc(parent_node_row_desc),
@@ -78,7 +80,7 @@ Status LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorter
     for (int i = 0; i < num_partitions; ++i) {
         _chunks_sorters[i] = std::make_shared<vectorized::ChunksSorterTopn>(
                 state, &_sort_exec_exprs.lhs_ordering_expr_ctxs(), &_is_asc_order, &_is_null_first, _sort_keys, _offset,
-                _partition_limit, vectorized::ChunksSorterTopn::tunning_buffered_chunks(_partition_limit));
+                _partition_limit, _topn_type, vectorized::ChunksSorterTopn::tunning_buffered_chunks(_partition_limit));
     }
     RETURN_IF_ERROR(
             _chunks_partitioner->accept([this, state](int32_t partition_idx, const vectorized::ChunkPtr& chunk) {
@@ -140,7 +142,7 @@ StatusOr<vectorized::ChunkPtr> LocalPartitionTopnContext::pull_one_chunk_from_so
 LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
         const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
         SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-        const std::string& sort_keys, int64_t offset, int64_t partition_limit,
+        const std::string& sort_keys, int64_t offset, int64_t partition_limit, const TTopNType::type topn_type,
         const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
         const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc)
         : _ctxs(degree_of_parallelism),
@@ -151,6 +153,7 @@ LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
           _sort_keys(sort_keys),
           _offset(offset),
           _partition_limit(partition_limit),
+          _topn_type(topn_type),
           _order_by_types(order_by_types),
           _materialized_tuple_desc(materialized_tuple_desc),
           _parent_node_row_desc(parent_node_row_desc),
@@ -162,7 +165,7 @@ LocalPartitionTopnContext* LocalPartitionTopnContextFactory::create(int32_t driv
     if (_ctxs[driver_sequence] == nullptr) {
         _ctxs[driver_sequence] = std::make_shared<LocalPartitionTopnContext>(
                 _t_partition_exprs, _sort_exec_exprs, _is_asc_order, _is_null_first, _sort_keys, _offset,
-                _partition_limit, _order_by_types, _materialized_tuple_desc, _parent_node_row_desc,
+                _partition_limit, _topn_type, _order_by_types, _materialized_tuple_desc, _parent_node_row_desc,
                 _parent_node_child_row_desc);
     }
 

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -28,8 +28,8 @@ public:
     LocalPartitionTopnContext(const std::vector<TExpr>& t_partition_exprs, SortExecExprs& sort_exec_exprs,
                               std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
                               const std::string& sort_keys, int64_t offset, int64_t partition_limit,
-                              const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-                              const RowDescriptor& parent_node_row_desc,
+                              const TTopNType::type topn_type, const std::vector<OrderByType>& order_by_types,
+                              TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
                               const RowDescriptor& parent_node_child_row_desc);
 
     Status prepare(RuntimeState* state);
@@ -84,6 +84,7 @@ private:
     const std::string _sort_keys;
     int64_t _offset;
     int64_t _partition_limit;
+    const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
     TupleDescriptor* _materialized_tuple_desc;
     const RowDescriptor& _parent_node_row_desc;
@@ -99,7 +100,8 @@ public:
     LocalPartitionTopnContextFactory(const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
                                      SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order,
                                      std::vector<bool> is_null_first, const std::string& sort_keys, int64_t offset,
-                                     int64_t partition_limit, const std::vector<OrderByType>& order_by_types,
+                                     int64_t partition_limit, const TTopNType::type topn_type,
+                                     const std::vector<OrderByType>& order_by_types,
                                      TupleDescriptor* materialized_tuple_desc,
                                      const RowDescriptor& parent_node_row_desc,
                                      const RowDescriptor& parent_node_child_row_desc);
@@ -118,6 +120,7 @@ private:
     const std::string _sort_keys;
     int64_t _offset;
     int64_t _partition_limit;
+    const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
     TupleDescriptor* _materialized_tuple_desc;
     const RowDescriptor& _parent_node_row_desc;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -67,7 +67,7 @@ Status PartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
 OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver_sequence) {
     std::shared_ptr<ChunksSorter> chunks_sorter;
     if (_limit >= 0) {
-        if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
+        if (_topn_type == TTopNType::ROW_NUMBER && _limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
             chunks_sorter = std::make_unique<ChunksSorterHeapSort>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
                     _sort_keys, _offset, _limit);
@@ -75,7 +75,7 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
             size_t max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, _offset, _limit, max_buffered_chunks);
+                    _sort_keys, _offset, _limit, _topn_type, max_buffered_chunks);
         }
     } else {
         chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(runtime_state(),

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -86,9 +86,10 @@ public:
     PartitionSortSinkOperatorFactory(
             int32_t id, int32_t plan_node_id, std::shared_ptr<SortContextFactory> sort_context_factory,
             SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-            const std::string& sort_keys, int64_t offset, int64_t limit, const std::vector<OrderByType>& order_by_types,
-            TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
-            const RowDescriptor& parent_node_child_row_desc, const std::vector<ExprContext*>& analytic_partition_exprs)
+            const std::string& sort_keys, int64_t offset, int64_t limit, const TTopNType::type topn_type,
+            const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
+            const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc,
+            const std::vector<ExprContext*>& analytic_partition_exprs)
             : OperatorFactory(id, "partition_sort_sink", plan_node_id),
               _sort_context_factory(sort_context_factory),
               _sort_exec_exprs(sort_exec_exprs),
@@ -97,6 +98,7 @@ public:
               _sort_keys(sort_keys),
               _offset(offset),
               _limit(limit),
+              _topn_type(topn_type),
               _order_by_types(order_by_types),
               _materialized_tuple_desc(materialized_tuple_desc),
               _parent_node_row_desc(parent_node_row_desc),
@@ -119,6 +121,7 @@ private:
     const std::string _sort_keys;
     int64_t _offset;
     int64_t _limit;
+    const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
 
     // Cached descriptor for the materialized tuple. Assigned in Prepare().

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -24,9 +24,11 @@ using vectorized::SortedRuns;
 
 class SortContext final : public ContextWithDependency {
 public:
-    explicit SortContext(RuntimeState* state, int64_t limit, const int32_t num_right_sinkers,
-                         const std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs)
+    explicit SortContext(RuntimeState* state, const TTopNType::type topn_type, int64_t limit,
+                         const int32_t num_right_sinkers, const std::vector<ExprContext*> sort_exprs,
+                         const SortDescs& sort_descs)
             : _state(state),
+              _topn_type(topn_type),
               _limit(limit),
               _num_partition_sinkers(num_right_sinkers),
               _sort_exprs(sort_exprs),
@@ -59,6 +61,7 @@ private:
     Status _merge_inputs();
 
     RuntimeState* _state;
+    const TTopNType::type _topn_type;
     const int64_t _limit;
     const int32_t _num_partition_sinkers;
     const std::vector<ExprContext*> _sort_exprs;
@@ -75,14 +78,15 @@ private:
 
 class SortContextFactory {
 public:
-    SortContextFactory(RuntimeState* state, bool is_merging, int64_t limit, int32_t num_right_sinkers,
-                       const std::vector<ExprContext*>& sort_exprs, const std::vector<bool>& _is_asc_order,
-                       const std::vector<bool>& is_null_first);
+    SortContextFactory(RuntimeState* state, const TTopNType::type topn_type, bool is_merging, int64_t limit,
+                       int32_t num_right_sinkers, const std::vector<ExprContext*>& sort_exprs,
+                       const std::vector<bool>& _is_asc_order, const std::vector<bool>& is_null_first);
 
     SortContextPtr create(int32_t idx);
 
 private:
     RuntimeState* _state;
+    const TTopNType::type _topn_type;
     // _is_merging is true means to merge multiple output streams of PartitionSortSinkOperators into a common
     // LocalMergeSortSourceOperator that will produce a total order output stream.
     // _is_merging is false means to pipe each output stream of PartitionSortSinkOperators to an independent

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -14,7 +14,7 @@
 
 namespace starrocks::vectorized {
 
-static void get_compare_results_colwise(size_t row_to_sort, Columns& order_by_columns,
+static void get_compare_results_colwise(size_t number_of_rows_to_sort, Columns& order_by_columns,
                                         std::vector<CompareVector>& compare_results_array,
                                         std::vector<DataSegment>& data_segments,
                                         const std::vector<int>& sort_order_flags,
@@ -32,7 +32,7 @@ static void get_compare_results_colwise(size_t row_to_sort, Columns& order_by_co
         std::vector<Datum> rhs_values;
         auto& segment = data_segments[i];
         for (size_t col_idx = 0; col_idx < order_by_column_size; col_idx++) {
-            rhs_values.push_back(order_by_columns[col_idx]->get(row_to_sort));
+            rhs_values.push_back(order_by_columns[col_idx]->get(number_of_rows_to_sort));
         }
         compare_columns(segment.order_by_columns, compare_results_array[i], rhs_values, sort_order_flags,
                         null_first_flags);
@@ -86,6 +86,9 @@ Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, si
             size_t local_first_size = middle_num;
             for (size_t j = 0; j < rows; ++j) {
                 if (compare_results_array[i][j] < 0) {
+                    filter_array[i][j] = DataSegment::IN_LAST_RESULT;
+                    ++middle_num;
+                } else if (compare_results_array[i][j] == 0) {
                     filter_array[i][j] = DataSegment::IN_LAST_RESULT;
                     ++middle_num;
                 }

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -14,7 +14,7 @@
 
 namespace starrocks::vectorized {
 
-static void get_compare_results_colwise(size_t number_of_rows_to_sort, Columns& order_by_columns,
+static void get_compare_results_colwise(size_t rows_to_sort, Columns& order_by_columns,
                                         std::vector<CompareVector>& compare_results_array,
                                         std::vector<DataSegment>& data_segments,
                                         const std::vector<int>& sort_order_flags,
@@ -32,14 +32,14 @@ static void get_compare_results_colwise(size_t number_of_rows_to_sort, Columns& 
         std::vector<Datum> rhs_values;
         auto& segment = data_segments[i];
         for (size_t col_idx = 0; col_idx < order_by_column_size; col_idx++) {
-            rhs_values.push_back(order_by_columns[col_idx]->get(number_of_rows_to_sort));
+            rhs_values.push_back(order_by_columns[col_idx]->get(rows_to_sort));
         }
         compare_columns(segment.order_by_columns, compare_results_array[i], rhs_values, sort_order_flags,
                         null_first_flags);
     }
 }
 
-Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, size_t number_of_rows_to_sort,
+Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, size_t rows_to_sort,
                                      std::vector<std::vector<uint8_t>>& filter_array,
                                      const std::vector<int>& sort_order_flags, const std::vector<int>& null_first_flags,
                                      uint32_t& least_num, uint32_t& middle_num) {
@@ -48,14 +48,14 @@ Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, si
 
     // first compare with last row of this chunk.
     {
-        get_compare_results_colwise(number_of_rows_to_sort - 1, order_by_columns, compare_results_array, data_segments,
+        get_compare_results_colwise(rows_to_sort - 1, order_by_columns, compare_results_array, data_segments,
                                     sort_order_flags, null_first_flags);
     }
 
     // but we only have one compare.
     // compare with first row of this DataSegment,
     // then we set BEFORE_LAST_RESULT and IN_LAST_RESULT at filter_array.
-    if (number_of_rows_to_sort == 1) {
+    if (rows_to_sort == 1) {
         least_num = 0, middle_num = 0;
         filter_array.resize(dats_segment_size);
         for (size_t i = 0; i < dats_segment_size; ++i) {
@@ -85,10 +85,7 @@ Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, si
 
             size_t local_first_size = middle_num;
             for (size_t j = 0; j < rows; ++j) {
-                if (compare_results_array[i][j] < 0) {
-                    filter_array[i][j] = DataSegment::IN_LAST_RESULT;
-                    ++middle_num;
-                } else if (compare_results_array[i][j] == 0) {
+                if (compare_results_array[i][j] <= 0) {
                     filter_array[i][j] = DataSegment::IN_LAST_RESULT;
                     ++middle_num;
                 }

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -123,9 +123,6 @@ public:
 
     virtual int64_t mem_usage() const = 0;
 
-    // For test only
-    void set_compare_strategy(CompareStrategy cmp) { _compare_strategy = cmp; }
-
 protected:
     size_t _get_number_of_order_by_columns() const { return _sort_exprs->size(); }
 
@@ -147,8 +144,6 @@ protected:
     RuntimeProfile::Counter* _output_timer = nullptr;
 
     std::atomic<bool> _is_sink_complete = false;
-
-    CompareStrategy _compare_strategy = ColumnWise;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -148,7 +148,7 @@ protected:
 
     std::atomic<bool> _is_sink_complete = false;
 
-    CompareStrategy _compare_strategy = Default;
+    CompareStrategy _compare_strategy = ColumnWise;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -35,14 +35,14 @@ struct DataSegment {
 
     // there is two compares in the method,
     // the first is:
-    //     compare every row in every DataSegment of data_segments with number_of_rows_to_sort - 1 row of this DataSegment,
+    //     compare every row in every DataSegment of data_segments with rows_to_sort - 1 row of this DataSegment,
     //     obtain every row compare result in compare_results_array, if < 0, use it to set IN at filter_array.
     // the second is:
     //     compare every row in compare_results_array that less than 0, use it to compare with first row of this DataSegment,
     //     as the first step, we set BEFORE_LAST_RESULT at filter_array.
     //
     // Actually, we Count the results in the first compare for the second compare.
-    Status get_filter_array(std::vector<DataSegment>& data_segments, size_t number_of_rows_to_sort,
+    Status get_filter_array(std::vector<DataSegment>& data_segments, size_t rows_to_sort,
                             std::vector<std::vector<uint8_t>>& filter_array, const std::vector<int>& sort_order_flags,
                             const std::vector<int>& null_first_flags, uint32_t& least_num, uint32_t& middle_num);
 

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -377,7 +377,6 @@ Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& s
     merged_perm.reserve(rows_to_keep);
     SortDescs sort_desc(_sort_order_flag, _null_first_flag);
 
-    DCHECK_EQ(_compare_strategy, ColumnWise);
     RETURN_IF_ERROR(merge_sorted_chunks_two_way(sort_desc, {left_chunk, left_columns}, {right_chunk, right_columns},
                                                 &merged_perm));
     CHECK_GE(merged_perm.size(), rows_to_keep);
@@ -471,7 +470,6 @@ Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutatio
     big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
 
     // Initial this big chunk.
-    DCHECK_EQ(_compare_strategy, ColumnWise);
     std::vector<ChunkPtr> chunks;
     for (auto& segment : segments) {
         chunks.push_back(segment.chunk);

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -16,14 +16,17 @@
 namespace starrocks::vectorized {
 
 ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
-                                   const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                                   const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
                                    const std::string& sort_keys, size_t offset, size_t limit,
-                                   size_t max_buffered_chunks)
-        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true),
-          _offset(offset),
-          _limit(limit),
+                                   const TTopNType::type topn_type, size_t max_buffered_chunks)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, true),
           _max_buffered_chunks(max_buffered_chunks),
-          _init_merged_segment(false) {
+          _init_merged_segment(false),
+          _limit(limit),
+          _topn_type(topn_type),
+          _offset(offset) {
+    DCHECK_GT(_get_number_of_rows_to_sort(), 0) << "output rows can't be empty";
+    DCHECK(_topn_type == TTopNType::ROW_NUMBER || _offset == 0);
     auto& raw_chunks = _raw_chunks.chunks;
     raw_chunks.reserve(max_buffered_chunks);
 }
@@ -135,7 +138,7 @@ Status ChunksSorterTopn::_sort_chunks(RuntimeState* state) {
     // permutations for this batch:
     // if _init_merged_segment == false, means this is first batch:
     //     permutations.first is empty, and permutations.second is contains this batch.
-    // else if _init_merged_segment == false, means this is not first batch, _merged_segment[low_value, high_value] is not empty:
+    // else if _init_merged_segment == true, means this is not first batch, _merged_segment[low_value, high_value] is not empty:
     //     permutations.first < low_value and low_value <= permutations.second < high_value(in the case of asc).
     //
     std::pair<Permutation, Permutation> permutations;
@@ -234,7 +237,7 @@ void ChunksSorterTopn::_set_permutation_complete(std::pair<Permutation, Permutat
 // step 3: set this result in filter_array, BEOFRE(filter_array's value is 2), IN(filter_array's value is 1), others is give up.
 // all this is done in get_filter_array.
 //
-// and maybe _merged_segment'size is not enough as < number_of_rows_to_sort,
+// and maybe _merged_segment'size is not enough as < rows_to_sort,
 // this case we just use first row to filter all rows to get BEFORE.
 // this is done in get_filter_array
 //
@@ -246,28 +249,22 @@ Status ChunksSorterTopn::_filter_and_sort_data(RuntimeState* state, std::pair<Pe
 
     DCHECK(_get_number_of_order_by_columns() > 0) << "order by columns can't be empty";
 
-    const int64_t number_of_rows_to_sort = _get_number_of_rows_to_sort();
-    DCHECK(number_of_rows_to_sort > 0) << "output rows can't be empty";
+    const size_t rows_to_sort = _get_number_of_rows_to_sort();
 
     if (_init_merged_segment) {
         std::vector<std::vector<uint8_t>> filter_array;
         uint32_t least_num, middle_num;
 
-        // bytes_for_filter is use to check memory usage,
-        // because memory increase in get_filter_array and get_filter_array
-        // and that maybe return ERROR Status, so we use bytes_for_filter for memory that release after filter.
-        // bytes_for_filter's use have 2 cases:
-        // in get_filter_array:
-        // part 1: std::vector<std::vector<uint64_t>> rows_to_compare_array;
-        // part 2: std::vector<std::vector<uint8_t>>& filter_array, std::vector<size_t> first_size_array and std::vector<std::vector<uint64_t>> rows_to_compare_array(second compare).
-        //
-        // part 1 and part 2 is not coexistence, and we use bytes_for_filter to get the larger of them,
-        // subtract filter_array's memory in bytes_for_filter at end. because filter_array is used remainly.
+        // Here are 2 cases:
+        // case 1: _merged_segment.chunk->num_rows() >= rows_to_sort, which means we already have enough rows,
+        // so we can use both index of `0` and `rows_to_sort - 1` as the left and right boundary to filter the coming input chunks
+        // into three parts, BEFORE_LAST_RESULT, IN_LAST_RESULT and the part to be dropped
+        // case 2: _merged_segment.chunk->num_rows() < rows_to_sort, which means we haven't have enough rows,
+        // so we can only use the index of `0` as the left boundary to filter the coming input chunks into two parts, BEFORE_LAST_RESULT and IN_LAST_RESULT
 
-        if (number_of_rows_to_sort > 1 && _merged_segment.chunk->num_rows() >= number_of_rows_to_sort) {
-            RETURN_IF_ERROR(_merged_segment.get_filter_array(segments, number_of_rows_to_sort, filter_array,
-                                                             _sort_order_flag, _null_first_flag, least_num,
-                                                             middle_num));
+        if (_merged_segment.chunk->num_rows() >= rows_to_sort) {
+            RETURN_IF_ERROR(_merged_segment.get_filter_array(segments, rows_to_sort, filter_array, _sort_order_flag,
+                                                             _null_first_flag, least_num, middle_num));
         } else {
             RETURN_IF_ERROR(_merged_segment.get_filter_array(segments, 1, filter_array, _sort_order_flag,
                                                              _null_first_flag, least_num, middle_num));
@@ -278,12 +275,16 @@ Status ChunksSorterTopn::_filter_and_sort_data(RuntimeState* state, std::pair<Pe
             ScopedTimer<MonotonicStopWatch> timer(_build_timer);
             permutations.first.resize(least_num);
             // BEFORE's size is enough, so we ignore IN.
-            if (least_num >= number_of_rows_to_sort) {
+            if (least_num >= rows_to_sort) {
                 // use filter_array to set permutations.first.
                 _set_permutation_before(permutations.first, segments.size(), filter_array);
-            } else if (number_of_rows_to_sort > 1) {
-                // if number_of_rows_to_sort == 1, first row and last row is the same identity. so we do nothing.
-                // BEFORE's size < number_of_rows_to_sort, we need set permutations.first and permutations.second.
+            } else if (rows_to_sort > 1 || _topn_type == TTopNType::RANK) {
+                // If rows_to_sort == 1, here are two cases:
+                // case 1: _topn_type is TTopNType::ROW_NUMBER, first row and last row is the same identity. so we do nothing.
+                // case 2: _topn_type is TTopNType::RANK, we need to contain all the rows equal with the last row of merged segment,
+                // and these equals row maybe exist in the second part
+
+                // BEFORE's size < rows_to_sort, we need set permutations.first and permutations.second.
                 permutations.second.resize(middle_num);
 
                 // use filter_array to set permutations.first and permutations.second.
@@ -293,18 +294,19 @@ Status ChunksSorterTopn::_filter_and_sort_data(RuntimeState* state, std::pair<Pe
         timer.start();
     }
 
-    return _partial_sort_col_wise(state, permutations, segments, chunk_size, number_of_rows_to_sort);
+    return _partial_sort_col_wise(state, permutations, segments, chunk_size, rows_to_sort);
 }
 
 Status ChunksSorterTopn::_partial_sort_col_wise(RuntimeState* state, std::pair<Permutation, Permutation>& permutations,
-                                                DataSegments& segments, const size_t chunk_size, size_t rows_to_sort) {
+                                                DataSegments& segments, const size_t chunk_size,
+                                                const size_t rows_to_sort) {
     std::vector<Columns> vertical_chunks;
     for (auto& segment : segments) {
         vertical_chunks.push_back(segment.order_by_columns);
     }
     auto do_sort = [&](Permutation& perm, size_t limit) {
         return sort_vertical_chunks(state->cancelled_ref(), vertical_chunks, _sort_order_flag, _null_first_flag, perm,
-                                    limit);
+                                    limit, _topn_type == TTopNType::RANK);
     };
 
     size_t first_size = std::min(permutations.first.size(), rows_to_sort);
@@ -318,6 +320,11 @@ Status ChunksSorterTopn::_partial_sort_col_wise(RuntimeState* state, std::pair<P
     if (rows_to_sort > first_size) {
         RETURN_IF_CANCELLED(state);
         RETURN_IF_ERROR(do_sort(permutations.second, rows_to_sort - first_size));
+    } else if (_topn_type == TTopNType::RANK) {
+        // if _topn_type is TTopNType::RANK, we need to contain all the rows equal with the last row of merged segment,
+        // and these equals row maybe exist in the second part, we can fetch these part by set rank limit number to 1
+        RETURN_IF_CANCELLED(state);
+        RETURN_IF_ERROR(do_sort(permutations.second, 1));
     }
 
     return Status::OK();
@@ -328,14 +335,11 @@ Status ChunksSorterTopn::_merge_sort_data_as_merged_segment(RuntimeState* state,
                                                             DataSegments& segments) {
     ScopedTimer<MonotonicStopWatch> timer(_merge_timer);
 
-    size_t sort_row_number = _get_number_of_rows_to_sort();
-    DCHECK(sort_row_number > 0) << "output rows can't be empty";
-
     if (_init_merged_segment) {
-        RETURN_IF_ERROR(_hybrid_sort_common(state, new_permutation, segments, sort_row_number));
+        RETURN_IF_ERROR(_hybrid_sort_common(state, new_permutation, segments));
     } else {
         // the first batch chunks, just new_permutation.second.
-        RETURN_IF_ERROR(_hybrid_sort_first_time(state, new_permutation.second, segments, sort_row_number));
+        RETURN_IF_ERROR(_hybrid_sort_first_time(state, new_permutation.second, segments));
         _init_merged_segment = true;
     }
 
@@ -347,9 +351,9 @@ Status ChunksSorterTopn::_merge_sort_data_as_merged_segment(RuntimeState* state,
     return Status::OK();
 }
 
-// take sort_row_number rows from permutation_second merge-sort with _merged_segment.
+// take rows_to_sort rows from permutation_second merge-sort with _merged_segment.
 // And take result datas into big_chunk.
-Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, size_t sort_row_number,
+Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, const size_t rows_to_keep,
                                             size_t sorted_size, size_t permutation_size,
                                             Permutation& permutation_second) {
     // Assemble the permutated segments into a chunk
@@ -370,18 +374,14 @@ Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& s
     Columns left_columns = _merged_segment.order_by_columns;
 
     Permutation merged_perm;
-    merged_perm.reserve(sort_row_number);
+    merged_perm.reserve(rows_to_keep);
     SortDescs sort_desc(_sort_order_flag, _null_first_flag);
 
-    if (_compare_strategy == RowWise) {
-        RETURN_IF_ERROR(merge_sorted_chunks_two_way_rowwise(sort_desc, left_columns, right_columns, &merged_perm,
-                                                            sort_row_number));
-    } else {
-        RETURN_IF_ERROR(merge_sorted_chunks_two_way(sort_desc, {left_chunk, left_columns}, {right_chunk, right_columns},
-                                                    &merged_perm));
-        CHECK_GE(merged_perm.size(), sort_row_number);
-        merged_perm.resize(sort_row_number);
-    }
+    DCHECK_EQ(_compare_strategy, ColumnWise);
+    RETURN_IF_ERROR(merge_sorted_chunks_two_way(sort_desc, {left_chunk, left_columns}, {right_chunk, right_columns},
+                                                &merged_perm));
+    CHECK_GE(merged_perm.size(), rows_to_keep);
+    merged_perm.resize(rows_to_keep);
 
     std::vector<ChunkPtr> chunks{left_chunk, right_chunk};
     append_by_permutation(big_chunk.get(), chunks, merged_perm);
@@ -389,12 +389,22 @@ Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& s
 }
 
 Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Permutation, Permutation>& new_permutation,
-                                             DataSegments& segments, size_t sort_row_number) {
+                                             DataSegments& segments) {
+    const size_t rows_to_sort = _get_number_of_rows_to_sort();
+
     size_t first_size = new_permutation.first.size();
     size_t second_size = new_permutation.second.size();
 
     if (first_size == 0 && second_size == 0) {
         return Status::OK();
+    }
+
+    size_t rows_to_keep = rows_to_sort;
+    if (_topn_type == TTopNType::RANK && first_size > rows_to_keep) {
+        // For rank type, the number of rows may be greater than the specified limit rank number
+        // For example, given set [1, 1, 1, 1, 1] and limit rank number=2, all the element's rank is 1,
+        // so the size of BEFORE_LAST_RESULT part may greater than the specified limit rank number(2)
+        rows_to_keep = first_size;
     }
 
     ChunkPtr big_chunk;
@@ -404,22 +414,28 @@ Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Perm
     }
 
     if (first_size > 0) {
-        big_chunk.reset(segments[new_permutation.first[0].chunk_index].chunk->clone_empty(sort_row_number).release());
+        big_chunk.reset(segments[new_permutation.first[0].chunk_index].chunk->clone_empty(first_size).release());
         append_by_permutation(big_chunk.get(), chunks, new_permutation.first);
-        sort_row_number -= first_size;
+        rows_to_keep -= first_size;
     }
 
-    if (sort_row_number > 0) {
+    if (rows_to_keep > 0 || _topn_type == TTopNType::RANK) {
+        // In case of rows_to_keep == 0, through _merged_segment.get_filter_array,
+        // all the rows that equal to the last value of merged segment are stored in the IN_LAST_RESULT,
+        // so we also need to consider this part in type rank
         if (big_chunk == nullptr) {
-            big_chunk.reset(
-                    segments[new_permutation.second[0].chunk_index].chunk->clone_empty(sort_row_number).release());
+            big_chunk.reset(segments[new_permutation.second[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
         }
         size_t sorted_size = _merged_segment.chunk->num_rows();
-        sort_row_number = std::min(sort_row_number, sorted_size + second_size);
+        rows_to_keep = std::min(rows_to_keep, sorted_size + second_size);
+        if (_topn_type == TTopNType::RANK && sorted_size + second_size > rows_to_keep) {
+            rows_to_keep = sorted_size + second_size;
+        }
 
-        RETURN_IF_ERROR(_merge_sort_common(big_chunk, segments, sort_row_number, sorted_size, second_size,
+        RETURN_IF_ERROR(_merge_sort_common(big_chunk, segments, rows_to_keep, sorted_size, second_size,
                                            new_permutation.second));
     }
+
     if (big_chunk->reach_capacity_limit()) {
         LOG(WARNING) << "TopN sort encounter big chunk overflow";
         return Status::InternalError(fmt::format("TopN sort encounter big chunk overflow"));
@@ -433,34 +449,35 @@ Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Perm
 }
 
 Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutation& new_permutation,
-                                                 DataSegments& segments, size_t sort_row_number) {
-    sort_row_number = std::min(new_permutation.size(), sort_row_number);
+                                                 DataSegments& segments) {
+    const size_t rows_to_sort = _get_number_of_rows_to_sort();
 
-    if (sort_row_number > Column::MAX_CAPACITY_LIMIT) {
-        LOG(WARNING) << "topn sort row exceed rows limit " << sort_row_number;
-        return Status::InternalError(fmt::format("TopN sort exceed rows limit {}", sort_row_number));
+    size_t rows_to_keep = rows_to_sort;
+
+    rows_to_keep = std::min(new_permutation.size(), rows_to_keep);
+    if (_topn_type == TTopNType::RANK && new_permutation.size() > rows_to_keep) {
+        // For rank type, the number of rows may be greater than the specified limit rank number
+        // For example, given set [1, 1, 1, 1, 1], all the element's rank is 1, so we must keep
+        // all the element if rank limit number is 1
+        rows_to_keep = new_permutation.size();
+    }
+
+    if (rows_to_keep > Column::MAX_CAPACITY_LIMIT) {
+        LOG(WARNING) << "topn sort row exceed rows limit " << rows_to_keep;
+        return Status::InternalError(fmt::format("TopN sort exceed rows limit {}", rows_to_keep));
     }
 
     ChunkPtr big_chunk;
-    big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(sort_row_number).release());
+    big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
 
     // Initial this big chunk.
-    if (_compare_strategy != RowWise) {
-        std::vector<ChunkPtr> chunks;
-        for (auto& segment : segments) {
-            chunks.push_back(segment.chunk);
-        }
-        new_permutation.resize(sort_row_number);
-        append_by_permutation(big_chunk.get(), chunks, new_permutation);
-    } else {
-        // TODO: remove it
-        size_t index_of_merging = 0;
-        while (index_of_merging < sort_row_number) {
-            auto& permutation = new_permutation[index_of_merging];
-            big_chunk->append_safe(*segments[permutation.chunk_index].chunk, permutation.index_in_chunk, 1);
-            ++index_of_merging;
-        }
+    DCHECK_EQ(_compare_strategy, ColumnWise);
+    std::vector<ChunkPtr> chunks;
+    for (auto& segment : segments) {
+        chunks.push_back(segment.chunk);
     }
+    new_permutation.resize(rows_to_keep);
+    append_by_permutation(big_chunk.get(), chunks, new_permutation);
 
     if (big_chunk->reach_capacity_limit()) {
         LOG(WARNING) << "TopN sort encounter big chunk overflow";

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -40,15 +40,17 @@ public:
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
-     * @param is_asc         Orders on each column.
+     * @param is_asc_order         Orders on each column.
      * @param is_null_first  NULL values should at the head or tail.
      * @param offset         Number of top rows to skip.
      * @param limit          Number of top rows after those skipped to extract. Zero means no limit.
      * @param max_buffered_chunks  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
-    ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                     const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset = 0,
-                     size_t limit = 0, size_t max_buffered_chunks = kDefaultBufferedChunks);
+    ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                     const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
+                     const std::string& sort_keys, size_t offset = 0, size_t limit = 0,
+                     const TTopNType::type topn_type = TTopNType::ROW_NUMBER,
+                     size_t max_buffered_chunks = kDefaultBufferedChunks);
     ~ChunksSorterTopn() override;
 
     // Append a Chunk for sort.
@@ -74,31 +76,29 @@ private:
     // build data for top-n
     Status _build_sorting_data(RuntimeState* state, Permutation& permutation_second, DataSegments& segments);
 
-    Status _hybrid_sort_first_time(RuntimeState* state, Permutation& new_permutation, DataSegments& segments,
-                                   size_t sort_row_number);
+    Status _hybrid_sort_first_time(RuntimeState* state, Permutation& new_permutation, DataSegments& segments);
 
     Status _hybrid_sort_common(RuntimeState* state, std::pair<Permutation, Permutation>& new_permutation,
-                               DataSegments& segments, size_t sort_row_number);
+                               DataSegments& segments);
 
-    Status _merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, size_t sort_row_number, size_t sorted_size,
-                              size_t permutation_size, Permutation& new_permutation);
+    Status _merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, const size_t rows_to_keep,
+                              size_t sorted_size, size_t permutation_size, Permutation& new_permutation);
 
     static void _set_permutation_before(Permutation&, size_t size, std::vector<std::vector<uint8_t>>& filter_array);
 
     static void _set_permutation_complete(std::pair<Permutation, Permutation>&, size_t size,
                                           std::vector<std::vector<uint8_t>>& filter_array);
 
-    Status _filter_and_sort_data(RuntimeState* state, std::pair<Permutation, Permutation>& permutation,
+    Status _filter_and_sort_data(RuntimeState* state, std::pair<Permutation, Permutation>& permutations,
                                  DataSegments& segments, size_t chunk_size);
 
     Status _merge_sort_data_as_merged_segment(RuntimeState* state, std::pair<Permutation, Permutation>& new_permutation,
                                               DataSegments& segments);
 
     Status _partial_sort_col_wise(RuntimeState* state, std::pair<Permutation, Permutation>& permutations,
-                                  DataSegments& segments, const size_t chunk_size, size_t number_of_rows_to_sort);
+                                  DataSegments& segments, const size_t chunk_size, const size_t rows_to_sort);
 
     // buffer
-
     struct RawChunks {
         std::vector<ChunkPtr> chunks;
         size_t size_of_rows = 0;
@@ -116,14 +116,15 @@ private:
             size_of_rows = 0;
         }
     };
-
-    const size_t _offset;
-    const size_t _limit;
     const size_t _max_buffered_chunks;
-
     RawChunks _raw_chunks;
     bool _init_merged_segment;
     DataSegment _merged_segment;
+
+    const size_t _limit;
+    const TTopNType::type _topn_type;
+
+    const size_t _offset;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -423,7 +423,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
 
 Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<Columns>& vertical_chunks,
                             const std::vector<int>& sort_orders, const std::vector<int>& null_firsts, Permutation& perm,
-                            size_t limit) {
+                            size_t limit, bool is_limit_by_rank) {
     if (vertical_chunks.empty() || perm.empty()) {
         return Status::OK();
     }
@@ -453,7 +453,14 @@ Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<C
     }
 
     if (limit < perm.size()) {
-        perm.resize(limit);
+        if (is_limit_by_rank) {
+            int first_non_equal_pos = SIMD::find_zero(tie, limit);
+            if (first_non_equal_pos < perm.size()) {
+                perm.resize(first_non_equal_pos);
+            }
+        } else {
+            perm.resize(limit);
+        }
     }
 
     return Status::OK();

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -345,13 +345,14 @@ private:
     size_t _pruned_limit; // The pruned limit during partial sorting
 };
 
-Status sort_and_tie_column(const bool& cancel, const ColumnPtr column, bool is_asc_order, bool is_null_first,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, bool build_tie) {
+Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const bool is_asc_order,
+                           const bool is_null_first, SmallPermutation& permutation, Tie& tie, std::pair<int, int> range,
+                           bool build_tie) {
     ColumnSorter column_sorter(cancel, is_asc_order, is_null_first, permutation, tie, range, build_tie);
     return column->accept(&column_sorter);
 }
 
-Status sort_and_tie_columns(const bool& cancel, const Columns& columns, const std::vector<int>& sort_orders,
+Status sort_and_tie_columns(const bool cancel, const Columns& columns, const std::vector<int>& sort_orders,
                             const std::vector<int>& null_firsts, Permutation* permutation) {
     if (columns.size() < 1) {
         return Status::OK();
@@ -375,7 +376,7 @@ Status sort_and_tie_columns(const bool& cancel, const Columns& columns, const st
     return Status::OK();
 }
 
-Status stable_sort_and_tie_columns(const bool& cancel, const Columns& columns, const std::vector<int>& sort_orders,
+Status stable_sort_and_tie_columns(const bool cancel, const Columns& columns, const std::vector<int>& sort_orders,
                                    const std::vector<int>& null_firsts, SmallPermutation* small_perm) {
     if (columns.size() < 1) {
         return Status::OK();
@@ -407,9 +408,9 @@ Status stable_sort_and_tie_columns(const bool& cancel, const Columns& columns, c
     return Status::OK();
 }
 
-Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<ColumnPtr>& columns, bool is_asc_order,
-                             bool is_null_first, Permutation& permutation, Tie& tie, std::pair<int, int> range,
-                             bool build_tie, size_t limit, size_t* limited) {
+Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<ColumnPtr>& columns,
+                             const bool is_asc_order, const bool is_null_first, Permutation& permutation, Tie& tie,
+                             std::pair<int, int> range, const bool build_tie, const size_t limit, size_t* limited) {
     DCHECK_GT(columns.size(), 0);
     DCHECK_GT(permutation.size(), 0);
     VerticalColumnSorter sorter(cancel, columns, is_asc_order, is_null_first, permutation, tie, range, build_tie,
@@ -423,7 +424,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
 
 Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<Columns>& vertical_chunks,
                             const std::vector<int>& sort_orders, const std::vector<int>& null_firsts, Permutation& perm,
-                            size_t limit, bool is_limit_by_rank) {
+                            const size_t limit, const bool is_limit_by_rank) {
     if (vertical_chunks.empty() || perm.empty()) {
         return Status::OK();
     }
@@ -454,6 +455,14 @@ Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<C
 
     if (limit < perm.size()) {
         if (is_limit_by_rank) {
+            // Given that
+            // * number array `[1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5]`
+            // * rank array `[1, 1, 1, 1, 1, 1, 1, 8, 8, 10, 11, 12]`
+            // * tie array `[1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1]`
+            //
+            // Suppose we need to find rank-5, the 5-th of number array is `1`, so we need to consider the trailing equal values,
+            // but how to find the end of the trailing equal values? Use the tie structure, we can find the first non-equal value by `SIMD::find_zero(tie, limit)`.
+            // In this case, the first non-equals value is 2, index is 7, so we can get the limied array through truncating by 7
             int first_non_equal_pos = SIMD::find_zero(tie, limit);
             if (first_non_equal_pos < perm.size()) {
                 perm.resize(first_non_equal_pos);

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -10,6 +10,17 @@
 
 namespace starrocks::vectorized {
 
+enum RankType {
+    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 2, 3, 4, 5, 6]
+    RowNumber = 0,
+
+    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 1, 3, 3, 5, 6]
+    Rank = 1,
+
+    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 1, 2, 2, 3, 4]
+    DenseRank = 2,
+};
+
 enum CompareStrategy {
     Default = 0,
     RowWise = 1,
@@ -20,6 +31,7 @@ enum CompareStrategy {
 struct PermutationItem {
     uint32_t chunk_index;
     uint32_t index_in_chunk;
+    uint32_t rank_in_chunk;
 
     PermutationItem() = default;
     PermutationItem(uint32_t ci, uint32_t ii) : chunk_index(ci), index_in_chunk(ii) {}

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -10,13 +10,6 @@
 
 namespace starrocks::vectorized {
 
-enum CompareStrategy {
-    Default = 0,
-    RowWise = 1,
-    ColumnWise = 2,
-    ColumnInc = 3,
-};
-
 struct PermutationItem {
     uint32_t chunk_index;
     uint32_t index_in_chunk;

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -13,7 +13,6 @@ namespace starrocks::vectorized {
 struct PermutationItem {
     uint32_t chunk_index;
     uint32_t index_in_chunk;
-    uint32_t rank_in_chunk;
 
     PermutationItem() = default;
     PermutationItem(uint32_t ci, uint32_t ii) : chunk_index(ci), index_in_chunk(ii) {}

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -10,17 +10,6 @@
 
 namespace starrocks::vectorized {
 
-enum RankType {
-    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 2, 3, 4, 5, 6]
-    RowNumber = 0,
-
-    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 1, 3, 3, 5, 6]
-    Rank = 1,
-
-    // Of this type, rank of [13, 13, 17, 17, 21, 25] is [1, 1, 2, 2, 3, 4]
-    DenseRank = 2,
-};
-
 enum CompareStrategy {
     Default = 0,
     RowWise = 1,

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -35,7 +35,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
 // Sort multiple chunks in column-wise style
 Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<Columns>& vertical_chunks,
                             const std::vector<int>& sort_orders, const std::vector<int>& null_firsts, Permutation& perm,
-                            size_t limit);
+                            size_t limit, bool is_limit_by_rank = false);
 
 // Compare the column with the `rhs_value`, which must have the some type with column.
 // @param cmp_result compare result is written into this array, value must within -1,0,1

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -16,32 +16,34 @@ namespace starrocks::vectorized {
 // @param permutation input and output permutation
 // @param tie input and output tie
 // @param range sort range, {0, 0} means not build tie but sort data
-Status sort_and_tie_column(const bool& cancel, const ColumnPtr column, bool is_asc_order, bool is_null_first,
-                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, bool build_tie);
+Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const bool is_asc_order,
+                           const bool is_null_first, SmallPermutation& permutation, Tie& tie, std::pair<int, int> range,
+                           const bool build_tie);
 
 // Sort multiple columns using column-wise algorithm, output the order in permutation array
-Status sort_and_tie_columns(const bool& cancel, const Columns& columns, const std::vector<int>& sort_orders,
+Status sort_and_tie_columns(const bool cancel, const Columns& columns, const std::vector<int>& sort_orders,
                             const std::vector<int>& null_firsts, Permutation* permutation);
 
 // Sort multiple columns, and stable
-Status stable_sort_and_tie_columns(const bool& cancel, const Columns& columns, const std::vector<int>& sort_orders,
+Status stable_sort_and_tie_columns(const bool cancel, const Columns& columns, const std::vector<int>& sort_orders,
                                    const std::vector<int>& null_firsts, SmallPermutation* permutation);
 
 // Sort multiple columns in vertical
-Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<ColumnPtr>& columns, bool is_asc_order,
-                             bool is_null_first, Permutation& permutation, Tie& tie, std::pair<int, int> range,
-                             bool build_tie, size_t limit = 0, size_t* limited = nullptr);
+Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<ColumnPtr>& columns,
+                             const bool is_asc_order, const bool is_null_first, Permutation& permutation, Tie& tie,
+                             std::pair<int, int> range, const bool build_tie, const size_t limit = 0,
+                             size_t* limited = nullptr);
 
 // Sort multiple chunks in column-wise style
 Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<Columns>& vertical_chunks,
                             const std::vector<int>& sort_orders, const std::vector<int>& null_firsts, Permutation& perm,
-                            size_t limit, bool is_limit_by_rank = false);
+                            const size_t limit, const bool is_limit_by_rank = false);
 
 // Compare the column with the `rhs_value`, which must have the some type with column.
 // @param cmp_result compare result is written into this array, value must within -1,0,1
 // @param rhs_value the compare value
-int compare_column(const ColumnPtr column, std::vector<int8_t>& cmp_result, Datum rhs_value, int sort_order,
-                   int null_first);
+int compare_column(const ColumnPtr column, std::vector<int8_t>& cmp_result, Datum rhs_value, const int sort_order,
+                   const int null_first);
 void compare_columns(const Columns columns, std::vector<int8_t>& cmp_result, const std::vector<Datum>& rhs_values,
                      const std::vector<int>& sort_orders, const std::vector<int>& null_firsts);
 

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -506,7 +506,8 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_fisrt) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2, 7, 2);
+        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2, 7,
+                                TTopNType::ROW_NUMBER, 2);
         sorter.set_compare_strategy(strategy);
 
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -548,7 +549,8 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
         int offset = 7;
         for (int limit = 8; limit + offset <= 16; limit++) {
             std::cerr << "sort with strategy: " << strategy << " limit:" << limit << std::endl;
-            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", offset, limit, 2);
+            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", offset, limit,
+                                    TTopNType::ROW_NUMBER, 2);
             sorter.set_compare_strategy(strategy);
             size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
@@ -570,7 +572,8 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
             EXPECT_EQ(permutation, result);
 
             // part sort with large offset
-            ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 100, limit, 2);
+            ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 100, limit,
+                                     TTopNType::ROW_NUMBER, 2);
             sorter2.set_compare_strategy(strategy);
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
@@ -596,7 +599,8 @@ TEST_F(ChunksSorterTest, order_by_with_unequal_sized_chunks) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
     // partial sort
-    ChunksSorterTopn full_sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1, 6, 2);
+    ChunksSorterTopn full_sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1, 6,
+                                 TTopNType::ROW_NUMBER, 2);
     ChunkPtr chunk_1 = _chunk_1->clone_empty();
     ChunkPtr chunk_2 = _chunk_2->clone_empty();
     for (size_t i = 0; i < _chunk_1->num_columns(); ++i) {

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -220,7 +220,6 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
-    sorter.set_compare_strategy(ColumnInc);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -303,7 +302,6 @@ TEST_F(ChunksSorterTest, topn_sort_with_limit) {
         for (int limit = 1; limit < kTotalRows; limit++) {
             std::cerr << fmt::format("order by column {} limit {}", name, limit) << std::endl;
             ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 0, limit);
-            sorter.set_compare_strategy(ColumnInc);
             size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
@@ -327,10 +325,6 @@ TEST_F(ChunksSorterTest, topn_sort_with_limit) {
     }
 }
 
-static std::vector<CompareStrategy> all_compare_strategy() {
-    return {RowWise, ColumnWise, ColumnInc};
-}
-
 // NOLINTNEXTLINE
 TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     std::vector<bool> is_asc, is_null_first;
@@ -342,29 +336,25 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
-        sorter.set_compare_strategy(strategy);
-        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-        sorter.update(_runtime_state.get(), _chunk_1);
-        sorter.update(_runtime_state.get(), _chunk_2);
-        sorter.update(_runtime_state.get(), _chunk_3);
-        sorter.done(_runtime_state.get());
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+    sorter.update(_runtime_state.get(), _chunk_1);
+    sorter.update(_runtime_state.get(), _chunk_2);
+    sorter.update(_runtime_state.get(), _chunk_3);
+    sorter.done(_runtime_state.get());
 
-        ChunkPtr page_1 = consume_page_from_sorter(sorter);
+    ChunkPtr page_1 = consume_page_from_sorter(sorter);
 
-        ASSERT_EQ(16, total_rows);
-        ASSERT_EQ(16, page_1->num_rows());
-        const size_t Size = 16;
-        std::vector<int32_t> permutation{69, 70, 71, 2, 4, 6, 12, 16, 24, 41, 49, 52, 54, 55, 56, 58};
-        std::vector<int32_t> result;
-        for (size_t i = 0; i < Size; ++i) {
-            result.push_back(page_1->get(i).get(0).get_int32());
-        }
-        EXPECT_EQ(permutation, result);
-        fmt::print("result: {}\n", fmt::join(result, ","));
+    ASSERT_EQ(16, total_rows);
+    ASSERT_EQ(16, page_1->num_rows());
+    const size_t Size = 16;
+    std::vector<int32_t> permutation{69, 70, 71, 2, 4, 6, 12, 16, 24, 41, 49, 52, 54, 55, 56, 58};
+    std::vector<int32_t> result;
+    for (size_t i = 0; i < Size; ++i) {
+        result.push_back(page_1->get(i).get(0).get_int32());
     }
+    EXPECT_EQ(permutation, result);
+    fmt::print("result: {}\n", fmt::join(result, ","));
 
     clear_sort_exprs(sort_exprs);
 }
@@ -380,28 +370,24 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
-        sorter.set_compare_strategy(strategy);
-        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-        sorter.update(_runtime_state.get(), _chunk_1);
-        sorter.update(_runtime_state.get(), _chunk_2);
-        sorter.update(_runtime_state.get(), _chunk_3);
-        sorter.done(_runtime_state.get());
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+    sorter.update(_runtime_state.get(), _chunk_1);
+    sorter.update(_runtime_state.get(), _chunk_2);
+    sorter.update(_runtime_state.get(), _chunk_3);
+    sorter.done(_runtime_state.get());
 
-        ChunkPtr page_1 = consume_page_from_sorter(sorter);
+    ChunkPtr page_1 = consume_page_from_sorter(sorter);
 
-        ASSERT_EQ(16, total_rows);
-        ASSERT_EQ(16, page_1->num_rows());
-        const size_t Size = 16;
-        std::vector<int32_t> permutation{58, 56, 55, 54, 52, 49, 41, 24, 16, 12, 6, 4, 2, 71, 70, 69};
-        std::vector<int32_t> result;
-        for (size_t i = 0; i < Size; ++i) {
-            result.push_back(page_1->get(i).get(0).get_int32());
-        }
-        EXPECT_EQ(permutation, result);
+    ASSERT_EQ(16, total_rows);
+    ASSERT_EQ(16, page_1->num_rows());
+    const size_t Size = 16;
+    std::vector<int32_t> permutation{58, 56, 55, 54, 52, 49, 41, 24, 16, 12, 6, 4, 2, 71, 70, 69};
+    std::vector<int32_t> result;
+    for (size_t i = 0; i < Size; ++i) {
+        result.push_back(page_1->get(i).get(0).get_int32());
     }
+    EXPECT_EQ(permutation, result);
 
     clear_sort_exprs(sort_exprs);
 }
@@ -420,28 +406,24 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
-        sorter.set_compare_strategy(strategy);
-        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-        sorter.update(_runtime_state.get(), _chunk_1);
-        sorter.update(_runtime_state.get(), _chunk_2);
-        sorter.update(_runtime_state.get(), _chunk_3);
-        sorter.done(_runtime_state.get());
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+    sorter.update(_runtime_state.get(), _chunk_1);
+    sorter.update(_runtime_state.get(), _chunk_2);
+    sorter.update(_runtime_state.get(), _chunk_3);
+    sorter.done(_runtime_state.get());
 
-        ChunkPtr page_1 = consume_page_from_sorter(sorter);
+    ChunkPtr page_1 = consume_page_from_sorter(sorter);
 
-        ASSERT_EQ(16, total_rows);
-        ASSERT_EQ(16, page_1->num_rows());
-        const size_t Size = 16;
-        std::vector<int32_t> permutation{71, 70, 69, 54, 4, 56, 55, 49, 41, 16, 52, 58, 24, 12, 2, 6};
-        std::vector<int32_t> result;
-        for (size_t i = 0; i < Size; ++i) {
-            result.push_back(page_1->get(i).get(0).get_int32());
-        }
-        ASSERT_EQ(permutation, result);
+    ASSERT_EQ(16, total_rows);
+    ASSERT_EQ(16, page_1->num_rows());
+    const size_t Size = 16;
+    std::vector<int32_t> permutation{71, 70, 69, 54, 4, 56, 55, 49, 41, 16, 52, 58, 24, 12, 2, 6};
+    std::vector<int32_t> result;
+    for (size_t i = 0; i < Size; ++i) {
+        result.push_back(page_1->get(i).get(0).get_int32());
     }
+    ASSERT_EQ(permutation, result);
 
     clear_sort_exprs(sort_exprs);
 }
@@ -463,29 +445,25 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
-        sorter.set_compare_strategy(strategy);
-        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-        sorter.update(_runtime_state.get(), _chunk_1);
-        sorter.update(_runtime_state.get(), _chunk_2);
-        sorter.update(_runtime_state.get(), _chunk_3);
-        sorter.done(_runtime_state.get());
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+    sorter.update(_runtime_state.get(), _chunk_1);
+    sorter.update(_runtime_state.get(), _chunk_2);
+    sorter.update(_runtime_state.get(), _chunk_3);
+    sorter.done(_runtime_state.get());
 
-        ChunkPtr page_1 = consume_page_from_sorter(sorter);
-        // print_chunk(page_1);
+    ChunkPtr page_1 = consume_page_from_sorter(sorter);
+    // print_chunk(page_1);
 
-        ASSERT_EQ(16, total_rows);
-        ASSERT_EQ(16, page_1->num_rows());
-        const size_t Size = 16;
-        std::vector<int32_t> permutation{24, 55, 4, 58, 12, 52, 41, 56, 49, 16, 6, 2, 54, 71, 70, 69};
-        std::vector<int32_t> result;
-        for (size_t i = 0; i < Size; ++i) {
-            result.push_back(page_1->get(i).get(0).get_int32());
-        }
-        EXPECT_EQ(permutation, result);
+    ASSERT_EQ(16, total_rows);
+    ASSERT_EQ(16, page_1->num_rows());
+    const size_t Size = 16;
+    std::vector<int32_t> permutation{24, 55, 4, 58, 12, 52, 41, 56, 49, 16, 6, 2, 54, 71, 70, 69};
+    std::vector<int32_t> result;
+    for (size_t i = 0; i < Size; ++i) {
+        result.push_back(page_1->get(i).get(0).get_int32());
     }
+    EXPECT_EQ(permutation, result);
 
     clear_sort_exprs(sort_exprs);
 }
@@ -504,28 +482,24 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_fisrt) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2, 7,
-                                TTopNType::ROW_NUMBER, 2);
-        sorter.set_compare_strategy(strategy);
+    ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2, 7, TTopNType::ROW_NUMBER,
+                            2);
 
-        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
-        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
-        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
-        sorter.done(_runtime_state.get());
+    size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+    sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
+    sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
+    sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
+    sorter.done(_runtime_state.get());
 
-        ChunkPtr page_1 = consume_page_from_sorter(sorter);
+    ChunkPtr page_1 = consume_page_from_sorter(sorter);
 
-        ASSERT_EQ(16, total_rows);
-        ASSERT_EQ(7, page_1->num_rows());
-        // full sort: {69, 70, 71, 4, 54, 16, 41, 49, 55, 56, 52, 2, 12, 24, 58, 6};
-        const size_t Size = 7;
-        int32_t permutation[Size] = {71, 4, 54, 16, 41, 49, 55};
-        for (size_t i = 0; i < Size; ++i) {
-            ASSERT_EQ(permutation[i], page_1->get(i).get(0).get_int32());
-        }
+    ASSERT_EQ(16, total_rows);
+    ASSERT_EQ(7, page_1->num_rows());
+    // full sort: {69, 70, 71, 4, 54, 16, 41, 49, 55, 56, 52, 2, 12, 24, 58, 6};
+    const size_t Size = 7;
+    int32_t permutation[Size] = {71, 4, 54, 16, 41, 49, 55};
+    for (size_t i = 0; i < Size; ++i) {
+        ASSERT_EQ(permutation[i], page_1->get(i).get(0).get_int32());
     }
 
     clear_sort_exprs(sort_exprs);
@@ -545,43 +519,38 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    for (auto strategy : all_compare_strategy()) {
-        int offset = 7;
-        for (int limit = 8; limit + offset <= 16; limit++) {
-            std::cerr << "sort with strategy: " << strategy << " limit:" << limit << std::endl;
-            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", offset, limit,
-                                    TTopNType::ROW_NUMBER, 2);
-            sorter.set_compare_strategy(strategy);
-            size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
-            sorter.done(_runtime_state.get());
+    int offset = 7;
+    for (int limit = 8; limit + offset <= 16; limit++) {
+        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", offset, limit,
+                                TTopNType::ROW_NUMBER, 2);
+        size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
+        sorter.done(_runtime_state.get());
 
-            ChunkPtr page_1 = consume_page_from_sorter(sorter);
+        ChunkPtr page_1 = consume_page_from_sorter(sorter);
 
-            ASSERT_EQ(16, total_rows);
-            ASSERT_EQ(limit, page_1->num_rows());
-            // full sort: {4, 54, 16, 41, 49, 55, 56, 52, 2, 12, 24, 58, 6, 69, 70, 71};
-            std::vector<int32_t> permutation{52, 2, 12, 24, 58, 6, 69, 70, 71};
-            std::vector<int32_t> result;
-            for (size_t i = 0; i < page_1->num_rows(); ++i) {
-                result.push_back(page_1->get(i).get(0).get_int32());
-            }
-            permutation.resize(limit);
-            EXPECT_EQ(permutation, result);
-
-            // part sort with large offset
-            ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 100, limit,
-                                     TTopNType::ROW_NUMBER, 2);
-            sorter2.set_compare_strategy(strategy);
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
-            sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
-            sorter2.done(_runtime_state.get());
-            page_1 = consume_page_from_sorter(sorter2);
-            ASSERT_TRUE(page_1 == nullptr);
+        ASSERT_EQ(16, total_rows);
+        ASSERT_EQ(limit, page_1->num_rows());
+        // full sort: {4, 54, 16, 41, 49, 55, 56, 52, 2, 12, 24, 58, 6, 69, 70, 71};
+        std::vector<int32_t> permutation{52, 2, 12, 24, 58, 6, 69, 70, 71};
+        std::vector<int32_t> result;
+        for (size_t i = 0; i < page_1->num_rows(); ++i) {
+            result.push_back(page_1->get(i).get(0).get_int32());
         }
+        permutation.resize(limit);
+        EXPECT_EQ(permutation, result);
+
+        // part sort with large offset
+        ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 100, limit,
+                                 TTopNType::ROW_NUMBER, 2);
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
+        sorter.update(_runtime_state.get(), ChunkPtr(_chunk_3->clone_unique().release()));
+        sorter2.done(_runtime_state.get());
+        page_1 = consume_page_from_sorter(sorter2);
+        ASSERT_TRUE(page_1 == nullptr);
     }
 
     clear_sort_exprs(sort_exprs);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -31,6 +31,7 @@ import com.starrocks.analysis.SortInfo;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.thrift.TExchangeNode;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TPartitionType;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Receiver side of a 1:n data stream. Logically, an ExchangeNode consumes the data
@@ -95,7 +97,8 @@ public class ExchangeNode extends PlanNode {
         if (inputNode.getFragment().isPartitioned()) {
             if (inputNode instanceof SortNode) {
                 SortNode sortNode = (SortNode) inputNode;
-                if (CollectionUtils.isEmpty(sortNode.getSortInfo().getPartitionExprs())) {
+                if (Objects.equals(TopNType.ROW_NUMBER, sortNode.getTopNType()) &&
+                        CollectionUtils.isEmpty(sortNode.getSortInfo().getPartitionExprs())) {
                     limit = inputNode.limit;
                 } else {
                     unsetLimit();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/SortProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/SortProperty.java
@@ -7,6 +7,7 @@ import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 
 public class SortProperty implements PhysicalProperty {
@@ -57,7 +58,9 @@ public class SortProperty implements PhysicalProperty {
     @Override
     public GroupExpression appendEnforcers(Group child) {
         return new GroupExpression(new PhysicalTopNOperator(spec,
-                Operator.DEFAULT_LIMIT, Operator.DEFAULT_OFFSET, null, Operator.DEFAULT_LIMIT, SortPhase.FINAL, false,
-                true, null, null), Lists.newArrayList(child));
+                Operator.DEFAULT_LIMIT, Operator.DEFAULT_OFFSET, null, Operator.DEFAULT_LIMIT, SortPhase.FINAL,
+                TopNType.ROW_NUMBER, false,
+                true, null, null),
+                Lists.newArrayList(child));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/TopNType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/TopNType.java
@@ -1,0 +1,29 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.sql.optimizer.operator;
+
+import com.starrocks.thrift.TTopNType;
+
+public enum TopNType {
+    ROW_NUMBER,
+    RANK,
+    DENSE_RANK;
+
+    public TTopNType toThrift() {
+        if (ROW_NUMBER.equals(this)) {
+            return TTopNType.ROW_NUMBER;
+        } else if (RANK.equals(this)) {
+            return TTopNType.RANK;
+        } else {
+            return TTopNType.DENSE_RANK;
+        }
+    }
+
+    public static TopNType parse(String name) {
+        for (TopNType value : values()) {
+            if (value.name().equalsIgnoreCase(name)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -12,6 +12,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
@@ -24,6 +25,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     private final List<ColumnRefOperator> partitionByColumns;
     private final long partitionLimit;
     private final SortPhase sortPhase;
+    private final TopNType topNType;
     private final boolean isSplit;
     private final boolean isEnforced;
 
@@ -32,6 +34,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
                                 List<ColumnRefOperator> partitionByColumns,
                                 long partitionLimit,
                                 SortPhase sortPhase,
+                                TopNType topNType,
                                 boolean isSplit,
                                 boolean isEnforced,
                                 ScalarOperator predicate,
@@ -42,6 +45,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
         this.partitionByColumns = partitionByColumns;
         this.partitionLimit = partitionLimit;
         this.sortPhase = sortPhase;
+        this.topNType = topNType;
         this.isSplit = isSplit;
         this.isEnforced = isEnforced;
         this.predicate = predicate;
@@ -58,6 +62,10 @@ public class PhysicalTopNOperator extends PhysicalOperator {
 
     public SortPhase getSortPhase() {
         return sortPhase;
+    }
+
+    public TopNType getTopNType() {
+        return topNType;
     }
 
     public boolean isSplit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -489,6 +489,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     null,
                     Operator.DEFAULT_LIMIT,
                     operator.getSortPhase(),
+                    operator.getTopNType(),
                     operator.isSplit(),
                     operator.isEnforced(),
                     predicate,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ExchangeSortToMergeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ExchangeSortToMergeRule.java
@@ -34,14 +34,15 @@ public class ExchangeSortToMergeRule extends OptExpressionVisitor<OptExpression,
             if (topN.getSortPhase().isFinal() && !topN.isSplit() && topN.getLimit() == Operator.DEFAULT_LIMIT) {
                 OptExpression child = OptExpression.create(new PhysicalTopNOperator(
                         topN.getOrderSpec(), topN.getLimit(), topN.getOffset(), topN.getPartitionByColumns(),
-                        topN.getPartitionLimit(), SortPhase.PARTIAL, false, false, null, null
+                        topN.getPartitionLimit(), SortPhase.PARTIAL, topN.getTopNType(), false, false, null, null
                 ), optExpr.inputAt(0).getInputs());
                 child.setLogicalProperty(optExpr.inputAt(0).getLogicalProperty());
                 child.setStatistics(optExpr.getStatistics());
 
                 OptExpression newOpt = OptExpression.create(new PhysicalTopNOperator(
                                 topN.getOrderSpec(), topN.getLimit(), topN.getOffset(), topN.getPartitionByColumns(),
-                                topN.getPartitionLimit(), SortPhase.FINAL, true, false, null, topN.getProjection()),
+                                topN.getPartitionLimit(), SortPhase.FINAL, topN.getTopNType(), true, false, null,
+                                topN.getProjection()),
                         Lists.newArrayList(child));
                 newOpt.setLogicalProperty(optExpr.getLogicalProperty());
                 newOpt.setStatistics(optExpr.getStatistics());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/TopNImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/TopNImplementationRule.java
@@ -31,6 +31,7 @@ public class TopNImplementationRule extends ImplementationRule {
                         logicalTopN.getPartitionByColumns(),
                         logicalTopN.getPartitionLimit(),
                         logicalTopN.getSortPhase(),
+                        logicalTopN.getTopNType(),
                         logicalTopN.isSplit(),
                         false,
                         logicalTopN.getPredicate(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateWindowRankRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateWindowRankRule.java
@@ -10,6 +10,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
@@ -61,8 +62,9 @@ public class PushDownPredicateWindowRankRule extends TransformationRule {
         ColumnRefOperator windowCol = Lists.newArrayList(windowOperator.getWindowCall().keySet()).get(0);
         CallOperator callOperator = windowOperator.getWindowCall().get(windowCol);
 
-        // TODO(hcf) we support rank/dense_rank later
-        if (!FunctionSet.ROW_NUMBER.equalsIgnoreCase(callOperator.getFnName())) {
+        // TODO(hcf) we support dense_rank later
+        if (!FunctionSet.ROW_NUMBER.equalsIgnoreCase(callOperator.getFnName()) &&
+                !FunctionSet.RANK.equalsIgnoreCase(callOperator.getFnName())) {
             return false;
         }
 
@@ -84,6 +86,7 @@ public class PushDownPredicateWindowRankRule extends TransformationRule {
         LogicalWindowOperator windowOperator = childExpr.getOp().cast();
 
         ColumnRefOperator windowCol = Lists.newArrayList(windowOperator.getWindowCall().keySet()).get(0);
+        CallOperator callOperator = windowOperator.getWindowCall().get(windowCol);
 
         List<BinaryPredicateOperator> lessPredicates =
                 filters.stream().filter(op -> op instanceof BinaryPredicateOperator)
@@ -112,6 +115,8 @@ public class PushDownPredicateWindowRankRule extends TransformationRule {
             return Collections.emptyList();
         }
 
+        TopNType topNType = TopNType.parse(callOperator.getFnName());
+
         // If partition by columns is not empty, then we cannot derive sort property from the SortNode
         // OutputPropertyDeriver will generate PhysicalPropertySet.EMPTY if sortPhase is SortPhase.PARTIAL
         final SortPhase sortPhase = partitionByColumns.isEmpty() ? SortPhase.FINAL : SortPhase.PARTIAL;
@@ -122,6 +127,7 @@ public class PushDownPredicateWindowRankRule extends TransformationRule {
                 .setPartitionLimit(partitionLimit)
                 .setOrderByElements(windowOperator.getEnforceSortColumns())
                 .setLimit(limit)
+                .setTopNType(topNType)
                 .setSortPhase(sortPhase)
                 .build(), childExpr.getInputs());
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -527,6 +527,12 @@ struct TSortInfo {
   4: optional list<Exprs.TExpr> sort_tuple_slot_exprs
 }
 
+enum TTopNType {
+  ROW_NUMBER,
+  RANK,
+  DENSE_RANK
+}
+
 struct TSortNode {
   1: required TSortInfo sort_info
   // Indicates whether the backend service should use topn vs. sorting
@@ -556,6 +562,7 @@ struct TSortNode {
   22: optional list<Exprs.TExpr> analytic_partition_exprs
   23: optional list<Exprs.TExpr> partition_exprs
   24: optional i64 partition_limit
+  25: optional TTopNType topn_type;
 }
 
 enum TAnalyticWindowType {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5885

## Enhancement

```sql
select * from (
    select *, rank() over (partition by v2 order by v3) as rk from t0
) sub_t0
where rk < 5;
```

For rank window function, including `rank`、`dense_rank`、`row_number`, if it has a related predicate (`rk < 5`), then it can be optimized by inserting a `PartitionTopN` operator before the `Sort` operator of window function. 

**The main purpose of `PartitionTopN` is to filter data, and it's output still remain unordered. It consists of three components:**

* `partitioner`：Divide the input chunk based on the partition exprs
* `sorter(topn)`：Each partition has an instance of sorter and is sorted independently
* `gather`：fetch chunks from all sorters into one data stream, so the data is still unordered after gahtering. Moreover, gather is a only logical concetp, not an actual component

```


                                   ┌────► topn─────┐
                                   │               │
 (unordered)                       │               │                  (unordered)
 inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
                                   │               │
                                   │               │
                                   └────► topn ────┘
```

**The implementation on the optimizer and the executor is a little different:**

* In optimizer, for simplicity, we do not define a new pair of `{Logical/Physical}PartitionTopNOperator`  but reuse the existing `{Logical/Physical}TopNOperator` by adding a new field `partitionByExprs` to record the partition by information. Besides, we need to pay attentation to the following things: 
    * Make sure that we cannot derive sort property from PartitionTopN
    * Make sure that ExchangeNode not set limit if PartitionTopN
* In executor, we define a new pair of `LocalPartitionTopN{Sink/Source}Operator`, and we may use different implementation based on the field `partitionByExprs`
    * if `partitionByExprs` is unset or empty, then the original pair of `PartitionSortSinkOperator/LocalMergeSortSourceOperator` is used
    * if `partitionByExprs` is not empty, then pair of `LocalPartitionTopN{Sink/Source}Operator` is used

## Tasks

- [x] Support component partitioner
    * only support one partition expr right now
- [x] Support PartitionTopN
- [x] Support `row_number`
- [x] **Support `rank`(this pr)**
    * by supporting TopN limit by rank
- [ ] Support `dense_rank`
    * by supporting TopN limit by dense_rank
- [ ] Support multi partition exprs

## Performance Improvement of this pr

**test Info**

* TPCDS-100g
* 3 be of which is 64c/128g

**test sql**

```sql
-- query 67
select  *
from (select i_category
            ,i_class
            ,i_brand
            ,i_product_name
            ,d_year
            ,d_qoy
            ,d_moy
            ,s_store_id
            ,sumsales
            ,rank() over (partition by i_category order by sumsales desc) rk
      from (select i_category
                  ,i_class
                  ,i_brand
                  ,i_product_name
                  ,d_year
                  ,d_qoy
                  ,d_moy
                  ,s_store_id
                  ,sum(coalesce(ss_sales_price*ss_quantity,0)) sumsales
            from store_sales
                ,date_dim
                ,store
                ,item
       where  ss_sold_date_sk=d_date_sk
          and ss_item_sk=i_item_sk
          and ss_store_sk = s_store_sk
          and d_month_seq between 1200 and 1200+11
       group by  rollup(i_category, i_class, i_brand, i_product_name, d_year, d_qoy, d_moy,s_store_id))dw1) dw2
where rk <= 100
order by i_category
        ,i_class
        ,i_brand
        ,i_product_name
        ,d_year
        ,d_qoy
        ,d_moy
        ,s_store_id
        ,sumsales
        ,rk
limit 100;
```

**test result**
|  before | after |
|:-- |:--|
| 20s | 9.5s |