### PR TITLE
[Feature] Add array function of array_contains_all

### DIFF
--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -160,6 +160,9 @@ public:
     DEFINE_VECTORIZED_FN(array_cum_sum_bigint);
     DEFINE_VECTORIZED_FN(array_cum_sum_double);
 
+    DEFINE_VECTORIZED_FN(array_contains_any);
+    DEFINE_VECTORIZED_FN(array_contains_all);
+
     enum ArithmeticType { SUM, AVG, MIN, MAX };
 
 private:

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -735,4 +735,7 @@ vectorized_functions = [
 
     [150270, 'array_cum_sum', 'ARRAY_BIGINT', ['ARRAY_BIGINT'], 'ArrayFunctions::array_cum_sum_bigint'],
     [150271, 'array_cum_sum', 'ARRAY_DOUBLE', ['ARRAY_DOUBLE'], 'ArrayFunctions::array_cum_sum_double'],
+
+    # reserve 150281
+    [150282, 'array_contains_all', 'BOOLEAN', ['ANY_ARRAY', 'ANY_ARRAY'], 'ArrayFunctions::array_contains_all'],
 ]


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
> select c1, c2, array_contains_all(c1, c2) from t2;
+------------+----------+----------------------------+
| c1         | c2       | array_contains_all(c1, c2) |
+------------+----------+----------------------------+
| [1,2,3]    | [1]      |                          1 |
| NULL       | [1]      |                       NULL |
| [1,2,3]    | NULL     |                       NULL |
| [1,2,null] | NULL     |                       NULL |
| [1,2,null] | [null,1] |                          1 |
| NULL       | [null,1] |                       NULL |
| [1,2,null] | [null]   |                          1 |
| [1,2,3]    | [4]      |                          0 |
| [1,2,3]    | [1,4]    |                          0 |
| [1,2,3]    | [1,2]    |                          1 |
+------------+----------+----------------------------+
```

