### PR TITLE
[Enhancement] Add size check for memtable before flush

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -145,8 +145,8 @@ public:
 
     std::string debug_string() const override;
 
-    bool reach_capacity_limit() const override {
-        return _elements->reach_capacity_limit() || _offsets->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _elements->reach_capacity_limit(msg) || _offsets->reach_capacity_limit(msg);
     }
 
     StatusOr<ColumnPtr> upgrade_if_overflow() override;

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -613,7 +613,7 @@ template <typename T>
 bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
     if constexpr (std::is_same_v<T, uint32_t>) {
-        // The size limit of a single element is 2^32.
+        // The size limit of a single element is 2^32 - 1.
         // The size limit of all elements is 2^32.
         // The number limit of elements is 2^32.
         if (_bytes.size() >= Column::MAX_CAPACITY_LIMIT) {
@@ -632,7 +632,7 @@ bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
             return false;
         }
     } else {
-        // The size limit of a single element is 2^32.
+        // The size limit of a single element is 2^32 - 1.
         // The size limit of all elements is 2^64.
         // The number limit of elements is 2^32.
         if (_bytes.size() >= Column::MAX_LARGE_CAPACITY_LIMIT) {

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -614,15 +614,15 @@ bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
     if constexpr (std::is_same_v<T, uint32_t>) {
         // The size limit of a single element is 2^32 - 1.
-        // The size limit of all elements is 2^32.
-        // The number limit of elements is 2^32.
+        // The size limit of all elements is 2^32 - 1.
+        // The number limit of elements is 2^32 - 1.
         if (_bytes.size() >= Column::MAX_CAPACITY_LIMIT) {
             if (msg != nullptr) {
                 msg->append("Total byte size of binary column exceed the limit: " +
                             std::to_string(Column::MAX_CAPACITY_LIMIT));
             }
             return true;
-        } else if (_offsets.size() > Column::MAX_CAPACITY_LIMIT) {
+        } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
             if (msg != nullptr) {
                 msg->append("Total row count of binary column exceed the limit: " +
                             std::to_string(Column::MAX_CAPACITY_LIMIT));
@@ -633,8 +633,8 @@ bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
         }
     } else {
         // The size limit of a single element is 2^32 - 1.
-        // The size limit of all elements is 2^64.
-        // The number limit of elements is 2^32.
+        // The size limit of all elements is 2^64 - 1.
+        // The number limit of elements is 2^32 - 1.
         if (_bytes.size() >= Column::MAX_LARGE_CAPACITY_LIMIT) {
             if (msg != nullptr) {
                 msg->append("Total byte size of large binary column exceed the limit: " +
@@ -643,8 +643,8 @@ bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
             return true;
         } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
             if (msg != nullptr) {
-                msg->append("Total byte size of large binary column exceed the limit: " +
-                            std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT));
+                msg->append("Total row count of large binary column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
             }
             return true;
         } else {

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -609,6 +609,50 @@ bool BinaryColumnBase<T>::has_large_column() const {
     }
 }
 
+template <typename T>
+bool BinaryColumnBase<T>::reach_capacity_limit(std::string* msg) const {
+    static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
+    if constexpr (std::is_same_v<T, uint32_t>) {
+        // The size limit of a single element is 2^32.
+        // The size limit of all elements is 2^32.
+        // The number limit of elements is 2^32.
+        if (_bytes.size() >= Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Total byte size of binary column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        } else if (_offsets.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Total row count of binary column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        // The size limit of a single element is 2^32.
+        // The size limit of all elements is 2^64.
+        // The number limit of elements is 2^32.
+        if (_bytes.size() >= Column::MAX_LARGE_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Total byte size of large binary column exceed the limit: " +
+                            std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT));
+            }
+            return true;
+        } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Total byte size of large binary column exceed the limit: " +
+                            std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT));
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
 template class BinaryColumnBase<uint32_t>;
 template class BinaryColumnBase<uint64_t>;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -288,20 +288,7 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
-        if constexpr (std::is_same_v<T, uint32_t>) {
-            // The size limit of a single element is 2^32.
-            // The size limit of all elements is 2^32.
-            // The number limit of elements is 2^32.
-            return _bytes.size() >= Column::MAX_CAPACITY_LIMIT || _offsets.size() > Column::MAX_CAPACITY_LIMIT;
-        } else {
-            // The size limit of a single element is 2^32.
-            // The size limit of all elements is 2^64.
-            // The number limit of elements is 2^32.
-            return _bytes.size() >= Column::MAX_LARGE_CAPACITY_LIMIT || _offsets.size() > Column::MAX_CAPACITY_LIMIT;
-        }
-    }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override;
 
 private:
     void _build_slices() const;

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -229,9 +229,9 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
-    bool reach_capacity_limit() const {
+    bool reach_capacity_limit(std::string* msg = nullptr) const {
         for (const auto& column : _columns) {
-            if (column->reach_capacity_limit()) {
+            if (column->reach_capacity_limit(msg)) {
                 return true;
             }
         }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -342,7 +342,7 @@ public:
 
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
-    virtual bool reach_capacity_limit() const = 0;
+    virtual bool reach_capacity_limit(std::string* msg = nullptr) const = 0;
 
     virtual Status accept(ColumnVisitor* visitor) const = 0;
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -212,8 +212,15 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _data->reach_capacity_limit() || _size > Column::MAX_CAPACITY_LIMIT;
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        RETURN_IF_UNLIKELY(_data->reach_capacity_limit(msg), true);
+        if (_size > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Row count of const column reach limit: " + std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
     }
 
     void check_or_die() const override;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -201,7 +201,16 @@ public:
 
     // The `_data` support one size(> 2^32), but some interface such as update_rows() will use index of uint32_t to
     // access the item, so we should use 2^32 as the limit
-    bool reach_capacity_limit() const override { return _data.size() > Column::MAX_CAPACITY_LIMIT; }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_data.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of fixed length column exceend the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
     void check_or_die() const override {}
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -279,8 +279,8 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _data_column->reach_capacity_limit() || _null_column->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _data_column->reach_capacity_limit(msg) || _null_column->reach_capacity_limit(msg);
     }
 
     void check_or_die() const override;

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -196,7 +196,16 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override { return _pool.size() > Column::MAX_CAPACITY_LIMIT; }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_pool.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of object column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
     StatusOr<ColumnPtr> upgrade_if_overflow() override;
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -219,8 +219,10 @@ Status MemTable::flush() {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
-    if (_result_chunk->reach_capacity_limit()) {
-        return Status::InternalError("memtable size exceed the limit");
+    std::string msg;
+    if (_result_chunk->reach_capacity_limit(&msg)) {
+        return Status::InternalError(
+                fmt::format("memtable of tablet {} reache the capacity limit, detail msg: {}", _tablet_id, msg));
     }
     int64_t duration_ns = 0;
     {

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -219,6 +219,9 @@ Status MemTable::flush() {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
+    if (_result_chunk->reach_capacity_limit()) {
+        return Status::InternalError("memtable size exceed the limit");
+    }
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6288 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently BinaryColumn supports a maximum of 4G, and other column support a maximum of 2^32 rows. If it exceeds, it will write dirty data, so when memtable flush, should add a size check to prevent generation dirty data
