### PR TITLE
[Enhancement] set query_id at TLS to improve diagnostic ability

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -88,6 +88,10 @@ void GlobalDriverExecutor::_worker_thread() {
 
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
+        tls_thread_status.set_query_id(query_ctx->query_id());
+        tls_thread_status.set_fragment_instance_id(fragment_ctx->fragment_instance_id());
+        tls_thread_status.set_pipeline_driver_id(driver->driver_id());
+
         // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
         //  This writing method is a bit tricky, and when there is a better way, replace it
         auto runtime_state_ptr = fragment_ctx->runtime_state_ptr();

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -50,8 +50,12 @@ public:
     }
 
     void set_query_id(const starrocks::TUniqueId& query_id) { _query_id = query_id; }
-
     const starrocks::TUniqueId& query_id() { return _query_id; }
+
+    void set_fragment_instance_id(const starrocks::TUniqueId& fragment_instance_id) {
+        _fragment_instance_id = fragment_instance_id;
+    }
+    void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
@@ -152,7 +156,10 @@ private:
     const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
 
     int64_t _cache_size = 0;
+    // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
+    TUniqueId _fragment_instance_id;
+    int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;
 };


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Store some query information at TLS to improve diagnostic ability.

When diagnose a coredump, just run the command `print tls_thread_status`.
