### PR TITLE
[BugFix] this.wait -> thread.sleep to avoid discontinuous journal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -161,7 +161,7 @@ public class BDBJEJournal implements Journal {
                 } catch (DatabaseException e) {
                     LOG.error("catch an exception when writing to database. sleep and retry. journal id {}", id, e);
                     try {
-                        this.wait(5 * 1000);
+                        Thread.sleep(5 * 1000);
                     } catch (InterruptedException e1) {
                         e1.printStackTrace();
                     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This bug is introduced in https://github.com/StarRocks/starrocks/pull/4364

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the above PR, sonar suggests we change `Thread.sleep()` to `this.wait()` on failure in BDBJEJournal.write().
As a result, if one thread failed to write a journal, write() will give out the lock and wait, while other threads had the chance to get the lock and write the next journal, which lead to a discontinuous journal.
We should fix it by changing it back.