### PR TITLE
[BugFix] InsertStmt add shuffle property for non-duplicate keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/HashDistributionDesc.java
@@ -39,7 +39,7 @@ import java.util.Set;
 
 public class HashDistributionDesc extends DistributionDesc {
     private int numBucket;
-    private List<String> distributionColumnNames;
+    private final List<String> distributionColumnNames;
 
     public HashDistributionDesc() {
         type = DistributionInfoType.HASH;
@@ -125,8 +125,7 @@ public class HashDistributionDesc extends DistributionDesc {
             }
         }
 
-        HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(numBucket, distributionColumns);
-        return hashDistributionInfo;
+        return new HashDistributionInfo(numBucket, distributionColumns);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -80,12 +80,12 @@ import java.util.stream.Collectors;
 public class OlapTableSink extends DataSink {
     private static final Logger LOG = LogManager.getLogger(OlapTableSink.class);
 
-    private int clusterId;
+    private final int clusterId;
     // input variables
-    private OlapTable dstTable;
-    private TupleDescriptor tupleDescriptor;
+    private final OlapTable dstTable;
+    private final TupleDescriptor tupleDescriptor;
     // specified partition ids. this list should not be empty and should contains all related partition ids
-    private List<Long> partitionIds;
+    private final List<Long> partitionIds;
 
     // set after init called
     private TDataSink tDataSink;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -348,7 +348,7 @@ public class InsertPlanner {
         });
 
         HashDistributionDesc desc =
-                new HashDistributionDesc(keyColumnIds, HashDistributionDesc.SourceType.SHUFFLE_JOIN);
+                new HashDistributionDesc(keyColumnIds, HashDistributionDesc.SourceType.SHUFFLE_AGG);
         DistributionSpec spec = DistributionSpec.createHashDistributionSpec(desc);
         DistributionProperty property = new DistributionProperty(spec);
         return new PhysicalPropertySet(property);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -64,6 +64,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class InsertPlanner {
+    // Only for unit test
+    public static boolean enableSingleReplicationShuffle = false;
+
     public ExecPlan plan(InsertStmt insertStmt, ConnectContext session) {
         QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
@@ -332,6 +335,11 @@ public class InsertPlanner {
         OlapTable table = (OlapTable) insertStmt.getTargetTable();
 
         if (KeysType.DUP_KEYS.equals(table.getKeysType())) {
+            return new PhysicalPropertySet();
+        }
+
+        // No extra distribution property is needed if replication num is 1
+        if (!enableSingleReplicationShuffle && table.getDefaultReplicationNum() <= 1) {
             return new PhysicalPropertySet();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -14,6 +14,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Pair;
@@ -36,6 +37,9 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.DistributionProperty;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
@@ -89,10 +93,11 @@ public class InsertPlanner {
         logicalPlan = new LogicalPlan(optExprBuilder, outputColumns, logicalPlan.getCorrelation());
 
         Optimizer optimizer = new Optimizer();
+        PhysicalPropertySet requiredPropertySet = createPhysicalPropertySet(insertStmt, outputColumns);
         OptExpression optimizedPlan = optimizer.optimize(
                 session,
                 logicalPlan.getRoot(),
-                new PhysicalPropertySet(),
+                requiredPropertySet,
                 new ColumnRefSet(logicalPlan.getOutputColumn()),
                 columnRefFactory);
 
@@ -144,7 +149,7 @@ public class InsertPlanner {
         return execPlan;
     }
 
-    void castLiteralToTargetColumnsType(InsertStmt insertStatement) {
+    private void castLiteralToTargetColumnsType(InsertStmt insertStatement) {
         Preconditions.checkState(insertStatement.getQueryStatement().getQueryRelation() instanceof ValuesRelation,
                 "must values");
         List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
@@ -175,8 +180,8 @@ public class InsertPlanner {
         }
     }
 
-    OptExprBuilder fillDefaultValue(LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
-                                    InsertStmt insertStatement, List<ColumnRefOperator> outputColumns) {
+    private OptExprBuilder fillDefaultValue(LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
+                                            InsertStmt insertStatement, List<ColumnRefOperator> outputColumns) {
         List<Column> baseSchema = insertStatement.getTargetTable().getBaseSchema();
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
@@ -217,9 +222,9 @@ public class InsertPlanner {
         return logicalPlan.getRootBuilder().withNewRoot(new LogicalProjectOperator(new HashMap<>(columnRefMap)));
     }
 
-    OptExprBuilder fillShadowColumns(ColumnRefFactory columnRefFactory, InsertStmt insertStatement,
-                                     List<ColumnRefOperator> outputColumns, OptExprBuilder root,
-                                     ConnectContext session) {
+    private OptExprBuilder fillShadowColumns(ColumnRefFactory columnRefFactory, InsertStmt insertStatement,
+                                             List<ColumnRefOperator> outputColumns, OptExprBuilder root,
+                                             ConnectContext session) {
         List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
@@ -291,9 +296,10 @@ public class InsertPlanner {
         return root.withNewRoot(new LogicalProjectOperator(new HashMap<>(columnRefMap)));
     }
 
-    OptExprBuilder castOutputColumnsTypeToTargetColumns(ColumnRefFactory columnRefFactory,
-                                                        InsertStmt insertStatement,
-                                                        List<ColumnRefOperator> outputColumns, OptExprBuilder root) {
+    private OptExprBuilder castOutputColumnsTypeToTargetColumns(ColumnRefFactory columnRefFactory,
+                                                                InsertStmt insertStatement,
+                                                                List<ColumnRefOperator> outputColumns,
+                                                                OptExprBuilder root) {
         List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
@@ -309,5 +315,42 @@ public class InsertPlanner {
             }
         }
         return root.withNewRoot(new LogicalProjectOperator(new HashMap<>(columnRefMap)));
+    }
+
+    /**
+     * OlapTableSink may be executed in multiply fragment instances of different machines
+     * For non-duplicate key types, we must guarantee that the orders of the same key are
+     * exactly the same. In order to achieve this goal, we can perform shuffle before TableSink
+     * so that the same key will be sent to the same fragment instance
+     */
+    private PhysicalPropertySet createPhysicalPropertySet(InsertStmt insertStmt,
+                                                          List<ColumnRefOperator> outputColumns) {
+        if (!(insertStmt.getTargetTable() instanceof OlapTable)) {
+            return new PhysicalPropertySet();
+        }
+
+        OlapTable table = (OlapTable) insertStmt.getTargetTable();
+
+        if (KeysType.DUP_KEYS.equals(table.getKeysType())) {
+            return new PhysicalPropertySet();
+        }
+
+        List<Column> columns = table.getFullSchema();
+        Preconditions.checkState(columns.size() == outputColumns.size(),
+                "outputColumn's size must equal with table's column size");
+
+        List<Column> keyColumns = table.getKeyColumnsByIndexId(table.getBaseIndexId());
+        List<Integer> keyColumnIds = Lists.newArrayList();
+        keyColumns.forEach(column -> {
+            int index = columns.indexOf(column);
+            Preconditions.checkState(index >= 0);
+            keyColumnIds.add(outputColumns.get(index).getId());
+        });
+
+        HashDistributionDesc desc =
+                new HashDistributionDesc(keyColumnIds, HashDistributionDesc.SourceType.SHUFFLE_JOIN);
+        DistributionSpec spec = DistributionSpec.createHashDistributionSpec(desc);
+        DistributionProperty property = new DistributionProperty(spec);
+        return new PhysicalPropertySet(property);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.plan;
 import com.starrocks.analysis.InsertStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
@@ -570,6 +571,7 @@ public class InsertPlanTest extends PlanTestBase {
     @Test
     public void testInsertExchange() throws Exception {
         FeConstants.runningUnitTest = true;
+        InsertPlanner.enableSingleReplicationShuffle = true;
         {
             // keysType is DUP_KEYS
             String sql = "explain insert into t0 select * from t0";
@@ -676,6 +678,7 @@ public class InsertPlanTest extends PlanTestBase {
                     "  |  output: min(10: k8), max(11: k9)\n" +
                     "  |  group by: 1: k1, 2: k2, 3: k3, 4: k4, 5: k5, 6: k6, 7: k10, 8: k11, 9: k7");
         }
+        InsertPlanner.enableSingleReplicationShuffle = false;
         FeConstants.runningUnitTest = false;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -566,4 +566,101 @@ public class InsertPlanTest extends PlanTestBase {
         ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
         Assert.assertTrue(((InsertStmt) statementBase).getQueryStatement().isExplain());
     }
+
+    @Test
+    public void testInsertExchange() throws Exception {
+        FeConstants.runningUnitTest = true;
+        {
+            // keysType is DUP_KEYS
+            String sql = "explain insert into t0 select * from t0";
+            String plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 1\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+        }
+        {
+            // KesType is PRIMARY_KEYS
+            String sql = "explain insert into tprimary select * from tprimary";
+            String plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 1\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: tprimary");
+
+            // Group by columns is different from the key columns, so extra exchange is needed
+            sql = "explain insert into tprimary select min(pk), v1, max(v2) from tprimary group by v1";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  STREAM DATA SINK\n" +
+                    "    EXCHANGE ID: 04\n" +
+                    "    HASH_PARTITIONED: 4: min\n" +
+                    "\n" +
+                    "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: min(4: min), max(5: max)\n" +
+                    "  |  group by: 2: v1");
+
+            // Group by columns are compatible with the key columns, so there is no need to add extra exchange node
+            sql = "explain insert into tprimary select pk, min(v1), max(v2) from tprimary group by pk";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 2\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: min(2: v1), max(3: v2)\n" +
+                    "  |  group by: 1: pk");
+        }
+        {
+            // KesType is AGG_KEYS
+            String sql = "explain insert into baseall select * from baseall";
+            String plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 1\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: baseall");
+
+            // Group by columns is different from the key columns, so extra exchange is needed
+            sql =
+                    "explain insert into baseall select min(k1), max(k2), min(k3), max(k4), min(k5), max(k6), min(k10), max(k11), min(k7), k8, k9 from baseall group by k8, k9";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  STREAM DATA SINK\n" +
+                    "    EXCHANGE ID: 04\n" +
+                    "    HASH_PARTITIONED: 12: min, 13: max, 14: min, 15: max, 16: min, 17: max, 18: min, 19: max, 20: min\n" +
+                    "\n" +
+                    "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: max(17: max), min(18: min), max(19: max), min(20: min), min(12: min), max(13: max), min(14: min), max(15: max), min(16: min)\n" +
+                    "  |  group by: 10: k8, 11: k9");
+
+            // Group by columns are compatible with the key columns, so there is no need to add extra exchange node
+            sql =
+                    "explain insert into baseall select k1, k2, min(k3), max(k4), min(k5), max(k6), min(k10), max(k11), min(k7), min(k8), max(k9) from baseall group by k1, k2";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 2\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: max(8: k11), min(9: k7), min(10: k8), max(11: k9), min(3: k3), max(4: k4), min(5: k5), max(6: k6), min(7: k10)\n" +
+                    "  |  group by: 1: k1, 2: k2");
+
+            // Group by columns are compatible with the key columns, so there is no need to add extra exchange node
+            sql =
+                    "explain insert into baseall select k1, k2, k3, k4, k5, k6, k10, k11, k7, min(k8), max(k9) from baseall group by k1, k2, k3, k4, k5, k6, k10, k11, k7";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 2\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: min(10: k8), max(11: k9)\n" +
+                    "  |  group by: 1: k1, 2: k2, 3: k3, 4: k4, 5: k5, 6: k6, 7: k10, 8: k11, 9: k7");
+        }
+        FeConstants.runningUnitTest = false;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -580,6 +580,21 @@ public class InsertPlanTest extends PlanTestBase {
                     "\n" +
                     "  0:OlapScanNode\n" +
                     "     TABLE: t0");
+
+            // Specify only part of the columns
+            sql = "explain insert into t0(v1, v2) select v1, v2 from t0;";
+            plan = getInsertExecPlan(sql);
+            assertContains(plan, "  OLAP TABLE SINK\n" +
+                    "    TUPLE ID: 2\n" +
+                    "    RANDOM\n" +
+                    "\n" +
+                    "  1:Project\n" +
+                    "  |  <slot 1> : 1: v1\n" +
+                    "  |  <slot 2> : 2: v2\n" +
+                    "  |  <slot 4> : NULL\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
         }
         {
             // KesType is PRIMARY_KEYS


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6230

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

OlapTableSink may be executed in multiply fragment instances of different machines

For non-duplicate key types, we must guarantee that the orders of the same key are exactly the same. In order to achieve this goal, we can solve this issue by performing shuffle exchange before TableSink so that the same key will be sent to the same fragment instance
