### PR TITLE
[BugFix] RLE encoder stuck in FlushRepeatedRun when repeat_count_ >= 0x40000000

### DIFF
--- a/be/src/util/bit_stream_utils.h
+++ b/be/src/util/bit_stream_utils.h
@@ -61,7 +61,7 @@ public:
 
     // Write a Vlq encoded int to the buffer. The value is written byte aligned.
     // For more details on vlq: en.wikipedia.org/wiki/Variable-length_quantity
-    void PutVlqInt(int32_t v);
+    void PutVlqInt(uint32_t v);
 
     // Get the index to the next aligned byte and advance the underlying buffer by num_bytes.
     size_t GetByteIndexAndAdvance(int num_bytes) {
@@ -114,7 +114,7 @@ public:
 
     // Reads a vlq encoded int from the stream.  The encoded int must start at the
     // beginning of a byte. Return false if there were not enough bytes in the buffer.
-    bool GetVlqInt(int32_t* v);
+    bool GetVlqInt(uint32_t* v);
 
     // Returns the number of bytes left in the stream, not including the current byte (i.e.,
     // there may be an additional fraction of a byte).

--- a/be/src/util/bit_stream_utils.h
+++ b/be/src/util/bit_stream_utils.h
@@ -77,6 +77,9 @@ public:
     // to the next byte boundary.
     void Flush(bool align = false);
 
+    // Maximum byte length of a vlq encoded int
+    static const int MAX_VLQ_BYTE_LEN = 5;
+
 private:
     // Bit-packed values are initially written to this variable before being memcpy'd to
     // buffer_. This is faster than writing values byte by byte directly to buffer_.

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -86,7 +86,7 @@ inline void BitWriter::PutAligned(T val, int num_bytes) {
 }
 
 inline void BitWriter::PutVlqInt(uint32_t v) {
-    int num_bytes = 0;
+    [[maybe_unused]] int num_bytes = 0;
     while ((v & 0xFFFFFF80) != 0L) {
         PutAligned<uint8_t>((v & 0x7F) | 0x80, 1);
         v >>= 7;
@@ -195,7 +195,7 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
 inline bool BitReader::GetVlqInt(uint32_t* v) {
     *v = 0;
     int shift = 0;
-    int num_bytes = 0;
+    [[maybe_unused]] int num_bytes = 0;
     uint8_t byte = 0;
     do {
         if (!GetAligned<uint8_t>(1, &byte)) return false;

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -85,15 +85,14 @@ inline void BitWriter::PutAligned(T val, int num_bytes) {
     memcpy(ptr, &val, num_bytes);
 }
 
-inline void BitWriter::PutVlqInt(int32_t v) {
-    uint32_t uv = reinterpret_cast<int32_t>(v);
+inline void BitWriter::PutVlqInt(uint32_t v) {
     int num_bytes = 0;
-    while ((uv & 0xFFFFFF80) != 0L) {
-        PutAligned<uint8_t>((uv & 0x7F) | 0x80, 1);
-        uv >>= 7;
+    while ((v & 0xFFFFFF80) != 0L) {
+        PutAligned<uint8_t>((v & 0x7F) | 0x80, 1);
+        v >>= 7;
         DCHECK_LE(++num_bytes, MAX_VLQ_BYTE_LEN);
     }
-    PutAligned<uint8_t>(uv & 0x7F, 1);
+    PutAligned<uint8_t>(v & 0x7F, 1);
 }
 
 inline BitReader::BitReader(const uint8_t* buffer, int buffer_len) : buffer_(buffer), max_bytes_(buffer_len) {
@@ -193,7 +192,7 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
     return true;
 }
 
-inline bool BitReader::GetVlqInt(int32_t* v) {
+inline bool BitReader::GetVlqInt(uint32_t* v) {
     *v = 0;
     int shift = 0;
     int num_bytes = 0;

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -86,11 +86,14 @@ inline void BitWriter::PutAligned(T val, int num_bytes) {
 }
 
 inline void BitWriter::PutVlqInt(int32_t v) {
-    while ((v & 0xFFFFFF80) != 0L) {
-        PutAligned<uint8_t>((v & 0x7F) | 0x80, 1);
-        v >>= 7;
+    uint32_t uv = reinterpret_cast<int32_t>(v);
+    int num_bytes = 0;
+    while ((uv & 0xFFFFFF80) != 0L) {
+        PutAligned<uint8_t>((uv & 0x7F) | 0x80, 1);
+        uv >>= 7;
+        DCHECK_LE(++num_bytes, MAX_VLQ_BYTE_LEN);
     }
-    PutAligned<uint8_t>(v & 0x7F, 1);
+    PutAligned<uint8_t>(uv & 0x7F, 1);
 }
 
 inline BitReader::BitReader(const uint8_t* buffer, int buffer_len) : buffer_(buffer), max_bytes_(buffer_len) {

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -231,12 +231,12 @@ private:
     // if we are in a literal run.  If the repeat_count_ get high enough, we switch
     // to encoding repeated runs.
     uint64_t current_value_;
-    int repeat_count_;
+    uint32_t repeat_count_;
 
     // Number of literals in the current run.  This does not include the literals
     // that might be in buffered_values_.  Only after we've got a group big enough
     // can we decide if they should part of the literal_count_ or repeat_count_
-    int literal_count_;
+    uint32_t literal_count_;
 
     // Index of a byte in the underlying buffer that stores the indicator byte.
     // This is reserved as soon as we need a literal run but the value is written
@@ -252,7 +252,7 @@ inline bool RleDecoder<T>::ReadHeader() {
     if (PREDICT_FALSE(literal_count_ == 0 && repeat_count_ == 0)) {
         // Read the next run's indicator int, it could be a literal or repeated run
         // The int is encoded as a vlq-encoded value.
-        int32_t indicator_value = 0;
+        uint32_t indicator_value = 0;
         bool result = bit_reader_.GetVlqInt(&indicator_value);
         if (PREDICT_FALSE(!result)) {
             return false;
@@ -483,8 +483,8 @@ inline void RleEncoder<T>::FlushLiteralRun(bool update_indicator_byte) {
         // The logic makes sure we flush literal runs often enough to not overrun
         // the 1 byte.
         //int num_groups = BitUtil::Ceil(literal_count_, 8);
-        int num_groups = literal_count_ / 8;
-        int32_t indicator_value = (num_groups << 1) | 1;
+        uint32_t num_groups = literal_count_ / 8;
+        uint32_t indicator_value = (num_groups << 1) | 1;
         DCHECK_EQ(indicator_value & 0xFFFFFF00, 0);
         bit_writer_.buffer()->data()[literal_indicator_byte_idx_] = indicator_value;
         literal_indicator_byte_idx_ = -1;
@@ -496,7 +496,15 @@ template <typename T>
 inline void RleEncoder<T>::FlushRepeatedRun() {
     DCHECK_GT(repeat_count_, 0);
     // The lsb of 0 indicates this is a repeated run
-    int32_t indicator_value = repeat_count_ << 1 | 0;
+
+    // Don't try to handle run lengths that don't fit in an int32_t - just fail gracefully.
+    // The Parquet standard does not allow longer runs - see PARQUET-1290.
+    if (UNLIKELY(repeat_count_ > std::numeric_limits<int32_t>::max())) {
+        LOG(WARNING) << "Run length don't fit in an int32_t";
+        return;
+    }
+
+    uint32_t indicator_value = repeat_count_ << 1 | 0;
     bit_writer_.PutVlqInt(indicator_value);
     bit_writer_.PutAligned(current_value_, BitUtil::Ceil(bit_width_, 8));
     num_buffered_values_ = 0;

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -500,6 +500,8 @@ inline void RleEncoder<T>::FlushRepeatedRun() {
     // Don't try to handle run lengths that don't fit in an int32_t - just fail gracefully.
     // The Parquet standard does not allow longer runs - see PARQUET-1290.
     if (UNLIKELY(repeat_count_ > std::numeric_limits<int32_t>::max())) {
+        num_buffered_values_ = 0;
+        repeat_count_ = 0;
         LOG(WARNING) << "Run length don't fit in an int32_t";
         return;
     }

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -158,7 +158,7 @@ TEST(Rle, SpecificSequences) {
     }
 }
 
-TEST(Rle, ISSUE_6513_1) {
+TEST(Rle, ISSUE_6513) {
     std::vector<uint64_t> values;
 
     values.resize(0x40000000);
@@ -169,16 +169,6 @@ TEST(Rle, ISSUE_6513_1) {
     ValidateRle(values, 1, nullptr, -1);
 }
 
-TEST(Rle, ISSUE_6513_2) {
-    std::vector<uint64_t> values;
-
-    values.resize(0xFFFFFFFF);
-    for (uint32_t i = 0; i < 0xFFFFFFFF; ++i) {
-        values[i] = 0;
-    }
-
-    ValidateRle(values, 1, nullptr, -1);
-}
 
 // ValidateRle on 'num_vals' values with width 'bit_width'. If 'value' != -1, that value
 // is used, otherwise alternating values are used.

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -185,12 +185,11 @@ TEST(Rle, ISSUE_6513_2) {
 TEST(Rle, ISSUE_6513_3) {
     std::vector<uint64_t> values;
 
-    values.resize(0x70000000);
-    for (uint32_t i = 0; i < 0x70000000; ++i) {
+    values.resize(0xFFFFFFFF);
+    for (uint32_t i = 0; i < 0xFFFFFFFF; ++i) {
         values[i] = 0;
     }
 
-   
     ValidateRle(values, 1, nullptr, -1);
 }
 

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -161,28 +161,15 @@ TEST(Rle, SpecificSequences) {
 TEST(Rle, ISSUE_6513_1) {
     std::vector<uint64_t> values;
 
-    values.resize(0x40000000 - 1);
-    for (uint32_t i = 0; i < 0x40000000 - 1; ++i) {
-        values[i] = 0;
-    }
-
-    ValidateRle(values, 1, nullptr, -1);
-}
-
-
-TEST(Rle, ISSUE_6513_2) {
-    std::vector<uint64_t> values;
-
     values.resize(0x40000000);
     for (uint32_t i = 0; i < 0x40000000; ++i) {
         values[i] = 0;
     }
 
-   
     ValidateRle(values, 1, nullptr, -1);
 }
 
-TEST(Rle, ISSUE_6513_3) {
+TEST(Rle, ISSUE_6513_2) {
     std::vector<uint64_t> values;
 
     values.resize(0xFFFFFFFF);

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -158,6 +158,42 @@ TEST(Rle, SpecificSequences) {
     }
 }
 
+TEST(Rle, ISSUE_6513_1) {
+    std::vector<uint64_t> values;
+
+    values.resize(0x40000000 - 1);
+    for (uint32_t i = 0; i < 0x40000000 - 1; ++i) {
+        values[i] = 0;
+    }
+
+    ValidateRle(values, 1, nullptr, -1);
+}
+
+
+TEST(Rle, ISSUE_6513_2) {
+    std::vector<uint64_t> values;
+
+    values.resize(0x40000000);
+    for (uint32_t i = 0; i < 0x40000000; ++i) {
+        values[i] = 0;
+    }
+
+   
+    ValidateRle(values, 1, nullptr, -1);
+}
+
+TEST(Rle, ISSUE_6513_3) {
+    std::vector<uint64_t> values;
+
+    values.resize(0x70000000);
+    for (uint32_t i = 0; i < 0x70000000; ++i) {
+        values[i] = 0;
+    }
+
+   
+    ValidateRle(values, 1, nullptr, -1);
+}
+
 // ValidateRle on 'num_vals' values with width 'bit_width'. If 'value' != -1, that value
 // is used, otherwise alternating values are used.
 void TestRleValues(int bit_width, int num_vals, int value = -1) {


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6513

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when repeat_count_ >= 0x40000000, repeat_count_ << 1 | 0 is a negative number(indicator_value).
In PutVlqInt function, indicator_value >>= 7 is a logical right move, it will move the right 7 value out
and append 1 at the beginning of the number, finally lead to a dead loop.
