### PR TITLE
[BugFix] Fix NPE in tablet_updates::erase_expired_versions (#6079)

### DIFF
--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -265,6 +265,8 @@ private:
 
     void _update_total_stats(const std::vector<uint32_t>& rowsets);
 
+    void _check_creation_time_increasing();
+
 private:
     Tablet& _tablet;
 


### PR DESCRIPTION
If creation times of the editversions is not strictly increasing, there may be some editversion ptr left NULL, casing BE crash. This PR fixes this bug.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6046
Cherrypick https://github.com/StarRocks/starrocks/pull/6079

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If creation times of the editversions are not strictly increasing, there may be some editversion ptr left NULL, casing BE crash. This PR fixes this bug.