### PR TITLE
[BugFix]  return null if json function receive null parameter

### DIFF
--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -472,6 +472,10 @@ ColumnPtr JsonFunctions::json_query(FunctionContext* context, const Columns& col
 
     JsonPath stored_path;
     for (int row = 0; row < num_rows; ++row) {
+        if (json_viewer.is_null(row) || path_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
         JsonValue* json_value = json_viewer.value(row);
         auto path_value = path_viewer.value(row);
 
@@ -502,7 +506,7 @@ ColumnPtr JsonFunctions::json_exists(FunctionContext* context, const Columns& co
 
     JsonPath stored_path;
     for (int row = 0; row < num_rows; row++) {
-        if (json_viewer.is_null(row) || json_viewer.value(row) == nullptr) {
+        if (json_viewer.is_null(row) || json_viewer.value(row) == nullptr || path_viewer.is_null(row)) {
             result.append_null();
             continue;
         }

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -392,7 +392,11 @@ TEST_P(JsonQueryTestFixture, json_query) {
     JsonValue json;
     ASSERT_TRUE(JsonValue::parse(param_json, &json).ok());
     ints->append(&json);
-    builder.append(param_path);
+    if (param_path == "NULL") {
+        builder.append_null();
+    } else {
+        builder.append(param_path);
+    }
 
     Columns columns{ints, builder.build(true)};
 
@@ -425,6 +429,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(
                 // clang-format off
                 // empty
+                std::make_tuple(R"( {"k1":1} )", "NULL", R"(NULL)"),
                 std::make_tuple(R"( {"k1":1} )", "$", R"( {"k1": 1} )"),
                 std::make_tuple(R"( {"k1":1} )", "", R"( {"k1": 1} )"),
 
@@ -501,7 +506,11 @@ TEST_P(JsonExistTestFixture, json_exists) {
     auto json = JsonValue::parse(param_json);
     ASSERT_TRUE(json.ok());
     ints->append(&*json);
-    builder.append(param_result);
+    if (param_result == "NULL") {
+        builder.append_null();
+    } else {
+        builder.append(param_result);
+    }
 
     Columns columns{ints, builder.build(true)};
 
@@ -552,6 +561,7 @@ INSTANTIATE_TEST_SUITE_P(JsonExistTest, JsonExistTestFixture,
                                            // special case
                                            std::make_tuple(R"({ "k1": {}})", "$", true),
                                            std::make_tuple(R"({ "k1": {}})", "", true),
+                                           std::make_tuple(R"( { "k1": 1} )", "NULL", false),
 
                                            // error case
                                            std::make_tuple(R"( {"k1": null} )", std::string(10, 0x1), false)));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6553

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

JSON functions should return null if any parameter is null.