### PR TITLE
[Build] Fix compile warnings about unused function crc_hash_32

### DIFF
--- a/be/src/column/column_hash.h
+++ b/be/src/column/column_hash.h
@@ -107,7 +107,7 @@ public:
     }
 };
 
-static uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
+inline uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
 #if defined(__x86_64__) && !defined(__SSE4_2__)
     return crc32(hash, (const unsigned char*)data, bytes);
 #else
@@ -145,7 +145,7 @@ static uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
 #endif
 }
 
-static uint64_t crc_hash_64(const void* data, int32_t length, uint64_t hash) {
+inline uint64_t crc_hash_64(const void* data, int32_t length, uint64_t hash) {
 #if defined(__x86_64__) && !defined(__SSE4_2__)
     return crc32(hash, (const unsigned char*)data, length);
 #else


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix compile warnings about unused function crc_hash_32