### PR TITLE
[Enhancement] improve the scalability of DataStreamMgr

### DIFF
--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -41,7 +41,7 @@ DataStreamMgr::DataStreamMgr() {
 inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id) {
     uint32_t value = RawValue::get_hash_value(&fragment_instance_id.lo, TYPE_BIGINT, 0);
     value = RawValue::get_hash_value(&fragment_instance_id.hi, TYPE_BIGINT, value);
-    return value % BUCKET_NUM;
+    return value & BUCKET_NUM;
 }
 
 std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -41,7 +41,7 @@ DataStreamMgr::DataStreamMgr() {
 inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id) {
     uint32_t value = RawValue::get_hash_value(&fragment_instance_id.lo, TYPE_BIGINT, 0);
     value = RawValue::get_hash_value(&fragment_instance_id.hi, TYPE_BIGINT, value);
-    return value & BUCKET_NUM;
+    return value % BUCKET_NUM;
 }
 
 std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -34,21 +34,14 @@
 namespace starrocks {
 
 DataStreamMgr::DataStreamMgr() {
-    REGISTER_GAUGE_STARROCKS_METRIC(data_stream_receiver_count, [this]() {
-        std::lock_guard<std::mutex> l(_lock);
-        return _receiver_map.size();
-    });
-    REGISTER_GAUGE_STARROCKS_METRIC(fragment_endpoint_count, [this]() {
-        std::lock_guard<std::mutex> l(_lock);
-        return _fragment_stream_set.size();
-    });
+    REGISTER_GAUGE_STARROCKS_METRIC(data_stream_receiver_count, [this]() { return _receiver_count.load(); });
+    REGISTER_GAUGE_STARROCKS_METRIC(fragment_endpoint_count, [this]() { return _fragment_count.load(); });
 }
 
-inline uint32_t DataStreamMgr::get_hash_value(const TUniqueId& fragment_instance_id, PlanNodeId node_id) {
+inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id) {
     uint32_t value = RawValue::get_hash_value(&fragment_instance_id.lo, TYPE_BIGINT, 0);
     value = RawValue::get_hash_value(&fragment_instance_id.hi, TYPE_BIGINT, value);
-    value = RawValue::get_hash_value(&node_id, TYPE_INT, value);
-    return value;
+    return value % BUCKET_NUM;
 }
 
 std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
@@ -64,33 +57,33 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
             new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
                                 buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline,
                                 degree_of_parallelism, keep_order, pass_through_chunk_buffer));
-    uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
-    std::lock_guard<std::mutex> l(_lock);
-    _fragment_stream_set.emplace(fragment_instance_id, dest_node_id);
-    _receiver_map.insert(std::make_pair(hash_value, recvr));
+
+    uint32_t bucket = get_bucket(fragment_instance_id);
+    auto& receiver_map = _receiver_map[bucket];
+    std::lock_guard<Mutex> l(_lock[bucket]);
+    auto iter = receiver_map.find(fragment_instance_id);
+    if (iter == receiver_map.end()) {
+        receiver_map.insert(std::make_pair(fragment_instance_id, std::make_shared<RecvrMap>()));
+        iter = receiver_map.find(fragment_instance_id);
+        _fragment_count += 1;
+    }
+    iter->second->insert(std::make_pair(dest_node_id, recvr));
+    _receiver_count += 1;
     return recvr;
 }
 
