### PR TITLE
[cherry-pick-2.2][BugFix] Fix bdb disk expand bug

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -154,8 +154,8 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>com.starrocks</groupId>
-            <artifactId>starrocks-bdb-je</artifactId>
+            <groupId>com.sleepycat</groupId>
+            <artifactId>je</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.mortbay.jetty/jetty -->

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -312,7 +312,7 @@ public class StarRocksFE {
             try {
                 Thread t = new Thread(() -> {
                     try {
-                        Journal journal = GlobalStateMgr.getCurrentState().getEditLog().getJournal();
+                        Journal journal = Catalog.getCurrentCatalog().getEditLog().getJournal();
                         if (journal instanceof BDBJEJournal) {
                             BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
                             if (bdbEnvironment != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -31,6 +31,9 @@ import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
 import com.starrocks.common.util.JdkUtils;
 import com.starrocks.http.HttpServer;
+import com.starrocks.journal.Journal;
+import com.starrocks.journal.bdbje.BDBEnvironment;
+import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.journal.bdbje.BDBTool;
 import com.starrocks.journal.bdbje.BDBToolOptions;
 import com.starrocks.qe.QeService;
@@ -122,6 +125,8 @@ public class StarRocksFE {
             qeService.start();
 
             ThreadPoolManager.registerAllThreadPoolMetric();
+
+            addShutdownHook();
 
             while (true) {
                 Thread.sleep(2000);
@@ -296,6 +301,40 @@ public class StarRocksFE {
         } catch (IOException e) {
             throw e;
         }
+    }
+
+    // NOTE: To avoid dead lock
+    //      1. never call System.exit in shutdownHook
+    //      2. shutdownHook cannot have lock conflict with the function calling System.exit
+    private static void addShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOG.info("start to execute shutdown hook");
+            try {
+                Thread t = new Thread(() -> {
+                    try {
+                        Journal journal = GlobalStateMgr.getCurrentState().getEditLog().getJournal();
+                        if (journal instanceof BDBJEJournal) {
+                            BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
+                            if (bdbEnvironment != null) {
+                                bdbEnvironment.flushVLSNMapping();
+                            }
+                        }
+                    } catch (Throwable e) {
+                        LOG.warn("flush vlsn mapping failed", e);
+                    }
+                });
+
+                t.start();
+
+                // it is necessary to set shutdown timeout,
+                // because in addition to kill by user, System.exit(-1) will trigger the shutdown hook too,
+                // if no timeout and shutdown hook blocked indefinitely, Fe will fall into a catastrophic state.
+                t.join(30000);
+            } catch (Throwable e) {
+                LOG.warn("shut down hook failed", e);
+            }
+            LOG.info("shutdown hook end");
+        }));
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -35,6 +35,7 @@ import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.sleepycat.je.rep.NoConsistencyRequiredPolicy;
 import com.sleepycat.je.rep.NodeType;
+import com.sleepycat.je.rep.RepInternal;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.je.rep.ReplicationConfig;
 import com.sleepycat.je.rep.RollbackException;
@@ -463,6 +464,13 @@ public class BDBEnvironment {
             lock.writeLock().unlock();
         }
         return closeSuccess;
+    }
+
+    public void flushVLSNMapping() {
+        if (replicatedEnvironment != null) {
+            RepInternal.getRepImpl(replicatedEnvironment).getVLSNIndex()
+                    .flushToDatabase(Durability.COMMIT_SYNC);
+        }
     }
 
     private SyncPolicy getSyncPolicy(String policy) {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -277,9 +277,9 @@ under the License.
             </dependency>
 
             <dependency>
-                <groupId>com.starrocks</groupId>
-                <artifactId>starrocks-bdb-je</artifactId>
-                <version>7.3.8</version>
+                <groupId>com.sleepycat</groupId>
+                <artifactId>je</artifactId>
+                <version>7.3.7</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.mortbay.jetty/jetty -->


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6634

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Finding the root cause and fixing the bug of disk expand take a long time, so we downgrade the bdb-je version first.
Add shutdown hook to avoid the bug of vlsn mismatch as much as possible.