### PR TITLE
Fix unstable UT RoutineLoadManagerTest.testExpired

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -846,6 +846,9 @@ public class RoutineLoadManagerTest {
         long saveChecksum = loadManager.saveRoutineLoadJobs(dos, checksum);
         dos.close();
 
+        // make sure it can not be clean
+        idToRoutineLoadJob.get(goodJob.getId()).endTimestamp = System.currentTimeMillis() + 100000L;
+
         // 6. clean expire
         loadManager.cleanOldRoutineLoadJobs();
         Assert.assertEquals(1, idToRoutineLoadJob.size());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is because he built 2 jobs in this test. If the system is stuck, it will clear both jobs, so try to make the second job can't be cleared in time.