### PR TITLE
[Cherry-Pick][BugFix] Fix bdb inconsistent bug (#6407) (#6709)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -227,21 +227,19 @@ public class BDBEnvironment {
         }
     }
 
-    private void refreshLog(InsufficientLogException insufficientLogEx) {
-        NetworkRestore restore = new NetworkRestore();
-        NetworkRestoreConfig config = new NetworkRestoreConfig();
-        config.setRetainLogFiles(false); // delete obsolete log files.
-        // Use the members returned by insufficientLogEx.getLogProviders()
-        // to select the desired subset of members and pass the resulting
-        // list as the argument to config.setLogProviders(), if the
-        // default selection of providers is not suitable.
-        restore.execute(insufficientLogEx, config);
-    }
-
-    public void refreshAndSetup(InsufficientLogException insufficientLogEx) {
-        refreshLog(insufficientLogEx);
-        close();
-        setup();
+    public void refreshLog(InsufficientLogException insufficientLogEx) {
+        try {
+            NetworkRestore restore = new NetworkRestore();
+            NetworkRestoreConfig config = new NetworkRestoreConfig();
+            config.setRetainLogFiles(false); // delete obsolete log files.
+            // Use the members returned by insufficientLogEx.getLogProviders()
+            // to select the desired subset of members and pass the resulting
+            // list as the argument to config.setLogProviders(), if the
+            // default selection of providers is not suitable.
+            restore.execute(insufficientLogEx, config);
+        } catch (Throwable t) {
+            LOG.warn("refresh log failed", t);
+        }
     }
 
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
@@ -372,14 +370,15 @@ public class BDBEnvironment {
                 names = replicatedEnvironment.getDatabaseNames();
                 break;
             } catch (InsufficientLogException e) {
-                LOG.warn("catch insufficient log exception. refresh and setup again.", e);
+                // for InsufficientLogException we should refresh the log and
+                // then exit the process because we may have read dirty data.
+                LOG.warn("catch insufficient log exception. please restart.", e);
                 refreshLog(e);
-                close();
-                setup();
+                System.exit(-1);
             } catch (RollbackException exception) {
-                LOG.warn("rollback exception, setup again", exception);
-                close();
-                setup();
+                // for RollbackException we should exit the process because we may have read dirty data.
+                LOG.warn("catch rollback exception, please restart", exception);
+                System.exit(-1);
             } catch (EnvironmentFailureException e) {
                 tried++;
                 if (tried == RETRY_TIME) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -310,9 +310,11 @@ public class BDBJEJournal implements Journal {
 
                 break;
             } catch (InsufficientLogException insufficientLogEx) {
-                // Copy the missing log files from a member of the replication group who owns the files
-                LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
-                bdbEnvironment.refreshAndSetup(insufficientLogEx);
+                LOG.warn("catch insufficient log exception. please restart", insufficientLogEx);
+                // for InsufficientLogException we should refresh the log and
+                // then exit the process because we may have read dirty data.
+                bdbEnvironment.refreshLog(insufficientLogEx);
+                System.exit(-1);
             } catch (Throwable t) {
                 LOG.warn("catch exception, retried: {} ", i, t);
             }


### PR DESCRIPTION
In bdb, synchronizing data with the master node is an asynchronous process. If a node finds dirty data in its own data, the dirty data should be truncated, but the dirty data may have been read by our replayer thread. So we should catch the RollbackException and exit the process. When truncating the dirty data, if the data precedes a checkpoint that deleted log files, an InsufficientLogException will be thrown, so we also should catch the InsufficientLogException and exit the process.