### PR TITLE
[Bug] Fix colocate/buck_shuf grf with bucket absent

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -325,6 +325,10 @@ public:
     }
 
     bool test_data_with_hash(CppType value, const uint32_t shuffle_hash) const {
+        static constexpr uint32_t BUCKET_ABSENT = 2147483647;
+        if (shuffle_hash == BUCKET_ABSENT) {
+            return false;
+        }
         if constexpr (!IsSlice<CppType>) {
             if (value < _min || value > _max) {
                 return false;
@@ -367,11 +371,7 @@ public:
             compute_hash(&Column::fnv_hash, _num_hash_partitions);
             break;
         }
-        case TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET: {
-            hash_values.assign(num_rows, 0);
-            compute_hash(&Column::crc32_hash, _num_hash_partitions);
-            break;
-        }
+        case TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET:
         case TRuntimeFilterBuildJoinMode::COLOCATE: {
             hash_values.assign(num_rows, 0);
             // shuffle-aware grf is partitioned into multiple parts the number of whom equals to the number of

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -138,8 +138,9 @@ public class RuntimeFilterDescription {
         joinMode = mode;
     }
 
-    public boolean isColocate() {
-        return joinMode.equals(JoinNode.DistributionMode.COLOCATE);
+    public boolean isColocateOrBucketShuffle() {
+        return joinMode.equals(JoinNode.DistributionMode.COLOCATE) ||
+                joinMode.equals(JoinNode.DistributionMode.LOCAL_HASH_BUCKET);
     }
 
     public int getBuildPlanNodeId() {
@@ -253,7 +254,7 @@ public class RuntimeFilterDescription {
         if (broadcastGRFDestinations != null && !broadcastGRFDestinations.isEmpty()) {
             t.setBroadcast_grf_destinations(broadcastGRFDestinations);
         }
-        if (isColocate() && bucketSeqToInstance!=null && !bucketSeqToInstance.isEmpty()) {
+        if (isColocateOrBucketShuffle() && bucketSeqToInstance!=null && !bucketSeqToInstance.isEmpty()) {
             t.setBucketseq_to_instance(bucketSeqToInstance);
         }
         assert (joinMode != JoinNode.DistributionMode.NONE);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1269,9 +1269,7 @@ public class Coordinator {
 
             if (hasColocate || hasBucketShuffle) {
                 computeColocatedJoinInstanceParam(fragment.getFragmentId(), parallelExecInstanceNum, params);
-                if (hasColocate) {
-                    computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
-                }
+                computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
             } else {
                 for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> tNetworkAddressMapEntry :
                         fragmentExecParamsMap.get(fragment.getFragmentId()).scanRangeAssignment.entrySet()) {
@@ -1339,10 +1337,13 @@ public class Coordinator {
         }
     }
 
+    static final int BUCKET_ABSENT = 2147483647;
     public void computeBucketSeq2InstanceOrdinal(FragmentExecParams params, int numBuckets) {
         Integer[] bucketSeq2InstanceOrdinal = new Integer[numBuckets];
+        // some buckets are pruned, so set the corresponding instance ordinal to BUCKET_ABSENT to indicate
+        // absence of buckets.
         for (int bucketSeq = 0; bucketSeq < numBuckets; ++bucketSeq) {
-            bucketSeq2InstanceOrdinal[bucketSeq] = -1;
+            bucketSeq2InstanceOrdinal[bucketSeq] = BUCKET_ABSENT;
         }
         for (int i = 0; i < params.instanceExecParams.size(); ++i) {
             FInstanceExecParam instance = params.instanceExecParams.get(i);
@@ -2088,23 +2089,23 @@ public class Coordinator {
         public List<FInstanceExecParam> instanceExecParams = Lists.newArrayList();
         public FragmentScanRangeAssignment scanRangeAssignment = new FragmentScanRangeAssignment();
         TRuntimeFilterParams runtimeFilterParams = new TRuntimeFilterParams();
-        public boolean bucketSeqToInstanceForColocateRuntimeFilterIsSet = false;
+        public boolean bucketSeqToInstanceForFilterIsSet = false;
 
         public FragmentExecParams(PlanFragment fragment) {
             this.fragment = fragment;
         }
 
-        void setBucketSeqToInstanceForColocateRuntimeFilters() {
-            if (bucketSeqToInstanceForColocateRuntimeFilterIsSet) {
+        void setBucketSeqToInstanceForRuntimeFilters() {
+            if (bucketSeqToInstanceForFilterIsSet) {
                 return;
             }
-            bucketSeqToInstanceForColocateRuntimeFilterIsSet = true;
+            bucketSeqToInstanceForFilterIsSet = true;
             List<Integer> seqToInstance = fragmentIdToSeqToInstanceMap.get(fragment.getFragmentId());
             if (seqToInstance == null || seqToInstance.isEmpty()) {
                 return;
             }
             for (RuntimeFilterDescription rf : fragment.getBuildRuntimeFilters().values()) {
-                if (!rf.isColocate()) {
+                if (!rf.isColocateOrBucketShuffle()) {
                     continue;
                 }
                 rf.setBucketSeqToInstance(seqToInstance);
@@ -2143,7 +2144,7 @@ public class Coordinator {
                             connectContext, WorkGroupClassifier.QueryType.SELECT, dbIds);
                 }
             }
-            setBucketSeqToInstanceForColocateRuntimeFilters();
+            setBucketSeqToInstanceForRuntimeFilters();
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();
             for (int i = 0; i < instanceExecParams.size(); ++i) {
                 final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/6686
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When a runtime filter generated buck_shuf join is used as a global rf, it aslo needs bucketseq-to-partition mapping to keep the build side and probe side have the same data partition policy. 

In both colocate and buck_shuf grf,  some buckets would be pruned, so set the corresponding partition index in bucketseq-to-partition mapping to a special value(BUCKET_ABSENT) to indicate that the bucket is absent.
