### PR TITLE
[BugFix] fix #6319: dangling pointer at chunk_source

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -37,6 +37,13 @@ OlapChunkSource::~OlapChunkSource() {
     _predicate_free_pool.clear();
 }
 
+void OlapChunkSource::close(RuntimeState* state) {
+    _update_counter();
+    _prj_iter->close();
+    _reader.reset();
+    _predicate_free_pool.clear();
+}
+
 Status OlapChunkSource::prepare(RuntimeState* state) {
     _runtime_state = state;
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
@@ -414,13 +421,6 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
         return Status::EndOfFile("limit reach");
     }
     return Status::OK();
-}
-
-void OlapChunkSource::close(RuntimeState* state) {
-    _update_counter();
-    _prj_iter->close();
-    _reader.reset();
-    _predicate_free_pool.clear();
 }
 
 int64_t OlapChunkSource::last_spent_cpu_time_ns() {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -32,6 +32,11 @@ OlapChunkSource::OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& mo
           _limit(scan_node->limit()),
           _scan_range(down_cast<ScanMorsel*>(_morsel.get())->get_olap_scan_range()) {}
 
+OlapChunkSource::~OlapChunkSource() {
+    _reader.reset();
+    _predicate_free_pool.clear();
+}
+
 Status OlapChunkSource::prepare(RuntimeState* state) {
     _runtime_state = state;
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -99,7 +99,7 @@ private:
     // For release memory.
     using PredicatePtr = std::unique_ptr<vectorized::ColumnPredicate>;
     std::vector<PredicatePtr> _predicate_free_pool;
-    
+
     // NOTE: _reader may reference the _predicate_free_pool, it should be released before the _predicate_free_pool
     std::shared_ptr<vectorized::TabletReader> _reader;
     // projection iterator, doing the job of choosing |_scanner_columns| from |_reader_columns|.

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -35,7 +35,7 @@ public:
     OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, vectorized::OlapScanNode* scan_node,
                     OlapScanContext* scan_ctx);
 
-    ~OlapChunkSource() override = default;
+    ~OlapChunkSource() override;
 
     Status prepare(RuntimeState* state) override;
 
@@ -96,15 +96,17 @@ private:
     RuntimeState* _runtime_state = nullptr;
     const std::vector<SlotDescriptor*>* _slots = nullptr;
 
+    // For release memory.
+    using PredicatePtr = std::unique_ptr<vectorized::ColumnPredicate>;
+    std::vector<PredicatePtr> _predicate_free_pool;
+    
+    // NOTE: _reader may reference the _predicate_free_pool, it should be released before the _predicate_free_pool
     std::shared_ptr<vectorized::TabletReader> _reader;
     // projection iterator, doing the job of choosing |_scanner_columns| from |_reader_columns|.
     std::shared_ptr<vectorized::ChunkIterator> _prj_iter;
 
     const std::vector<std::string>* _unused_output_columns = nullptr;
     std::unordered_set<uint32_t> _unused_output_column_ids;
-    // For release memory.
-    using PredicatePtr = std::unique_ptr<vectorized::ColumnPredicate>;
-    std::vector<PredicatePtr> _predicate_free_pool;
 
     // slot descriptors for each one of |output_columns|.
     std::vector<SlotDescriptor*> _query_slots;

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -43,8 +43,10 @@ ExprContext::ExprContext(Expr* root)
 
 ExprContext::~ExprContext() {
     // DCHECK(!_prepared || _closed) << ". expr context address = " << this;
+    if (_prepared) {
+        close(_runtime_state);
+    }
     for (auto& _fn_context : _fn_contexts) {
-        _fn_context->impl()->close();
         delete _fn_context;
     }
 }
@@ -55,6 +57,7 @@ Status ExprContext::prepare(RuntimeState* state) {
     }
     DCHECK(_pool.get() == nullptr);
     _prepared = true;
+    _runtime_state = state;
     _pool = std::make_unique<MemPool>();
     return _root->prepare(state, this);
 }

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -149,6 +149,7 @@ private:
     /// Variables keeping track of current state.
     bool _prepared;
     bool _opened;
+    RuntimeState* _runtime_state = nullptr;
     // In operator, the ExprContext::close method will be called concurrently
     std::atomic<bool> _closed;
 };

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -31,6 +31,22 @@ ColumnExprPredicate::~ColumnExprPredicate() {
     }
 }
 
