### PR TITLE
[StarRocks On ES] support configurable node sniffing property for ES

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -69,6 +69,8 @@ public class EsTable extends Table {
     public static final String KEYWORD_SNIFF = "enable_keyword_sniff";
     public static final String MAX_DOCVALUE_FIELDS = "max_docvalue_fields";
 
+    public static final String WAN_ONLY = "es.nodes.wan.only";
+
     private String hosts;
     private String[] seeds;
     private String userName = "";
@@ -101,6 +103,8 @@ public class EsTable extends Table {
     // Here we have a slightly conservative value of 20, but at the same time we also provide configurable parameters for expert-using
     // @see `MAX_DOCVALUE_FIELDS`
     private static final int DEFAULT_MAX_DOCVALUE_FIELDS = 20;
+
+    private boolean wanOnly = false;
 
     // version would be used to be compatible with different ES Cluster
     public EsMajorVersion majorVersion = null;
@@ -140,6 +144,10 @@ public class EsTable extends Table {
 
     public boolean isKeywordSniffEnable() {
         return enableKeywordSniff;
+    }
+
+    public boolean wanOnly() {
+        return wanOnly;
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -232,6 +240,14 @@ public class EsTable extends Table {
                 maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
             }
         }
+
+        if (properties.containsKey(WAN_ONLY)) {
+            try {
+                wanOnly = Boolean.parseBoolean(properties.get(WAN_ONLY).trim());
+            } catch (Exception e) {
+                wanOnly = false;
+            }
+        }
         tableContext.put("hosts", hosts);
         tableContext.put("userName", userName);
         tableContext.put("passwd", passwd);
@@ -244,6 +260,7 @@ public class EsTable extends Table {
         tableContext.put("enableDocValueScan", String.valueOf(enableDocValueScan));
         tableContext.put("enableKeywordSniff", String.valueOf(enableKeywordSniff));
         tableContext.put("maxDocValueFields", String.valueOf(maxDocValueFields));
+        tableContext.put("es.nodes.wan.only", String.valueOf(wanOnly));
     }
 
     @Override
@@ -341,6 +358,11 @@ public class EsTable extends Table {
                     maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
                 }
             }
+            if (tableContext.containsKey(WAN_ONLY)) {
+                wanOnly = Boolean.parseBoolean(tableContext.get(wanOnly));
+            } else {
+                wanOnly = false;
+            }
 
             PartitionType partType = PartitionType.valueOf(Text.readString(in));
             if (partType == PartitionType.UNPARTITIONED) {
@@ -375,6 +397,7 @@ public class EsTable extends Table {
             tableContext.put("transport", transport);
             tableContext.put("enableDocValueScan", "false");
             tableContext.put(KEYWORD_SNIFF, "true");
+            tableContext.put(WAN_ONLY, "false");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsNodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsNodeInfo.java
@@ -100,6 +100,24 @@ public class EsNodeInfo {
         }
     }
 
+    public EsNodeInfo(String id, String seed) {
+        this.id = id;
+        String[] scratch = seed.split(":");
+        int port = 80;
+        if (scratch.length == 3) {
+            port = Integer.parseInt(scratch[2]);
+        }
+        String remoteHost = scratch[0] + ":" + scratch[1];
+        this.name = remoteHost;
+        this.host = remoteHost;
+        this.ip = remoteHost;
+        this.isClient = true;
+        this.isData = true;
+        this.isIngest = true;
+        this.publishAddress = new TNetworkAddress(remoteHost, port);
+        this.hasHttp = true;
+    }
+
     public boolean hasHttp() {
         return hasHttp;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/PartitionPhase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/PartitionPhase.java
@@ -19,6 +19,7 @@ package com.starrocks.external.elasticsearch;
 
 import com.starrocks.catalog.EsTable;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,6 +39,15 @@ public class PartitionPhase implements SearchPhase {
     public void execute(SearchContext context) throws StarRocksESException {
         shardPartitions = client.searchShards(context.sourceIndex());
         nodesInfo = client.getHttpNodes();
+        if (!context.wanOnly()) {
+            nodesInfo = client.getHttpNodes();
+        } else {
+            nodesInfo = new HashMap<>();
+            String[] seeds = context.esTable().getSeeds();
+            for (int i = 0; i < seeds.length; i++) {
+                nodesInfo.put(String.valueOf(i), new EsNodeInfo(String.valueOf(i), seeds[i]));
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/SearchContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/SearchContext.java
@@ -81,11 +81,15 @@ public class SearchContext {
     // the ES cluster version
     private EsMajorVersion version;
 
+    // whether discovery the nodes where shards reside in
+    private boolean wanOnly;
+
     public SearchContext(EsTable table) {
         this.table = table;
         fullSchema = table.getFullSchema();
         sourceIndex = table.getIndexName();
         type = table.getMappingType();
+        wanOnly = table.wanOnly();
     }
 
     public String sourceIndex() {
@@ -135,5 +139,9 @@ public class SearchContext {
     // this will be refactor soon
     public EsTablePartitions tablePartitions() throws Exception {
         return EsTablePartitions.fromShardPartitions(table, shardPartitions);
+    }
+
+    public boolean wanOnly() {
+        return wanOnly;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2094,7 +2094,8 @@ public class GlobalStateMgr {
             sb.append("\"transport\" = \"").append(esTable.getTransport()).append("\",\n");
             sb.append("\"enable_docvalue_scan\" = \"").append(esTable.isDocValueScanEnable()).append("\",\n");
             sb.append("\"max_docvalue_fields\" = \"").append(esTable.maxDocValueFields()).append("\",\n");
-            sb.append("\"enable_keyword_sniff\" = \"").append(esTable.isKeywordSniffEnable()).append("\"\n");
+            sb.append("\"enable_keyword_sniff\" = \"").append(esTable.isKeywordSniffEnable()).append("\",\n");
+            sb.append("\"es.nodes.wan.only\" = \"").append(esTable.wanOnly()).append("\"\n");
             sb.append(")");
         } else if (table.getType() == TableType.HIVE) {
             HiveTable hiveTable = (HiveTable) table;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6314

When creating a Elasticsearch Table,  we add a **s.nodes.wan.only** parameter to control whether to sniff the data nodes address of the ES cluster

```
CREATE EXTERNAL TABLE `test` (
  `k1` bigint(20) COMMENT "",
  `k2` datetime COMMENT "",
) ENGINE=ELASTICSEARCH
PROPERTIES (
"hosts" = "http://192.168.0.1:8200",
"index" = "test”,
"type" = "doc",
"user" = "root",
"password" = "***",
"es.nodes.wan.only" = "ture"
);
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
StarRocks no longer sniff the internal data node addresses of the ES cluster, and only accesses the load balancing IP address provided by the user when `es.nodes.wan.only` is "true"
