### PR TITLE
[cherry-pick][branch-2.0]Do rocksdb compact before data dir load. (#5076)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -657,6 +657,8 @@ CONF_mInt32(max_hdfs_file_handle, "1000");
 CONF_mInt32(buffer_stream_reserve_size, "8192000");
 
 CONF_Int64(meta_threshold_to_manual_compact, "10737418240"); // 10G
+
+CONF_Bool(manual_compact_before_data_dir_load, "false");
 } // namespace config
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5075

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some case, meta loading cost very long time, about two hours

```
I0408 18:26:57.769011  7661 data_dir.cpp:457] begin loading tablet from meta
I0408 20:37:58.819820  7661 data_dir.cpp:493] load tablet from meta finished, loaded tablet: 43, error tablet: 0, path: /home/disk1/x/sr/be/storage
```

Time is mostly spent in rocksdb Seek().
It will go much faster after manual compact, shorten to a few dozen seconds approximately, enhance this case by it provisionally.