### PR TITLE
[License] Keep the Apache License for not changed files

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerBootstrap.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerBootstrap.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/BrokerBootstrap.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/BrokerConfig.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerException.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerException.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/BrokerException.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerFileSystem.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/BrokerFileSystem.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/ClientContextManager.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemIdentity.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemIdentity.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/FileSystemIdentity.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -2,7 +2,7 @@
 // This file is based on code available under the Apache license here:
 //   https://github.com/apache/incubator-doris/blob/master
 //                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/FileSystemManager.java 
+//                     /org/apache/doris/broker/hdfs/FileSystemManager.java
 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/HDFSBrokerServiceImpl.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/HDFSBrokerServiceImpl.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/BrokerPerfMonitor.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/BrokerPerfMonitor.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/common/BrokerPerfMonitor.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/LoggerMessageFormat.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/LoggerMessageFormat.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/common/LoggerMessageFormat.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/ThriftServer.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/common/ThriftServer.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/WildcardURI.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/WildcardURI.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/main/java
-//                     /org/apache/doris/common/WildcardURI.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/TestFileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/TestFileSystemManager.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/test/java
-//                     /org/apache/doris/broker/hdfs/TestFileSystemManager.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/TestHDFSBrokerService.java
+++ b/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/TestHDFSBrokerService.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/test/java
-//                     /org/apache/doris/broker/hdfs/TestHDFSBrokerService.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/WildcardURITest.java
+++ b/fs_brokers/apache_hdfs_broker/src/test/java/com/starrocks/broker/hdfs/WildcardURITest.java
@@ -1,9 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master
-//                     /fs_brokers/apache_hdfs_broker/src/test/java
-//                     /org/apache/doris/broker/hdfs/WildcardURITest.java 
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/gensrc/proto/status.proto
+++ b/gensrc/proto/status.proto
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/proto/status.proto
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/gensrc/thrift/Metrics.thrift
+++ b/gensrc/thrift/Metrics.thrift
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/Metrics.thrift
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/gensrc/thrift/Opcodes.thrift
+++ b/gensrc/thrift/Opcodes.thrift
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/Opcodes.thrift
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/RuntimeProfile.thrift
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/gensrc/thrift/parquet.thrift
+++ b/gensrc/thrift/parquet.thrift
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/parquet.thrift
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Many files come from Apache Doris and have not been changed.
According to the License rule, the files should keep the Apache License.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
