### PR TITLE
[Enhancement] constcolumn ctor check datacolumn size

### DIFF
--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -10,7 +10,8 @@
 
 namespace starrocks::vectorized {
 
-ConstColumn::ConstColumn(ColumnPtr data) : _data(std::move(data)), _size(0) {
+ConstColumn::ConstColumn(ColumnPtr data) : ConstColumn(data, 0) {}
+
     DCHECK(!_data->is_constant());
     if (_data->size() > 1) {
         _data->resize(1);

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -12,12 +12,6 @@ namespace starrocks::vectorized {
 
 ConstColumn::ConstColumn(ColumnPtr data) : ConstColumn(data, 0) {}
 
-    DCHECK(!_data->is_constant());
-    if (_data->size() > 1) {
-        _data->resize(1);
-    }
-}
-
 ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), _size(size) {
     DCHECK(!_data->is_constant());
     if (_data->size() > 1) {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -3,6 +3,7 @@
 #include "column/const_column.h"
 
 #include <algorithm>
+#include <iostream>
 
 #include "column/column_helper.h"
 #include "simd/simd.h"
@@ -12,10 +13,17 @@ namespace starrocks::vectorized {
 
 ConstColumn::ConstColumn(ColumnPtr data) : _data(std::move(data)), _size(0) {
     DCHECK(!_data->is_constant());
+    // _data->resize(1);
+    // DCHECK(_data->size() == 1);
 }
 
 ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), _size(size) {
     DCHECK(!_data->is_constant());
+    std::cout << _data->size() << std::endl;
+    if (_data->size() > 1) {
+        _data->resize(1);
+        DCHECK(_data->size() == 1);
+    }
 }
 
 void ConstColumn::append(const Column& src, size_t offset, size_t count) {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -3,7 +3,6 @@
 #include "column/const_column.h"
 
 #include <algorithm>
-#include <iostream>
 
 #include "column/column_helper.h"
 #include "simd/simd.h"
@@ -13,16 +12,15 @@ namespace starrocks::vectorized {
 
 ConstColumn::ConstColumn(ColumnPtr data) : _data(std::move(data)), _size(0) {
     DCHECK(!_data->is_constant());
-    // _data->resize(1);
-    // DCHECK(_data->size() == 1);
+    if (_data->size() > 1) {
+        _data->resize(1);
+    }
 }
 
 ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), _size(size) {
     DCHECK(!_data->is_constant());
-    std::cout << _data->size() << std::endl;
     if (_data->size() > 1) {
         _data->resize(1);
-        DCHECK(_data->size() == 1);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] enhancement

## Which issues of this PR fixes ：
Fixes #5186 

## Problem Summary(Required) ：
For ConstColumn's datacolumn only the first element is useful, but sometime the datacolumn's size is not only one(for example, PercentileFunctions::percentile_hash, VectorizedInConstPredicate::eval_on_chunk_both_column_and_set_not_has_null, HyperloglogFunction::hll_hash, DecimalBinaryFunction::evaluate, ColumnHelper::create_column and ColumnBuilder::build), and the datacolumn;s size will be  used in class UnpackConstColumnUnaryFunction( UnaryFunction, StringUnaryFunction and so on),so check and resize the datacolumn at constcolumn::ctor  
