### PR TITLE
[Enhancement] Add max memory limit for sorting schema change

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -213,6 +213,7 @@ CONF_mInt64(column_dictionary_key_ratio_threshold, "0");
 CONF_mInt64(column_dictionary_key_size_threshold, "0");
 // The memory_limitation_per_thread_for_schema_change unit GB.
 CONF_mInt32(memory_limitation_per_thread_for_schema_change, "2");
+CONF_mDouble(memory_ratio_for_sorting_schema_change, "0.8");
 
 CONF_mInt32(update_cache_expire_sec, "360");
 CONF_mInt32(file_descriptor_cache_clean_interval, "3600");


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since the large memtable may decrease the sort performance, we limit the max size of memtable
and add `memory_ratio_for_sorting_schema_change` as the ratio of `memory_limitation_per_thread_for_schema_change` using for memtable, In some case, reader of schema change may using lot of memory, so that we can adjust this parameter.