### PR TITLE
[Feature]Consider external catalog when checking privilege

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropTableStmt.java
@@ -49,6 +49,10 @@ public class DropTableStmt extends DdlStmt {
         return ifExists;
     }
 
+    public TableName getTbl() {
+        return tableName;
+    }
+
     public String getDbName() {
         return tableName.getDb();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -59,7 +59,7 @@ public class CreateTableAnalyzer {
         FeNameFormat.verifyTableName(tableName.getTbl());
 
         if (!GlobalStateMgr.getCurrentState().getAuth()
-                .checkTblPriv(ConnectContext.get(), tableName, PrivPredicate.CREATE)) {
+                .checkTblPriv(ConnectContext.get(), tableName.getDb(), tableName.getTbl(), PrivPredicate.CREATE)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.common.FeNameFormat;
 import com.starrocks.external.elasticsearch.EsUtil;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.Relation;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -57,7 +58,8 @@ public class CreateTableAnalyzer {
 
         FeNameFormat.verifyTableName(tableName.getTbl());
 
-        if (!PrivilegeChecker.checkTblPriv(ConnectContext.get(), tableName, PrivPredicate.CREATE)) {
+        if (!GlobalStateMgr.getCurrentState().getAuth()
+                .checkTblPriv(ConnectContext.get(), tableName, PrivPredicate.CREATE)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -28,7 +28,6 @@ import com.starrocks.common.FeNameFormat;
 import com.starrocks.external.elasticsearch.EsUtil;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.Relation;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -58,8 +57,7 @@ public class CreateTableAnalyzer {
 
         FeNameFormat.verifyTableName(tableName.getTbl());
 
-        if (!GlobalStateMgr.getCurrentState().getAuth()
-                .checkTblPriv(ConnectContext.get(), tableName.getDb(), tableName.getTbl(), PrivPredicate.CREATE)) {
+        if (!PrivilegeChecker.checkTblPriv(ConnectContext.get(), tableName, PrivPredicate.CREATE)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -43,9 +43,26 @@ public class PrivilegeChecker {
     public static boolean checkTblPriv(ConnectContext context,
                                        TableName tableName,
                                        PrivPredicate predicate) {
-        return !CatalogMgr.isInternalCatalog(tableName.getCatalog()) ||
+        return checkTblPriv(context, tableName.getCatalog(),
+                tableName.getDb(), tableName.getTbl(), predicate);
+    }
+
+    public static boolean checkTblPriv(ConnectContext context,
+                                       String catalogName,
+                                       String dbName,
+                                       String tableName,
+                                       PrivPredicate predicate) {
+        return !CatalogMgr.isInternalCatalog(catalogName) ||
                 GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
-                        context, tableName.getDb(), tableName.getTbl(), predicate);
+                        context, dbName, tableName, predicate);
+    }
+
+    public static boolean checkDbPriv(ConnectContext context,
+                                       String catalogName,
+                                       String dbName,
+                                       PrivPredicate predicate) {
+        return !CatalogMgr.isInternalCatalog(catalogName) ||
+                GlobalStateMgr.getCurrentState().getAuth().checkDbPriv(context, dbName, predicate);
     }
 
     private static class PrivilegeCheckerVisitor extends AstVisitor<Void, ConnectContext> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -43,8 +43,7 @@ public class PrivilegeChecker {
     public static boolean checkTblPriv(ConnectContext context,
                                        TableName tableName,
                                        PrivPredicate predicate) {
-        String catalogName = ""; // TODO: wait for TableName to add catalogName
-        return !CatalogMgr.isInternalCatalog(catalogName) ||
+        return !CatalogMgr.isInternalCatalog(tableName.getCatalog()) ||
                 GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
                         context, tableName.getDb(), tableName.getTbl(), predicate);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -24,6 +24,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseGrantRevokeImpersonateStmt;
@@ -39,6 +40,15 @@ public class PrivilegeChecker {
         new PrivilegeCheckerVisitor().check(statement, session);
     }
 
+    public static boolean checkTblPriv(ConnectContext context,
+                                       TableName tableName,
+                                       PrivPredicate predicate) {
+        String catalogName = ""; // TODO: wait for TableName to add catalogName
+        return !CatalogMgr.isInternalCatalog(catalogName) ||
+                GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
+                        context, tableName.getDb(), tableName.getTbl(), predicate);
+    }
+
     private static class PrivilegeCheckerVisitor extends AstVisitor<Void, ConnectContext> {
         public void check(StatementBase statement, ConnectContext session) {
             visit(statement, session);
@@ -46,9 +56,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitAlterTableStatement(AlterTableStmt statement, ConnectContext session) {
-            String dbName = statement.getTbl().getDb();
-            String tableName = statement.getTbl().getTbl();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, dbName, tableName, PrivPredicate.ALTER)) {
+            if (!checkTblPriv(session, statement.getTbl(), PrivPredicate.ALTER)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "Alter");
             }
             return null;
@@ -65,8 +73,7 @@ public class PrivilegeChecker {
         @Override
         public Void visitAlterViewStatement(AlterViewStmt statement, ConnectContext session) {
             TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.ALTER)) {
+            if (!checkTblPriv(session, tableName, PrivPredicate.ALTER)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "ALTER VIEW",
                         session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
             }
@@ -95,8 +102,7 @@ public class PrivilegeChecker {
         @Override
         public Void visitCreateViewStatement(CreateViewStmt statement, ConnectContext session) {
             TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.CREATE)) {
+            if (!checkTblPriv(session, tableName, PrivPredicate.CREATE)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE");
             }
 
@@ -115,10 +121,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitDropTableStmt(DropTableStmt statement, ConnectContext session) {
-            String dbName = statement.getDbName();
-            String tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth()
-                    .checkTblPriv(session, dbName, tableName, PrivPredicate.DROP)) {
+            if (!checkTblPriv(session, statement.getTbl(), PrivPredicate.DROP)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "DROP");
             }
             return null;
@@ -135,8 +138,7 @@ public class PrivilegeChecker {
         @Override
         public Void visitInsertStatement(InsertStmt statement, ConnectContext session) {
             TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.LOAD)) {
+            if (!checkTblPriv(session, tableName, PrivPredicate.LOAD)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                         session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
             }
@@ -149,8 +151,7 @@ public class PrivilegeChecker {
             Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(stmt);
             for (Map.Entry<TableName, Table> table : tables.entrySet()) {
                 TableName tableName = table.getKey();
-                if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                        tableName.getTbl(), PrivPredicate.SELECT)) {
+                if (!checkTblPriv(session, tableName, PrivPredicate.SELECT)) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
                             session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
                 }
@@ -169,9 +170,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitCreateMaterializedViewStatement(CreateMaterializedViewStatement statement, ConnectContext session) {
-            TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.CREATE)) {
+            if (!checkTblPriv(session, statement.getTableName(), PrivPredicate.CREATE)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE");
             }
             check(statement.getQueryStatement(), session);
@@ -180,8 +179,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitDropMaterializedViewStatement(DropMaterializedViewStmt statement, ConnectContext session) {
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(ConnectContext.get(), statement.getDbName(),
-                    statement.getMvName(), PrivPredicate.DROP)) {
+            if (!checkTblPriv(ConnectContext.get(), statement.getDbMvName(), PrivPredicate.DROP)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "DROP");
             }
             return null;
@@ -245,8 +243,7 @@ public class PrivilegeChecker {
             // TODO We're planning to refactor the whole privilege framework to align with mainstream databases such as
             //      MySQL by fine-grained administrative permissions.
             TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.LOAD)) {
+            if (!checkTblPriv(session, tableName, PrivPredicate.LOAD)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                         session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
             }
@@ -259,8 +256,7 @@ public class PrivilegeChecker {
             // TODO We're planning to refactor the whole privilege framework to align with mainstream databases such as
             //      MySQL by fine-grained administrative permissions.
             TableName tableName = statement.getTableName();
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
-                    tableName.getTbl(), PrivPredicate.LOAD)) {
+            if (!checkTblPriv(session, tableName, PrivPredicate.LOAD)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                         session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Related with #5062 
DLA New Framework add catalog level. We support hive connector in this milestone. In this pr we skip check privilege for tables and dbs in some limited operation.

1. Table privilege checker in PrivilegeChecker
2. Show databases from catalog