### PR TITLE
[BugFix] Support for handling tencent cosn prefixed file paths

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/ObjectStorageUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/ObjectStorageUtils.java
@@ -6,6 +6,8 @@ public class ObjectStorageUtils {
     private static final String SCHEME_S3A = "s3a://";
     private static final String SCHEME_S3 = "s3://";
     private static final String SCHEME_S3N = "s3n://";
+    private static final String SCHEME_COS = "cos://";
+    private static final String SCHEME_COSN = "cosn://";
     private static final String SCHEME_S3_PREFIX = "s3";
     private static final String SCHEME_OSS_PREFIX = "oss";
 
@@ -19,6 +21,12 @@ public class ObjectStorageUtils {
         }
         if (path.startsWith(SCHEME_S3N)) {
             return SCHEME_S3A + path.substring(SCHEME_S3N.length());
+        }
+        if (path.startsWith(SCHEME_COSN)) {
+            return SCHEME_S3A + path.substring(SCHEME_COSN.length());
+        }
+        if (path.startsWith(SCHEME_COS)) {
+            return SCHEME_S3A + path.substring(SCHEME_COS.length());
         }
         return path;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/ObjectStorageUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/ObjectStorageUtilsTest.java
@@ -1,0 +1,22 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.external.hive;
+
+import com.starrocks.external.ObjectStorageUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ObjectStorageUtilsTest {
+    @Test
+    public void testFormatObjectStoragePath() {
+        String s3aPath = "s3a://xxx";
+        String s3Path = "s3://xxx";
+        String s3nPath = "s3n://xxx";
+        String cosPath = "cos://xxx";
+        String cosnPath = "cosn://xxx";
+        Assert.assertEquals(s3aPath, ObjectStorageUtils.formatObjectStoragePath(s3Path));
+        Assert.assertEquals(s3aPath, ObjectStorageUtils.formatObjectStoragePath(s3nPath));
+        Assert.assertEquals(s3aPath, ObjectStorageUtils.formatObjectStoragePath(cosnPath));
+        Assert.assertEquals(s3aPath, ObjectStorageUtils.formatObjectStoragePath(cosPath));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/6726

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Tencent cos compatible S3 protocol. If the file location passed from hive Metastore starts with 'cos', we need to change the prefix to 's3a' or add the corresponding jar package. At present, we choose to modify the prefix.





