### PR TITLE
[Enhancement] Selectivity estimate support more functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -48,59 +48,308 @@ public class FunctionSet {
     // Functions in this set is defined in `gensrc/script/starrocks_builtins_functions.py`,
     // and will be built automatically.
 
-    // Aggregate Functions:
+    // Date functions:
+    public static final String CONVERT_TZ = "convert_tz";
+    public static final String CURDATE = "curdate";
+    public static final String CURRENT_TIMESTAMP = "current_timestamp";
+    public static final String CURTIME = "curtime";
+    public static final String CURRENT_TIME = "current_time";
+    public static final String DATEDIFF = "datediff";
+    public static final String DATE_ADD = "date_add";
+    public static final String DATE_FORMAT = "date_format";
+    public static final String DATE_SUB = "date_sub";
+    public static final String DATE_TRUNC = "date_trunc";
+    public static final String DAY = "day";
+    public static final String DAYNAME = "dayname";
+    public static final String DAYOFMONTH = "dayofmonth";
+    public static final String DAYOFWEEK = "dayofweek";
+    public static final String DAYOFYEAR = "dayofyear";
+    public static final String FROM_DAYS = "from_days";
+    public static final String FROM_UNIXTIME = "from_unixtime";
+    public static final String HOUR = "hour";
+    public static final String MINUTE = "minute";
+    public static final String MONTH = "month";
+    public static final String MONTHNAME = "monthname";
+    public static final String NOW = "now";
+    public static final String SECOND = "second";
+    public static final String STR_TO_DATE = "str_to_date";
+    public static final String TIMEDIFF = "timediff";
+    public static final String TIMESTAMPADD = "timestampadd";
+    public static final String TIMESTAMPDIFF = "timestampdiff";
+    public static final String TO_DATE = "to_date";
+    public static final String TO_DAYS = "to_days";
+    public static final String UNIX_TIMESTAMP = "unix_timestamp";
+    public static final String UTC_TIMESTAMP = "utc_timestamp";
+    public static final String WEEKOFYEAR = "weekofyear";
+    public static final String YEAR = "year";
+    public static final String MINUTES_DIFF = "minutes_diff";
+    public static final String HOURS_DIFF = "hours_diff";
+    public static final String DAYS_DIFF = "days_diff";
+    public static final String MONTHS_DIFF = "months_diff";
+    public static final String SECONDS_DIFF = "seconds_diff";
+    public static final String WEEKS_DIFF = "weeks_diff";
+    public static final String YEARS_DIFF = "years_diff";
+    public static final String QUARTER = "quarter";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String TIME_TO_SEC = "time_to_sec";
+    public static final String STR2DATE = "str2date";
+    public static final String MICROSECONDS_ADD = "microseconds_add";
+    public static final String MICROSECONDS_SUB = "microseconds_sub";
+    public static final String YEARS_ADD = "years_add";
+    public static final String YEARS_SUB = "years_sub";
+    public static final String MONTHS_ADD = "months_add";
+    public static final String MONTHS_SUB = "months_sub";
+    public static final String DAYS_ADD = "days_add";
+    public static final String DAYS_SUB = "days_sub";
+    public static final String ADDDATE = "adddate";
+    public static final String SUBDATE = "subdate";
+    public static final String TIME_SLICE = "time_slice";
+    public static final String DATE_FLOOR = "date_floor";
+    public static final String STRFTIME = "strftime";
+    public static final String TIME_FORMAT = "time_format";
+    public static final String ALIGNMENT_TIMESTAMP = "alignment_timestamp";
+    public static final String SUBSTITUTE = "substitute";
+
+    // Encryption functions:
+    public static final String AES_DECRYPT = "aes_decrypt";
+    public static final String AES_ENCRYPT = "aes_encrypt";
+    public static final String FROM_BASE64 = "from_base64";
+    public static final String TO_BASE64 = "to_base64";
+    public static final String MD5 = "md5";
+    public static final String MD5_SUM = "md5sum";
+    public static final String SHA2 = "sha2";
+    public static final String SM3 = "sm3";
+
+    // Geo functions:
+    public static final String ST_ASTEXT = "st_astext";
+    public static final String ST_ASWKT = "st_aswkt";
+    public static final String ST_CIRCLE = "st_circle";
+    public static final String ST_CONTAINS = "st_contains";
+    public static final String ST_DISTANCE_SPHERE = "st_distance_sphere";
+    public static final String ST_GEOMETRYFROMTEXT = "st_geometryfromtext";
+    public static final String ST_GEOMFROMTEXT = "st_geomfromtext";
+    public static final String ST_LINEFROMTEXT = "st_linefromtext";
+    public static final String ST_LINESTRINGFROMTEXT = "st_linestringfromtext";
+    public static final String ST_POINT = "st_point";
+    public static final String ST_POLYGON = "st_polygon";
+    public static final String ST_POLYFROMTEXT = "st_polyfromtext";
+    public static final String ST_POLYGONFROMTEXT = "st_polygonfromtext";
+    public static final String ST_X = "st_x";
+    public static final String ST_Y = "st_y";
+
+    // String functions
+    public static final String APPEND_TRAILING_CHAR_IF_ABSENT = "append_trailing_char_if_absent";
+    public static final String ASCII = "ascii";
+    public static final String CHAR_LENGTH = "char_length";
+    public static final String CONCAT = "concat";
+    public static final String CONCAT_WS = "concat_ws";
+    public static final String ENDS_WITH = "ends_with";
+    public static final String FIND_IN_SET = "find_in_set";
+    public static final String GROUP_CONCAT = "group_concat";
+    public static final String INSTR = "instr";
+    public static final String LCASE = "lcase";
+    public static final String LEFT = "left";
+    public static final String LENGTH = "length";
+    public static final String LOCATE = "locate";
+    public static final String LOWER = "lower";
+    public static final String LPAD = "lpad";
+    public static final String LTRIM = "ltrim";
+    public static final String RTRIM = "rtrim";
+    public static final String MONEY_FORMAT = "money_format";
+    public static final String NULL_OR_EMPTY = "null_or_empty";
+    public static final String REGEXP_EXTRACT = "regexp_extract";
+    public static final String REGEXP_REPLACE = "regexp_replace";
+    public static final String REPEAT = "repeat";
+    public static final String REVERSE = "reverse";
+    public static final String RIGHT = "right";
+    public static final String RPAD = "rpad";
+    public static final String SPLIT = "split";
+    public static final String SPLIT_PART = "split_part";
+    public static final String STARTS_WITH = "starts_with";
+    public static final String STRLEFT = "strleft";
+    public static final String STRRIGHT = "strright";
+    public static final String HEX = "hex";
+    public static final String UNHEX = "unhex";
+    public static final String SUBSTR = "substr";
+    public static final String SUBSTRING = "substring";
+    public static final String SPACE = "space";
+    public static final String PARSE_URL = "parse_url";
+    public static final String TRIM = "trim";
+    public static final String UPPER = "upper";
+
+    // Json functions:
+    public static final String JSON_ARRAY = "json_array";
+    public static final String JSON_OBJECT = "json_object";
+    public static final String PARSE_JSON = "parse_json";
+    public static final String JSON_QUERY = "json_query";
+    public static final String JSON_EXIST = "json_exists";
+    public static final String JSON_EACH = "json_each";
+    public static final String GET_JSON_DOUBLE = "get_json_double";
+    public static final String GET_JSON_INT = "get_json_int";
+    public static final String GET_JSON_STRING = "get_json_string";
+
+    // Matching functions:
+    public static final String LIKE = "like";
+    public static final String REGEXP = "regexp";
+
+    // Utility functions:
+    public static final String CURRENT_VERSION = "current_version";
+    public static final String LAST_QUERY_ID = "last_query_id";
+    public static final String UUID = "uuid";
+    public static final String SLEEP = "sleep";
+    public static final String ISNULL = "isnull";
+
+    // Aggregate functions:
+    public static final String APPROX_COUNT_DISTINCT = "approx_count_distinct";
+    public static final String AVG = "avg";
     public static final String COUNT = "count";
+    public static final String HLL_UNION_AGG = "hll_union_agg";
     public static final String MAX = "max";
     public static final String MIN = "min";
-    public static final String SUM = "sum";
-    public static final String SUM_DISTINCT = "sum_distinct";
-    public static final String AVG = "avg";
-    public static final String STD = "std";
+    public static final String PERCENTILE_APPROX = "percentile_approx";
+    public static final String RETENTION = "retention";
     public static final String STDDEV = "stddev";
-    public static final String STDDEV_SAMP = "stddev_samp";
     public static final String STDDEV_POP = "stddev_pop";
-    public static final String STDDEV_VAL = "stddev_val";
+    public static final String STDDEV_SAMP = "stddev_samp";
+    public static final String SUM = "sum";
     public static final String VARIANCE = "variance";
-    public static final String VARIANCE_SAMP = "variance_samp";
-    public static final String VAR_SAMP = "var_samp";
-    public static final String VARIANCE_POP = "variance_pop";
     public static final String VAR_POP = "var_pop";
-    public static final String MONEY_FORMAT = "money_format";
-    public static final String STR_TO_DATE = "str_to_date";
+    public static final String VARIANCE_POP = "variance_pop";
+    public static final String VAR_SAMP = "var_samp";
+    public static final String VARIANCE_SAMP = "variance_samp";
+    public static final String ANY_VALUE = "any_value";
+    public static final String SUM_DISTINCT = "sum_distinct";
+    public static final String STD = "std";
+    public static final String STDDEV_VAL = "stddev_val";
     public static final String HLL_UNION = "hll_union";
-    public static final String HLL_UNION_AGG = "hll_union_agg";
     public static final String HLL_RAW_AGG = "hll_raw_agg";
     public static final String NDV = "ndv";
     public static final String NDV_NO_FINALIZE = "ndv_no_finalize";
-    public static final String APPROX_COUNT_DISTINCT = "approx_count_distinct";
-    public static final String PERCENTILE_APPROX = "percentile_approx";
-    public static final String PERCENTILE_APPROX_RAW = "percentile_approx_raw";
-    public static final String PERCENTILE_UNION = "percentile_union";
-    public static final String BITMAP_UNION = "bitmap_union";
-    public static final String BITMAP_UNION_COUNT = "bitmap_union_count";
-    public static final String BITMAP_UNION_INT = "bitmap_union_int";
-    public static final String INTERSECT_COUNT = "intersect_count";
-    public static final String BITMAP_INTERSECT = "bitmap_intersect";
     public static final String MULTI_DISTINCT_COUNT = "multi_distinct_count";
     public static final String MULTI_DISTINCT_SUM = "multi_distinct_sum";
     public static final String DICT_MERGE = "dict_merge";
-    public static final String ANY_VALUE = "any_value";
-    public static final String RETENTION = "retention";
-    public static final String GROUP_CONCAT = "group_concat";
-    public static final String ARRAY_AGG = "array_agg";
-    public static final String ARRAYS_OVERLAP = "arrays_overlap";
     public static final String WINDOW_FUNNEL = "window_funnel";
     public static final String DISTINCT_PC = "distinct_pc";
     public static final String DISTINCT_PCSA = "distinct_pcsa";
 
-    // Unary functions:
-    public static final String ABS = "abs";
-    public static final String POSITIVE = "positive";
-    public static final String NEGATIVE = "negative";
-
     // Bitmap functions:
+    public static final String BITMAP_AND = "bitmap_and";
+    public static final String BITMAP_ANDNOT = "bitmap_andnot";
+    public static final String BITMAP_CONTAINS = "bitmap_contains";
+    public static final String BITMAP_EMPTY = "bitmap_empty";
+    public static final String BITMAP_FROM_STRING = "bitmap_from_string";
     public static final String BITMAP_HASH = "bitmap_hash";
+    public static final String BITMAP_HAS_ANY = "bitmap_has_any";
+    public static final String BITMAP_INTERSECT = "bitmap_intersect";
+    public static final String BITMAP_MAX = "bitmap_max";
+    public static final String BITMAP_MIN = "bitmap_min";
+    public static final String BITMAP_OR = "bitmap_or";
+    public static final String BITMAP_REMOVE = "bitmap_remove";
+    public static final String BITMAP_TO_STRING = "bitmap_to_string";
+    public static final String BITMAP_TO_ARRAY = "bitmap_to_array";
+    public static final String BITMAP_UNION = "bitmap_union";
+    public static final String BITMAP_XOR = "bitmap_xor";
+    public static final String TO_BITMAP = "to_bitmap";
+    public static final String BITMAP_COUNT = "bitmap_count";
+    public static final String BITMAP_UNION_COUNT = "bitmap_union_count";
+    public static final String BITMAP_UNION_INT = "bitmap_union_int";
+    public static final String INTERSECT_COUNT = "intersect_count";
     public static final String BITMAP_DICT = "bitmap_dict";
+
+    // Array functions:
+    public static final String ARRAY_AGG = "array_agg";
+    public static final String ARRAY_CONCAT = "array_concat";
+    public static final String ARRAY_DIFFERENCE = "array_difference";
+    public static final String ARRAY_INTERSECT = "array_intersect";
+    public static final String ARRAY_SLICE = "array_slice";
+    public static final String ARRAYS_OVERLAP = "arrays_overlap";
+    public static final String ARRAY_APPEND = "array_append";
+    public static final String ARRAY_AVG = "array_avg";
+    public static final String ARRAY_CONTAINS = "array_contains";
+    public static final String ARRAY_JOIN = "array_join";
+    public static final String ARRAY_DISTINCT = "array_distinct";
+    public static final String ARRAY_LENGTH = "array_length";
+    public static final String ARRAY_MAX = "array_max";
+    public static final String ARRAY_MIN = "array_min";
+    public static final String ARRAY_POSITION = "array_position";
+    public static final String ARRAY_SORT = "array_sort";
+    public static final String ARRAY_SUM = "array_sum";
+    public static final String ARRAY_REMOVE = "array_remove";
+
+    // Bit functions:
+    public static final String BITAND = "bitand";
+    public static final String BITNOT = "bitnot";
+    public static final String BITOR = "bitor";
+    public static final String BITXOR = "bitxor";
+
+    // Hash functions:
+    public static final String MURMUR_HASH3_32 = "murmur_hash3_32";
+
+    // Percentile functions:
+    public static final String PERCENTILE_APPROX_RAW = "percentile_approx_raw";
+    public static final String PERCENTILE_EMPTY = "percentile_empty";
+    public static final String PERCENTILE_HASH = "percentile_hash";
+    public static final String PERCENTILE_UNION = "percentile_union";
+
+    // Condition functions:
+    public static final String COALESCE = "coalesce";
+    public static final String IF = "if";
+    public static final String IFNULL = "ifnull";
+    public static final String NULLIF = "nullif";
+
+    // Math functions:
+    public static final String ABS = "abs";
+    public static final String ACOS = "acos";
+    public static final String ADD = "add";
+    public static final String ASIN = "asin";
+    public static final String ATAN = "atan";
+    public static final String ATAN2 = "atan2";
+    public static final String BIN = "bin";
+    public static final String CEIL = "ceil";
+    public static final String DCEIL = "dceil";
+    public static final String CEILING = "ceiling";
+    public static final String CONV = "conv";
+    public static final String COS = "cos";
+    public static final String COT = "cot";
+    public static final String DEGRESS = "degress";
+    public static final String DIVIDE = "divide";
+    public static final String E = "e";
+    public static final String EXP = "exp";
+    public static final String DEXP = "dexp";
+    public static final String FLOOR = "floor";
+    public static final String DFLOOR = "dfloor";
+    public static final String FMOD = "fmod";
+    public static final String GREATEST = "greatest";
+    public static final String LEAST = "least";
+    public static final String LN = "ln";
+    public static final String DLOG1 = "dlog1";
+    public static final String LOG = "log";
+    public static final String LOG2 = "log2";
+    public static final String LOG10 = "log10";
+    public static final String DLOG10 = "dlog10";
+    public static final String MOD = "mod";
+    public static final String MULTIPLY = "multiply";
+    public static final String NEGATIVE = "negative";
+    public static final String PI = "pi";
+    public static final String PMOD = "pmod";
+    public static final String POSITIVE = "positive";
+    public static final String POW = "pow";
+    public static final String POWER = "power";
+    public static final String DPOW = "dpow";
+    public static final String FPOW = "fpow";
+    public static final String RADIANS = "radians";
+    public static final String RAND = "rand";
+    public static final String RANDOM = "random";
+    public static final String ROUND = "round";
+    public static final String DROUND = "dround";
+    public static final String SIGN = "sign";
+    public static final String SIN = "sin";
+    public static final String SQRT = "sqrt";
+    public static final String SUBTRACT = "subtract";
+    public static final String DSQRT = "dsqrt";
+    public static final String SQUARE = "square";
+    public static final String TAN = "tan";
+    public static final String TRUNCATE = "truncate";
 
     // Window functions:
     public static final String LEAD = "lead";
@@ -113,112 +362,17 @@ public class FunctionSet {
     public static final String NTILE = "ntile";
     public static final String ROW_NUMBER = "row_number";
 
-    // Scalar functions:
-    public static final String BITMAP_COUNT = "bitmap_count";
+    // Other functions:
     public static final String HLL_HASH = "hll_hash";
     public static final String HLL_CARDINALITY = "hll_cardinality";
-    public static final String PERCENTILE_HASH = "percentile_hash";
-    public static final String TO_BITMAP = "to_bitmap";
-    public static final String NULL_OR_EMPTY = "null_or_empty";
-    public static final String IF = "if";
-    public static final String IF_NULL = "ifnull";
-    public static final String NULL_IF = "nullif";
-    public static final String COALESCE = "coalesce";
-    public static final String MD5_SUM = "md5sum";
-    public static final String HEX = "hex";
-    public static final String TRUNCATE = "truncate";
-    public static final String ROUND = "round";
-    public static final String DROUND = "dround";
-    public static final String RAND = "rand";
-    public static final String RANDOM = "random";
-
-    // Arithmetic functions:
-    public static final String ADD = "add";
-    public static final String SUBTRACT = "subtract";
-    public static final String MULTIPLY = "multiply";
-    public static final String DIVIDE = "divide";
-    public static final String LEAST = "least";
-    public static final String GREATEST = "greatest";
-    public static final String MOD = "mod";
-
-    // date functions
-    public static final String YEAR = "year";
-    public static final String YEARS_ADD = "years_add";
-    public static final String YEARS_SUB = "years_sub";
-    public static final String MONTH = "month";
-    public static final String MONTHS_ADD = "months_add";
-    public static final String MONTHS_SUB = "months_sub";
-    public static final String DAY = "day";
-    public static final String DAYS_ADD = "days_add";
-    public static final String DAYS_SUB = "days_sub";
-    public static final String ADDDATE = "adddate";
-    public static final String SUBDATE = "subdate";
-    public static final String DATE_ADD = "date_add";
-    public static final String DATE_SUB = "date_sub";
-    public static final String HOUR = "hour";
-    public static final String MINUTE = "minute";
-    public static final String SECOND = "second";
-    public static final String CURDATE = "curdate";
-    public static final String CURRENT_TIMESTAMP = "current_timestamp";
-    public static final String CURRENT_TIME = "current_time";
-    public static final String NOW = "now";
-    public static final String UNIX_TIMESTAMP = "unix_timestamp";
-    public static final String UTC_TIMESTAMP = "utc_timestamp";
-    public static final String TIMESTAMPADD = "timestampadd";
-    public static final String DATE_TRUNC = "date_trunc";
-    public static final String TIME_SLICE = "time_slice";
-    public static final String STRFTIME = "strftime";
-    public static final String TIME_FORMAT = "time_format";
-    public static final String DATE_FORMAT = "date_format";
-    public static final String ALIGNMENT_TIMESTAMP = "alignment_timestamp";
     public static final String DEFAULT_VALUE = "default_value";
     public static final String REPLACE_VALUE = "replace_value";
-    public static final String SUBSTITUTE = "substitute";
-    public static final String FROM_UNIXTIME = "from_unixtime";
-
-    // string functions
-    public static final String APPEND_TRAILING_CHAR_IF_ABSENT = "append_trailing_char_if_absent";
-    public static final String CONCAT = "concat";
-    public static final String CONCAT_WS = "concat_ws";
-    public static final String LEFT = "left";
-    public static final String LIKE = "like";
-    public static final String LOWER = "lower";
-    public static final String LPAD = "lpad";
-    public static final String LTRIM = "ltrim";
-    public static final String REGEXP_EXTRACT = "regexp_extract";
-    public static final String REGEXP_REPLACE = "regexp_replace";
-    public static final String REPEAT = "repeat";
-    public static final String REVERSE = "reverse";
-    public static final String RIGHT = "right";
-    public static final String RPAD = "rpad";
-    public static final String RTRIM = "rtrim";
-    public static final String SPLIT_PART = "split_part";
-    public static final String SUBSTR = "substr";
-    public static final String SUBSTRING = "substring";
-    public static final String STARTS_WITH = "starts_with";
-    public static final String TRIM = "trim";
-    public static final String UPPER = "upper";
-
-    // geo functions
-    public static final String ST_ASTEXT = "st_astext";
 
     // JSON functions
-    public static final String JSON_QUERY = "json_query";
-    public static final String PARSE_JSON = "parse_json";
-    public static final String JSON_ARRAY = "json_array";
-    public static final String JSON_OBJECT = "json_object";
     public static final Function JSON_QUERY_FUNC = new Function(
             new FunctionName(JSON_QUERY), new Type[] {Type.JSON, Type.VARCHAR}, Type.JSON, false);
 
-    // Array functions
-    public static final String ARRAY_DIFFERENCE = "array_difference";
-
-    // Util functions
-    public static final String UUID = "uuid";
-    public static final String SLEEP = "sleep";
-    public static final String ISNULL = "isnull";
-
-    private static final Logger LOG = LogManager.getLogger(FunctionSet.class);
+    private static final Logger LOGGER = LogManager.getLogger(FunctionSet.class);
 
     private static final Map<Type, Type> MULTI_DISTINCT_SUM_RETURN_TYPE =
             ImmutableMap.<Type, Type>builder()
@@ -260,7 +414,7 @@ public class FunctionSet {
     // This contains the nullable functions, which cannot return NULL result directly for the NULL parameter.
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
     private final ImmutableSet<String> notAlwaysNullResultWithNullParamFunctions =
-            ImmutableSet.of(IF, CONCAT_WS, IF_NULL, NULL_IF, NULL_OR_EMPTY, COALESCE, BITMAP_HASH, PERCENTILE_HASH,
+            ImmutableSet.of(IF, CONCAT_WS, IFNULL, NULLIF, NULL_OR_EMPTY, COALESCE, BITMAP_HASH, PERCENTILE_HASH,
                     HLL_HASH, JSON_ARRAY, JSON_OBJECT);
 
     // If low cardinality string column with global dict, for some string functions,
@@ -353,8 +507,8 @@ public class FunctionSet {
         // ifnull, nullif(DATE, DATETIME) should return datetime, not bigint
         // if(boolean, DATE, DATETIME) should return datetime
         int arg_index = 0;
-        if (functionName.equalsIgnoreCase(IF_NULL) ||
-                functionName.equalsIgnoreCase(NULL_IF) ||
+        if (functionName.equalsIgnoreCase(IFNULL) ||
+                functionName.equalsIgnoreCase(NULLIF) ||
                 functionName.equalsIgnoreCase(IF)) {
             if (functionName.equalsIgnoreCase(IF)) {
                 arg_index = 1;
@@ -918,7 +1072,7 @@ public class FunctionSet {
                 if (typeArray == null) {
                     typeArray = (ArrayType) realType;
                 } else if ((typeArray = (ArrayType) getSuperType(typeArray, realType)) == null) {
-                    LOG.warn("could not determine polymorphic type because input has non-match types");
+                    LOGGER.warn("could not determine polymorphic type because input has non-match types");
                     return null;
                 }
             } else if (declType instanceof AnyElementType) {
@@ -928,11 +1082,11 @@ public class FunctionSet {
                 if (typeElement == null) {
                     typeElement = realType;
                 } else if ((typeElement = getSuperType(typeElement, realType)) == null) {
-                    LOG.warn("could not determine polymorphic type because input has non-match types");
+                    LOGGER.warn("could not determine polymorphic type because input has non-match types");
                     return null;
                 }
             } else {
-                LOG.warn("has unhandled pseudo type '{}'", declType);
+                LOGGER.warn("has unhandled pseudo type '{}'", declType);
                 return null;
             }
         }
@@ -940,7 +1094,7 @@ public class FunctionSet {
         if (typeArray != null && typeElement != null) {
             typeArray = (ArrayType) getSuperType(typeArray, new ArrayType(typeElement));
             if (typeArray == null) {
-                LOG.warn("could not determine polymorphic type because has non-match types");
+                LOGGER.warn("could not determine polymorphic type because has non-match types");
                 return null;
             }
             typeElement = typeArray.getItemType();
@@ -954,7 +1108,7 @@ public class FunctionSet {
         }
 
         if (!typeArray.getItemType().matchesType(typeElement)) {
-            LOG.warn("could not determine polymorphic type because has non-match types");
+            LOGGER.warn("could not determine polymorphic type because has non-match types");
             return null;
         }
 
@@ -1016,7 +1170,7 @@ public class FunctionSet {
             return new TableFunction(fn.getFunctionName(), ((TableFunction) fn).getDefaultColumnNames(),
                     Arrays.asList(realTypes), realTableFnRetTypes);
         }
-        LOG.error("polymorphic function has unknown type: {}", fn);
+        LOGGER.error("polymorphic function has unknown type: {}", fn);
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -26,8 +26,8 @@ public class DecimalV3FunctionAnalyzer {
 
     public static final Set<String> DECIMAL_IDENTICAL_TYPE_FUNCTION_SET =
             new ImmutableSortedSet.Builder<>(String::compareTo)
-                    .add(FunctionSet.LEAST).add(FunctionSet.GREATEST).add(FunctionSet.NULL_IF)
-                    .add(FunctionSet.IF_NULL).add(FunctionSet.COALESCE).add(FunctionSet.MOD).build();
+                    .add(FunctionSet.LEAST).add(FunctionSet.GREATEST).add(FunctionSet.NULLIF)
+                    .add(FunctionSet.IFNULL).add(FunctionSet.COALESCE).add(FunctionSet.MOD).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_SAME_TYPE =
             new ImmutableSortedSet.Builder<>(String::compareTo)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -287,7 +287,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
         if (FunctionSet.IF.equalsIgnoreCase(call.getFnName())) {
             return ifCall(call);
-        } else if (FunctionSet.IF_NULL.equalsIgnoreCase(call.getFnName())) {
+        } else if (FunctionSet.IFNULL.equalsIgnoreCase(call.getFnName())) {
             return ifNull(call);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -19,6 +19,8 @@ public class ColumnStatistic {
     private static final ColumnStatistic
             UNKNOWN = new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 1, StatisticType.UNKNOWN);
 
+    // For time types, including Date, DateTime, Timestamp. They all represented as timestamp in ColumnStatistic,
+    // regardless of their different storage format
     private final double minValue;
     private final double maxValue;
     private final double nullsFraction;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -18,14 +18,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.Utils.getDatetimeFromLong;
-
 public class ExpressionStatisticCalculator {
     private static final Logger LOG = LogManager.getLogger(ExpressionStatisticCalculator.class);
+
+    private static final int DAYS_FROM_0_TO_1970 = 719528;
+    private static final int BC_EPOCH_JULIAN = 1721060;
 
     public static ColumnStatistic calculate(ScalarOperator operator, Statistics input) {
         return calculate(operator, input, input != null ? input.getOutputRowCount() : 0);
@@ -121,7 +125,7 @@ public class ExpressionStatisticCalculator {
                     min = min.castTo(cast.getType());
                 }
             } catch (Exception e) {
-                LOG.debug("expression statistic compute cast failed: " + max.toString() + ", " + min.toString() +
+                LOG.debug("expression statistic compute cast failed: " + max.toString() + ", " + min +
                         ", to type: " + cast.getType());
                 return childStatistic;
             }
@@ -156,121 +160,347 @@ public class ExpressionStatisticCalculator {
         }
 
         private ColumnStatistic nullaryExpressionCalculate(CallOperator callOperator) {
+            double minValue;
+            double maxValue;
+            double distinctValue = rowCount;
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.COUNT:
-                    return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
-                            callOperator.getType().getTypeSize(), rowCount);
+                    minValue = 0;
+                    maxValue = inputStatistics.getOutputRowCount();
+                    break;
+                case FunctionSet.RAND:
+                case FunctionSet.RANDOM:
+                    minValue = 0;
+                    maxValue = 1;
+                    break;
+                case FunctionSet.E:
+                    minValue = Math.E;
+                    maxValue = Math.E;
+                    distinctValue = 1;
+                    break;
+                case FunctionSet.PI:
+                    minValue = Math.PI;
+                    maxValue = Math.PI;
+                    distinctValue = 1;
+                    break;
+                case FunctionSet.CURDATE:
+                    minValue = getJulianDate(LocalDate.now());
+                    maxValue = minValue;
+                    distinctValue = 1;
+                    break;
+                case FunctionSet.CURTIME:
+                case FunctionSet.CURRENT_TIME: {
+                    LocalDateTime now = LocalDateTime.now();
+                    minValue = now.getHour() * 3600 + now.getMinute() * 60 + now.getSecond();
+                    maxValue = minValue;
+                    distinctValue = 1;
+                    break;
+                }
+                case FunctionSet.NOW:
+                case FunctionSet.CURRENT_TIMESTAMP:
+                case FunctionSet.UNIX_TIMESTAMP:
+                    minValue = LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond();
+                    maxValue = minValue;
+                    distinctValue = 1;
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }
+            return new ColumnStatistic(minValue, maxValue, 0, callOperator.getType().getTypeSize(), distinctValue);
         }
 
         private ColumnStatistic unaryExpressionCalculate(CallOperator callOperator, ColumnStatistic columnStatistic) {
-            double aggFunDistinctValue = Math.max(1.0, Math.min(rowCount, columnStatistic.getDistinctValuesCount()));
+            double minValue = columnStatistic.getMinValue();
+            double maxValue = columnStatistic.getMaxValue();
+            double distinctValue = Math.min(rowCount, columnStatistic.getDistinctValuesCount());
             switch (callOperator.getFnName().toLowerCase()) {
+                case FunctionSet.SIGN:
+                    minValue = -1;
+                    maxValue = 1;
+                    distinctValue = 3;
+                    break;
+                case FunctionSet.GREATEST:
+                case FunctionSet.LEAST:
                 case FunctionSet.MAX:
                 case FunctionSet.MIN:
                 case FunctionSet.ANY_VALUE:
                 case FunctionSet.AVG:
-                    double maxValue = columnStatistic.getMaxValue();
-                    double minValue = columnStatistic.getMinValue();
-                    return new ColumnStatistic(minValue, maxValue, 0, columnStatistic.getAverageRowSize(),
-                            aggFunDistinctValue);
+                    maxValue = columnStatistic.getMaxValue();
+                    minValue = columnStatistic.getMinValue();
+                    break;
                 case FunctionSet.SUM:
-                    double sumFunMinValue = columnStatistic.getMinValue() > 0 ? columnStatistic.getMinValue() :
-                            columnStatistic.getMinValue() * rowCount / aggFunDistinctValue;
-                    double sumFunMaxValue = columnStatistic.getMaxValue() < 0 ? columnStatistic.getMaxValue() :
-                            columnStatistic.getMaxValue() * rowCount / aggFunDistinctValue;
-                    sumFunMaxValue = Math.max(sumFunMaxValue, sumFunMinValue);
-                    return new ColumnStatistic(sumFunMinValue, sumFunMaxValue, 0,
-                            columnStatistic.getAverageRowSize(), aggFunDistinctValue);
+                    minValue = columnStatistic.getMinValue() > 0 ? columnStatistic.getMinValue() :
+                            columnStatistic.getMinValue() * rowCount / distinctValue;
+                    maxValue = columnStatistic.getMaxValue() < 0 ? columnStatistic.getMaxValue() :
+                            columnStatistic.getMaxValue() * rowCount / distinctValue;
+                    break;
+                case FunctionSet.COUNT:
+                    minValue = 0;
+                    maxValue = inputStatistics.getOutputRowCount();
+                    distinctValue = rowCount;
+                    break;
+                case FunctionSet.MULTI_DISTINCT_COUNT:
+                    minValue = 0;
+                    maxValue = columnStatistic.getDistinctValuesCount();
+                    distinctValue = rowCount;
+                    break;
+                case FunctionSet.ASCII:
+                    minValue = 0;
+                    maxValue = 127;
+                    distinctValue = 128;
+                    break;
                 case FunctionSet.YEAR:
-                    int minYearValue = 1700;
-                    int maxYearValue = 2100;
+                    minValue = 1700;
+                    maxValue = 2100;
                     try {
-                        minYearValue = getDatetimeFromLong((long) columnStatistic.getMinValue()).getYear();
-                        maxYearValue = getDatetimeFromLong((long) columnStatistic.getMaxValue()).getYear();
+                        minValue = Utils.getDatetimeFromLong((long) columnStatistic.getMinValue()).getYear();
+                        maxValue = Utils.getDatetimeFromLong((long) columnStatistic.getMaxValue()).getYear();
                     } catch (DateTimeException e) {
                         LOG.debug("get date type column statistics min/max failed. " + e);
                     }
-                    return new ColumnStatistic(minYearValue, maxYearValue, 0,
-                            callOperator.getType().getTypeSize(),
-                            Math.min(columnStatistic.getDistinctValuesCount(), (maxYearValue - minYearValue + 1)));
+                    distinctValue =
+                            Math.min(columnStatistic.getDistinctValuesCount(), (maxValue - minValue + 1));
+                    break;
+                case FunctionSet.QUARTER:
+                    minValue = 1;
+                    maxValue = 4;
+                    distinctValue = 4;
+                    break;
                 case FunctionSet.MONTH:
-                    return new ColumnStatistic(1, 12, 0,
-                            callOperator.getType().getTypeSize(),
-                            Math.min(columnStatistic.getDistinctValuesCount(), 12));
+                    minValue = 1;
+                    maxValue = 12;
+                    distinctValue = 12;
+                    break;
+                case FunctionSet.WEEKOFYEAR:
+                    minValue = 1;
+                    maxValue = 54;
+                    distinctValue = 54;
+                    break;
                 case FunctionSet.DAY:
-                    return new ColumnStatistic(1, 31, 0,
-                            callOperator.getType().getTypeSize(),
-                            Math.min(columnStatistic.getDistinctValuesCount(), 31));
+                case FunctionSet.DAYOFMONTH:
+                    minValue = 1;
+                    maxValue = 31;
+                    distinctValue = 31;
+                    break;
+                case FunctionSet.DAYOFWEEK:
+                    minValue = 1;
+                    maxValue = 7;
+                    distinctValue = 7;
+                    break;
+                case FunctionSet.DAYOFYEAR:
+                    minValue = 1;
+                    maxValue = 366;
+                    distinctValue = 366;
+                    break;
                 case FunctionSet.HOUR:
-                    return new ColumnStatistic(0, 23, 0,
-                            callOperator.getType().getTypeSize(),
-                            Math.min(columnStatistic.getDistinctValuesCount(), 24));
+                    minValue = 0;
+                    maxValue = 23;
+                    distinctValue = 24;
+                    break;
                 case FunctionSet.MINUTE:
                 case FunctionSet.SECOND:
-                    return new ColumnStatistic(0, 59, 0,
-                            callOperator.getType().getTypeSize(),
-                            Math.min(columnStatistic.getDistinctValuesCount(), 60));
-                case FunctionSet.COUNT:
-                    return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
-                            callOperator.getType().getTypeSize(), rowCount);
-                case FunctionSet.MULTI_DISTINCT_COUNT:
-                    // use child column averageRowSize instead call operator type size
-                    return new ColumnStatistic(0, columnStatistic.getDistinctValuesCount(), 0,
-                            columnStatistic.getAverageRowSize(), rowCount);
+                    minValue = 0;
+                    maxValue = 59;
+                    distinctValue = 60;
+                    break;
+                case FunctionSet.TO_DATE:
+                    minValue = getJulianDate(Utils.getDatetimeFromLong((long) minValue).toLocalDate());
+                    maxValue = getJulianDate(Utils.getDatetimeFromLong((long) maxValue).toLocalDate());
+                    break;
+                case FunctionSet.TO_DAYS:
+                    minValue = minValue - BC_EPOCH_JULIAN;
+                    maxValue = maxValue - BC_EPOCH_JULIAN;
+                    break;
+                case FunctionSet.FROM_DAYS:
+                    minValue = minValue + BC_EPOCH_JULIAN;
+                    maxValue = maxValue + BC_EPOCH_JULIAN;
+                    break;
+                case FunctionSet.TIMESTAMP:
+                    break;
+                case FunctionSet.ABS:
+                    double absMinValue;
+                    double absMaxValue = Math.max(Math.abs(minValue), Math.abs(maxValue));
+                    if (minValue < 0 && maxValue < 0 || minValue >= 0 && maxValue >= 0) {
+                        absMinValue = Math.min(Math.abs(minValue), Math.abs(maxValue));
+                    } else {
+                        absMinValue = 0;
+                    }
+                    minValue = absMinValue;
+                    maxValue = absMaxValue;
+                    distinctValue = maxValue - minValue + 1;
+                    break;
+                case FunctionSet.ACOS:
+                case FunctionSet.ASIN:
+                case FunctionSet.ATAN:
+                case FunctionSet.ATAN2:
+                    minValue = 0;
+                    maxValue = Math.PI;
+                    break;
+                case FunctionSet.SIN:
+                case FunctionSet.COS:
+                    minValue = -1;
+                    maxValue = 1;
+                    break;
+                case FunctionSet.SQRT:
+                    minValue = 0;
+                    if (maxValue < 0) {
+                        return ColumnStatistic.unknown();
+                    }
+                    maxValue = Math.sqrt(maxValue);
+                    break;
+                case FunctionSet.SQUARE:
+                    double squareMinValue;
+                    double squareMaxValue = Math.max(minValue * minValue, maxValue * maxValue);
+                    if (minValue < 0 && maxValue < 0 || minValue >= 0 && maxValue >= 0) {
+                        squareMinValue = Math.min(minValue * minValue, maxValue * maxValue);
+                    } else {
+                        squareMinValue = 0;
+                    }
+                    minValue = squareMinValue;
+                    maxValue = squareMaxValue;
+                    break;
+                case FunctionSet.RADIANS:
+                    // π = 180°, so the ratio is 57.3
+                    minValue = minValue / 57.3;
+                    maxValue = maxValue / 57.3;
+                    break;
+                case FunctionSet.RAND:
+                case FunctionSet.RANDOM:
+                    minValue = 0;
+                    maxValue = 1;
+                    break;
+                case FunctionSet.NEGATIVE:
+                    double negativeMinValue = -maxValue;
+                    double negativeMaxValue = -minValue;
+                    minValue = negativeMinValue;
+                    maxValue = negativeMaxValue;
+                    break;
+                case FunctionSet.POSITIVE:
+                case FunctionSet.FLOOR:
+                case FunctionSet.DFLOOR:
+                case FunctionSet.CEIL:
+                case FunctionSet.CEILING:
+                case FunctionSet.ROUND:
+                case FunctionSet.DROUND:
+                case FunctionSet.TRUNCATE:
+                    // Just use the input's statistics as output's statistics
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }
+
+            final double averageRowSize;
+            if (callOperator.getType().isIntegerType() || callOperator.getType().isFloatingPointType()
+                    || callOperator.getType().isDateType()) {
+                averageRowSize = callOperator.getType().getTypeSize();
+            } else {
+                averageRowSize = columnStatistic.getAverageRowSize();
+            }
+            return new ColumnStatistic(minValue, maxValue, columnStatistic.getNullsFraction(), averageRowSize,
+                    distinctValue);
         }
 
         private ColumnStatistic binaryExpressionCalculate(CallOperator callOperator, ColumnStatistic left,
                                                           ColumnStatistic right) {
-            double distinctValues = Math.max(left.getDistinctValuesCount(), right.getDistinctValuesCount());
+            final double minValue;
+            final double maxValue;
             double nullsFraction = 1 - ((1 - left.getNullsFraction()) * (1 - right.getNullsFraction()));
+            double distinctValues = Math.max(left.getDistinctValuesCount(), right.getDistinctValuesCount());
+            double averageRowSize = callOperator.getType().getTypeSize();
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.ADD:
-                    return new ColumnStatistic(left.getMinValue() + right.getMinValue(),
-                            left.getMaxValue() + right.getMaxValue(), nullsFraction,
-                            callOperator.getType().getTypeSize(),
-                            distinctValues);
+                case FunctionSet.DATE_ADD:
+                    minValue = left.getMinValue() + right.getMinValue();
+                    maxValue = left.getMaxValue() + right.getMaxValue();
+                    break;
                 case FunctionSet.SUBTRACT:
-                    return new ColumnStatistic(left.getMinValue() - right.getMaxValue(),
-                            left.getMaxValue() - right.getMinValue(), nullsFraction,
-                            callOperator.getType().getTypeSize(),
-                            distinctValues);
+                case FunctionSet.TIMEDIFF:
+                case FunctionSet.DATE_SUB:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    break;
+                case FunctionSet.DATEDIFF:
+                    minValue = Utils.getDatetimeFromLong((long) left.getMinValue()).toLocalDate().toEpochDay() -
+                            Utils.getDatetimeFromLong((long) right.getMaxValue()).toLocalDate().toEpochDay();
+                    maxValue = Utils.getDatetimeFromLong((long) left.getMaxValue()).toLocalDate().toEpochDay() -
+                            Utils.getDatetimeFromLong((long) right.getMinValue()).toLocalDate().toEpochDay();
+                    break;
+                case FunctionSet.YEARS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 3600 * 24 * 365));
+                    break;
+                case FunctionSet.MONTHS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 3600 * 24 * 31));
+                    break;
+                case FunctionSet.WEEKS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 3600 * 24 * 7));
+                    break;
+                case FunctionSet.DAYS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 3600 * 24));
+                    break;
+                case FunctionSet.HOURS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 3600));
+                    break;
+                case FunctionSet.MINUTES_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 60));
+                    break;
+                case FunctionSet.SECONDS_DIFF:
+                    minValue = left.getMinValue() - right.getMaxValue();
+                    maxValue = left.getMaxValue() - right.getMinValue();
+                    distinctValues = Math.min(distinctValues, distinctOfInterval(minValue, maxValue, 1));
+                    break;
                 case FunctionSet.MULTIPLY:
