### PR TITLE
[Bugfix] Fix wrong initial value for timeoutMs in TransactionState

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -209,7 +209,7 @@ public class TransactionState implements Writable {
     private TransactionStatus preStatus = null;
 
     private long callbackId = -1;
-    private long timeoutMs = Config.stream_load_default_timeout_second;
+    private long timeoutMs = Config.stream_load_default_timeout_second * 1000;
 
     // optional
     private TxnCommitAttachment txnCommitAttachment;
@@ -427,8 +427,8 @@ public class TransactionState implements Writable {
     }
 
     public void afterStateTransform(TransactionStatus transactionStatus, boolean txnOperated,
-            TxnStateChangeCallback callback,
-            String txnStatusChangeReason)
+                                    TxnStateChangeCallback callback,
+                                    String txnStatusChangeReason)
             throws UserException {
         // after status changed
         if (callback != null) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix wrong initial value for timeoutMs in TransactionState. Notice that there is no actual bug since the initial value will be overwritten.