### PR TITLE
Fix Graceful exit crash in UDF

### DIFF
--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -162,7 +162,7 @@ void JVMFunctionHelper::_init() {
 
     name = JVMFunctionHelper::to_jni_class_name(UDAFStateList::clazz_name);
     jclass loaded_clazz = JNI_FIND_CLASS(name.c_str());
-    _function_states_clazz = std::make_unique<JVMClass>(std::move(loaded_clazz));
+    _function_states_clazz = new JVMClass(std::move(loaded_clazz));
 }
 
 // https://stackoverflow.com/questions/45232522/how-to-set-classpath-of-a-running-jvm-in-cjni

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -166,7 +166,7 @@ private:
     jclass _direct_buffer_class;
     jmethodID _direct_buffer_clear;
 
-    std::unique_ptr<JVMClass> _function_states_clazz;
+    JVMClass* _function_states_clazz = nullptr;
 };
 
 // local object reference guard.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
when BE graceful exit. vm_direct_exit has been called first. then when we
call JNI api, be will crash
