### PR TITLE
[BugFix] fix issue 6723 about bitmap_max function data overflow

### DIFF
--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -385,13 +385,17 @@ ColumnPtr BitmapFunctions::bitmap_max(FunctionContext* context, const starrocks:
     ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
 
     size_t size = columns[0]->size();
-    ColumnBuilder<TYPE_BIGINT> builder(size);
+    ColumnBuilder<TYPE_LARGEINT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (viewer.is_null(row)) {
             builder.append_null();
         } else {
-            int64_t value = viewer.value(row)->max();
-            builder.append(value);
+            if (auto max_value = viewer.value(row)->max(); max_value.has_value()) {
+                int128_t value128 = max_value.value();
+                builder.append(value128);
+            } else {
+                builder.append_null();
+            }
         }
     }
 
@@ -402,13 +406,17 @@ ColumnPtr BitmapFunctions::bitmap_min(FunctionContext* context, const starrocks:
     ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
 
     size_t size = columns[0]->size();
-    ColumnBuilder<TYPE_BIGINT> builder(size);
+    ColumnBuilder<TYPE_LARGEINT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (viewer.is_null(row)) {
             builder.append_null();
         } else {
-            int64_t value = viewer.value(row)->min();
-            builder.append(value);
+            if (auto min_value = viewer.value(row)->min(); min_value.has_value()) {
+                int128_t value128 = min_value.value();
+                builder.append(value128);
+            } else {
+                builder.append_null();
+            }
         }
     }
 

--- a/be/src/exprs/vectorized/bitmap_functions.h
+++ b/be/src/exprs/vectorized/bitmap_functions.h
@@ -117,14 +117,14 @@ public:
     /**
      * @param:
      * @paramType columns: [TYPE_OBJECT]
-     * @return TYPE_BIGINT
+     * @return TYPE_LARGEINT
      */
     DEFINE_VECTORIZED_FN(bitmap_max);
 
     /**
      * @param:
      * @paramType columns: [TYPE_OBJECT]
-     * @return TYPE_BIGINT
+     * @return TYPE_LARGEINT
      */
     DEFINE_VECTORIZED_FN(bitmap_min);
 

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -98,9 +98,9 @@ public:
     // TODO should the return type be uint64_t?
     int64_t cardinality() const;
 
-    uint64_t max() const;
+    std::optional<uint64_t> max() const;
 
-    int64_t min() const;
+    std::optional<uint64_t> min() const;
 
     // Return how many bytes are required to serialize this bitmap.
     // See BitmapTypeCode for the serialized format.

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -177,26 +177,26 @@ public:
      * Return the largest value (if not empty)
      *
      */
