### PR TITLE
[Cherry-pick 2.2][BugFix] Add retry for fe thrift rpc (#5656)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -231,7 +231,6 @@ import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.task.DropReplicaTask;
 import com.starrocks.task.MasterTaskExecutor;
-import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TRefreshTableRequest;
 import com.starrocks.thrift.TRefreshTableResponse;
@@ -252,7 +251,6 @@ import org.apache.hadoop.util.ThreadUtil;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.thrift.TException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.BufferedInputStream;
@@ -6830,20 +6828,18 @@ public class Catalog {
 
     public Future<TStatus> refreshOtherFesTable(TNetworkAddress thriftAddress, String dbName, String tableName,
                                                 List<String> partitions) {
-        int timeout = ConnectContext.get().getSessionVariable().getQueryTimeoutS() * 1000;
+        int timeout = ConnectContext.get().getSessionVariable().getQueryTimeoutS() * 1000
+                + Config.thrift_rpc_timeout_ms;
         FutureTask<TStatus> task = new FutureTask<TStatus>(() -> {
             TRefreshTableRequest request = new TRefreshTableRequest();
             request.setDb_name(dbName);
             request.setTable_name(tableName);
             request.setPartitions(partitions);
             try {
-                TRefreshTableResponse response = FrontendServiceProxy.call(thriftAddress, timeout,
-                        new FrontendServiceProxy.MethodCallable<TRefreshTableResponse>() {
-                            @Override
-                            public TRefreshTableResponse invoke(FrontendService.Client client) throws TException {
-                                return client.refreshTable(request);
-                            }
-                        });
+                TRefreshTableResponse response = FrontendServiceProxy.call(thriftAddress,
+                        timeout,
+                        Config.thrift_rpc_retry_times,
+                        client -> client.refreshTable(request));
                 return response.getStatus();
             } catch (Exception e) {
                 LOG.warn("call fe {} refreshTable rpc method failed", thriftAddress, e);
@@ -7284,7 +7280,8 @@ public class Catalog {
         setFrontendConfig(configs);
 
         List<Frontend> allFrontends = Catalog.getCurrentCatalog().getFrontends(null);
-        int timeout = ConnectContext.get().getSessionVariable().getQueryTimeoutS() * 1000;
+        int timeout = ConnectContext.get().getSessionVariable().getQueryTimeoutS() * 1000
+                + Config.thrift_rpc_timeout_ms;
         StringBuilder errMsg = new StringBuilder();
         for (Frontend fe : allFrontends) {
             if (fe.getHost().equals(Catalog.getCurrentCatalog().getSelfNode().first)) {
@@ -7296,16 +7293,10 @@ public class Catalog {
             request.setValues(new ArrayList<>(configs.values()));
             try {
                 TSetConfigResponse response = FrontendServiceProxy
-                        .call(new TNetworkAddress(fe.getHost(),
-                                        fe.getRpcPort()),
+                        .call(new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
                                 timeout,
-                                new FrontendServiceProxy.MethodCallable<TSetConfigResponse>() {
-                                    @Override
-                                    public TSetConfigResponse invoke(FrontendService.Client client) throws TException {
-                                        return client.setConfig(request);
-                                    }
-                                }
-                        );
+                                Config.thrift_rpc_retry_times,
+                                client -> client.setConfig(request));
                 TStatus status = response.getStatus();
                 if (status.getStatus_code() != TStatusCode.OK) {
                     errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ");
@@ -7315,7 +7306,7 @@ public class Catalog {
                     errMsg.append(";");
                 }
             } catch (Exception e) {
-                LOG.warn("set remote fe[%s] config failed", fe.getHost(), e);
+                LOG.warn("set remote fe: {} config failed", fe.getHost(), e);
                 errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ").append(e.getMessage());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -465,6 +465,18 @@ public class Config extends ConfigBase {
     @ConfField
     public static String thrift_server_type = ThriftServer.THREAD_POOL;
 
+    /**
+     * the timeout for thrift rpc call
+     */
+    @ConfField(mutable = true)
+    public static int thrift_rpc_timeout_ms = 10000;
+
+    /**
+     * the retry times for thrift rpc call
+     */
+    @ConfField(mutable = true)
+    public static int thrift_rpc_retry_times = 3;
+
     // May be necessary to modify the following BRPC configurations in high concurrency scenarios.
 
     // The size of BRPC connection pool. It will limit the concurrency of sending requests, because

--- a/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
@@ -3,8 +3,8 @@
 package com.starrocks.external.starrocks;
 
 import com.starrocks.catalog.ExternalOlapTable;
-import com.starrocks.common.ClientPool;
-import com.starrocks.thrift.FrontendService;
+import com.starrocks.common.Config;
+import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TGetTableMetaRequest;
 import com.starrocks.thrift.TGetTableMetaResponse;
@@ -12,8 +12,6 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.List;
 
 // TableMetaSyncer is used to sync olap external 
 // table meta info from remote dorisdb cluster
@@ -24,14 +22,6 @@ public class TableMetaSyncer {
         String host = table.getSourceTableHost();
         int port = table.getSourceTablePort();
         TNetworkAddress addr = new TNetworkAddress(host, port);
-        FrontendService.Client client = null;
-        try {
-            client = ClientPool.frontendPool.borrowObject(addr, 1000);
-        } catch (Exception e) {
-            LOG.warn("get frontend client from pool failed", e);
-            return;
-        }
-
         TGetTableMetaRequest request = new TGetTableMetaRequest();
         request.setDb_name(table.getSourceTableDbName());
         request.setTable_name(table.getSourceTableName());
@@ -39,23 +29,24 @@ public class TableMetaSyncer {
         authInfo.setUser(table.getSourceTableUser());
         authInfo.setPasswd(table.getSourceTablePassword());
         request.setAuth_info(authInfo);
-        boolean returnToPool = false;
         try {
-            TGetTableMetaResponse response = client.getTableMeta(request);
-            returnToPool = true;
-            List<String> errmsgs = response.status.getError_msgs(); 
+            TGetTableMetaResponse response = FrontendServiceProxy.call(addr,
+                    Config.thrift_rpc_timeout_ms,
+                    Config.thrift_rpc_retry_times,
+                    client -> client.getTableMeta(request));
             if (response.status.getStatus_code() != TStatusCode.OK) {
-                LOG.info("errmsg: {}", errmsgs.get(0));
+                String errMsg;
+                if (response.status.getError_msgs() != null) {
+                    errMsg = String.join(",", response.status.getError_msgs());
+                } else {
+                    errMsg = "";
+                }
+                LOG.warn("get TableMeta failed: {}", errMsg);
             } else {
                 table.updateMeta(request.getDb_name(), response.getTable_meta(), response.getBackends());
             }
         } catch (Exception e) {
             LOG.warn("call fe {} refreshTable rpc method failed", addr, e);
-        }
-        if (returnToPool) {
-            ClientPool.frontendPool.returnObject(addr, client);
-        } else {
-            ClientPool.frontendPool.invalidateObject(addr, client);
         }
     }
 };

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/SystemAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/SystemAction.java
@@ -90,7 +90,7 @@ public class SystemAction extends WebBaseAction {
             // forward to master
             String showProcStmt = "SHOW PROC \"" + procPath + "\"";
             MasterOpExecutor masterOpExecutor = new MasterOpExecutor(new OriginStatement(showProcStmt, 0),
-                    ConnectContext.get(), RedirectStatus.FORWARD_NO_SYNC, true);
+                    ConnectContext.get(), RedirectStatus.FORWARD_NO_SYNC);
             try {
                 masterOpExecutor.execute();
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
@@ -76,7 +76,7 @@ public class ShowProcAction extends RestBaseAction {
             // ConnectContext build in RestBaseAction
             ConnectContext context = ConnectContext.get();
             MasterOpExecutor masterOpExecutor = new MasterOpExecutor(new OriginStatement(showProcStmt, 0), context,
-                    RedirectStatus.FORWARD_NO_SYNC, true);
+                    RedirectStatus.FORWARD_NO_SYNC);
             LOG.debug("need to transfer to Master. stmt: {}", context.getStmtId());
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -59,12 +59,13 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.cluster.ClusterNamespace;
-import com.starrocks.common.ClientPool;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;
 import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -84,7 +85,6 @@ import com.starrocks.task.SchemaChangeTask;
 import com.starrocks.task.SnapshotTask;
 import com.starrocks.task.UpdateTabletMetaInfoTask;
 import com.starrocks.task.UploadTask;
-import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TAbortRemoteTxnRequest;
 import com.starrocks.thrift.TAbortRemoteTxnResponse;
 import com.starrocks.thrift.TBackend;
@@ -1218,22 +1218,21 @@ public class MasterImpl {
         // if current node is follower, forward it to leader
         if (!catalog.isMaster()) {
             TNetworkAddress addr = masterAddr();
-            FrontendService.Client client = null;
             try {
                 LOG.info("beginRemoteTxn as follower, forward it to master. Label: {}, master: {}",
-                         request.getLabel(), addr.toString());
-                client = ClientPool.frontendPool.borrowObject(addr, 1000);
-                response = client.beginRemoteTxn(request);
-                ClientPool.frontendPool.returnObject(addr, client);
+                        request.getLabel(), addr.toString());
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
+                        client -> client.beginRemoteTxn(request));
             } catch (Exception e) {
-                LOG.warn("create thrift client failed during beginRemoteTxn, label: {}, exception: {}", request.getLabel(), e);
+                LOG.warn("create thrift client failed during beginRemoteTxn, label: {}, exception: {}",
+                        request.getLabel(), e);
                 TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
                 status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
                 response.setStatus(status);
-                ClientPool.frontendPool.invalidateObject(addr, client);
-            } finally {
-                return response;
             }
+            return response;
         }
 
         Database db = catalog.getDb(request.getDb_id());
@@ -1275,22 +1274,21 @@ public class MasterImpl {
         // if current node is follower, forward it to leader
         if (!catalog.isMaster()) {
             TNetworkAddress addr = masterAddr();
-            FrontendService.Client client = null;
             try {
                 LOG.info("commitRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
-                         request.getTxn_id(), addr.toString());
-                client = ClientPool.frontendPool.borrowObject(addr, 1000);
-                response = client.commitRemoteTxn(request);
-                ClientPool.frontendPool.returnObject(addr, client);
+                        request.getTxn_id(), addr.toString());
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
+                        client -> client.commitRemoteTxn(request));
             } catch (Exception e) {
-                LOG.warn("create thrift client failed during commitRemoteTxn, txn_id: {}, exception: {}", request.getTxn_id(), e);
+                LOG.warn("create thrift client failed during commitRemoteTxn, txn_id: {}, exception: {}",
+                        request.getTxn_id(), e);
                 TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
                 status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
                 response.setStatus(status);
-                ClientPool.frontendPool.invalidateObject(addr, client);
-            } finally {
-                return response;
             }
+            return response;
         }
 
         Database db = catalog.getDb(request.getDb_id());
@@ -1341,22 +1339,21 @@ public class MasterImpl {
         // if current node is follower, forward it to leader
         if (!catalog.isMaster()) {
             TNetworkAddress addr = masterAddr();
-            FrontendService.Client client = null;
             try {
                 LOG.info("abortRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
-                         request.getTxn_id(), addr.toString());
-                client = ClientPool.frontendPool.borrowObject(addr, 1000);
-                response = client.abortRemoteTxn(request);
-                ClientPool.frontendPool.returnObject(addr, client);
+                        request.getTxn_id(), addr.toString());
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
+                        client -> client.abortRemoteTxn(request));
             } catch (Exception e) {
-                LOG.warn("create thrift client failed during abortRemoteTxn, txn_id: {}, exception: {}", request.getTxn_id(), e);
+                LOG.warn("create thrift client failed during abortRemoteTxn, txn_id: {}, exception: {}",
+                        request.getTxn_id(), e);
                 TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
                 status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
                 response.setStatus(status);
-                ClientPool.frontendPool.invalidateObject(addr, client);
-            } finally {
-                return response;
             }
+            return response;
         }
 
         Database db = catalog.getDb(request.getDb_id());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -579,8 +579,7 @@ public class StmtExecutor {
     }
 
     private void forwardToMaster() throws Exception {
-        boolean isQuery = parsedStmt instanceof QueryStmt || parsedStmt instanceof QueryStatement;
-        masterOpExecutor = new MasterOpExecutor(parsedStmt, originStmt, context, redirectStatus, isQuery);
+        masterOpExecutor = new MasterOpExecutor(parsedStmt, originStmt, context, redirectStatus);
         LOG.debug("need to transfer to Master. stmt: {}", context.getStmtId());
         masterOpExecutor.execute();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/FrontendServiceProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/FrontendServiceProxy.java
@@ -5,26 +5,50 @@ package com.starrocks.rpc;
 import com.starrocks.common.ClientPool;
 import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TNetworkAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+
+import java.net.SocketTimeoutException;
 
 public class FrontendServiceProxy {
+    private static final Logger LOG = LogManager.getLogger(FrontendServiceProxy.class);
 
-    public static <T> T call(TNetworkAddress address, int timeoutMs, MethodCallable<T> callable) throws Exception {
+    public static <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes, MethodCallable<T> callable)
+            throws Exception {
         FrontendService.Client client = ClientPool.frontendPool.borrowObject(address, timeoutMs);
-
-        boolean returnToPool = false;
-        T res;
+        boolean isConnValid = false;
         try {
-            res = callable.invoke(client);
-            returnToPool = true;
+            for (int i = 0; i < retryTimes; i++) {
+                try {
+                    T t = callable.invoke(client);
+                    isConnValid = true;
+                    return t;
+                } catch (TTransportException te) {
+                    LOG.warn("call frontend thrift rpc failed, addr: {}, retried: {}", address, i, te);
+                    // The frontendPool may return a broken conn,
+                    // because there is no validation of the conn in the frontendPool.
+                    // In this case we should reopen the conn and retry the rpc call,
+                    // but we do not retry for the timeout exception, because it may be a network timeout
+                    // or the target server may be running slow.
+                    isConnValid = ClientPool.frontendPool.reopen(client, timeoutMs);
+                    if (i == retryTimes - 1 ||
+                            !isConnValid ||
+                            (te.getCause() instanceof SocketTimeoutException)) {
+                        throw te;
+                    }
+                }
+            }
         } finally {
-            if (returnToPool) {
+            if (isConnValid) {
                 ClientPool.frontendPool.returnObject(address, client);
             } else {
                 ClientPool.frontendPool.invalidateObject(address, client);
             }
         }
-        return res;
+
+        throw new Exception("unexpected");
     }
 
     public interface MethodCallable<T> {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -135,8 +135,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setTimeout_second(timeoutSecond);
         TBeginRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.beginRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} beginRemoteTransaction rpc method failed, label: {}", addr, label, e);
@@ -174,8 +175,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setCommit_infos(tabletCommitInfos);
         TCommitRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.commitRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} commitRemoteTransaction rpc method failed, txn_id: {} e: {}", addr, transactionId, e);
@@ -209,8 +211,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setError_msg(errorMsg);
         TAbortRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.abortRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} abortRemoteTransaction rpc method failed, txn_id: {} e: {}", addr, transactionId, e);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5655
Fixes #3077

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some cases, such as fe restart, a broken conn will be returned from the connection pool, because there is no validation of the conn before being returned to user. We should reopen the conn and retry the rpc.
But for the timeout exception, it may be a network timeout or the target server may be running slow. We just reopen the conn in this case but do not retry.
Since we do not retry for the timeout exception, there is no need to distinguish between the types of statements that should be retried, so we discard the isQuery param from MasterOpExecutor.