### PR TITLE
[Enhancement] limit scanner concurrency for pipeline

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -29,14 +29,16 @@ void ConnectorScanOperatorFactory::do_close(RuntimeState* state) {
 }
 
 OperatorPtr ConnectorScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, _scan_node);
+    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, _scan_node, _max_scan_concurrency,
+                                                   _num_committed_scan_tasks);
 }
 
 // ==================== ConnectorScanOperator ====================
 
 ConnectorScanOperator::ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence,
-                                             ScanNode* scan_node)
-        : ScanOperator(factory, id, driver_sequence, scan_node) {}
+                                             ScanNode* scan_node, int max_scan_concurrency,
+                                             std::atomic<int>& num_committed_scan_tasks)
+        : ScanOperator(factory, id, driver_sequence, scan_node, max_scan_concurrency, num_committed_scan_tasks) {}
 
 Status ConnectorScanOperator::do_prepare(RuntimeState* state) {
     return Status::OK();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -26,7 +26,8 @@ public:
 
 class ConnectorScanOperator final : public ScanOperator {
 public:
-    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
+    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
+                          int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks);
 
     ~ConnectorScanOperator() override = default;
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -28,14 +28,17 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _ctx);
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _max_scan_concurrency,
+                                              _num_committed_scan_tasks, _ctx);
 }
 
 // ==================== OlapScanOperator ====================
 
 OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
+                                   int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks,
                                    OlapScanContextPtr ctx)
-        : ScanOperator(factory, id, driver_sequence, scan_node), _ctx(std::move(ctx)) {
+        : ScanOperator(factory, id, driver_sequence, scan_node, max_scan_concurrency, num_committed_scan_tasks),
+          _ctx(std::move(ctx)) {
     _ctx->ref();
 }
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -33,7 +33,7 @@ private:
 class OlapScanOperator final : public ScanOperator {
 public:
     OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                     OlapScanContextPtr ctx);
+                     int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx);
 
     ~OlapScanOperator() override;
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -16,10 +16,13 @@ namespace starrocks::pipeline {
 
 // ========== ScanOperator ==========
 
-ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node)
+ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
+                           int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks)
         : SourceOperator(factory, id, scan_node->name(), scan_node->id(), driver_sequence),
           _scan_node(scan_node),
           _chunk_source_profiles(MAX_IO_TASKS_PER_OP),
+          _max_scan_concurrency(max_scan_concurrency),
+          _num_committed_scan_tasks(num_committed_scan_tasks),
           _is_io_task_running(MAX_IO_TASKS_PER_OP),
           _chunk_sources(MAX_IO_TASKS_PER_OP) {
     for (auto i = 0; i < MAX_IO_TASKS_PER_OP; i++) {
@@ -82,7 +85,7 @@ bool ScanOperator::has_output() const {
         return false;
     }
     // if storage layer returns an error, we should make sure `pull_chunk` has a chance to get it
-    if (!get_scan_status().ok()) {
+    if (!_get_scan_status().ok()) {
         return true;
     }
 
@@ -92,7 +95,7 @@ bool ScanOperator::has_output() const {
         }
     }
 
-    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP) {
+    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP || _num_committed_scan_tasks.load() >= _max_scan_concurrency) {
         return false;
     }
 
@@ -124,7 +127,7 @@ bool ScanOperator::is_finished() const {
         return true;
     }
     // if storage layer returns an error, we should make sure `pull_chunk` has a chance to get it
-    if (!get_scan_status().ok()) {
+    if (!_get_scan_status().ok()) {
         return false;
     }
 
@@ -150,7 +153,7 @@ Status ScanOperator::set_finishing(RuntimeState* state) {
 }
 
 StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
-    RETURN_IF_ERROR(get_scan_status());
+    RETURN_IF_ERROR(_get_scan_status());
     RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
     if (_workgroup != nullptr) {
         _workgroup->incr_period_ask_chunk_num(1);
@@ -211,6 +214,10 @@ inline bool is_uninitialized(const std::weak_ptr<QueryContext>& ptr) {
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
+    if (!_try_to_increase_committed_scan_tasks()) {
+        return Status::OK();
+    }
+
     _num_running_io_tasks++;
     _is_io_task_running[chunk_source_index] = true;
 
@@ -229,7 +236,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                     Status status = _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking_for_workgroup(
                             _buffer_size, state, &num_read_chunks, worker_id, _workgroup);
                     if (!status.ok() && !status.is_end_of_file()) {
-                        set_scan_status(status);
+                        _set_scan_status(status);
                     }
                     // TODO (by laotan332): More detailed information is needed
                     _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
@@ -240,6 +247,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                     _last_scan_bytes += _chunk_sources[chunk_source_index]->last_scan_bytes();
                 }
 
+                _decrease_committed_scan_tasks();
                 _num_running_io_tasks--;
                 _is_io_task_running[chunk_source_index] = false;
             }
@@ -259,13 +267,14 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                     Status status =
                             _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, state);
                     if (!status.ok() && !status.is_end_of_file()) {
-                        set_scan_status(status);
+                        _set_scan_status(status);
                     }
                     _last_growth_cpu_time_ns += _chunk_sources[chunk_source_index]->last_spent_cpu_time_ns();
                     _last_scan_rows_num += _chunk_sources[chunk_source_index]->last_scan_rows_num();
                     _last_scan_bytes += _chunk_sources[chunk_source_index]->last_scan_bytes();
                 }
 
