### PR TITLE
[Bugfix] consider TYPE_ARRAY when estimating scan row bytes

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -611,6 +611,27 @@ struct TypeMemoryUsed {
     }
 };
 
+size_t _estimate_type_bytes(PrimitiveType ptype) {
+    switch (ptype) {
+    case TYPE_VARCHAR:
+    case TYPE_CHAR:
+    case TYPE_ARRAY:
+        return 128;
+    case TYPE_JSON:
+        // 1KB.
+        return 1024;
+    case TYPE_HLL:
+        // 16KB.
+        return 16 * 1024;
+    case TYPE_OBJECT:
+    case TYPE_PERCENTILE:
+        // 1MB.
+        return 1024 * 1024;
+    default:
+        return 0;
+    }
+}
+
 void OlapScanNode::_estimate_scan_and_output_row_bytes() {
     const TOlapScanNode& thrift_scan_node = thrift_olap_scan_node();
     const TupleDescriptor* tuple_desc = runtime_state()->desc_tbl().get_tuple_descriptor(thrift_scan_node.tuple_id);
@@ -623,7 +644,7 @@ void OlapScanNode::_estimate_scan_and_output_row_bytes() {
 
     for (const auto& slot : slots) {
         size_t filed_bytes = std::max<size_t>(slot->slot_size(), 0);
-        filed_bytes += type_dispatch_column(slot->type().type, TypeMemoryUsed());
+        filed_bytes += _estimate_type_bytes(slot->type().type);
 
         _estimated_scan_row_bytes += filed_bytes;
         if (unused_output_column_set.find(slot->col_name()) == unused_output_column_set.end()) {

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -588,29 +588,6 @@ Status OlapScanNode::_capture_tablet_rowsets() {
     return Status::OK();
 }
 
-struct TypeMemoryUsed {
-    template <PrimitiveType ptype>
-    size_t operator()() {
-        switch (ptype) {
-        case TYPE_VARCHAR:
-        case TYPE_CHAR:
-            return 128;
-        case TYPE_JSON:
-            // 1KB.
-            return 1024;
-        case TYPE_HLL:
-            // 16KB.
-            return 16 * 1024;
-        case TYPE_OBJECT:
-        case TYPE_PERCENTILE:
-            // 1MB.
-            return 1024 * 1024;
-        default:
-            return 0;
-        }
-    }
-};
-
 size_t _estimate_type_bytes(PrimitiveType ptype) {
     switch (ptype) {
     case TYPE_VARCHAR:

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -620,12 +620,12 @@ void OlapScanNode::_estimate_scan_and_output_row_bytes() {
     }
 
     for (const auto& slot : slots) {
-        size_t filed_bytes = std::max<size_t>(slot->slot_size(), 0);
-        filed_bytes += _estimate_type_bytes(slot->type().type);
+        size_t field_bytes = std::max<size_t>(slot->slot_size(), 0);
+        field_bytes += _estimate_type_bytes(slot->type().type);
 
-        _estimated_scan_row_bytes += filed_bytes;
+        _estimated_scan_row_bytes += field_bytes;
         if (unused_output_column_set.find(slot->col_name()) == unused_output_column_set.end()) {
-            _estimated_output_row_bytes += filed_bytes;
+            _estimated_output_row_bytes += field_bytes;
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`type_dispatch_column` doesn't consider `PrimitiveType::TYPE_ARRAY`, so when estimating the column bytes of `TYPE_ARRAY`, it will falls into `CHECK(false) << "Unknown type: " << ptype;`.
