### PR TITLE
Fix fe dead lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -109,7 +109,13 @@ public class ResourceMgr implements Writable {
      * <p>2. Clear cache in memory </p>
      */
     public void replayCreateResource(Resource resource) {
-        nameToResource.put(resource.getName(), resource);
+        this.writeLock();
+        try {
+            nameToResource.put(resource.getName(), resource);
+        } finally {
+            this.writeUnLock();
+        }
+
         if (resource instanceof HiveResource || resource instanceof HudiResource) {
             GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(resource.getName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -181,8 +181,6 @@ public class ResourceMgr implements Writable {
      *
      */
     public void alterResource(AlterResourceStmt stmt) throws DdlException {
-        Resource alteredResource;
-
         this.writeLock();
         try {
             // check if the target resource exists .
@@ -203,8 +201,6 @@ public class ResourceMgr implements Writable {
                 throw new DdlException("Alter resource statement only support external hive/hudi now");
             }
 
-            alteredResource = resource;
-
             GlobalStateMgr.getCurrentState().getEditLog().logCreateResource(resource);
         } finally {
             this.writeUnLock();
@@ -212,7 +208,7 @@ public class ResourceMgr implements Writable {
 
         // Do not invoke HiveRepository::clearCache inside `Resource.rwLock`. Otherwise, it might cause deadlock.
         // Because HiveRepository::getClient will hold `Resource.rwLock` inside `HiveRepository::xxxLock`
-        GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(alteredResource.getName());
+        GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(stmt.getResourceName());
     }
 
     public int getResourceNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -107,7 +107,6 @@ public class ResourceMgr implements Writable {
      * When we replay alter resource log
      * <p>1. Overwrite the resource </p>
      * <p>2. Clear cache in memory </p>
-     * @param resource
      */
     public void replayCreateResource(Resource resource) {
         nameToResource.put(resource.getName(), resource);
@@ -118,6 +117,8 @@ public class ResourceMgr implements Writable {
     }
 
     public void dropResource(DropResourceStmt stmt) throws DdlException {
+        Resource droppedResource;
+
         this.writeLock();
         try {
             String name = stmt.getResourceName();
@@ -126,7 +127,7 @@ public class ResourceMgr implements Writable {
                 throw new DdlException("Resource(" + name + ") does not exist");
             }
 
-            onDropResource(resource);
+            droppedResource = resource;
 
             // log drop
             GlobalStateMgr.getCurrentState().getEditLog().logDropResource(new DropResourceOperationLog(name));
@@ -134,6 +135,10 @@ public class ResourceMgr implements Writable {
         } finally {
             this.writeUnLock();
         }
+
+        // Do not invoke HiveRepository::clearCache inside `Resource.rwLock`. Otherwise, it might cause deadlock.
+        // Because HiveRepository::getClient will hold `Resource.rwLock` inside `HiveRepository::xxxLock`
+        onDropResource(droppedResource);
     }
 
     public void replayDropResource(DropResourceOperationLog operationLog) {
@@ -168,10 +173,10 @@ public class ResourceMgr implements Writable {
     /**
      * alter resource statement only support external hive/hudi now .
      *
-     * @param stmt
-     * @throws DdlException
      */
     public void alterResource(AlterResourceStmt stmt) throws DdlException {
+        Resource droppedResource;
+
         this.writeLock();
         try {
             // check if the target resource exists .
@@ -191,11 +196,17 @@ public class ResourceMgr implements Writable {
             } else {
                 throw new DdlException("Alter resource statement only support external hive/hudi now");
             }
-            GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(resource.getName());
+
+            droppedResource = resource;
+
             GlobalStateMgr.getCurrentState().getEditLog().logCreateResource(resource);
         } finally {
             this.writeUnLock();
         }
+
+        // Do not invoke HiveRepository::clearCache inside `Resource.rwLock`. Otherwise, it might cause deadlock.
+        // Because HiveRepository::getClient will hold `Resource.rwLock` inside `HiveRepository::xxxLock`
+        GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(droppedResource.getName());
     }
 
     public int getResourceNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -181,7 +181,7 @@ public class ResourceMgr implements Writable {
      *
      */
     public void alterResource(AlterResourceStmt stmt) throws DdlException {
-        Resource droppedResource;
+        Resource alteredResource;
 
         this.writeLock();
         try {
@@ -203,7 +203,7 @@ public class ResourceMgr implements Writable {
                 throw new DdlException("Alter resource statement only support external hive/hudi now");
             }
 
-            droppedResource = resource;
+            alteredResource = resource;
 
             GlobalStateMgr.getCurrentState().getEditLog().logCreateResource(resource);
         } finally {
@@ -212,7 +212,7 @@ public class ResourceMgr implements Writable {
 
         // Do not invoke HiveRepository::clearCache inside `Resource.rwLock`. Otherwise, it might cause deadlock.
         // Because HiveRepository::getClient will hold `Resource.rwLock` inside `HiveRepository::xxxLock`
-        GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(droppedResource.getName());
+        GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(alteredResource.getName());
     }
 
     public int getResourceNum() {


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6423

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The concurrent call of `HiveReposiroty::getClient` and `ResourceMgr::dropResource` might cause dead lock. Say there are two threads call above two method concurrently, the execution sequence is as below:

```
thread 1:                                            thread 2:
HiveRepository::getClient                            ResourceMgr::dropResource
                  |                 
  hiveRepository::metaClientsLock                      Resource::writeLock
                  |                                         |
  Resource::getResource                                onDropResource
                  |                                         |
                  |                                     HiveRepository::clearCache                                                            
     Resource::readLock                                     |
                                                         HiveRepository::metaClientsLock
``` 
the thread 1 will hold `HiveRepository::metaClientsLock` and wait on `Resource::readLock` while thread 2 will hold ` Resource::writeLock` and wait on `HiveRepository::metaClientsLock`. So we shouldn't call `HiveRepository::clearCache` inside the `Resource::writeLock`



