### PR TITLE
[Cherry-pick][Branch-2.2][BugFix]: BE start failed when enable StoragePageCache (#5593)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -364,8 +364,7 @@ CONF_Int32(num_threads_per_disk, "0");
 // There is a trade off of latency and throughout, trying to keep disks busy but
 // not introduce seeks.  The literature seems to agree that with 8 MB reads, random
 // io and sequential io perform similarly.
-CONF_Int32(read_size, "8388608");    // 8 * 1024 * 1024, Read Size (in bytes)
-CONF_Int32(min_buffer_size, "1024"); // 1024, The minimum read buffer size (in bytes)
+CONF_Int32(read_size, "8388608"); // 8 * 1024 * 1024, Read Size (in bytes)
 
 // For each io buffer size, the maximum number of buffers the IoMgr will hold onto
 // With 1024B through 8MB buffers, this is up to ~2GB of buffers.

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -170,7 +170,7 @@ private:
     Status _init(const std::vector<StorePath>& store_paths);
     void _destroy();
 
-    Status _init_mem_tracker();
+    Status _init_storage_page_cache();
 
     std::vector<StorePath> _store_paths;
     // Leave protected so that subclasses can override


### PR DESCRIPTION

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5592

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we start BE, we will create `apply thread` for PrimaryKey table to do `rowset apply`.

The `apply thread` start in `load` phase, when the StoragePageCache has not yet been created. So if  `disable_storage_page_cache` is false, the `apply thread` will try to get page from StroagePageCache which will cause a nullptr exception. 

The solution is create StoragePageCache before start `apply thread`.

In addition, the `min_buffer_size` configuration does not seem to be used anymore, delete it.
