### PR TITLE
[StarRocks On ES] BE crash when doc do not have some field in doc-value-scan mode

### DIFF
--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -228,7 +228,7 @@ Status ScrollParser::fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line
             if (has_col) {
                 const rapidjson::Value& col = line[col_name];
                 // doc value
-                bool is_null = (pure_doc_value && col.IsArray() && col[0].IsNull()) || col.IsNull();
+                bool is_null = col.IsNull() || (pure_doc_value && col.IsArray() && (col.Empty() || col[0].IsNull()));
                 if (!is_null) {
                     // append value from ES to column
                     RETURN_IF_ERROR(


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6577

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 
when some fields do not exists in document, when fetch the value from `doc_value` would return an empty array, and BE es_scroll_parser do not take this into account, which result in null pointer exception