### PR TITLE
[BugFix] Fix the HttpServer not wait the threads finished.

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -39,6 +39,7 @@
 #include "http/http_request.h"
 #include "service/brpc.h"
 #include "util/debug_util.h"
+#include "util/errno.h"
 #include "util/thread.h"
 
 namespace starrocks {
@@ -99,40 +100,69 @@ Status EvHttpServer::start() {
     for (int i = 0; i < _num_workers; ++i) {
         auto worker = [this, i]() {
             LOG(INFO) << "EvHttpServer worker start, id=" << i;
-            std::shared_ptr<event_base> base(event_base_new(), [](event_base* base) { event_base_free(base); });
+            struct event_base* base = event_base_new();
             if (base == nullptr) {
                 LOG(WARNING) << "Couldn't create an event_base.";
                 return;
             }
+            _event_bases.push_back(base);
+
             /* Create a new evhttp object to handle requests. */
-            std::shared_ptr<evhttp> http(evhttp_new(base.get()), [](evhttp* http) { evhttp_free(http); });
+            struct evhttp* http = evhttp_new(base);
             if (http == nullptr) {
                 LOG(WARNING) << "Couldn't create an evhttp.";
                 return;
             }
-            auto res = evhttp_accept_socket(http.get(), _server_fd);
+            auto res = evhttp_accept_socket(http, _server_fd);
             if (res < 0) {
-                LOG(WARNING) << "evhttp accept socket failed";
+                LOG(WARNING) << "evhttp accept socket failed"
+                             << ", error:" << errno_to_string(errno);
                 return;
             }
 
-            evhttp_set_newreqcb(http.get(), on_connection, this);
-            evhttp_set_gencb(http.get(), on_request, this);
+            evhttp_set_newreqcb(http, on_connection, this);
+            evhttp_set_gencb(http, on_request, this);
 
-            event_base_dispatch(base.get());
+            event_base_dispatch(base);
         };
         _workers.emplace_back(worker);
-        Thread::set_thread_name(_workers.back(), "ev_http_server");
-        _workers[i].detach();
+        Thread::set_thread_name(_workers.back(), "http_server");
     }
     return Status::OK();
 }
 
 void EvHttpServer::stop() {
+    // break the base to stop the event
+    for (auto base : _event_bases) {
+        event_base_loopbreak(base);
+    }
+
+    // shutdown the socket to wake up the epoll_wait
+    shutdown(_server_fd, SHUT_RDWR);
+
+    // join the thread before close the socket
+    join();
+
+    // close the socket at last
     close(_server_fd);
+
+    // free the evhttp and event_base
+    for (auto http : _https) {
+        evhttp_free(http);
+    }
+
+    for (auto base : _event_bases) {
+        event_base_free(base);
+    }
 }
 
-void EvHttpServer::join() {}
+void EvHttpServer::join() {
+    for (auto& thread : _workers) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+}
 
 Status EvHttpServer::_bind() {
     butil::EndPoint point;
@@ -146,10 +176,8 @@ Status EvHttpServer::_bind() {
     // default reuse_addr is true and reuse_port is false.
     _server_fd = butil::tcp_listen(point);
     if (_server_fd < 0) {
-        char buf[64];
         std::stringstream ss;
-        ss << "tcp listen failed, errno=" << errno << ", errmsg=webserver_port:" << _port << ". "
-           << strerror_r(errno, buf, sizeof(buf));
+        ss << "Failed to listen port. port: " << _port << ", error: " << errno_to_string(errno);
         return Status::InternalError(ss.str());
     }
     if (_port == 0) {
@@ -162,10 +190,8 @@ Status EvHttpServer::_bind() {
     }
     res = butil::make_non_blocking(_server_fd);
     if (res < 0) {
-        char buf[64];
         std::stringstream ss;
-        ss << "make socket to non_blocking failed, errno=" << errno
-           << ", errmsg=" << strerror_r(errno, buf, sizeof(buf));
+        ss << "Failed to generate a non-blocking socket. error: " << errno_to_string(errno);
         return Status::InternalError(ss.str());
     }
     return Status::OK();

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -113,6 +113,8 @@ Status EvHttpServer::start() {
                 LOG(WARNING) << "Couldn't create an evhttp.";
                 return;
             }
+            _https.push_back(http);
+
             auto res = evhttp_accept_socket(http, _server_fd);
             if (res < 0) {
                 LOG(WARNING) << "evhttp accept socket failed"

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <event2/event.h>
+
 #include <string>
 #include <thread>
 #include <vector>
@@ -75,6 +77,8 @@ private:
     PathTrie<HttpHandler*> _delete_handlers;
     PathTrie<HttpHandler*> _head_handlers;
     PathTrie<HttpHandler*> _options_handlers;
+    std::vector<struct event_base*> _event_bases;
+    std::vector<struct evhttp*> _https;
 };
 
 } // namespace starrocks

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -34,7 +34,6 @@ class HttpClient {
 public:
     HttpClient();
     ~HttpClient();
-
     // you can call this function to execute HTTP request with retry,
     // if callback return OK, this function will end and return OK.
     // This function will return FAIL if three are more than retry_times

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -54,6 +54,7 @@ HttpServiceBE::HttpServiceBE(ExecEnv* env, int port, int num_threads)
           _web_page_handler(new WebPageHandler(_ev_http_server.get())) {}
 
 HttpServiceBE::~HttpServiceBE() {
+    _ev_http_server->stop();
     _ev_http_server.reset();
     _web_page_handler.reset();
     STLDeleteElements(&_http_handlers);

--- a/be/src/service/service_cn/http_service.cpp
+++ b/be/src/service/service_cn/http_service.cpp
@@ -45,6 +45,7 @@ HttpServiceCN::HttpServiceCN(ExecEnv* env, int port, int num_threads)
           _web_page_handler(new WebPageHandler(_ev_http_server.get())) {}
 
 HttpServiceCN::~HttpServiceCN() {
+    _ev_http_server->stop();
     _ev_http_server.reset();
     _web_page_handler.reset();
     STLDeleteElements(&_http_handlers);

--- a/be/test/exec/es_scan_reader_test.cpp
+++ b/be/test/exec/es_scan_reader_test.cpp
@@ -215,7 +215,10 @@ public:
         ASSERT_NE(0, real_port);
     }
 
-    static void TearDownTestCase() { delete mock_es_server; }
+    static void TearDownTestCase() {
+        mock_es_server->stop();
+        delete mock_es_server;
+    }
 };
 
 } // namespace starrocks

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -812,8 +812,8 @@ TEST_F(AggregateTest, test_window_funnel) {
     std::vector<FunctionContext::TypeDesc> arg_types = {
             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_BIGINT)),
             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_DATETIME)),
-             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_INT)),
-              AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_ARRAY))};
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_INT)),
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_ARRAY))};
 
     auto return_type = AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_INT));
     std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
