### PR TITLE
[Enhancement] Optimize primary tablet clone to copy all the versions it is missing

### DIFF
--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -99,6 +99,18 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
         LOG(INFO) << "make incremental snapshot tablet:" << request.tablet_id << " cur_version:" << cur_tablet_version
                   << " req_version:" << JoinInts(request.missing_version, ",") << " timeout:" << timeout_s;
         res = snapshot_incremental(tablet, request.missing_version, timeout_s);
+    } else if (request.__isset.missing_version_ranges) {
+        if (tablet->updates() == nullptr) {
+            string msg = strings::Substitute(
+                    "non-primary tablet does not support snapshot by missing_version_ranges tablet:$0",
+                    request.tablet_id);
+            LOG(INFO) << msg;
+            return Status::NotSupported(msg);
+        }
+        LOG(INFO) << "make primary snapshot tablet:" << request.tablet_id << " cur_version:" << cur_tablet_version
+                  << " missing_version_ranges:" << JoinInts(request.missing_version_ranges, ",")
+                  << " timeout:" << timeout_s;
+        res = snapshot_primary(tablet, request.missing_version_ranges, timeout_s);
     } else if (request.__isset.version) {
         LOG(INFO) << "make full snapshot tablet:" << request.tablet_id << " cur_version:" << cur_tablet_version
                   << " req_version:" << request.version << " timeout:" << timeout_s;
@@ -444,6 +456,86 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
     }
 }
 
+StatusOr<std::string> SnapshotManager::snapshot_primary(const TabletSharedPtr& tablet,
+                                                        const std::vector<int64_t>& missing_version_ranges,
+                                                        int64_t timeout_s) {
+    // this is an optimized version of snapshot specifically for primary tablet
+    // 1. it will try to do incremental snapshot at best, to catch source tablet's max version
+    // 2. if it can not catch source tablet's max version, it will switch to full snapshot at src's max version
+    // 3. if it's missing_version_ranges is greater than src's max version, just return error
+    SnapshotTypePB snapshot_type = SNAPSHOT_TYPE_INCREMENTAL;
+    int64_t full_snapshot_version = 0;
+    std::vector<RowsetSharedPtr> snapshot_rowsets;
+
+    // 1. get missing rowsets for snapshot
+    std::shared_lock rdlock(tablet->get_header_lock());
+    auto st = tablet->updates()->get_rowsets_for_incremental_snapshot(missing_version_ranges, snapshot_rowsets);
+    if (st.ok() && snapshot_rowsets.empty()) {
+        snapshot_type = SNAPSHOT_TYPE_FULL;
+        full_snapshot_version = tablet->updates()->max_version();
+        st = tablet->updates()->get_applied_rowsets(full_snapshot_version, &snapshot_rowsets);
+        LOG(INFO) << "incremental_snapshot switch to full_snaphost tablet:" << tablet->tablet_id()
+                  << " version:" << full_snapshot_version << " #rowset:" << snapshot_rowsets.size();
+    }
+    rdlock.unlock();
+    if (!st.ok()) {
+        return st;
+    }
+
+    // 2. Create snapshot directory.
+    std::string snapshot_id_path = _calc_snapshot_id_path(tablet, timeout_s);
+    if (UNLIKELY(snapshot_id_path.empty())) {
+        return Status::RuntimeError("empty snapshot_id_path");
+    }
+    std::string snapshot_dir = get_schema_hash_full_path(tablet, snapshot_id_path);
+    (void)FileUtils::remove_all(snapshot_dir);
+    RETURN_IF_ERROR(FileUtils::create_dir(snapshot_dir));
+
+    // If tablet is PrimaryKey tablet, we should dump snapshot meta file first and then link files
+    // to snapshot directory
+    // The reason is tablet clone assumes rowset file is immutable, but during rowset apply for partial update,
+    // rowset file may be changed.
+    // When doing partial update, if dump snapshot meta file first, there are four conditions as below
+    //  1. rowset status is committed in meta, rowset file is partial rowset
+    //  2. rowset status is committed in meta, rowset file is `partial rowset` when we link files, and rowset apply
+    //     success after link files.
+    //  3. rowset status is committed in meta, rowset file is full rowset
+    //  4. rowset status is applied in meta, rowset file is full rowset
+    // case1 and case4 is normal case, we don't need do additional process.
+    // case2 is almost the same as case1. In normal case, partial rowset files will be delete after rowset apply. But
+    // we do a hard link of partial rowset files, so the partial rowset files will not be delete until snapshot dir is
+    // deleted. So the src BE will download the partial rowset files.
+    // case3 is a bit trick. If the rowset status is committed in meta but the rowset file is full rowset. The src be
+    // will download the full rowset file and apply it again. But we handle this contingency in partial rowset apply,
+    // because if BE crash before update meta, we also need apply this rowset again after BE restart.
+
+    // 3. Build snapshot header/meta file.
+    std::vector<RowsetMetaSharedPtr> snapshot_rowset_metas;
+    snapshot_rowset_metas.reserve(snapshot_rowsets.size());
+    for (const auto& rowset : snapshot_rowsets) {
+        snapshot_rowset_metas.emplace_back(rowset->rowset_meta());
+    }
+
+    st = make_snapshot_on_tablet_meta(snapshot_type, snapshot_dir, tablet, snapshot_rowset_metas, full_snapshot_version,
+                                      g_Types_constants.TSNAPSHOT_REQ_VERSION2);
+    if (!st.ok()) {
+        (void)FileUtils::remove_all(snapshot_id_path);
+        return st;
+    }
+
+    // 4. Link files to snapshot directory.
+    for (const auto& rowset : snapshot_rowsets) {
+        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id());
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to link rowset file:" << st;
+            (void)FileUtils::remove_all(snapshot_id_path);
+            return st;
+        }
+    }
+
+    return snapshot_id_path;
+}
+
 Status SnapshotManager::make_snapshot_on_tablet_meta(const TabletSharedPtr& tablet) {
     std::vector<RowsetSharedPtr> snapshot_rowsets;
     std::shared_lock rdlock(tablet->get_header_lock());
@@ -506,9 +598,9 @@ Status SnapshotManager::make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_typ
         }
     }
 
