### PR TITLE
[BugFix] clear cache in follower when alter resource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -101,8 +101,19 @@ public class ResourceMgr implements Writable {
         }
     }
 
+    /**
+     * Replay create or alter resource log
+     * When we replay alter resource log
+     * <p>1. Overwrite the resource </p>
+     * <p>2. Clear cache in memory </p>
+     * @param resource
+     */
     public void replayCreateResource(Resource resource) {
         nameToResource.put(resource.getName(), resource);
+        if (resource instanceof HiveResource || resource instanceof HudiResource) {
+            GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(resource.getName());
+        }
+        LOG.info("replay create/alter resource log success. resource name: {}", resource.getName());
     }
 
     public void dropResource(DropResourceStmt stmt) throws DdlException {
@@ -154,7 +165,7 @@ public class ResourceMgr implements Writable {
     }
 
     /**
-     * alter resource statement only support external hive now .
+     * alter resource statement only support external hive/hudi now .
      *
      * @param stmt
      * @throws DdlException


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
FIX #6273

## Problem Summary(Required) ：
clear cache in follower when replay create/alter resource
