### PR TITLE
[Bug] fix cancel multi times cause pipeline hang

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -246,8 +246,10 @@ void SubQuerySharedDriverQueue::put(const DriverRawPtr driver) {
 }
 
 void SubQuerySharedDriverQueue::cancel(const DriverRawPtr driver) {
-    DCHECK(driver->is_in_ready_queue());
-    pending_cancel_queue.emplace(driver);
+    if (cancelled_set.count(driver) == 0) {
+        DCHECK(driver->is_in_ready_queue());
+        pending_cancel_queue.emplace(driver);
+    }
 }
 
 DriverRawPtr SubQuerySharedDriverQueue::take() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

Fixes #6160

## Problem Summary(Required) ：
FE cancel query multi times pipeline, driver_number in
SubQuerySharedDriverQueue will decrease greater than once.
which will cause driver_number to zero. so pipeline executor
won't take any driver

