### PR TITLE
[Bugfix] fix #6179: check resource group property supported

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/WorkGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/WorkGroupAnalyzer.java
@@ -197,6 +197,8 @@ public class WorkGroupAnalyzer {
                 }
                 continue;
             }
+
+            throw new SemanticException("Unknown property: " + key);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/WorkGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/WorkGroupStmtTest.java
@@ -237,6 +237,28 @@ public class WorkGroupStmtTest {
     }
 
     @Test
+    public void testCreateDResourceGroupWithUnknownProperty() throws Exception {
+        String sql = "create resource group rg_unknown\n" +
+                "to\n" +
+                "    (user='rg1_user3', source_ip='192.168.4.1/24'),\n" +
+                "    (user='rg1_user4')\n" +
+                "with (\n" +
+                "    'cpu_core_limit' = '10',\n" +
+                "    'mem_limit' = '20%',\n" +
+                "    'concurrency_limit' = '11',\n" +
+                "    'type' = 'normal', \n" +
+                "    'unknown' = 'unknown'" +
+                ");";
+        try {
+            starRocksAssert.executeWorkGroupDdlSql(sql);
+            Assert.fail("should throw error");
+        } catch (Exception e) {
+            Assert.assertEquals("Unknown property: unknown", e.getMessage());
+        }
+    }
+
+
+    @Test
     public void testAlterResourceGroupDropManyClassifiers() throws Exception {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeWorkGroupShowSql("show resource groups all");


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6179

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Throw exception when create resource with unknown property.
