### PR TITLE
[Bugfix] release resources in destructor not close for ScanOperator

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -134,6 +134,10 @@ void Operator::eval_runtime_bloom_filters(vectorized::Chunk* chunk) {
     ExecNode::eval_filter_null_values(chunk, filter_null_value_columns());
 }
 
+RuntimeState* Operator::runtime_state() {
+    return _factory->runtime_state();
+}
+
 void Operator::_init_rf_counters(bool init_bloom) {
     if (_runtime_in_filter_num_counter == nullptr) {
         _runtime_in_filter_num_counter = ADD_COUNTER(_common_metrics, "RuntimeInFilterNum", TUnit::UNIT);

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -146,6 +146,8 @@ public:
         return growth_time;
     }
 
+    RuntimeState* runtime_state();
+
 protected:
     OperatorFactory* _factory;
     const int32_t _id;

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -61,6 +61,9 @@ bool OlapScanOperator::is_finished() const {
         return true;
     }
 
+    // ScanOperator::is_finished() will check whether the morsel queue has more morsels,
+    // and some kinds of morsel queue will be ready after the scan context prepares ready.
+    // Therefore, return false when the context is not ready.
     if (!_ctx->is_prepare_finished()) {
         return false;
     }

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -57,7 +57,7 @@ bool OlapScanOperator::has_output() const {
 }
 
 bool OlapScanOperator::is_finished() const {
-    if (_ctx->is_finished()) {
+    if (_ctx->is_finished() || _is_finished) {
         return true;
     }
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -39,6 +39,15 @@ OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t
     _ctx->ref();
 }
 
+OlapScanOperator::~OlapScanOperator() {
+    auto* state = runtime_state();
+    if (state == nullptr) {
+        return;
+    }
+
+    _ctx->unref(state);
+}
+
 bool OlapScanOperator::has_output() const {
     if (!_ctx->is_prepare_finished() || _ctx->is_finished()) {
         return false;
@@ -63,9 +72,7 @@ Status OlapScanOperator::do_prepare(RuntimeState*) {
     return Status::OK();
 }
 
-void OlapScanOperator::do_close(RuntimeState* state) {
-    _ctx->unref(state);
-}
+void OlapScanOperator::do_close(RuntimeState* state) {}
 
 ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -35,7 +35,7 @@ public:
     OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
                      OlapScanContextPtr ctx);
 
-    ~OlapScanOperator() override = default;
+    ~OlapScanOperator() override;
 
     bool has_output() const override;
     bool is_finished() const override;

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -14,6 +14,15 @@ OlapScanPrepareOperator::OlapScanPrepareOperator(OperatorFactory* factory, int32
     _ctx->ref();
 }
 
+OlapScanPrepareOperator::~OlapScanPrepareOperator() {
+    auto* state = runtime_state();
+    if (state == nullptr) {
+        return;
+    }
+
+    _ctx->unref(state);
+}
+
 Status OlapScanPrepareOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
@@ -22,7 +31,6 @@ Status OlapScanPrepareOperator::prepare(RuntimeState* state) {
 }
 
 void OlapScanPrepareOperator::close(RuntimeState* state) {
-    _ctx->unref(state);
     SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
@@ -18,6 +18,7 @@ class OlapScanPrepareOperator final : public SourceOperator {
 public:
     OlapScanPrepareOperator(OperatorFactory* factory, int32_t id, const string& name, int32_t plan_node_id,
                             int32_t driver_sequence, OlapScanContextPtr ctx);
+    ~OlapScanPrepareOperator() override;
 
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -61,6 +61,8 @@ protected:
     // And all these parallel profiles will be merged to ScanOperator's profile at the end.
     std::vector<std::shared_ptr<RuntimeProfile>> _chunk_source_profiles;
 
+    bool _is_finished = false;
+
 private:
     inline void set_scan_status(const Status& status) {
         std::lock_guard<SpinLock> l(_scan_status_mutex);
@@ -77,8 +79,6 @@ private:
     static constexpr int MAX_IO_TASKS_PER_OP = 4;
 
     const size_t _buffer_size = config::pipeline_io_buffer_size;
-
-    bool _is_finished = false;
 
     int32_t _io_task_retry_cnt = 0;
     PriorityThreadPool* _io_threads = nullptr;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -17,10 +17,14 @@ class ScanOperator : public SourceOperator {
 public:
     ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
 
-    ~ScanOperator() override = default;
+    ~ScanOperator() override;
 
     Status prepare(RuntimeState* state) override;
 
+    // The running I/O task committed by ScanOperator holds the reference of query context,
+    // so it can prevent the scan operator from deconstructored, but cannot prevent it from closed.
+    // Therefore, release resources used by the I/O task in ~ScanOperator and ScanOperatorFactory::close,
+    // **NOT** in ScanOperator::close.
     void close(RuntimeState* state) override;
 
     bool has_output() const override;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6073.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The running I/O task committed by `ScanOperator` holds the reference of query context, so it can prevent the scan operator from deconstructored, but cannot prevent it from closed.

Therefore, release resources used by the I/O task in `~ScanOperator` and `ScanOperatorFactory::close`, **NOT** in `ScanOperator::close`.

The bug is introduced when I add `OlapScanPreapreOperator` in the PR #5649.