### PR TITLE
[BugFix] Fix reorder rule not deal column to  column projection with different…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAssertOneRowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAssertOneRowOperator.java
@@ -68,7 +68,7 @@ public class LogicalAssertOneRowOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assertion, checkRows, tips);
+        return System.identityHashCode(this);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAssertOneRowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAssertOneRowOperator.java
@@ -11,7 +11,6 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class LogicalAssertOneRowOperator extends LogicalOperator {
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
@@ -60,6 +60,6 @@ public class PhysicalAssertOneRowOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(assertion, checkRows, tips);
+        return System.identityHashCode(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.analysis.AssertNumRowsElement;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalAssertOneRowOperator.java
@@ -55,14 +55,7 @@ public class PhysicalAssertOneRowOperator extends PhysicalOperator {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        PhysicalAssertOneRowOperator that = (PhysicalAssertOneRowOperator) o;
-        return checkRows == that.checkRows && assertion == that.assertion && Objects.equal(tips, that.tips);
+        return this == o;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -164,10 +164,15 @@ public class JoinAssociativityRule extends TransformationRule {
         if (leftChildJoinProjection != null) {
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : leftChildJoinProjection.getColumnRefMap()
                     .entrySet()) {
-                if (!entry.getValue().isColumnRef() &&
+                // To handle mappings of expressions in projection, special processing is needed like
+                // ColumnRefOperator -> ColumnRefOperator mappings with name ("expr" -> column_name), it need to be handled
+                // like expression mapping.
+                boolean isProjectToColumnRef = entry.getValue().isColumnRef() &&
+                        entry.getKey().getName().equals(((ColumnRefOperator) entry.getValue()).getName());
+                if (! isProjectToColumnRef &&
                         newRightChildColumns.containsAll(entry.getValue().getUsedColumns())) {
                     rightExpression.put(entry.getKey(), entry.getValue());
-                } else if (!entry.getValue().isColumnRef() &&
+                } else if (!isProjectToColumnRef &&
                         leftChild1.getOutputColumns().containsAll(entry.getValue().getUsedColumns())) {
                     leftExpression.put(entry.getKey(), entry.getValue());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -97,7 +97,11 @@ public class SemiReorderRule extends TransformationRule {
         if (leftChildJoinProjection != null) {
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : leftChildJoinProjection.getColumnRefMap()
                     .entrySet()) {
-                boolean isProjectToColumnRef = entry.getValue().isColumnRef();
+                // To handle mappings of expressions in projection, special processing is needed like
+                // ColumnRefOperator -> ColumnRefOperator mappings with name ("expr" -> column_name), it need to be handled
+                // like expression mapping.
+                boolean isProjectToColumnRef = entry.getValue().isColumnRef() &&
+                        entry.getKey().getName().equals(((ColumnRefOperator) entry.getValue()).getName());
                 if (!isProjectToColumnRef &&
                         leftChildJoinRightChildOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
                     rightExpression.put(entry.getKey(), entry.getValue());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2590,4 +2590,56 @@ public class JoinTest extends PlanTestBase {
         assertContains(plan, "1:EMPTYSET");
         assertContains(plan, "2:EMPTYSET");
     }
+
+    @Test
+    public void testSemiJoinReorderProjections() throws Exception {
+        String sql = "WITH with_t_0 as (\n" +
+                "  SELECT \n" +
+                "    t1_3.t1b, \n" +
+                "    t1_3.t1d \n" +
+                "  FROM \n" +
+                "    test_all_type AS t1_3 \n" +
+                "  WHERE \n" +
+                "    (\n" +
+                "      (\n" +
+                "        SELECT \n" +
+                "          t1_3.t1a \n" +
+                "        FROM \n" +
+                "          test_all_type AS t1_3\n" +
+                "      )\n" +
+                "    ) < (\n" +
+                "      (\n" +
+                "        SELECT \n" +
+                "          11\n" +
+                "      )\n" +
+                "    )\n" +
+                ") \n" +
+                "SELECT \n" +
+                "  SUM(count) \n" +
+                "FROM \n" +
+                "  (\n" +
+                "    SELECT \n" +
+                "      CAST(false AS INT) as count \n" +
+                "    FROM \n" +
+                "      test_all_type AS t1_3 FULL \n" +
+                "      JOIN (\n" +
+                "        SELECT \n" +
+                "          with_t_0.t1b \n" +
+                "        FROM \n" +
+                "          with_t_0 AS with_t_0 \n" +
+                "        WHERE \n" +
+                "          (with_t_0.t1d) IN (\n" +
+                "            (\n" +
+                "              SELECT \n" +
+                "                t1_3.t1d \n" +
+                "              FROM \n" +
+                "                test_all_type AS t1_3\n" +
+                "            )\n" +
+                "          )\n" +
+                "      ) subwith_t_0 ON t1_3.id_decimal = subwith_t_0.t1b\n" +
+                "  ) t;";
+        String plan = getFragmentPlan(sql);
+        // check no error
+        assertContains(plan, "16:ASSERT NUMBER OF ROWS");
+    }
 }


### PR DESCRIPTION
… name

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6089 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
During the processing of subqueries, a column-to-column mapping is generated with name "expr"->column_name, we should deal with this situation at reorder rule,  treat it as expression mapping of projection.
