### PR TITLE
[BugFix] fix query memory usage metrics are negative after query close GRF

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -32,15 +32,12 @@ QueryContext::~QueryContext() {
     }
 
     // Accounting memory usage during QueryContext's destruction should not use query-level MemTracker, but its released
-    // in the mid of QueryContext destruction, so use its parent MemTracker.
-    if (_mem_tracker) {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker->parent());
-        if (_exec_env != nullptr) {
-            if (_is_runtime_filter_coordinator) {
-                _exec_env->runtime_filter_worker()->close_query(_query_id);
-            }
-            _exec_env->runtime_filter_cache()->remove(_query_id);
+    // in the mid of QueryContext destruction, so use process-level memory tracker
+    if (_exec_env != nullptr) {
+        if (_is_runtime_filter_coordinator) {
+            _exec_env->runtime_filter_worker()->close_query(_query_id);
         }
+        _exec_env->runtime_filter_cache()->remove(_query_id);
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：

If the memory in the GRF is requested from the query level and is not freed at this time. When the query-leverl tracker is destructured, we will return the unrecovered values to the memory in the query-pool statistics.
If we rebind the memtracker in the query-pool, it will be destructured twice at this time