### PR TITLE
[License] Keep the Apache License for not changed files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DistributionPruner.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/planner/DistributionPruner.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragmentId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragmentId.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragmentId.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNodeId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNodeId.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNodeId.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditPlugin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditPlugin.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditPlugin.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/BuiltinPluginLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/BuiltinPluginLoader.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/BuiltinPluginLoader.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/ExtendedPluginsClassLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/ExtendedPluginsClassLoader.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/ExtendedPluginsClassLoader.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/Plugin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/Plugin.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/Plugin.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginClassLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginClassLoader.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginClassLoader.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginContext.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginContext.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginLoader.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginLoader.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/AuditEventProcessor.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HelpCategory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HelpCategory.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/HelpCategory.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HelpModule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HelpModule.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/HelpModule.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HelpObjectIface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HelpObjectIface.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/HelpObjectIface.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HelpObjectLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HelpObjectLoader.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/HelpObjectLoader.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HelpTopic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HelpTopic.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/HelpTopic.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/JournalObservable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/JournalObservable.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/JournalObservable.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/OriginStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/OriginStatement.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/OriginStatement.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessor.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStateException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStateException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/QueryStateException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/QueryStatisticsItem.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/RowBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/RowBatch.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/RowBatch.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSetMetaData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSetMetaData.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/ShowResultSetMetaData.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverterI.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverterI.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverterI.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarConverters.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/AttachmentRequest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/PExecPlanFragmentRequest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PFetchDataRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PFetchDataRequest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/PFetchDataRequest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PTriggerProfileReportRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PTriggerProfileReportRequest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/PTriggerProfileReportRequest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/RpcException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ThriftClientAttachmentHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ThriftClientAttachmentHandler.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/rpc/ThriftClientAttachmentHandler.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendEvent.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/system/BackendEvent.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatFlags.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatFlags.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatFlags.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentClient.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/AgentClient.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskExecutor.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskExecutor.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/ClearAlterTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ClearAlterTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/ClearAlterTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/ClearTransactionTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateRollupTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateRollupTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/CreateRollupTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/DirMoveTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/DirMoveTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/DirMoveTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/DownloadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/DownloadTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/DownloadTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/LoadEtlTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LoadEtlTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/LoadEtlTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/MasterTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/MasterTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/MasterTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReleaseSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReleaseSnapshotTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/ReleaseSnapshotTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/SchemaChangeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/SchemaChangeTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/SchemaChangeTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/StorageMediaMigrationTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/StorageMediaMigrationTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/StorageMediaMigrationTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/task/UploadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UploadTask.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/task/UploadTask.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/AbortTransactionException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/AbortTransactionException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/AbortTransactionException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/AbstractTxnStateChangeCallback.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/AbstractTxnStateChangeCallback.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/AbstractTxnStateChangeCallback.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/BeginTransactionException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/BeginTransactionException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/BeginTransactionException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/IllegalTransactionParameterException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/IllegalTransactionParameterException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/IllegalTransactionParameterException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionCommitFailedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionCommitFailedException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionCommitFailedException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionIdGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionIdGenerator.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionIdGenerator.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionNotFoundException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionNotFoundException.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionNotFoundException.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionStatus.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TxnStateCallbackFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TxnStateCallbackFactory.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TxnStateCallbackFactory.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupClauseTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/AddRollupClauseTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminShowReplicaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminShowReplicaTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminShowReplicaTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterDatabaseQuotaStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterDatabaseQuotaStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterDatabaseQuotaStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/BackendStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/BackendStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/BackendStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnPositionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnPositionTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ColumnPositionTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateDbStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropColumnClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropColumnClauseTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/DropColumnClauseTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropRollupClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropRollupClauseTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/DropRollupClauseTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/DropUserStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GroupByClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GroupByClauseTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/GroupByClauseTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/IndexDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/IndexDefTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/IndexDefTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InstallPluginStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InstallPluginStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/InstallPluginStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LabelNameTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LabelNameTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/LabelNameTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/LiteralExprCompareTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PartitionKeyDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PartitionKeyDescTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionKeyDescTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ReorderColumnsClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ReorderColumnsClauseTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ReorderColumnsClauseTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetNamesVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetNamesVarTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SetNamesVarTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetOperationStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SetOperationStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetTypeTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SetTypeTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetUserPropertyStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetUserPropertyStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SetUserPropertyStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetUserPropertyVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetUserPropertyVarTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SetUserPropertyVarTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateDbStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateDbStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateTableStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDbStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowIndexStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowUserPropertyStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowUserPropertyStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowUserPropertyStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SysVariableDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SysVariableDescTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SysVariableDescTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseStmtTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/UseStmtTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/VirtualSlotRefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/VirtualSlotRefTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/VirtualSlotRefTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/backup/PartitionNameTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/PartitionNameTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/PartitionNameTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/backup/PathMakerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/PathMakerTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/PathMakerTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreFileMappingTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreFileMappingTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/ColocateTableIndexTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnStatsTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnStatsTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/RangePartitionInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/TablePropertyTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/clone/RootPathLoadStatisticTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/RootPathLoadStatisticTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/clone/RootPathLoadStatisticTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/clone/TabletSchedCtxTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/ExceptionChecker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ExceptionChecker.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/ExceptionChecker.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/GenericPoolTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/JdkUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/JdkUtilsTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/JdkUtilsTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/MD5Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/MD5Test.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/MD5Test.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/MarkDownParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/MarkDownParserTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/MarkDownParserTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/PatternMatcherTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PatternMatcherTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/PatternMatcherTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/ThreadPoolManagerTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/io/DeepCopyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/io/DeepCopyTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/io/DeepCopyTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/path/PathTrieTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/path/PathTrieTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/path/PathTrieTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ProcServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ProcServiceTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/proc/ProcServiceTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DebugUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DebugUtilTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugUtilTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DynamicPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DynamicPartitionUtilTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/DynamicPartitionUtilTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ListComparatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ListComparatorTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/ListComparatorTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ListUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ListUtilTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/ListUtilTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/QueryableReentrantLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/QueryableReentrantLockTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/QueryableReentrantLockTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/VersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/VersionTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/common/util/VersionTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/EsUtilTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/QueryBuildersTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/QueryBuildersTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/QueryBuildersTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpAuthManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpAuthManagerTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/HttpAuthManagerTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/http/MimeTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/MimeTypeTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/MimeTypeTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableRowCountActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableRowCountActionTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/TableRowCountActionTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableSchemaActionTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/http/TableSchemaActionTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/load/EtlJobStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/EtlJobStatusTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/load/EtlJobStatusTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/load/FailMsgTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/FailMsgTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/load/FailMsgTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerFileGroupAggInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerFileGroupAggInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerFileGroupAggInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlAuthPacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlCapabilityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlCapabilityTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCapabilityTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChangeUserPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChangeUserPacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlChangeUserPacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlChannelTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColDefTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlColDefTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColTypeTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlColTypeTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlCommandTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlCommandTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCommandTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlEofPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlEofPacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlEofPacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlErrPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlErrPacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlErrPacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlHandshakePacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlHandshakePacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlHandshakePacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlOkPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlOkPacketTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlOkPacketTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlPasswordTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlPasswordTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/WrappedAuth.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/WrappedAuth.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/WrappedAuth.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/WrapperSocketChannel.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/WrapperSocketChannel.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/WrapperSocketChannel.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/MockedAuth.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/MockedAuth.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/UserIdentityTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/FsBrokerTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ModifyDynamicPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ModifyDynamicPartitionInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/ModifyDynamicPartitionInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ReplicaPersistInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ReplicaPersistInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/ReplicaPersistInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/StorageInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/StorageInfoTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/StorageInfoTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/ThriftToJsonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/ThriftToJsonTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/gson/ThriftToJsonTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/PluginTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/PluginTestUtil.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/plugin/PluginTestUtil.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/PluginZipTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/PluginZipTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/plugin/PluginZipTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HelpModuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HelpModuleTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/HelpModuleTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HelpObjectLoaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HelpObjectLoaderTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/HelpObjectLoaderTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/JournalObservableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/JournalObservableTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/JournalObservableTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStateTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/QueryStateTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/SetExecutorTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultSetMetaDataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultSetMetaDataTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/ShowResultSetMetaDataTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultSetTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/ShowResultSetTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SqlModeHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SqlModeHelperTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/qe/SqlModeHelperTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/service/ExecuteEnvTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/ExecuteEnvTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/service/ExecuteEnvTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/task/MasterTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/MasterTaskExecutorTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/task/MasterTaskExecutorTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/FakeTransactionIDGenerator.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/FakeTransactionIDGenerator.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/transaction/FakeTransactionIDGenerator.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionStateTest.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -1,7 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackend.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information


### PR DESCRIPTION
Many files come from Apache Doris and have not been changed.
According to the License rule, the files should keep the Apache License.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
