### PR TITLE
[cherry-pick][branch-2.2][BugFix] `get_json_string` parse json field in non-string type as string #6449

### DIFF
--- a/be/src/exprs/vectorized/json_functions.h
+++ b/be/src/exprs/vectorized/json_functions.h
@@ -186,6 +186,15 @@ public:
     }
 
 private:
+#define APPEND_NULL_AND_RETURN_IF_ERROR(builder, err) \
+    do {                                              \
+        const simdjson::error_code& e = err;          \
+        if (UNLIKELY(e)) {                            \
+            builder.append_null();                    \
+            return;                                   \
+        }                                             \
+    } while (false)
+
     static Status _get_parsed_paths(const std::vector<std::string>& path_exprs,
                                     std::vector<SimpleJsonPath>* parsed_paths);
 

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -164,6 +164,68 @@ TEST_F(JsonFunctionsTest, get_json_stringTest) {
                         .ok());
 }
 
+TEST_F(JsonFunctionsTest, get_json_string_casting) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto strings = BinaryColumn::create();
+    auto strings2 = BinaryColumn::create();
+
+    std::string values[] = {
+            R"({"k1":    1})",          //int, 1 key
+            R"({"k1":    1, "k2": 2})", // 2 keys, get the former
+            R"({"k0":    0, "k1": 1})", // 2 keys, get  the latter
+
+            R"({"k1":    3.14159})",                 //double, 1 key
+            R"({"k0":    2.71828, "k1":  3.14159})", // 2 keys, get  the former
+            R"({"k1":    3.14159, "k2":  2.71828})", // 2 keys, get  the latter
+
+            R"({"k1":    "{\"k11\":       \"v11\"}"})",                                        //string, 1 key
+            R"({"k0":    "{\"k01\":       \"v01\"}",  "k1":     "{\"k11\":       \"v11\"}"})", // 2 keys, get  the former
+            R"({"k1":    "{\"k11\":       \"v11\"}",  "k2":     "{\"k21\": \"v21\"}"})", // 2 keys, get  the latter
+
+            R"({"k1":    {"k11":       "v11"}})",                             //object, 1 key
+            R"({"k0":    {"k01":       "v01"},  "k1":     {"k11": "v11"}})",  // 2 keys, get  the former
+            R"({"k1":    {"k11":       "v11"},  "k2":     {"k21": "v21"}})"}; // 2 keys, get  the latter
+
+    std::string strs[] = {"$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1",
+                          "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1"};
+    std::string length_strings[] = {"1",
+                                    "1",
+                                    "1",
+                                    "3.14159",
+                                    "3.14159",
+                                    "3.14159",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})"};
+
+    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        strings->append(values[j]);
+        strings2->append(strs[j]);
+    }
+
+    columns.emplace_back(strings);
+    columns.emplace_back(strings2);
+
+    ctx.get()->impl()->set_constant_columns(columns);
+    ASSERT_TRUE(JsonFunctions::json_path_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+
+    ColumnPtr result = JsonFunctions::get_json_string(ctx.get(), columns);
+
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        ASSERT_EQ(length_strings[j], v->get_data()[j].to_string());
+    }
+
+    ASSERT_TRUE(JsonFunctions::json_path_close(ctx.get(),
+                                               FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+}
+
 TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());


### PR DESCRIPTION
This the backport of #6449 to branch-2.2.