### PR TITLE
[Enhancement] rank window function optimization, add threshold of partition number (4)

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
@@ -20,7 +20,7 @@ StatusOr<vectorized::ChunkPtr> LocalPartitionTopnSinkOperator::pull_chunk(Runtim
 }
 
 Status LocalPartitionTopnSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    return _partition_topn_ctx->push_one_chunk_to_partitioner(chunk);
+    return _partition_topn_ctx->push_one_chunk_to_partitioner(state, chunk);
 }
 
 Status LocalPartitionTopnSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_source.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_source.cpp
@@ -19,7 +19,7 @@ bool LocalPartitionTopnSourceOperator::is_finished() const {
 }
 
 StatusOr<vectorized::ChunkPtr> LocalPartitionTopnSourceOperator::pull_chunk(RuntimeState* state) {
-    return _partition_topn_ctx->pull_one_chunk_from_sorters();
+    return _partition_topn_ctx->pull_one_chunk();
 }
 
 LocalPartitionTopnSourceOperatorFactory::LocalPartitionTopnSourceOperatorFactory(

--- a/be/src/exec/vectorized/partition/chunks_partitioner.cpp
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.cpp
@@ -52,6 +52,7 @@ ChunksPartitioner::ChunksPartitioner(const bool has_nullable_partition_column,
 Status ChunksPartitioner::prepare(RuntimeState* state) {
     _state = state;
     _mem_pool = std::make_unique<MemPool>();
+    _obj_pool = state->obj_pool();
     _init_hash_map_variant();
     return Status::OK();
 }

--- a/be/src/exec/vectorized/partition/chunks_partitioner.h
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.h
@@ -74,7 +74,7 @@ private:
 
     template <typename HashMapWithKey>
     void split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
-        hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get());
+        hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool);
     }
 
     // Fetch chunks from hash map, return true if reaches eos
