### PR TITLE
[BugFix] `get_json_string` parse json field in non-string type as string

### DIFF
--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -322,43 +322,63 @@ ColumnPtr JsonFunctions::_iterate_rows(FunctionContext* context, const Columns& 
     return result.build(ColumnHelper::is_all_const(columns));
 } // namespace starrocks::vectorized
 
-template <PrimitiveType primitive_type>
-void JsonFunctions::_build_column(ColumnBuilder<primitive_type>& result, simdjson::ondemand::value& value) {
-    if constexpr (primitive_type == TYPE_INT) {
-        int64_t i64;
-        auto err = value.get_int64().get(i64);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
-
-        result.append(i64);
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_INT>& result, simdjson::ondemand::value& value) {
+    int64_t i64;
+    auto err = value.get_int64().get(i64);
+    if (UNLIKELY(err)) {
+        result.append_null();
         return;
+    }
 
-    } else if constexpr (primitive_type == TYPE_DOUBLE) {
-        double d;
-        auto err = value.get_double().get(d);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+    result.append(i64);
+    return;
+}
 
-        result.append(d);
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_DOUBLE>& result, simdjson::ondemand::value& value) {
+    double d;
+    auto err = value.get_double().get(d);
+    if (UNLIKELY(err)) {
+        result.append_null();
         return;
+    }
 
-    } else if constexpr (primitive_type == TYPE_VARCHAR) {
+    result.append(d);
+    return;
+}
+
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_VARCHAR>& result, simdjson::ondemand::value& value) {
+    simdjson::ondemand::json_type tp;
+    auto err = value.type().get(tp);
+    if (UNLIKELY(err)) {
+        result.append_null();
+        return;
+    }
+
+    if (tp == simdjson::ondemand::json_type::string) {
         std::string_view sv;
         auto err = value.get_string().get(sv);
         if (UNLIKELY(err)) {
             result.append_null();
             return;
         }
-
         result.append(Slice{sv.data(), sv.size()});
-        return;
     } else {
-        result.append_null();
+        // For compatible consideration, format json in non-string type as string.
+        std::string_view sv = simdjson::to_json_string(value);
+        std::unique_ptr<char[]> buf{new char[sv.size()]};
+        size_t new_length{};
+        auto err = simdjson::minify(sv.data(), sv.size(), buf.get(), new_length);
+        if (UNLIKELY(err)) {
+            result.append_null();
+            return;
+        }
+        result.append(Slice{buf.get(), new_length});
     }
+
+    return;
 }
 
 ColumnPtr JsonFunctions::get_json_int(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -326,10 +326,7 @@ template <>
 void JsonFunctions::_build_column(ColumnBuilder<TYPE_INT>& result, simdjson::ondemand::value& value) {
     int64_t i64;
     auto err = value.get_int64().get(i64);
-    if (UNLIKELY(err)) {
-        result.append_null();
-        return;
-    }
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
     result.append(i64);
     return;
@@ -339,10 +336,7 @@ template <>
 void JsonFunctions::_build_column(ColumnBuilder<TYPE_DOUBLE>& result, simdjson::ondemand::value& value) {
     double d;
     auto err = value.get_double().get(d);
-    if (UNLIKELY(err)) {
-        result.append_null();
-        return;
-    }
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
     result.append(d);
     return;
@@ -352,29 +346,23 @@ template <>
 void JsonFunctions::_build_column(ColumnBuilder<TYPE_VARCHAR>& result, simdjson::ondemand::value& value) {
     simdjson::ondemand::json_type tp;
     auto err = value.type().get(tp);
-    if (UNLIKELY(err)) {
-        result.append_null();
-        return;
-    }
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
     if (tp == simdjson::ondemand::json_type::string) {
         std::string_view sv;
         auto err = value.get_string().get(sv);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+        APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
+
         result.append(Slice{sv.data(), sv.size()});
     } else {
         // For compatible consideration, format json in non-string type as string.
         std::string_view sv = simdjson::to_json_string(value);
         std::unique_ptr<char[]> buf{new char[sv.size()]};
         size_t new_length{};
+
         auto err = simdjson::minify(sv.data(), sv.size(), buf.get(), new_length);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+        APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
+
         result.append(Slice{buf.get(), new_length});
     }
 

--- a/be/src/exprs/vectorized/json_functions.h
+++ b/be/src/exprs/vectorized/json_functions.h
@@ -186,13 +186,13 @@ public:
     }
 
 private:
-#define APPEND_NULL_AND_RETURN_IF_ERROR(builder, err)     \
-    do {                                                  \
-        const simdjson::error_code& e = err;              \
-        if (UNLIKELY(e)) {                                \
-            builder.append_null();                             \
-            return;                                       \
-        }                                                 \
+#define APPEND_NULL_AND_RETURN_IF_ERROR(builder, err) \
+    do {                                              \
+        const simdjson::error_code& e = err;          \
+        if (UNLIKELY(e)) {                            \
+            builder.append_null();                    \
+            return;                                   \
+        }                                             \
     } while (false)
 
     static Status _get_parsed_paths(const std::vector<std::string>& path_exprs,

--- a/be/src/exprs/vectorized/json_functions.h
+++ b/be/src/exprs/vectorized/json_functions.h
@@ -186,6 +186,15 @@ public:
     }
 
 private:
+#define APPEND_NULL_AND_RETURN_IF_ERROR(builder, err)     \
+    do {                                                  \
+        const simdjson::error_code& e = err;              \
+        if (UNLIKELY(e)) {                                \
+            builder.append_null();                             \
+            return;                                       \
+        }                                                 \
+    } while (false)
+
     static Status _get_parsed_paths(const std::vector<std::string>& path_exprs,
                                     std::vector<SimpleJsonPath>* parsed_paths);
 

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -171,12 +171,35 @@ TEST_F(JsonFunctionsTest, get_json_string_casting) {
     auto strings2 = BinaryColumn::create();
 
     std::string values[] = {
-            "{\"k1\":    1}", //int
-            "{\"k1\":    3.14159}", //double
-            "{\"k1\":    {\"k2\":       \"v2\"}}"}; //object
+            R"({"k1":    1})",             //int, 1 key
+            R"({"k1":    1, "k2": 2})", // 2 keys, get the former
+            R"({"k0":    0, "k1": 1})", // 2 keys, get  the latter
 
-    std::string strs[] = {"$.k1", "$.k1", "$.k1"};
-    std::string length_strings[] = {"1", "3.14159", "{\"k2\":\"v2\"}"};
+            R"({"k1":    3.14159})",                   //double, 1 key
+            R"({"k0":    2.71828, "k1":  3.14159})", // 2 keys, get  the former
+            R"({"k1":    3.14159, "k2":  2.71828})", // 2 keys, get  the latter
+
+            R"({"k1":    "{\"k11\":       \"v11\"}"})",                                                      //string
+            R"({"k0":    "{\"k01\":       \"v01\"}",  "k1":     "{\"k11\":       \"v11\"}"})", // 2 keys, get  the former
+            R"({"k1":    "{\"k11\":       \"v11\"}",  "k2":     "{\"k21\": \"v21\"}"})", // 2 keys, get  the latter
+
+            R"({"k1":    {"k11":       "v11"}})",                                   //object
+            R"({"k0":    {"k01":       "v01"},  "k1":     {"k11": "v11"}})",  // 2 keys, get  the former
+            R"({"k1":    {"k11":       "v11"},  "k2":     {"k21": "v21"}})"}; // 2 keys, get  the latter
+
+    std::string strs[] = {"$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1","$.k1","$.k1"};
+    std::string length_strings[] = {"1",
+                                    "1",
+                                    "1",
+                                    "3.14159",
+                                    "3.14159",
+                                    "3.14159",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})"};
 
     for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
         strings->append(values[j]);

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -171,23 +171,24 @@ TEST_F(JsonFunctionsTest, get_json_string_casting) {
     auto strings2 = BinaryColumn::create();
 
     std::string values[] = {
-            R"({"k1":    1})",             //int, 1 key
+            R"({"k1":    1})",          //int, 1 key
             R"({"k1":    1, "k2": 2})", // 2 keys, get the former
             R"({"k0":    0, "k1": 1})", // 2 keys, get  the latter
 
-            R"({"k1":    3.14159})",                   //double, 1 key
+            R"({"k1":    3.14159})",                 //double, 1 key
             R"({"k0":    2.71828, "k1":  3.14159})", // 2 keys, get  the former
             R"({"k1":    3.14159, "k2":  2.71828})", // 2 keys, get  the latter
 
-            R"({"k1":    "{\"k11\":       \"v11\"}"})",                                                      //string
+            R"({"k1":    "{\"k11\":       \"v11\"}"})",                                        //string, 1 key
             R"({"k0":    "{\"k01\":       \"v01\"}",  "k1":     "{\"k11\":       \"v11\"}"})", // 2 keys, get  the former
             R"({"k1":    "{\"k11\":       \"v11\"}",  "k2":     "{\"k21\": \"v21\"}"})", // 2 keys, get  the latter
 
-            R"({"k1":    {"k11":       "v11"}})",                                   //object
+            R"({"k1":    {"k11":       "v11"}})",                             //object, 1 key
             R"({"k0":    {"k01":       "v01"},  "k1":     {"k11": "v11"}})",  // 2 keys, get  the former
             R"({"k1":    {"k11":       "v11"},  "k2":     {"k21": "v21"}})"}; // 2 keys, get  the latter
 
-    std::string strs[] = {"$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1","$.k1","$.k1"};
+    std::string strs[] = {"$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1",
+                          "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1"};
     std::string length_strings[] = {"1",
                                     "1",
                                     "1",


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6447,#6426

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This makes `get_json_string` parse json field in non-string type as string.
