### PR TITLE
[Enhancement] Ignore the expired txns and jobs when replay

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -901,13 +901,15 @@ public class DeleteHandler implements Writable {
         if (deleteInfo == null) {
             return;
         }
-        if (isDeleteInfoExpired(deleteInfo, System.currentTimeMillis())) {
-            LOG.warn("discard expired delete info {}", deleteInfo);
-            return;
-        }
         long dbId = deleteInfo.getDbId();
         LOG.info("replay delete, dbId {}", dbId);
         updateTableDeleteInfo(globalStateMgr, dbId, deleteInfo.getTableId());
+
+        if (isDeleteInfoExpired(deleteInfo, System.currentTimeMillis())) {
+            LOG.info("discard expired delete info {}", deleteInfo);
+            return;
+        }
+
         dbToDeleteInfos.putIfAbsent(dbId, Lists.newArrayList());
         List<MultiDeleteInfo> deleteInfoList = dbToDeleteInfos.get(dbId);
         lock.writeLock().lock();
@@ -916,6 +918,7 @@ public class DeleteHandler implements Writable {
         } finally {
             lock.writeLock().unlock();
         }
+
     }
 
     public void replayMultiDelete(MultiDeleteInfo deleteInfo, GlobalStateMgr globalStateMgr) {
@@ -923,13 +926,16 @@ public class DeleteHandler implements Writable {
         if (deleteInfo == null) {
             return;
         }
-        if (isDeleteInfoExpired(deleteInfo, System.currentTimeMillis())) {
-            LOG.warn("discard expired delete info {}", deleteInfo);
-            return;
-        }
+
         long dbId = deleteInfo.getDbId();
         LOG.info("replay delete, dbId {}", dbId);
         updateTableDeleteInfo(globalStateMgr, dbId, deleteInfo.getTableId());
+
+        if (isDeleteInfoExpired(deleteInfo, System.currentTimeMillis())) {
+            LOG.info("discard expired delete info {}", deleteInfo);
+            return;
+        }
+
         dbToDeleteInfos.putIfAbsent(dbId, Lists.newArrayList());
         List<MultiDeleteInfo> deleteInfoList = dbToDeleteInfos.get(dbId);
         lock.writeLock().lock();

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -771,6 +771,13 @@ public class ExportJob implements Writable {
         }
     }
 
+    /**
+     * for ut only
+     */
+    public void setTableName(TableName tableName) {
+        this.tableName = tableName;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -315,7 +315,7 @@ public class ExportMgr {
                 Map.Entry<Long, ExportJob> entry = iter.next();
                 ExportJob job = entry.getValue();
                 if (isJobExpired(job, currentTimeMs)) {
-                    LOG.warn("remove expired job: {}", job);
+                    LOG.info("remove expired job: {}", job);
                     iter.remove();
                 }
             }
@@ -341,7 +341,7 @@ public class ExportMgr {
             ExportJob job = idToJob.get(jobId);
             job.updateState(newState, true);
             if (isJobExpired(job, System.currentTimeMillis())) {
-                LOG.warn("remove expired job: {}", job);
+                LOG.info("remove expired job: {}", job);
                 idToJob.remove(jobId);
             }
         } finally {
@@ -377,7 +377,7 @@ public class ExportMgr {
                 job.readFields(dis);
                 // discard expired job right away
                 if (isJobExpired(job, currentTimeMs)) {
-                    LOG.warn("discard expired job: {}", job);
+                    LOG.info("discard expired job: {}", job);
                     continue;
                 }
                 unprotectAddJob(job);

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -378,6 +378,7 @@ public class ExportMgr {
                 // discard expired job right away
                 if (isJobExpired(job, currentTimeMs)) {
                     LOG.warn("discard expired job: {}", job);
+                    continue;
                 }
                 unprotectAddJob(job);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -299,6 +299,12 @@ public class ExportMgr {
         return results;
     }
 
+    private boolean isJobExpired(ExportJob job, long currentTimeMs) {
+        return (currentTimeMs - job.getCreateTimeMs()) / 1000 > Config.history_job_keep_max_second
+                        && (job.getState() == ExportJob.JobState.CANCELLED
+                        || job.getState() == ExportJob.JobState.FINISHED);
+    }
+
     public void removeOldExportJobs() {
         long currentTimeMs = System.currentTimeMillis();
 
@@ -308,9 +314,8 @@ public class ExportMgr {
             while (iter.hasNext()) {
                 Map.Entry<Long, ExportJob> entry = iter.next();
                 ExportJob job = entry.getValue();
-                if ((currentTimeMs - job.getCreateTimeMs()) / 1000 > Config.history_job_keep_max_second
-                        && (job.getState() == ExportJob.JobState.CANCELLED
-                        || job.getState() == ExportJob.JobState.FINISHED)) {
+                if (isJobExpired(job, currentTimeMs)) {
+                    LOG.warn("remove expired job: {}", job);
                     iter.remove();
                 }
             }
@@ -335,6 +340,10 @@ public class ExportMgr {
         try {
             ExportJob job = idToJob.get(jobId);
             job.updateState(newState, true);
+            if (isJobExpired(job, System.currentTimeMillis())) {
+                LOG.warn("remove expired job: {}", job);
+                idToJob.remove(jobId);
+            }
         } finally {
             writeUnlock();
         }
@@ -356,6 +365,7 @@ public class ExportMgr {
     }
 
     public long loadExportJob(DataInputStream dis, long checksum) throws IOException, DdlException {
+        long currentTimeMs = System.currentTimeMillis();
         long newChecksum = checksum;
         if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_32) {
             int size = dis.readInt();
@@ -365,6 +375,10 @@ public class ExportMgr {
                 newChecksum ^= jobId;
                 ExportJob job = new ExportJob();
                 job.readFields(dis);
+                // discard expired job right away
+                if (isJobExpired(job, currentTimeMs)) {
+                    LOG.warn("discard expired job: {}", job);
+                }
                 unprotectAddJob(job);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -56,14 +56,15 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -218,6 +219,10 @@ public class LoadManager implements Writable {
                 .add("operation", operation)
                 .add("msg", "replay end load job")
                 .build());
+        if (isJobExpired(job, System.currentTimeMillis())) {
+            LOG.warn("remove expired job: {}", job);
+            unprotectedRemoveJobReleatedMeta(job);
+        }
     }
 
     public void replayUpdateLoadJobStateInfo(LoadJob.LoadJobStateUpdateInfo info) {
@@ -229,6 +234,11 @@ public class LoadManager implements Writable {
         }
 
         job.replayUpdateStateInfo(info);
+
+        if (isJobExpired(job, System.currentTimeMillis())) {
+            LOG.warn("remove expired job: {}", job);
+            unprotectedRemoveJobReleatedMeta(job);
+        }
     }
 
     public long getLoadJobNum(JobState jobState, long dbId) {
@@ -280,33 +290,51 @@ public class LoadManager implements Writable {
         }
     }
 
+    private boolean isJobExpired(LoadJob job, long currentTimeMs) {
+        if (!job.isCompleted()) {
+            return false;
+        }
+        return (currentTimeMs - job.getFinishTimestamp()) / 1000 > Config.label_keep_max_second;
+    }
+
     public void removeOldLoadJob() {
         long currentTimeMs = System.currentTimeMillis();
 
         writeLock();
         try {
-            // get completed jobs
-            List<LoadJob> jobs =
-                    idToLoadJob.values().stream().filter(job -> job.isCompleted()).collect(Collectors.toList());
-            if (jobs.isEmpty()) {
-                return;
-            }
-
-            // sort by finish time asc
-            Collections.sort(jobs, new Comparator<LoadJob>() {
+            // add load job to a sorted tree set
+            Set<LoadJob> jobs = new TreeSet<>(new Comparator<LoadJob>() {
                 @Override
                 public int compare(LoadJob o1, LoadJob o2) {
+                    // sort by finish time desc
                     return Long.signum(o1.getFinishTimestamp() - o2.getFinishTimestamp());
                 }
             });
 
-            // remove jobs by label_keep_max_second and label_keep_max_num
-            int labelKeepMaxSecond = Config.label_keep_max_second;
-            int numJobsToRemove = idToLoadJob.size() - Config.label_keep_max_num;
-            for (LoadJob job : jobs) {
-                if ((currentTimeMs - job.getFinishTimestamp()) / 1000 > labelKeepMaxSecond || numJobsToRemove > 0) {
+            for (Map.Entry<Long, LoadJob> entry : idToLoadJob.entrySet()) {
+                LoadJob job = entry.getValue();
+                if (!job.isCompleted()) {
+                    continue;
+                }
+                if (isJobExpired(job, currentTimeMs)) {
+                    // remove expired job
+                    LOG.warn("remove expired job: {}", job);
                     unprotectedRemoveJobReleatedMeta(job);
-                    --numJobsToRemove;
+                } else {
+                    jobs.add(job);
+                }
+            }
+
+            // if there are still more jobs than LABEL_KEEP_MAX_NUM
+            // remove the ones that finished earlier
+            int numJobsToRemove = idToLoadJob.size() - Config.label_keep_max_num;
+            LOG.info("remove {} jobs from {}", numJobsToRemove, jobs.size());
+            if (numJobsToRemove > 0) {
+                Iterator<LoadJob> iterator = jobs.iterator();
+                for (int i = 0; i != numJobsToRemove && iterator.hasNext(); ++i) {
+                    LoadJob job = iterator.next();
+                    LOG.warn("remove redundant job: {}", job);
+                    unprotectedRemoveJobReleatedMeta(job);
                 }
             }
         } finally {
@@ -570,8 +598,14 @@ public class LoadManager implements Writable {
 
     public void readFields(DataInput in) throws IOException {
         int size = in.readInt();
+        long now = System.currentTimeMillis();
         for (int i = 0; i < size; i++) {
             LoadJob loadJob = LoadJob.read(in);
+            // discard expired job right away
+            if (isJobExpired(loadJob, now)) {
+                LOG.warn("discard expired job: {}", loadJob);
+                continue;
+            }
             idToLoadJob.put(loadJob.getId(), loadJob);
             Map<String, List<LoadJob>> map = dbIdToLabelToLoadJobs.get(loadJob.getDbId());
             if (map == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -220,7 +220,7 @@ public class LoadManager implements Writable {
                 .add("msg", "replay end load job")
                 .build());
         if (isJobExpired(job, System.currentTimeMillis())) {
-            LOG.warn("remove expired job: {}", job);
+            LOG.info("remove expired job: {}", job);
             unprotectedRemoveJobReleatedMeta(job);
         }
     }
@@ -236,7 +236,7 @@ public class LoadManager implements Writable {
         job.replayUpdateStateInfo(info);
 
         if (isJobExpired(job, System.currentTimeMillis())) {
-            LOG.warn("remove expired job: {}", job);
+            LOG.info("remove expired job: {}", job);
             unprotectedRemoveJobReleatedMeta(job);
         }
     }
@@ -318,7 +318,7 @@ public class LoadManager implements Writable {
                 }
                 if (isJobExpired(job, currentTimeMs)) {
                     // remove expired job
-                    LOG.warn("remove expired job: {}", job);
+                    LOG.info("remove expired job: {}", job);
                     unprotectedRemoveJobReleatedMeta(job);
                 } else {
                     jobs.add(job);
@@ -333,7 +333,7 @@ public class LoadManager implements Writable {
                 Iterator<LoadJob> iterator = jobs.iterator();
                 for (int i = 0; i != numJobsToRemove && iterator.hasNext(); ++i) {
                     LoadJob job = iterator.next();
-                    LOG.warn("remove redundant job: {}", job);
+                    LOG.info("remove redundant job: {}", job);
                     unprotectedRemoveJobReleatedMeta(job);
                 }
             }
@@ -603,7 +603,7 @@ public class LoadManager implements Writable {
             LoadJob loadJob = LoadJob.read(in);
             // discard expired job right away
             if (isJobExpired(loadJob, now)) {
-                LOG.warn("discard expired job: {}", loadJob);
+                LOG.info("discard expired job: {}", loadJob);
                 continue;
             }
             idToLoadJob.put(loadJob.getId(), loadJob);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -328,8 +328,8 @@ public class LoadManager implements Writable {
             // if there are still more jobs than LABEL_KEEP_MAX_NUM
             // remove the ones that finished earlier
             int numJobsToRemove = idToLoadJob.size() - Config.label_keep_max_num;
-            LOG.info("remove {} jobs from {}", numJobsToRemove, jobs.size());
             if (numJobsToRemove > 0) {
+                LOG.info("remove {} jobs from {}", numJobsToRemove, jobs.size());
                 Iterator<LoadJob> iterator = jobs.iterator();
                 for (int i = 0; i != numJobsToRemove && iterator.hasNext(); ++i) {
                     LoadJob job = iterator.next();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -551,11 +551,6 @@ public class RoutineLoadManager implements Writable {
                 .add("current_state", operation.getJobState())
                 .add("msg", "replay change routine load job")
                 .build());
-        if (job.needRemove()) {
-            LOG.warn("remove expired job {}", job);
-            idToRoutineLoadJob.remove(operation.getId());
-            unprotectedRemoveJobFromDb(job);
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -612,7 +612,7 @@ public class RoutineLoadManager implements Writable {
         for (int i = 0; i < size; i++) {
             RoutineLoadJob routineLoadJob = RoutineLoadJob.read(in);
             if (routineLoadJob.needRemove()) {
-                LOG.warn("discard expired job [{}]", routineLoadJob.getId());
+                LOG.info("discard expired job [{}]", routineLoadJob.getId());
                 continue;
             }
             idToRoutineLoadJob.put(routineLoadJob.getId(), routineLoadJob);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1524,7 +1524,7 @@ public class DatabaseTransactionMgr {
             }
             unprotectUpsertTransactionState(transactionState, true);
             if (transactionState.isExpired(System.currentTimeMillis())) {
-                LOG.warn("remove expired transaction: {}", transactionState);
+                LOG.info("remove expired transaction: {}", transactionState);
                 deleteTransaction(transactionState);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1523,6 +1523,10 @@ public class DatabaseTransactionMgr {
                 updateCatalogAfterVisible(transactionState, db);
             }
             unprotectUpsertTransactionState(transactionState, true);
+            if (transactionState.isExpired(System.currentTimeMillis())) {
+                LOG.warn("remove expired transaction: {}", transactionState);
+                deleteTransaction(transactionState);
+            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -580,7 +580,7 @@ public class GlobalTransactionMgr implements Writable {
             TransactionState transactionState = new TransactionState();
             transactionState.readFields(in);
             if (transactionState.isExpired(now)) {
-                LOG.warn("discard expired transaction state: {}", transactionState);
+                LOG.info("discard expired transaction state: {}", transactionState);
                 continue;
             }
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -574,10 +574,15 @@ public class GlobalTransactionMgr implements Writable {
     }
 
     public void readFields(DataInput in) throws IOException {
+        long now = System.currentTimeMillis();
         int numTransactions = in.readInt();
         for (int i = 0; i < numTransactions; ++i) {
             TransactionState transactionState = new TransactionState();
             transactionState.readFields(in);
+            if (transactionState.isExpired(now)) {
+                LOG.warn("discard expired transaction state: {}", transactionState);
+                continue;
+            }
             try {
                 DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(transactionState.getDbId());
                 dbTransactionMgr.unprotectUpsertTransactionState(transactionState, true);

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -1,0 +1,74 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.load;
+
+import com.starrocks.analysis.ExportStmt;
+import com.starrocks.analysis.TableName;
+import com.starrocks.common.Config;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.UUID;
+
+public class ExportMgrTest {
+
+    @Test
+    public void testExpiredJob() throws Exception {
+        Config.history_job_keep_max_second = 10;
+        ExportMgr mgr = new ExportMgr();
+
+        // 1. create job 1
+        ExportJob job1 = new ExportJob(1, new UUID(1, 1));
+        job1.setTableName(new TableName("dummy", "dummy"));
+        mgr.replayCreateExportJob(job1);
+        Assert.assertEquals(1, mgr.getIdToJob().size());
+
+        // 2. create job 2
+        ExportJob job2 = new ExportJob(2, new UUID(2, 2));
+        mgr.replayCreateExportJob(job2);
+        Assert.assertEquals(2, mgr.getIdToJob().size());
+
+        // 3. job 1 finished
+        mgr.replayUpdateJobState(job1.getId(), ExportJob.JobState.FINISHED);
+        Assert.assertEquals(2, mgr.getIdToJob().size());
+
+        // 4. job 2 finished, but expired
+        Config.history_job_keep_max_second = 1;
+        Thread.sleep(2000);
+        mgr.replayUpdateJobState(job2.getId(), ExportJob.JobState.FINISHED);
+        Assert.assertEquals(1, mgr.getIdToJob().size());
+
+        // 5. create job 3
+        ExportJob job3 = new ExportJob(3, new UUID(3, 3));
+        job3.setTableName(new TableName("dummy", "dummy"));
+        mgr.replayCreateExportJob(job3);
+        mgr.replayUpdateJobState(job3.getId(), ExportJob.JobState.FINISHED);
+        Assert.assertEquals(2, mgr.getIdToJob().size());
+
+        // 5. save image
+        File tempFile = File.createTempFile("GlobalTransactionMgrTest", ".image");
+        System.err.println("write image " + tempFile.getAbsolutePath());
+        DataOutputStream dos = new DataOutputStream(new FileOutputStream(tempFile));
+        long checksum = 0;
+        long saveChecksum = mgr.saveExportJob(dos, checksum);
+        dos.close();
+
+        // 6. clean expire
+        mgr.removeOldExportJobs();
+        Assert.assertEquals(1, mgr.getIdToJob().size());
+
+        // 7. load image, will filter job1
+        ExportMgr newMgr = new ExportMgr();
+        DataInputStream dis = new DataInputStream(new FileInputStream(tempFile));
+        checksum = 0;
+        long loadChecksum = newMgr.loadExportJob(dis, checksum);
+        Assert.assertEquals(1, mgr.getIdToJob().size());
+        Assert.assertEquals(saveChecksum, loadChecksum);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadManagerTest.java
@@ -130,6 +130,50 @@ public class LoadManagerTest {
         Assert.assertEquals(0, newLoadJobs.size());
     }
 
+    @Test
+    public void testDeserializationWithJobRemoved(@Mocked MetaContext metaContext,
+                                                @Mocked GlobalStateMgr globalStateMgr,
+                                                @Injectable Database database,
+                                                @Injectable Table table) throws Exception {
+        new Expectations() {
+            {
+                globalStateMgr.getDb(anyLong);
+                minTimes = 0;
+                result = database;
+                database.getTable(anyLong);
+                minTimes = 0;
+                result = table;
+                table.getName();
+                minTimes = 0;
+                result = "tablename";
+                GlobalStateMgr.getCurrentStateJournalVersion();
+                minTimes = 0;
+                result = FeMetaVersion.VERSION_CURRENT;
+            }
+        };
+
+        Config.label_keep_max_second = 10;
+
+        // 1. serialize 1 job to file
+        loadManager = new LoadManager(new LoadJobScheduler());
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "", "");
+        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+        File file = serializeToFile(loadManager);
+
+        // 2. read it directly, expect 1 job
+        LoadManager newLoadManager = deserializeFromFile(file);
+        Map<Long, LoadJob> newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
+        Assert.assertEquals(1, newLoadJobs.size());
+
+        // 3. set max keep second to 1, then read it again
+        // the job expired, expect read 0 job
+        Config.label_keep_max_second = 1;
+        Thread.sleep(2000);
+        newLoadManager = deserializeFromFile(file);
+        newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
+        Assert.assertEquals(0, newLoadJobs.size());
+    }
+
     private File serializeToFile(LoadManager loadManager) throws Exception {
         File file = new File("./loadManagerTest");
         file.createNewFile();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -67,6 +67,7 @@ public class DatabaseTransactionMgrTest {
     @Before
     public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
             InvocationTargetException, NoSuchMethodException, SecurityException, UserException {
+        Config.label_keep_max_second = 10;
         fakeEditLog = new FakeEditLog();
         fakeGlobalStateMgr = new FakeGlobalStateMgr();
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5394

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Discard expired transaction/export job/load job/delete info when replaying & loading image.
2. Refactor: use treemap instead of list + in-memory sorting. 

To verify this PR, I created a cluster that won't make checkpoint or clean jobs for a long time by modifying a lot of configurations, such as extending the time of checkpoint interval and extending the expiration time of the transaction. Then I created a primary key table, and execute 10k delete & insert SQL, which ended with 70k journal logs. Finally, I modify all those configurations to a normal value and restart FE. It turns out that the memory usage of the master FE magnifically decreases after this PR. 

1. The virtual memory of FE after replaying all journals is 18.7g in the old version and 12.7g after this PR.
2. The virtual memory of FE after making the checkpoint is 23.1g in the old version and 13.8g after this PR.
3. RSS of FE after replaying all journals is 1.1g in the old version and 690M after this PR.
4. RSS of FE after making the checkpoint is 1.4g in the old version and 877M after this PR.