### PR TITLE
[Feature] Support FileIO cache for iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -45,7 +45,7 @@ public class IcebergUtil {
         IcebergCatalogType catalogType = table.getCatalogType();
         switch (catalogType) {
             case HIVE_CATALOG:
-                return getIcebergHiveCatalog(table.getIcebergHiveMetastoreUris());
+                return getIcebergHiveCatalog(table.getIcebergHiveMetastoreUris(), table.getIcebergProperties());
             case CUSTOM_CATALOG:
                 return getIcebergCustomCatalog(table.getCatalogImpl(), table.getIcebergProperties());
             default:
@@ -57,9 +57,9 @@ public class IcebergUtil {
     /**
      * Returns the corresponding hive catalog implementation.
      */
-    public static IcebergCatalog getIcebergHiveCatalog(String metastoreUris)
+    public static IcebergCatalog getIcebergHiveCatalog(String metastoreUris, Map<String, String> icebergProperties)
             throws StarRocksIcebergException {
-        return IcebergHiveCatalog.getInstance(metastoreUris);
+        return IcebergHiveCatalog.getInstance(metastoreUris, icebergProperties);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/ByteBufferInputStream.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/ByteBufferInputStream.java
@@ -1,0 +1,73 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/io/ByteBufferInputStream.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.external.iceberg.io;
+
+import org.apache.iceberg.io.SeekableInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class ByteBufferInputStream extends SeekableInputStream {
+
+    public static ByteBufferInputStream wrap(ByteBuffer... buffers) {
+        if (buffers.length == 1) {
+            return new SingleBufferInputStream(buffers[0]);
+        } else {
+            return new MultiBufferInputStream(Arrays.asList(buffers));
+        }
+    }
+
+    public static ByteBufferInputStream wrap(List<ByteBuffer> buffers) {
+        if (buffers.size() == 1) {
+            return new SingleBufferInputStream(buffers.get(0));
+        } else {
+            return new MultiBufferInputStream(buffers);
+        }
+    }
+
+    public void skipFully(long length) throws IOException {
+        long skipped = skip(length);
+        if (skipped < length) {
+            throw new EOFException(
+                "Not enough bytes to skip: " + skipped + " < " + length);
+        }
+    }
+
+    public abstract int read(ByteBuffer out);
+
+    public abstract ByteBuffer slice(int length) throws EOFException;
+
+    public abstract List<ByteBuffer> sliceBuffers(long length) throws EOFException;
+
+    public ByteBufferInputStream sliceStream(long length) throws EOFException {
+        return ByteBufferInputStream.wrap(sliceBuffers(length));
+    }
+
+    public abstract List<ByteBuffer> remainingBuffers();
+
+    public ByteBufferInputStream remainingStream() {
+        return ByteBufferInputStream.wrap(remainingBuffers());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/IOUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/IOUtil.java
@@ -1,0 +1,57 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/io/IOUtil.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.external.iceberg.io;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class IOUtil {
+    // not meant to be instantiated
+    private IOUtil() {
+    }
+
+    public static void readFully(InputStream stream, byte[] bytes, int offset, int length) throws IOException {
+        int bytesRead = readRemaining(stream, bytes, offset, length);
+        if (bytesRead < length) {
+            throw new EOFException(
+                "Reached the end of stream with " + (length - bytesRead) + " bytes left to read");
+        }
+    }
+
+
+    public static int readRemaining(InputStream stream, byte[] bytes, int offset, int length) throws IOException {
+        int pos = offset;
+        int remaining = length;
+        while (remaining > 0) {
+            int bytesRead = stream.read(bytes, pos, remaining);
+            if (bytesRead < 0) {
+                break;
+            }
+
+            remaining -= bytesRead;
+            pos += bytesRead;
+        }
+
+        return length - remaining;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/IcebergCachingFileIO.java
@@ -1,0 +1,220 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/iceberg/pull/4518
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.external.iceberg.io;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Implementation of FileIO that adds metadata content caching features.
+ */
+public class IcebergCachingFileIO implements FileIO {
+    private static final Logger LOG = LogManager.getLogger(IcebergCachingFileIO.class);
+    private static final int BUFFER_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+    private static final long DEFAULT_FILEIO_CACHE_MAX_CONTENT_LENGTH = 8 * 1024 * 1024;
+    private static final long DEFAULT_FILEIO_CACHE_MAX_TOTAL_BYTES = 128 * 1024 * 1024;
+
+    public static final String FILEIO_CACHE_MAX_TOTAL_BYTES = "fileIO.cache.max-total-bytes";
+
+    private ContentCache fileContentCache;
+    private FileIO wrappedIO;
+
+    public IcebergCachingFileIO(FileIO io) {
+        this.wrappedIO = io;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        long maxTotalBytes = PropertyUtil.propertyAsLong(properties, FILEIO_CACHE_MAX_TOTAL_BYTES,
+                                                        DEFAULT_FILEIO_CACHE_MAX_TOTAL_BYTES);
+        this.fileContentCache = new ContentCache(DEFAULT_FILEIO_CACHE_MAX_CONTENT_LENGTH, maxTotalBytes);
+    }
+
+    @Override
+    public InputFile newInputFile(String path) {
+        return new CachingInputFile(fileContentCache, wrappedIO.newInputFile(path));
+    }
+
+    @Override
+    public OutputFile newOutputFile(String path) {
+        return wrappedIO.newOutputFile(path);
+    }
+
+    @Override
+    public void deleteFile(String path) {
+        wrappedIO.deleteFile(path);
+        // remove from cache.
+        fileContentCache.invalidate(path);
+    }
+
+    private static class CacheEntry {
+        private final long length;
+        private final List<ByteBuffer> buffers;
+
+        private CacheEntry(long length, List<ByteBuffer> buffers) {
+            this.length = length;
+            this.buffers = buffers;
+        }
+    }
+
+    public static class ContentCache {
+        private final long maxTotalBytes;
+        private final long maxContentLength;
+        private final Cache<String, CacheEntry> cache;
+
+        private ContentCache(long maxContentLength, long maxTotalBytes) {
+            this.maxTotalBytes = maxTotalBytes;
+            this.maxContentLength = maxContentLength;
+
+            Caffeine<Object, Object> builder = Caffeine.newBuilder();
+            this.cache = builder.maximumWeight(maxTotalBytes)
+                        .weigher((Weigher<String, CacheEntry>) (key, value) -> (int) Math.min(value.length, Integer.MAX_VALUE))
+                        .recordStats()
+                        .removalListener(((key, value, cause) -> {
+                            LOG.debug(key + " to be eliminated, reason: " + cause);
+                        }))
+                        .build();
+        }
+
+        public long maxContentLength() {
+            return maxContentLength;
+        }
+
+        public CacheEntry get(String key, Function<String, CacheEntry> mappingFunction) {
+            return cache.get(key, mappingFunction);
+        }
+
+        public CacheEntry getIfPresent(String location) {
+            return cache.getIfPresent(location);
+        }
+
+        public void invalidate(String key) {
+            cache.invalidate(key);
+        }
+    }
+
+    private static class CachingInputFile implements InputFile {
+        private final ContentCache contentCache;
+        private final InputFile wrappedInputFile;
+
+        private CachingInputFile(ContentCache cache, InputFile inFile) {
+            this.contentCache = cache;
+            this.wrappedInputFile = inFile;
+        }
+
+        @Override
+        public long getLength() {
+            CacheEntry buf = contentCache.getIfPresent(location());
+            return (buf != null) ? buf.length : wrappedInputFile.getLength();
+        }
+
+        @Override
+        public SeekableInputStream newStream() {
+            try {
+                // read-through cache if file length is less than or equal to maximum length allowed to cache.
+                if (getLength() <= contentCache.maxContentLength()) {
+                    return cachedStream();
+                }
+
+                // fallback to non-caching input stream.
+                return wrappedInputFile.newStream();
+            } catch (FileNotFoundException e) {
+                throw new NotFoundException(e, "Failed to open input stream for file: %s", wrappedInputFile.location());
+            } catch (IOException e) {
+                throw new RuntimeIOException(e, "Failed to open input stream for file: %s", wrappedInputFile.location());
+            }
+        }
+
+        @Override
+        public String location() {
+            return wrappedInputFile.location();
+        }
+
+        @Override
+        public boolean exists() {
+            CacheEntry buf = contentCache.getIfPresent(location());
+            return buf != null || wrappedInputFile.exists();
+        }
+
+        private CacheEntry newCacheEntry() {
+            try {
+                long fileLength = getLength();
+                long totalBytesToRead = fileLength;
+                SeekableInputStream stream = wrappedInputFile.newStream();
+                List<ByteBuffer> buffers = Lists.newArrayList();
+
+                while (totalBytesToRead > 0) {
+                    // read the stream in 4MB chunk
+                    int bytesToRead = (int) Math.min(BUFFER_CHUNK_SIZE, totalBytesToRead);
+                    byte[] buf = new byte[bytesToRead];
+                    int bytesRead = IOUtil.readRemaining(stream, buf, 0, bytesToRead);
+                    totalBytesToRead -= bytesRead;
+
+                    if (bytesRead < bytesToRead) {
+                        // Read less than it should be, possibly hitting EOF.
+                        // Set smaller ByteBuffer limit and break out of the loop.
+                        buffers.add(ByteBuffer.wrap(buf, 0, bytesRead));
+                        break;
+                    } else {
+                        buffers.add(ByteBuffer.wrap(buf));
+                    }
+                }
+
+                stream.close();
+                return new CacheEntry(fileLength - totalBytesToRead, buffers);
+            } catch (IOException ex) {
+                throw new RuntimeIOException(ex);
+            }
+        }
+
+        private SeekableInputStream cachedStream() throws IOException {
+            try {
+                CacheEntry entry = contentCache.get(location(), k -> newCacheEntry());
+                Preconditions.checkNotNull(entry, "CacheEntry should not be null when there is no RuntimeException occurs");
+                return ByteBufferInputStream.wrap(entry.buffers);
+            } catch (RuntimeIOException ex) {
+                throw ex.getCause();
+            } catch (RuntimeException ex) {
+                throw new IOException("Caught an error while reading through cache", ex);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/MultiBufferInputStream.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/MultiBufferInputStream.java
@@ -1,0 +1,349 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.external.iceberg.io;
+
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+class MultiBufferInputStream extends ByteBufferInputStream {
+    private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
+
+    private final List<ByteBuffer> buffers;
+    private final long length;
+
+    private Iterator<ByteBuffer> iterator;
+    private ByteBuffer current = EMPTY;
+    private long position;
+
+    private long mark;
+    private long markLimit;
+    private List<ByteBuffer> markBuffers;
+
+    MultiBufferInputStream(List<ByteBuffer> buffers) {
+        this.buffers = buffers;
+
+        long totalLen = 0;
+        for (ByteBuffer buffer : buffers) {
+            totalLen += buffer.remaining();
+        }
+        this.length = totalLen;
+        initFromBuffers();
+    }
+
+    private void initFromBuffers() {
+        discardMark();
+        this.position = 0;
+        this.iterator = buffers.stream().map(ByteBuffer::duplicate).iterator();
+        nextBuffer();
+    }
+
+    @Override
+    public long getPos() {
+        return position;
+    }
+
+    @Override
+    public void seek(long newPosition) throws IOException {
+        if (newPosition > length) {
+            throw new EOFException(String.format("Cannot seek to position after end of file: %s", newPosition));
+        }
+
+        if (position > newPosition) {
+            // backward seek requires returning to the initial state
+            initFromBuffers();
+        }
+
+        long bytesToSkip = newPosition - position;
+        skipFully(bytesToSkip);
+    }
+
+    @Override
+    public long skip(long n) {
+        if (n <= 0) {
+            return 0;
+        }
+
+        if (current == null) {
+            return -1;
+        }
+
+        long bytesSkipped = 0;
+        while (bytesSkipped < n) {
+            if (current.remaining() > 0) {
+                long bytesToSkip = Math.min(n - bytesSkipped, current.remaining());
+                current.position(current.position() + (int) bytesToSkip);
+                bytesSkipped += bytesToSkip;
+                this.position += bytesToSkip;
+            } else if (!nextBuffer()) {
+                // there are no more buffers
+                return bytesSkipped > 0 ? bytesSkipped : -1;
+            }
+        }
+
+        return bytesSkipped;
+    }
+
+    @Override
+    public int read(ByteBuffer out) {
+        int len = out.remaining();
+        if (len <= 0) {
+            return 0;
+        }
+
+        if (current == null) {
+            return -1;
+        }
+
+        int bytesCopied = 0;
+        while (bytesCopied < len) {
+            if (current.remaining() > 0) {
+                int bytesToCopy;
+                ByteBuffer copyBuffer;
+                if (current.remaining() <= out.remaining()) {
+                    // copy all of the current buffer
+                    bytesToCopy = current.remaining();
+                    copyBuffer = current;
+                } else {
+                    // copy a slice of the current buffer
+                    bytesToCopy = out.remaining();
+                    copyBuffer = current.duplicate();
+                    copyBuffer.limit(copyBuffer.position() + bytesToCopy);
+                    current.position(copyBuffer.position() + bytesToCopy);
+                }
+
+                out.put(copyBuffer);
+                bytesCopied += bytesToCopy;
+                this.position += bytesToCopy;
+
+            } else if (!nextBuffer()) {
+                // there are no more buffers
+                return bytesCopied > 0 ? bytesCopied : -1;
+            }
+        }
+
+        return bytesCopied;
+    }
+
+    @Override
+    public ByteBuffer slice(int len) throws EOFException {
+        if (len <= 0) {
+            return EMPTY;
+        }
+
+        if (current == null) {
+            throw new EOFException();
+        }
+
+        ByteBuffer slice;
+        if (len > current.remaining()) {
+            // a copy is needed to return a single buffer
+            slice = ByteBuffer.allocate(len);
+            int bytesCopied = read(slice);
+            slice.flip();
+            if (bytesCopied < len) {
+                throw new EOFException();
+            }
+        } else {
+            slice = current.duplicate();
+            slice.limit(slice.position() + len);
+            current.position(slice.position() + len);
+            this.position += len;
+        }
+        return slice;
+    }
+
+    @Override
+    public List<ByteBuffer> sliceBuffers(long len) throws EOFException {
+        if (len <= 0) {
+            return ImmutableList.of();
+        }
+
+        if (current == null) {
+            throw new EOFException();
+        }
+
+        List<ByteBuffer> sliceBuffers = Lists.newArrayList();
+        long bytesAccumulated = 0;
+        while (bytesAccumulated < len) {
+            if (current.remaining() > 0) {
+                // get a slice of the current buffer to return
+                // always fits in an int because remaining returns an int that is >= 0
+                int bufLen = (int) Math.min(len - bytesAccumulated, current.remaining());
+                ByteBuffer slice = current.duplicate();
+                slice.limit(slice.position() + bufLen);
+                sliceBuffers.add(slice);
+                bytesAccumulated += bufLen;
+
+                // update state; the bytes are considered read
+                current.position(current.position() + bufLen);
+                this.position += bufLen;
+            } else if (!nextBuffer()) {
+                // there are no more buffers
+                throw new EOFException();
+            }
+        }
+
+        return sliceBuffers;
+    }
+
+    @Override
+    public List<ByteBuffer> remainingBuffers() {
+        if (position >= length) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return sliceBuffers(length - position);
+        } catch (EOFException e) {
+            throw new RuntimeException(
+                    "[Parquet bug] Stream is bad: incorrect bytes remaining " +
+                    (length - position));
+        }
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) {
+        if (len <= 0) {
+            if (len < 0) {
+                throw new IndexOutOfBoundsException("Read length must be greater than 0: " + len);
+            }
+            return 0;
+        }
+
+        if (current == null) {
+            return -1;
+        }
+
+        int bytesRead = 0;
+        while (bytesRead < len) {
+            if (current.remaining() > 0) {
+                int bytesToRead = Math.min(len - bytesRead, current.remaining());
+                current.get(bytes, off + bytesRead, bytesToRead);
+                bytesRead += bytesToRead;
+                this.position += bytesToRead;
+            } else if (!nextBuffer()) {
+                // there are no more buffers
+                return bytesRead > 0 ? bytesRead : -1;
+            }
+        }
+
+        return bytesRead;
+    }
+
+    @Override
+    public int read(byte[] bytes) {
+        return read(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (current == null) {
+            throw new EOFException();
+        }
+
+        while (true) {
+            if (current.remaining() > 0) {
+                this.position += 1;
+                return current.get() & 0xFF; // as unsigned
+            } else if (!nextBuffer()) {
+                // there are no more buffers
+                throw new EOFException();
+            }
+        }
+    }
+
+    @Override
+    public int available() {
+        long remaining = length - position;
+        if (remaining > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        } else {
+            return (int) remaining;
+        }
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        if (mark >= 0) {
+            discardMark();
+        }
+        this.mark = position;
+        this.markLimit = mark + readlimit + 1;
+        if (current != null) {
+            markBuffers.add(current.duplicate());
+        }
+    }
+
+    @Override
+    public void reset() throws IOException {
+        if (mark >= 0 && position < markLimit) {
+            this.position = mark;
+            // replace the current iterator with one that adds back the buffers that
+            // have been used since mark was called.
+            this.iterator = Iterators.concat(markBuffers.iterator(), iterator);
+            discardMark();
+            nextBuffer(); // go back to the marked buffers
+        } else {
+            throw new IOException("No mark defined or has read past the previous mark limit");
+        }
+    }
+
+    private void discardMark() {
+        this.mark = -1;
+        this.markLimit = 0;
+        markBuffers = Lists.newArrayList();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    private boolean nextBuffer() {
+        if (!iterator.hasNext()) {
+            this.current = null;
+            return false;
+        }
+
+        this.current = iterator.next().duplicate();
+
+        if (mark >= 0) {
+            if (position < markLimit) {
+                // the mark is defined and valid. save the new buffer
+                markBuffers.add(current.duplicate());
+            } else {
+                // the mark has not been used and is no longer valid
+                discardMark();
+            }
+        }
+
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/SingleBufferInputStream.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/io/SingleBufferInputStream.java
@@ -1,0 +1,204 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.external.iceberg.io;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This ByteBufferInputStream does not consume the ByteBuffer being passed in,
+ * but will create a slice of the current buffer.
+ */
+class SingleBufferInputStream extends ByteBufferInputStream {
+
+    private final ByteBuffer original;
+    private final long startPosition;
+    private final int length;
+    private ByteBuffer buffer;
+    private int mark;
+
+    SingleBufferInputStream(ByteBuffer buffer) {
+        // duplicate the buffer because its state will be modified
+        this.original = buffer;
+        this.startPosition = buffer.position();
+        this.length = original.remaining();
+        initFromBuffer();
+    }
+
+    private void initFromBuffer() {
+        this.mark = -1;
+        this.buffer = original.duplicate();
+    }
+
+    @Override
+    public long getPos() {
+        // position is relative to the start of the stream, not the buffer
+        return buffer.position() - startPosition;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (!buffer.hasRemaining()) {
+            throw new EOFException();
+        }
+        return buffer.get() & 0xFF; // as unsigned
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+
+        int remaining = buffer.remaining();
+        if (remaining <= 0) {
+            return -1;
+        }
+
+        int bytesToRead = Math.min(buffer.remaining(), len);
+        buffer.get(bytes, offset, bytesToRead);
+
+        return bytesToRead;
+    }
+
+    @Override
+    public void seek(long newPosition) throws IOException {
+        if (newPosition > length) {
+            throw new EOFException(String.format("Cannot seek to position after end of file: %s", newPosition));
+        }
+
+        if (getPos() > newPosition) {
+            // backwards seek requires returning to the initial state
+            initFromBuffer();
+        }
+
+        long bytesToSkip = newPosition - getPos();
+        skipFully(bytesToSkip);
+    }
+
+    @Override
+    public long skip(long len) {
+        if (len == 0) {
+            return 0;
+        }
+
+        if (buffer.remaining() <= 0) {
+            return -1;
+        }
+
+        // buffer.remaining is an int, so this will always fit in an int
+        int bytesToSkip = (int) Math.min(buffer.remaining(), len);
+        buffer.position(buffer.position() + bytesToSkip);
+
+        return bytesToSkip;
+    }
+
+    @Override
+    public int read(ByteBuffer out) {
+        int bytesToCopy;
+        ByteBuffer copyBuffer;
+        if (buffer.remaining() <= out.remaining()) {
+            // copy all of the buffer
+            bytesToCopy = buffer.remaining();
+            copyBuffer = buffer;
+        } else {
+            // copy a slice of the current buffer
+            bytesToCopy = out.remaining();
+            copyBuffer = buffer.duplicate();
+            copyBuffer.limit(buffer.position() + bytesToCopy);
+            buffer.position(buffer.position() + bytesToCopy);
+        }
+
+        out.put(copyBuffer);
+        out.flip();
+
+        return bytesToCopy;
+    }
+
+    @Override
+    public ByteBuffer slice(int len) throws EOFException {
+        if (buffer.remaining() < len) {
+            throw new EOFException();
+        }
+
+        // length is less than remaining, so it must fit in an int
+        ByteBuffer copy = buffer.duplicate();
+        copy.limit(copy.position() + len);
+        buffer.position(buffer.position() + len);
+
+        return copy;
+    }
+
+    @Override
+    public List<ByteBuffer> sliceBuffers(long len) throws EOFException {
+        if (len == 0) {
+            return Collections.emptyList();
+        }
+
+        if (len > buffer.remaining()) {
+            throw new EOFException();
+        }
+
+        // length is less than remaining, so it must fit in an int
+        return Collections.singletonList(slice((int) len));
+    }
+
+    @Override
+    public List<ByteBuffer> remainingBuffers() {
+        if (buffer.remaining() <= 0) {
+            return Collections.emptyList();
+        }
+
+        ByteBuffer remaining = buffer.duplicate();
+        buffer.position(buffer.limit());
+
+        return Collections.singletonList(remaining);
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        this.mark = buffer.position();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        if (mark >= 0) {
+            buffer.position(mark);
+            this.mark = -1;
+        } else {
+            throw new IOException("No mark defined");
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public int available() {
+        return buffer.remaining();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2139,6 +2139,10 @@ public class GlobalStateMgr {
             sb.append("\nPROPERTIES (\n");
             sb.append("\"database\" = \"").append(icebergTable.getDb()).append("\",\n");
             sb.append("\"table\" = \"").append(icebergTable.getTable()).append("\",\n");
+            String maxTotalBytes = icebergTable.getFileIOMaxTotalBytes();
+            if (!Strings.isNullOrEmpty(maxTotalBytes)) {
+                sb.append("\"fileIO.cache.max-total-bytes\" = \"").append(maxTotalBytes).append("\",\n");
+            }
             sb.append("\"resource\" = \"").append(icebergTable.getResourceName()).append("\"");
             sb.append("\n)");
         } else if (table.getType() == TableType.JDBC) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -65,7 +65,7 @@ public class IcebergTableTest {
 
         new MockUp<IcebergUtil>() {
             @Mock
-            public IcebergCatalog getIcebergHiveCatalog(String uris) {
+            public IcebergCatalog getIcebergHiveCatalog(String uris, Map<String, String> icebergProperties) {
                 return icebergCatalog;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergHiveCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergHiveCatalogTest.java
@@ -16,13 +16,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class IcebergHiveCatalogTest {
 
     @Test
     public void testCatalogType() {
-        IcebergHiveCatalog icebergHiveCatalog = IcebergHiveCatalog.getInstance("thrift://test:9030");
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergHiveCatalog icebergHiveCatalog = IcebergHiveCatalog.getInstance("thrift://test:9030", icebergProperties);
         Assert.assertEquals(IcebergCatalogType.HIVE_CATALOG, icebergHiveCatalog.getIcebergCatalogType());
     }
 
@@ -46,7 +48,8 @@ public class IcebergHiveCatalogTest {
             }
         };
 
-        IcebergHiveCatalog icebergHiveCatalog = IcebergHiveCatalog.getInstance("thrift://test:9030");
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergHiveCatalog icebergHiveCatalog = IcebergHiveCatalog.getInstance("thrift://test:9030", icebergProperties);
         Table table = icebergHiveCatalog.loadTable(identifier);
         Assert.assertTrue(table.name().equals("test"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
@@ -8,6 +8,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class IcebergUtilTest {
 
     @Test
@@ -27,7 +30,8 @@ public class IcebergUtilTest {
 
     @Test
     public void testGetIcebergHiveCatalog() {
-        IcebergCatalog catalog = IcebergUtil.getIcebergHiveCatalog("thrift://test:9030");
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergCatalog catalog = IcebergUtil.getIcebergHiveCatalog("thrift://test:9030", icebergProperties);
         Assert.assertTrue(catalog instanceof IcebergHiveCatalog);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/io/IcebergCachingFileIOTest.java
@@ -1,0 +1,56 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.external.iceberg.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.InputFile;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergCachingFileIOTest {
+
+	public void writeIcebergMetaTestFile() {
+		try {
+			BufferedWriter out = new BufferedWriter(new FileWriter("/tmp/0001.metadata.json"));
+        	out.write("test iceberg metadata json file content");
+        	out.close();
+		} catch (IOException e) {
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testnewInputFile() {
+		writeIcebergMetaTestFile();
+		String path = "file:/tmp/0001.metadata.json";
+
+		// create hadoopFileIO
+		HadoopFileIO hadoopFileIO = new HadoopFileIO(new Configuration());
+		// create iceberg cachingFileIO
+		IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO(hadoopFileIO);
+		Map<String, String> icebergProperties = new HashMap<>();
+		cachingFileIO.initialize(icebergProperties);
+
+		// get inputfile by hadoopFileIO and cachingFileIO
+		InputFile hadoopFileIOInputFile = hadoopFileIO.newInputFile(path);
+		InputFile cachingFileIOInputFile = cachingFileIO.newInputFile(path);
+		cachingFileIOInputFile.newStream();
+
+		String cachingFileIOPath = cachingFileIOInputFile.location();
+		String hadoopFileIOPath = hadoopFileIOInputFile.location();
+		Assert.assertEquals(path, hadoopFileIOPath);
+		Assert.assertEquals(path, cachingFileIOPath);
+
+		long cacheIOInputFileSize = cachingFileIOInputFile.getLength();
+		long hadoopIOInputFileSize = hadoopFileIOInputFile.getLength();
+		Assert.assertEquals(cacheIOInputFileSize, 39);
+		Assert.assertEquals(hadoopIOInputFileSize, 39);
+	}
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  #6235

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

I use   this pr: https://github.com/apache/iceberg/pull/4518
and copy  `ByteBufferInputStream`,    `MultiBufferInputStream` , `SingleBufferInputStream` class, becase iceberg master branch  hava implements this interface `SeekableInputStream` .

I only expose `fileIO.cache.max-total-bytes`  to limit max cache size and to evict data if reach this limit.
