### PR TITLE
[BugFix] Fix the wrong function id in Java UDF

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -328,6 +328,7 @@ public class AggregateFunction extends Function {
     @Override
     public String getProperties() {
         Map<String, String> properties = Maps.newHashMap();
+        properties.put("fid", getFunctionId() + "");
         properties.put(CreateFunctionStmt.FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName == null ? "" : symbolName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -105,7 +105,7 @@ public class Function implements Writable {
     protected String checksum = "";
 
     // for vectorized engine, function-id
-    private long functionId;
+    protected long functionId;
 
     private boolean isPolymorphic = false;
 
@@ -613,7 +613,7 @@ public class Function implements Writable {
     }
 
     protected void writeFields(DataOutput output) throws IOException {
-        output.writeLong(id);
+        output.writeLong(functionId);
         name.write(output);
         ColumnType.write(output, retType);
         output.writeInt(argTypes.length);
@@ -638,7 +638,8 @@ public class Function implements Writable {
     }
 
     public void readFields(DataInput input) throws IOException {
-        id = input.readLong();
+        id = 0;
+        functionId = input.readLong();
         name = FunctionName.read(input);
         retType = ColumnType.read(input);
         int numArgs = input.readInt();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -230,6 +230,7 @@ public class ScalarFunction extends Function {
     @Override
     public String getProperties() {
         Map<String, String> properties = Maps.newHashMap();
+        properties.put("fid", getFunctionId() + "");
         properties.put(CreateFunctionStmt.FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -102,6 +102,7 @@ public class TableFunction extends Function {
     @Override
     public String getProperties() {
         Map<String, String> properties = Maps.newHashMap();
+        properties.put("fid", getFunctionId() + "");
         properties.put(CreateFunctionStmt.FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateFunctionTest.java
@@ -45,6 +45,7 @@ public class CreateFunctionTest {
         retTypes.add(Type.VARCHAR);
 
         final TableFunction tableFunction = new TableFunction(functionName, colNames, argTypes, retTypes);
+        tableFunction.setFunctionId(-1024);
 
         final ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.buffer(4096);
         final ByteBufOutputStream byteBufOutputStream = new ByteBufOutputStream(byteBuf);
@@ -56,8 +57,10 @@ public class CreateFunctionTest {
         newFunction.readFields(byteBufInputStream);
 
         Assert.assertEquals(newFunction.getFunctionName().getFunction(), fn);
+        Assert.assertEquals(newFunction.getFunctionId(), tableFunction.getFunctionId());
         Assert.assertEquals(newFunction.getDefaultColumnNames(), colNames);
         Assert.assertEquals(Arrays.asList(newFunction.getArgs()), argTypes);
+        Assert.assertEquals(newFunction.getTableFnReturnTypes(), retTypes);
         Assert.assertEquals(newFunction.getTableFnReturnTypes(), retTypes);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #6231 

## Problem Summary(Required) ：
fid is not persisted after it is set. So after FE restart or follower
node gets fid always 0.

now our id is no longer in use, so I use the persistent location of the
id instead of the fid.
