### PR TITLE
[Enhancement] Support 4 phase aggregate for group by constant

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -28,6 +29,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.ArrayList;
@@ -176,9 +178,15 @@ public class SplitAggregateRule extends TransformationRule {
 
             if (!operator.getGroupingKeys().isEmpty()) {
                 if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0) {
-                    newExpressions.addAll(implementOneDistinctWithGroupByAgg(
-                            context.getColumnRefFactory(), input, operator,
-                            singleDistinctFunctionPos));
+                    if (isGroupByAllConstant(input, operator)) {
+                        newExpressions.addAll(implementOneDistinctWithConstantGroupByAgg(context.getColumnRefFactory(),
+                                input, operator, distinctColumns, singleDistinctFunctionPos,
+                                operator.getGroupingKeys()));
+                    } else {
+                        newExpressions.addAll(implementOneDistinctWithGroupByAgg(
+                                context.getColumnRefFactory(), input, operator,
+                                singleDistinctFunctionPos));
+                    }
                     if (!canGenerateTwoStageAggregate(operator, distinctColumns)) {
                         return newExpressions;
                     }
@@ -188,9 +196,14 @@ public class SplitAggregateRule extends TransformationRule {
                         canGenerateTwoStageAggregate(operator, distinctColumns)) {
                     return implementTwoStageAgg(input, operator);
                 } else {
-                    return implementOneDistinctWithGroupByAgg(
-                            context.getColumnRefFactory(), input, operator,
-                            singleDistinctFunctionPos);
+                    if (isGroupByAllConstant(input, operator)) {
+                        return implementOneDistinctWithConstantGroupByAgg(context.getColumnRefFactory(),
+                                input, operator, distinctColumns, singleDistinctFunctionPos,
+                                operator.getGroupingKeys());
+                    } else {
+                        return implementOneDistinctWithGroupByAgg(context.getColumnRefFactory(), input, operator,
+                                singleDistinctFunctionPos);
+                    }
                 }
             } else {
                 if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0) {
@@ -212,6 +225,19 @@ public class SplitAggregateRule extends TransformationRule {
         }
 
         return implementTwoStageAgg(input, operator);
+    }
+
+    private boolean isGroupByAllConstant(OptExpression input, LogicalAggregationOperator operator) {
+        Map<ColumnRefOperator, ScalarOperator> rewriteProjectMap = Maps.newHashMap();
+        Projection childProjection = input.getInputs().get(0).getOp().getProjection();
+        if (childProjection != null) {
+            rewriteProjectMap.putAll(childProjection.getColumnRefMap());
+        }
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteProjectMap);
+        List<ScalarOperator> groupingKeys = operator.getGroupingKeys().stream().map(rewriter::rewrite).
+                collect(Collectors.toList());
+        return groupingKeys.stream().allMatch(ScalarOperator::isConstant);
     }
 
     private boolean canGenerateTwoStageAggregate(LogicalAggregationOperator operator,
@@ -305,6 +331,81 @@ public class SplitAggregateRule extends TransformationRule {
                 .build();
         OptExpression globalOptExpression = OptExpression.create(global, distinctGlobalOptExpression);
 
+        return Lists.newArrayList(globalOptExpression);
+    }
+
+    private List<OptExpression> implementOneDistinctWithConstantGroupByAgg(
+            ColumnRefFactory columnRefFactory,
+            OptExpression input,
+            LogicalAggregationOperator oldAgg,
+            List<ColumnRefOperator> distinctAggColumns,
+            int singleDistinctFunctionPos,
+            List<ColumnRefOperator> groupByColumns) {
+        List<ColumnRefOperator> partitionColumns = distinctAggColumns;
+
+        LogicalAggregationOperator local = createDistinctAggForFirstPhase(
+                columnRefFactory,
+                Lists.newArrayList(), oldAgg.getAggregations(), AggType.LOCAL);
+        local.setPartitionByColumns(partitionColumns);
+        OptExpression localOptExpression = OptExpression.create(local, input.getInputs());
+
+        LogicalAggregationOperator distinctGlobal = createDistinctAggForFirstPhase(
+                columnRefFactory, Lists.newArrayList(), oldAgg.getAggregations(), AggType.DISTINCT_GLOBAL);
+        distinctGlobal.setPartitionByColumns(partitionColumns);
+
+        // build projection for DISTINCT_GLOBAL aggregate node
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
+        distinctGlobal.getGroupingKeys().forEach(k -> columnRefMap.put(k, k));
+        columnRefMap.putAll(distinctGlobal.getAggregations());
+        Projection childProjection = input.getInputs().get(0).getOp().getProjection();
+        if (childProjection != null) {
+            childProjection.getColumnRefMap().entrySet().stream()
+                    .filter(entry -> groupByColumns.contains(entry.getKey())).forEach(entry -> columnRefMap.put(
+                    entry.getKey(), entry.getValue()));
+        }
+
+        LogicalAggregationOperator distinctGlobalWithProjection = new LogicalAggregationOperator.Builder()
+                .withOperator(distinctGlobal)
+                .setProjection(new Projection(columnRefMap))
+                .build();
+
+        OptExpression distinctGlobalExpression = OptExpression.create(distinctGlobalWithProjection, localOptExpression);
+
+        LogicalAggregationOperator distinctLocal = new LogicalAggregationOperator.Builder()
+                .withOperator(oldAgg)
+                .setType(AggType.DISTINCT_LOCAL)
+                .setAggregations(createDistinctAggForSecondPhase(AggType.DISTINCT_LOCAL, oldAgg.getAggregations()))
+                .setGroupingKeys(groupByColumns)
+                .setPartitionByColumns(partitionColumns)
+                .setSingleDistinctFunctionPos(singleDistinctFunctionPos)
+                .setPredicate(null)
+                .setLimit(Operator.DEFAULT_LIMIT)
+                .setProjection(null)
+                .build();
+        OptExpression distinctLocalExpression = OptExpression.create(distinctLocal, distinctGlobalExpression);
+
+        // in DISTINCT_LOCAL phase, may rewrite the aggregate function, we use the rewrite function in GLOBAL phase
+        Map<ColumnRefOperator, CallOperator> reRewriteAggregate = Maps.newHashMap(oldAgg.getAggregations());
+        Map<ColumnRefOperator, CallOperator> countDistinctMap = oldAgg.getAggregations().entrySet().stream().
+                filter(entry -> entry.getValue().isDistinct() &&
+                        entry.getValue().getFnName().equalsIgnoreCase(FunctionSet.COUNT)).
+                collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (!countDistinctMap.isEmpty()) {
+            for (Map.Entry<ColumnRefOperator, CallOperator> entry : countDistinctMap.entrySet()) {
+                reRewriteAggregate.put(entry.getKey(), distinctLocal.getAggregations().get(entry.getKey()));
+            }
+        }
+
+        LogicalAggregationOperator.Builder builder = new LogicalAggregationOperator.Builder();
+        LogicalAggregationOperator global = builder.withOperator(oldAgg)
+                .setType(AggType.GLOBAL)
+                .setGroupingKeys(groupByColumns)
+                .setPartitionByColumns(Lists.newArrayList())
+                .setAggregations(createNormalAgg(AggType.GLOBAL, reRewriteAggregate))
+                .setSplit()
+                .build();
+
+        OptExpression globalOptExpression = OptExpression.create(global, distinctLocalExpression);
         return Lists.newArrayList(globalOptExpression);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1182,4 +1182,29 @@ public class AggregateTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "output: sum(CAST(4: N_COMMENT AS DOUBLE))");
     }
