### PR TITLE
[Bugfix] add backticks around table and column identifiers in JDBC MySQL table

### DIFF
--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -9,6 +9,7 @@
 #include "exprs/expr.h"
 #include "runtime/jdbc_driver_manager.h"
 #include "storage/chunk_helper.h"
+#include "util/slice.h"
 
 namespace starrocks {
 namespace connector {
@@ -32,14 +33,15 @@ DataSourcePtr JDBCDataSourceProvider::create_data_source(const TScanRange& scan_
 
 // ================================
 
-static std::string get_jdbc_sql(const std::string& table, const std::vector<std::string>& columns,
+static std::string get_jdbc_sql(const Slice jdbc_url, const std::string& table, const std::vector<std::string>& columns,
                                 const std::vector<std::string>& filters, int64_t limit) {
+    std::string object_identifier = jdbc_url.starts_with("jdbc:mysql") ? "`" : "";
     std::ostringstream oss;
     oss << "SELECT";
     for (size_t i = 0; i < columns.size(); i++) {
-        oss << (i == 0 ? "" : ",") << " " << columns[i];
+        oss << (i == 0 ? "" : ",") << " " << object_identifier << columns[i] << object_identifier;
     }
-    oss << " FROM " << table;
+    oss << " FROM " << object_identifier << table << object_identifier;
     if (!filters.empty()) {
         oss << " WHERE ";
         for (size_t i = 0; i < filters.size(); i++) {
@@ -115,7 +117,8 @@ Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     scan_ctx.jdbc_url = jdbc_table->jdbc_url();
     scan_ctx.user = jdbc_table->jdbc_user();
     scan_ctx.passwd = jdbc_table->jdbc_passwd();
-    scan_ctx.sql = get_jdbc_sql(jdbc_table->jdbc_table(), jdbc_scan_node.columns, jdbc_scan_node.filters, _read_limit);
+    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_table->jdbc_table(), jdbc_scan_node.columns,
+                                jdbc_scan_node.filters, _read_limit);
     _scanner = _pool->add(new vectorized::JDBCScanner(scan_ctx, _tuple_desc, _runtime_profile));
 
     RETURN_IF_ERROR(_scanner->open(state));

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -881,10 +881,9 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return toSql();
     }
 
-    public String toJDBCSQL() {
+    public String toJDBCSQL(boolean isMySQL) {
         return toSql();
     }
-
     /**
      * Return a column label for the expression
      */

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -219,6 +219,15 @@ public class SlotRef extends Expr {
         }
     }
 
+    @Override
+    public String toJDBCSQL(boolean isMySQL) {
+        if (col != null) {
+            return isMySQL ? "`" + col + "`" : col;
+        } else {
+            return "<slot " + Integer.toString(desc.getId().asInt()) + ">";
+        }
+    }
+
     public TableName getTableName() {
         Preconditions.checkState(isAnalyzed);
         Preconditions.checkNotNull(desc);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -70,7 +70,6 @@ public class JDBCTable extends Table {
         if (resource.getType() != ResourceType.JDBC) {
             throw new DdlException("resource [" + resourceName + "] is not jdbc resource");
         }
-
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6018 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
MySQL allow double quotes in column name, in this case ,we should add backticks around column identifiers to avoid it being confused with string variables.