### PR TITLE
[Enhancement] skip Chunk::filter if no data to filter

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -8,6 +8,7 @@
 #include "gen_cpp/data.pb.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
+#include "simd/simd.h"
 #include "util/coding.h"
 
 namespace starrocks::vectorized {
@@ -244,7 +245,10 @@ void Chunk::rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32
     }
 }
 
-size_t Chunk::filter(const Buffer<uint8_t>& selection) {
+size_t Chunk::filter(const Buffer<uint8_t>& selection, bool force) {
+    if (!force && SIMD::count_zero(selection) == 0) {
+        return num_rows();
+    }
     for (auto& column : _columns) {
         column->filter(selection);
     }

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -166,8 +166,9 @@ public:
     // Remove rows from this chunk according to the vector |selection|.
     // The n-th row will be removed if selection[n] is zero.
     // The size of |selection| must be equal to the number of rows.
-    // Return the number of rows after filter.
-    size_t filter(const Buffer<uint8_t>& selection);
+    // @param force whether check zero-count of filter, skip the filter procedure if no data to filter
+    // @return the number of rows after filter.
+    size_t filter(const Buffer<uint8_t>& selection, bool force = false);
 
     // Return the number of rows after filter.
     size_t filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


The `Chunk::filter` should be skipped if no data to filter, but some code does not check it, which could introduce some overhead.

Such as:
- `OlapChunkSource::_read_chunk_from_storage` does not skip if for `_not_push_down_predicates`
- `HashJoiner::_process_outer_join_with_other_conjunct` does not skip the filter
