### PR TITLE
[Enhancement] Add audit log for TaskRun & use ttl instead of label clean

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -189,13 +189,13 @@ public class Config extends ConfigBase {
      *  for task set expire time
      */
     @ConfField(mutable = true)
-    public static int default_task_ttl = 3 * 24 * 3600;         // 3 day
+    public static int task_ttl_second = 3 * 24 * 3600;         // 3 day
 
     /**
      *  for task run set expire time
      */
     @ConfField(mutable = true)
-    public static int default_task_run_ttl = 3 * 24 * 3600;     // 3 day
+    public static int task_runs_ttl_second = 3 * 24 * 3600;     // 3 day
 
     /**
      * The max keep time of some kind of jobs.
@@ -738,17 +738,17 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int export_running_job_num_limit = 5;
     /**
-     * Limitation of the pending TaskRun.
+     * Limitation of the pending TaskRun queue length.
      * Default is 500.
      */
     @ConfField(mutable = false)
-    public static int pending_task_run_num_limit = 500;
+    public static int task_runs_queue_length = 500;
     /**
      * Limitation of the running TaskRun.
      * Default is 20.
      */
     @ConfField(mutable = false)
-    public static int running_task_run_num_limit = 20;
+    public static int task_runs_concurrency = 20;
     /**
      * Default timeout of export jobs.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -739,11 +739,16 @@ public class Config extends ConfigBase {
     public static int export_running_job_num_limit = 5;
     /**
      * Limitation of the pending TaskRun.
-     * Default is 20.
-     * 0 is unlimited
+     * Default is 500.
      */
     @ConfField(mutable = false)
-    public static int pending_task_run_num_limit = 20;
+    public static int pending_task_run_num_limit = 500;
+    /**
+     * Limitation of the running TaskRun.
+     * Default is 20.
+     */
+    @ConfField(mutable = false)
+    public static int running_task_run_num_limit = 20;
     /**
      * Default timeout of export jobs.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -186,6 +186,18 @@ public class Config extends ConfigBase {
     public static int label_clean_interval_second = 4 * 3600; // 4 hours
 
     /**
+     *  for task set expire time
+     */
+    @ConfField(mutable = true)
+    public static int default_task_ttl = 3 * 24 * 3600;         // 3 day
+
+    /**
+     *  for task run set expire time
+     */
+    @ConfField(mutable = true)
+    public static int default_task_run_ttl = 3 * 24 * 3600;     // 3 day
+
+    /**
      * The max keep time of some kind of jobs.
      * like schema change job and rollup job.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.scheduler;
+
+public class Constants {
+
+    // PENDING -> RUNNING -> FAILED
+    //                    -> SUCCESS
+    public enum TaskRunState {
+        PENDING,
+        RUNNING,
+        FAILED,
+        SUCCESS,
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -22,7 +22,7 @@ import org.apache.commons.codec.binary.Hex;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-// Execute a basic task of SQL
+// Execute a basic task of SQL\
 public class SqlTaskRunProcessor implements TaskRunProcessor {
 
     @Override
@@ -109,6 +109,9 @@ public class SqlTaskRunProcessor implements TaskRunProcessor {
     }
 
     public String computeStatementDigest(StatementBase queryStmt) {
+        if (queryStmt == null) {
+            return "";
+        }
         String digest;
         if (queryStmt instanceof QueryStmt) {
             digest = ((QueryStmt) queryStmt).toDigest();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -2,22 +2,130 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.analysis.QueryStmt;
 import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.Config;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.ResourceGroupMetricMgr;
+import com.starrocks.plugin.AuditEvent;
+import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.common.SqlDigestBuilder;
 import com.starrocks.sql.parser.SqlParser;
+import org.apache.commons.codec.binary.Hex;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 // Execute a basic task of SQL
 public class SqlTaskRunProcessor implements TaskRunProcessor {
 
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
-        ConnectContext ctx = context.getCtx();
-        StatementBase sqlStmt = SqlParser.parse(context.getDefinition(), ctx.getSessionVariable().getSqlMode()).get(0);
-        StmtExecutor executor = new StmtExecutor(ctx, sqlStmt);
-        ctx.setExecutor(executor);
-        ctx.setThreadLocalInfo();
-        executor.execute();
+        StmtExecutor executor = null;
+        try {
+            ConnectContext ctx = context.getCtx();
+            ctx.getAuditEventBuilder().reset();
+            ctx.getAuditEventBuilder()
+                    .setTimestamp(System.currentTimeMillis())
+                    .setClientIp(context.getRemoteIp())
+                    .setUser(ctx.getQualifiedUser())
+                    .setDb(ctx.getDatabase());
+            ctx.getPlannerProfile().reset();
+            String definition = context.getDefinition();
+            StatementBase sqlStmt = SqlParser.parse(definition, ctx.getSessionVariable().getSqlMode()).get(0);
+            sqlStmt.setOrigStmt(new OriginStatement(definition, 0));
+            executor = new StmtExecutor(ctx, sqlStmt);
+            ctx.setExecutor(executor);
+            ctx.setThreadLocalInfo();
+            executor.execute();
+        } finally {
+            if (executor != null) {
+                auditAfterExec(context, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            } else {
+                // executor can be null if we encounter analysis error.
+                auditAfterExec(context, null, null);
+            }
+        }
     }
 
+    private void auditAfterExec(TaskRunContext context, StatementBase parsedStmt, PQueryStatistics statistics) {
+        String origStmt = context.getDefinition();
+        ConnectContext ctx = context.getCtx();
+
+        // slow query
+        long endTime = System.currentTimeMillis();
+        long elapseMs = endTime - ctx.getStartTime();
+
+        ctx.getAuditEventBuilder().setEventType(AuditEvent.EventType.AFTER_QUERY)
+                .setState(ctx.getState().toString()).setErrorCode(ctx.getErrorCode()).setQueryTime(elapseMs)
+                .setScanBytes(statistics == null ? 0 : statistics.scanBytes)
+                .setScanRows(statistics == null ? 0 : statistics.scanRows)
+                .setCpuCostNs(statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs)
+                .setMemCostBytes(statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes)
+                .setReturnRows(ctx.getReturnRows())
+                .setStmtId(ctx.getStmtId())
+                .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString());
+
+        if (ctx.getState().isQuery()) {
+            MetricRepo.COUNTER_QUERY_ALL.increase(1L);
+            ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
+            if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                // err query
+                MetricRepo.COUNTER_QUERY_ERR.increase(1L);
+                ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
+            } else {
+                // ok query
+                MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
+                MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);
+                if (elapseMs > Config.qe_slow_log_ms || ctx.getSessionVariable().isEnableSQLDigest()) {
+                    MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
+                    ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
+                }
+            }
+            ctx.getAuditEventBuilder().setIsQuery(true);
+        } else {
+            ctx.getAuditEventBuilder().setIsQuery(false);
+        }
+
+        ctx.getAuditEventBuilder().setFeIp(FrontendOptions.getLocalHostAddress());
+
+        // We put origin query stmt at the end of audit log, for parsing the log more convenient.
+        if (!ctx.getState().isQuery() && (parsedStmt != null && parsedStmt.needAuditEncryption())) {
+            ctx.getAuditEventBuilder().setStmt(parsedStmt.toSql());
+        } else if (ctx.getState().isQuery() && containsComment(origStmt)) {
+            // avoid audit log can't replay
+            ctx.getAuditEventBuilder().setStmt(origStmt);
+        } else {
+            ctx.getAuditEventBuilder().setStmt(origStmt.replace("\n", " "));
+        }
+
+        GlobalStateMgr.getCurrentAuditEventProcessor().handleAuditEvent(ctx.getAuditEventBuilder().build());
+    }
+
+    public String computeStatementDigest(StatementBase queryStmt) {
+        String digest;
+        if (queryStmt instanceof QueryStmt) {
+            digest = ((QueryStmt) queryStmt).toDigest();
+        } else {
+            digest = SqlDigestBuilder.build(queryStmt);
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.reset();
+            md.update(digest.getBytes());
+            return Hex.encodeHexString(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            return "";
+        }
+    }
+
+    private boolean containsComment(String sql) {
+        return (sql.contains("--")) || sql.contains("#");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -32,6 +32,9 @@ public class Task implements Writable {
     @SerializedName("properties")
     private Map<String, String> properties;
 
+    @SerializedName("expireTime")
+    private long expireTime = -1;
+
     public long getId() {
         return id;
     }
@@ -78,6 +81,14 @@ public class Task implements Writable {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
+    }
+
+    public Long getExpireTime() {
+        return expireTime;
+    }
+
+    public void setExpireTime(Long expireTime) {
+        this.expireTime = expireTime;
     }
 
     public static Task read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -24,7 +24,7 @@ public class TaskBuilder {
         task.setDbName(submitTaskStmt.getDbName());
         task.setDefinition(submitTaskStmt.getSqlText());
         task.setProperties(submitTaskStmt.getProperties());
-        task.setExpireTime(System.currentTimeMillis() + Config.default_task_ttl * 1000L);
+        task.setExpireTime(System.currentTimeMillis() + Config.task_ttl_second * 1000L);
         return task;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.scheduler;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -23,6 +24,7 @@ public class TaskBuilder {
         task.setDbName(submitTaskStmt.getDbName());
         task.setDefinition(submitTaskStmt.getSqlText());
         task.setProperties(submitTaskStmt.getProperties());
+        task.setExpireTime(System.currentTimeMillis() + Config.default_task_ttl * 1000L);
         return task;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -22,7 +22,6 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SubmitTaskStmt;
-import com.starrocks.statistic.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -417,8 +417,8 @@ public class TaskManager {
         if (!tryTaskLock()) {
             return;
         }
-        List<Task> currentTask = showTasks(null);
         try {
+            List<Task> currentTask = showTasks(null);
             for (Task task : currentTask) {
                 Long expireTime = task.getExpireTime();
                 if (expireTime > 0 && currentTimeMs > expireTime) {
@@ -440,9 +440,9 @@ public class TaskManager {
         if (!tryTaskRunLock()) {
             return;
         }
-        // only SUCCESS and FAILED in taskRunHistory
-        Deque<TaskRunStatus> taskRunHistory = taskRunManager.getTaskRunHistory().getAllHistory();
         try {
+            // only SUCCESS and FAILED in taskRunHistory
+            Deque<TaskRunStatus> taskRunHistory = taskRunManager.getTaskRunHistory().getAllHistory();
             Iterator<TaskRunStatus> iterator = taskRunHistory.iterator();
             while (iterator.hasNext()) {
                 TaskRunStatus taskRunStatus = iterator.next();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Queues;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.QueryableReentrantLock;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -134,7 +134,7 @@ public class TaskRun {
         }
         status.setDbName(task.getDbName());
         status.setDefinition(task.getDefinition());
-        status.setExpireTime(System.currentTimeMillis() + Config.default_task_run_ttl * 1000L);
+        status.setExpireTime(System.currentTimeMillis() + Config.task_runs_ttl_second * 1000L);
         this.status = status;
         return status;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -4,6 +4,7 @@ package com.starrocks.scheduler;
 
 import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
@@ -95,6 +96,7 @@ public class TaskRun {
         }
         newCtx.setSessionVariable(sessionVariable);
         taskRunContext.setCtx(newCtx);
+        taskRunContext.setRemoteIp(ctx.getMysqlChannel().getRemoteHostPortString());
         processor.processTaskRun(taskRunContext);
         QueryState queryState = newCtx.getState();
         if (newCtx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
@@ -132,6 +134,7 @@ public class TaskRun {
         }
         status.setDbName(task.getDbName());
         status.setDefinition(task.getDefinition());
+        status.setExpireTime(System.currentTimeMillis() + Config.default_task_run_ttl * 1000L);
         this.status = status;
         return status;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
@@ -6,6 +6,7 @@ import com.starrocks.qe.ConnectContext;
 public class TaskRunContext {
     ConnectContext ctx;
     String definition;
+    String remoteIp;
 
 
     public ConnectContext getCtx() {
@@ -24,4 +25,11 @@ public class TaskRunContext {
         this.definition = definition;
     }
 
+    public String getRemoteIp() {
+        return remoteIp;
+    }
+
+    public void setRemoteIp(String remoteIp) {
+        this.remoteIp = remoteIp;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -3,7 +3,6 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.scheduler.persist.TaskRunStatus;
-import com.starrocks.statistic.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -42,9 +42,9 @@ public class TaskRunManager {
             return new SubmitResult(taskRun.getStatus().getQueryId(), SubmitResult.SubmitStatus.FAILED);
         }
 
-        if (pendingTaskRunMap.keySet().size() > Config.pending_task_run_num_limit) {
-            LOG.warn("pending TaskRun exceeds pending_task_run_num_limit:{}, reject the submit.",
-                    Config.pending_task_run_num_limit);
+        if (pendingTaskRunMap.keySet().size() > Config.task_runs_queue_length) {
+            LOG.warn("pending TaskRun exceeds task_runs_queue_length:{}, reject the submit.",
+                    Config.task_runs_queue_length);
             return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
         }
 
@@ -93,7 +93,7 @@ public class TaskRunManager {
                 if (taskRunQueue.size() == 0) {
                     pendingIterator.remove();
                 } else {
-                    if (currentRunning >= Config.running_task_run_num_limit) {
+                    if (currentRunning >= Config.task_runs_concurrency) {
                         break;
                     }
                     TaskRun pendingTaskRun = taskRunQueue.poll();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -9,7 +9,6 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.statistic.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.statistic.Constants;
+import com.starrocks.scheduler.Constants;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -41,6 +41,9 @@ public class TaskRunStatus implements Writable {
     @SerializedName("errorMessage")
     private String errorMessage;
 
+    @SerializedName("expireTime")
+    private long expireTime;
+
     public String getQueryId() {
         return queryId;
     }
@@ -111,6 +114,14 @@ public class TaskRunStatus implements Writable {
 
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
+    }
+
+    public long getExpireTime() {
+        return expireTime;
+    }
+
+    public void setExpireTime(long expireTime) {
+        this.expireTime = expireTime;
     }
 
     public static TaskRunStatus read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.statistic.Constants;
+import com.starrocks.scheduler.Constants;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/Constants.java
@@ -30,13 +30,4 @@ public class Constants {
         FINISH,
     }
 
-    // PENDING -> RUNNING -> FAILED
-    //                    -> SUCCESS
-    public enum TaskRunState {
-        PENDING,
-        RUNNING,
-        FAILED,
-        SUCCESS,
-    }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -8,7 +8,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SubmitTaskStmt;
-import com.starrocks.statistic.Constants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1.add audit log for TaskRun sql
2.use ttl instead of previous clean strategy
The previous Task has a binding with the Label's cleanup mechanism, and now take this parameter out.
The previous cleaning strategy was more complicated, but now it is simpler to unify into TTL. In addition, the Submit task will definitely expire. If there are other types that do not set TTL, they will never be cleaned up.
3.Optimize the submission result of Submit, and prompt Reject when the concurrent high lock acquisition fails.
separate task & taskrun lock and add config for control running taskrun and pending taskrun limit.