-    uint64_t maximum() const {
+    std::optional<uint64_t> maximum() const {
         for (auto roaring_iter = roarings.crbegin(); roaring_iter != roarings.crend(); ++roaring_iter) {
             if (!roaring_iter->second.isEmpty()) {
                 return uniteBytes(roaring_iter->first, roaring_iter->second.maximum());
             }
         }
-        return 0;
+        return {};
     }
 
     /**
      * Return the smallest value (if not empty)
      *
      */
-    int64_t minimum() const {
+    std::optional<uint64_t> minimum() const {
         for (const auto& roaring : roarings) {
             if (!roaring.second.isEmpty()) {
                 return uniteBytes(roaring.first, roaring.second.minimum());
             }
         }
-        return -1;
+        return {};
     }
 
     /**

--- a/be/test/exprs/vectorized/bitmap_functions_test.cpp
+++ b/be/test/exprs/vectorized/bitmap_functions_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "column/array_column.h"
+#include "column/column_viewer.h"
 #include "exprs/base64.h"
 #include "types/bitmap_value.h"
 #include "util/phmap/phmap.h"
@@ -1734,14 +1735,23 @@ TEST_F(VecBitmapFunctionsTest, bitmapMaxTest) {
 
         auto column = BitmapFunctions::bitmap_max(ctx, columns);
 
-        ASSERT_TRUE(column->is_numeric());
+        ASSERT_FALSE(column->is_numeric());
 
-        auto p = ColumnHelper::cast_to<TYPE_BIGINT>(column);
+        ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
 
-        ASSERT_EQ(0, p->get_data()[0]);
-        ASSERT_EQ(0, p->get_data()[1]);
-        ASSERT_EQ(4, p->get_data()[2]);
-        ASSERT_EQ(4123102120, p->get_data()[3]);
+        auto max_value0 = viewer.value(0)->max();
+        ASSERT_TRUE(max_value0.has_value());
+        ASSERT_EQ(0, max_value0.value());
+
+        ASSERT_TRUE(column->is_null(1));
+
+        auto max_value2 = viewer.value(2)->max();
+        ASSERT_TRUE(max_value2.has_value());
+        ASSERT_EQ(4, max_value2.value());
+
+        auto max_value3 = viewer.value(3)->max();
+        ASSERT_TRUE(max_value3.has_value());
+        ASSERT_EQ(4123102120, max_value3.value());
     }
 
     {
@@ -1766,12 +1776,18 @@ TEST_F(VecBitmapFunctionsTest, bitmapMaxTest) {
 
         ASSERT_TRUE(v->is_nullable());
 
-        auto p = ColumnHelper::cast_to<TYPE_BIGINT>(ColumnHelper::as_column<NullableColumn>(v)->data_column());
+        ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
 
-        ASSERT_EQ(0, p->get_data()[0]);
+        auto max_value0 = viewer.value(0)->max();
+        ASSERT_TRUE(max_value0.has_value());
+        ASSERT_EQ(0, max_value0.value());
+
         ASSERT_TRUE(v->is_null(1));
         ASSERT_TRUE(v->is_null(2));
-        ASSERT_EQ(4123102120, p->get_data()[3]);
+
+        auto max_value3 = viewer.value(3)->max();
+        ASSERT_TRUE(max_value3.has_value());
+        ASSERT_EQ(4123102120, max_value3.value());
     }
 }
 
@@ -1810,14 +1826,23 @@ TEST_F(VecBitmapFunctionsTest, bitmapMinTest) {
 
         auto column = BitmapFunctions::bitmap_min(ctx, columns);
 
-        ASSERT_TRUE(column->is_numeric());
+        ASSERT_FALSE(column->is_numeric());
 
-        auto p = ColumnHelper::cast_to<TYPE_BIGINT>(column);
+        ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
 
-        ASSERT_EQ(0, p->get_data()[0]);
-        ASSERT_EQ(-1, p->get_data()[1]);
-        ASSERT_EQ(1, p->get_data()[2]);
-        ASSERT_EQ(23074, p->get_data()[3]);
+        auto min_value0 = viewer.value(0)->min();
+        ASSERT_TRUE(min_value0.has_value());
+        ASSERT_EQ(0, min_value0.value());
+
+        ASSERT_TRUE(column->is_null(1));
+
+        auto min_value2 = viewer.value(2)->min();
+        ASSERT_TRUE(min_value2.has_value());
+        ASSERT_EQ(1, min_value2.value());
+
+        auto min_value3 = viewer.value(3)->min();
+        ASSERT_TRUE(min_value3.has_value());
+        ASSERT_EQ(23074, min_value3.value());
     }
 
     {
@@ -1842,9 +1867,9 @@ TEST_F(VecBitmapFunctionsTest, bitmapMinTest) {
 
         ASSERT_TRUE(v->is_nullable());
 
-        auto p = ColumnHelper::cast_to<TYPE_BIGINT>(ColumnHelper::as_column<NullableColumn>(v)->data_column());
+        auto p = ColumnHelper::cast_to<TYPE_LARGEINT>(ColumnHelper::as_column<NullableColumn>(v)->data_column());
 
-        ASSERT_EQ(0, p->get_data()[0]);
+        ASSERT_EQ(NULL, p->get_data()[0]);
         ASSERT_TRUE(v->is_null(1));
         ASSERT_TRUE(v->is_null(2));
         ASSERT_EQ(23074, p->get_data()[3]);

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -26,11 +26,14 @@
 
 #include "util/coding.h"
 #define private public
+#include "column/vectorized_fwd.h"
+#include "exprs/vectorized/bitmap_functions.h"
 #include "types/bitmap_value.h"
 #include "types/bitmap_value_detail.h"
 #include "util/phmap/phmap.h"
 
 namespace starrocks {
+namespace vectorized {
 
 TEST(BitmapValueTest, bitmap_union) {
     BitmapValue empty;
@@ -337,8 +340,19 @@ TEST(BitmapValueTest, bitmap_single_convert) {
 }
 
 TEST(BitmapValueTest, bitmap_max) {
+    std::unique_ptr<FunctionContext> ctx_ptr;
+    FunctionContext* ctx;
+    ctx_ptr.reset(FunctionContext::create_test_context());
+    ctx = ctx_ptr.get();
+
     BitmapValue bitmap;
-    ASSERT_EQ(bitmap.max(), 0);
+    Columns columns;
+    auto s = BitmapColumn::create();
+    s->append(&bitmap);
+    columns.push_back(s);
+    auto column = BitmapFunctions::bitmap_max(ctx, columns);
+    ASSERT_TRUE(column->is_null(0));
+
     bitmap.add(0);
     ASSERT_EQ(bitmap.max(), 0);
     bitmap.add(1);
@@ -350,8 +364,19 @@ TEST(BitmapValueTest, bitmap_max) {
 }
 
 TEST(BitmapValueTest, bitmap_min) {
+    std::unique_ptr<FunctionContext> ctx_ptr;
+    FunctionContext* ctx;
+    ctx_ptr.reset(FunctionContext::create_test_context());
+    ctx = ctx_ptr.get();
+
     BitmapValue bitmap;
-    ASSERT_EQ(bitmap.min(), -1);
+    Columns columns;
+    auto s = BitmapColumn::create();
+    s->append(&bitmap);
+    columns.push_back(s);
+    auto column = BitmapFunctions::bitmap_min(ctx, columns);
+    ASSERT_TRUE(column->is_null(0));
+
     bitmap.add(std::numeric_limits<uint64_t>::max());
     ASSERT_EQ(bitmap.min(), std::numeric_limits<uint64_t>::max());
     bitmap.add(1);
@@ -381,4 +406,5 @@ TEST(BitmapValueTest, bitmap_xor) {
     }
 }
 
+} // namespace vectorized
 } // namespace starrocks

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -474,8 +474,8 @@ vectorized_functions = [
     [90300, 'bitmap_xor', 'BITMAP', ['BITMAP', 'BITMAP'], 'BitmapFunctions::bitmap_xor', False],
     [90400, 'bitmap_remove', 'BITMAP', ['BITMAP', 'BIGINT'], 'BitmapFunctions::bitmap_remove', False],
     [90500, 'bitmap_to_array', 'ARRAY_BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_to_array', False],
-    [90600, 'bitmap_max', 'BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_max', False],
-    [90700, 'bitmap_min', 'BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_min', False],
+    [90600, 'bitmap_max', 'LARGEINT', ['BITMAP'], 'BitmapFunctions::bitmap_max', False],
+    [90700, 'bitmap_min', 'LARGEINT', ['BITMAP'], 'BitmapFunctions::bitmap_min', False],
     [90800, 'base64_to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::base64_to_bitmap', False],
     [90900, 'array_to_bitmap', 'ARRAY_BIGINT', ['BITMAP'], 'BitmapFunctions::array_to_bitmap', False],
 


### PR DESCRIPTION
## What type of PR is this：
- [x]  bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes issue #6723

## Problem Summary(Required) ：
bitmap_max function should return unsigned int64, and convert to int128_t
