### PR TITLE
[BugFix] deal with base_compaction_num_threads_per_disk and cumulation compaction_num_threads_per_disk boundary

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -255,6 +255,8 @@ CONF_Bool(disable_column_pool, "false");
 CONF_mInt32(base_compaction_check_interval_seconds, "60");
 CONF_mInt64(min_base_compaction_num_singleton_deltas, "5");
 CONF_mInt64(max_base_compaction_num_singleton_deltas, "100");
+// This config is to limit the max concurrency of running base compaction tasks.
+// -1 means no limit if enable event_based_compaction_framework, and the max concurrency will be:
 CONF_Int32(base_compaction_num_threads_per_disk, "1");
 CONF_mDouble(base_cumulative_delta_ratio, "0.3");
 CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
@@ -263,6 +265,8 @@ CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
 CONF_mInt32(cumulative_compaction_check_interval_seconds, "1");
 CONF_mInt64(min_cumulative_compaction_num_singleton_deltas, "5");
 CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, "1000");
+// This config is to limit the max concurrency of running cumulative compaction tasks.
+// -1 means no limit if enable event_based_compaction_framework, and the max concurrency will be:
 CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
 // CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
 // cumulative compaction skips recently published deltas in order to prevent

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -18,9 +18,15 @@ CompactionManager::CompactionManager() : _next_task_id(0) {
 }
 
 void CompactionManager::init_max_task_num() {
-    _max_task_num = static_cast<int32_t>(
-            StorageEngine::instance()->get_store_num() *
-            (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
+    if (config::base_compaction_num_threads_per_disk >= 0 && config::cumulative_compaction_num_threads_per_disk >= 0) {
+        _max_task_num = static_cast<int32_t>(
+                StorageEngine::instance()->get_store_num() *
+                (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
+    } else {
+        // When cumulative_compaction_num_threads_per_disk or config::base_compaction_num_threads_per_disk is less than 0,
+        // there is no limit to _max_task_num if max_compaction_concurrency is also less than 0, and here we set maximum value to be 20.
+        _max_task_num = std::min(20, static_cast<int32_t>(StorageEngine::instance()->get_store_num() * 5));
+    }
     if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
         _max_task_num = config::max_compaction_concurrency;
     }

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -18,7 +18,7 @@ namespace starrocks {
 CompactionScheduler::CompactionScheduler() {
     auto st = ThreadPoolBuilder("compact_pool")
                       .set_min_threads(1)
-                      .set_max_threads(StorageEngine::instance()->compaction_manager()->max_task_num())
+                      .set_max_threads(std::max(1, StorageEngine::instance()->compaction_manager()->max_task_num()))
                       .set_max_queue_size(1000)
                       .build(&_compaction_pool);
     DCHECK(st.ok());


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6198 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


1. When base_compaction_num_threads_per_disk and cumulative_compaction_num_threads_per_disk are both 0, _max_task_num is 0, this may leads to be crash when compaction_scheduler set_max_threads
2. When cumulative_compaction_num_threads_per_disk or config::base_compaction_num_threads_per_disk is less than 0, there is no limit to _max_task_num if max_compaction_concurrency is also less than 0.

