### PR TITLE
[Bugfix] Fix bug CTAS with union all failed in 2.1.x version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -60,7 +60,10 @@ public class CTASAnalyzer {
         Map<String, Table> tableRefToTable = Maps.newHashMap();
 
         // For replication_num, we select the maximum value of all tables replication_num
-        int defaultReplicationNum = getReplicationNumAndGenTableRef((SelectStmt) queryStmt, tableRefToTable);
+        int defaultReplicationNum = 1;
+        if (queryStmt instanceof SelectStmt) {
+            defaultReplicationNum = getReplicationNumAndGenTableRef((SelectStmt) queryStmt, tableRefToTable);
+        }
 
         List<Field> allFields = queryRelation.getRelationFields().getAllFields();
         List<String> finalColumnNames = Lists.newArrayList();
@@ -143,10 +146,12 @@ public class CTASAnalyzer {
             String[] aliases = tableRef.getAliases();
             if (tableRef instanceof InlineViewRef) {
                 InlineViewRef inlineViewRef = (InlineViewRef) tableRef;
-                int detectReplicateNum = getReplicationNumAndGenTableRef((SelectStmt) inlineViewRef.getViewStmt(),
-                        tableRefToTable);
-                if (detectReplicateNum > defaultReplicationNum) {
-                    defaultReplicationNum = detectReplicateNum;
+                if (inlineViewRef.getViewStmt() instanceof SelectStmt) {
+                    int detectReplicateNum = getReplicationNumAndGenTableRef((SelectStmt) inlineViewRef.getViewStmt(),
+                            tableRefToTable);
+                    if (detectReplicateNum > defaultReplicationNum) {
+                        defaultReplicationNum = detectReplicateNum;
+                    }
                 }
             } else {
                 Table table = catalog.getDb(tableRef.getName().getDb()).getTable(tableRef.getName().getTbl());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -342,6 +342,15 @@ public class CTASAnalyzerTest {
         String ctasSql2 = "CREATE TABLE v2 as select NULL from t2";
         CreateTableAsSelectStmt createTableStmt2 = (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewAnalyzer(ctasSql2, ctx);
 
+        String ctasSql4 = "create table test_union_all as select * from \n" +
+                "(select * from (select 1 as k1) a\n" +
+                "left join (select 1 as k2) b\n" +
+                "on b.k2=a.k1\n" +
+                "union all\n" +
+                "select 2 as k1, 3 as k2\n" +
+                ")aa";
+        CreateTableAsSelectStmt createTableStmt4 = (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewAnalyzer(ctasSql4, ctx);
+
     }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6564

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This because CTAS not consider union all cast to SetOperationStmt
This only affects 2.1.x and will not affect versions after 2.2