### PR TITLE
[Feature] record memory cost in audit log

### DIFF
--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -197,7 +197,7 @@ protected:
 
     // Some extra cpu cost of this operator that not accounted by pipeline driver,
     // such as OlapScanOperator( use separated IO thread to execute the IO task)
-    int64_t _last_growth_cpu_time_ns = 0;
+    std::atomic_int64_t _last_growth_cpu_time_ns = 0;
 
 private:
     void _init_rf_counters(bool init_bloom);

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -197,7 +197,7 @@ protected:
 
     // Some extra cpu cost of this operator that not accounted by pipeline driver,
     // such as OlapScanOperator( use separated IO thread to execute the IO task)
-    std::atomic_int64_t _last_growth_cpu_time_ns = 0;
+    int64_t _last_growth_cpu_time_ns = 0;
 
 private:
     void _init_rf_counters(bool init_bloom);

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -83,8 +83,9 @@ public:
     Status init_query(workgroup::WorkGroup* wg);
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
-    void incr_cpu_cost(int64_t cost) { _cur_cpu_cost += cost; }
-    int64_t cpu_cost() const { return _cur_cpu_cost; }
+    void incr_cpu_cost(int64_t cost) { _cur_cpu_cost_ns += cost; }
+    int64_t cpu_cost() const { return _cur_cpu_cost_ns; }
+    int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
     void incr_cur_scan_rows_num(int64_t rows_num) { _cur_scan_rows_num += rows_num; }
     int64_t cur_scan_rows_num() const { return _cur_scan_rows_num; }
     void incr_cur_scan_bytes(int64_t scan_bytes) { _cur_scan_bytes += scan_bytes; }
