### PR TITLE
[Enhancement] Remove redundant get rowset from txn_tablet_map and other related refactors

### DIFF
--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -38,9 +38,8 @@ EnginePublishVersionTask::EnginePublishVersionTask(TTransactionId transaction_id
           _rowset(rowset) {}
 
 Status EnginePublishVersionTask::finish() {
-    VLOG(1) << "begin to publish version on tablet. "
-            << "tablet_id=" << _tablet_info.tablet_id << ", schema_hash=" << _tablet_info.schema_hash
-            << ", version=" << _version << ", transaction_id=" << _transaction_id;
+    VLOG(1) << "Begin publish txn tablet:" << _tablet_info.tablet_id << " version:" << _version
+            << " partition:" << _partition_id << " txn:" << _transaction_id << " rowset:" << _rowset->rowset_id();
 
     TabletSharedPtr tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_info.tablet_id, _tablet_info.tablet_uid);
@@ -51,35 +50,17 @@ Status EnginePublishVersionTask::finish() {
         return Status::NotFound(fmt::format("Not found tablet to publish_version. tablet_id: {}, txn_id: {}",
                                             _tablet_info.tablet_id, _transaction_id));
     }
-
-    Status st = Status::OK();
-    if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-        VLOG(1) << "UpdateManager::on_rowset_published tablet:" << tablet->tablet_id()
-                << " rowset: " << _rowset->rowset_id().to_string() << " version: " << _version;
-        st = StorageEngine::instance()->txn_manager()->publish_txn2(_transaction_id, _partition_id, tablet, _version);
-    } else {
-        st = StorageEngine::instance()->txn_manager()->publish_txn(_partition_id, tablet, _transaction_id,
-                                                                   Version{_version, _version});
-    }
+    auto st = StorageEngine::instance()->txn_manager()->publish_txn(_partition_id, tablet, _transaction_id, _version,
+                                                                    _rowset);
     if (!st.ok()) {
-        LOG(WARNING) << "Failed to publish version. rowset_id=" << _rowset->rowset_id()
-                     << ", tablet_id=" << _tablet_info.tablet_id << ", txn_id=" << _transaction_id;
-        return st;
+        LOG(WARNING) << "Publish txn failed tablet:" << _tablet_info.tablet_id << " version:" << _version
+                     << " partition:" << _partition_id << " txn:" << _transaction_id
+                     << " rowset:" << _rowset->rowset_id();
+    } else {
+        LOG(INFO) << "Publish txn success tablet:" << _tablet_info.tablet_id << " version:" << _version
+                  << " partition:" << _partition_id << " txn:" << _transaction_id << " rowset:" << _rowset->rowset_id();
     }
-
-    if (tablet->keys_type() != KeysType::PRIMARY_KEYS) {
-        // add visible rowset to tablet
-        auto st = tablet->add_inc_rowset(_rowset);
-        if (!st.ok() && !st.is_already_exist()) {
-            LOG(WARNING) << "fail to add visible rowset to tablet. rowset_id=" << _rowset->rowset_id()
-                         << ", tablet_id=" << _tablet_info.tablet_id << ", txn_id=" << _transaction_id
-                         << ", res=" << st;
-            return st;
-        }
-    }
-    LOG(INFO) << "Publish version successfully on tablet. tablet=" << tablet->full_name()
-              << ", transaction_id=" << _transaction_id << ", version=" << _version << ", res=" << st.to_string();
-    return Status::OK();
+    return st;
 }
 
 } // namespace starrocks

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -78,14 +78,10 @@ public:
                       const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     Status publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                       const Version& version);
+                       int64_t version, const RowsetSharedPtr& rowset);
 
     // persist_tablet_related_txns persists the tablets' meta and make it crash-safe.
     Status persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets);
-
-    // publish_txn for updatable tablet
-    Status publish_txn2(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
-                        int64_t version);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
@@ -101,10 +97,6 @@ public:
     Status commit_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
                       SchemaHash schema_hash, const TabletUid& tablet_uid, const PUniqueId& load_id,
                       const RowsetSharedPtr& rowset_ptr, bool is_recovery);
-
-    // remove a txn from txn manager & persist rowset meta
-    Status publish_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                       SchemaHash schema_hash, const TabletUid& tablet_uid, const Version& version);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Before calling publish_txn in txn_manager, the shared ptr of rowset is already retrieved from txn_tablet_map,  There is unnecessary to get it from txn_tablet_map again. This PR passes the shared ptr of rowset to the publish_txn method as a new parameter, so it won't be retrieved again. Also, refactor 3 different publish_txn methods into 1.