### PR TITLE
[cherry-pick][branch-2.0][Enhancement] Early release stale rowsets after compaction. (#5056)

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -232,7 +232,7 @@ public:
     void release() {
         // if the refs by reader is 0 and the rowset is closed, should release the resouce
         uint64_t current_refs = --_refs_by_reader;
-        if (current_refs == 0 && _rowset_state_machine.rowset_state() == ROWSET_UNLOADING) {
+        if (current_refs == 0) {
             {
                 std::lock_guard<std::mutex> release_lock(_lock);
                 // rejudge _refs_by_reader because we do not add lock in create reader
@@ -248,6 +248,25 @@ public:
                         << ", tabletid:" << _rowset_meta->tablet_id();
             }
         }
+    }
+
+    static size_t get_segment_num(const std::vector<RowsetSharedPtr>& rowsets) {
+        size_t num_segments = 0;
+        std::for_each(rowsets.begin(), rowsets.end(),
+                      [&num_segments](const RowsetSharedPtr& rowset) { num_segments += rowset->num_segments(); });
+        return num_segments;
+    }
+
+    static void acquire_readers(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->acquire(); });
+    }
+
+    static void release_readers(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->release(); });
+    }
+
+    static void close_rowsets(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->close(); });
     }
 
 protected:

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1147,31 +1147,6 @@ Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     return _updates->rowset_commit(version, rowset);
 }
 
-StatusOr<Tablet::IteratorList> Tablet::capture_segment_iterators(const Version& spec_version,
-                                                                 const vectorized::Schema& schema,
-                                                                 const vectorized::RowsetReadOptions& options) const {
-    if (_updates) {
-        if (spec_version.first != 0) {
-            LOG(WARNING) << "cannot capture with version.first:" << spec_version.first;
-            return Status::InvalidArgument("cannot capture with version.first != 0");
-        }
-        return _updates->read(spec_version.second, schema, options);
-    }
-    std::shared_lock rdlock(_meta_lock);
-    std::vector<Version> version_path;
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(capture_consistent_versions(spec_version, &version_path));
-    RETURN_IF_ERROR(_capture_consistent_rowsets_unlocked(version_path, &rowsets));
-    // Release lock before acquiring segment iterators.
-    rdlock.unlock();
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
-}
-
 void Tablet::on_shutdown() {
     if (_updates) {
         _updates->_stop_and_wait_apply_done();

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -135,10 +135,6 @@ public:
 
     using IteratorList = std::vector<ChunkIteratorPtr>;
 
-    // Get the segment iterators for the specified version |spec_version|.
-    StatusOr<IteratorList> capture_segment_iterators(const Version& spec_version, const vectorized::Schema& schema,
-                                                     const vectorized::RowsetReadOptions& options) const;
-
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     bool version_for_delete_predicate(const Version& version);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -404,21 +404,6 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
     return Status::OK();
 }
 
-StatusOr<IteratorList> TabletUpdates::read(int64_t version, const vectorized::Schema& schema,
-                                           const vectorized::RowsetReadOptions& options) {
-    if (_error) {
-        return Status::InternalError("tablet updates is in error state");
-    }
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(get_applied_rowsets(version, &rowsets));
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
-}
-
 Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     if (_error) {
         return Status::InternalError("tablet updates is in error state");

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -67,10 +67,6 @@ public:
 
     using IteratorList = std::vector<std::shared_ptr<vectorized::ChunkIterator>>;
 
-    // Return NotFound if the |version| does not exist.
-    StatusOr<IteratorList> read(int64_t version, const vectorized::Schema& schema,
-                                const vectorized::RowsetReadOptions& options);
-
     // get latest version's number of rows
     size_t num_rows() const;
 

--- a/be/src/storage/vectorized/meta_reader.h
+++ b/be/src/storage/vectorized/meta_reader.h
@@ -79,6 +79,7 @@ public:
 private:
     TabletSharedPtr _tablet;
     Version _version;
+    std::vector<RowsetSharedPtr> _rowsets;
 
     bool _is_init;
     bool _has_more;

--- a/be/src/storage/vectorized/tablet_reader.cpp
+++ b/be/src/storage/vectorized/tablet_reader.cpp
@@ -33,11 +33,25 @@ void TabletReader::close() {
         _collect_iter.reset();
     }
     STLDeleteElements(&_predicate_free_list);
+    Rowset::release_readers(_rowsets);
+    _rowsets.clear();
 }
 
 Status TabletReader::prepare() {
     std::shared_lock l(_tablet->get_header_lock());
     auto st = _tablet->capture_consistent_rowsets(_version, &_rowsets);
+    if (!st.ok()) {
+        _rowsets.clear();
+        std::stringstream ss;
+        ss << "fail to init reader. tablet=" << _tablet->full_name() << "res=" << st;
+        LOG(WARNING) << ss.str();
+        return Status::InternalError(ss.str().c_str());
+    }
+    Rowset::acquire_readers(_rowsets);
+    // ensure all input rowsets are loaded into memory
+    for (const auto& rowset : _rowsets) {
+        rowset->load();
+    }
     return st;
 }
 
@@ -47,7 +61,6 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         return Status::NotSupported("reader type not supported now");
     }
     Status st = _init_collector(read_params);
