### PR TITLE
[Feature] use session variable to specify the resource group

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5254,8 +5254,6 @@ keyword ::=
     {: RESULT = id; :}
     | KW_RESOURCES:id
     {: RESULT = id; :}
-    | KW_RESOURCE_GROUP:id
-    {: RESULT = id; :}
     | KW_RESTORE:id
     {: RESULT = id; :}
     | KW_RETURNS:id

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5254,6 +5254,8 @@ keyword ::=
     {: RESULT = id; :}
     | KW_RESOURCES:id
     {: RESULT = id; :}
+    | KW_RESOURCE_GROUP:id
+    {: RESULT = id; :}
     | KW_RESTORE:id
     {: RESULT = id; :}
     | KW_RETURNS:id

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SetVar.java
@@ -22,6 +22,7 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Strings;
+import com.starrocks.catalog.WorkGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -170,6 +171,14 @@ public class SetVar {
                 }
             } catch (NumberFormatException ex) {
                 throw new AnalysisException(SessionVariable.SQL_SELECT_LIMIT + " is not a number");
+            }
+        }
+
+        if (getVariable().equalsIgnoreCase(SessionVariable.RESOURCE_GROUP)) {
+            String wgName = getValue().getStringValue();
+            WorkGroup wg = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroupByName(wgName);
+            if (wg == null) {
+                throw new AnalysisException("resource group not exists: " + wgName);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -392,8 +392,7 @@ public class WorkGroupMgr implements Writable {
     public WorkGroup chooseWorkGroupByName(String wgName) {
         readLock();
         try {
-            WorkGroup wg = workGroupMap.get(wgName);
-            return wg;
+            return workGroupMap.get(wgName);
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -389,6 +389,16 @@ public class WorkGroupMgr implements Writable {
         }
     }
 
+    public WorkGroup chooseWorkGroupByName(String wgName) {
+        readLock();
+        try {
+            WorkGroup wg = workGroupMap.get(wgName);
+            return wg;
+        } finally {
+            readUnlock();
+        }
+    }
+
     public WorkGroup chooseWorkGroup(ConnectContext ctx, WorkGroupClassifier.QueryType queryType, Set<Long> databases) {
         String user = getUnqualifiedUser(ctx);
         String role = getUnqualifiedRole(ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -119,4 +119,15 @@ public class SetStmtTest {
         expectedEx.expectMessage("Set statement only support constant expr.");
         var.analyze(analyzer);
     }
+
+    @Test
+    public void setResourceGroup() {
+        SetVar setVar = new SetVar(SetType.DEFAULT, SessionVariable.RESOURCE_GROUP, new StringLiteral("not_exists"));
+        try {
+            setVar.analyze(analyzer);
+            Assert.fail("should fail");
+        } catch (UserException e) {
+            Assert.assertEquals("resource group not exists: not_exists", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6181

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support use `resource_group`, to specify resource group of a query.
1. Change the variable to `SESSION_ONLY`, skip the persistence step
2. Add `resource_group` as keyword, to allow usage in `set xxx=yyy` command