+
+    @Test
+    public void testGroupByConstant() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(4);
+        String sql = "select count(distinct L_ORDERKEY) from lineitem group by 1.0001";
+        String plan = getFragmentPlan(sql);
+        // check four phase aggregate
+        assertContains(plan, "8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(19: count)\n" +
+                "  |  group by: 18: expr");
+
+        sql = "select count(distinct L_ORDERKEY) from lineitem group by 1.0001, 2.0001";
+        plan = getFragmentPlan(sql);
+        // check four phase aggregate
+        assertContains(plan, " 8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(20: count)\n" +
+                "  |  group by: 18: expr");
+
+        sql = "select count(distinct L_ORDERKEY + 1) from lineitem group by 1.0001";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(20: count)\n" +
+                "  |  group by: 18: expr");
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6218 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support 4 phase for group by constant
plan like this :
```
mysql> explain   select count(distinct lo_orderkey) from lineorder group by 1.00001;
+-------------------------------------------------------------------------------------------------+
| Explain String                                                                                  |
+-------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                 |
|  OUTPUT EXPRS:19: count                                                                         |
|   PARTITION: UNPARTITIONED                                                                      |
|                                                                                                 |
|   RESULT SINK                                                                                   |
|                                                                                                 |
|   8:Project                                                                                     |
|   |  <slot 19> : 19: count                                                                      |
|   |                                                                                             |
|   7:AGGREGATE (merge finalize)                                                                  |
|   |  output: count(19: count)                                                                   |
|   |  group by: 18: expr                                                                         |
|   |                                                                                             |
|   6:EXCHANGE                                                                                    |
|                                                                                                 |
| PLAN FRAGMENT 1                                                                                 |
|  OUTPUT EXPRS:                                                                                  |
|   PARTITION: RANDOM                                                                             |
|                                                                                                 |
|   STREAM DATA SINK                                                                              |
|     EXCHANGE ID: 06                                                                             |
|     UNPARTITIONED                                                                               |
|                                                                                                 |
|   5:AGGREGATE (update serialize)                                                                |
|   |  STREAMING                                                                                  |
|   |  output: count(1: lo_orderkey)                                                              |
|   |  group by: 18: expr                                                                         |
|   |                                                                                             |
|   4:Project                                                                                     |
|   |  <slot 1> : 1: lo_orderkey                                                                  |
|   |  <slot 18> : 1.00001                                                                        |
|   |                                                                                             |
|   3:AGGREGATE (merge serialize)                                                                 |
|   |  group by: 1: lo_orderkey                                                                   |
|   |                                                                                             |
|   2:AGGREGATE (update serialize)                                                                |
|   |  STREAMING                                                                                  |
|   |  group by: 1: lo_orderkey                                                                   |
|   |                                                                                             |
|   1:Project                                                                                     |
|   |  <slot 1> : 1: lo_orderkey                                                                  |
|   |  <slot 18> : 1.00001                                                                        |
|   |                                                                                             |
|   0:OlapScanNode                                                                                |
|      TABLE: lineorder                                                                           |
|      PREAGGREGATION: ON                                                                         |
|      partitions=1/1                                                                             |
|      rollup: lineorder                                                                          |
|      tabletRatio=10/10                                                                          |
|      tabletList=5970031,5970033,5970035,5970037,5970039,5970041,5970043,5970045,5970047,5970049 |
|      cardinality=600037902                                                                      |
|      avgRowSize=8.0                                                                             |
|      numNodes=0                                                                                 |
+-------------------------------------------------------------------------------------------------+
53 rows in set (0.00 sec)
```