-                    double multiplyMinValue = Math.min(Math.min(
+                    minValue = Math.min(Math.min(
                             Math.min(left.getMinValue() * right.getMinValue(),
                                     left.getMinValue() * right.getMaxValue()),
                             left.getMaxValue() * right.getMinValue()), left.getMaxValue() * right.getMaxValue());
-                    double multiplyMaxValue = Math.max(Math.max(
+                    maxValue = Math.max(Math.max(
                             Math.max(left.getMinValue() * right.getMinValue(),
                                     left.getMinValue() * right.getMaxValue()),
                             left.getMaxValue() * right.getMinValue()), left.getMaxValue() * right.getMaxValue());
-                    return new ColumnStatistic(multiplyMinValue, multiplyMaxValue, nullsFraction,
-                            callOperator.getType().getTypeSize(), distinctValues);
+                    break;
                 case FunctionSet.DIVIDE:
-                    double divideMinValue = Math.min(Math.min(
-                            Math.min(left.getMinValue() / divisorNotZero(right.getMinValue()),
-                                    left.getMinValue() / divisorNotZero(right.getMaxValue())),
-                            left.getMaxValue() / divisorNotZero(right.getMinValue())),
+                    minValue = Math.min(Math.min(
+                                    Math.min(left.getMinValue() / divisorNotZero(right.getMinValue()),
+                                            left.getMinValue() / divisorNotZero(right.getMaxValue())),
+                                    left.getMaxValue() / divisorNotZero(right.getMinValue())),
                             left.getMaxValue() / divisorNotZero(right.getMaxValue()));
-                    double divideMaxValue = Math.max(Math.max(
-                            Math.max(left.getMinValue() / divisorNotZero(right.getMinValue()),
-                                    left.getMinValue() / divisorNotZero(right.getMaxValue())),
-                            left.getMaxValue() / divisorNotZero(right.getMinValue())),
+                    maxValue = Math.max(Math.max(
+                                    Math.max(left.getMinValue() / divisorNotZero(right.getMinValue()),
+                                            left.getMinValue() / divisorNotZero(right.getMaxValue())),
+                                    left.getMaxValue() / divisorNotZero(right.getMinValue())),
                             left.getMaxValue() / divisorNotZero(right.getMaxValue()));
-                    return new ColumnStatistic(divideMinValue, divideMaxValue, nullsFraction,
-                            callOperator.getType().getTypeSize(),
-                            distinctValues);
-                // use child column statistics for now
-                case FunctionSet.SUBSTRING:
-                    return left;
+                    break;
+                case FunctionSet.MOD:
+                case FunctionSet.FMOD:
+                case FunctionSet.PMOD:
+                    minValue = -Math.max(Math.abs(right.getMinValue()), Math.abs(right.getMaxValue()));
+                    maxValue = -minValue;
+                    break;
+                case FunctionSet.IFNULL:
+                    minValue = Math.min(left.getMinValue(), right.getMinValue());
+                    maxValue = Math.max(left.getMaxValue(), right.getMaxValue());
+                    break;
+                case FunctionSet.NULLIF:
+                    minValue = left.getMinValue();
+                    maxValue = left.getMaxValue();
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }
+
+            return new ColumnStatistic(minValue, maxValue, nullsFraction, averageRowSize, distinctValues);
         }
 
         private ColumnStatistic multiaryExpressionCalculate(CallOperator callOperator,
@@ -291,6 +521,34 @@ public class ExpressionStatisticCalculator {
 
         private double divisorNotZero(double value) {
             return value == 0 ? 1.0 : value;
+        }
+
+        private double distinctOfInterval(double min, double max, double interval) {
+            return ((max - min) / interval) + 2;
+        }
+
+        private int getJulianDate(LocalDate date) {
+            int year = date.getYear();
+            int month = date.getMonthValue();
+            int day = date.getDayOfMonth();
+
+            int century;
+            int julian;
+
+            if (month > 2) {
+                month += 1;
+                year += 4800;
+            } else {
+                month += 13;
+                year += 4799;
+            }
+
+            century = year / 100;
+            julian = year * 365 - 32167;
+            julian += year / 4 - century + century / 4;
+            julian += 7834 * month / 256 + day;
+
+            return julian;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
@@ -277,9 +277,9 @@ public class SubqueryTransformer {
                     ((SelectRelation) queryRelation).getAggregate().get(0).getFnName().getFunction()
                             .equalsIgnoreCase(FunctionSet.COUNT)) {
 
-                subqueryOutput = new CallOperator(FunctionSet.IF_NULL, Type.BIGINT,
+                subqueryOutput = new CallOperator(FunctionSet.IFNULL, Type.BIGINT,
                         Lists.newArrayList(subqueryOutput, ConstantOperator.createBigint(0)),
-                        Expr.getBuiltinFunction(FunctionSet.IF_NULL, new Type[] {Type.BIGINT, Type.BIGINT},
+                        Expr.getBuiltinFunction(FunctionSet.IFNULL, new Type[] {Type.BIGINT, Type.BIGINT},
                                 Function.CompareMode.IS_IDENTICAL));
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 public class ScalarOperatorEvaluatorTest {
     @Test
     public void evaluationNotConstant() {
-        CallOperator operator = new CallOperator(FunctionSet.IF_NULL, Type.INT,
+        CallOperator operator = new CallOperator(FunctionSet.IFNULL, Type.INT,
                 Lists.newArrayList(new ColumnRefOperator(1, Type.INT, "test", true), ConstantOperator.createInt(2)));
 
         ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -15,7 +15,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 
@@ -56,6 +58,69 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testnullaryFunctionCall() {
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, Type.INT, "id", true);
+
+        Statistics.Builder builder = Statistics.builder();
+        Statistics statistics = builder.addColumnStatistic(columnRefOperator,
+                        ColumnStatistic.builder().setMinValue(0).setMaxValue(100).
+                                setDistinctValuesCount(100).setNullsFraction(0).setAverageRowSize(10).build())
+                .setOutputRowCount(100).build();
+
+        // test rand/random function
+        CallOperator callOperator = new CallOperator(FunctionSet.RAND, Type.DOUBLE, Lists.newArrayList());
+        ColumnStatistic columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0);
+        callOperator = new CallOperator(FunctionSet.RANDOM, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0);
+        // test e function
+        callOperator = new CallOperator(FunctionSet.E, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.E, 0);
+        Assert.assertEquals(columnStatistic.getMinValue(), Math.E, 0);
+        // test pi function
+        callOperator = new CallOperator(FunctionSet.PI, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.PI, 0);
+        Assert.assertEquals(columnStatistic.getMinValue(), Math.PI, 0);
+        // test curdate function
+        callOperator = new CallOperator(FunctionSet.CURDATE, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        long epochDay = LocalDate.now().toEpochDay();
+        Assert.assertTrue(columnStatistic.getMaxValue() <
+                LocalDate.ofEpochDay(epochDay + 1).atStartOfDay(ZoneId.systemDefault()).toEpochSecond());
+        Assert.assertTrue(columnStatistic.getMinValue() >
+                LocalDate.ofEpochDay(epochDay - 1).atStartOfDay(ZoneId.systemDefault()).toEpochSecond());
+        // test curtime/current_time function
+        callOperator = new CallOperator(FunctionSet.CURTIME, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        LocalDateTime now = LocalDateTime.now();
+        long time = now.getHour() * 3600 + now.getMinute() * 60 + now.getSecond();
+        Assert.assertTrue(columnStatistic.getMaxValue() < time + 1);
+        Assert.assertTrue(columnStatistic.getMinValue() > time - 1);
+        callOperator = new CallOperator(FunctionSet.CURRENT_TIME, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        now = LocalDateTime.now();
+        time = now.getHour() * 3600 + now.getMinute() * 60 + now.getSecond();
+        Assert.assertTrue(columnStatistic.getMaxValue() < time + 1);
+        Assert.assertTrue(columnStatistic.getMinValue() > time - 1);
+        // test current_timestamp/unix_timestamp function
+        callOperator = new CallOperator(FunctionSet.CURRENT_TIMESTAMP, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        long timestamp = System.currentTimeMillis() / 1000;
+        Assert.assertTrue(columnStatistic.getMaxValue() < timestamp + 1);
+        Assert.assertTrue(columnStatistic.getMinValue() > timestamp - 1);
+        callOperator = new CallOperator(FunctionSet.UNIX_TIMESTAMP, Type.DOUBLE, Lists.newArrayList());
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        timestamp = System.currentTimeMillis() / 1000;
+        Assert.assertTrue(columnStatistic.getMaxValue() < timestamp + 1);
+        Assert.assertTrue(columnStatistic.getMinValue() > timestamp - 1);
+    }
+
+    @Test
     public void testUnaryFunctionCall() {
         ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, Type.INT, "id", true);
         CallOperator callOperator = new CallOperator(FunctionSet.MAX, Type.INT, Lists.newArrayList(columnRefOperator));
@@ -77,12 +142,235 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assert.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
         Assert.assertEquals(columnStatistic.getMinValue(), min, 0.001);
-        // test count function
+        // test sign function
+        callOperator = new CallOperator(FunctionSet.SIGN, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -1, 0.001);
+        Assert.assertEquals(columnStatistic.getDistinctValuesCount(), 3, 0.001);
+        // test greast function
+        callOperator = new CallOperator(FunctionSet.GREATEST, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        // test least function
+        callOperator = new CallOperator(FunctionSet.LEAST, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        // test sum function
+        callOperator = new CallOperator(FunctionSet.SUM, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics, 10);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test count/multi_distinct_count function
         callOperator = new CallOperator(FunctionSet.COUNT, Type.INT, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics, 10);
         Assert.assertEquals(columnStatistic.getMaxValue(), statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(columnStatistic.getMinValue(), 0.0, 0.001);
         Assert.assertEquals(columnStatistic.getDistinctValuesCount(), 10, 0.001);
+        callOperator =
+                new CallOperator(FunctionSet.MULTI_DISTINCT_COUNT, Type.INT, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics, 10);
+        Assert.assertEquals(columnStatistic.getMaxValue(), statistics.getOutputRowCount(), 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0.0, 0.001);
+        Assert.assertEquals(columnStatistic.getDistinctValuesCount(), 10, 0.001);
+        // test ascii function
+        callOperator = new CallOperator(FunctionSet.ASCII, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 127, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        Assert.assertEquals(columnStatistic.getDistinctValuesCount(), 10, 128);
+        // test year function
+        callOperator = new CallOperator(FunctionSet.YEAR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1970, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1970, 0.001);
+        // test quarter function
+        callOperator = new CallOperator(FunctionSet.QUARTER, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 4, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test month function
+        callOperator = new CallOperator(FunctionSet.MONTH, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 12, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test weekofyear function
+        callOperator = new CallOperator(FunctionSet.WEEKOFYEAR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 54, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test day function
+        callOperator = new CallOperator(FunctionSet.DAY, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 31, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test dayofmonth function
+        callOperator = new CallOperator(FunctionSet.DAY, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 31, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test dayofweek function
+        callOperator = new CallOperator(FunctionSet.DAYOFWEEK, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 7, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test dayofyear function
+        callOperator = new CallOperator(FunctionSet.DAYOFYEAR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 366, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test hour function
+        callOperator = new CallOperator(FunctionSet.HOUR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 23, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test minute function
+        callOperator = new CallOperator(FunctionSet.MINUTE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 59, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test second function
+        callOperator = new CallOperator(FunctionSet.SECOND, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 59, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test to_date function
+        callOperator = new CallOperator(FunctionSet.TO_DATE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        LocalDate epochDay = LocalDate.of(1970, 1, 1);
+        Assert.assertEquals(columnStatistic.getMaxValue(),
+                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(),
+                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        // test to_days function
+        callOperator = new CallOperator(FunctionSet.TO_DAYS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), ExpressionStatisticCalculator.DAYS_FROM_0_TO_1970, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), ExpressionStatisticCalculator.DAYS_FROM_0_TO_1970, 0.001);
+        // test from_days function
+        callOperator = new CallOperator(FunctionSet.FROM_DAYS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(),
+                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(),
+                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        // test timestamp function
+        callOperator = new CallOperator(FunctionSet.TIMESTAMP, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        // test abs function
+        callOperator = new CallOperator(FunctionSet.ABS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        // test acos function
+        callOperator = new CallOperator(FunctionSet.ACOS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.PI, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test asin function
+        callOperator = new CallOperator(FunctionSet.ASIN, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.PI, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test atan function
+        callOperator = new CallOperator(FunctionSet.ATAN, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.PI / 2, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -Math.PI / 2, 0.001);
+        // test atan2 function
+        callOperator = new CallOperator(FunctionSet.ATAN2, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), Math.PI / 2, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -Math.PI / 2, 0.001);
+        // test sin function
+        callOperator = new CallOperator(FunctionSet.SIN, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -1, 0.001);
+        // test cos function
+        callOperator = new CallOperator(FunctionSet.COS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -1, 0.001);
+        // test sqrt function
+        callOperator = new CallOperator(FunctionSet.SQRT, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 10, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test square function
+        callOperator = new CallOperator(FunctionSet.SQUARE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 10000, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test radians function
+        callOperator = new CallOperator(FunctionSet.RADIANS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100 / 57.3, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test rand function
+        callOperator = new CallOperator(FunctionSet.RAND, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test rand function
+        callOperator = new CallOperator(FunctionSet.RAND, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test random function
+        callOperator = new CallOperator(FunctionSet.RANDOM, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 1, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test negative function
+        callOperator = new CallOperator(FunctionSet.NEGATIVE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 0, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), -100, 0.001);
+        // test positive function
+        callOperator = new CallOperator(FunctionSet.POSITIVE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test floor function
+        callOperator = new CallOperator(FunctionSet.FLOOR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test dfloor function
+        callOperator = new CallOperator(FunctionSet.DFLOOR, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test ceil function
+        callOperator = new CallOperator(FunctionSet.CEIL, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test ceiling function
+        callOperator = new CallOperator(FunctionSet.CEILING, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test round function
+        callOperator = new CallOperator(FunctionSet.ROUND, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test dround function
+        callOperator = new CallOperator(FunctionSet.DROUND, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test truncate function
+        callOperator = new CallOperator(FunctionSet.TRUNCATE, Type.DOUBLE, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assert.assertEquals(columnStatistic.getMaxValue(), 100, 0.001);
+        Assert.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
     }
 
     @Test
@@ -95,15 +383,96 @@ public class ExpressionStatisticsCalculatorTest {
         builder.addColumnStatistic(left, leftStatistic);
         builder.addColumnStatistic(right, rightStatistic);
 
+        // test add function
         CallOperator callOperator = new CallOperator(FunctionSet.ADD, Type.BIGINT, Lists.newArrayList(left, right));
         ColumnStatistic columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(300, columnStatistic.getMaxValue(), 0.001);
-
+        // test date_add function
+        callOperator = new CallOperator(FunctionSet.DATE_ADD, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(300, columnStatistic.getMaxValue(), 0.001);
+        // test substract function
         callOperator = new CallOperator(FunctionSet.SUBTRACT, Type.BIGINT, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(-300, columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test timediff function
+        callOperator = new CallOperator(FunctionSet.TIMEDIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-300, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test date_sub function
+        callOperator = new CallOperator(FunctionSet.DATE_SUB, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-300, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test datediff function
+        callOperator = new CallOperator(FunctionSet.DATEDIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test years_diff function
+        callOperator = new CallOperator(FunctionSet.YEARS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test months_diff function
+        callOperator = new CallOperator(FunctionSet.MONTHS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test weeks_diff function
+        callOperator = new CallOperator(FunctionSet.WEEKS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test days_diff function
+        callOperator = new CallOperator(FunctionSet.DAYS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.01);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.01);
+        // test hours_diff function
+        callOperator = new CallOperator(FunctionSet.HOURS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 1);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 1);
+        // test minutes_diff function
+        callOperator = new CallOperator(FunctionSet.MINUTES_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-5, columnStatistic.getMinValue(), 1);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 1);
+        // test seconds_diff function
+        callOperator = new CallOperator(FunctionSet.SECONDS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-300, columnStatistic.getMinValue(), 1);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 1);
+        // test mod function
+        callOperator = new CallOperator(FunctionSet.MOD, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-200, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(200, columnStatistic.getMaxValue(), 0.001);
+        // test fmod function
+        callOperator = new CallOperator(FunctionSet.FMOD, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-200, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(200, columnStatistic.getMaxValue(), 0.001);
+        // test pmod function
+        callOperator = new CallOperator(FunctionSet.PMOD, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-200, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(200, columnStatistic.getMaxValue(), 0.001);
+        // test ifnull function
+        callOperator = new CallOperator(FunctionSet.IFNULL, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-100, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(200, columnStatistic.getMaxValue(), 0.001);
+        // test nullif function
+        callOperator = new CallOperator(FunctionSet.NULLIF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(-100, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(100, columnStatistic.getMaxValue(), 0.001);
 
         callOperator = new CallOperator(FunctionSet.MULTIPLY, Type.BIGINT, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -753,11 +753,11 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         // check cardinality is not 0
         String sql = "SELECT sum(L_DISCOUNT * L_TAX) AS revenue FROM lineitem WHERE weekofyear(L_RECEIPTDATE) = 6";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "cardinality=300000000");
+        assertContains(plan, "cardinality=11111111");
 
         sql = "SELECT sum(L_DISCOUNT * L_TAX) AS revenue FROM lineitem WHERE weekofyear(L_RECEIPTDATE) in (6)";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "cardinality=300000000");
+        assertContains(plan, "cardinality=11111111");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6967

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

**Add following functions:**

* `rand`、`random`
* `e`、`pi`
* `sign`
* `abs`
* `acos`、`asin`、`atan`、`atan2`
* `sin`、`cos`
* `sqrt`
* `square`
* `radians`
* `negative`、`positive`
* `floor`、`dfloor`
* `ceil`、`ceiling`
* `round`、`dround`
* `truncate`
* `mod`、`fmod`、`pmod`
* `greatest`
* `least`
* `any_value`
* `count`
* `multi_distinct_count`
* `ascii`
* `curdate`
* `curtime`
* `current_time`
* `now`
* `current_timestamp`
* `unix_timestamp`
* `quarter`
* `weekofyear`、`dayofmonth`、`dayofweek`、`dayofyear`
* `to_date`
* `to_days`、`from_days`
* `timestamp`
* `timediff`
* `date_sub`
* `datediff`
* `years_diff`、`months_diff`、`weeks_diff`、`days_diff`、`hours_diff`、`minutes_diff`、`seconds_diff`
* `ifnull`、`nullif`


Besides, functions with non-numerical parameters are not supported now, such as `from_unixtime`、`timestampadd`