### PR TITLE
[BugFix] fix crash when order by limit 0

### DIFF
--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
@@ -19,7 +19,7 @@ namespace starrocks::vectorized {
 Status ChunksSorterHeapSort::update(RuntimeState* state, const ChunkPtr& chunk) {
     ScopedTimer<MonotonicStopWatch> timer(_build_timer);
 
-    if (chunk->is_empty()) {
+    if (chunk->is_empty() || _number_of_rows_to_sort() == 0) {
         return Status::OK();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix the following sql: `order by xxx limit 0`.
