### PR TITLE
[Feat] Pass rowid range to tablet reader

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(Storage STATIC
     rowset/segment_chunk_iterator_adapter.cpp
     rowset/segment_iterator.cpp
     rowset/segment_options.cpp
+    rowset/rowid_range_option.cpp
     task/engine_batch_load_task.cpp
     task/engine_checksum_task.cpp
     task/engine_clone_task.cpp

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -19,9 +19,14 @@ class Range {
     using rowid_t = starrocks::rowid_t;
 
 public:
-    Range() {}
-
+    Range() = default;
     Range(rowid_t begin, rowid_t end);
+
+    // Enable copy/move ctor and assignment.
+    Range(const Range&) = default;
+    Range& operator=(const Range&) = default;
+    Range(Range&&) = default;
+    Range& operator=(Range&&) = default;
 
     // the id of start row, inclusive.
     rowid_t begin() const { return _begin; }

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -1,0 +1,21 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/rowset/rowid_range_option.h"
+
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/segment.h"
+
+namespace starrocks::vectorized {
+
+RowidRangeOption::RowidRangeOption(const string& rowset_id, const uint64_t segment_id, const SparseRange& rowid_range)
+        : rowset_id(rowset_id), segment_id(segment_id), rowid_range(rowid_range) {}
+
+bool RowidRangeOption::match_rowset(const Rowset* rowset) const {
+    return rowset->rowset_id().to_string() == rowset_id;
+}
+
+bool RowidRangeOption::match_segment(const Segment* segment) const {
+    return segment->id() == segment_id;
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -7,11 +7,11 @@
 
 namespace starrocks::vectorized {
 
-RowidRangeOption::RowidRangeOption(const string& rowset_id, const uint64_t segment_id, const SparseRange& rowid_range)
+RowidRangeOption::RowidRangeOption(const RowsetId& rowset_id, uint64_t segment_id, const SparseRange& rowid_range)
         : rowset_id(rowset_id), segment_id(segment_id), rowid_range(rowid_range) {}
 
 bool RowidRangeOption::match_rowset(const Rowset* rowset) const {
-    return rowset->rowset_id().to_string() == rowset_id;
+    return rowset->rowset_id() == rowset_id;
 }
 
 bool RowidRangeOption::match_segment(const Segment* segment) const {

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -1,0 +1,31 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <string>
+
+#include "storage/range.h"
+
+namespace starrocks {
+
+class Rowset;
+class Segment;
+
+namespace vectorized {
+
+// It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
+struct RowidRangeOption {
+public:
+    RowidRangeOption(const std::string& rowset_id, const uint64_t segment_id, const SparseRange& rowid_range);
+
+    bool match_rowset(const Rowset* rowset) const;
+    bool match_segment(const Segment* segment) const;
+
+public:
+    const std::string rowset_id;
+    const uint64_t segment_id;
+    const SparseRange rowid_range;
+};
+
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#include "storage/olap_common.h"
 #include "storage/range.h"
 
 namespace starrocks {
@@ -16,13 +17,13 @@ namespace vectorized {
 // It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
 struct RowidRangeOption {
 public:
-    RowidRangeOption(const std::string& rowset_id, const uint64_t segment_id, const SparseRange& rowid_range);
+    RowidRangeOption(const RowsetId& rowset_id, uint64_t segment_id, const SparseRange& rowid_range);
 
     bool match_rowset(const Rowset* rowset) const;
     bool match_segment(const Segment* segment) const;
 
 public:
-    const std::string rowset_id;
+    const RowsetId rowset_id;
     const uint64_t segment_id;
     const SparseRange rowid_range;
 };

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -25,6 +25,7 @@ namespace starrocks::vectorized {
 class ColumnPredicate;
 class DeletePredicates;
 class Schema;
+struct RowidRangeOption;
 
 class RowsetReadOptions {
 public:
@@ -56,6 +57,8 @@ public:
 
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
+
+    RowidRangeOption* rowid_range_option = nullptr;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -26,6 +26,7 @@ class ColumnPredicate;
 class DeletePredicates;
 class Schema;
 struct RowidRangeOption;
+using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
 
 class RowsetReadOptions {
 public:
@@ -58,7 +59,7 @@ public:
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
 
-    RowidRangeOption* rowid_range_option = nullptr;
+    RowidRangeOptionPtr rowid_range_option = nullptr;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -226,7 +226,7 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const vectorized::Schema& schem
     }
 }
 
-Status Segment::_load_index(MemTracker* mem_tracker) {
+Status Segment::load_index(MemTracker* mem_tracker) {
     return _load_index_once.call([this, mem_tracker] {
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         // read and parse short key index page

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -145,6 +145,10 @@ public:
 
     uint32_t num_rows() const { return _num_rows; }
 
+    // Load and decode short key index.
+    // May be called multiple times, subsequent calls will no op.
+    Status load_index(MemTracker* mem_tracker);
+
 private:
     Segment(const Segment&) = delete;
     const Segment& operator=(const Segment&) = delete;
@@ -156,9 +160,6 @@ private:
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open(MemTracker* mem_tracker, size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer);
     Status _create_column_readers(MemTracker* mem_tracker, SegmentFooterPB* footer);
-    // Load and decode short key index.
-    // May be called multiple times, subsequent calls will no op.
-    Status _load_index(MemTracker* mem_tracker);
 
     StatusOr<ChunkIteratorPtr> _new_iterator(const vectorized::Schema& schema,
                                              const vectorized::SegmentReadOptions& read_options);

--- a/be/src/storage/rowset/segment_options.cpp
+++ b/be/src/storage/rowset/segment_options.cpp
@@ -32,6 +32,8 @@ Status SegmentReadOptions::convert_to(SegmentReadOptions* dst, const std::vector
     dst->use_page_cache = use_page_cache;
     dst->profile = profile;
     dst->global_dictmaps = global_dictmaps;
+    dst->rowid_range_option = rowid_range_option;
+
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -23,6 +23,7 @@ namespace starrocks::vectorized {
 
 class ColumnPredicate;
 struct RowidRangeOption;
+using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
 
 class SegmentReadOptions {
 public:
@@ -59,7 +60,7 @@ public:
 
     bool has_delete_pred = false;
 
-    RowidRangeOption* rowid_range_option = nullptr;
+    RowidRangeOptionPtr rowid_range_option = nullptr;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -22,6 +22,7 @@ class KVStore;
 namespace starrocks::vectorized {
 
 class ColumnPredicate;
+struct RowidRangeOption;
 
 class SegmentReadOptions {
 public:
@@ -50,11 +51,6 @@ public:
 
     bool use_page_cache = false;
 
-    Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;
-
-    // Only used for debugging
-    std::string debug_string() const;
-
     ReaderType reader_type = READER_QUERY;
     int chunk_size = DEFAULT_CHUNK_SIZE;
 
@@ -62,6 +58,14 @@ public:
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
 
     bool has_delete_pred = false;
+
+    RowidRangeOption* rowid_range_option = nullptr;
+
+public:
+    Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;
+
+    // Only used for debugging
+    std::string debug_string() const;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -383,8 +383,8 @@ Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet, const std::
         return {};
     }
 
-    bool inc_lower = range_start_op == "ge" || range_start_op == "eq";
-    bool inc_upper = range_end_op == "le" || range_end_op == "eq";
+    bool lower_inclusive = range_start_op == "ge" || range_start_op == "eq";
+    bool upper_inclusive = range_end_op == "le" || range_end_op == "eq";
 
     CHECK_EQ(range_start_key.size(), range_end_key.size());
     size_t n = range_start_key.size();
@@ -396,8 +396,8 @@ Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet, const std::
         RETURN_IF_ERROR(_to_seek_tuple(tablet->tablet_schema(), range_start_key[i], &lower, mempool));
         RETURN_IF_ERROR(_to_seek_tuple(tablet->tablet_schema(), range_end_key[i], &upper, mempool));
         ranges->emplace_back(SeekRange{std::move(lower), std::move(upper)});
-        ranges->back().set_inclusive_lower(inc_lower);
-        ranges->back().set_inclusive_upper(inc_upper);
+        ranges->back().set_inclusive_lower(lower_inclusive);
+        ranges->back().set_inclusive_upper(upper_inclusive);
     }
     return Status::OK();
 }

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -41,6 +41,11 @@ public:
 
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
+    static Status parse_seek_range(const TabletSharedPtr& tablet, const std::string& range_start_op,
+                                   const std::string& range_end_op, const std::vector<OlapTuple>& range_start_key,
+                                   const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
+                                   MemPool* mempool);
+
 public:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override;
@@ -49,11 +54,12 @@ private:
     using PredicateList = std::vector<const ColumnPredicate*>;
     using PredicateMap = std::unordered_map<ColumnId, PredicateList>;
 
-    Status _parse_seek_range(const TabletReaderParams& read_params, std::vector<SeekRange>* ranges);
     Status _init_predicates(const TabletReaderParams& read_params);
     Status _init_delete_predicates(const TabletReaderParams& read_params, DeletePredicates* dels);
     Status _init_collector(const TabletReaderParams& read_params);
-    Status _to_seek_tuple(const TabletSchema& tablet_schema, const OlapTuple& input, SeekTuple* tuple);
+
+    static Status _to_seek_tuple(const TabletSchema& tablet_schema, const OlapTuple& input, SeekTuple* tuple,
+                                 MemPool* mempool);
 
     TabletSharedPtr _tablet;
     Version _version;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -19,6 +19,7 @@ class RuntimeState;
 namespace vectorized {
 
 class ColumnPredicate;
+struct RowidRangeOption;
 
 static inline std::unordered_set<uint32_t> EMPTY_FILTERED_COLUMN_IDS;
 
@@ -50,11 +51,15 @@ struct TabletReaderParams {
 
     RuntimeProfile* profile = nullptr;
 
-    std::string to_string() const;
     int chunk_size = 1024;
 
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = &EMPTY_FILTERED_COLUMN_IDS;
+
+    RowidRangeOption* rowid_range_option = nullptr;
+
+public:
+    std::string to_string() const;
 };
 
 } // namespace vectorized

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -20,6 +20,7 @@ namespace vectorized {
 
 class ColumnPredicate;
 struct RowidRangeOption;
+using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
 
 static inline std::unordered_set<uint32_t> EMPTY_FILTERED_COLUMN_IDS;
 
@@ -56,7 +57,7 @@ struct TabletReaderParams {
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = &EMPTY_FILTERED_COLUMN_IDS;
 
-    RowidRangeOption* rowid_range_option = nullptr;
+    RowidRangeOptionPtr rowid_range_option = nullptr;
 
 public:
     std::string to_string() const;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR relates ：
Relates #6110.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Parallel scan on the tablet will split a tablet into multiple tasks (that is, morsels), each of which pick up a different rowid range from the tablet.
Therefore, pass rowid range to tablet reader. The reader can only read the rows in this rowid range.

## Modifications
- Restrict the TabletReader to only read the specific rowid range from the segment with `segment_id` of the rowset with `rowset_id`.

- In addition, make `TabletReader::parse_seek_range` static and `Tablet::load_index` public, to make others able to use them.