### PR TITLE
[cherry-pick][branch-2.1]Do rocksdb compact before data dir load. (#5076)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -677,6 +677,8 @@ CONF_Bool(use_hdfs_pread, "true");
 
 CONF_Int64(meta_threshold_to_manual_compact, "10737418240"); // 10G
 
+CONF_Bool(manual_compact_before_data_dir_load, "false");
+
 // enable optimized implementation of schema change
 CONF_Bool(enable_schema_change_v2, "false");
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -122,6 +122,25 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
     threads.reserve(data_dirs.size());
     for (auto data_dir : data_dirs) {
         threads.emplace_back([data_dir] {
+            if (config::manual_compact_before_data_dir_load) {
+                uint64_t live_sst_files_size_before = 0;
+                if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_before)) {
+                    LOG(WARNING) << "data dir " << data_dir->path() << " get_live_sst_files_size failed";
+                }
+                Status s = data_dir->get_meta()->compact();
+                if (!s.ok()) {
+                    LOG(WARNING) << "data dir " << data_dir->path() << " manual compact meta failed: " << s;
+                } else {
+                    uint64_t live_sst_files_size_after = 0;
+                    if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_after)) {
+                        LOG(WARNING) << "data dir " << data_dir->path() << " get_live_sst_files_size failed";
+                    }
+                    LOG(INFO) << "data dir " << data_dir->path() << " manual compact meta successfully, "
+                              << "live_sst_files_size_before: " << live_sst_files_size_before
+                              << " live_sst_files_size_after: " << live_sst_files_size_after
+                              << data_dir->get_meta()->get_stats();
+                }
+            }
             auto res = data_dir->load();
             if (!res.ok()) {
                 LOG(WARNING) << "Fail to load data dir=" << data_dir->path() << ", res=" << res.to_string();
@@ -160,6 +179,7 @@ Status StorageEngine::_open() {
     RETURN_IF_ERROR_WITH_WARN(_update_manager->init(), "init update_manager failed");
 
     auto dirs = get_stores<false>();
+
     // `load_data_dirs` depend on |_update_manager|.
     load_data_dirs(dirs);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5075

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some case, meta loading cost very long time, about two hours

```
I0408 18:26:57.769011  7661 data_dir.cpp:457] begin loading tablet from meta
I0408 20:37:58.819820  7661 data_dir.cpp:493] load tablet from meta finished, loaded tablet: 43, error tablet: 0, path: /home/disk1/x/sr/be/storage
```

Time is mostly spent in rocksdb Seek().
It will go much faster after manual compact, shorten to a few dozen seconds approximately, enhance this case by it provisionally.