### PR TITLE
[Bugfix] set pipeline query_mem_limit correctly

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -61,7 +61,7 @@ int64_t QueryContext::compute_query_mem_limit(int64_t parent_mem_limit, int64_t 
     int64_t mem_limit = per_instance_mem_limit;
     // query's mem_limit = per-instance mem_limit * num_instances * pipeline_dop
     static constexpr int64_t MEM_LIMIT_MAX = std::numeric_limits<int64_t>::max();
-    if (MEM_LIMIT_MAX / total_fragments() / pipeline_dop < mem_limit) {
+    if (MEM_LIMIT_MAX / total_fragments() / pipeline_dop > mem_limit) {
         mem_limit *= total_fragments() * pipeline_dop;
     } else {
         mem_limit = MEM_LIMIT_MAX;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When `mem_limit < MEM_LIMIT_MAX / total_fragments() / pipeline_dop`, it means `mem_limit * pipeline_dop * total_fragments() < MEM_LIMIT_MAX`. Therefore, it should set as `mem_limit * pipeline_dop * total_fragments()` not `MEM_LIMIT_MAX`.
