### PR TITLE
[bugfix] Use all rowsets's accumulated average data to compute get_segment_max_rows

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1028,8 +1028,8 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, boo
                 return Status::InternalError(msg);
             } else {
                 input_rowsets[i] = itr->second;
-                input_rowsets_size = input_rowsets[i]->data_disk_size();
-                input_row_num = input_rowsets[i]->num_rows();
+                input_rowsets_size += input_rowsets[i]->data_disk_size();
+                input_row_num += input_rowsets[i]->num_rows();
             }
         }
     }


### PR DESCRIPTION
## What type of PR is this：
-  bugfix

## Which issues of this PR fixes ：
the do_compaction compute get_segment_max_rows just use the last Rowset not all Rowsets's accumulated average data

## Problem Summary(Required) ：
Use all rowsets's accumulated average data to compute get_segment_max_rows.
