### PR TITLE
[Refactor] Add log for slow database lock and fix some logging (#5453)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -121,7 +121,8 @@ public class Replica implements Writable {
     // we should ensure that all txns on this replicas are finished.
     private long watermarkTxnId = -1;
 
-    public Replica() {}
+    public Replica() {
+    }
 
     // for rollup
     // the new replica's version is -1 and last failed version is -1
@@ -256,7 +257,7 @@ public class Replica implements Writable {
     }
 
     public synchronized void updateRowCount(long newVersion, long newDataSize,
-                                               long newRowCount) {
+                                            long newRowCount) {
         updateReplicaInfo(newVersion, this.lastFailedVersion,
                 this.lastSuccessVersion, newDataSize, newRowCount);
     }
@@ -347,8 +348,8 @@ public class Replica implements Writable {
 
         // TODO: this case is unknown, add log to observe
         if (this.version > lastFailedVersion && lastFailedVersion > 0) {
-            LOG.debug("current version {} is larger than last failed version {}, "
-                            + "maybe a fatal error or be report version, print a stack here ",
+            LOG.info("current version {} is larger than last failed version {}, "
+                    + "maybe a fatal error or be report version, print a stack here ",
                     this.version, lastFailedVersion, new Exception());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1023,9 +1023,6 @@ public class TabletScheduler extends MasterDaemon {
                 replica.getBackendId());
 
         Catalog.getCurrentCatalog().getEditLog().logDeleteReplica(info);
-
-        LOG.info("delete replica. tablet id: {}, backend id: {}. reason: {}, force: {}",
-                tabletCtx.getTabletId(), replica.getBackendId(), reason, force);
     }
 
     private void sendDeleteReplicaTask(long backendId, long tabletId, int schemaHash) {
@@ -1240,7 +1237,7 @@ public class TabletScheduler extends MasterDaemon {
         long tabletId = cloneTask.getTabletId();
         TabletSchedCtx tabletCtx = takeRunningTablets(tabletId);
         if (tabletCtx == null) {
-            LOG.warn("tablet info does not exist: {}", tabletId);
+            LOG.warn("tablet info does not exist, tablet:{} backend:{}", tabletId, cloneTask.getBackendId());
             // tablet does not exist, no need to keep task.
             return true;
         }


### PR DESCRIPTION
This PR adds warning log with some debug information when db's read/write lock takes a long time to lock, this helps identify lock contention issues. Also fix a logging error in TabletScheduler.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
