### PR TITLE
[BugFix] Report tablet ids when publish is failed

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -742,33 +742,32 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
 
             uint32_t retry_time = 0;
 
-            Status st;
+            auto st = &statuses[idx];
             while (retry_time++ < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
                 // submit publishing tablet version task to the threadpool.
-                st = threadpool->submit_func([&worker_pool_this, &tablet_rs, &statuses, idx, &version, &transaction_id,
+                *st = threadpool->submit_func([&worker_pool_this, &tablet_rs, st, &version, &transaction_id,
                                               &partition_id]() {
                     const TabletInfo& tablet_info = tablet_rs.first;
                     const RowsetSharedPtr& rowset = tablet_rs.second;
-                    auto& status = statuses[idx];
                     // if rowset is null, it means this be received write task, but failed during write
                     // and receive fe's publish version task
                     // this be must return as an error tablet
                     if (rowset == nullptr) {
                         LOG(WARNING) << "Not found rowset of tablet: " << tablet_info.tablet_id << ", txn_id "
                                      << transaction_id;
-                        status = Status::NotFound(fmt::format("Not found rowset of tablet: {}, txn_id: {}",
-                                                              tablet_info.tablet_id, transaction_id));
+                        *st = Status::NotFound(fmt::format("Not found rowset of tablet: {}, txn_id: {}",
+                                                          tablet_info.tablet_id, transaction_id));
                         return;
                     }
                     EnginePublishVersionTask engine_task(transaction_id, partition_id, version, tablet_info, rowset);
 
-                    status = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
-                    if (!status.ok())
-                        LOG(WARNING) << "failed to publish version for tablet, tablet_id: " << tablet_info.tablet_id
-                                     << ", txn_id: " << transaction_id << ", err: " << status;
+                    *st = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
+                    if (!st->ok())
+                        LOG(WARNING) << "failed to publish version for tablet, tablet_id " << tablet_info.tablet_id
+                                     << ", txn_id " << transaction_id << ", err: " << st;
                 });
 
-                if (st.is_service_unavailable()) {
+                if (st->is_service_unavailable()) {
                     // Status::ServiceUnavailable is returned when all of the threads of the pool are busy.
                     LOG(WARNING) << "publish version threadpool is busy, retry later. [txn_id: "
                                  << publish_version_req.transaction_id << ", tablet_id: " << tablet_rs.first.tablet_id;
@@ -778,11 +777,6 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
                 }
                 break;
             }
-
-            // error category:
-            // 1. ServiceUnavailable, which means that the threadpool is busy even in retry.
-            // 2. error that is not ServiceUnavailable.
-            if (!st.ok()) return st;
 
             ++idx;
         }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -746,7 +746,7 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
             while (retry_time++ < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
                 // submit publishing tablet version task to the threadpool.
                 *st = threadpool->submit_func([&worker_pool_this, &tablet_rs, st, &version, &transaction_id,
-                                              &partition_id]() {
+                                               &partition_id]() {
                     const TabletInfo& tablet_info = tablet_rs.first;
                     const RowsetSharedPtr& rowset = tablet_rs.second;
                     // if rowset is null, it means this be received write task, but failed during write
@@ -756,7 +756,7 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
                         LOG(WARNING) << "Not found rowset of tablet: " << tablet_info.tablet_id << ", txn_id "
                                      << transaction_id;
                         *st = Status::NotFound(fmt::format("Not found rowset of tablet: {}, txn_id: {}",
-                                                          tablet_info.tablet_id, transaction_id));
+                                                           tablet_info.tablet_id, transaction_id));
                         return;
                     }
                     EnginePublishVersionTask engine_task(transaction_id, partition_id, version, tablet_info, rowset);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6500 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR fix the problem that no error tablet id is reported when the publish task submitting is failed.