### PR TITLE
[BugFix] expose the shadowed field in ScanOperator

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -38,7 +38,7 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     void set_io_threads(PriorityThreadPool* io_threads) override { _io_threads = io_threads; }
-    void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
+    void set_workgroup(workgroup::WorkGroupPtr wg) override { _workgroup = std::move(wg); }
 
     /// interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -38,6 +38,7 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     void set_io_threads(PriorityThreadPool* io_threads) override { _io_threads = io_threads; }
+    void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
 
     /// interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -64,7 +64,7 @@ public:
         return scan_rows_num;
     }
 
-    void set_workgroup(workgroup::WorkGroupPtr wg) {}
+    virtual void set_workgroup(workgroup::WorkGroupPtr wg) {}
 
     // Some specific source operators need execute i/o tasks in io_threads.
     virtual void set_io_threads(PriorityThreadPool* io_threads) {}

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -64,7 +64,7 @@ public:
         return scan_rows_num;
     }
 
-    void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
+    void set_workgroup(workgroup::WorkGroupPtr wg) {}
 
     // Some specific source operators need execute i/o tasks in io_threads.
     virtual void set_io_threads(PriorityThreadPool* io_threads) {}
@@ -79,8 +79,6 @@ protected:
 
     int64_t _last_scan_rows_num = 0;
     int64_t _last_scan_bytes = 0;
-
-    workgroup::WorkGroupPtr _workgroup = nullptr;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6188
Fixes #6190

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The `_workgroup` in `SourceOperator` is shadowed by `ScanOperator`.
