### PR TITLE
[Feature] Adapting the catalog in fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
@@ -1359,6 +1359,10 @@ public class Analyzer {
         return globalState.context.getDatabase();
     }
 
+    public String getDefaultCatalog() {
+        return globalState.context.getCurrentCatalog();
+    }
+
     public String getClusterName() {
         return globalState.context.getClusterName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -83,6 +83,9 @@ public class TableName implements Writable {
     public void normalization(ConnectContext connectContext) {
         try {
             if (Strings.isNullOrEmpty(catalog)) {
+                if (Strings.isNullOrEmpty(connectContext.getCurrentCatalog())) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR);
+                }
                 catalog = connectContext.getCurrentCatalog();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -29,6 +29,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 
 import java.io.DataInput;
@@ -36,6 +37,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class TableName implements Writable {
+    private String catalog;
     private String tbl;
     private String db;
 
@@ -44,11 +46,20 @@ public class TableName implements Writable {
     }
 
     public TableName(String db, String tbl) {
+        this(null, db, tbl);
+    }
+
+    public TableName(String catalog, String db, String tbl) {
+        this.catalog = catalog;
         this.db = db;
         this.tbl = tbl;
     }
 
     public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (Strings.isNullOrEmpty(catalog)) {
+            catalog = analyzer.getDefaultCatalog();
+        }
+
         if (Strings.isNullOrEmpty(db)) {
             db = analyzer.getDefaultDb();
             if (Strings.isNullOrEmpty(db)) {
@@ -58,7 +69,10 @@ public class TableName implements Writable {
             if (Strings.isNullOrEmpty(analyzer.getClusterName())) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NAME_NULL);
             }
-            db = ClusterNamespace.getFullName(analyzer.getClusterName(), db);
+
+            if (CatalogMgr.isInternalCatalog(catalog)) {
+                db = ClusterNamespace.getFullName(analyzer.getClusterName(), db);
+            }
         }
 
         if (Strings.isNullOrEmpty(tbl)) {
@@ -68,6 +82,10 @@ public class TableName implements Writable {
 
     public void normalization(ConnectContext connectContext) {
         try {
+            if (Strings.isNullOrEmpty(catalog)) {
+                catalog = connectContext.getCurrentCatalog();
+            }
+
             if (Strings.isNullOrEmpty(db)) {
                 db = connectContext.getDatabase();
                 if (Strings.isNullOrEmpty(db)) {
@@ -77,7 +95,10 @@ public class TableName implements Writable {
                 if (Strings.isNullOrEmpty(connectContext.getClusterName())) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_CLUSTER_NAME_NULL);
                 }
-                db = ClusterNamespace.getFullName(connectContext.getClusterName(), db);
+
+                if (CatalogMgr.isInternalCatalog(catalog)) {
+                    db = ClusterNamespace.getFullName(connectContext.getClusterName(), db);
+                }
             }
 
             if (Strings.isNullOrEmpty(tbl)) {
@@ -98,6 +119,14 @@ public class TableName implements Writable {
 
     public String getTbl() {
         return tbl;
+    }
+
+    public String getCatalog() {
+        return catalog;
+    }
+
+    public void setCatalog(String catalog) {
+        this.catalog = catalog;
     }
 
     public boolean isEmpty() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -322,6 +322,7 @@ public class HiveMetaCache {
         }
     }
 
+
     private Table loadTable(HiveTableName hiveTableName) throws TException, DdlException {
         org.apache.hadoop.hive.metastore.api.Table hiveTable = client.getTable(hiveTableName);
         return HiveMetaStoreTableUtils.convertToSRTable(hiveTable, resourceName);
@@ -339,7 +340,7 @@ public class HiveMetaCache {
     private Database loadDatabase(String dbName) throws TException {
         // Check whether the db exists, if not, an exception will be thrown here
         org.apache.hadoop.hive.metastore.api.Database db = client.getDb(dbName);
-        if (db.getName() == null) {
+        if (db == null || db.getName() == null) {
             throw new TException("Hive db " + dbName + " doesn't exist");
         }
         return HiveMetaStoreTableUtils.convertToSRDatabase(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -128,7 +128,9 @@ import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.meta.BlackListSql;
 import com.starrocks.meta.SqlBlackList;
 import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.ShowAnalyzeStmt;
 import com.starrocks.sql.ast.ShowCatalogsStmt;
 import com.starrocks.statistic.AnalyzeJob;
@@ -155,11 +157,13 @@ public class ShowExecutor {
     private ConnectContext ctx;
     private ShowStmt stmt;
     private ShowResultSet resultSet;
+    private MetadataMgr metadataMgr;
 
     public ShowExecutor(ConnectContext ctx, ShowStmt stmt) {
         this.ctx = ctx;
         this.stmt = stmt;
         resultSet = null;
+        metadataMgr = ctx.globalStateMgr.getMetadataMgr();
     }
 
     public ShowResultSet execute() throws AnalysisException {
@@ -525,41 +529,53 @@ public class ShowExecutor {
     private void handleShowTable() throws AnalysisException {
         ShowTableStmt showTableStmt = (ShowTableStmt) stmt;
         List<List<String>> rows = Lists.newArrayList();
-        Database db = ctx.getGlobalStateMgr().getDb(showTableStmt.getDb());
+        String catalog = ctx.getCurrentCatalog();
+        String dbName = showTableStmt.getDb();
+        Database db = metadataMgr.getDb(catalog, dbName);
+
+        PatternMatcher matcher = null;
+        if (showTableStmt.getPattern() != null) {
+            matcher = PatternMatcher.createMysqlPattern(showTableStmt.getPattern(),
+                    CaseSensibility.TABLE.getCaseSensibility());
+        }
+
+        Map<String, String> tableMap = Maps.newTreeMap();
         if (db != null) {
-            Map<String, String> tableMap = Maps.newTreeMap();
             db.readLock();
             try {
-                PatternMatcher matcher = null;
-                if (showTableStmt.getPattern() != null) {
-                    matcher = PatternMatcher.createMysqlPattern(showTableStmt.getPattern(),
-                            CaseSensibility.TABLE.getCaseSensibility());
-                }
-                for (Table tbl : db.getTables()) {
-                    if (matcher != null && !matcher.match(tbl.getName())) {
-                        continue;
+                if (CatalogMgr.isInternalCatalog(catalog)) {
+                    for (Table tbl : db.getTables()) {
+                        if (matcher != null && !matcher.match(tbl.getName())) {
+                            continue;
+                        }
+                        // check tbl privs
+                        if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(ConnectContext.get(),
+                                db.getFullName(), tbl.getName(),
+                                PrivPredicate.SHOW)) {
+                            continue;
+                        }
+                        tableMap.put(tbl.getName(), tbl.getMysqlType());
                     }
-                    // check tbl privs
-                    if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(ConnectContext.get(),
-                            db.getFullName(), tbl.getName(),
-                            PrivPredicate.SHOW)) {
-                        continue;
+                } else {
+                    List<String> tableNames = metadataMgr.listTableNames(catalog, dbName);
+                    if (matcher != null) {
+                        tableNames = tableNames.stream().filter(matcher::match).collect(Collectors.toList());
                     }
-                    tableMap.put(tbl.getName(), tbl.getMysqlType());
+                    tableNames.forEach(name -> tableMap.put(name, "BASE TABLE"));
                 }
             } finally {
                 db.readUnlock();
             }
-
-            for (Map.Entry<String, String> entry : tableMap.entrySet()) {
-                if (showTableStmt.isVerbose()) {
-                    rows.add(Lists.newArrayList(entry.getKey(), entry.getValue()));
-                } else {
-                    rows.add(Lists.newArrayList(entry.getKey()));
-                }
-            }
         } else {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, showTableStmt.getDb());
+        }
+
+        for (Map.Entry<String, String> entry : tableMap.entrySet()) {
+            if (showTableStmt.isVerbose()) {
+                rows.add(Lists.newArrayList(entry.getKey(), entry.getValue()));
+            } else {
+                rows.add(Lists.newArrayList(entry.getKey()));
+            }
         }
         resultSet = new ShowResultSet(showTableStmt.getMetaData(), rows);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -163,7 +163,7 @@ public class ShowExecutor {
         this.ctx = ctx;
         this.stmt = stmt;
         resultSet = null;
-        metadataMgr = ctx.globalStateMgr.getMetadataMgr();
+        metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
     }
 
     public ShowResultSet execute() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -18,15 +18,20 @@ import com.starrocks.persist.CreateCatalogLog;
 import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class CatalogMgr {
-
+    private static final Logger LOG = LogManager.getLogger(CatalogMgr.class);
     private final ConcurrentHashMap<String, Catalog> catalogs = new ConcurrentHashMap<>();
     private final ConnectorMgr connectorMgr;
+    private final ReadWriteLock catalogLock = new ReentrantReadWriteLock();
 
     public static final ImmutableList<String> CATALOG_PROC_NODE_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Catalog").add("Type").add("Comment")
@@ -35,6 +40,7 @@ public class CatalogMgr {
     private final CatalogProcNode procNode = new CatalogProcNode();
 
     public CatalogMgr(ConnectorMgr connectorMgr) {
+        Preconditions.checkNotNull(connectorMgr, "ConnectorMgr is null");
         this.connectorMgr = connectorMgr;
     }
 
@@ -47,25 +53,56 @@ public class CatalogMgr {
             throw new DdlException("Missing properties 'type'");
         }
 
-        Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
+        readLock();
+        try {
+            Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
+        } finally {
+            readUnlock();
+        }
+
         connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties));
         Catalog catalog = new ExternalCatalog(catalogName, comment, properties);
-        catalogs.put(catalogName, catalog);
+
+        writeLock();
+        try {
+            catalogs.put(catalogName, catalog);
+        } finally {
+            writeUnLock();
+        }
         // TODO edit log
     }
 
     public synchronized void dropCatalog(DropCatalogStmt stmt) {
         String catalogName = stmt.getName();
-        Preconditions.checkState(catalogs.containsKey(catalogName), "Catalog '%s' doesn't exist", catalogName);
+        readLock();
+        try {
+            Preconditions.checkState(catalogs.containsKey(catalogName), "Catalog '%s' doesn't exist", catalogName);
+        } finally {
+            readUnlock();
+        }
         connectorMgr.removeConnector(catalogName);
-        catalogs.remove(catalogName);
+
+        writeLock();
+        try {
+            catalogs.remove(catalogName);
+        } finally {
+            writeUnLock();
+        }
         // TODO edit log
     }
 
     // TODO @caneGuy we should put internal catalog into catalogmgr
     public boolean catalogExists(String catalogName) {
-        return catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME) ||
-                catalogs.containsKey(catalogName);
+        if (catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+            return true;
+        }
+
+        readLock();
+        try {
+            return catalogs.containsKey(catalogName);
+        } finally {
+            readUnlock();
+        }
     }
 
     public static boolean isInternalCatalog(String name) {
@@ -98,6 +135,22 @@ public class CatalogMgr {
 
     public CatalogProcNode getProcNode() {
         return procNode;
+    }
+
+    private void readLock() {
+        this.catalogLock.readLock().lock();
+    }
+
+    private void readUnlock() {
+        this.catalogLock.readLock().unlock();
+    }
+
+    private void writeLock() {
+        this.catalogLock.writeLock().lock();
+    }
+
+    private void writeUnLock() {
+        this.catalogLock.writeLock().unlock();
     }
 
     public class CatalogProcNode implements ProcNodeInterface {

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -22,11 +22,12 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class MetadataMgr {
     private static final Logger LOG = LogManager.getLogger(MetadataMgr.class);
 
-    ReadWriteLock metaLock = new ReentrantReadWriteLock();
+    private final ReadWriteLock metaLock = new ReentrantReadWriteLock();
     private final LocalMetastore localMetastore;
     private final Map<String, ConnectorMetadata> connectorMetadatas = new HashMap<>();
 
     public MetadataMgr(LocalMetastore localMetastore) {
+        Preconditions.checkNotNull(localMetastore, "localMetastore is null");
         this.localMetastore = localMetastore;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -26,6 +26,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.JoinRelation;
@@ -200,7 +201,11 @@ public class AnalyzerUtils {
             if (Strings.isNullOrEmpty(dbName)) {
                 dbName = session.getDatabase();
             } else {
-                dbName = ClusterNamespace.getFullName(session.getClusterName(), dbName);
+                if (CatalogMgr.isInternalCatalog(session.getCurrentCatalog())) {
+                    dbName = ClusterNamespace.getFullName(session.getClusterName(), dbName);
+                } else {
+                    return;
+                }
             }
 
             Database db = session.getGlobalStateMgr().getDb(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -52,6 +52,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.common.TypeManager;
@@ -73,8 +75,10 @@ import static com.starrocks.sql.common.UnsupportedException.unsupportedException
 public class ExpressionAnalyzer {
     private static final Pattern HAS_TIME_PART = Pattern.compile("^.*[HhIiklrSsT]+.*$");
     private final ConnectContext session;
+    private final MetadataMgr metadataMgr;
 
     public ExpressionAnalyzer(ConnectContext session) {
+        metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         this.session = session;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -52,8 +52,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.qe.VariableMgr;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.common.TypeManager;
@@ -75,10 +73,8 @@ import static com.starrocks.sql.common.UnsupportedException.unsupportedException
 public class ExpressionAnalyzer {
     private static final Pattern HAS_TIME_PART = Pattern.compile("^.*[HhIiklrSsT]+.*$");
     private final ConnectContext session;
-    private final MetadataMgr metadataMgr;
 
     public ExpressionAnalyzer(ConnectContext session) {
-        metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         this.session = session;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -264,7 +264,7 @@ public class QueryAnalyzer {
 
             node.setColumns(columns.build());
             String dbName = node.getName().getDb();
-            if (CatalogMgr.isInternalCatalog(tableName.getCatalog())) {
+            if (CatalogMgr.isInternalCatalog(node.getName().getCatalog())) {
                 dbName = dbName.split(":")[1];
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -30,6 +30,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CTERelation;
@@ -66,7 +67,7 @@ public class QueryAnalyzer {
 
     public QueryAnalyzer(ConnectContext session) {
         this.session = session;
-        this.metadataMgr = session.getGlobalStateMgr().getMetadataMgr();
+        this.metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
     }
 
     public void analyze(StatementBase node) {
@@ -639,7 +640,7 @@ public class QueryAnalyzer {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
             }
 
-            if (!session.getGlobalStateMgr().getCatalogMgr().catalogExists(catalogName)) {
+            if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalogName);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -29,6 +29,8 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.ExceptRelation;
@@ -60,9 +62,11 @@ import static com.starrocks.sql.common.UnsupportedException.unsupportedException
 
 public class QueryAnalyzer {
     private final ConnectContext session;
+    private final MetadataMgr metadataMgr;
 
     public QueryAnalyzer(ConnectContext session) {
         this.session = session;
+        this.metadataMgr = session.getGlobalStateMgr().getMetadataMgr();
     }
 
     public void analyze(StatementBase node) {
@@ -259,7 +263,12 @@ public class QueryAnalyzer {
             }
 
             node.setColumns(columns.build());
-            session.getDumpInfo().addTable(node.getName().getDb().split(":")[1], table);
+            String dbName = node.getName().getDb();
+            if (CatalogMgr.isInternalCatalog(tableName.getCatalog())) {
+                dbName = dbName.split(":")[1];
+            }
+
+            session.getDumpInfo().addTable(dbName, table);
 
             Scope scope = new Scope(RelationId.of(node), new RelationFields(fields.build()));
             node.setScope(scope);
@@ -623,17 +632,23 @@ public class QueryAnalyzer {
     private Table resolveTable(TableName tableName) {
         try {
             MetaUtils.normalizationTableName(session, tableName);
+            String catalogName = tableName.getCatalog();
             String dbName = tableName.getDb();
             String tbName = tableName.getTbl();
             if (Strings.isNullOrEmpty(dbName)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
             }
 
-            Database database = session.getGlobalStateMgr().getDb(dbName);
+            if (!session.getGlobalStateMgr().getCatalogMgr().catalogExists(catalogName)) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalogName);
+            }
+
+            Database database = metadataMgr.getDb(catalogName, dbName);
             if (database == null) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }
-            Table table = database.getTable(tbName);
+
+            Table table = metadataMgr.getTable(catalogName, dbName, tbName);
             if (table == null) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, tbName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -13,6 +13,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.ast.AstVisitor;
 
 public class ShowStmtAnalyzer {
@@ -68,14 +69,19 @@ public class ShowStmtAnalyzer {
         }
 
         String getFullDatabaseName(String db, ConnectContext session) {
+            String catalog = session.getCurrentCatalog();
             if (Strings.isNullOrEmpty(db)) {
                 db = session.getDatabase();
-                db = ClusterNamespace.getFullName(session.getClusterName(), db);
+                if (CatalogMgr.isInternalCatalog(catalog)) {
+                    db = ClusterNamespace.getFullName(session.getClusterName(), db);
+                }
                 if (Strings.isNullOrEmpty(db)) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
                 }
             } else {
-                db = ClusterNamespace.getFullName(session.getClusterName(), db);
+                if (CatalogMgr.isInternalCatalog(catalog)) {
+                    db = ClusterNamespace.getFullName(session.getClusterName(), db);
+                }
             }
             return db;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2353,6 +2353,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     private TableName qualifiedNameToTableName(QualifiedName qualifiedName) {
+        // Hierarchy: catalog.database.table
         List<String> parts = qualifiedName.getParts();
         if (parts.size() == 3) {
             return new TableName(parts.get(0), parts.get(1), parts.get(2));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2353,10 +2353,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     private TableName qualifiedNameToTableName(QualifiedName qualifiedName) {
-        if (qualifiedName.getParts().size() == 2) {
-            return new TableName(qualifiedName.getParts().get(0), qualifiedName.getParts().get(1));
-        } else if (qualifiedName.getParts().size() == 1) {
-            return new TableName(null, qualifiedName.getParts().get(0));
+        List<String> parts = qualifiedName.getParts();
+        if (parts.size() == 3) {
+            return new TableName(parts.get(0), parts.get(1), parts.get(2));
+        } else if (parts.size() == 2) {
+            return new TableName(null, qualifiedName.getParts().get(0), qualifiedName.getParts().get(1));
+        } else if (parts.size() == 1) {
+            return new TableName(null, null, qualifiedName.getParts().get(0));
         } else {
             throw new ParsingException("error table name ");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.BrokerMgr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FakeEditLog;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
@@ -323,6 +324,10 @@ public class AccessTestUtil {
         Analyzer analyzer = new Analyzer(fetchAdminCatalog(), new ConnectContext(null));
         new Expectations(analyzer) {
             {
+                analyzer.getDefaultCatalog();
+                minTimes = 0;
+                result = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+
                 analyzer.getDefaultDb();
                 minTimes = 0;
                 result = withCluster ? prefix + "testDb" : "testDb";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
@@ -108,6 +108,11 @@ public class DropMaterializedViewStmtTest {
             String getClusterName() {
                 return "testCluster";
             }
+
+            @Mock
+            String getDefaultCatalog() {
+                return "default";
+            }
         };
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -50,6 +50,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testQueryPlanAction() throws IOException, TException {
+        super.setUpWithCatalog();
         RequestBody body =
                 RequestBody.create(JSON, "{ \"sql\" :  \" select k1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }");
         Request request = new Request.Builder()

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -166,6 +166,10 @@ public class ShowExecutorTest {
                 db.getTable(anyString);
                 minTimes = 0;
                 result = table;
+
+                db.getTables();
+                minTimes = 0;
+                result = Lists.newArrayList(table);
             }
         };
 
@@ -209,6 +213,14 @@ public class ShowExecutorTest {
 
                 GlobalStateMgr.getDdlStmt((Table) any, (List) any, null, null, anyBoolean, anyBoolean);
                 minTimes = 0;
+
+                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default", "testCluster:testDb");
+                minTimes = 0;
+                result = db;
+
+                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default", "testCluster:emptyDb");
+                minTimes = 0;
+                result = null;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
related with https://github.com/StarRocks/starrocks/issues/6514

related with https://github.com/StarRocks/starrocks/issues/5062


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
DLA New Framework add catalog level. We need to adapt the catalog concept where we use the hive connector table at present. we only support querying hive connector table in this milestone. Therefore, we only adapt the catalog in the new parser and new analyzer. we also need refresh_stmt in old parser when we using hive connector table. we will support it in next pr. ref https://github.com/StarRocks/starrocks/issues/6509.
And other stmt like describe table on external catalog https://github.com/StarRocks/starrocks/issues/6510. we will support it  step by step in future.

The main point of adaption:
- Add catalog field in TableName
- Use `MetadataMgr.getDb` or `MetadataMgr.getTable` when getting metadata.
- Remove cluster_name from dbname when process table in external catalog.
- Permission related will be merged after this pr https://github.com/StarRocks/starrocks/pull/6496