### PR TITLE
[Enhance] change the default chunk-size in pipeline to 4096

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -355,7 +355,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CHUNK_SIZE, flag = VariableMgr.INVISIBLE)
     private int chunkSize = 4096;
 
-    public static final int PIPELINE_BATCH_SIZE = 16384;
+    public static final int PIPELINE_BATCH_SIZE = 4096;
 
     @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
     private boolean disableStreamPreaggregations = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Current pipeline engine use a pretty large chunk size 16384, pretty larger than the original 4096 chunk size. And it could introduce several bad case:
- A larger memory size could hit the tcmalloc's central cache easier
- For some huge type(HLL, string), a big chunk could occupy large memory size

Why the difference between 4069 and 16384?
- Previously, the pipeline scheduler would yield after move 100 chunks, so a larger chunk size would reduce the schedule overhead
- But since we could remove this yield strategy, the schedule overhead would not dominate
- For vectorized computation, there's no significant difference between 4096 and 16384

## Experiment Result
- For ssb + tpch + tpds: (chunk-size=16384) **186825.0** seconds, (chunk-size=4096) **192642.0** seconds
- For scan test:, (chunk-size=16384) **446903.0** seconds, (chunk-size=4096) **425281.0** seconds

To conclude, a little regression for tpch benchmark, and a little optimization for scan benchmark. 

Cause scan scenario would allocate a lot of memory, which could hit the memory allocation bottleneck easier.