@@ -106,7 +106,7 @@ private:
         });
 
         while (partition_it != partition_end) {
-            std::vector<ChunkPtr>& chunks = partition_it->second.chunks;
+            std::vector<ChunkPtr>& chunks = partition_it->second->chunks;
             if (!_chunk_it.has_value()) {
                 _chunk_it = chunks.begin();
             }
@@ -171,6 +171,7 @@ private:
 
     RuntimeState* _state = nullptr;
     std::unique_ptr<MemPool> _mem_pool = nullptr;
+    ObjectPool* _obj_pool = nullptr;
 
     Columns _partition_columns;
     // Hash map which holds chunks of different partitions

--- a/be/src/exec/vectorized/partition/partition_hash_map.h
+++ b/be/src/exec/vectorized/partition/partition_hash_map.h
@@ -28,34 +28,34 @@ struct PartitionChunks {
 // =====================
 // one level partition hash map
 template <PhmapSeed seed>
-using Int8PartitionHashMap = phmap::flat_hash_map<int8_t, PartitionChunks, StdHashWithSeed<int8_t, seed>>;
+using Int8PartitionHashMap = phmap::flat_hash_map<int8_t, PartitionChunks*, StdHashWithSeed<int8_t, seed>>;
 template <PhmapSeed seed>
-using Int16PartitionHashMap = phmap::flat_hash_map<int16_t, PartitionChunks, StdHashWithSeed<int16_t, seed>>;
+using Int16PartitionHashMap = phmap::flat_hash_map<int16_t, PartitionChunks*, StdHashWithSeed<int16_t, seed>>;
 template <PhmapSeed seed>
-using Int32PartitionHashMap = phmap::flat_hash_map<int32_t, PartitionChunks, StdHashWithSeed<int32_t, seed>>;
+using Int32PartitionHashMap = phmap::flat_hash_map<int32_t, PartitionChunks*, StdHashWithSeed<int32_t, seed>>;
 template <PhmapSeed seed>
-using Int64PartitionHashMap = phmap::flat_hash_map<int64_t, PartitionChunks, StdHashWithSeed<int64_t, seed>>;
+using Int64PartitionHashMap = phmap::flat_hash_map<int64_t, PartitionChunks*, StdHashWithSeed<int64_t, seed>>;
 template <PhmapSeed seed>
-using Int128PartitionHashMap = phmap::flat_hash_map<int128_t, PartitionChunks, Hash128WithSeed<seed>>;
+using Int128PartitionHashMap = phmap::flat_hash_map<int128_t, PartitionChunks*, Hash128WithSeed<seed>>;
 template <PhmapSeed seed>
-using DatePartitionHashMap = phmap::flat_hash_map<DateValue, PartitionChunks, StdHashWithSeed<DateValue, seed>>;
+using DatePartitionHashMap = phmap::flat_hash_map<DateValue, PartitionChunks*, StdHashWithSeed<DateValue, seed>>;
 template <PhmapSeed seed>
 using TimeStampPartitionHashMap =
-        phmap::flat_hash_map<TimestampValue, PartitionChunks, StdHashWithSeed<TimestampValue, seed>>;
+        phmap::flat_hash_map<TimestampValue, PartitionChunks*, StdHashWithSeed<TimestampValue, seed>>;
 template <PhmapSeed seed>
-using SlicePartitionHashMap = phmap::flat_hash_map<Slice, PartitionChunks, SliceHashWithSeed<seed>, SliceEqual>;
+using SlicePartitionHashMap = phmap::flat_hash_map<Slice, PartitionChunks*, SliceHashWithSeed<seed>, SliceEqual>;
 
 // ==================
 // one level fixed size slice hash map
 template <PhmapSeed seed>
 using FixedSize4SlicePartitionHashMap =
-        phmap::flat_hash_map<SliceKey4, PartitionChunks, FixedSizeSliceKeyHash<SliceKey4, seed>>;
+        phmap::flat_hash_map<SliceKey4, PartitionChunks*, FixedSizeSliceKeyHash<SliceKey4, seed>>;
 template <PhmapSeed seed>
 using FixedSize8SlicePartitionHashMap =
-        phmap::flat_hash_map<SliceKey8, PartitionChunks, FixedSizeSliceKeyHash<SliceKey8, seed>>;
+        phmap::flat_hash_map<SliceKey8, PartitionChunks*, FixedSizeSliceKeyHash<SliceKey8, seed>>;
 template <PhmapSeed seed>
 using FixedSize16SlicePartitionHashMap =
-        phmap::flat_hash_map<SliceKey16, PartitionChunks, FixedSizeSliceKeyHash<SliceKey16, seed>>;
+        phmap::flat_hash_map<SliceKey16, PartitionChunks*, FixedSizeSliceKeyHash<SliceKey16, seed>>;
 
 struct PartitionHashMapBase {
     const int32_t chunk_size;
@@ -90,13 +90,18 @@ protected:
     // @key_loader used to load key for number type or slice type
     template <typename HashMap, typename KeyLoader, typename KeyAllocator>
     void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
-                                  KeyAllocator&& key_allocator) {
+                                  KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
+        phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
+                             typename HashMap::allocator_type>
+                visited_keys(chunk->num_rows());
         const auto size = chunk->num_rows();
         for (uint32_t i = 0; i < size; i++) {
             const auto& key = key_loader(i);
-            auto iter = hash_map.lazy_emplace(
-                    key, [&](const auto& ctor) { return ctor(key_allocator(key), PartitionChunks()); });
-            auto& value = iter->second;
+            visited_keys.insert(key);
+            auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
+                return ctor(key_allocator(key), obj_pool->add(new PartitionChunks()));
+            });
+            auto& value = *(iter->second);
             if (value.chunks.empty() || value.remain_size <= 0) {
                 if (!value.chunks.empty()) {
                     value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0,
@@ -109,8 +114,8 @@ protected:
             value.remain_size--;
         }
 
-        for (auto& [key, value] : hash_map) {
-            flush(value, chunk);
+        for (const auto& key : visited_keys) {
+            flush(*(hash_map[key]), chunk);
         }
     }
 
@@ -123,7 +128,7 @@ protected:
     template <typename HashMap, typename KeyLoader, typename KeyAllocator>
     void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
                                            const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
-                                           KeyAllocator&& key_allocator) {
+                                           KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
         if (nullable_key_column->only_null()) {
             const auto size = chunk->num_rows();
             if (null_key_value.chunks.empty() || null_key_value.remain_size <= 0) {
@@ -146,6 +151,10 @@ protected:
             null_key_value.chunks.back()->append(*chunk, offset, cur_remain_size);
             null_key_value.remain_size = chunk_size - null_key_value.chunks.back()->num_rows();
         } else {
+            phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
+                                 typename HashMap::allocator_type>
+                    visited_keys(chunk->num_rows());
+
             const auto& null_flag_data = nullable_key_column->null_column()->get_data();
             const auto size = chunk->num_rows();
 
@@ -155,9 +164,11 @@ protected:
                     value_ptr = &null_key_value;
                 } else {
                     const auto& key = key_loader(i);
-                    auto iter = hash_map.lazy_emplace(
-                            key, [&](const auto& ctor) { return ctor(key_allocator(key), PartitionChunks()); });
-                    value_ptr = &iter->second;
+                    visited_keys.insert(key);
+                    auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
+                        return ctor(key_allocator(key), obj_pool->add(new PartitionChunks()));
+                    });
+                    value_ptr = iter->second;
                 }
 
                 auto& value = *value_ptr;
@@ -173,8 +184,8 @@ protected:
                 value.remain_size--;
             }
 
-            for (auto& [_, value] : hash_map) {
-                flush(value, chunk);
+            for (const auto& key : visited_keys) {
+                flush(*(hash_map[key]), chunk);
             }
             flush(null_key_value, chunk);
         }
@@ -190,13 +201,13 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
         const auto& key_column_data = key_column->get_data();
         append_chunk_for_one_key(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
-                [](const FieldType& key) { return key; });
+                [](const FieldType& key) { return key; }, obj_pool);
     }
 };
 
