### PR TITLE
[cherry-pick][branch-2.1][BugFix] `get_json_string` parse json field in non-string type as string #6449

### DIFF
--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -301,43 +301,51 @@ ColumnPtr JsonFunctions::_iterate_rows(FunctionContext* context, const Columns& 
     return result.build(ColumnHelper::is_all_const(columns));
 } // namespace starrocks::vectorized
 
-template <PrimitiveType primitive_type>
-void JsonFunctions::_build_column(ColumnBuilder<primitive_type>& result, simdjson::ondemand::value& value) {
-    if constexpr (primitive_type == TYPE_INT) {
-        int64_t i64;
-        auto err = value.get_int64().get(i64);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_INT>& result, simdjson::ondemand::value& value) {
+    int64_t i64;
+    auto err = value.get_int64().get(i64);
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
-        result.append(i64);
-        return;
+    result.append(i64);
+    return;
+}
 
-    } else if constexpr (primitive_type == TYPE_DOUBLE) {
-        double d;
-        auto err = value.get_double().get(d);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_DOUBLE>& result, simdjson::ondemand::value& value) {
+    double d;
+    auto err = value.get_double().get(d);
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
-        result.append(d);
-        return;
+    result.append(d);
+    return;
+}
 
-    } else if constexpr (primitive_type == TYPE_VARCHAR) {
+template <>
+void JsonFunctions::_build_column(ColumnBuilder<TYPE_VARCHAR>& result, simdjson::ondemand::value& value) {
+    simdjson::ondemand::json_type tp;
+    auto err = value.type().get(tp);
+    APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
+
+    if (tp == simdjson::ondemand::json_type::string) {
         std::string_view sv;
         auto err = value.get_string().get(sv);
-        if (UNLIKELY(err)) {
-            result.append_null();
-            return;
-        }
+        APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
 
         result.append(Slice{sv.data(), sv.size()});
-        return;
     } else {
-        result.append_null();
+        // For compatible consideration, format json in non-string type as string.
+        std::string_view sv = simdjson::to_json_string(value);
+        std::unique_ptr<char[]> buf{new char[sv.size()]};
+        size_t new_length{};
+
+        auto err = simdjson::minify(sv.data(), sv.size(), buf.get(), new_length);
+        APPEND_NULL_AND_RETURN_IF_ERROR(result, err);
+
+        result.append(Slice{buf.get(), new_length});
     }
+
+    return;
 }
 
 ColumnPtr JsonFunctions::get_json_int(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/vectorized/json_functions.h
+++ b/be/src/exprs/vectorized/json_functions.h
@@ -117,6 +117,15 @@ public:
     }
 
 private:
+#define APPEND_NULL_AND_RETURN_IF_ERROR(builder, err) \
+    do {                                              \
+        const simdjson::error_code& e = err;          \
+        if (UNLIKELY(e)) {                            \
+            builder.append_null();                    \
+            return;                                   \
+        }                                             \
+    } while (false)
+
     static Status _get_parsed_paths(const std::vector<std::string>& path_exprs, std::vector<JsonPath>* parsed_paths);
 
     /* Following functions are only used in test. */

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -156,6 +156,68 @@ TEST_F(JsonFunctionsTest, get_json_stringTest) {
                         .ok());
 }
 
+TEST_F(JsonFunctionsTest, get_json_string_casting) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto strings = BinaryColumn::create();
+    auto strings2 = BinaryColumn::create();
+
+    std::string values[] = {
+            R"({"k1":    1})",          //int, 1 key
+            R"({"k1":    1, "k2": 2})", // 2 keys, get the former
+            R"({"k0":    0, "k1": 1})", // 2 keys, get  the latter
+
+            R"({"k1":    3.14159})",                 //double, 1 key
+            R"({"k0":    2.71828, "k1":  3.14159})", // 2 keys, get  the former
+            R"({"k1":    3.14159, "k2":  2.71828})", // 2 keys, get  the latter
+
+            R"({"k1":    "{\"k11\":       \"v11\"}"})",                                        //string, 1 key
+            R"({"k0":    "{\"k01\":       \"v01\"}",  "k1":     "{\"k11\":       \"v11\"}"})", // 2 keys, get  the former
+            R"({"k1":    "{\"k11\":       \"v11\"}",  "k2":     "{\"k21\": \"v21\"}"})", // 2 keys, get  the latter
+
+            R"({"k1":    {"k11":       "v11"}})",                             //object, 1 key
+            R"({"k0":    {"k01":       "v01"},  "k1":     {"k11": "v11"}})",  // 2 keys, get  the former
+            R"({"k1":    {"k11":       "v11"},  "k2":     {"k21": "v21"}})"}; // 2 keys, get  the latter
+
+    std::string strs[] = {"$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1",
+                          "$.k1", "$.k1", "$.k1", "$.k1", "$.k1", "$.k1"};
+    std::string length_strings[] = {"1",
+                                    "1",
+                                    "1",
+                                    "3.14159",
+                                    "3.14159",
+                                    "3.14159",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":       "v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})",
+                                    R"({"k11":"v11"})"};
+
+    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        strings->append(values[j]);
+        strings2->append(strs[j]);
+    }
+
+    columns.emplace_back(strings);
+    columns.emplace_back(strings2);
+
+    ctx.get()->impl()->set_constant_columns(columns);
+    ASSERT_TRUE(JsonFunctions::json_path_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+
+    ColumnPtr result = JsonFunctions::get_json_string(ctx.get(), columns);
+
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        ASSERT_EQ(length_strings[j], v->get_data()[j].to_string());
+    }
+
+    ASSERT_TRUE(JsonFunctions::json_path_close(ctx.get(),
+                                               FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+}
+
 TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());


### PR DESCRIPTION
This is the backport of #6449 to branch-2.1.