### PR TITLE
[Enhance] adjust buffer size of LocalExchange

### DIFF
--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -14,7 +14,7 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(R
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers * num_receivers *
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers *
                                                                 kLocalExchangeBufferChunks);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -14,7 +14,8 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(R
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers * num_receivers);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers * num_receivers *
+                                                                kLocalExchangeBufferChunks);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
@@ -52,7 +53,8 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    int buffer_size = std::max(num_receivers, static_cast<int>(source_operator->degree_of_parallelism()));
+    int buffer_size = std::max(num_receivers, static_cast<int>(source_operator->degree_of_parallelism())) *
+                      kLocalExchangeBufferChunks;
     auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * buffer_size);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
@@ -88,7 +90,8 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
 
     // To make sure at least one partition source operator is ready to output chunk before sink operators are full.
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num * state->chunk_size());
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num * state->chunk_size() *
+                                                                kLocalExchangeBufferChunks);
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_shuffle_source->set_runtime_state(state);
@@ -125,7 +128,7 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_row_count);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_row_count * kLocalExchangeBufferChunks);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -61,6 +61,8 @@ public:
     MorselQueue* morsel_queue_of_source_operator(const SourceOperatorFactory* source_op);
 
 private:
+    static constexpr int kLocalExchangeBufferChunks = 8;
+
     FragmentContext* _fragment_context;
     Pipelines _pipelines;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Current buffer size of LocalExchange is one chunk per dop, it has some drawbacks:
- Cause more schedule overhead: the sink pipeline must be scheduled after put one chunk, same as source
- Could not balance the speed between source and sink

So, here we change the buffer to 8 chunks. The experiment result should significant improvement through this change.

## Experiment result
- The chunk size is 4096
- Test some local-exchange intensive query

| Query | Before | After | 
| --- | ---- | ---- |
| `SELECT COUNT(c1),COUNT(c2),COUNT(c3) FROM ( SELECT LO_SUPPKEY c1, LO_ORDERDATE c2, sum(LO_REVENUE) OVER( PARTITION BY LO_SUPPKEY ORDER BY LO_ORDERDATE ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) c3 FROM ssb_100g.lineorder_flat ) as a;` |  29227ms | 6913ms | 
| `SELECT COUNT(c1),count(c2),count(c3) FROM ( SELECT LO_CUSTKEY c1, LO_ORDERDATE c2, sum(LO_REVENUE) OVER( PARTITION BY LO_CUSTKEY ORDER BY LO_ORDERDATE ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) c3 FROM ssb_100g.lineorder_flat ) as a;`| 25486ms | 6928ms|