-    _rowsets.clear(); // unused anymore.
     return st;
 }
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -24,6 +24,7 @@
 #include "storage/update_manager.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/empty_iterator.h"
+#include "storage/vectorized/tablet_reader.h"
 #include "storage/vectorized/union_iterator.h"
 #include "util/defer_op.h"
 #include "util/path_util.h"
@@ -312,24 +313,22 @@ static TabletSharedPtr load_same_tablet_from_store(MemTracker* mem_tracker, cons
     return tablet1;
 }
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_and_compare(const vectorized::ChunkIteratorPtr& iter, const vector<int64_t>& keys) {
@@ -378,7 +377,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }
@@ -386,7 +387,9 @@ static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
 }
 
 static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, int64_t version, const vector<int64_t>& keys) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }
@@ -554,10 +557,15 @@ TEST_F(TabletUpdatesTest, remove_expired_versions) {
     ASSERT_EQ(0, read_tablet(_tablet, 1));
 
     // Create iterators before remove expired version, but read them after removal.
-    auto iter_v0 = create_tablet_iterator(_tablet, 1);
-    auto iter_v1 = create_tablet_iterator(_tablet, 2);
-    auto iter_v2 = create_tablet_iterator(_tablet, 3);
-    auto iter_v3 = create_tablet_iterator(_tablet, 4);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
+    vectorized::TabletReader reader1(_tablet, Version(0, 1), schema);
+    vectorized::TabletReader reader2(_tablet, Version(0, 2), schema);
+    vectorized::TabletReader reader3(_tablet, Version(0, 3), schema);
+    vectorized::TabletReader reader4(_tablet, Version(0, 4), schema);
+    auto iter_v0 = create_tablet_iterator(reader1, schema);
+    auto iter_v1 = create_tablet_iterator(reader2, schema);
+    auto iter_v2 = create_tablet_iterator(reader3, schema);
+    auto iter_v3 = create_tablet_iterator(reader4, schema);
 
     // Remove all but the last version.
     _tablet->updates()->remove_expired_versions(time(NULL));

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -19,6 +19,7 @@
 #include "storage/update_manager.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/empty_iterator.h"
+#include "storage/vectorized/tablet_reader.h"
 #include "storage/vectorized/union_iterator.h"
 
 namespace starrocks::vectorized {
@@ -146,24 +147,22 @@ protected:
     TabletSharedPtr _tablet;
 };
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
@@ -184,7 +183,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }


### PR DESCRIPTION
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still read the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4873 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still reading the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.