-    TabletMetaPB& meta_pb = snapshot_meta.tablet_meta();
-    tablet->tablet_meta()->to_meta_pb(&meta_pb);
     if (snapshot_type == SNAPSHOT_TYPE_FULL) {
+        TabletMetaPB& meta_pb = snapshot_meta.tablet_meta();
+        tablet->tablet_meta()->to_meta_pb(&meta_pb);
         // Construct a new UpdatesPB
         meta_pb.mutable_updates()->Clear();
         auto version = meta_pb.mutable_updates()->add_versions();

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -81,6 +81,10 @@ public:
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
 
+    // On success, return the absolute path of the root directory of snapshot.
+    StatusOr<std::string> snapshot_primary(const TabletSharedPtr& tablet,
+                                           const std::vector<int64_t>& missing_version_ranges, int64_t timeout_s);
+
     Status make_snapshot_on_tablet_meta(const TabletSharedPtr& tablet);
 
     Status assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir);

--- a/be/src/storage/snapshot_meta.h
+++ b/be/src/storage/snapshot_meta.h
@@ -51,7 +51,7 @@ private:
     SnapshotTypePB _snapshot_type = SNAPSHOT_TYPE_UNKNOWN;
     int32_t _format_version = -1 /* default invalid value*/;
     int64_t _snapshot_version = -1 /*default invalid value*/;