```
mysql> explain   select count(distinct lo_custkey) from lineorder group by 1.00001;
+-------------------------------------------------------------------------------------------------+
| Explain String                                                                                  |
+-------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                 |
|  OUTPUT EXPRS:19: count                                                                         |
|   PARTITION: UNPARTITIONED                                                                      |
|                                                                                                 |
|   RESULT SINK                                                                                   |
|                                                                                                 |
|   9:Project                                                                                     |
|   |  <slot 19> : 19: count                                                                      |
|   |                                                                                             |
|   8:AGGREGATE (merge finalize)                                                                  |
|   |  output: count(19: count)                                                                   |
|   |  group by: 18: expr                                                                         |
|   |                                                                                             |
|   7:EXCHANGE                                                                                    |
|                                                                                                 |
| PLAN FRAGMENT 1                                                                                 |
|  OUTPUT EXPRS:                                                                                  |
|   PARTITION: HASH_PARTITIONED: 3: lo_custkey                                                    |
|                                                                                                 |
|   STREAM DATA SINK                                                                              |
|     EXCHANGE ID: 07                                                                             |
|     UNPARTITIONED                                                                               |
|                                                                                                 |
|   6:AGGREGATE (update serialize)                                                                |
|   |  STREAMING                                                                                  |
|   |  output: count(3: lo_custkey)                                                               |
|   |  group by: 18: expr                                                                         |
|   |                                                                                             |
|   5:Project                                                                                     |
|   |  <slot 3> : 3: lo_custkey                                                                   |
|   |  <slot 18> : 1.00001                                                                        |
|   |                                                                                             |
|   4:AGGREGATE (merge serialize)                                                                 |
|   |  group by: 3: lo_custkey                                                                    |
|   |                                                                                             |
|   3:EXCHANGE                                                                                    |
|                                                                                                 |
| PLAN FRAGMENT 2                                                                                 |
|  OUTPUT EXPRS:                                                                                  |
|   PARTITION: RANDOM                                                                             |
|                                                                                                 |
|   STREAM DATA SINK                                                                              |
|     EXCHANGE ID: 03                                                                             |
|     HASH_PARTITIONED: 3: lo_custkey                                                             |
|                                                                                                 |
|   2:AGGREGATE (update serialize)                                                                |
|   |  STREAMING                                                                                  |
|   |  group by: 3: lo_custkey                                                                    |
|   |                                                                                             |
|   1:Project                                                                                     |
|   |  <slot 3> : 3: lo_custkey                                                                   |
|   |  <slot 18> : 1.00001                                                                        |
|   |                                                                                             |
|   0:OlapScanNode                                                                                |
|      TABLE: lineorder                                                                           |
|      PREAGGREGATION: ON                                                                         |
|      partitions=1/1                                                                             |
|      rollup: lineorder                                                                          |
|      tabletRatio=10/10                                                                          |
|      tabletList=5970031,5970033,5970035,5970037,5970039,5970041,5970043,5970045,5970047,5970049 |
|      cardinality=600037902                                                                      |
|      avgRowSize=5.0                                                                             |
|      numNodes=0                                                                                 |
+-------------------------------------------------------------------------------------------------+
63 rows in set (0.01 sec)
```
The time cost from 8s+ to 3.5s.
The four-stage plan will perform better with more BE