@@ -117,7 +118,7 @@ private:
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;
-    std::atomic<int64_t> _cur_cpu_cost = 0;
+    std::atomic<int64_t> _cur_cpu_cost_ns = 0;
     std::atomic<int64_t> _cur_scan_rows_num = 0;
     std::atomic<int64_t> _cur_scan_bytes = 0;
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -50,7 +50,7 @@ void ResultSinkOperator::close(RuntimeState* state) {
             QueryContext* query_ctx = state->query_ctx();
             query_statistic->add_scan_stats(query_ctx->cur_scan_rows_num(), query_ctx->get_scan_bytes());
             query_statistic->add_cpu_costs(query_ctx->cpu_cost());
-            query_statistic->set_mem_costs(query_ctx->mem_cost_bytes());
+            query_statistic->add_mem_costs(query_ctx->mem_cost_bytes());
             query_statistic->set_returned_rows(_num_written_rows);
             _sender->set_query_statistics(query_statistic);
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -50,6 +50,7 @@ void ResultSinkOperator::close(RuntimeState* state) {
             QueryContext* query_ctx = state->query_ctx();
             query_statistic->add_scan_stats(query_ctx->cur_scan_rows_num(), query_ctx->get_scan_bytes());
             query_statistic->add_cpu_costs(query_ctx->cpu_cost());
+            query_statistic->set_mem_costs(query_ctx->mem_cost_bytes());
             query_statistic->set_returned_rows(_num_written_rows);
             _sender->set_query_statistics(query_statistic);
 

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -23,8 +23,26 @@
 
 namespace starrocks {
 
+void QueryStatistics::to_pb(PQueryStatistics* statistics) {
+    DCHECK(statistics != nullptr);
+    statistics->set_scan_rows(scan_rows);
+    statistics->set_scan_bytes(scan_bytes);
+    statistics->set_returned_rows(returned_rows);
+    statistics->set_cpu_cost_ns(cpu_ns);
+    statistics->set_mem_cost_bytes(mem_cost_bytes);
+    *statistics->mutable_stats_items() = {_stats_items.begin(), _stats_items.end()};
+}
+
 void QueryStatistics::merge(QueryStatisticsRecvr* recvr) {
     recvr->merge(this);
+}
+
+void QueryStatistics::merge_pb(const PQueryStatistics& statistics) {
+    scan_rows += statistics.scan_rows();
+    scan_bytes += statistics.scan_bytes();
+    cpu_ns += statistics.cpu_cost_ns();
+    mem_cost_bytes += statistics.mem_cost_bytes();
+    _stats_items.insert(_stats_items.end(), statistics.stats_items().begin(), statistics.stats_items().end());
 }
 
 void QueryStatisticsRecvr::insert(const PQueryStatistics& statistics, int sender_id) {

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -58,7 +58,7 @@ public:
 
     void add_cpu_costs(int64_t cpu_ns) { this->cpu_ns += cpu_ns; }
 
-    void set_mem_costs(int64_t bytes) { mem_cost_bytes = bytes; }
+    void add_mem_costs(int64_t bytes) { mem_cost_bytes += bytes; }
 
     void merge(QueryStatisticsRecvr* recvr);
 
@@ -69,21 +69,9 @@ public:
         _stats_items.clear();
     }
 
-    void to_pb(PQueryStatistics* statistics) {
-        DCHECK(statistics != nullptr);
-        statistics->set_scan_rows(scan_rows);
-        statistics->set_scan_bytes(scan_bytes);
-        statistics->set_returned_rows(returned_rows);
-        statistics->set_cpu_cost_ns(cpu_ns);
-        statistics->set_mem_cost_bytes(mem_cost_bytes);
-        *statistics->mutable_stats_items() = {_stats_items.begin(), _stats_items.end()};
-    }
+    void to_pb(PQueryStatistics* statistics);
 
-    void merge_pb(const PQueryStatistics& statistics) {
-        scan_rows += statistics.scan_rows();
-        scan_bytes += statistics.scan_bytes();
-        _stats_items.insert(_stats_items.end(), statistics.stats_items().begin(), statistics.stats_items().end());
-    }
+    void merge_pb(const PQueryStatistics& statistics);
 
 private:
     int64_t scan_rows{0};

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -58,6 +58,8 @@ public:
 
     void add_cpu_costs(int64_t cpu_ns) { this->cpu_ns += cpu_ns; }
 
+    void set_mem_costs(int64_t bytes) { mem_cost_bytes = bytes; }
+
     void merge(QueryStatisticsRecvr* recvr);
 
     void clear() {
@@ -73,6 +75,7 @@ public:
         statistics->set_scan_bytes(scan_bytes);
         statistics->set_returned_rows(returned_rows);
         statistics->set_cpu_cost_ns(cpu_ns);
+        statistics->set_mem_cost_bytes(mem_cost_bytes);
         *statistics->mutable_stats_items() = {_stats_items.begin(), _stats_items.end()};
     }
 
@@ -86,6 +89,7 @@ private:
     int64_t scan_rows{0};
     int64_t scan_bytes{0};
     int64_t cpu_ns{0};
+    int64_t mem_cost_bytes = 0;
     // number rows returned by query.
     // only set once by result sink when closing.
     int64_t returned_rows{0};

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DebugUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DebugUtil.java
@@ -92,10 +92,19 @@ public class DebugUtil {
         }
     }
 
+    public static String getPrettyStringNs(long timestampNs) {
+        return getPrettyStringMs(timestampNs / 1000 / 1000);
+    }
+
     public static String getPrettyStringMs(long timestampMs) {
         StringBuilder builder = new StringBuilder();
         printTimeMs(timestampMs, builder);
         return builder.toString();
+    }
+
+    public static String getPrettyStringBytes(long bytes) {
+        Pair<Double, String> valueAndUnit = getByteUint(bytes);
+        return String.format("%.3f%s", valueAndUnit.first, valueAndUnit.second);
     }
 
     public static Pair<Double, String> getByteUint(long value) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -61,6 +61,8 @@ public class ProfileManager {
     public static final String SQL_STATEMENT = "Sql Statement";
     public static final String USER = "User";
     public static final String DEFAULT_DB = "Default Db";
+    public static final String QUERY_CPU_COST = "QueryCpuCost";
+    public static final String QUERY_MEM_COST = "QueryMemCost";
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList(
             Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -75,6 +75,8 @@ public class AuditEvent {
     public long returnRows = -1;
     @AuditField(value = "CpuCostNs")
     public long cpuCostNs = -1;
+    @AuditField(value = "MemCostBytes")
+    public long memCostBytes = 0;
     @AuditField(value = "StmtId")
     public long stmtId = -1;
     @AuditField(value = "QueryId")
@@ -168,6 +170,11 @@ public class AuditEvent {
          */
         public AuditEventBuilder setCpuCostNs(long cpuNs) {
             auditEvent.cpuCostNs = cpuNs;
+            return this;
+        }
+
+        public AuditEventBuilder setMemCostBytes(long memCostBytes) {
+            auditEvent.memCostBytes = memCostBytes;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -148,6 +148,7 @@ public class ConnectProcessor {
                 .setScanBytes(statistics == null ? 0 : statistics.scanBytes)
                 .setScanRows(statistics == null ? 0 : statistics.scanRows)
                 .setCpuCostNs(statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs)
+                .setMemCostBytes(statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes)
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
                 .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -993,6 +993,9 @@ public class StmtExecutor {
         if (statisticsForAuditLog.cpuCostNs == null) {
             statisticsForAuditLog.cpuCostNs = 0L;
         }
+        if (statisticsForAuditLog.memCostBytes == null) {
+            statisticsForAuditLog.memCostBytes = 0L;
+        }
         return statisticsForAuditLog;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -189,6 +189,12 @@ public class StmtExecutor {
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
+
+        PQueryStatistics statistics = getQueryStatisticsForAuditLog();
+        long memCostBytes = statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes;
+        long cpuCostNs = statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs;
+        summaryProfile.addInfoString(ProfileManager.QUERY_CPU_COST, DebugUtil.getPrettyStringNs(cpuCostNs));
+        summaryProfile.addInfoString(ProfileManager.QUERY_MEM_COST, DebugUtil.getPrettyStringBytes(memCostBytes));
         profile.addChild(summaryProfile);
 
         RuntimeProfile plannerProfile = new RuntimeProfile("Planner");

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -354,6 +354,7 @@ public class MockedBackend {
                 pQueryStatistics.scanRows = 0L;
                 pQueryStatistics.scanBytes = 0L;
                 pQueryStatistics.cpuCostNs = 0L;
+                pQueryStatistics.memCostBytes = 0L;
 
                 result.status = pStatus;
                 result.packetSeq = 0L;

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -31,6 +31,7 @@ message PQueryStatistics {
     optional int64 scan_bytes = 2;
     optional int64 returned_rows = 3;
     optional int64 cpu_cost_ns = 4;
+    optional int64 mem_cost_bytes = 5;
     repeated QueryStatisticsItemPB stats_items = 10;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6352

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Record memory costs in audit log for further analysis.

## TODO
Current memory computation just sum up the peak consumption of all query mem-tracker, in some cases it could be imprecise, without considering the shared memory between some fragments.