### PR TITLE
[BugFix] Fix bucket shuffle join delivery sort property error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -207,8 +207,7 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
     private void addChildEnforcer(PhysicalPropertySet oldOutputProperty,
                                   DistributionProperty newDistributionProperty,
                                   double childCost, Group childGroup) {
-        PhysicalPropertySet newOutputProperty = oldOutputProperty.copy();
-        newOutputProperty.setDistributionProperty(newDistributionProperty);
+        PhysicalPropertySet newOutputProperty = new PhysicalPropertySet(newDistributionProperty);
         GroupExpression enforcer = newDistributionProperty.appendEnforcers(childGroup);
 
         enforcer.setOutputPropertySatisfyRequiredProperty(newOutputProperty, newOutputProperty);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6479 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When child has property [sort property, shuffle] and need to trans to bucket shuffle, the property of enforer should be [empty,bucket join], not [sort property, bucket shuffle]