### PR TITLE
[Bugfix] Add outer join satisfy aggregate shuffle required check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
@@ -123,7 +123,8 @@ public class HashDistributionSpec extends DistributionSpec {
                 return false;
             }
         }
-        // Left outer join will cause right table produce NULL in different node, also right outer join
+        // Outer join will produce NULL rows in different node, do aggregate may output multi null rows
+        // if satisfy required shuffle directly
         if (otherSourceType == HashDistributionDesc.SourceType.SHUFFLE_AGG &&
                 (thisSourceType == HashDistributionDesc.SourceType.LOCAL ||
                         thisSourceType == HashDistributionDesc.SourceType.SHUFFLE_JOIN)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
@@ -124,8 +124,9 @@ public class HashDistributionSpec extends DistributionSpec {
             }
         }
         // Left outer join will cause right table produce NULL in different node, also right outer join
-        if (thisSourceType == HashDistributionDesc.SourceType.LOCAL &&
-                otherSourceType == HashDistributionDesc.SourceType.SHUFFLE_AGG) {
+        if (otherSourceType == HashDistributionDesc.SourceType.SHUFFLE_AGG &&
+                (thisSourceType == HashDistributionDesc.SourceType.LOCAL ||
+                        thisSourceType == HashDistributionDesc.SourceType.SHUFFLE_JOIN)) {
             ColumnRefSet otherColumns = new ColumnRefSet();
             other.hashDistributionDesc.getColumns().forEach(otherColumns::union);
             if (propertyInfo.nullableColumns.isIntersect(otherColumns)) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6460 #6552

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For SQL:
```
MySQL td> explain select distinct t0.v1  from t0 full outer join[shuffle] t1 on t0.v1 = t1.v1;
```

Finalize aggregate node worked after outer join, then result maybe produce multi null rows in different instances.
Should check null column when join shuffle property satisfy aggregate required
```
+---------------------------------------------+
| Explain String                              |
+---------------------------------------------+
..........
|                                             |
|   6:AGGREGATE (update finalize)             |
|   |  group by: 1: v1                        |
|   |                                         |
|   5:Project                                 |
|   |  <slot 1> : 1: v1                       |
|   |                                         |
|   4:HASH JOIN                               |
|   |  join op: FULL OUTER JOIN (PARTITIONED) |
|   |  hash predicates:                       |
|   |  colocate: false, reason:               |
|   |  equal join conjunct: 1: v1 = 4: v1     |
|   |                                         |
|   |----3:EXCHANGE                           |
|   |                                         |
|   1:EXCHANGE                                |
...........
```