### PR TITLE
[BugFix] ESDataSource to use uninitialized variable

### DIFF
--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -201,11 +201,11 @@ void ESDataSource::_init_counter() {
 }
 
 Status ESDataSource::get_next(RuntimeState* state, vectorized::ChunkPtr* chunk) {
-    SCOPED_TIMER(_read_timer);
     if (_no_data || (_line_eof && _batch_eof)) {
         return Status::EndOfFile("");
     }
 
+    SCOPED_TIMER(_read_timer);
     while (!_batch_eof) {
         RETURN_IF_CANCELLED(state);
         COUNTER_UPDATE(_read_counter, 1);

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -201,6 +201,8 @@ void ESDataSource::_init_counter() {
 }
 
 Status ESDataSource::get_next(RuntimeState* state, vectorized::ChunkPtr* chunk) {
+    // Notice that some variables are not initialized
+    // if `_no_data == true` because of short-circuits logic.
     if (_no_data || (_line_eof && _batch_eof)) {
         return Status::EndOfFile("");
     }

--- a/be/src/connector/es_connector.h
+++ b/be/src/connector/es_connector.h
@@ -75,7 +75,7 @@ private:
     int64_t _rows_read_number = 0;
     int64_t _rows_return_number = 0;
 
-    ESScanReader* _es_reader;
+    ESScanReader* _es_reader = nullptr;
     std::unique_ptr<vectorized::ScrollParser> _es_scroll_parser;
 
     RuntimeProfile::Counter* _read_counter;

--- a/be/src/connector/es_connector.h
+++ b/be/src/connector/es_connector.h
@@ -78,10 +78,10 @@ private:
     ESScanReader* _es_reader = nullptr;
     std::unique_ptr<vectorized::ScrollParser> _es_scroll_parser;
 
-    RuntimeProfile::Counter* _read_counter;
-    RuntimeProfile::Counter* _read_timer;
-    RuntimeProfile::Counter* _materialize_timer;
-    RuntimeProfile::Counter* _rows_read_counter;
+    RuntimeProfile::Counter* _read_counter = nullptr;
+    RuntimeProfile::Counter* _read_timer = nullptr;
+    RuntimeProfile::Counter* _materialize_timer = nullptr;
+    RuntimeProfile::Counter* _rows_read_counter = nullptr;
 
     // =========================
 


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6413,  #6408

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`_read_timer` and `_es_reader` are not initailized if `_no_data = true`
