### PR TITLE
[BugFix] Add CloneOperator clone method and reduce genergate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CloneOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CloneOperator.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class CloneOperator extends ScalarOperator {
-    private final List<ScalarOperator> arguments;
+    private List<ScalarOperator> arguments;
 
     public CloneOperator(ScalarOperator argument) {
         super(OperatorType.CLONE, argument.getType());
@@ -60,5 +60,15 @@ public class CloneOperator extends ScalarOperator {
     @Override
     public ColumnRefSet getUsedColumns() {
         return arguments.get(0).getUsedColumns();
+    }
+
+    @Override
+    public ScalarOperator clone() {
+        CloneOperator operator = (CloneOperator) super.clone();
+        // Deep copy here
+        List<ScalarOperator> newArguments = Lists.newArrayList();
+        this.arguments.forEach(p -> newArguments.add(p.clone()));
+        operator.arguments = newArguments;
+        return operator;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -9,12 +9,12 @@ import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.CloneExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
-import com.starrocks.analysis.FunctionParams;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.TreeNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
@@ -326,20 +326,15 @@ class QueryTransformer {
         // after: select sum(clone(a)) from xx group by rollup(a);
         if (groupingSetsList != null) {
             for (Expr groupBy : groupByExpressions) {
-                aggregates.forEach(f -> f.getParams().exprs()
-                        .replaceAll(root -> replaceExprBottomUp(root, groupBy, new CloneExpr(groupBy))));
                 aggregates.replaceAll(
                         root -> (FunctionCallExpr) replaceExprBottomUp(root, groupBy, new CloneExpr(groupBy)));
             }
         }
 
         ImmutableList.Builder<Expr> arguments = ImmutableList.builder();
-        aggregates.stream().map(FunctionCallExpr::getParams)
-                .filter(e -> !(e.isStar()))
-                .map(FunctionParams::exprs)
-                .flatMap(List::stream)
-                .filter(e -> !(e.isConstant()))
-                .forEach(arguments::add);
+        aggregates.stream().filter(f -> !f.getParams().isStar())
+                .map(TreeNode::getChildren).flatMap(List::stream)
+                .filter(e -> !(e.isConstant())).forEach(arguments::add);
 
         Iterable<Expr> inputs = Iterables.concat(groupByExpressions, arguments.build());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2278,6 +2278,7 @@ public class PlanFragmentBuilder {
                             .collect(Collectors.toList()),
                     Arrays.stream(physicalTableFunction.getFnResultColumnRefSet().getColumnIds()).boxed()
                             .collect(Collectors.toList()));
+            tableFunctionNode.computeStatistics(optExpression.getStatistics());
             tableFunctionNode.setLimit(physicalTableFunction.getLimit());
             inputFragment.setPlanRoot(tableFunctionNode);
             return inputFragment;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -274,8 +274,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimal32Stddev() throws Exception {
         String sql = "select stddev(col_decimal32p9s2) from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet =
-                "stddev[(cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))); args: DECIMAL128; result: DECIMAL128(38,9)";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -283,8 +282,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimal32Variance() throws Exception {
         String sql = "select variance(col_decimal32p9s2) from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet =
-                "variance[(cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))); args: DECIMAL128; result: DECIMAL128(38,9)";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))";
         Assert.assertTrue(plan.contains(snippet));
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6574

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Two bug:
1. CloneOperator doesn't override clone method, the children of CloneOperator is shallow copy, will modify origin object when rewrite operator in physical rule.

2. AggregateFunction build project from Fn's children, but build expression mapping from Fn's params,  but there may same object(some special function), then rewrite clone operator will modify twice.