-    TabletMetaPB _tablet_meta;
+    TabletMetaPB _tablet_meta; // only valid in full snapshot mode, will empty in incremental snapshot mode
     std::vector<RowsetMetaPB> _rowset_metas;
     std::unordered_map<uint32_t, DelVector> _delete_vectors;
 };

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1299,7 +1299,6 @@ TabletManager::TabletsShard& TabletManager::_get_tablets_shard(TTabletId tabletI
 
 Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId tablet_id, SchemaHash schema_hash,
                                                        const string& schema_hash_path, bool restore) {
-    LOG(INFO) << "Loading tablet " << tablet_id << " from snapshot " << schema_hash_path;
     auto meta_path = strings::Substitute("$0/meta", schema_hash_path);
     auto shard_path = path_util::dir_name(path_util::dir_name(path_util::dir_name(meta_path)));
     auto shard_str = shard_path.substr(shard_path.find_last_of('/') + 1);
@@ -1322,6 +1321,8 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     if (snapshot_meta->tablet_meta().updates().next_log_id() != 0) {
         return Status::InternalError("non-zero log id in tablet meta");
     }
+    LOG(INFO) << Substitute("create tablet from snapshot tablet:$0 version:$1 path:", tablet_id,
+                            snapshot_meta->snapshot_version(), schema_hash_path);
 
     // Set of rowset id collected from rowset meta.
     std::set<uint32_t> set1;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -213,6 +213,11 @@ public:
                                          EditVersion* read_version, uint32_t* next_rowset_id,
                                          std::vector<std::vector<uint64_t>*>* rss_rowids);
 
+    Status get_missing_version_ranges(std::vector<int64_t>& missing_version_ranges);
+
+    Status get_rowsets_for_incremental_snapshot(const std::vector<int64_t>& missing_version_ranges,
+                                                std::vector<RowsetSharedPtr>& rowsets);
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -43,6 +43,8 @@ public:
     Status execute() override;
 
 private:
+    Status _do_clone_primary_tablet(Tablet* tablet);
+
     Status _do_clone(Tablet* tablet);
 
     Status _finish_clone(Tablet* tablet, const std::string& clone_dir, int64_t committed_version,
@@ -53,7 +55,8 @@ private:
     Status _clone_full_data(Tablet* tablet, TabletMeta* cloned_tablet_meta);
 
     Status _clone_copy(DataDir& data_dir, const string& local_data_path, vector<string>* error_msgs,
-                       const vector<Version>* missing_versions);
+                       const vector<Version>* missing_versions,
+                       const std::vector<int64_t>* missing_version_ranges = nullptr);
 
     void _set_tablet_info(Status status, bool is_new_tablet);
 
@@ -61,7 +64,8 @@ private:
     Status _download_files(DataDir* data_dir, const std::string& remote_url_prefix, const std::string& local_path);
 
     Status _make_snapshot(const std::string& ip, int port, TTableId tablet_id, TSchemaHash schema_hash, int timeout_s,
-                          const std::vector<Version>* missed_versions, std::string* snapshot_path,
+                          const std::vector<Version>* missed_versions,
+                          const std::vector<int64_t>* missing_version_ranges, std::string* snapshot_path,
                           int32_t* snapshot_version);
 
     Status _release_snapshot(const std::string& ip, int port, const std::string& snapshot_path);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2351,13 +2351,13 @@ void TabletUpdatesTest::test_get_missing_version_ranges(const std::vector<int64_
             keys.push_back(num_keys_per_rowset * i + i);
         }
         auto rs = create_rowset(tablet, keys);
-        ASSERT_TRUE(_tablet->rowset_commit(v, rs).ok());
+        ASSERT_TRUE(tablet->rowset_commit(v, rs).ok());
     };
     for (auto v : versions) {
         add_version(v);
     }
     vector<int64_t> missing_version_ranges;
-    ASSERT_TRUE(_tablet->updates()->get_missing_version_ranges(missing_version_ranges).ok());
+    ASSERT_TRUE(tablet->updates()->get_missing_version_ranges(missing_version_ranges).ok());
     ASSERT_EQ(missing_version_ranges, expected_missing_ranges);
 }
 
