### PR TITLE
[BugFix] Call `hdfsCloseFile` in pthread

### DIFF
--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 
 #include "runtime/hdfs/hdfs_fs_cache.h"
+#include "udf/java/utils.h"
 #include "util/hdfs_util.h"
 
 namespace starrocks {
@@ -39,8 +40,16 @@ private:
 };
 
 HdfsInputStream::~HdfsInputStream() {
-    int r = hdfsCloseFile(_fs, _file);
-    PLOG_IF(ERROR, r != 0) << "close " << _file_name << " failed";
+    auto ret = call_hdfs_scan_function_in_pthread([this]() {
+        int r = hdfsCloseFile(this->_fs, this->_file);
+        if (r == 0) {
+            return Status::OK();
+        } else {
+            return Status::IOError("");
+        }
+    });
+    Status st = ret->get_future().get();
+    PLOG_IF(ERROR, !st.ok()) << "close " << _file_name << " failed";
 }
 
 StatusOr<int64_t> HdfsInputStream::read(void* data, int64_t size) {

--- a/be/src/udf/java/utils.cpp
+++ b/be/src/udf/java/utils.cpp
@@ -24,4 +24,16 @@ PromiseStatusPtr call_function_in_pthread(RuntimeState* state, std::function<Sta
     }
     return ms;
 }
+
+PromiseStatusPtr call_hdfs_scan_function_in_pthread(std::function<Status()> func) {
+    PromiseStatusPtr ms = std::make_unique<PromiseStatus>();
+    if (bthread_self()) {
+        ExecEnv::GetInstance()->pipeline_hdfs_scan_io_thread_pool()->offer(
+                [promise = ms.get(), func]() { promise->set_value(func()); });
+    } else {
+        ms->set_value(func());
+    }
+    return ms;
+}
+
 } // namespace starrocks

--- a/be/src/udf/java/utils.h
+++ b/be/src/udf/java/utils.h
@@ -14,4 +14,6 @@ using PromiseStatusPtr = std::unique_ptr<PromiseStatus>;
 // if current thread was pthread. call func in current thread and return promise
 // if current thread was bthread. call func in udf_thread and return promise
 PromiseStatusPtr call_function_in_pthread(RuntimeState* state, std::function<Status()> func);
+PromiseStatusPtr call_hdfs_scan_function_in_pthread(std::function<Status()> func);
+
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6621

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

JNI does not work well with bthread.  
- In most cases, JNI function is running in `std::thread`(or pthread). 
- But when JNI function runs in bthread in some cases like `cancel_fragment`, it fails.

https://github.com/apache/incubator-brpc/blob/master/docs/cn/server.md

<img width="898" alt="image" src="https://user-images.githubusercontent.com/1081215/170824864-b9995699-8891-4894-a96c-342dd05620ad.png">


```
#60 starrocks::pipeline::FragmentContextManager::~FragmentContextManager (this=0x176f25440, __in_chrg=<optimized out>) at /root/starrocks/be/src/exec/pipeline/fragment_context.h:156
#61 std::default_delete<starrocks::pipeline::FragmentContextManager>::operator() (__ptr=0x176f25440, this=0xef96f290) at /usr/include/c++/10.3.0/bits/unique_ptr.h:85
#62 std::__uniq_ptr_impl<starrocks::pipeline::FragmentContextManager, std::default_delete<starrocks::pipeline::FragmentContextManager> >::reset (__p=0x0, this=0xef96f290) at /usr/include/c++/10.3.0/bits/unique_ptr.h:182
#63 std::unique_ptr<starrocks::pipeline::FragmentContextManager, std::default_delete<starrocks::pipeline::FragmentContextManager> >::reset (__p=0x0, this=0xef96f290) at /usr/include/c++/10.3.0/bits/unique_ptr.h:456
#64 starrocks::pipeline::QueryContext::~QueryContext (this=0xef96f270, __in_chrg=<optimized out>) at /root/starrocks/be/src/exec/pipeline/query_context.cpp:31
#65 0x0000000001974b6a in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0xef96f260) at /usr/include/c++/10.3.0/ext/atomicity.h:70
#66 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0xef96f260) at /usr/include/c++/10.3.0/bits/shared_ptr_base.h:151
#67 0x0000000003322cff in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7f00f6d2fb98, __in_chrg=<optimized out>) at /root/starrocks/be/src/exec/pipeline/fragment_context.h:80
#68 std::__shared_ptr<starrocks::pipeline::QueryContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7f00f6d2fb90, __in_chrg=<optimized out>) at /usr/include/c++/10.3.0/bits/shared_ptr_base.h:1183
#69 std::shared_ptr<starrocks::pipeline::QueryContext>::~shared_ptr (this=0x7f00f6d2fb90, __in_chrg=<optimized out>) at /usr/include/c++/10.3.0/bits/shared_ptr.h:121
#70 starrocks::PInternalServiceImplBase<doris::PBackendService>::cancel_plan_fragment (this=<optimized out>, cntl_base=<optimized out>, request=0x354e2630, result=0x1b208b540, done=<optimized out>) at /root/starrocks/be/src/service/internal_service.cpp:243
#71 0x000000000409e82e in brpc::policy::ProcessRpcRequest (msg_base=<optimized out>) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/brpc/policy/baidu_rpc_protocol.cpp:496
#72 0x0000000004095297 in brpc::ProcessInputMessage (void_arg=void_arg@entry=0x45bdd900) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/brpc/input_messenger.cpp:135
#73 0x0000000004096143 in brpc::RunLastMessage::operator() (last_msg=0x45bdd900, this=<synthetic pointer>) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/brpc/input_messenger.cpp:141
#74 std::unique_ptr<brpc::InputMessageBase, brpc::RunLastMessage>::~unique_ptr (this=<synthetic pointer>, __in_chrg=<optimized out>) at /usr/include/c++/10.3.0/bits/unique_ptr.h:361
#75 brpc::InputMessenger::OnNewMessages (m=0x40b00000) at /usr/include/c++/10.3.0/bits/unique_ptr.h:355
#76 0x000000000413ce0e in brpc::Socket::ProcessEvent (arg=0x40b00000) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/brpc/socket.cpp:1017
#77 0x000000000404ad9f in bthread::TaskGroup::task_runner (skip_remained=<optimized out>) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/bthread/task_group.cpp:296
#78 0x00000000041d3581 in bthread_make_fcontext ()
```