### PR TITLE
[BugFix] check supported type when join/orderby/aggregation

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -27,6 +27,12 @@ LocalPartitionTopnContext::LocalPartitionTopnContext(
 
 Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_partition_exprs, &_partition_exprs));
+    for (auto& expr : _partition_exprs) {
+        auto& type_desc = expr->root()->type();
+        if (!type_desc.support_groupby()) {
+            return Status::NotSupported(fmt::format("partition by type {} is not supported", type_desc.debug_string()));
+        }
+    }
     auto partition_size = _t_partition_exprs.size();
     _partition_types.resize(partition_size);
     for (auto i = 0; i < partition_size; ++i) {

--- a/be/src/exec/sort_exec_exprs.cpp
+++ b/be/src/exec/sort_exec_exprs.cpp
@@ -31,6 +31,13 @@ Status SortExecExprs::init(const TSortInfo& sort_info, ObjectPool* pool) {
 Status SortExecExprs::init(const std::vector<TExpr>& ordering_exprs, const std::vector<TExpr>* sort_tuple_slot_exprs,
                            ObjectPool* pool) {
     RETURN_IF_ERROR(Expr::create_expr_trees(pool, ordering_exprs, &_lhs_ordering_expr_ctxs));
+    for (auto& expr : _lhs_ordering_expr_ctxs) {
+        auto& type_desc = expr->root()->type();
+        if (!type_desc.support_orderby()) {
+            return Status::NotSupported(fmt::format("ordre by type {} is not supported", type_desc.debug_string()));
+        }
+    }
+
     if (sort_tuple_slot_exprs != nullptr) {
         _materialize_tuple = true;
         RETURN_IF_ERROR(Expr::create_expr_trees(pool, *sort_tuple_slot_exprs, &_sort_tuple_slot_expr_ctxs));

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -19,6 +19,12 @@ AggregateBaseNode::~AggregateBaseNode() {
 Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
     RETURN_IF_ERROR(Expr::create_expr_trees(_pool, tnode.agg_node.grouping_exprs, &_group_by_expr_ctxs));
+    for (auto& expr : _group_by_expr_ctxs) {
+        auto& type_desc = expr->root()->type();
+        if (!type_desc.support_groupby()) {
+            return Status::NotSupported(fmt::format("group by type {} is not supported", type_desc.debug_string()));
+        }
+    }
     return Status::OK();
 }
 Status AggregateBaseNode::prepare(RuntimeState* state) {

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -42,6 +42,13 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.sort_node.__isset.analytic_partition_exprs) {
         RETURN_IF_ERROR(
                 Expr::create_expr_trees(_pool, tnode.sort_node.analytic_partition_exprs, &_analytic_partition_exprs));
+        for (auto& expr : _analytic_partition_exprs) {
+            auto& type_desc = expr->root()->type();
+            if (!type_desc.support_groupby()) {
+                return Status::NotSupported(
+                        fmt::format("partition by type {} is not supported", type_desc.debug_string()));
+            }
+        }
     }
     _is_asc_order = tnode.sort_node.sort_info.is_asc_order;
     _is_null_first = tnode.sort_node.sort_info.nulls_first;

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -24,6 +24,7 @@
 #include <ostream>
 
 #include "gutil/strings/substitute.h"
+#include "runtime/primitive_type.h"
 #include "storage/types.h"
 
 namespace starrocks {
@@ -235,6 +236,21 @@ std::string TypeDescriptor::debug_string() const {
     default:
         return type_to_string(type);
     }
+}
+
+bool TypeDescriptor::support_join() const {
+    return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
+           type != TYPE_MAP && type != TYPE_STRUCT && type != TYPE_ARRAY;
+}
+
+bool TypeDescriptor::support_orderby() const {
+    return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
+           type != TYPE_MAP && type != TYPE_STRUCT && type != TYPE_ARRAY;
+}
+
+bool TypeDescriptor::support_groupby() const {
+    return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
+           type != TYPE_MAP && type != TYPE_STRUCT && type != TYPE_ARRAY;
 }
 
 TypeDescriptor TypeDescriptor::from_storage_type_info(TypeInfo* type_info) {

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -270,6 +270,13 @@ struct TypeDescriptor {
 
     inline bool is_collection_type() const { return type == TYPE_ARRAY || type == TYPE_MAP; }
 
+    // Could this type be used at join on conjuncts
+    bool support_join() const;
+    // Could this type be used at order by clause
+    bool support_orderby() const;
+    // Could this type be used at group by clause
+    bool support_groupby() const;
+
     // For some types with potential huge length, whose memory consumption is far more than normal types,
     // they need a different chunk_size setting
     bool is_huge_type() const { return type == TYPE_JSON || type == TYPE_OBJECT || type == TYPE_HLL; }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6291

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Check whether type supported when hashjoin/orderby/groupby.

Although we have check it at FE, and disable join/groupby/order for these types, but some exceptional query still exists. So disable it at BE could be a more thorough solution.
