### PR TITLE
[BugFix] Make ut more stable

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -50,7 +50,7 @@ public class ThreadPoolManagerTest {
 
         Runnable task = () -> {
             try {
-                Thread.sleep(500);
+                Thread.sleep(1000);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -64,7 +64,7 @@ public class ThreadPoolManagerTest {
         Assert.assertEquals(0, testCachedPool.getQueue().size());
         Assert.assertEquals(0, testCachedPool.getCompletedTaskCount());
 
-        Thread.sleep(700);
+        Thread.sleep(1400);
 
         Assert.assertEquals(2, testCachedPool.getPoolSize());
         Assert.assertEquals(0, testCachedPool.getActiveCount());
@@ -80,7 +80,7 @@ public class ThreadPoolManagerTest {
         Assert.assertEquals(2, testFixedThreaddPool.getQueue().size());
         Assert.assertEquals(0, testFixedThreaddPool.getCompletedTaskCount());
 
-        Thread.sleep(2000);
+        Thread.sleep(4000);
 
         Assert.assertEquals(2, testFixedThreaddPool.getPoolSize());
         Assert.assertEquals(0, testFixedThreaddPool.getActiveCount());

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -59,12 +59,14 @@ public class ThreadPoolManagerTest {
             testCachedPool.submit(task);
         }
 
+        Thread.sleep(200);
+
         Assert.assertEquals(2, testCachedPool.getPoolSize());
         Assert.assertEquals(2, testCachedPool.getActiveCount());
         Assert.assertEquals(0, testCachedPool.getQueue().size());
         Assert.assertEquals(0, testCachedPool.getCompletedTaskCount());
 
-        Thread.sleep(1400);
+        Thread.sleep(1500);
 
         Assert.assertEquals(2, testCachedPool.getPoolSize());
         Assert.assertEquals(0, testCachedPool.getActiveCount());
@@ -74,13 +76,14 @@ public class ThreadPoolManagerTest {
         for (int i = 0; i < 4; i++) {
             testFixedThreaddPool.submit(task);
         }
+        Thread.sleep(200);
 
         Assert.assertEquals(2, testFixedThreaddPool.getPoolSize());
         Assert.assertEquals(2, testFixedThreaddPool.getActiveCount());
         Assert.assertEquals(2, testFixedThreaddPool.getQueue().size());
         Assert.assertEquals(0, testFixedThreaddPool.getCompletedTaskCount());
 
-        Thread.sleep(4000);
+        Thread.sleep(4500);
 
         Assert.assertEquals(2, testFixedThreaddPool.getPoolSize());
         Assert.assertEquals(0, testFixedThreaddPool.getActiveCount());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

com.starrocks.common.ThreadPoolManagerTest.testNormal easy to get error result like following.
```
ava.lang.AssertionError: expected:<2> but was:<1>
	at com.starrocks.common.ThreadPoolManagerTest.testNormal(ThreadPoolManagerTest.java:63)
```
add more time to make the test stable.