### PR TITLE
[Bug] Fix deadlock when routine load job aborted and transaction between beforeStateTransform and afterStateTransform

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -549,7 +549,7 @@ public class DatabaseTransactionMgr {
         }
 
         // before state transform
-        transactionState.beforeStateTransform(TransactionStatus.COMMITTED);
+        TxnStateChangeCallback callback = transactionState.beforeStateTransform(TransactionStatus.COMMITTED);
         // transaction state transform
         boolean txnOperated = false;
         writeLock();
@@ -561,7 +561,7 @@ public class DatabaseTransactionMgr {
         } finally {
             writeUnlock();
             // after state transform
-            transactionState.afterStateTransform(TransactionStatus.COMMITTED, txnOperated);
+            transactionState.afterStateTransform(TransactionStatus.COMMITTED, txnOperated, callback, null);
         }
 
         // 6. update nextVersion because of the failure of persistent transaction resulting in error version
@@ -1072,14 +1072,14 @@ public class DatabaseTransactionMgr {
         }
 
         // before state transform
-        transactionState.beforeStateTransform(TransactionStatus.ABORTED);
+        TxnStateChangeCallback callback = transactionState.beforeStateTransform(TransactionStatus.ABORTED);
         boolean txnOperated = false;
         writeLock();
         try {
             txnOperated = unprotectAbortTransaction(transactionId, reason);
         } finally {
             writeUnlock();
-            transactionState.afterStateTransform(TransactionStatus.ABORTED, txnOperated, reason);
+            transactionState.afterStateTransform(TransactionStatus.ABORTED, txnOperated, callback, reason);
         }
 
         // send clear txn task to BE to clear the transactions on BE.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -379,10 +379,13 @@ public class TransactionState implements Writable {
         }
     }
 
-    public void beforeStateTransform(TransactionStatus transactionStatus) throws TransactionException {
-        // before status changed
+    public TxnStateChangeCallback beforeStateTransform(TransactionStatus transactionStatus)
+            throws TransactionException {
+        // callback will pass to afterStateTransform since it may be deleted from
+        // GlobalTransactionMgr between beforeStateTransform and afterStateTransform
         TxnStateChangeCallback callback = GlobalStateMgr.getCurrentGlobalTransactionMgr()
                 .getCallbackFactory().getCallback(callbackId);
+        // before status changed
         if (callback != null) {
             switch (transactionStatus) {
                 case ABORTED:
@@ -404,18 +407,30 @@ public class TransactionState implements Writable {
                     break;
             }
         }
+
+        return callback;
     }
 
     public void afterStateTransform(TransactionStatus transactionStatus, boolean txnOperated) throws UserException {
-        afterStateTransform(transactionStatus, txnOperated, null);
-    }
-
-    public void afterStateTransform(TransactionStatus transactionStatus, boolean txnOperated,
-                                    String txnStatusChangeReason)
-            throws UserException {
         // after status changed
         TxnStateChangeCallback callback = GlobalStateMgr.getCurrentGlobalTransactionMgr()
                 .getCallbackFactory().getCallback(callbackId);
+        if (callback != null) {
+            switch (transactionStatus) {
+                case VISIBLE:
+                    callback.afterVisible(this, txnOperated);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    public void afterStateTransform(TransactionStatus transactionStatus, boolean txnOperated,
+            TxnStateChangeCallback callback,
+            String txnStatusChangeReason)
+            throws UserException {
+        // after status changed
         if (callback != null) {
             switch (transactionStatus) {
                 case ABORTED:
@@ -423,9 +438,6 @@ public class TransactionState implements Writable {
                     break;
                 case COMMITTED:
                     callback.afterCommitted(this, txnOperated);
-                    break;
-                case VISIBLE:
-                    callback.afterVisible(this, txnOperated);
                     break;
                 default:
                     break;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6450

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
Transaction callback may be deleted between transactionState `beforeStateTransform` and `afterStateTransform`, routine load job acquire lock in beforeStateTransform and relase in afterStateTransform, it will be deadlock if not release in afterStateTransform.