### PR TITLE
[BugFix] fix money_format when the result only has fractional part

### DIFF
--- a/be/src/exprs/vectorized/string_functions.h
+++ b/be/src/exprs/vectorized/string_functions.h
@@ -459,8 +459,20 @@ void StringFunctions::money_format_decimal_impl(FunctionContext* context, Column
         CppType rounded_cent_money;
         auto overflow = DecimalV3Cast::round<CppType, ROUND_HALF_EVEN, scale_up, check_overflow>(
                 money_value, scale_factor, &rounded_cent_money);
-        auto str = DecimalV3Cast::to_string<CppType>(rounded_cent_money, max_precision, 0);
-        std::string concurr_format = transform_currency_format(context, str);
+        std::string concurr_format;
+        if (rounded_cent_money == 0) {
+            concurr_format = "0.00";
+        } else {
+            bool is_negative = rounded_cent_money < 0;
+            CppType abs_rounded_cent_money = is_negative ? -rounded_cent_money : rounded_cent_money;
+            auto str = DecimalV3Cast::to_string<CppType>(abs_rounded_cent_money, max_precision, 0);
+            std::string prefix = is_negative ? "-" : "";
+            // if there is only fractional part, we need to add leading zeros so that transform_currency_format can work
+            if (abs_rounded_cent_money < 100) {
+                prefix.append(abs_rounded_cent_money < 10 ? "00" : "0");
+            }
+            concurr_format = transform_currency_format(context, prefix + str);
+        }
         result->append(Slice(concurr_format.data(), concurr_format.size()), overflow);
     }
 }

--- a/be/test/exprs/vectorized/string_fn_money_format_decimal_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_money_format_decimal_test.cpp
@@ -47,7 +47,7 @@ void test_money_format_decimal(TestArray const& test_cases, int precision, int s
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqZero) {
     TestArray test_cases = {
-            {"0", ".00"},
+            {"0", "0.00"},
             {"9999999", "9,999,999.00"},
             {"-999999", "-999,999.00"},
             {"1", "1.00"},
@@ -62,7 +62,7 @@ TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqZero) {
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqTwo) {
     TestArray test_cases = {
-            {"0", ".00"},
+            {"0", "0.00"},
             {"9999999.99", "9,999,999.99"},
             {"-9999999.99", "-9,999,999.99"},
             {"1.01", "1.01"},
@@ -76,10 +76,9 @@ TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqTwo) {
 }
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqPrecision) {
-    TestArray test_cases = {
-            {"0", ".00"},         {"0.999999999", "1.00"}, {"-0.99", "-.99"},    {"0.000001", ".00"},
-            {"0.1234567", ".12"}, {"-0.101", "-.10"},      {"-0.55555", "-.56"}, {"0.555555", ".56"},
-    };
+    TestArray test_cases = {{"0", "0.00"},         {"0.999999999", "1.00"}, {"-0.99", "-0.99"},
+                            {"0.000001", "0.00"},  {"0.1234567", "0.12"},   {"-0.101", "-0.10"},
+                            {"-0.55555", "-0.56"}, {"0.555555", "0.56"},    {"-0.01", "-0.01"}};
     test_money_format_decimal<TYPE_DECIMAL32>(test_cases, 9, 9);
     test_money_format_decimal<TYPE_DECIMAL64>(test_cases, 18, 18);
     test_money_format_decimal<TYPE_DECIMAL128>(test_cases, 38, 38);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6607

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
