### PR TITLE
[BugFix]Fix bug IsNullPredicate miss fn analyze in Materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IsNullPredicate.java
@@ -22,13 +22,25 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFunctionBinaryType;
 
 public class IsNullPredicate extends Predicate {
+
+    static Function isNullFN = new Function(new FunctionName("is_null_pred"),
+            new Type[] {Type.INVALID}, Type.BOOLEAN, false);
+    static Function isNotNullFN = new Function(new FunctionName("is_not_null_pred"),
+            new Type[] {Type.INVALID}, Type.BOOLEAN, false);
+    {
+        isNullFN.setBinaryType(TFunctionBinaryType.BUILTIN);
+        isNotNullFN.setBinaryType(TFunctionBinaryType.BUILTIN);
+    }
 
     private final boolean isNotNull;
 
@@ -78,6 +90,12 @@ public class IsNullPredicate extends Predicate {
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         super.analyzeImpl(analyzer);
+
+        if (isNotNull) {
+            fn = isNullFN;
+        } else {
+            fn = isNotNullFN;
+        }
 
         // determine selectivity
         selectivity = 0.1;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6124

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In the issue, creating a materialized view to support COUNT is done through CaseWhenExpr
Implemented by CASE WHEN `field` IS NULL THEN 0 ELSE 1 END,
And this function that depends on BE is_null_pred, and if FE does not send this fn to BE, 
BE will report Vectorized engine doesn't implement function. To fix this, so we add this fn.