### PR TITLE
[BugFix] Fix bug timezone for Spark Load does not work

### DIFF
--- a/be/src/exec/vectorized/parquet_reader.cpp
+++ b/be/src/exec/vectorized/parquet_reader.cpp
@@ -234,45 +234,6 @@ const std::shared_ptr<arrow::RecordBatch>& ParquetReaderWrap::get_batch() {
     return _batch;
 }
 
-Status ParquetReaderWrap::handle_timestamp(const std::shared_ptr<arrow::TimestampArray>& ts_array, uint8_t* buf,
-                                           int32_t* wbytes) {
-    const auto type = std::dynamic_pointer_cast<arrow::TimestampType>(ts_array->type());
-    // StarRocks only supports seconds
-    int64_t timestamp = 0;
-    switch (type->unit()) {
-    case arrow::TimeUnit::type::NANO: {                                    // INT96
-        timestamp = ts_array->Value(_current_line_of_batch) / 1000000000L; // convert to Second
-        break;
-    }
-    case arrow::TimeUnit::type::SECOND: {
-        timestamp = ts_array->Value(_current_line_of_batch);
-        break;
-    }
-    case arrow::TimeUnit::type::MILLI: {
-        timestamp = ts_array->Value(_current_line_of_batch) / 1000; // convert to Second
-        break;
-    }
-    case arrow::TimeUnit::type::MICRO: {
-        timestamp = ts_array->Value(_current_line_of_batch) / 1000000; // convert to Second
-        break;
-    }
-    default:
-        return Status::InternalError("Invalid Time Type.");
-    }
-
-    DateTimeValue dtv;
-    if (!dtv.from_unixtime(timestamp, _timezone)) {
-        std::stringstream str_error;
-        str_error << "Parse timestamp (" + std::to_string(timestamp) + ") error";
-        LOG(WARNING) << str_error.str();
-        return Status::InternalError(str_error.str());
-    }
-    char* buf_end = (char*)buf;
-    buf_end = dtv.to_string((char*)buf_end);
-    *wbytes = buf_end - (char*)buf - 1;
-    return Status::OK();
-}
-
 // ====================================================================================================================
 ParquetChunkReader::ParquetChunkReader(std::shared_ptr<ParquetReaderWrap>&& parquet_reader,
                                        const std::vector<SlotDescriptor*>& src_slot_desc, std::string time_zone)

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -36,7 +36,9 @@ Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TPushR
     fragment_params.protocol_version = InternalServiceVersion::V1;
     TQueryOptions query_options;
     TQueryGlobals query_globals;
-    query_globals.__set_time_zone(request.time_zone);
+    if (request.__isset.timezone) {
+        query_globals.__set_time_zone(request.timezone);
+    }
     _runtime_state =
             std::make_unique<RuntimeState>(fragment_params.params.query_id, fragment_params.params.fragment_instance_id,
                                            query_options, query_globals, ExecEnv::GetInstance());

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -23,7 +23,7 @@ PushBrokerReader::~PushBrokerReader() {
     _scanner.reset();
 }
 
-Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TDescriptorTable& t_desc_tbl) {
+Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TPushReq& request) {
     // init runtime state, runtime profile, counter
     TUniqueId dummy_id;
     dummy_id.hi = 0;
@@ -36,13 +36,14 @@ Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TDescr
     fragment_params.protocol_version = InternalServiceVersion::V1;
     TQueryOptions query_options;
     TQueryGlobals query_globals;
+    query_globals.__set_time_zone(request.time_zone);
     _runtime_state =
             std::make_unique<RuntimeState>(fragment_params.params.query_id, fragment_params.params.fragment_instance_id,
                                            query_options, query_globals, ExecEnv::GetInstance());
 
     DescriptorTbl* desc_tbl = nullptr;
     RETURN_IF_ERROR(
-            DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl, config::vector_chunk_size));
+            DescriptorTbl::create(_runtime_state->obj_pool(), request.desc_tbl, &desc_tbl, config::vector_chunk_size));
     _runtime_state->set_desc_tbl(desc_tbl);
 
     _runtime_profile = _runtime_state->runtime_profile();
@@ -555,7 +556,7 @@ Status PushHandler::_load_convert(const TabletSharedPtr& cur_tablet, RowsetShare
             t_scan_range.ranges[0].__set_start_offset(0);
             t_scan_range.ranges[0].__set_size(_request.broker_scan_range.ranges[0].file_size);
         }
