### PR TITLE
[BugFix] When the OP_TIMESTAMP type log write occur an error also need to exit the process

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -39,7 +39,6 @@ import com.starrocks.journal.JournalCursor;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalException;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.persist.OperationType;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -196,15 +195,6 @@ public class BDBJEJournal implements Journal {
         }
 
         if (!writeSuccessed) {
-            if (op == OperationType.OP_TIMESTAMP) {
-                /*
-                 * Do not exit if the write operation is OP_TIMESTAMP.
-                 * If all the followers exit except master, master should continue provide query service.
-                 * To prevent master exit, we should exempt OP_TIMESTAMP write
-                 */
-                LOG.warn("master can not achieve quorum. write timestamp fail. but will not exit.");
-                return;
-            }
             String msg = "write bdb failed. will exit. journalId: " + id + ", bdb database Name: " +
                     currentJournalDB.getDb().getDatabaseName();
             LOG.error(msg);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5923

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the OP_TIMESTAMP type log write occur an error also need to exit the process, if do not  exit the process, may lead to more serious errors, such as the OP_TIMESTAMP type log write occur a timeout error, we can not judge if this log was actually not written on the follower. So when the next log which log id not increase send to the follower, follower maybe think it is a log that have replayed, so this log will not be replayed. All subsequent log operations that depend on this un-replayed log will occur an error.

In this case，the error occurs through the following steps
1. master send OP_TIMESTAMP log which log id is 1000 to follower and timeout, but the follower actually has written the log.
2. master send erase tableA log to follower, because of last log failed, the log id also is 1000,  and timeout. master shutdown, but the follower has received  the erase log(1000), and replace the log  which log id is 1000 in bdb. so the log which log id is 1000 is a erase tableA log now. but the log 1000 have replayed before, so the new erase tableA log will not be replayed.
3. Because of old master shutdown, the follower become a new master, new master found that tableA need to be erase, and erase it, and than write a erase tableA log, the log id is 1001.
4. When this fe restart and replay 1000 and 1001 log will occur NullPointerException