### PR TITLE
[cherry-pick][branch-2.2][BugFix] Json loader will lead to BE crash if it reads an error row (#6061)

### DIFF
--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -94,7 +94,7 @@ private:
                              const std::string& col_name);
 
     // _build_slot_descs builds _slot_descs as the order of first json object and builds _slot_desc_dict;
-    void _build_slot_descs();
+    Status _build_slot_descs();
 
 private:
     RuntimeState* _state = nullptr;

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -185,7 +185,7 @@ Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, cons
         }
 
         auto st = add_nullable_column(column, type_desc, name, value);
-        if (st.is_invalid_argument() && invalid_as_null) {
+        if (!st.ok() && invalid_as_null) {
             column->append_nulls(1);
             return Status::OK();
         }

--- a/be/test/formats/json/numeric_column_test.cpp
+++ b/be/test/formats/json/numeric_column_test.cpp
@@ -67,4 +67,81 @@ TEST_F(AddNumericColumnTest, test_add_int_overflow) {
     ASSERT_TRUE(st.is_invalid_argument());
 }
 
+TEST_F(AddNumericColumnTest, test_add_int64_lowerbound) {
+    auto column = FixedLengthColumn<int64_t>::create();
+    TypeDescriptor t(TYPE_BIGINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int64": -9223372036854775808} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int64");
+
+    auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", &val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[-9223372036854775808]", column->debug_string());
+}
+
+TEST_F(AddNumericColumnTest, test_add_int64_overflow) {
+    auto column = FixedLengthColumn<int64_t>::create();
+    TypeDescriptor t(TYPE_BIGINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int64": -9223372036854775809} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int64");
+    auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", &val);
+    ASSERT_TRUE(st.is_data_quality_error());
+}
+
+TEST_F(AddNumericColumnTest, test_add_int64_overflow2) {
+    auto column = FixedLengthColumn<int64_t>::create();
+    TypeDescriptor t(TYPE_BIGINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int64": 9223372036854775808} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int64");
+
+    auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", &val);
+    ASSERT_TRUE(st.is_invalid_argument());
+}
+
+TEST_F(AddNumericColumnTest, test_add_int128) {
+    auto column = FixedLengthColumn<int128_t>::create();
+    TypeDescriptor t(TYPE_LARGEINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int128": 9223372036854775808} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int128");
+
+    auto st = add_numeric_column<int128_t>(column.get(), t, "f_int128", &val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[9223372036854775808]", column->debug_string());
+}
+
+// Currently simdjson can not parse number < -9223372036854775808 (lower bound of int64_t)
+// or > 18446744073709551615 (upper bound of uint64_t)
+TEST_F(AddNumericColumnTest, test_add_int128_invalid) {
+    auto column = FixedLengthColumn<int128_t>::create();
+    TypeDescriptor t(TYPE_LARGEINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int128": -9223372036854775809} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int128");
+
+    auto st = add_numeric_column<int128_t>(column.get(), t, "f_int128", &val);
+    ASSERT_TRUE(st.is_data_quality_error());
+
+    json = R"(  { "f_int128": 18446744073709551616} )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_int128");
+
+    st = add_numeric_column<int128_t>(column.get(), t, "f_int128", &val);
+    ASSERT_TRUE(st.is_data_quality_error());
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6052
Fixes #6051
Fixes #6098
Fixes #6097
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Now, the JSON loader will lead to BE crash if it meets an error row.
In the non-strict model, the data(number, string) which cannot be parsed by simdjson will be filled with NULL. However, in the strict model, the data which can not be parsed by simdjson will not be filled with NULL. This will lead to the error column containing one row less than the other columns. In this pr, we will remove the error row before we continue to parse other rows.

Apart from this, there's a bug in simdjson which will recognize -9223372036854775808 as an unsigned number, this pr also adds additional logic to handle this.
