### PR TITLE
[WIP] [Enhancement] Enable memtable sync write when there are too many memtables in the queue

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -455,6 +455,12 @@ CONF_mInt64(write_buffer_size, "104857600");
 CONF_Int64(load_process_max_memory_limit_bytes, "107374182400"); // 100GB
 CONF_Int32(load_process_max_memory_limit_percent, "30");         // 30%
 CONF_Bool(enable_new_load_on_memory_limit_exceeded, "false");
+// If we enable_sync_memtable_write_transfer, then memtable write will become sync
+// when flush count >= `load_process_async_memtable_write_flush_queue_count_limit`
+// or execution_queue_count >= `load_process_async_memtable_write_execution_queue_count_limit`
+CONF_Bool(enable_sync_memtable_write_transfer, "false");
+CONF_Int32(load_process_async_memtable_write_flush_queue_count_limit, "8");
+CONF_Int32(load_process_async_memtable_write_execution_queue_count_limit, "48");
 CONF_Int64(compaction_max_memory_limit, "-1");
 CONF_Int32(compaction_max_memory_limit_percent, "100");
 CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -11,6 +11,7 @@ DIAGNOSTIC_POP
 #include <google/protobuf/service.h>
 
 #include "storage/delta_writer.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks::vectorized {
 
@@ -43,6 +44,8 @@ public:
     // [thread-safe and wait-free]
     void write(const AsyncDeltaWriterRequest& req, AsyncDeltaWriterCallback* cb);
 
+    void sync_write(const AsyncDeltaWriterRequest& req, AsyncDeltaWriterCallback* cb);
+
     // [thread-safe and wait-free]
     void commit(AsyncDeltaWriterCallback* cb);
 
@@ -63,6 +66,8 @@ private:
         AsyncDeltaWriterCallback* write_cb;
         uint32_t indexes_size = 0;
         bool commit_after_write = false;
+        bool sync_write_task = false;
+        std::atomic<bool>* sync_write_finish_flag;
     };
 
     Status _init();

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -144,6 +144,11 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
 
     _metrics.register_metric("stream_load", MetricLabels().add("type", "receive_bytes"), &stream_receive_bytes_total);
     _metrics.register_metric("stream_load", MetricLabels().add("type", "load_rows"), &stream_load_rows_total);
+
+    _metrics.register_metric("memtable", MetricLabels().add("type", "execution_queue_count"),
+                             &memtable_execution_queue_count);
+    _metrics.register_metric("memtable", MetricLabels().add("type", "flush_queue_count"), &memtable_flush_queue_count);
+
     _metrics.register_metric("load_rows", &load_rows_total);
     _metrics.register_metric("load_bytes", &load_bytes_total);
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -147,6 +147,8 @@ public:
 
     METRIC_DEFINE_INT_COUNTER(memtable_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(memtable_execution_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_queue_count, MetricUnit::NOUNIT);
 
     METRIC_DEFINE_INT_COUNTER(update_rowset_commit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(update_rowset_commit_request_failed, MetricUnit::REQUESTS);


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6735

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the concurrent stream load is fast enough, memtable write and flush thread can not catch up, continue to write the memtable will only make the memtable queue even longer, resulting in a large number of memtable in the memory.
In order to solve this problem, we can transfer from the async memtable table write to sync memtable write. Let the import speed to be slowed down and flush the memtable table in the queue.