### PR TITLE
[cherry-pick][branch-2.2] By default reserve 1MB bytes for parquet column reader (#5294)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -646,10 +646,6 @@ CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 CONF_Int16(bitmap_serialize_version, "1");
 // The max hdfs file handle.
 CONF_mInt32(max_hdfs_file_handle, "1000");
-// Buffer stream reserve size
-// each column will reserve buffer_stream_reserve_size bytes for read
-// default: 8M
-CONF_mInt32(buffer_stream_reserve_size, "8192000");
 
 CONF_Int64(max_segment_file_size, "1073741824");
 
@@ -672,7 +668,10 @@ CONF_String(object_storage_endpoint, "");
 CONF_Int64(object_storage_max_connection, "102400");
 
 CONF_Bool(enable_orc_late_materialization, "true");
+// orc reader, if RowGroup/Stripe/File size is less than this value, read all data.
 CONF_Int32(orc_file_cache_max_size, "2097152");
+// parquet reader, each column will reserve X bytes for read
+CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/exec/parquet/page_reader.cpp
+++ b/be/src/exec/parquet/page_reader.cpp
@@ -2,6 +2,7 @@
 
 #include "exec/parquet/page_reader.h"
 
+#include "common/config.h"
 #include "env/env.h"
 #include "gutil/strings/substitute.h"
 #include "util/thrift_util.h"
@@ -12,7 +13,9 @@ static constexpr size_t kHeaderBufSize = 1024;
 static constexpr size_t kHeaderBufMaxSize = 16 * 1024;
 
 PageReader::PageReader(RandomAccessFile* file, uint64_t start_offset, uint64_t length)
-        : _stream(file, start_offset, length), _start_offset(start_offset), _finish_offset(start_offset + length) {}
+        : _stream(file, start_offset, length), _start_offset(start_offset), _finish_offset(start_offset + length) {
+    _stream.reserve(config::parquet_buffer_stream_reserve_size);
+}
 
 Status PageReader::next_header() {
     if (_offset != _next_header_pos) {

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -9,9 +9,7 @@
 namespace starrocks {
 
 BufferedInputStream::BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
-        : _file(file), _offset(offset), _end_offset(offset + length) {
-    _reserve(config::buffer_stream_reserve_size);
-}
+        : _file(file), _offset(offset), _end_offset(offset + length) {}
 
 Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {
     if (*nbytes <= num_remaining()) {
@@ -22,7 +20,7 @@ Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bo
         return Status::OK();
     }
 
-    _reserve(*nbytes);
+    reserve(*nbytes);
     RETURN_IF_ERROR(_read_data());
 
     size_t max_get = std::min(*nbytes, num_remaining());
@@ -34,7 +32,7 @@ Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bo
     return Status::OK();
 }
 
-void BufferedInputStream::_reserve(size_t nbytes) {
+void BufferedInputStream::reserve(size_t nbytes) {
     if (nbytes <= _buf_capacity - _buf_position) {
         return;
     }

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -15,6 +15,7 @@ class RandomAccessFile;
 class BufferedInputStream {
 public:
     BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length);
+
     ~BufferedInputStream() = default;
 
     void seek_to(uint64_t offset) {
@@ -43,8 +44,9 @@ public:
 
     Status get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek = false);
 
+    void reserve(size_t nbytes);
+
 private:
-    void _reserve(size_t nbytes);
     Status _read_data();
     size_t num_remaining() const { return _buf_written - _buf_position; }
     size_t left_capactiy() const { return _buf_capacity - _buf_written; }


### PR DESCRIPTION
(cherry picked from commit 392dd439c3abbbd3c7a2942d96b67424b603fc8a)

## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
