### PR TITLE
[Refactor] make convert_scan_range_to_morsel_queue and global_rf_wait_timeout_ns virtual

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -142,6 +142,7 @@ set(EXEC_FILES
     pipeline/scan/olap_scan_prepare_operator.cpp
     pipeline/scan/olap_scan_context.cpp
     pipeline/scan/connector_scan_operator.cpp
+    pipeline/scan/morsel.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp
     pipeline/crossjoin/cross_join_left_operator.cpp

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -295,6 +295,7 @@ protected:
     void init_runtime_profile(const std::string& name);
 
     RuntimeState* runtime_state() { return _runtime_state; }
+    const RuntimeState* runtime_state() const { return _runtime_state; }
 
     // Executes _debug_action if phase matches _debug_phase.
     // 'phase' must not be INVALID.

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -90,6 +90,18 @@ std::vector<ExprContext*>& Operator::runtime_in_filters() {
 RuntimeFilterProbeCollector* Operator::runtime_bloom_filters() {
     return _factory->get_runtime_bloom_filters();
 }
+const RuntimeFilterProbeCollector* Operator::runtime_bloom_filters() const {
+    return _factory->get_runtime_bloom_filters();
+}
+
+int64_t Operator::global_rf_wait_timeout_ns() const {
+    const auto* global_rf_collector = runtime_bloom_filters();
+    if (global_rf_collector == nullptr) {
+        return 0;
+    }
+
+    return 1000'000L * global_rf_collector->wait_timeout_ms();
+}
 
 const std::vector<SlotId>& Operator::filter_null_value_columns() const {
     return _factory->get_filter_null_value_columns();

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -118,6 +118,9 @@ public:
     std::vector<ExprContext*>& runtime_in_filters();
 
     RuntimeFilterProbeCollector* runtime_bloom_filters();
+    const RuntimeFilterProbeCollector* runtime_bloom_filters() const;
+
+    virtual int64_t global_rf_wait_timeout_ns() const;
 
     const std::vector<SlotId>& filter_null_value_columns() const;
 
@@ -243,12 +246,18 @@ public:
 
     std::vector<ExprContext*>& get_runtime_in_filters() { return _runtime_in_filters; }
     RuntimeFilterProbeCollector* get_runtime_bloom_filters() {
-        if (_runtime_filter_collector) {
-            return _runtime_filter_collector->get_rf_probe_collector();
-        } else {
+        if (_runtime_filter_collector == nullptr) {
             return nullptr;
         }
+        return _runtime_filter_collector->get_rf_probe_collector();
     }
+    const RuntimeFilterProbeCollector* get_runtime_bloom_filters() const {
+        if (_runtime_filter_collector == nullptr) {
+            return nullptr;
+        }
+        return _runtime_filter_collector->get_rf_probe_collector();
+    }
+
     const std::vector<SlotId>& get_filter_null_value_columns() const { return _filter_null_value_columns; }
 
     void set_runtime_state(RuntimeState* state) { this->_state = state; }

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -61,10 +61,12 @@ public:
 private:
     FragmentContext* _fragment_context;
     Pipelines _pipelines;
+
     uint32_t _next_pipeline_id = 0;
     uint32_t _next_operator_id = 0;
     int32_t _next_pseudo_plan_node_id = Operator::s_pseudo_plan_node_id_upper_bound;
-    size_t _degree_of_parallelism = 1;
+
+    const size_t _degree_of_parallelism;
 };
 
 class PipelineBuilder {

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -177,6 +177,7 @@ public:
     }
 
     RuntimeFilterProbeCollector* get_rf_probe_collector() { return &_rf_probe_collector; }
+    const RuntimeFilterProbeCollector* get_rf_probe_collector() const { return &_rf_probe_collector; }
 
 private:
     // a refcount, low 32 bit used count the close invocation times, and the high 32 bit used to count the

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -100,19 +100,10 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
 }
 
 Status OlapChunkSource::_get_tablet(const TInternalScanRange* scan_range) {
-    TTabletId tablet_id = scan_range->tablet_id;
-    SchemaHash schema_hash = strtoul(scan_range->schema_hash.c_str(), nullptr, 10);
     _version = strtoul(scan_range->version.c_str(), nullptr, 10);
 
-    std::string err;
-    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
-    if (!_tablet) {
-        std::stringstream ss;
-        ss << "failed to get tablet. tablet_id=" << tablet_id << ", with schema_hash=" << schema_hash
-           << ", reason=" << err;
-        LOG(WARNING) << ss.str();
-        return Status::InternalError(ss.str());
-    }
+    ASSIGN_OR_RETURN(_tablet, vectorized::OlapScanNode::get_tablet(scan_range));
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -156,6 +156,15 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     return nullptr;
 }
 
+int64_t ScanOperator::global_rf_wait_timeout_ns() const {
+    const auto* global_rf_collector = runtime_bloom_filters();
+    if (global_rf_collector == nullptr) {
+        return 0;
+    }
+
+    return 1000'000L * global_rf_collector->scan_wait_timeout_ms();
+}
+
 Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP) {
         return Status::OK();

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -35,6 +35,8 @@ public:
 
     void set_io_threads(PriorityThreadPool* io_threads) override { _io_threads = io_threads; }
 
+    int64_t global_rf_wait_timeout_ns() const override;
+
     /// interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;
     virtual void do_close(RuntimeState* state) = 0;

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -29,6 +29,11 @@
 
 namespace starrocks {
 
+namespace pipeline {
+class MorselQueue;
+using MorselQueuePtr = std::unique_ptr<MorselQueue>;
+} // namespace pipeline
+
 class TScanRange;
 
 // Abstract base class of all scan nodes; introduces set_scan_range().
@@ -58,6 +63,8 @@ public:
     // Convert scan_ranges into node-specific scan restrictions.  This should be
     // called after prepare()
     virtual Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) = 0;
+    virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request);
 
     // If this scan node accept empty scan ranges.
     virtual bool accept_empty_scan_ranges() const { return true; }

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -52,6 +52,7 @@ public:
     Status close(RuntimeState* statue) override;
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
+
     void debug_string(int indentation_level, std::stringstream* out) const override {
         *out << "vectorized::OlapScanNode";
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR relates ：
Relates #6110.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Parallel scan on the tablet needs different `convert_scan_range_to_morsel_queue `and `global_rf_wait_timeout_ns`, so make them virtual.