@@ -210,13 +221,14 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
         append_chunk_for_one_nullable_key(
                 hash_map, null_key_value, chunk, nullable_key_column,
-                [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; });
+                [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
+                obj_pool);
     }
 };
 
@@ -227,16 +239,17 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
         append_chunk_for_one_key(
                 hash_map, chunk, [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = mem_pool->allocate(key.size);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     return Slice{pos, key.size};
-                });
+                },
+                obj_pool);
     }
 };
 
@@ -248,7 +261,7 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
@@ -256,10 +269,11 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = mem_pool->allocate(key.size);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     return Slice{pos, key.size};
-                });
+                },
+                obj_pool);
     }
 };
 
@@ -270,7 +284,7 @@ struct PartitionHashMapWithSerializedKey {
     HashMap hash_map;
 
     PartitionHashMapWithSerializedKey(int32_t chunk_size) {}
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {}
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {}
 };
 
 // TODO(hcf) to be implemented
@@ -282,7 +296,7 @@ struct PartitionHashMapWithSerializedKeyFixedSize {
     int fixed_byte_size = -1; // unset state
 
     PartitionHashMapWithSerializedKeyFixedSize(int32_t chunk_size) {}
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {}
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {}
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5885

## Enhancement

For high cardinality of partition columns, each partition has only a few rows of data which result in performance degradation. So we can downgrade to stream mode if number of partition reaches threshold (the value is set to 4096 based on test ). 

Degradation is easy to implementation, because `PartitionTopN` makes no guarantees about the order of the output data, the only purpose of `PartitionTopN` is to filter data in order to alleviate the overhead of the following exchange and full sort operators.

```


                                   ┌────► topn─────┐
                                   │               │
 (unordered)                       │               │                  (unordered)
 inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
                                   │               │
                                   │               │
                                   └────► topn ────┘
```
