### PR TITLE
[BugFix] Fix drop database forcibly using DROP SCHEMA Statement (#6163)

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1785,7 +1785,7 @@ drop_stmt ::=
     :}
     | KW_DROP KW_SCHEMA opt_if_exists:ifExists ident:db opt_force:force
     {:
-        RESULT = new DropDbStmt(ifExists, db, !force);
+        RESULT = new DropDbStmt(ifExists, db, force);
     :}
     /* cluster */
     | KW_DROP KW_CLUSTER opt_if_exists:ifExists ident:cluster
@@ -1849,6 +1849,10 @@ drop_stmt ::=
 // Recover statement
 recover_stmt ::=
     KW_RECOVER KW_DATABASE ident:dbName
+    {:
+        RESULT = new RecoverDbStmt(dbName);
+    :}
+    | KW_RECOVER KW_SCHEMA ident:dbName
     {:
         RESULT = new RecoverDbStmt(dbName);
     :}


### PR DESCRIPTION
DROP SCHEMA drop database forcily and can not recover.
The pull request change the default force option to be false.
And also, adding a RECOVER SCHEMA Statement to recover database.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6201 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
