### PR TITLE
[BugFix] Remove the helpers from bdb ReplicationGroupAdmin when dropped fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -236,6 +236,17 @@ public class BDBHA implements HAProtocol {
         }
     }
 
+    public void removeHelperSocket(String ip, Integer port) {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        Set<InetSocketAddress> helperSockets = Sets.newHashSet(replicationGroupAdmin.getHelperSockets());
+        InetSocketAddress targetAddress = new InetSocketAddress(ip, port);
+        if (helperSockets.contains(targetAddress)) {
+            helperSockets.remove(targetAddress);
+            environment.setNewReplicationGroupAdmin(helperSockets);
+            LOG.info("remove helper socket {}:{} from replicationGroupAdmin", ip, port);
+        }
+    }
+
     public void removeNodeIfExist(String host, int port) {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -731,6 +731,7 @@ public class NodeMgr {
 
                 BDBHA ha = (BDBHA) stateMgr.getHaProtocol();
                 ha.removeUnstableNode(host, getFollowerCnt());
+                ha.removeHelperSocket(host, port);
             }
             stateMgr.getEditLog().logRemoveFrontend(fe);
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
@@ -1,5 +1,9 @@
 package com.starrocks.ha;
 
+import java.net.InetSocketAddress;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.server.GlobalStateMgr;
@@ -53,6 +57,11 @@ public class BDBHATest {
         Assert.assertEquals(1,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
 
+        Set<InetSocketAddress> helperSocketsBefore = Sets.newHashSet(environment.getReplicationGroupAdmin().getHelperSockets());
+        InetSocketAddress targetAddress = new InetSocketAddress("host1", 9010);
+        Assert.assertTrue(helperSocketsBefore.contains(targetAddress));        
+
+
         // one joined successfully
         new Frontend(FrontendNodeType.FOLLOWER, "node1", "host2", 9010)
                 .handleHbResponse(new FrontendHbResponse("n1", 8030, 9050,
@@ -63,6 +72,10 @@ public class BDBHATest {
 
         // the other one is dropped
         GlobalStateMgr.getCurrentState().dropFrontend(FrontendNodeType.FOLLOWER, "host1", 9010);
+
+        Set<InetSocketAddress> helperSocketsAfter = Sets.newHashSet(environment.getReplicationGroupAdmin().getHelperSockets());
+        Assert.assertTrue(!helperSocketsAfter.contains(targetAddress));
+
         Assert.assertEquals(0,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5663

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove the helpers from bdb ReplicationGroupAdmin when dropped fe