### PR TITLE
[cherry-pick][branch-2.2][Enhancement] Early release stale rowsets after compaction. (#5056)

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1100,31 +1100,6 @@ Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     return _updates->rowset_commit(version, rowset);
 }
 
-StatusOr<Tablet::IteratorList> Tablet::capture_segment_iterators(const Version& spec_version,
-                                                                 const vectorized::Schema& schema,
-                                                                 const vectorized::RowsetReadOptions& options) const {
-    if (_updates) {
-        if (spec_version.first != 0) {
-            LOG(WARNING) << "cannot capture with version.first:" << spec_version.first;
-            return Status::InvalidArgument("cannot capture with version.first != 0");
-        }
-        return _updates->read(spec_version.second, schema, options);
-    }
-    std::shared_lock rdlock(_meta_lock);
-    std::vector<Version> version_path;
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(capture_consistent_versions(spec_version, &version_path));
-    RETURN_IF_ERROR(_capture_consistent_rowsets_unlocked(version_path, &rowsets));
-    // Release lock before acquiring segment iterators.
-    rdlock.unlock();
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
-}
-
 void Tablet::on_shutdown() {
     if (_updates) {
         _updates->_stop_and_wait_apply_done();

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -132,10 +132,6 @@ public:
 
     using IteratorList = std::vector<ChunkIteratorPtr>;
 
-    // Get the segment iterators for the specified version |spec_version|.
-    StatusOr<IteratorList> capture_segment_iterators(const Version& spec_version, const vectorized::Schema& schema,
-                                                     const vectorized::RowsetReadOptions& options) const;
-
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     bool version_for_delete_predicate(const Version& version);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -420,22 +420,6 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
     return Status::OK();
 }
 
-StatusOr<IteratorList> TabletUpdates::read(int64_t version, const vectorized::Schema& schema,
-                                           const vectorized::RowsetReadOptions& options) {
-    if (_error) {
-        return Status::InternalError(Substitute("read failed, tablet updates is in error state: tablet:$0 $1",
-                                                _tablet.tablet_id(), _error_msg));
-    }
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(get_applied_rowsets(version, &rowsets));
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
-}
-
 Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     if (_error) {
         return Status::InternalError(Substitute("rowset_commit failed, tablet updates is in error state: tablet:$0 $1",

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -59,10 +59,6 @@ public:
 
     using IteratorList = std::vector<std::shared_ptr<vectorized::ChunkIterator>>;
 
-    // Return NotFound if the |version| does not exist.
-    StatusOr<IteratorList> read(int64_t version, const vectorized::Schema& schema,
-                                const vectorized::RowsetReadOptions& options);
-
     // get latest version's number of rows
     size_t num_rows() const;
 

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -254,6 +254,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
 
         Schema schema = ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema(), _column_groups[i]);
         TabletReader reader(_tablet, _output_rs_writer->version(), schema, is_key, mask_buffer.get());
+        RETURN_IF_ERROR(reader.prepare());
         TabletReaderParams reader_params;
         reader_params.reader_type = compaction_type();
         reader_params.profile = _runtime_profile.create_child("merge_rowsets");
@@ -282,7 +283,6 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
                                                                   total_mem_footprint, segment_iterator_num);
         VLOG(1) << "tablet=" << _tablet->tablet_id() << ", column group=" << i << ", reader chunk size=" << chunk_size;
         reader_params.chunk_size = chunk_size;
-        RETURN_IF_ERROR(reader.prepare());
         RETURN_IF_ERROR(reader.open(reader_params));
 
         int64_t output_rows = 0;
@@ -372,6 +372,7 @@ Status Compaction::modify_rowsets() {
     std::unique_lock wrlock(_tablet->get_header_lock());
     _tablet->modify_rowsets(output_rowsets, _input_rowsets);
     _tablet->save_meta();
+    Rowset::close_rowsets(_input_rowsets);
 
     return Status::OK();
 }

--- a/be/src/storage/vectorized/meta_reader.h
+++ b/be/src/storage/vectorized/meta_reader.h
@@ -79,6 +79,7 @@ public:
 private:
     TabletSharedPtr _tablet;
     Version _version;
+    std::vector<RowsetSharedPtr> _rowsets;
 
     bool _is_init;
     bool _has_more;

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -26,6 +26,8 @@
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/chunk_iterator.h"
 #include "storage/vectorized/empty_iterator.h"
+#include "storage/vectorized/tablet_reader.h"
+#include "storage/vectorized/tablet_reader_params.h"
 #include "storage/vectorized/union_iterator.h"
 #include "testutil/assert.h"
 #include "util/file_utils.h"
@@ -156,24 +158,22 @@ protected:
     std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
 };
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
@@ -195,7 +195,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -18,6 +18,7 @@
 #include "storage/update_manager.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/empty_iterator.h"
+#include "storage/vectorized/tablet_reader.h"
 #include "storage/vectorized/union_iterator.h"
 #include "testutil/assert.h"
 
@@ -171,24 +172,22 @@ protected:
     TabletSharedPtr _tablet;
 };
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
@@ -209,7 +208,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }


### PR DESCRIPTION
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still read the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4873 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still reading the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.