### PR TITLE
[BugFix]Can not see the loaded data when the state of broker load turn into finished from follower node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowLoadStmt.java
@@ -289,6 +289,6 @@ public class ShowLoadStmt extends ShowStmt {
 
     @Override
     public RedirectStatus getRedirectStatus() {
-        return RedirectStatus.FORWARD_NO_SYNC;
+        return RedirectStatus.FORWARD_WITH_SYNC;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadTaskStmt.java
@@ -150,7 +150,7 @@ public class ShowRoutineLoadTaskStmt extends ShowStmt {
 
     @Override
     public RedirectStatus getRedirectStatus() {
-        return RedirectStatus.FORWARD_NO_SYNC;
+        return RedirectStatus.FORWARD_WITH_SYNC;
     }
 
     public static List<String> getTitleNames() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
@@ -117,4 +117,10 @@ public class ShowLoadStmtTest {
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW LOAD FROM `testCluster:testDb` WHERE `label` LIKE \'abc\' LIMIT 10", stmt.toString());
     }
+
+    @Test 
+    public void testGetRedirectStatus() {
+        ShowLoadStmt loadStmt = new ShowLoadStmt(null, null, null, null);
+        Assert.assertTrue(loadStmt.getRedirectStatus().equals(RedirectStatus.FORWARD_WITH_SYNC));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadTaskStmtTest.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ShowRoutineLoadTaskStmtTest {
+    
+    @Test 
+    public void testGetRedirectStatus() {
+        ShowRoutineLoadTaskStmt loadStmt = new ShowRoutineLoadTaskStmt("", null);
+        Assert.assertTrue(loadStmt.getRedirectStatus().equals(RedirectStatus.FORWARD_WITH_SYNC));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6220

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Show Load & Show Routine do not use FORWARD_WITH_SYNC. If the metadata of the imported data results are not synchronized to followers, querying these data will report an error. Using FORWARD_WITH_SYNC will keep the metadata consistent for these queries