### PR TITLE
[BugFix] keep PhysicalOperator equals with their LogicalOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -9,7 +9,6 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class LogicalLimitOperator extends LogicalOperator {
     public enum Phase {
@@ -101,7 +100,7 @@ public class LogicalLimitOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), offset, phase);
+        return System.identityHashCode(this);
     }
 
     public static class Builder extends LogicalOperator.Builder<LogicalLimitOperator, LogicalLimitOperator.Builder> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalFilterOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalFilterOperator.java
@@ -23,6 +23,11 @@ public class PhysicalFilterOperator extends PhysicalOperator {
     }
 
     @Override
+    public boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
     public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
         return visitor.visitPhysicalFilter(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
@@ -9,8 +9,6 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 
-import java.util.Objects;
-
 public class PhysicalLimitOperator extends PhysicalOperator {
     private final long offset;
 
@@ -37,21 +35,11 @@ public class PhysicalLimitOperator extends PhysicalOperator {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        PhysicalLimitOperator that = (PhysicalLimitOperator) o;
-        return offset == that.offset;
+        return this == o;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), offset);
+        return System.identityHashCode(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
@@ -11,7 +11,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
-import java.util.Objects;
 
 public class PhysicalValuesOperator extends PhysicalOperator {
     private final List<ColumnRefOperator> columnRefSet;
@@ -49,23 +48,12 @@ public class PhysicalValuesOperator extends PhysicalOperator {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        PhysicalValuesOperator empty = (PhysicalValuesOperator) o;
-        return Objects.equals(columnRefSet, empty.columnRefSet) &&
-                Objects.equals(rows, empty.rows);
+        return this == o;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), columnRefSet, rows);
+        return System.identityHashCode(this);
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6362

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

All table data is empty.
The bug sql:
```
SELECT *
FROM (
    SELECT ref_1.s_suppkey AS c3
    FROM (select * from primary_table where false) ref_0
        INNER JOIN hive_ssb_100g_csv_supplier ref_1 ON ref_0.k4 = ref_1.s_suppkey
        INNER JOIN tpcds_100g_web_page ref_2 ON ref_0.v1 = ref_2.wp_web_page_sk
        RIGHT JOIN es_ssb_10g_supplier ref_3 ON ref_1.s_address = ref_3.s_name
    WHERE ref_2.wp_web_page_id <= ref_1.s_name
) subq_0
WHERE subq_0.c3 = 96;
```

but I test sql is normal
```
SELECT *
FROM (
    SELECT ref_1.s_suppkey AS c3
    FROM (select * from primary_table where true) ref_0
        INNER JOIN hive_ssb_100g_csv_supplier ref_1 ON ref_0.k4 = ref_1.s_suppkey
        INNER JOIN tpcds_100g_web_page ref_2 ON ref_0.v1 = ref_2.wp_web_page_sk
        RIGHT JOIN es_ssb_10g_supplier ref_3 ON ref_1.s_address = ref_3.s_name
    WHERE ref_2.wp_web_page_id <= ref_1.s_name
) subq_0
WHERE subq_0.c3 = 96;
```

I guess the reason is copy `ValueOperator` into memo happend wrong, so I find the `equals` method of `PhyiscalValueOperator` is different with `LogicalValueOperator`.