@@ -2498,7 +2498,7 @@ void TabletUpdatesTest::test_load_snapshot_primary(int64_t max_version, const st
     ASSERT_EQ(max_version, dest_tablet->updates()->max_version());
 }
 
-TEST_F(TabletUpdatesTest, test_load_snapshot_primary) {
+TEST_F(TabletUpdatesTest, load_snapshot_primary) {
     srand(GetCurrentTimeMicros());
     test_load_snapshot_primary(7, {3, 4, 5});
     test_load_snapshot_primary(7, {3, 5, 7});

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -390,6 +390,9 @@ public:
     void test_load_snapshot_incremental_with_partial_rowset_old(bool enable_persistent_index);
     void test_load_snapshot_incremental_with_partial_rowset_new(bool enable_persistent_index,
                                                                 PartialUpdateCloneCase update_case);
+    void test_load_snapshot_primary(int64_t num_version, const std::vector<uint64_t>& holes);
+    void test_load_snapshot_primary(int64_t max_version, const std::vector<uint64_t>& holes,
+                                    bool enable_persistent_index);
     void test_load_snapshot_full(bool enable_persistent_index);
     void test_load_snapshot_full_file_not_exist(bool enable_persistent_index);
     void test_load_snapshot_full_mismatched_tablet_id(bool enable_persistent_index);
@@ -397,6 +400,12 @@ public:
     void test_issue_4181(bool enable_persistent_index);
     void test_snapshot_with_empty_rowset(bool enable_persistent_index);
     void test_get_column_values(bool enable_persistent_index);
+    void test_get_missing_version_ranges(const std::vector<int64_t>& versions,
+                                         const std::vector<int64_t>& expected_missing_ranges);
+    void test_get_rowsets_for_incremental_snapshot(const std::vector<int64_t>& versions,
+                                                   const std::vector<int64_t>& missing_ranges,
+                                                   const std::vector<int64_t>& expect_rowset_versions, bool gc,
+                                                   bool expect_error);
 
     void tablets_prepare(TabletSharedPtr tablet0, TabletSharedPtr tablet1, std::vector<int32_t>& column_indexes,
                          const std::shared_ptr<TabletSchema>& partial_schema);
@@ -2259,19 +2268,24 @@ TEST_F(TabletUpdatesTest, snapshot_with_empty_rowset_with_persistent_index) {
 
 void TabletUpdatesTest::test_get_column_values(bool enable_persistent_index) {
     srand(GetCurrentTimeMicros());
-    _tablet = create_tablet(rand(), rand());
-    _tablet->set_enable_persistent_index(enable_persistent_index);
+    auto tablet = create_tablet(rand(), rand());
+    DeferOp del_tablet([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(tablet->tablet_id());
+        (void)FileUtils::remove_all(tablet->schema_hash_path());
+    });
+    tablet->set_enable_persistent_index(enable_persistent_index);
     const int N = 8000;
     std::vector<int64_t> keys;
     for (int i = 0; i < N; i++) {
         keys.push_back(i);
     }
     std::size_t max_rows_per_segment = 1000;
-    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowsets(_tablet, keys, max_rows_per_segment)).ok());
-    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowsets(_tablet, keys, max_rows_per_segment)).ok());
+    ASSERT_TRUE(tablet->rowset_commit(2, create_rowsets(tablet, keys, max_rows_per_segment)).ok());
+    ASSERT_TRUE(tablet->rowset_commit(3, create_rowsets(tablet, keys, max_rows_per_segment)).ok());
     std::vector<uint32_t> read_column_ids = {1, 2};
     std::vector<std::unique_ptr<vectorized::Column>> read_columns(read_column_ids.size());
