### PR TITLE
[BugFix] fix #6605: thread safety of workgroup queue

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -119,6 +119,8 @@ void QuerySharedDriverQueue::cancel(DriverRawPtr driver) {
 }
 
 size_t QuerySharedDriverQueue::size() const {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
     size_t size = 0;
     for (const auto& sub_queue : _queues) {
         size += sub_queue.size();
@@ -127,6 +129,8 @@ size_t QuerySharedDriverQueue::size() const {
 }
 
 void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
     _queues[driver->get_driver_queue_level()].update_accu_time(driver);
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -373,6 +373,9 @@ void DriverQueueWithWorkGroup::update_statistics(const DriverRawPtr driver) {
 }
 
 size_t DriverQueueWithWorkGroup::size() const {
+    // TODO: reduce the lock scope
+    std::unique_lock<std::mutex> lock(_global_mutex);
+
     size_t size = 0;
     for (auto wg : _ready_wgs) {
         size += wg->driver_queue()->size();

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -210,7 +210,7 @@ private:
     // The ideal runtime of a work group is the weighted average of the schedule period.
     int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);
 
-    std::mutex _global_mutex;
+    mutable std::mutex _global_mutex;
     std::condition_variable _cv;
     // _ready_wgs contains the workgroups which include the drivers need to be run.
     std::unordered_set<workgroup::WorkGroup*> _ready_wgs;

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -123,7 +123,7 @@ private:
     // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns.
     int64_t _level_time_slices[QUEUE_SIZE];
 
-    std::mutex _global_mutex;
+    mutable std::mutex _global_mutex;
     std::condition_variable _cv;
     bool _is_closed = false;
 };


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6605

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`DriverQueueWithWorkGroup::size` could be accessed from two thread: executor thread and metric thread, but without a lock, which is not safe.