### PR TITLE
[Refactor] Simplify stream_load_pipe

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -707,14 +707,11 @@ Status JsonReader::_read_and_parse_json() {
     StreamLoadPipeInputStream* stream_file = down_cast<StreamLoadPipeInputStream*>(_file->stream().get());
     {
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
-        auto st = stream_file->pipe()->read();
-        if (!st.ok()) {
-            return st.status();
-        }
-        _parser_buf = st.value();
+        ASSIGN_OR_RETURN(_parser_buf, stream_file->pipe()->read());
 
         if (_parser_buf->capacity < _parser_buf->remaining() + simdjson::SIMDJSON_PADDING) {
             // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
+            // Hence, a re-allocation is needed if the space is not enough.
             auto buf = ByteBuffer::allocate(_parser_buf->remaining() + simdjson::SIMDJSON_PADDING);
             buf->put_bytes(_parser_buf->ptr, _parser_buf->remaining());
             buf->flip();

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -108,9 +108,7 @@ private:
     // For performance reason, the simdjson parser should be reused over several files.
     //https://github.com/simdjson/simdjson/blob/master/doc/performance.md
     simdjson::ondemand::parser _simdjson_parser;
-    std::unique_ptr<uint8_t[]> _parser_buf;
-    size_t _parser_buf_sz = 0;
-    size_t _parser_buf_cap = 0;
+    ByteBufferPtr _parser_buf;
     bool _is_ndjson = false;
 
     std::unique_ptr<JsonParser> _parser;

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -51,7 +51,7 @@ public:
     }
 
     Status append_json(const char* data, size_t size, char row_delimiter) {
-        auto buf = ByteBuffer::allocate(size);
+        auto buf = ByteBuffer::allocate(size + simdjson::SIMDJSON_PADDING);
         buf->put_bytes(data, size);
         return append(std::move(buf));
     }

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -29,6 +29,7 @@
 #include "librdkafka/rdkafka.h"
 #include "runtime/message_body_sink.h"
 #include "runtime/stream_load/stream_load_pipe.h"
+#include "simdjson.h"
 
 namespace starrocks {
 

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -50,7 +50,11 @@ public:
         return st;
     }
 
-    Status append_json(const char* data, size_t size, char row_delimiter) { return append_and_flush(data, size); }
+    Status append_json(const char* data, size_t size, char row_delimiter) {
+        auto buf = ByteBuffer::allocate(size);
+        buf->put_bytes(data, size);
+        return append(std::move(buf));
+    }
 };
 
 } // end namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -107,7 +107,7 @@ public:
             DCHECK(_finished);
             return Status::EndOfFile("all data has been read");
         }
-        auto buf = _buf_queue.front();
+        auto& buf = _buf_queue.front();
         _buf_queue.pop_front();
         _buffered_bytes -= buf->limit;
         _put_cond.notify_one();

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -107,7 +107,7 @@ public:
             DCHECK(_finished);
             return Status::EndOfFile("all data has been read");
         }
-        auto buf = _buf_queue.front();
+        auto buf = std::move(_buf_queue.front());
         _buf_queue.pop_front();
         _buffered_bytes -= buf->limit;
         _put_cond.notify_one();

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -45,9 +45,9 @@ public:
         if (buf != nullptr && buf->has_remaining()) {
             std::unique_lock<std::mutex> l(_lock);
             // if _buf_queue is empty, we append this buf without size check
-            while (!_cancelled && !_buf_queue.empty() && _buffered_bytes + buf->remaining() > _max_buffered_bytes) {
-                _put_cond.wait(l);
-            }
+            _put_cond.wait(l, [&]() {
+                    return _cancelled || _buf_queue.empty() || _buffered_bytes + buf->remaining() <= _max_buffered_bytes;
+            });
             if (_cancelled) {
                 return _err_st;
             }

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -51,8 +51,8 @@ public:
             if (_cancelled) {
                 return _err_st;
             }
-            _buf_queue.emplace_back(buf);
-            _buffered_bytes += buf->remaining();
+           _buffered_bytes += buf->remaining();
+            _buf_queue.emplace_back(std::move(buf));
             _get_cond.notify_one();
         }
         return Status::OK();

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -107,7 +107,7 @@ public:
             DCHECK(_finished);
             return Status::EndOfFile("all data has been read");
         }
-        auto& buf = _buf_queue.front();
+        auto buf = _buf_queue.front();
         _buf_queue.pop_front();
         _buffered_bytes -= buf->limit;
         _put_cond.notify_one();

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -41,13 +41,19 @@ public:
             : _max_buffered_bytes(max_buffered_bytes), _min_chunk_size(min_chunk_size) {}
     ~StreamLoadPipe() override = default;
 
-    Status append_and_flush(const char* data, size_t size) {
-        RETURN_IF_ERROR(append(data, size));
-        if (_write_buf != nullptr) {
-            ByteBufferPtr buf;
-            std::swap(buf, _write_buf);
-            buf->flip();
-            return _append(buf);
+    Status append(ByteBufferPtr&& buf) {
+        if (buf != nullptr && buf->has_remaining()) {
+            std::unique_lock<std::mutex> l(_lock);
+            // if _buf_queue is empty, we append this buf without size check
+            while (!_cancelled && !_buf_queue.empty() && _buffered_bytes + buf->remaining() > _max_buffered_bytes) {
+                _put_cond.wait(l);
+            }
+            if (_cancelled) {
+                return _err_st;
+            }
+            _buf_queue.emplace_back(buf);
+            _buffered_bytes += buf->remaining();
+            _get_cond.notify_one();
         }
         return Status::OK();
     }
@@ -86,7 +92,7 @@ public:
     * buf_sz: the actual size of data to return.
     * padding: the extra space reserved in the buffer capacity.
     */
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* buf_cap, size_t* buf_sz, size_t padding) {
+    StatusOr<ByteBufferPtr> read() {
         std::unique_lock<std::mutex> l(_lock);
         while (!_cancelled && !_finished && _buf_queue.empty()) {
             _get_cond.wait(l);
@@ -99,23 +105,13 @@ public:
         // finished
         if (_buf_queue.empty()) {
             DCHECK(_finished);
-            *buf_sz = 0;
-            return Status::OK();
+            return Status::EndOfFile("all data has been read");
         }
-        auto raw = _buf_queue.front();
-        auto raw_sz = raw->remaining();
-
-        if (*buf_cap < raw_sz + padding) {
-            buf->reset(new uint8_t[raw_sz + padding]);
-            *buf_cap = raw_sz + padding;
-        }
-        raw->get_bytes((char*)(buf->get()), raw_sz);
-        *buf_sz = raw_sz;
-
+        auto buf = _buf_queue.front();
         _buf_queue.pop_front();
-        _buffered_bytes -= raw->limit;
+        _buffered_bytes -= buf->limit;
         _put_cond.notify_one();
-        return Status::OK();
+        return buf;
     }
 
     Status read(uint8_t* data, size_t* data_size, bool* eof) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5515

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR simplifies `stream_load_pipe` and reduces extra memory copy. 
1. adding `Status append(ByteBufferPtr&& buf)` to append buffer directly to `stream_load_pipe`, which reduces memory copy
2. simplifying `Status read_one_message(...)` as `StatusOr<ByteBufferPtr> read()` to return buffer directly, which reduces memory copy
3. removing `Status append_and_flush(const char* data, size_t size)`, which could be instead of `Status append(ByteBufferPtr&& buf)`.
