### PR TITLE
[Enhance] remove runtime filter in ProjectOperator

### DIFF
--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -62,8 +62,6 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkP
     for (size_t i = 0; i < result_columns.size(); ++i) {
         _cur_chunk->append_column(result_columns[i], _column_ids[i]);
     }
-    eval_runtime_bloom_filters(_cur_chunk.get());
-    DCHECK_CHUNK(_cur_chunk);
     TRY_CATCH_ALLOC_SCOPE_END()
     return Status::OK();
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Runtime in ProjectOperator seems useless, just remove it.
