### PR TITLE
[Feature]Hive connector table support array type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -227,7 +227,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
                     needRefreshColumn = true;
                     break;
                 }
-                ScalarType type = convertColumnType(fieldSchema.getType());
+                Type type = convertColumnType(fieldSchema.getType());
                 if (!type.equals(column.getType())) {
                     needRefreshColumn = true;
                     break;
@@ -243,7 +243,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         nameToColumn.clear();
         for (Map.Entry<String, FieldSchema> entry : allHiveColumns.entrySet()) {
             FieldSchema fieldSchema = entry.getValue();
-            ScalarType srType = convertColumnType(fieldSchema.getType());
+            Type srType = convertColumnType(fieldSchema.getType());
             Column srColumn = preNameToColumn.get(entry.getKey());
             Column column;
             if (srColumn != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -11,6 +11,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.connector.ConnectorDatabaseId;
@@ -108,7 +109,7 @@ public class HiveMetaStoreTableUtils {
         return allHiveColumns;
     }
 
-    public static ScalarType convertColumnType(String hiveType) throws DdlException {
+    public static Type convertColumnType(String hiveType) throws DdlException {
         String typeUpperCase = Utils.getTypeKeyword(hiveType).toUpperCase();
         PrimitiveType primitiveType;
         switch (typeUpperCase) {
@@ -153,6 +154,11 @@ public class HiveMetaStoreTableUtils {
             case "BOOLEAN":
                 primitiveType = PrimitiveType.BOOLEAN;
                 break;
+            case "ARRAY":
+                Type type = Utils.convertToArrayType(hiveType);
+                if (type.isArrayType()) {
+                    return type;
+                }
             default:
                 throw new DdlException("hive table column type [" + typeUpperCase + "] transform failed.");
         }
@@ -177,7 +183,7 @@ public class HiveMetaStoreTableUtils {
         List<Column> fullSchema = Lists.newArrayList();
         for (Map.Entry<String, FieldSchema> entry : allHiveColumns.entrySet()) {
             FieldSchema fieldSchema = entry.getValue();
-            ScalarType srType = convertColumnType(fieldSchema.getType());
+            Type srType = convertColumnType(fieldSchema.getType());
             Column column = new Column(fieldSchema.getName(), srType, true);
             fullSchema.add(column);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
@@ -7,11 +7,13 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.external.HiveMetaStoreTableUtils;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.regex.Pattern;
 
 public class Utils {
     public static final String DECIMAL_PATTERN = "^decimal\\((\\d+),(\\d+)\\)";
+    public static final String ARRAY_PATTERN = "^array<([0-9a-z<>(),]+)>";
 
     public static PartitionKey createPartitionKey(List<String> values, List<Column> columns) throws AnalysisException {
         return createPartitionKey(values, columns, false);
@@ -156,5 +159,17 @@ public class Utils {
             return new int[]{Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))};
         }
         throw new DdlException("Failed to get precision and scale at " + typeStr);
+    }
+
+    // Array string like "Array<Array<int>>"
+    public static Type convertToArrayType(String typeStr) throws DdlException {
+        Matcher matcher = Pattern.compile(ARRAY_PATTERN).matcher(typeStr.toLowerCase(Locale.ROOT));
+        Type itemType;
+        if (matcher.find()) {
+            itemType = new ArrayType(convertToArrayType(matcher.group(1)));
+        } else {
+            itemType = HiveMetaStoreTableUtils.convertColumnType(typeStr);
+        }
+        return itemType;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
@@ -4,8 +4,10 @@ package com.starrocks.external.hive;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
@@ -144,6 +146,41 @@ public class UtilsTest {
             Assert.fail();
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("Failed to get"));
+        }
+    }
+
+    @Test
+    public void testArrayString() throws DdlException {
+        ScalarType itemType = ScalarType.createType(PrimitiveType.DATE);
+        ArrayType arrayType = new ArrayType(new ArrayType(itemType));
+        String typeStr = "Array<Array<date>>";
+        Type resType = Utils.convertToArrayType(typeStr);
+        Assert.assertEquals(arrayType, resType);
+
+        itemType = ScalarType.createType(PrimitiveType.VARCHAR);
+        arrayType = new ArrayType(itemType);
+        typeStr = "Array<string>";
+        resType = Utils.convertToArrayType(typeStr);
+        Assert.assertEquals(arrayType, resType);
+
+        itemType = ScalarType.createType(PrimitiveType.INT);
+        arrayType = new ArrayType(new ArrayType(new ArrayType(itemType)));
+        typeStr = "array<Array<Array<int>>>";
+        resType = Utils.convertToArrayType(typeStr);
+        Assert.assertEquals(arrayType, resType);
+
+        itemType = ScalarType.createType(PrimitiveType.BIGINT);
+        arrayType = new ArrayType(new ArrayType(new ArrayType(itemType)));
+        typeStr = "array<Array<Array<bigint>>>";
+        resType = Utils.convertToArrayType(typeStr);
+        Assert.assertEquals(arrayType, resType);
+
+        itemType = ScalarType.createUnifiedDecimalType(4, 2);
+        try {
+            new ArrayType(new ArrayType(itemType));
+            Assert.fail();
+        } catch (InternalError e) {
+            Assert.assertTrue(e.getMessage().contains("Decimal32/64/128"));
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
related with https://github.com/StarRocks/starrocks/issues/5062


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Hive connector table support array type.
we can get hive type which is an string like "array<array<int>>". we should convert it to StarRocks Type.