### PR TITLE
[BugFix] Fix NPE in tablet_updates::erase_expired_versions (#6079)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -536,6 +536,7 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
     edit_version_info->rowsets.swap(nrs);
     edit_version_info->deltas.push_back(rowsetid);
     _edit_version_infos.emplace_back(std::move(edit_version_info));
+    _check_creation_time_increasing();
     {
         std::lock_guard<std::mutex> lg(_rowsets_lock);
         _rowsets[rowsetid] = rowset;
@@ -554,6 +555,17 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
     }
     VLOG(1) << "rowset commit finished: " << _debug_string(false, true);
     return Status::OK();
+}
+void TabletUpdates::_check_creation_time_increasing() {
+    if (_edit_version_infos.size() >= 2) {
+        auto last2 = _edit_version_infos[_edit_version_infos.size() - 2].get();
+        auto last1 = _edit_version_infos[_edit_version_infos.size() - 1].get();
+        if (last2->creation_time > last1->creation_time) {
+            LOG(ERROR) << Substitute("creation_time decreased tablet:$0 $1:$2 > $3:$4", _tablet.tablet_id(),
+                                     last2->version.to_string(), last2->creation_time, last1->version.to_string(),
+                                     last1->creation_time);
+        }
+    }
 }
 
 void TabletUpdates::_try_commit_pendings_unlocked() {
@@ -1088,6 +1100,7 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
     edit_version_info->rowsets.swap(nrs);
     edit_version_info->compaction.swap(*pinfo);
     _edit_version_infos.emplace_back(std::move(edit_version_info));
+    _check_creation_time_increasing();
     auto edit_version_info_ptr = _edit_version_infos.back().get();
     {
         std::lock_guard<std::mutex> lg(_rowsets_lock);
@@ -1247,6 +1260,8 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
     for (int i = 0; i < _apply_version_idx; i++) {
         if (_edit_version_infos[i]->creation_time <= expire_time) {
             expire_list->emplace_back(std::move(_edit_version_infos[i]));
+        } else {
+            break;
         }
     }
     auto n = expire_list->size();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -330,6 +330,8 @@ private:
                                      vectorized::ChunkChanger* chunk_changer,
                                      const std::unique_ptr<RowsetWriter>& rowset_writer);
 
+    void _check_creation_time_increasing();
+
 private:
     Tablet& _tablet;
 


### PR DESCRIPTION
If creation times of the editversions is not strictly increasing, there may be some editversion ptr left NULL, casing BE crash. This PR fixes this bug.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6046
Cherrpick https://github.com/StarRocks/starrocks/pull/6079

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If creation times of the editversions are not strictly increasing, there may be some editversion ptr left NULL, casing BE crash. This PR fixes this bug.