### PR TITLE
[Enhancement] Support queuing the alter finish tasks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -21,27 +21,21 @@
 
 package com.starrocks.alter;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.alter.AlterJob.JobState;
 import com.starrocks.analysis.AlterClause;
 import com.starrocks.analysis.CancelStmt;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.LocalTablet;
-import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
-import com.starrocks.catalog.Replica;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.MasterDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.RemoveAlterJobV2OperationLog;
-import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AlterReplicaTask;
@@ -56,6 +50,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class AlterHandler extends MasterDaemon {
@@ -79,6 +75,8 @@ public abstract class AlterHandler extends MasterDaemon {
      */
     protected ReentrantLock lock = new ReentrantLock();
 
+    protected ThreadPoolExecutor executor;
+
     protected void lock() {
         lock.lock();
     }
@@ -89,6 +87,9 @@ public abstract class AlterHandler extends MasterDaemon {
 
     public AlterHandler(String name) {
         super(name, FeConstants.default_scheduler_interval_millisecond);
+        executor = ThreadPoolManager
+                .newDaemonCacheThreadPool(Config.alter_max_worker_threads, Config.alter_max_worker_queue_size,
+                        name + "_pool", true);
     }
 
     protected void addAlterJobV2(AlterJobV2 alterJob) {
@@ -400,85 +401,8 @@ public abstract class AlterHandler extends MasterDaemon {
         return jobNum;
     }
 
-    /*
-     * Handle the finish report of alter task.
-     * If task is success, which means the history data before specified version has been transformed successfully.
-     * So here we should modify the replica's version.
-     * We assume that the specified version is X.
-     * Case 1:
-     *      After alter table process starts, there is no new load job being submitted. So the new replica
-     *      should be with version (1-0). So we just modify the replica's version to partition's visible version, which is X.
-     * Case 2:
-     *      After alter table process starts, there are some load job being processed.
-     * Case 2.1:
-     *      Only one new load job, and it failed on this replica. so the replica's last failed version should be X + 1
-     *      and version is still 1. We should modify the replica's version to (last failed version - 1)
-     * Case 2.2
-     *      There are new load jobs after alter task, and at least one of them is succeed on this replica.
-     *      So the replica's version should be larger than X. So we don't need to modify the replica version
-     *      because its already looks like normal.
-     */
-    public void handleFinishAlterTask(AlterReplicaTask task) throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(task.getDbId());
-        if (db == null) {
-            throw new MetaNotFoundException("database " + task.getDbId() + " does not exist");
-        }
-
-        db.writeLock();
-        try {
-            OlapTable tbl = (OlapTable) db.getTable(task.getTableId());
-            if (tbl == null) {
-                throw new MetaNotFoundException("tbl " + task.getTableId() + " does not exist");
-            }
-            Partition partition = tbl.getPartition(task.getPartitionId());
-            if (partition == null) {
-                throw new MetaNotFoundException("partition " + task.getPartitionId() + " does not exist");
-            }
-            MaterializedIndex index = partition.getIndex(task.getIndexId());
-            if (index == null) {
-                throw new MetaNotFoundException("index " + task.getIndexId() + " does not exist");
-            }
-            Tablet tablet = index.getTablet(task.getTabletId());
-            Preconditions.checkNotNull(tablet, task.getTabletId());
-            Replica replica = ((LocalTablet) tablet).getReplicaById(task.getNewReplicaId());
-            if (replica == null) {
-                throw new MetaNotFoundException("replica " + task.getNewReplicaId() + " does not exist");
-            }
-
-            LOG.info("before handle alter task tablet {}, replica: {}, task version: {}-{}",
-                    task.getSignature(), replica, task.getVersion());
-            boolean versionChanged = false;
-            if (replica.getVersion() > task.getVersion()) {
-                // Case 2.2, do nothing
-            } else {
-                if (replica.getLastFailedVersion() > task.getVersion()) {
-                    // Case 2.1
-                    replica.updateRowCount(task.getVersion(), replica.getDataSize(),
-                            replica.getRowCount());
-                    versionChanged = true;
-                } else {
-                    // Case 1
-                    Preconditions.checkState(replica.getLastFailedVersion() == -1, replica.getLastFailedVersion());
-                    replica.updateRowCount(task.getVersion(), replica.getDataSize(),
-                            replica.getRowCount());
-                    versionChanged = true;
-                }
-            }
-
-            if (versionChanged) {
-                ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(task.getDbId(), task.getTableId(),
-                        task.getPartitionId(), task.getIndexId(), task.getTabletId(), task.getBackendId(),
-                        replica.getId(), replica.getVersion(), -1,
-                        replica.getDataSize(), replica.getRowCount(),
-                        replica.getLastFailedVersion(),
-                        replica.getLastSuccessVersion());
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateReplica(info);
-            }
-
-            LOG.info("after handle alter task tablet: {}, replica: {}", task.getSignature(), replica);
-        } finally {
-            db.writeUnlock();
-        }
+    public void handleFinishAlterTask(AlterReplicaTask task) throws RejectedExecutionException {
+        executor.submit(task);
     }
 
     // replay the alter job v2

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -687,6 +687,19 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int alter_table_timeout_second = 86400; // 1day
+
+    /**
+     * The alter handler max worker threads
+     */
+    @ConfField
+    public static int alter_max_worker_threads = 4;
+
+    /**
+     * The alter handler max queue size for worker threads
+     */
+    @ConfField
+    public static int alter_max_worker_queue_size = 4096;
+
     /**
      * When create a table(or partition), you can specify its storage medium(HDD or SSD).
      * If not set, this specifies the default medium when creat.

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -107,6 +107,13 @@ public class ThreadPoolManager {
                 new LogDiscardPolicy(poolName), poolName, needRegisterMetric);
     }
 
+    public static ThreadPoolExecutor newDaemonCacheThreadPool(int maxNumThread, int queueSize, String poolName,
+            boolean needRegisterMetric) {
+        return newDaemonThreadPool(0, maxNumThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(queueSize),
+                new BlockedPolicy(poolName, 5), poolName, needRegisterMetric);
+    }
+
     public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, int queueSize, String poolName,
                                                               boolean needRegisterMetric) {
         return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -136,6 +136,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
 public class MasterImpl {
@@ -278,6 +279,13 @@ public class MasterImpl {
                 default:
                     break;
             }
+        } catch (RejectedExecutionException e) {
+            tStatus.setStatus_code(TStatusCode.TOO_MANY_TASKS);
+            String errMsg = "task queue full";
+            List<String> errorMsgs = new ArrayList<String>();
+            LOG.warn(errMsg, e);
+            errorMsgs.add(errMsg);
+            tStatus.setError_msgs(errorMsgs);
         } catch (Exception e) {
             tStatus.setStatus_code(TStatusCode.CANCELLED);
             String errMsg = "finish agent task error.";
@@ -909,15 +917,10 @@ public class MasterImpl {
 
     private void finishAlterTask(AgentTask task) {
         AlterReplicaTask alterTask = (AlterReplicaTask) task;
-        try {
-            if (alterTask.getJobType() == JobType.ROLLUP) {
-                GlobalStateMgr.getCurrentState().getRollupHandler().handleFinishAlterTask(alterTask);
-            } else if (alterTask.getJobType() == JobType.SCHEMA_CHANGE) {
-                GlobalStateMgr.getCurrentState().getSchemaChangeHandler().handleFinishAlterTask(alterTask);
-            }
-            alterTask.setFinished(true);
-        } catch (MetaNotFoundException e) {
-            LOG.warn("failed to handle finish alter task: {}, {}", task.getSignature(), e.getMessage());
+        if (alterTask.getJobType() == JobType.ROLLUP) {
+            GlobalStateMgr.getCurrentState().getRollupHandler().handleFinishAlterTask(alterTask);
+        } else if (alterTask.getJobType() == JobType.SCHEMA_CHANGE) {
+            GlobalStateMgr.getCurrentState().getSchemaChangeHandler().handleFinishAlterTask(alterTask);
         }
         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.ALTER, task.getSignature());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -21,13 +21,26 @@
 
 package com.starrocks.task;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAlterMaterializedViewParam;
 import com.starrocks.thrift.TAlterTabletReqV2;
 import com.starrocks.thrift.TTaskType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -38,7 +51,8 @@ import java.util.Map;
  * The new replica should be created before.
  * The new replica can be a rollup replica, or a shadow replica of schema change.
  */
-public class AlterReplicaTask extends AgentTask {
+public class AlterReplicaTask extends AgentTask implements Runnable {
+    private static final Logger LOG = LogManager.getLogger(AlterReplicaTask.class);
 
     private long baseTabletId;
     private long newReplicaId;
@@ -123,4 +137,96 @@ public class AlterReplicaTask extends AgentTask {
         }
         return req;
     }
+
+    /*
+     * Handle the finish report of alter task.
+     * If task is success, which means the history data before specified version has been transformed successfully.
+     * So here we should modify the replica's version.
+     * We assume that the specified version is X.
+     * Case 1:
+     *      After alter table process starts, there is no new load job being submitted. So the new replica
+     *      should be with version (1-0). So we just modify the replica's version to partition's visible version, which is X.
+     * Case 2:
+     *      After alter table process starts, there are some load job being processed.
+     * Case 2.1:
+     *      Only one new load job, and it failed on this replica. so the replica's last failed version should be X + 1
+     *      and version is still 1. We should modify the replica's version to (last failed version - 1)
+     * Case 2.2
+     *      There are new load jobs after alter task, and at least one of them is succeed on this replica.
+     *      So the replica's version should be larger than X. So we don't need to modify the replica version
+     *      because its already looks like normal.
+     */
+    public void handleFinishAlterTask() throws MetaNotFoundException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(getDbId());
+        if (db == null) {
+            throw new MetaNotFoundException("database " + getDbId() + " does not exist");
+        }
+
+        db.writeLock();
+        try {
+            OlapTable tbl = (OlapTable) db.getTable(getTableId());
+            if (tbl == null) {
+                throw new MetaNotFoundException("tbl " + getTableId() + " does not exist");
+            }
+            Partition partition = tbl.getPartition(getPartitionId());
+            if (partition == null) {
+                throw new MetaNotFoundException("partition " + getPartitionId() + " does not exist");
+            }
+            MaterializedIndex index = partition.getIndex(getIndexId());
+            if (index == null) {
+                throw new MetaNotFoundException("index " + getIndexId() + " does not exist");
+            }
+            Tablet tablet = index.getTablet(getTabletId());
+            Preconditions.checkNotNull(tablet, getTabletId());
+            Replica replica = ((LocalTablet) tablet).getReplicaById(getNewReplicaId());
+            if (replica == null) {
+                throw new MetaNotFoundException("replica " + getNewReplicaId() + " does not exist");
+            }
+
+            LOG.info("before handle alter task tablet {}, replica: {}, task version: {}-{}",
+                    getSignature(), replica, getVersion());
+            boolean versionChanged = false;
+            if (replica.getVersion() > getVersion()) {
+                // Case 2.2, do nothing
+            } else {
+                if (replica.getLastFailedVersion() > getVersion()) {
+                    // Case 2.1
+                    replica.updateRowCount(getVersion(), replica.getDataSize(),
+                            replica.getRowCount());
+                    versionChanged = true;
+                } else {
+                    // Case 1
+                    Preconditions.checkState(replica.getLastFailedVersion() == -1, replica.getLastFailedVersion());
+                    replica.updateRowCount(getVersion(), replica.getDataSize(),
+                            replica.getRowCount());
+                    versionChanged = true;
+                }
+            }
+
+            if (versionChanged) {
+                ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(getDbId(), getTableId(),
+                        getPartitionId(), getIndexId(), getTabletId(), getBackendId(),
+                        replica.getId(), replica.getVersion(), -1,
+                        replica.getDataSize(), replica.getRowCount(),
+                        replica.getLastFailedVersion(),
+                        replica.getLastSuccessVersion());
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateReplica(info);
+            }
+
+            LOG.info("after handle alter task tablet: {}, replica: {}", getSignature(), replica);
+        } finally {
+            db.writeUnlock();
+        }
+        setFinished(true);
+    }
+
+    @Override
+    public void run() {
+        try {
+            handleFinishAlterTask();
+        } catch (MetaNotFoundException e) {
+            LOG.warn("failed to handle finish alter task: {}, {}", getSignature(), e.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6469 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, FE handles the alter finish tasks directly, there will be `be_num * alter_tablet_worker_count` concurrency requests. Each task will acquire db write lock & write bdbje, it will impact other operations like ingestion.