### PR TITLE
[cherry-pick] [branch-2.2] [Enhancement] add one interface for conservative estimize the size of one row (#6333)

### DIFF
--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -187,6 +187,10 @@ std::string TabletColumn::get_string_by_aggregation_type(FieldAggregationMethod 
     return "";
 }
 
+size_t TabletColumn::estimate_field_size(size_t variable_length) const {
+    return TypeUtils::estimate_field_size(_type, variable_length);
+}
+
 uint32_t TabletColumn::get_field_length_by_type(FieldType type, uint32_t string_length) {
     switch (type) {
     case OLAP_FIELD_TYPE_UNKNOWN:
@@ -512,6 +516,14 @@ std::unique_ptr<TabletSchema> TabletSchema::convert_to_format(DataFormatVersion 
     }
     auto schema = std::make_unique<TabletSchema>(schema_pb);
     return schema;
+}
+
+size_t TabletSchema::estimate_row_size(size_t variable_len) const {
+    size_t size = 0;
+    for (const auto& col : _cols) {
+        size += col.estimate_field_size(variable_len);
+    }
+    return size;
 }
 
 size_t TabletSchema::row_size() const {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -139,6 +139,7 @@ public:
     static std::string get_string_by_aggregation_type(FieldAggregationMethod aggregation_type);
     static FieldType get_field_type_by_string(const std::string& str);
     static FieldAggregationMethod get_aggregation_type_by_string(const std::string& str);
+    size_t estimate_field_size(size_t variable_length) const;
     static uint32_t get_field_length_by_type(FieldType type, uint32_t string_length);
 
     std::string debug_string() const;
@@ -233,6 +234,7 @@ public:
     SchemaId id() const { return _id; }
     size_t row_size() const;
     size_t field_index(const std::string_view& field_name) const;
+    size_t estimate_row_size(size_t variable_len) const;
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
     size_t num_columns() const { return _cols.size(); }

--- a/be/src/storage/vectorized/type_utils.h
+++ b/be/src/storage/vectorized/type_utils.h
@@ -25,6 +25,48 @@ public:
                type == OLAP_FIELD_TYPE_DECIMAL_V2;
     }
 
+    static inline size_t estimate_field_size(FieldType type, size_t variable_length) {
+        switch (type) {
+        case OLAP_FIELD_TYPE_UNKNOWN:
+        case OLAP_FIELD_TYPE_DISCRETE_DOUBLE:
+        case OLAP_FIELD_TYPE_STRUCT:
+        case OLAP_FIELD_TYPE_MAP:
+        case OLAP_FIELD_TYPE_NONE:
+        case OLAP_FIELD_TYPE_MAX_VALUE:
+        case OLAP_FIELD_TYPE_BOOL:
+        case OLAP_FIELD_TYPE_TINYINT:
+        case OLAP_FIELD_TYPE_UNSIGNED_TINYINT:
+            return 1;
+        case OLAP_FIELD_TYPE_SMALLINT:
+        case OLAP_FIELD_TYPE_UNSIGNED_SMALLINT:
+            return 2;
+        case OLAP_FIELD_TYPE_DATE:
+            return 3;
+        case OLAP_FIELD_TYPE_INT:
+        case OLAP_FIELD_TYPE_UNSIGNED_INT:
+        case OLAP_FIELD_TYPE_FLOAT:
+        case OLAP_FIELD_TYPE_DATE_V2:
+        case OLAP_FIELD_TYPE_DECIMAL32:
+            return 4;
+        case OLAP_FIELD_TYPE_BIGINT:
+        case OLAP_FIELD_TYPE_UNSIGNED_BIGINT:
+        case OLAP_FIELD_TYPE_DOUBLE:
+        case OLAP_FIELD_TYPE_DATETIME:
+        case OLAP_FIELD_TYPE_TIMESTAMP:
+        case OLAP_FIELD_TYPE_DECIMAL64:
+            return 8;
+        case OLAP_FIELD_TYPE_DECIMAL:
+            return 12;
+        case OLAP_FIELD_TYPE_LARGEINT:
+        case OLAP_FIELD_TYPE_DECIMAL_V2:
+        case OLAP_FIELD_TYPE_DECIMAL128:
+            return 16;
+        default:
+            // CHAR, VARCHAR, HLL, PERCENTILE, JSON, ARRAY, OBJECT
+            return variable_length;
+        }
+    }
+
     static inline FieldType convert_to_format(FieldType type, DataFormatVersion format_version) {
         if (format_version == kDataFormatV2) {
             switch (type) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -168,6 +168,7 @@ set(EXEC_FILES
         ./storage/storage_types_test.cpp
         ./storage/tablet_meta_test.cpp
         ./storage/tablet_meta_manager_test.cpp
+        ./storage/table_schema_test.cpp
         ./storage/tablet_updates_test.cpp
         ./storage/update_manager_test.cpp
         ./storage/compaction_utils_test.cpp

--- a/be/test/storage/table_schema_test.cpp
+++ b/be/test/storage/table_schema_test.cpp
@@ -1,0 +1,62 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include <gtest/gtest.h>
+
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_map.h"
+
+namespace starrocks {
+// NOLINTNEXTLINE
+TEST(TabletSchemaTest, test_estimate_row_size) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+
+    auto c1 = schema_pb.add_column();
+    c1->set_unique_id(1);
+    c1->set_name("c1");
+    c1->set_type("TINYINT");
+    c1->set_is_key(true);
+
+    auto c2 = schema_pb.add_column();
+    c2->set_unique_id(2);
+    c2->set_name("c2");
+    c2->set_type("SMALLINT");
+    c2->set_is_key(false);
+
+    auto c3 = schema_pb.add_column();
+    c3->set_unique_id(3);
+    c3->set_name("c3");
+    c3->set_type("DATE");
+    c3->set_is_key(false);
+
+    auto c4 = schema_pb.add_column();
+    c4->set_unique_id(4);
+    c4->set_name("c4");
+    c4->set_type("INT");
+    c4->set_is_key(false);
+
+    auto c5 = schema_pb.add_column();
+    c5->set_unique_id(5);
+    c5->set_name("c5");
+    c5->set_type("BIGINT");
+    c5->set_is_key(false);
+
+    auto c6 = schema_pb.add_column();
+    c6->set_unique_id(6);
+    c6->set_name("c6");
+    c6->set_type("LARGEINT");
+    c6->set_is_key(false);
+
+    auto c7 = schema_pb.add_column();
+    c7->set_unique_id(7);
+    c7->set_name("c7");
+    c7->set_type("VARCHAR");
+    c7->set_is_key(false);
+
+    TabletSchema tablet_schema;
+    tablet_schema.init_from_pb(schema_pb);
+    size_t row_size = tablet_schema.estimate_row_size(100);
+    ASSERT_EQ(row_size, 134);
+}
+}


### PR DESCRIPTION

At present, when doing `SortedSchemaChange`, the length of the varchar is used to estimate the size of one row, but when users use `String (Varchar(65536))` a lot, the estimation will be inaccurate, so the `SchemaChange` task that will execute failed because of invalid memory estimation.

The new strategy is to use a conservative estimate for the first chunk and then calibrate row_size every time a chunk is read. Whether to perform Sort and Flush is determined according to the current actual memory + the expected memory of the next chunk.
