### PR TITLE
[BugFix] Reset _persistent_index when PrimaryIndex::unload() is called

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -862,6 +862,9 @@ void PrimaryIndex::unload() {
     if (_pkey_to_rssid_rowid) {
         _pkey_to_rssid_rowid.reset();
     }
+    if (_persistent_index) {
+        _persistent_index.reset();
+    }
     _status = Status::OK();
     _loaded = false;
 }
@@ -924,6 +927,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
         // TODO
         // PersistentIndex and tablet data are currently stored in the same directory
         // We may need to support the separation of PersistentIndex and Tablet data
+        DCHECK(_persistent_index == nullptr);
         _persistent_index = std::make_unique<PersistentIndex>(tablet->schema_hash_path());
         return _persistent_index->load_from_tablet(tablet);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6637 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If PrimaryKey Table enable persistent index, function `PrimaryIndex::unload()` should reset `_persistent_index`. If not, this can lead to unpredictable results