@@ -830,27 +830,27 @@ TEST_F(AggregateTest, test_window_funnel) {
     auto data_col = builder.build(false);
 
     auto offsets = UInt32Column::create();
-    offsets->append(2); // [true, true]
-    offsets->append(4); // [true, true]
-    offsets->append(6); // [true, true]
-    auto column4 = ArrayColumn::create(data_col, offsets);  // array_column, 4th column
+    offsets->append(2);                                    // [true, true]
+    offsets->append(4);                                    // [true, true]
+    offsets->append(6);                                    // [true, true]
+    auto column4 = ArrayColumn::create(data_col, offsets); // array_column, 4th column
 
-    auto column1 = Int64Column::create();   // first column, but there use const.
+    auto column1 = Int64Column::create(); // first column, but there use const.
     column1->append(1800);
     // column1->append(1800);
 
     auto column2 = TimestampColumn::create();
-    column2->append(TimestampValue::create(2022, 6, 10, 12, 30, 30));  // 2nd column.
+    column2->append(TimestampValue::create(2022, 6, 10, 12, 30, 30)); // 2nd column.
 
     auto const_column1 = ColumnHelper::create_const_column<TYPE_BIGINT>(1800, 1);
     auto column3 = ColumnHelper::create_const_column<TYPE_INT>(2, 1);
     Columns const_columns;
-    const_columns.emplace_back(const_column1);    // first column
+    const_columns.emplace_back(const_column1); // first column
     const_columns.emplace_back(column3);
-    const_columns.emplace_back(column3);         // 3rd const column
+    const_columns.emplace_back(column3); // 3rd const column
     local_ctx->impl()->set_constant_columns(const_columns);
 
-    std::vector<const Column*> raw_column;  // to column list.
+    std::vector<const Column*> raw_column; // to column list.
     raw_column.resize(4);
     raw_column[0] = column1.get();
     raw_column[1] = column2.get();

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -1008,7 +1008,7 @@ TEST_F(TimeFunctionsTest, from_days) {
         ColumnPtr result = TimeFunctions::from_days(ctx, columns);
         ASSERT_TRUE(result->is_nullable());
         auto col = ColumnHelper::as_column<NullableColumn>(result);
-        ASSERT_EQ(1,col->size());
+        ASSERT_EQ(1, col->size());
         ASSERT_FALSE(col->is_null(0));
         ASSERT_EQ(col->get(0).get_date().to_string(), "0000-00-00");
     }

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -90,7 +90,10 @@ public:
         hostname = "http://127.0.0.1:" + std::to_string(real_port);
     }
 
-    static void TearDownTestCase() { delete s_server; }
+    static void TearDownTestCase() {
+        s_server->stop();
+        delete s_server;
+    }
 };
 
 TEST_F(HttpClientTest, get_normal) {

--- a/be/test/runtime/small_file_mgr_test.cpp
+++ b/be/test/runtime/small_file_mgr_test.cpp
@@ -93,6 +93,7 @@ public:
     }
 
     static void TearDownTestCase() {
+        s_server->stop();
         delete s_server;
         std::stringstream ss;
         ss << g_download_path << "/" << g_file_12345 << "." << g_md5_12345;

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -111,6 +111,7 @@ public:
         jar_md5sum = compute_md5("./be/test/runtime/test_data/user_function_cache/lib/my_udf.jar");
     }
     static void TearDownTestCase() {
+        s_server->stop();
         delete s_server;
         system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_add.so");
         system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_udf.jar");

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -59,7 +59,7 @@ TEST(CompactionUtilsTest, test_get_segment_max_rows) {
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
     ASSERT_EQ(2147483647, segment_max_rows);
 
-    max_segment_file_size = 1 << 63;
+    max_segment_file_size = 1LL << 63;
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
     ASSERT_EQ(2147483647, segment_max_rows);
 


### PR DESCRIPTION
Upon exit gracefully, the HttpServer should guarantee all the threads
are finished. Otherwise, the memory leak will be thrown. The pull request fixes the bug.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6738

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
