### PR TITLE
[cherry-pick][branch-2.0] Fix null pointer error of column upserted (#6764)

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -83,27 +83,26 @@ Status RowsetUpdateState::_do_load(Rowset* rowset) {
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
     auto chunk = chunk_shared_ptr.get();
     for (size_t i = 0; i < itrs.size(); i++) {
-        auto itr = itrs[i].get();
-        if (itr == nullptr) {
-            continue;
-        }
         auto& dest = _upserts[i];
         auto col = pk_column->clone();
-        auto num_rows = beta_rowset->segments()[i]->num_rows();
-        col->reserve(num_rows);
-        while (true) {
-            chunk->reset();
-            auto st = itr->get_next(chunk);
-            if (st.is_end_of_file()) {
-                break;
-            } else if (!st.ok()) {
-                return st;
-            } else {
-                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+        auto itr = itrs[i].get();
+        if (itr != nullptr) {
+            auto num_rows = beta_rowset->segments()[i]->num_rows();
+            col->reserve(num_rows);
+            while (true) {
+                chunk->reset();
+                auto st = itr->get_next(chunk);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                }
             }
+            itr->close();
+            CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
         }
-        itr->close();
-        CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
         dest = std::move(col);
     }
     for (const auto& upsert : upserts()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6697 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Jump out of current for loop if segment iterator is a nullptr. Otherwise, the columns upserted will throw a null pointer error.