### PR TITLE
[BugFix] fix #6155: handle hybrid input of json_each function

### DIFF
--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -103,6 +103,7 @@ StatusOr<vectorized::ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* s
         bool has_remain_repeat_times = _remain_repeat_times > 0;
 
         if (!has_remain_repeat_times) {
+            DCHECK_LT(_input_chunk_index + 1, _table_function_result.second->size());
             _remain_repeat_times = _table_function_result.second->get(_input_chunk_index + 1).get_int32() -
                                    _table_function_result.second->get(_input_chunk_index).get_int32();
         }
@@ -191,6 +192,7 @@ void TableFunctionOperator::_process_table_function() {
     if (!_table_function_result_eos) {
         SCOPED_TIMER(_table_function_exec_timer);
         _table_function_result = _table_function->process(_table_function_state, &_table_function_result_eos);
+        DCHECK_EQ(_input_chunk->num_rows() + 1, _table_function_result.second->size());
     }
 }
 } // namespace starrocks::pipeline

--- a/be/src/exprs/table_function/json_each.cpp
+++ b/be/src/exprs/table_function/json_each.cpp
@@ -49,9 +49,8 @@ std::pair<Columns, ColumnPtr> JsonEach::process(TableFunctionState* state, bool*
                 offset++;
                 arr_idx++;
             }
-        } else {
-            continue;
         }
+
         offset_column->append(offset);
     }
 

--- a/be/test/exprs/agg/json_each_test.cpp
+++ b/be/test/exprs/agg/json_each_test.cpp
@@ -13,20 +13,22 @@ namespace starrocks::vectorized {
 
 class JsonEachTest : public testing::Test {
 public:
-    void test_impl(std::string input, std::vector<std::tuple<std::string, std::string>> expected) {
+    void test_impl(std::vector<std::string> inputs, std::vector<std::tuple<std::string, std::string>> expected) {
         const TableFunction* func =
                 get_table_function("json_each", {TYPE_JSON}, {TYPE_VARCHAR, TYPE_JSON}, TFunctionBinaryType::BUILTIN);
 
         RuntimeState* rt_state = nullptr;
         // input
         auto json_column = JsonColumn::create();
-        if (input != "null" && input != "empty") {
-            json_column->append(JsonValue::parse(input).value());
-        } else {
-            json_column->append_nulls(1);
+        for (auto& input : inputs) {
+            if (input != "null" && input != "empty") {
+                json_column->append(JsonValue::parse(input).value());
+            } else {
+                json_column->append_nulls(1);
+            }
         }
         Columns input_columns;
-        if (input != "empty") {
+        if (!inputs.empty()) {
             input_columns.push_back(json_column);
         }
         TableFunctionState* func_state;
@@ -40,11 +42,6 @@ public:
 
         // check
         ASSERT_TRUE(eos);
-        if (input == "empty" || input == "null") {
-            ASSERT_EQ(1, offset_column->size());
-        } else {
-            ASSERT_EQ(2, offset_column->size());
-        }
         ASSERT_EQ(2, result_columns.size());
         ASSERT_EQ(expected.size(), result_columns[0]->size());
         auto result_key = ColumnHelper::cast_to<TYPE_VARCHAR>(result_columns[0]);
@@ -72,7 +69,7 @@ TEST_F(JsonEachTest, json_each_object) {
         {"k5", "{}"},
     };
     // clang-format on
-    test_impl(input, expect);
+    test_impl(std::vector<std::string>{input}, expect);
 }
 
 TEST_F(JsonEachTest, json_each_object_null) {
@@ -81,16 +78,15 @@ TEST_F(JsonEachTest, json_each_object_null) {
     std::vector<std::tuple<std::string, std::string>> expect = {
     };
     // clang-format on
-    test_impl(input, expect);
+    test_impl(std::vector<std::string>{input}, expect);
 }
 
 TEST_F(JsonEachTest, json_each_object_empty) {
-    std::string input = R"(empty)";
     // clang-format off
     std::vector<std::tuple<std::string, std::string>> expect = {
     };
     // clang-format on
-    test_impl(input, expect);
+    test_impl(std::vector<std::string>{}, expect);
 }
 
 TEST_F(JsonEachTest, json_each_array) {
@@ -105,6 +101,16 @@ TEST_F(JsonEachTest, json_each_array) {
         {"5", R"({"a": 1})"},
     };
     // clang-format on
-    test_impl(input, expect);
+    test_impl(std::vector<std::string>{input}, expect);
 }
+
+TEST_F(JsonEachTest, json_each_hybrid) {
+    // clang-format off
+    std::vector<std::tuple<std::string, std::string>> expect = {
+        {"0", "1"},
+    };
+    // clang-format on
+    test_impl(std::vector<std::string>{R"( 3.14 )", R"( [1] )", R"( [] )", R"( {} )"}, expect);
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6155

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The table function should output an offset element even if the input row produce empty result, but the `json_each` function does not follow this rule.
