### PR TITLE
[Enhancement] change chunk_size of IO thread to 4096

### DIFF
--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -164,17 +164,14 @@ Status OlapChunkSource::_get_tablet(const TInternalScanRange* scan_range) {
 }
 
 void OlapChunkSource::_decide_chunk_size() {
-    bool has_huge_length_type = std::any_of(_query_slots.begin(), _query_slots.end(),
-                                            [](auto& slot) { return slot->type().is_huge_type(); });
     if (_limit != -1 && _limit < _runtime_state->chunk_size()) {
         // Improve for select * from table limit x, x is small
         _params.chunk_size = _limit;
     } else {
         _params.chunk_size = _runtime_state->chunk_size();
     }
-    if (has_huge_length_type) {
-        _params.chunk_size = std::min(_params.chunk_size, CHUNK_SIZE_FOR_HUGE_TYPE);
-    }
+    // Use the default chunk size for IO, to avoid the memory allocation bottleneck
+    _params.chunk_size = std::min(_params.chunk_size, DEFAULT_CHUNK_SIZE);
 }
 
 Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& key_ranges,


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


For some cases, the `16384` chunk_size of IO thread would encounter the memory allocation bottleneck, which cause performance regression between `non-pipeline` mode.

As a workaround, we change the chunk_size of IO thread to `4096`, to eliminate the bottleneck.

In the future, we would decide the chunk_size based on the row-size, and optimize the memory allocator, to completely solve this issue.


## Effect

For `yandex.q22`, before query latency is 13s, this PR would reduce it to 3s.