### PR TITLE
[Bugfix] Implement hashCode for Type derived classes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1031,7 +1031,8 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     @Override
     public int hashCode() {
         // in group by clause, group by list need to remove duplicate exprs, the expr may be not not analyzed, the id
-        // may be null
+        // may be null.
+        // NOTE that all the types of the related member variables must implement hashCode() and equals().
         if (id == null) {
             int result = 31 * Objects.hashCode(type) + Objects.hashCode(opcode);
             for (Expr child : children) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
@@ -80,6 +81,11 @@ public class ArrayType extends Type {
         }
         ArrayType otherArrayType = (ArrayType) other;
         return otherArrayType.itemType.equals(itemType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(itemType);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1210,4 +1210,20 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 18: expr");
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
+
+    @Test
+    public void testAggregateDuplicatedExprs() throws Exception {
+        String plan = getFragmentPlan("SELECT " +
+                "sum(arrays_overlap(v3, [1])) as q1, " +
+                "sum(arrays_overlap(v3, [1])) as q2, " +
+                "sum(arrays_overlap(v3, [1])) as q3 FROM tarray;");
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(4: arrays_overlap)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 4> : arrays_overlap(3: v3, CAST(ARRAY<tinyint(4)>[1] AS ARRAY<BIGINT>))\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6518.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- When analyzing aggregates, it uses `List<Expr>` and `Expr::equals()` to deduplicate the duplicated aggregate expressions.
- class `ExpressionMapping` uses `HashMap<Expr, ColumnRefOperator>`. 

However ,`ArrayType`  only implements `equals()` not `hashCode()`, which causes the duplicated expression cannot find its corresponding operators.