-    const auto& tablet_schema = _tablet->tablet_schema();
+    const auto& tablet_schema = tablet->tablet_schema();
     for (auto i = 0; i < read_column_ids.size(); i++) {
         const auto read_column_id = read_column_ids[i];
         auto tablet_column = tablet_schema.column(read_column_id);
@@ -2290,7 +2304,7 @@ void TabletUpdatesTest::test_get_column_values(bool enable_persistent_index) {
         std::sort(rowids.begin(), rowids.end());
         rowids_by_rssid.emplace(i, rowids);
     }
-    _tablet->updates()->get_column_values(read_column_ids, false, rowids_by_rssid, &read_columns);
+    tablet->updates()->get_column_values(read_column_ids, false, rowids_by_rssid, &read_columns);
     auto values_str_generator = [&rowids_by_rssid](const int modulus, const int base) {
         std::stringstream ss;
         ss << "[";
@@ -2310,7 +2324,7 @@ void TabletUpdatesTest::test_get_column_values(bool enable_persistent_index) {
     for (const auto& read_column : read_columns) {
         read_column->reset_column();
     }
-    _tablet->updates()->get_column_values(read_column_ids, true, rowids_by_rssid, &read_columns);
+    tablet->updates()->get_column_values(read_column_ids, true, rowids_by_rssid, &read_columns);
     ASSERT_EQ(std::string("[0, ") + values_str_generator(100, 1).substr(1), read_columns[0]->debug_string());
     ASSERT_EQ(std::string("[0, ") + values_str_generator(1000, 2).substr(1), read_columns[1]->debug_string());
 }
@@ -2321,6 +2335,173 @@ TEST_F(TabletUpdatesTest, get_column_values) {
 
 TEST_F(TabletUpdatesTest, get_column_values_with_persistent_index) {
     test_get_column_values(true);
+}
+
+void TabletUpdatesTest::test_get_missing_version_ranges(const std::vector<int64_t>& versions,
+                                                        const std::vector<int64_t>& expected_missing_ranges) {
+    auto tablet = create_tablet(rand(), rand());
+    DeferOp del_tablet([&]() {
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
+        (void)FileUtils::remove_all(tablet->schema_hash_path());
+    });
+    const int num_keys_per_rowset = 1000;
+    auto add_version = [&](int64_t v) {
+        std::vector<int64_t> keys;
+        for (int i = 0; i < num_keys_per_rowset; i++) {
+            keys.push_back(num_keys_per_rowset * i + i);
+        }
+        auto rs = create_rowset(tablet, keys);
+        ASSERT_TRUE(_tablet->rowset_commit(v, rs).ok());
+    };
+    for (auto v : versions) {
+        add_version(v);
+    }
+    vector<int64_t> missing_version_ranges;
+    ASSERT_TRUE(_tablet->updates()->get_missing_version_ranges(missing_version_ranges).ok());
+    ASSERT_EQ(missing_version_ranges, expected_missing_ranges);
+}
+
+TEST_F(TabletUpdatesTest, get_missing_version_ranges) {
+    srand(GetCurrentTimeMicros());
+    test_get_missing_version_ranges({2, 3, 4, 6, 8, 10, 14, 15, 20, 23},
+                                    {5, 5, 7, 7, 9, 9, 11, 13, 16, 19, 21, 22, 24});
+    test_get_missing_version_ranges({}, {2});
+    test_get_missing_version_ranges({2, 3, 4, 5}, {6});
+    test_get_missing_version_ranges({3, 4, 5}, {2, 2, 6});
+}
+
+void TabletUpdatesTest::test_get_rowsets_for_incremental_snapshot(const std::vector<int64_t>& versions,
+                                                                  const std::vector<int64_t>& missing_ranges,
+                                                                  const std::vector<int64_t>& expect_rowset_versions,
+                                                                  bool gc, bool expect_error) {
+    auto tablet = create_tablet(rand(), rand());
+    DeferOp del_tablet([&]() {
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
+        (void)FileUtils::remove_all(tablet->schema_hash_path());
+    });
+    const int num_keys_per_rowset = 1000;
+    auto add_version = [&](int64_t v) {
+        std::vector<int64_t> keys;
+        for (int i = 0; i < num_keys_per_rowset; i++) {
+            keys.push_back(num_keys_per_rowset * i + i);
+        }
+        auto rs = create_rowset(tablet, keys);
+        ASSERT_TRUE(tablet->rowset_commit(v, rs).ok());
+    };
+    for (auto v : versions) {
+        add_version(v);
+    }
+    if (gc) {
+        while (true) {
+            EditVersion ev;
+            tablet->updates()->get_latest_applied_version(&ev);
+            if (ev.major() == versions.back()) {
+                break;
+            }
+            SleepForMs(50);
+        }
+        // only keep last version
+        tablet->updates()->remove_expired_versions(INT64_MAX);
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    auto st = tablet->updates()->get_rowsets_for_incremental_snapshot(missing_ranges, rowsets);
+    if (expect_error) {
+        EXPECT_TRUE(st.is_not_found());
+    } else {
+        EXPECT_TRUE(st.ok());
+    }
+    std::vector<int64_t> rowset_versions;
+    for (auto& rowset : rowsets) {
+        rowset_versions.push_back(rowset->version().first);
+    }
+    EXPECT_EQ(expect_rowset_versions, rowset_versions);
+}
+
+TEST_F(TabletUpdatesTest, get_rowsets_for_incremental_snapshot) {
+    srand(GetCurrentTimeMicros());
+    test_get_rowsets_for_incremental_snapshot({2}, {3, 4, 6}, {}, false, true);
+    test_get_rowsets_for_incremental_snapshot({2, 3, 4, 5}, {3, 3, 6}, {3}, false, false);
+    test_get_rowsets_for_incremental_snapshot({2, 3, 4, 5, 6}, {3, 3, 5, 5, 7}, {3, 5}, false, false);
+    test_get_rowsets_for_incremental_snapshot({2, 3, 4, 5, 6, 7}, {3, 3, 5, 5, 7}, {3, 5, 7}, false, false);
+    // after gc, there will only be version:7 left, should get empty rowset list
+    test_get_rowsets_for_incremental_snapshot({2, 3, 4, 5, 6, 7}, {3, 3, 5, 5, 7}, {}, true, false);
+}
+
+void TabletUpdatesTest::test_load_snapshot_primary(int64_t num_version, const std::vector<uint64_t>& holes) {
+    test_load_snapshot_primary(num_version, holes, false);
+    test_load_snapshot_primary(num_version, holes, true);
+}
+
+void TabletUpdatesTest::test_load_snapshot_primary(int64_t max_version, const std::vector<uint64_t>& holes,
+                                                   bool enable_persistent_index) {
+    auto src_tablet = create_tablet(rand(), rand());
+    auto dest_tablet = create_tablet(rand(), rand());
+    src_tablet->set_enable_persistent_index(enable_persistent_index);
+    dest_tablet->set_enable_persistent_index(enable_persistent_index);
+    DeferOp defer([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(src_tablet->tablet_id());
+        (void)tablet_mgr->drop_tablet(dest_tablet->tablet_id());
+        (void)FileUtils::remove_all(src_tablet->schema_hash_path());
+        (void)FileUtils::remove_all(dest_tablet->schema_hash_path());
+    });
+    const int num_keys_per_rowset = 1000;
+    auto add_version = [&](TabletSharedPtr& tablet, int64_t v) {
+        std::vector<int64_t> keys;
+        for (int i = 0; i < num_keys_per_rowset; i++) {
+            keys.push_back(num_keys_per_rowset * i + i);
+        }
+        auto rs = create_rowset(tablet, keys);
+        ASSERT_TRUE(tablet->rowset_commit(v, rs).ok());
+    };
+    size_t holes_index = 0;
+    for (int64_t v = 2; v <= max_version; v++) {
+        add_version(src_tablet, v);
+        if (holes_index < holes.size() && v == holes[holes_index]) {
+            holes_index++;
+        } else {
+            add_version(dest_tablet, v);
+        }
+    }
+    std::vector<int64_t> missing_version_ranges;
+    ASSERT_TRUE(dest_tablet->updates()->get_missing_version_ranges(missing_version_ranges).ok());
+
+    auto snapshot_dir = SnapshotManager::instance()->snapshot_primary(src_tablet, missing_version_ranges, 3600);
+    ASSERT_TRUE(snapshot_dir.ok()) << snapshot_dir.status();
+    DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
+
+    auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(src_tablet, *snapshot_dir);
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
+
+    std::set<std::string> files;
+    auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files);
+    ASSERT_TRUE(st.ok()) << st;
+    files.erase("meta");
+
+    for (const auto& f : files) {
+        std::string src = meta_dir + "/" + f;
+        std::string dst = dest_tablet->schema_hash_path() + "/" + f;
+        st = FileSystem::Default()->link_file(src, dst);
+        ASSERT_TRUE(st.ok()) << st;
+        LOG(INFO) << "Linked " << src << " to " << dst;
+    }
+    // Pretend that tablet0 is a peer replica of tablet1
+    snapshot_meta->tablet_meta().set_tablet_id(dest_tablet->tablet_id());
+    snapshot_meta->tablet_meta().set_schema_hash(dest_tablet->schema_hash());
+    for (auto& rm : snapshot_meta->rowset_metas()) {
+        rm.set_tablet_id(dest_tablet->tablet_id());
+    }
+
+    st = dest_tablet->updates()->load_snapshot(*snapshot_meta);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(max_version, dest_tablet->updates()->max_version());
+}
+
+TEST_F(TabletUpdatesTest, test_load_snapshot_primary) {
+    srand(GetCurrentTimeMicros());
+    test_load_snapshot_primary(7, {3, 4, 5});
+    test_load_snapshot_primary(7, {3, 5, 7});
 }
 
 } // namespace starrocks

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -191,7 +191,7 @@ struct TDownloadReq {
 struct TSnapshotRequest {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
-    3: optional Types.TVersion version
+    3: optional Types.TVersion version // not used
     4: optional Types.TVersionHash version_hash // Deprecated
     5: optional i64 timeout
     6: optional list<Types.TVersion> missing_version
@@ -199,6 +199,10 @@ struct TSnapshotRequest {
     // if all nodes has been upgraded, it can be removed.
     8: optional bool allow_incremental_clone
     9: optional i32 preferred_snapshot_format = Types.TPREFER_SNAPSHOT_REQ_VERSION
+    // new format to replace `missing_version`, currently only used for primary tablet snapshot
+    // [range1_start, range1_end(inclusive), ... rangeN_start (implicit to INT64_MAX)]
+    // size must be 2*N + 1
+    10:optional list<Types.TVersion> missing_version_ranges
 }
 
 struct TReleaseSnapshotRequest {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5163

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, when doing an incremental clone, FE will assign a `snapshot_version` to this cloned task(based on the current partition's visible version), a dest replica will use this to calculate `missed_versions` and request src replica for these rowsets. But src's replica maybe already at a much larger version than snapshot_version. As a result, the clone task will not clone the most recent version, after the clone, its version is still behind. 

This PR changes the whole clone process for the primary tablet, dest replica BE does not use FE's `snapshot_version` anymore, instead, it calculates all the missing version ranges, and sends them to src replica BE as a new `make_snapshot` parameter. After src BE get these `missing version ranges`, it will compare it to its own versions and decide which versions(rowsets) I can provide to dest BE, and if providing a missing version(incremental snapshot) can not make dest BE's version grow to its max version, src BE will switch to a full snapshot automatically.

Example:
```
partition visible version       4
src replica visions:            2 3 4 5 6 7
dest replica visions:           2 4 5

old strategy:
dest replica will request        3,4
src replica will return          3,4
after clone dest version becomes: 5

new strategy:
dest replica will request missing range: [3,3], [6, +inf]
src replica will return                  3, 6, 7
after clone dest version becomes:         7
```