### PR TITLE
[cherry-pick][branch-2.1][optimize] Reducing the memory footprint of columnReader. (#4875)

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -64,8 +64,9 @@ using strings::Substitute;
 StatusOr<std::shared_ptr<Segment>> Segment::open(MemTracker* mem_tracker, fs::BlockManager* blk_mgr,
                                                  const std::string& filename, uint32_t segment_id,
                                                  const TabletSchema* tablet_schema, size_t* footer_length_hint) {
-    auto segment = std::shared_ptr<Segment>(new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema),
-                                            DeleterWithMemTracker<Segment>(mem_tracker));
+    auto segment = std::shared_ptr<Segment>(
+            new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema, mem_tracker),
+            DeleterWithMemTracker<Segment>(mem_tracker));
     mem_tracker->consume(segment->mem_usage());
 
     RETURN_IF_ERROR(segment->_open(mem_tracker, footer_length_hint));
@@ -158,8 +159,12 @@ Status Segment::parse_segment_footer(fs::ReadableBlock* rblock, SegmentFooterPB*
 }
 
 Segment::Segment(const private_type&, fs::BlockManager* blk_mgr, std::string fname, uint32_t segment_id,
-                 const TabletSchema* tablet_schema)
-        : _block_mgr(blk_mgr), _fname(std::move(fname)), _tablet_schema(tablet_schema), _segment_id(segment_id) {}
+                 const TabletSchema* tablet_schema, MemTracker* mem_tracker)
+        : _block_mgr(blk_mgr),
+          _fname(std::move(fname)),
+          _tablet_schema(tablet_schema),
+          _segment_id(segment_id),
+          _mem_tracker(mem_tracker) {}
 
 Status Segment::_open(MemTracker* mem_tracker, size_t* footer_length_hint) {
     SegmentFooterPB footer;
@@ -261,11 +266,7 @@ Status Segment::_create_column_readers(MemTracker* mem_tracker, SegmentFooterPB*
             continue;
         }
 
-        ColumnReaderOptions opts;
-        opts.block_mgr = _block_mgr;
-        opts.storage_format_version = footer->version();
-        opts.kept_in_memory = _tablet_schema->is_in_memory();
-        auto res = ColumnReader::create(mem_tracker, opts, footer->mutable_columns(iter->second), _fname);
+        auto res = ColumnReader::create(footer->mutable_columns(iter->second), this);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -83,7 +83,7 @@ public:
                                        uint64_t* segment_data_size);
 
     Segment(const private_type&, fs::BlockManager* blk_mgr, std::string fname, uint32_t segment_id,
-            const TabletSchema* tablet_schema);
+            const TabletSchema* tablet_schema, MemTracker* mem_tracker);
 
     ~Segment() = default;
 
@@ -93,8 +93,6 @@ public:
                                             const vectorized::SegmentReadOptions& read_options);
 
     uint64_t id() const { return _segment_id; }
-
-    uint32_t num_rows() const { return _num_rows; }
 
     // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
     Status new_column_iterator(uint32_t cid, ColumnIterator** iter);
@@ -127,8 +125,6 @@ public:
         return _sk_index_decoder->num_items() - 1;
     }
 
-    const std::string& file_name() const { return _fname; }
-
     size_t num_columns() const { return _column_readers.size(); }
 
     const ColumnReader* column(size_t i) const { return _column_readers[i].get(); }
@@ -140,6 +136,16 @@ public:
         }
         return size;
     }
+
+    MemTracker* mem_tracker() const { return _mem_tracker; }
+
+    fs::BlockManager* block_manager() const { return _block_mgr; }
+
+    bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
+
+    const std::string& file_name() const { return _fname; }
+
+    uint32_t num_rows() const { return _num_rows; }
 
 private:
     Segment(const Segment&) = delete;
@@ -170,6 +176,7 @@ private:
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;
     PagePointer _short_key_index_page;
+    MemTracker* _mem_tracker;
 
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,
     // This means that this segment has no data for that column, which may be added

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -67,7 +67,6 @@ using starrocks::ColumnReader;
 using starrocks::BinaryPlainPageDecoder;
 using starrocks::PageHandle;
 using starrocks::PagePointer;
-using starrocks::ColumnReaderOptions;
 using starrocks::ColumnIteratorOptions;
 using starrocks::PageFooterPB;
 


### PR DESCRIPTION
In a large wide table scenario, a large number of Column Readers will occupy a lot of memory. This pr is mainly to strip the data structures that can be shared between Column Readers and put them into Segment.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_* 
-->
#4873

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In a large wide table scenario, when there are many columns, a large number of Column Readers will occupy a lot of memory. This pr is mainly to strip the data structures that can be shared between Column Readers and put them into Segment. 
Share these data field between ColumnReaders: 
```c++
class ColumnReader {
    MemTracker* _mem_tracker;
    int32_t _column_length = 0; 
    std::shared_ptr<fs::BlockManager> _block_mgr; 
    uint64_t _num_rows = 0;  
    const std::string& _file_name;  
    
    uint32_t _storage_format_version;  
    bool _kept_in_memory; 
};
```