### PR TITLE
[Cherry-pick][Bugfix] Fix bug timezone for Spark Load does not work

### DIFF
--- a/be/src/storage/vectorized/push_handler.h
+++ b/be/src/storage/vectorized/push_handler.h
@@ -27,7 +27,7 @@ public:
         _scanner.reset();
     }
 
-    Status init(const TBrokerScanRange& t_scan_range, const TDescriptorTable& t_desc_tbl);
+    Status init(const TBrokerScanRange& t_scan_range, const TPushReq& request);
     Status next_chunk(ChunkPtr* chunk);
 
     void print_profile();

--- a/be/test/storage/vectorized/push_handler_test.cpp
+++ b/be/test/storage/vectorized/push_handler_test.cpp
@@ -303,6 +303,8 @@ TEST_F(PushHandlerTest, PushBrokerReaderNormal) {
     range.file_type = TFileType::FILE_LOCAL;
     broker_scan_range.ranges.push_back(range);
 
+    TPushReq request;
+    request.__set_desc_tbl(_t_desc_table);
     // data
     // k1_int k2_smallint varchar bigint
     // 0           0       a0      0
@@ -310,7 +312,7 @@ TEST_F(PushHandlerTest, PushBrokerReaderNormal) {
     // 1           4       a2      6
     PushBrokerReader reader;
     Schema schema = _create_schema();
-    reader.init(broker_scan_range, _t_desc_table);
+    reader.init(broker_scan_range, request);
     ChunkPtr chunk = ChunkHelper::new_chunk(schema, 0);
 
     // next chunk

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -514,7 +514,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                                 0, id, TPushType.LOAD_V2,
                                                 TPriority.NORMAL, transactionId, taskSignature,
                                                 tBrokerScanRange, params.tDescriptorTable,
-                                                params.useVectorized);
+                                                params.useVectorized, timezone);
                                         if (AgentTaskQueue.addTask(pushTask)) {
                                             batchTask.addTask(pushTask);
                                             if (!tabletToSentReplicaPushTask.containsKey(tabletId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -69,6 +69,7 @@ public class PushTask extends AgentTask {
     private TBrokerScanRange tBrokerScanRange;
     private TDescriptorTable tDescriptorTable;
     private boolean useVectorized;
+    private String timezone;
 
     public PushTask(TResourceInfo resourceInfo, long backendId, long dbId, long tableId, long partitionId,
                     long indexId, long tabletId, long replicaId, int schemaHash, long version, long versionHash,
@@ -98,13 +99,14 @@ public class PushTask extends AgentTask {
     public PushTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
                     long replicaId, int schemaHash, int timeoutSecond, long loadJobId, TPushType pushType,
                     TPriority priority, long transactionId, long signature, TBrokerScanRange tBrokerScanRange,
-                    TDescriptorTable tDescriptorTable, boolean useVectorized) {
+                    TDescriptorTable tDescriptorTable, boolean useVectorized, String timezone) {
         this(null, backendId, dbId, tableId, partitionId, indexId,
                 tabletId, replicaId, schemaHash, -1, 0, timeoutSecond, loadJobId, pushType, null,
                 priority, TTaskType.REALTIME_PUSH, transactionId, signature);
         this.tBrokerScanRange = tBrokerScanRange;
         this.tDescriptorTable = tDescriptorTable;
         this.useVectorized = useVectorized;
+        this.timezone = timezone;
     }
 
     public TPushReq toThrift() {
@@ -112,6 +114,7 @@ public class PushTask extends AgentTask {
         if (taskType == TTaskType.REALTIME_PUSH) {
             request.setPartition_id(partitionId);
             request.setTransaction_id(transactionId);
+            request.setTimezone(timezone);
         }
         request.setIs_schema_changing(isSchemaChanging);
         switch (pushType) {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -134,6 +134,8 @@ struct TPushReq {
     15: optional Descriptors.TDescriptorTable desc_tbl
 
     30: optional bool use_vectorized
+    // 31 are used by spark load
+    31: optional string timezone
 }
 
 struct TCloneReq {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6592

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is because BE's default Timezone is +8 and spark load use realtime push but does not handle timezone.
but spark will load JVM properties to set timezone and convert timezone to UTC time.
If the machine's system timezone is UTC be will +8 time to deal with.
If the machine's system timezone is +8 spark will -8 time and be will +8 so the time is same.