-std::shared_ptr<DataStreamRecvr> DataStreamMgr::find_recvr(const TUniqueId& fragment_instance_id, PlanNodeId node_id,
-                                                           bool acquire_lock) {
+std::shared_ptr<DataStreamRecvr> DataStreamMgr::find_recvr(const TUniqueId& fragment_instance_id, PlanNodeId node_id) {
     VLOG_ROW << "looking up fragment_instance_id=" << fragment_instance_id << ", node=" << node_id;
-    size_t hash_value = get_hash_value(fragment_instance_id, node_id);
-    if (acquire_lock) {
-        _lock.lock();
-    }
-    std::pair<StreamMap::iterator, StreamMap::iterator> range = _receiver_map.equal_range(hash_value);
-    while (range.first != range.second) {
-        std::shared_ptr<DataStreamRecvr> recvr = range.first->second;
-        if (recvr->fragment_instance_id() == fragment_instance_id && recvr->dest_node_id() == node_id) {
-            if (acquire_lock) {
-                _lock.unlock();
-            }
-            return recvr;
+    uint32_t bucket = get_bucket(fragment_instance_id);
+    auto& receiver_map = _receiver_map[bucket];
+    std::lock_guard<Mutex> l(_lock[bucket]);
+
+    auto iter = receiver_map.find(fragment_instance_id);
+    if (iter != receiver_map.end()) {
+        auto sub_iter = iter->second->find(node_id);
+        if (sub_iter != iter->second->end()) {
+            return sub_iter->second;
         }
-        ++range.first;
-    }
-    if (acquire_lock) {
-        _lock.unlock();
     }
     return std::shared_ptr<DataStreamRecvr>();
 }
@@ -170,19 +163,22 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
 Status DataStreamMgr::deregister_recvr(const TUniqueId& fragment_instance_id, PlanNodeId node_id) {
     std::shared_ptr<DataStreamRecvr> target_recvr;
     VLOG_QUERY << "deregister_recvr(): fragment_instance_id=" << fragment_instance_id << ", node=" << node_id;
-    size_t hash_value = get_hash_value(fragment_instance_id, node_id);
+    uint32_t bucket = get_bucket(fragment_instance_id);
+    auto& receiver_map = _receiver_map[bucket];
     {
-        std::lock_guard<std::mutex> l(_lock);
-        std::pair<StreamMap::iterator, StreamMap::iterator> range = _receiver_map.equal_range(hash_value);
-        while (range.first != range.second) {
-            const std::shared_ptr<DataStreamRecvr>& recvr = range.first->second;
-            if (recvr->fragment_instance_id() == fragment_instance_id && recvr->dest_node_id() == node_id) {
-                target_recvr = recvr;
-                _fragment_stream_set.erase(std::make_pair(recvr->fragment_instance_id(), recvr->dest_node_id()));
-                _receiver_map.erase(range.first);
-                break;
+        std::lock_guard<Mutex> l(_lock[bucket]);
+        auto iter = receiver_map.find(fragment_instance_id);
+        if (iter != receiver_map.end()) {
+            auto sub_iter = iter->second->find(node_id);
+            if (sub_iter != iter->second->end()) {
+                target_recvr = sub_iter->second;
+                iter->second->erase(sub_iter);
+                _receiver_count -= 1;
+                if (iter->second->empty()) {
+                    _receiver_map[bucket].erase(iter);
+                    _fragment_count -= 1;
+                }
             }
-            ++range.first;
         }
     }
 
@@ -202,20 +198,16 @@ Status DataStreamMgr::deregister_recvr(const TUniqueId& fragment_instance_id, Pl
 void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {
     VLOG_QUERY << "cancelling all streams for fragment=" << fragment_instance_id;
     std::vector<std::shared_ptr<DataStreamRecvr>> recvrs;
+    uint32_t bucket = get_bucket(fragment_instance_id);
+    auto& receiver_map = _receiver_map[bucket];
     {
-        std::lock_guard<std::mutex> l(_lock);
-        FragmentStreamSet::iterator i = _fragment_stream_set.lower_bound(std::make_pair(fragment_instance_id, 0));
-        while (i != _fragment_stream_set.end() && i->first == fragment_instance_id) {
-            std::shared_ptr<DataStreamRecvr> recvr = find_recvr(i->first, i->second, false);
-            if (recvr == nullptr) {
-                // keep going but at least log it
-                std::stringstream err;
-                err << "cancel(): missing in stream_map: fragment=" << i->first << " node=" << i->second;
-                LOG(ERROR) << err.str();
-            } else {
-                recvrs.push_back(recvr);
+        std::lock_guard<Mutex> l(_lock[bucket]);
+        auto iter = receiver_map.find(fragment_instance_id);
+        if (iter != receiver_map.end()) {
+            // all of the value should collect
+            for (auto sub_iter = iter->second->begin(); sub_iter != iter->second->end(); sub_iter++) {
+                recvrs.push_back(sub_iter->second);
             }
-            ++i;
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In this PR, I try to improve the concurrent processing capability of `DataStreamMgr`:
1. use multiple locks partitioned by fragment_instance_id instead of a global lock to reduce lock contention between different fragment_instance_ids.
2. use a new data structure to represent StreamMap, it can reduce the comparisons and thus the time to hold the lock.
3. use bthread::Mutex instead of std::mutex, it allows brpc to schedule bthread by itself instead of directly suspending the corresponding pthread when lock competition occurs.
4. remove acquire_lock parameter from find_recvr because there is nowhere to use it
