### PR TITLE
[cherry-pick][branch-2.0][BugFix] RLE encoder stuck in FlushRepeatedRun when repeat_count_ >= 0x40000000 (#6526)

### DIFF
--- a/be/src/util/bit_stream_utils.h
+++ b/be/src/util/bit_stream_utils.h
@@ -61,7 +61,7 @@ public:
 
     // Write a Vlq encoded int to the buffer. The value is written byte aligned.
     // For more details on vlq: en.wikipedia.org/wiki/Variable-length_quantity
-    void PutVlqInt(int32_t v);
+    void PutVlqInt(uint32_t v);
 
     // Get the index to the next aligned byte and advance the underlying buffer by num_bytes.
     size_t GetByteIndexAndAdvance(int num_bytes) {
@@ -76,6 +76,9 @@ public:
     // If 'align' is true, buffered_values_ is reset and any future writes will be written
     // to the next byte boundary.
     void Flush(bool align = false);
+
+    // Maximum byte length of a vlq encoded int
+    static const int MAX_VLQ_BYTE_LEN = 5;
 
 private:
     // Bit-packed values are initially written to this variable before being memcpy'd to
@@ -111,7 +114,7 @@ public:
 
     // Reads a vlq encoded int from the stream.  The encoded int must start at the
     // beginning of a byte. Return false if there were not enough bytes in the buffer.
-    bool GetVlqInt(int32_t* v);
+    bool GetVlqInt(uint32_t* v);
 
     // Returns the number of bytes left in the stream, not including the current byte (i.e.,
     // there may be an additional fraction of a byte).

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -86,10 +86,12 @@ inline void BitWriter::PutAligned(T val, int num_bytes) {
     memcpy(ptr, &val, num_bytes);
 }
 
-inline void BitWriter::PutVlqInt(int32_t v) {
+inline void BitWriter::PutVlqInt(uint32_t v) {
+    [[maybe_unused]] int num_bytes = 0;
     while ((v & 0xFFFFFF80) != 0L) {
         PutAligned<uint8_t>((v & 0x7F) | 0x80, 1);
         v >>= 7;
+        DCHECK_LE(++num_bytes, MAX_VLQ_BYTE_LEN);
     }
     PutAligned<uint8_t>(v & 0x7F, 1);
 }
@@ -191,10 +193,10 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
     return true;
 }
 
-inline bool BitReader::GetVlqInt(int32_t* v) {
+inline bool BitReader::GetVlqInt(uint32_t* v) {
     *v = 0;
     int shift = 0;
-    int num_bytes = 0;
+    [[maybe_unused]] int num_bytes = 0;
     uint8_t byte = 0;
     do {
         if (!GetAligned<uint8_t>(1, &byte)) return false;


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6513

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when repeat_count_ >= 0x40000000, repeat_count_ << 1 | 0 is a negative number(indicator_value).
In PutVlqInt function, indicator_value >>= 7 is a logical right move, it will move the right 7 value out
and append 1 at the beginning of the number, finally lead to a dead loop.
