### PR TITLE
Fix BE Crash in CrossJoin RuntimeFilter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -158,23 +158,26 @@ public class CrossJoinNode extends PlanNode implements RuntimeFilterBuildNode {
                     continue;
                 }
 
+                if (!right.isBoundByTupleIds(getChild(1).getTupleIds())) {
+                    continue;
+                }
+
                 RuntimeFilterDescription rf = new RuntimeFilterDescription(sessionVariable);
                 rf.setFilterId(generator.getNextId().asInt());
                 rf.setBuildPlanNodeId(getId().asInt());
                 rf.setExprOrder(i);
                 rf.setJoinMode(distributionMode);
                 rf.setBuildCardinality(buildStageNode.getCardinality());
-                rf.setOnlyLocal(false);
+                rf.setOnlyLocal(true);
 
                 rf.setBuildExpr(right);
-                boolean accept = this.getChildren().get(0).pushDownRuntimeFilters(rf, left);
+                boolean accept = getChild(0).pushDownRuntimeFilters(rf, left);
                 if (accept) {
                     this.getBuildRuntimeFilters().add(rf);
                 }
             }
         }
     }
-
 
     @Override
     public int getNumInstances() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #6556

## Problem Summary(Required) ：
when conjuncts has a reference for left child column, we shouldn't build RF for CrossJoin.