+                _decrease_committed_scan_tasks();
                 _num_running_io_tasks--;
                 _is_io_task_running[chunk_source_index] = false;
             }
@@ -327,10 +336,21 @@ void ScanOperator::_merge_chunk_source_profiles() {
     _unique_metrics->copy_all_counters_from(merged_profile);
 }
 
+bool ScanOperator::_try_to_increase_committed_scan_tasks() {
+    int old_num = _num_committed_scan_tasks.fetch_add(1);
+    if (old_num >= _max_scan_concurrency) {
+        _decrease_committed_scan_tasks();
+        return false;
+    }
+    return true;
+}
+
 // ========== ScanOperatorFactory ==========
 
 ScanOperatorFactory::ScanOperatorFactory(int32_t id, ScanNode* scan_node)
-        : SourceOperatorFactory(id, scan_node->name(), scan_node->id()), _scan_node(scan_node) {}
+        : SourceOperatorFactory(id, scan_node->name(), scan_node->id()),
+          _scan_node(scan_node),
+          _max_scan_concurrency(scan_node->max_scan_concurrency()) {}
 
 Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -338,7 +338,8 @@ void ScanOperator::_merge_chunk_source_profiles() {
 
 bool ScanOperator::_try_to_increase_committed_scan_tasks() {
     int old_num = _num_committed_scan_tasks.fetch_add(1);
-    if (old_num >= _max_scan_concurrency) {
+    // _max_scan_concurrency takes effect, only when it is positive.
+    if (_max_scan_concurrency > 0 && old_num >= _max_scan_concurrency) {
         _decrease_committed_scan_tasks();
         return false;
     }

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -83,6 +83,7 @@ private:
 
     bool _try_to_increase_committed_scan_tasks();
     void _decrease_committed_scan_tasks() { _num_committed_scan_tasks.fetch_sub(1); }
+    bool _exceed_max_scan_concurrency(int num_committed_scan_tasks) const;
 
 protected:
     ScanNode* _scan_node = nullptr;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -15,7 +15,8 @@ namespace pipeline {
 
 class ScanOperator : public SourceOperator {
 public:
-    ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
+    ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
+                 int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks);
 
     ~ScanOperator() override;
 
@@ -68,6 +69,21 @@ private:
     Status _try_to_trigger_next_scan(RuntimeState* state);
     void _merge_chunk_source_profiles();
 
+    inline void _set_scan_status(const Status& status) {
+        std::lock_guard<SpinLock> l(_scan_status_mutex);
+        if (_scan_status.ok()) {
+            _scan_status = status;
+        }
+    }
+
+    inline Status _get_scan_status() const {
+        std::lock_guard<SpinLock> l(_scan_status_mutex);
+        return _scan_status;
+    }
+
+    bool _try_to_increase_committed_scan_tasks();
+    void _decrease_committed_scan_tasks() { _num_committed_scan_tasks.fetch_sub(1); }
+
 protected:
     ScanNode* _scan_node = nullptr;
     // ScanOperator may do parallel scan, so each _chunk_sources[i] needs to hold
@@ -79,19 +95,11 @@ protected:
 
     bool _is_finished = false;
 
+    const int _max_scan_concurrency;
+    // Shared by all the ScanOperators created by the same ScanOperatorFactory.
+    std::atomic<int>& _num_committed_scan_tasks;
+
 private:
-    inline void set_scan_status(const Status& status) {
-        std::lock_guard<SpinLock> l(_scan_status_mutex);
-        if (_scan_status.ok()) {
-            _scan_status = status;
-        }
-    }
-
-    inline Status get_scan_status() const {
-        std::lock_guard<SpinLock> l(_scan_status_mutex);
-        return _scan_status;
-    }
-
     static constexpr int MAX_IO_TASKS_PER_OP = 4;
 
     const size_t _buffer_size = config::pipeline_io_buffer_size;
@@ -130,7 +138,10 @@ public:
     virtual OperatorPtr do_create(int32_t dop, int32_t driver_sequence) = 0;
 
 protected:
-    ScanNode* _scan_node;
+    ScanNode* const _scan_node;
+
+    const int _max_scan_concurrency;
+    std::atomic<int> _num_committed_scan_tasks{0};
 };
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -92,6 +92,9 @@ public:
 
     const std::string& name() const { return _name; }
 
+    // Used by pipeline, 0 means there is no limitation.
+    virtual int max_scan_concurrency() const { return 0; }
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -594,12 +594,17 @@ struct TypeMemoryUsed {
         switch (ptype) {
         case TYPE_VARCHAR:
         case TYPE_CHAR:
+            return 128;
         case TYPE_JSON:
+            // 1KB.
+            return 1024;
         case TYPE_HLL:
+            // 16KB.
+            return 16 * 1024;
         case TYPE_OBJECT:
         case TYPE_PERCENTILE:
-            // Use 100 bytes to estimate types of indeterminate length.
-            return 100;
+            // 1MB.
+            return 1024 * 1024;
         default:
             return 0;
         }

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -69,6 +69,8 @@ public:
 
     static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
 
+    int max_scan_concurrency() const override;
+
 private:
     friend class TabletScanner;
 
@@ -124,13 +126,12 @@ private:
     Status _capture_tablet_rowsets();
 
     // scanner concurrency
-    size_t _scanner_concurrency();
+    size_t _scanner_concurrency() const;
     void _estimate_scan_and_output_row_bytes();
 
 private:
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
-    RuntimeState* _runtime_state = nullptr;
     TupleDescriptor* _tuple_desc = nullptr;
     OlapScanConjunctsManager _conjuncts_manager;
     DictOptimizeParser _dict_optimize_parser;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -125,7 +125,9 @@ private:
 
     // scanner concurrency
     size_t _scanner_concurrency();
+    void _estimate_scan_and_output_row_bytes();
 
+private:
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
     RuntimeState* _runtime_state = nullptr;
@@ -137,6 +139,8 @@ private:
 
     int32_t _num_scanners = 0;
     int32_t _chunks_per_scanner = 10;
+    size_t _estimated_scan_row_bytes = 0;
+    size_t _estimated_output_row_bytes = 0;
     bool _start = false;
 
     mutable SpinLock _status_mutex;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -116,6 +116,7 @@ public:
     MemTracker* instance_mem_tracker() { return _instance_mem_tracker.get(); }
     MemPool* instance_mem_pool() { return _instance_mem_pool.get(); }
     std::shared_ptr<MemTracker> query_mem_tracker_ptr() { return _query_mem_tracker; }
+    const std::shared_ptr<MemTracker>& query_mem_tracker_ptr() const { return _query_mem_tracker; }
     std::shared_ptr<MemTracker> instance_mem_tracker_ptr() { return _instance_mem_tracker; }
     ThreadResourceMgr::ResourcePool* resource_pool() { return _resource_pool; }
     RuntimeFilterPort* runtime_filter_port() { return _runtime_filter_port; }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4074.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures havelayou taken to fix the bug?) -->
Estimate the memory occupation of one scanning row in `OlapScanNode`, and limit the number of the committed i/o tasks  to `(query_mem_limit*config::scan_use_query_mem_ratio)/(estimated_row_bytes*chunk_size)`.

## TODO
- Use the estimated average row size from planner. However, Planner will include the expression related to the scan column. For example, for `select P_SIZE + P_SIZE from lineorder_flat;`, where `P_SIZE` is `TINYINT`, the avgRowSize is 3 not 1.
```
mysql> explain costs select P_SIZE + P_SIZE from lineorder_flat;
|   0:OlapScanNode                                                                                    |
|      table: lineorder_flat, rollup: lineorder_flat                                                  |
|      preAggregation: on                                                                             |
|      partitionsRatio=7/7, tabletsRatio=336/336                                                      |
|      tabletList=1298955,1298957,1298959,1298961,1298963,1298965,1298967,1298969,1298971,1298973 ... |
|      actualRows=600037902, avgRowSize=3.0                                                           |
|      cardinality: 600037902                                                                         |
|      column statistics:                                                                             |
|      * P_SIZE-->[1.0, 50.0, 0.0, 1.0, 50.0] ESTIMATE                                                |
|      * expr-->[2.0, 100.0, 0.0, 2.0, 50.0] ESTIMATE
```

- Dynamic adjust the concurrency after scanning specific number of row.