-        st = reader->init(t_scan_range, _request.desc_tbl);
+        st = reader->init(t_scan_range, _request);
         if (!st.ok()) {
             LOG(WARNING) << "fail to init reader. res=" << st.to_string() << ", tablet=" << cur_tablet->full_name();
             return st;

--- a/be/src/storage/push_handler.h
+++ b/be/src/storage/push_handler.h
@@ -24,7 +24,7 @@ public:
     PushBrokerReader() = default;
     ~PushBrokerReader();
 
-    Status init(const TBrokerScanRange& t_scan_range, const TDescriptorTable& t_desc_tbl);
+    Status init(const TBrokerScanRange& t_scan_range, const TPushReq& request);
     Status next_chunk(ChunkPtr* chunk);
 
     void print_profile();

--- a/be/test/storage/push_handler_test.cpp
+++ b/be/test/storage/push_handler_test.cpp
@@ -304,6 +304,9 @@ TEST_F(PushHandlerTest, PushBrokerReaderNormal) {
     range.file_type = TFileType::FILE_LOCAL;
     broker_scan_range.ranges.push_back(range);
 
+    TPushReq request;
+    request.__set_desc_tbl(_t_desc_table);
+
     // data
     // k1_int k2_smallint varchar bigint
     // 0           0       a0      0
@@ -311,7 +314,7 @@ TEST_F(PushHandlerTest, PushBrokerReaderNormal) {
     // 1           4       a2      6
     PushBrokerReader reader;
     Schema schema = _create_schema();
-    reader.init(broker_scan_range, _t_desc_table);
+    reader.init(broker_scan_range, request);
     ChunkPtr chunk = ChunkHelper::new_chunk(schema, 0);
 
     // next chunk

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1075,33 +1075,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("No key column left. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
             }
 
-            // 4. check distribution key:
-            DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
-            if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                List<Column> distributionColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
-                for (Column distributionCol : distributionColumns) {
-                    boolean found = false;
-                    for (Column alterColumn : alterSchema) {
-                        if (alterColumn.nameEquals(distributionCol.getName(), true)) {
-                            // 3.1 distribution column cannot be modified
-                            if (!alterColumn.equals(distributionCol)) {
-                                throw new DdlException("Can not modify distribution column["
-                                        + distributionCol.getName() + "]. index["
-                                        + olapTable.getIndexNameById(alterIndexId) + "]");
-                            }
-                            found = true;
-                            break;
-                        }
-                    } // end for alterColumns
-
-                    if (!found && alterIndexId == olapTable.getBaseIndexId()) {
-                        // 2.2 distribution column cannot be deleted.
-                        throw new DdlException("Distribution column[" + distributionCol.getName()
-                                + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                    }
-                } // end for distributionCols
-            }
-
             // 2. check compatible
             for (Column alterColumn : alterSchema) {
                 for (Column oriColumn : originSchema) {
@@ -1144,7 +1117,32 @@ public class SchemaChangeHandler extends AlterHandler {
                 } // end for partitionColumns
             }
 
+            // 4. check distribution key:
+            DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
+            if (distributionInfo.getType() == DistributionInfoType.HASH) {
+                List<Column> distributionColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
+                for (Column distributionCol : distributionColumns) {
+                    boolean found = false;
+                    for (Column alterColumn : alterSchema) {
+                        if (alterColumn.nameEquals(distributionCol.getName(), true)) {
+                            // 3.1 distribution column cannot be modified
+                            if (!alterColumn.equals(distributionCol)) {
+                                throw new DdlException("Can not modify distribution column["
+                                        + distributionCol.getName() + "]. index["
+                                        + olapTable.getIndexNameById(alterIndexId) + "]");
+                            }
+                            found = true;
+                            break;
+                        }
+                    } // end for alterColumns
 
+                    if (!found && alterIndexId == olapTable.getBaseIndexId()) {
+                        // 2.2 distribution column cannot be deleted.
+                        throw new DdlException("Distribution column[" + distributionCol.getName()
+                                + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
+                    }
+                } // end for distributionCols
+            }
 
             // 5. calc short key
             short newShortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -519,7 +519,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                                 0, id, TPushType.LOAD_V2,
                                                 TPriority.NORMAL, transactionId, taskSignature,
                                                 tBrokerScanRange, params.tDescriptorTable,
-                                                params.useVectorized);
+                                                params.useVectorized, timezone);
                                         if (AgentTaskQueue.addTask(pushTask)) {
                                             batchTask.addTask(pushTask);
                                             if (!tabletToSentReplicaPushTask.containsKey(tabletId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -122,7 +122,7 @@ public class PushTask extends AgentTask {
         if (taskType == TTaskType.REALTIME_PUSH) {
             request.setPartition_id(partitionId);
             request.setTransaction_id(transactionId);
-            request.setTime_zone(timeZone);
+            request.setTimezone(timeZone);
         }
         request.setIs_schema_changing(isSchemaChanging);
         switch (pushType) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -68,7 +68,7 @@ public class PushTask extends AgentTask {
     private TBrokerScanRange tBrokerScanRange;
     private TDescriptorTable tDescriptorTable;
     private boolean useVectorized;
-    private String timeZone;
+    private String timezone;
 
     public PushTask(TResourceInfo resourceInfo, long backendId, long dbId, long tableId, long partitionId,
                     long indexId, long tabletId, long replicaId, int schemaHash, long version,
@@ -107,14 +107,14 @@ public class PushTask extends AgentTask {
     public PushTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
                     long replicaId, int schemaHash, int timeoutSecond, long loadJobId, TPushType pushType,
                     TPriority priority, long transactionId, long signature, TBrokerScanRange tBrokerScanRange,
-                    TDescriptorTable tDescriptorTable, boolean useVectorized, String timeZone) {
+                    TDescriptorTable tDescriptorTable, boolean useVectorized, String timezone) {
         this(null, backendId, dbId, tableId, partitionId, indexId,
                 tabletId, replicaId, schemaHash, -1, timeoutSecond, loadJobId, pushType, null,
                 priority, TTaskType.REALTIME_PUSH, transactionId, signature);
         this.tBrokerScanRange = tBrokerScanRange;
         this.tDescriptorTable = tDescriptorTable;
         this.useVectorized = useVectorized;
-        this.timeZone = timeZone;
+        this.timezone = timezone;
     }
 
     public TPushReq toThrift() {
@@ -122,7 +122,7 @@ public class PushTask extends AgentTask {
         if (taskType == TTaskType.REALTIME_PUSH) {
             request.setPartition_id(partitionId);
             request.setTransaction_id(transactionId);
-            request.setTimezone(timeZone);
+            request.setTimezone(timezone);
         }
         request.setIs_schema_changing(isSchemaChanging);
         switch (pushType) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -68,6 +68,7 @@ public class PushTask extends AgentTask {
     private TBrokerScanRange tBrokerScanRange;
     private TDescriptorTable tDescriptorTable;
     private boolean useVectorized;
+    private String timeZone;
 
     public PushTask(TResourceInfo resourceInfo, long backendId, long dbId, long tableId, long partitionId,
                     long indexId, long tabletId, long replicaId, int schemaHash, long version,
@@ -106,13 +107,14 @@ public class PushTask extends AgentTask {
     public PushTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
                     long replicaId, int schemaHash, int timeoutSecond, long loadJobId, TPushType pushType,
                     TPriority priority, long transactionId, long signature, TBrokerScanRange tBrokerScanRange,
-                    TDescriptorTable tDescriptorTable, boolean useVectorized) {
+                    TDescriptorTable tDescriptorTable, boolean useVectorized, String timeZone) {
         this(null, backendId, dbId, tableId, partitionId, indexId,
                 tabletId, replicaId, schemaHash, -1, timeoutSecond, loadJobId, pushType, null,
                 priority, TTaskType.REALTIME_PUSH, transactionId, signature);
         this.tBrokerScanRange = tBrokerScanRange;
         this.tDescriptorTable = tDescriptorTable;
         this.useVectorized = useVectorized;
+        this.timeZone = timeZone;
     }
 
     public TPushReq toThrift() {
@@ -120,6 +122,7 @@ public class PushTask extends AgentTask {
         if (taskType == TTaskType.REALTIME_PUSH) {
             request.setPartition_id(partitionId);
             request.setTransaction_id(transactionId);
+            request.setTime_zone(timeZone);
         }
         request.setIs_schema_changing(isSchemaChanging);
         switch (pushType) {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -136,7 +136,7 @@ struct TPushReq {
 
     30: optional bool use_vectorized
     // 31 are used by spark load
-    31: optional string time_zone
+    31: optional string timezone
 }
 
 struct TCloneReq {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -135,6 +135,8 @@ struct TPushReq {
     15: optional Descriptors.TDescriptorTable desc_tbl
 
     30: optional bool use_vectorized
+    // 31 are used by spark load
+    31: optional string time_zone
 }
 
 struct TCloneReq {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6592

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is because BE's default Timezone is +8 and spark load use realtime push but does not handle timezone.
but spark will load JVM properties to set timezone and convert timezone to UTC time.
If the machine's system timezone is UTC be will +8 time to deal with.
If the machine's system timezone is +8 spark will -8 time and be will +8 so the time is same.