+void ColumnExprPredicate::_add_expr_ctxs(std::vector<ExprContext*> expr_ctxs) {
+    for (auto& expr : expr_ctxs) {
+        _add_expr_ctx(expr);
+    }
+}
+
+void ColumnExprPredicate::_add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx) {
+    if (expr_ctx != nullptr) {
+        DCHECK(expr_ctx->opened());
+        // Transfer the ownership to object pool
+        auto* ctx = _state->obj_pool()->add(expr_ctx.release());
+        _expr_ctxs.emplace_back(ctx);
+        _monotonic &= ctx->root()->is_monotonic();
+    }
+}
+
 void ColumnExprPredicate::_add_expr_ctx(ExprContext* expr_ctx) {
     if (expr_ctx != nullptr) {
         DCHECK(expr_ctx->opened());
@@ -152,17 +168,15 @@ Status ColumnExprPredicate::convert_to(const ColumnPredicate** output, const Typ
     Expr* cast_expr = VectorizedCastExprFactory::from_type(input_type, to_type, column_ref, obj_pool);
     column_ref->set_monotonic(true);
     cast_expr->set_monotonic(true);
-    ExprContext* cast_expr_ctx = obj_pool->add(new ExprContext(cast_expr));
 
+    auto cast_expr_ctx = std::make_unique<ExprContext>(cast_expr);
     RETURN_IF_ERROR(cast_expr_ctx->prepare(_state));
     RETURN_IF_ERROR(cast_expr_ctx->open(_state));
 
     ColumnExprPredicate* pred =
             obj_pool->add(new ColumnExprPredicate(target_type_info, _column_id, _state, nullptr, _slot_desc));
-    for (ExprContext* ctx : _expr_ctxs) {
-        pred->_add_expr_ctx(ctx);
-    }
-    pred->_add_expr_ctx(cast_expr_ctx);
+    pred->_add_expr_ctxs(_expr_ctxs);
+    pred->_add_expr_ctx(std::move(cast_expr_ctx));
     *output = pred;
     return Status::OK();
 }
@@ -224,16 +238,14 @@ Status ColumnExprPredicate::try_to_rewrite_for_zone_map_filter(starrocks::Object
     }
     // build new ColumnExprPredicates
     for (auto& expr : exprs_after_rewrite) {
-        ExprContext* ctx = pool->add(new ExprContext(expr));
-        RETURN_IF_ERROR(ctx->prepare(_state));
-        RETURN_IF_ERROR(ctx->open(_state));
-        pool->add(new DeferOp([ctx, this]() { ctx->close(_state); }));
+        auto expr_rewrite = std::make_unique<ExprContext>(expr);
+        RETURN_IF_ERROR(expr_rewrite->prepare(_state));
+        RETURN_IF_ERROR(expr_rewrite->open(_state));
+
         ColumnExprPredicate* new_pred =
-                pool->add(new ColumnExprPredicate(_type_info, _column_id, _state, ctx, _slot_desc));
-        // copy other cast exprs
-        for (size_t i = 1; i < _expr_ctxs.size(); i++) {
-            new_pred->_add_expr_ctx(_expr_ctxs[i]);
-        }
+                pool->add(new ColumnExprPredicate(_type_info, _column_id, _state, nullptr, _slot_desc));
+        new_pred->_add_expr_ctx(std::move(expr_rewrite));
+        new_pred->_add_expr_ctxs(_expr_ctxs);
         output->emplace_back(new_pred);
     }
 

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -245,7 +245,9 @@ Status ColumnExprPredicate::try_to_rewrite_for_zone_map_filter(starrocks::Object
         ColumnExprPredicate* new_pred =
                 pool->add(new ColumnExprPredicate(_type_info, _column_id, _state, nullptr, _slot_desc));
         new_pred->_add_expr_ctx(std::move(expr_rewrite));
-        new_pred->_add_expr_ctxs(_expr_ctxs);
+        for (int i = 1; i < _expr_ctxs.size(); i++) {
+            new_pred->_add_expr_ctx(_expr_ctxs[i]);
+        }
         output->emplace_back(new_pred);
     }
 

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -34,8 +34,6 @@ class ColumnExprPredicate : public ColumnPredicate {
 public:
     ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state, ExprContext* expr_ctx,
                         const SlotDescriptor* slot_desc);
-    ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state, std::unique_ptr<ExprContext> expr_ctx,
-                        const SlotDescriptor* slot_desc);
 
     ~ColumnExprPredicate() override;
 
@@ -63,13 +61,13 @@ public:
 
 private:
     void _add_expr_ctxs(std::vector<ExprContext*> expr_ctxs);
-    
+
     // Take ownership of this expression, not necessary to clone
     void _add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx);
-    
+
     // Share the ownership, is necessary to clone it
     void _add_expr_ctx(ExprContext* expr_ctx);
-    
+
     RuntimeState* _state;
     std::vector<ExprContext*> _expr_ctxs;
     const SlotDescriptor* _slot_desc;

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -34,6 +34,8 @@ class ColumnExprPredicate : public ColumnPredicate {
 public:
     ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state, ExprContext* expr_ctx,
                         const SlotDescriptor* slot_desc);
+    ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state, std::unique_ptr<ExprContext> expr_ctx,
+                        const SlotDescriptor* slot_desc);
 
     ~ColumnExprPredicate() override;
 
@@ -60,7 +62,14 @@ public:
                                               std::vector<const ColumnExprPredicate*>* output) const;
 
 private:
+    void _add_expr_ctxs(std::vector<ExprContext*> expr_ctxs);
+    
+    // Take ownership of this expression, not necessary to clone
+    void _add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx);
+    
+    // Share the ownership, is necessary to clone it
     void _add_expr_ctx(ExprContext* expr_ctx);
+    
     RuntimeState* _state;
     std::vector<ExprContext*> _expr_ctxs;
     const SlotDescriptor* _slot_desc;

--- a/be/src/udf/java/utils.cpp
+++ b/be/src/udf/java/utils.cpp
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
 #include "udf/java/utils.h"
 
 #include <memory>

--- a/be/src/udf/java/utils.h
+++ b/be/src/udf/java/utils.h
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
 #pragma once
 #include <functional>
 #include <future>

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -28,6 +28,7 @@ import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.qe.ConnectContext;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -28,7 +28,6 @@ import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
-import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.qe.ConnectContext;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6319
Fixed #6316
Fixed #6405

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In `OlapChunkSource`, the `_tablet_reader` would reference  object in `_predicate_free_pool`, so either manually call `OlapChunkSource::close` to ensure the release order, or ensure the release order in `~OlapChunkSource`.

And the other issue is `ColumnExprPredicate::try_to_rewrite_for_zone_map_filter`, the code construct a `DeferOp` to ensure the  `ExprContext::close`, which is unnecessary. We change it to call the `close` method if not closed.
