### PR TITLE
Pass TabletMetadata by shared pointer

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -13,7 +13,7 @@ Status Tablet::put_metadata(const TabletMetadata& metadata) {
 }
 
 Status Tablet::put_metadata(TabletMetadataPtr metadata) {
-    return _mgr->put_tablet_metadata(_group, metadata);
+    return _mgr->put_tablet_metadata(_group, std::move(metadata));
 }
 
 StatusOr<TabletMetadataPtr> Tablet::get_metadata(int64_t version) {
@@ -39,7 +39,7 @@ Status Tablet::put_txn_log(const TxnLog& log) {
 
 Status Tablet::put_txn_log(TxnLogPtr log) {
     // TODO: Check log.tablet_id() == _id
-    return _mgr->put_txn_log(_group, log);
+    return _mgr->put_txn_log(_group, std::move(log));
 }
 
 StatusOr<TxnLogPtr> Tablet::get_txn_log(int64_t txn_id) {

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -4,7 +4,6 @@
 
 #include "storage/lake/metadata_iterator.h"
 #include "storage/lake/tablet_manager.h"
-#include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 
 namespace starrocks::lake {
@@ -13,7 +12,11 @@ Status Tablet::put_metadata(const TabletMetadata& metadata) {
     return _mgr->put_tablet_metadata(_group, metadata);
 }
 
-StatusOr<TabletMetadata> Tablet::get_metadata(int64_t version) {
+Status Tablet::put_metadata(TabletMetadataPtr metadata) {
+    return _mgr->put_tablet_metadata(_group, metadata);
+}
+
+StatusOr<TabletMetadataPtr> Tablet::get_metadata(int64_t version) {
     return _mgr->get_tablet_metadata(_group, _id, version);
 }
 
@@ -34,7 +37,12 @@ Status Tablet::put_txn_log(const TxnLog& log) {
     return _mgr->put_txn_log(_group, log);
 }
 
-StatusOr<TxnLog> Tablet::get_txn_log(int64_t txn_id) {
+Status Tablet::put_txn_log(TxnLogPtr log) {
+    // TODO: Check log.tablet_id() == _id
+    return _mgr->put_txn_log(_group, log);
+}
+
+StatusOr<TxnLogPtr> Tablet::get_txn_log(int64_t txn_id) {
     return _mgr->get_txn_log(_group, _id, txn_id);
 }
 

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -2,17 +2,18 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "common/statusor.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/txn_log.h"
 
 namespace starrocks::lake {
 
 class MetadataIterator;
 class TabletManager;
 class TabletReader;
-class TxnLog;
 
 class Tablet {
 public:
@@ -24,7 +25,9 @@ public:
 
     Status put_metadata(const TabletMetadata& metadata);
 
-    StatusOr<TabletMetadata> get_metadata(int64_t version);
+    Status put_metadata(TabletMetadataPtr metadata);
+
+    StatusOr<TabletMetadataPtr> get_metadata(int64_t version);
 
     StatusOr<MetadataIterator> list_metadata();
 
@@ -34,7 +37,9 @@ public:
 
     Status put_txn_log(const TxnLog& log);
 
-    StatusOr<TxnLog> get_txn_log(int64_t txn_id);
+    Status put_txn_log(TxnLogPtr log);
+
+    StatusOr<TxnLogPtr> get_txn_log(int64_t txn_id);
 
     Status delete_txn_log(int64_t txn_id);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -34,8 +34,14 @@ Status TabletManager::put_tablet_metadata(const std::string& group, const Tablet
     return Status::NotSupported("TabletManager::put_tablet_metadata");
 }
 
-StatusOr<TabletMetadata> TabletManager::get_tablet_metadata(const std::string& group, int64_t tablet_id,
-                                                            int64_t version) {
+Status TabletManager::put_tablet_metadata(const std::string& group, TabletMetadataPtr metadata) {
+    (void)group;
+    (void)metadata;
+    return Status::NotSupported("TabletManager::put_tablet_metadata");
+}
+
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const std::string& group, int64_t tablet_id,
+                                                               int64_t version) {
     (void)group;
     (void)tablet_id;
     (void)version;
@@ -60,7 +66,7 @@ StatusOr<MetadataIterator> TabletManager::list_tablet_metadata(const std::string
     return Status::NotSupported("TabletManager::list_tablet_metadata");
 }
 
-StatusOr<TxnLog> TabletManager::get_txn_log(const std::string& group, int64_t tablet_id, int64_t txn_id) {
+StatusOr<TxnLogPtr> TabletManager::get_txn_log(const std::string& group, int64_t tablet_id, int64_t txn_id) {
     (void)group;
     (void)tablet_id;
     (void)txn_id;
@@ -68,6 +74,12 @@ StatusOr<TxnLog> TabletManager::get_txn_log(const std::string& group, int64_t ta
 }
 
 Status TabletManager::put_txn_log(const std::string& group, const TxnLog& log) {
+    (void)group;
+    (void)log;
+    return Status::NotSupported("TabletManager::put_txn_log");
+}
+
+Status TabletManager::put_txn_log(const std::string& group, TxnLogPtr log) {
     (void)group;
     (void)log;
     return Status::NotSupported("TabletManager::put_txn_log");

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "common/statusor.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/txn_log.h"
 
 namespace staros::starlet {
 class Starlet;
@@ -17,8 +19,6 @@ namespace starrocks::lake {
 
 class MetadataIterator;
 class Tablet;
-class TabletMetadata;
-class TxnLog;
 
 class TabletManager {
     friend class Tablet;
@@ -39,13 +39,15 @@ public:
 
 private:
     Status put_tablet_metadata(const std::string& group, const TabletMetadata& metadata);
-    StatusOr<TabletMetadata> get_tablet_metadata(const std::string& group, int64_t tablet_id, int64_t version);
+    Status put_tablet_metadata(const std::string& group, TabletMetadataPtr metadata);
+    StatusOr<TabletMetadataPtr> get_tablet_metadata(const std::string& group, int64_t tablet_id, int64_t version);
     Status delete_tablet_metadata(const std::string& group, int64_t tablet_id, int64_t version);
     StatusOr<MetadataIterator> list_tablet_metadata(const std::string& group);
     StatusOr<MetadataIterator> list_tablet_metadata(const std::string& group, int64_t tablet_id);
 
-    StatusOr<TxnLog> get_txn_log(const std::string& group, int64_t tablet_id, int64_t txn_id);
     Status put_txn_log(const std::string& group, const TxnLog& log);
+    Status put_txn_log(const std::string& group, TxnLogPtr log);
+    StatusOr<TxnLogPtr> get_txn_log(const std::string& group, int64_t tablet_id, int64_t txn_id);
     Status delete_txn_log(const std::string& group, int64_t tablet_id, int64_t txn_id);
     StatusOr<MetadataIterator> list_txn_log(const std::string& group);
     StatusOr<MetadataIterator> list_txn_log(const std::string& group, int64_t tablet_id);

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -4,13 +4,12 @@
 
 #include <memory>
 
-#include "storage/tablet_schema.h"
+#include "gen_cpp/starlake.pb.h"
 
 namespace starrocks::lake {
 
-// TODO:
-class TabletMetadata {
-public:
-};
+using TabletMetadata = TabletMetadataPB;
+using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
+using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log.h
+++ b/be/src/storage/lake/txn_log.h
@@ -2,9 +2,14 @@
 
 #pragma once
 
+#include <memory>
+
+#include "gen_cpp/starlake.pb.h"
+
 namespace starrocks::lake {
 
-// TODO
-class TxnLog {};
+using TxnLog = TxnLogPB;
+using TxnLogPtr = std::shared_ptr<const TxnLog>;
+using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
 
 } // namespace starrocks::lake


### PR DESCRIPTION
We'll save the `std::shared_ptr<const TabletMetadata>` in the in-memory
cache in the near future, so passing TabletMetadata by shared pointer can
estimate some memory copies thus bringing us better performance.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

