### PR TITLE
[BugFix] Fix ASAN crash when create JsonLiteral

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -50,6 +50,7 @@
 #include "exprs/vectorized/placeholder_ref.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Types_types.h"
+#include "runtime/primitive_type.h"
 #include "runtime/raw_value.h"
 #include "runtime/runtime_state.h"
 
@@ -144,10 +145,11 @@ Expr::Expr(TypeDescriptor type, bool is_slotref)
         case TYPE_DECIMAL32:
         case TYPE_DECIMAL64:
         case TYPE_DECIMAL128:
+        case TYPE_JSON:
             break;
 
         default:
-            DCHECK(false) << "Invalid type.";
+            DCHECK(false) << "Invalid type." << _type.type;
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #6663

## Problem Summary(Required) ：
RF in CrossJoin will generate a LiteralExpr

