### PR TITLE
[BugFix] SemiJoinReorder forbidden outer join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -39,12 +39,10 @@ import java.util.stream.Collectors;
 public class JoinAssociativityRule extends TransformationRule {
     private JoinAssociativityRule() {
         super(RuleType.TF_JOIN_ASSOCIATIVITY, Pattern.create(OperatorType.LOGICAL_JOIN)
-                .addChildren(
-                        Pattern.create(OperatorType.LOGICAL_JOIN).addChildren(
-                                Pattern.create(OperatorType.PATTERN_LEAF)
-                                        .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF)),
-                                Pattern.create(OperatorType.PATTERN_LEAF)),
-                        Pattern.create(OperatorType.PATTERN_LEAF)));
+                .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN)
+                        .addChildren(Pattern.create(OperatorType.PATTERN_LEAF, OperatorType.PATTERN_MULTI_LEAF))
+                        .addChildren(Pattern.create(OperatorType.PATTERN_LEAF)))
+                .addChildren(Pattern.create(OperatorType.PATTERN_LEAF)));
     }
 
     private static final JoinAssociativityRule instance = new JoinAssociativityRule();
@@ -169,7 +167,7 @@ public class JoinAssociativityRule extends TransformationRule {
                 // like expression mapping.
                 boolean isProjectToColumnRef = entry.getValue().isColumnRef() &&
                         entry.getKey().getName().equals(((ColumnRefOperator) entry.getValue()).getName());
-                if (! isProjectToColumnRef &&
+                if (!isProjectToColumnRef &&
                         newRightChildColumns.containsAll(entry.getValue().getUsedColumns())) {
                     rightExpression.put(entry.getKey(), entry.getValue());
                 } else if (!isProjectToColumnRef &&

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -1939,7 +1939,7 @@ public class JoinTest extends PlanTestBase {
                 "WHERE 0 < (\n" +
                 "    SELECT MAX(k9)\n" +
                 "    FROM test.pushdown_test);";
-        String plan  = starRocksAssert.query(sql).explainQuery();
+        String plan = starRocksAssert.query(sql).explainQuery();
         assertContains(plan, "  3:SELECT\n" +
                 "  |  predicates: CAST(23: max AS DOUBLE) > 0.0\n" +
                 "  |  \n" +
@@ -2612,5 +2612,22 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         // check no error
         assertContains(plan, "16:ASSERT NUMBER OF ROWS");
+    }
+
+    @Test
+    public void testSemiOuterJoin() throws Exception {
+        String sql = "select * from t0 full outer join t2 on t0.v1 = t2.v7 and t0.v1 > t2.v7 " +
+                "where t0.v2 in (select t1.v4 from t1 where false)";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  7:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 7: v4\n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  4:HASH JOIN\n" +
+                "  |  join op: FULL OUTER JOIN (PARTITIONED)");
     }
 }

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -313,16 +313,16 @@ LEFT OUTER JOIN (join-predicate [2: v2 = 8: v4] post-join-predicate [3: v3 = 3 O
 [sql]
 select v3, v1 from t0 where (t0.v3 = 3 or exists (select v6 from t1 where v5 = v1)) and not exists (select v5 from t1 where v4 = v2);
 [result]
-RIGHT OUTER JOIN (join-predicate [5: v5 = 1: v1] post-join-predicate [3: v3 = 3 OR 5: v5 IS NOT NULL])
-    AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v5]] having [null]
+LEFT ANTI JOIN (join-predicate [2: v2 = 8: v4] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [1: v1 = 5: v5] post-join-predicate [3: v3 = 3 OR 5: v5 IS NOT NULL])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
         EXCHANGE SHUFFLE[5]
-            AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v5]] having [null]
-                SCAN (columns[5: v5] predicate[null])
-    EXCHANGE SHUFFLE[1]
-        LEFT ANTI JOIN (join-predicate [2: v2 = 8: v4] post-join-predicate [null])
-            SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-            EXCHANGE BROADCAST
-                SCAN (columns[8: v4] predicate[null])
+            AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v5]] having [null]
+                EXCHANGE SHUFFLE[5]
+                    AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v5]] having [null]
+                        SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[8: v4] predicate[null])
 [end]
 
 [sql]


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6460

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Like SQL Tree:

```
       semi         outer-join
      /    \          /    \
outer-join  z       semi    y
   /   \           /   \
  x     y         x     z

```

Obviously, the two plans are different
left: add nulls and filter all data
right: filter data and add nulls

