### PR TITLE
[BugFix] Fix BE crash when Cross Join RF left child was not a slot ref

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.common.IdGenerator;
@@ -153,6 +154,10 @@ public class CrossJoinNode extends PlanNode implements RuntimeFilterBuildNode {
                 Expr left = expr.getChild(0);
                 Expr right = expr.getChild(1);
 
+                if (!(left instanceof SlotRef)) {
+                    continue;
+                }
+
                 RuntimeFilterDescription rf = new RuntimeFilterDescription(sessionVariable);
                 rf.setFilterId(generator.getNextId().asInt());
                 rf.setBuildPlanNodeId(getId().asInt());
@@ -162,10 +167,7 @@ public class CrossJoinNode extends PlanNode implements RuntimeFilterBuildNode {
                 rf.setOnlyLocal(false);
 
                 rf.setBuildExpr(right);
-                boolean accept = false;
-                for (PlanNode child : this.getChildren()) {
-                    accept = accept || child.pushDownRuntimeFilters(rf, left);
-                }
+                boolean accept = this.getChildren().get(0).pushDownRuntimeFilters(rf, left);
                 if (accept) {
                     this.getBuildRuntimeFilters().add(rf);
                 }


### PR DESCRIPTION


## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
introduced by #6105

## Problem Summary(Required) ：
for such conjunct in cross join (a + 1 <= b), we will create a `a + 1`
<= ? to left child, BE couldn't handle it.

```
select count(*) from test_basic l where l.id_int + 2 >= (select max(id_int) from test_basic);
```
