### PR TITLE
[Enhancement] Reduce header_lock time in PrimaryKey Table

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1408,9 +1408,12 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
     _erase_expired_versions(expire_time, &expired_edit_version_infos);
 
     if (!expired_edit_version_infos.empty()) {
-        std::unique_lock wrlock(_tablet.get_header_lock());
-        _tablet.save_meta();
-
+        int64_t tablet_id = 0;
+        {
+            std::unique_lock wrlock(_tablet.get_header_lock());
+            _tablet.save_meta();
+            tablet_id = _tablet.tablet_id();
+        }
         std::set<uint32_t> unused_rid;
         std::set<uint32_t> active_rid = _active_rowsets();
         for (const auto& expired_edit_version_info : expired_edit_version_infos) {
@@ -1437,7 +1440,6 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         /// Remove useless delete vectors.
         auto max_expired_version = expired_edit_version_infos.back()->version.major();
         auto meta_store = _tablet.data_dir()->get_meta();
-        auto tablet_id = _tablet.tablet_id();
 
         size_t n_delvec_range = 0;
         auto res = TabletMetaManager::list_del_vector(meta_store, tablet_id, max_expired_version + 1);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6425

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In the gc process of primaryKey table, scanning RocksDB may take a lot of time, which will lead to long time to hold header_lock, reduce the holding time of header_lock