### PR TITLE
[BugFix]Fix NoSuchElementException from query hive partition table, which has no partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -190,7 +190,7 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> matches = Sets.newHashSet();
         TreeMap<LiteralExpr, Set<Long>> partitionValueMap = columnToPartitionValuesMap.get(leftChild);
         Set<Long> nullPartitions = columnToNullPartitions.get(leftChild);
-        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.size() == 0) {
+        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.isEmpty()) {
             return null;
         }
 
@@ -307,7 +307,7 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> matches = Sets.newHashSet();
         TreeMap<LiteralExpr, Set<Long>> partitionValueMap = columnToPartitionValuesMap.get(child);
         Set<Long> nullPartitions = columnToNullPartitions.get(child);
-        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.size() == 0) {
+        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.isEmpty()) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -190,7 +190,7 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> matches = Sets.newHashSet();
         TreeMap<LiteralExpr, Set<Long>> partitionValueMap = columnToPartitionValuesMap.get(leftChild);
         Set<Long> nullPartitions = columnToNullPartitions.get(leftChild);
-        if (partitionValueMap == null || nullPartitions == null) {
+        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.size() == 0) {
             return null;
         }
 
@@ -307,7 +307,7 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> matches = Sets.newHashSet();
         TreeMap<LiteralExpr, Set<Long>> partitionValueMap = columnToPartitionValuesMap.get(child);
         Set<Long> nullPartitions = columnToNullPartitions.get(child);
-        if (partitionValueMap == null || nullPartitions == null) {
+        if (partitionValueMap == null || nullPartitions == null || partitionValueMap.size() == 0) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -25,10 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 public class ListPartitionPrunerTest {
     private Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap;
@@ -368,5 +365,33 @@ public class ListPartitionPrunerTest {
                 ConstantOperator.createDatetime(LocalDateTime.of(2021, 1, 4, 0, 0, 0)))));
         Assert.assertEquals(Lists.newArrayList(), pruner.prune());
 
+    }
+
+    @Test
+    public void testBinaryPredicateWithEmptyPartition() throws AnalysisException {
+        ColumnRefOperator operator = new ColumnRefOperator(5, Type.VARCHAR, "ds", true);
+        columnToPartitionValuesMap = Maps.newHashMap();
+        columnToPartitionValuesMap.put(operator, new TreeMap<>());
+        columnToNullPartitions = new HashMap<>();
+        columnToNullPartitions.put(operator, new HashSet<>());
+        conjuncts = Lists.newArrayList();
+        conjuncts.add(new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GT, intColumn,
+                ConstantOperator.createInt(1000)));
+        pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts);
+        Assert.assertNull(pruner.prune());
+    }
+
+    @Test
+    public void testInPredicateWithEmptyPartition() throws AnalysisException {
+        ColumnRefOperator operator = new ColumnRefOperator(5, Type.VARCHAR, "ds", true);
+        columnToPartitionValuesMap = Maps.newHashMap();
+        columnToPartitionValuesMap.put(operator, new TreeMap<>());
+        columnToNullPartitions = new HashMap<>();
+        columnToNullPartitions.put(operator, new HashSet<>());
+        conjuncts = Lists.newArrayList();
+        conjuncts.add(new InPredicateOperator(false,
+                Lists.newArrayList(intColumn, ConstantOperator.createInt(1000), ConstantOperator.createInt(2000))));
+        pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts);
+        Assert.assertNull(pruner.prune());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6613

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. How the bug is triggered?
    * When user queries from hive partitioned table with partition key in where clause, optimizer rule ListPartitionPruner will prune unreachable partitions.
    * In ListPartitionPruner, Map<partition key, partition id> is stored in partitionValueMap.When execute ListPartitionPruner, optimizer needs to fetch partition id from partitionValueMap.
    * If external table has no partitions, then when optimizer fetching from partitionValueMap, will leads to NoSuchElementException.
2. Bug example:
   * Select * from ex_tbl_par where parKey>'1000';
   * Select * from ex_tbl_par where parKey in ('1000');
   * explanation
        * ex_tbl_par: only external partition table having no partitons is effected now
        * parKey: partition key of external partition table
        * where clause: the binary operator of where clause is one of follows:
            * LE("<=")
            * GE(">=")
            * LT("<")
            * GT(">")
        * in clause: InPredicateOperator has partiton key as conditions
3. Hot to fix
    * Before pruning partitions, check partitionValueMap.If partitionValueMap is null, then return null.