### PR TITLE
[BugFix] Fix bdb inconsistent bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -375,12 +375,12 @@ public class BDBEnvironment {
             } catch (InsufficientLogException e) {
                 // for InsufficientLogException we should refresh the log and
                 // then exit the process because we may have read dirty data.
-                LOG.warn("catch insufficient log exception. refresh and exit.", e);
+                LOG.warn("catch insufficient log exception. please restart.", e);
                 refreshLog(e);
                 System.exit(-1);
             } catch (RollbackException exception) {
                 // for RollbackException we should exit the process because we may have read dirty data.
-                LOG.warn("rollback exception, exit", exception);
+                LOG.warn("catch rollback exception, please restart", exception);
                 System.exit(-1);
             } catch (EnvironmentFailureException e) {
                 tried++;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -230,21 +230,19 @@ public class BDBEnvironment {
         }
     }
 
-    private void refreshLog(InsufficientLogException insufficientLogEx) {
-        NetworkRestore restore = new NetworkRestore();
-        NetworkRestoreConfig config = new NetworkRestoreConfig();
-        config.setRetainLogFiles(false); // delete obsolete log files.
-        // Use the members returned by insufficientLogEx.getLogProviders()
-        // to select the desired subset of members and pass the resulting
-        // list as the argument to config.setLogProviders(), if the
-        // default selection of providers is not suitable.
-        restore.execute(insufficientLogEx, config);
-    }
-
-    public void refreshAndSetup(InsufficientLogException insufficientLogEx) {
-        refreshLog(insufficientLogEx);
-        close();
-        setup();
+    public void refreshLog(InsufficientLogException insufficientLogEx) {
+        try {
+            NetworkRestore restore = new NetworkRestore();
+            NetworkRestoreConfig config = new NetworkRestoreConfig();
+            config.setRetainLogFiles(false); // delete obsolete log files.
+            // Use the members returned by insufficientLogEx.getLogProviders()
+            // to select the desired subset of members and pass the resulting
+            // list as the argument to config.setLogProviders(), if the
+            // default selection of providers is not suitable.
+            restore.execute(insufficientLogEx, config);
+        } catch (Throwable t) {
+            LOG.warn("refresh log failed", t);
+        }
     }
 
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
@@ -375,14 +373,15 @@ public class BDBEnvironment {
                 names = replicatedEnvironment.getDatabaseNames();
                 break;
             } catch (InsufficientLogException e) {
-                LOG.warn("catch insufficient log exception. refresh and setup again.", e);
+                // for InsufficientLogException we should refresh the log and
+                // then exit the process because we may have read dirty data.
+                LOG.warn("catch insufficient log exception. refresh and exit.", e);
                 refreshLog(e);
-                close();
-                setup();
+                System.exit(-1);
             } catch (RollbackException exception) {
-                LOG.warn("rollback exception, setup again", exception);
-                close();
-                setup();
+                // for RollbackException we should exit the process because we may have read dirty data.
+                LOG.warn("rollback exception, exit", exception);
+                System.exit(-1);
             } catch (EnvironmentFailureException e) {
                 tried++;
                 if (tried == RETRY_TIME) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -315,7 +315,7 @@ public class BDBJEJournal implements Journal {
                 nextJournalId.set(getMaxJournalId() + 1);
                 return;
             } catch (InsufficientLogException insufficientLogEx) {
-                LOG.warn("catch insufficient log exception. refresh the log and exit", insufficientLogEx);
+                LOG.warn("catch insufficient log exception. please restart", insufficientLogEx);
                 // for InsufficientLogException we should refresh the log and
                 // then exit the process because we may have read dirty data.
                 bdbEnvironment.refreshLog(insufficientLogEx);

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -315,9 +315,11 @@ public class BDBJEJournal implements Journal {
                 nextJournalId.set(getMaxJournalId() + 1);
                 return;
             } catch (InsufficientLogException insufficientLogEx) {
-                // Copy the missing log files from a member of the replication group who owns the files
-                LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
-                bdbEnvironment.refreshAndSetup(insufficientLogEx);
+                LOG.warn("catch insufficient log exception. refresh the log and exit", insufficientLogEx);
+                // for InsufficientLogException we should refresh the log and
+                // then exit the process because we may have read dirty data.
+                bdbEnvironment.refreshLog(insufficientLogEx);
+                System.exit(-1);
             } catch (Throwable t) {
                 LOG.warn("catch exception, retried: {} ", i, t);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1486,7 +1486,7 @@ public class GlobalStateMgr {
                 } catch (InsufficientLogException insufficientLogEx) {
                     // for InsufficientLogException we should refresh the log and
                     // then exit the process because we may have read dirty data.
-                    LOG.error("catch insufficient log exception. refresh and exit", insufficientLogEx);
+                    LOG.error("catch insufficient log exception. please restart", insufficientLogEx);
                     ((BDBJEJournal) editLog.getJournal()).getBdbEnvironment().refreshLog(insufficientLogEx);
                     System.exit(-1);
                 } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -30,8 +30,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Range;
 import com.sleepycat.je.rep.InsufficientLogException;
-import com.sleepycat.je.rep.NetworkRestore;
-import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.starrocks.StarRocksFE;
 import com.starrocks.alter.Alter;
 import com.starrocks.alter.AlterJob;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -161,6 +161,7 @@ import com.starrocks.ha.HAProtocol;
 import com.starrocks.ha.MasterInfo;
 import com.starrocks.journal.JournalCursor;
 import com.starrocks.journal.JournalEntity;
+import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.journal.bdbje.Timestamp;
 import com.starrocks.load.DeleteHandler;
 import com.starrocks.load.ExportChecker;
@@ -1485,13 +1486,10 @@ public class GlobalStateMgr {
                     hasLog = replayJournal(-1);
                     metaReplayState.setOk();
                 } catch (InsufficientLogException insufficientLogEx) {
-                    // Copy the missing log files from a member of the
-                    // replication group who owns the files
-                    LOG.error("catch insufficient log exception. please restart.", insufficientLogEx);
-                    NetworkRestore restore = new NetworkRestore();
-                    NetworkRestoreConfig config = new NetworkRestoreConfig();
-                    config.setRetainLogFiles(false);
-                    restore.execute(insufficientLogEx, config);
+                    // for InsufficientLogException we should refresh the log and
+                    // then exit the process because we may have read dirty data.
+                    LOG.error("catch insufficient log exception. refresh and exit", insufficientLogEx);
+                    ((BDBJEJournal) editLog.getJournal()).getBdbEnvironment().refreshLog(insufficientLogEx);
                     System.exit(-1);
                 } catch (Throwable e) {
                     LOG.error("replayer thread catch an exception when replay journal.", e);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6404

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In bdb, synchronizing data with the master node is an asynchronous process. If a node finds dirty data in its own data, the dirty data should be truncated, but the dirty data may have been read by our replayer thread. So we should catch the RollbackException and exit the process. When truncating the dirty data, if the data precedes a checkpoint that deleted log files, an InsufficientLogException will be thrown, so we also should catch the InsufficientLogException and exit the process.