### PR TITLE
[Bugfix] release large memory when construct rpc attachment

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -608,7 +608,7 @@ void ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParamsPtr chu
         chunk->set_data_size(chunk->data().size());
         attachment.append(chunk->data());
         chunk->clear_data();
-        // If the request is too big, free the memory in advance to avoid OOM
+        // If the request is too big, free the memory in order to avoid OOM
         if (_is_large_chunk(chunk->data_size())) {
             chunk->mutable_data()->shrink_to_fit();
         }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -608,6 +608,10 @@ void ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParamsPtr chu
         chunk->set_data_size(chunk->data().size());
         attachment.append(chunk->data());
         chunk->clear_data();
+        // If the request is too big, free the memory in advance to avoid OOM
+        if (_is_large_chunk(chunk->data_size())) {
+            chunk->mutable_data()->shrink_to_fit();
+        }
     }
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -66,6 +66,11 @@ public:
     void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
 
 private:
+    bool _is_large_chunk(size_t sz) const {
+        // ref olap_scan_node.cpp release_large_columns
+        return sz > runtime_state()->chunk_size() * 512;
+    }
+
     class Channel;
 
     static const int32_t DEFAULT_DRIVER_SEQUENCE = 0;

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -144,7 +144,7 @@ void Operator::eval_runtime_bloom_filters(vectorized::Chunk* chunk) {
     ExecNode::eval_filter_null_values(chunk, filter_null_value_columns());
 }
 
-RuntimeState* Operator::runtime_state() {
+RuntimeState* Operator::runtime_state() const {
     return _factory->runtime_state();
 }
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -148,7 +148,7 @@ public:
         return res;
     }
 
-    RuntimeState* runtime_state();
+    RuntimeState* runtime_state() const;
 
 protected:
     OperatorFactory* _factory;
@@ -264,7 +264,7 @@ public:
 
     void set_runtime_state(RuntimeState* state) { this->_state = state; }
 
-    RuntimeState* runtime_state() { return _state; }
+    RuntimeState* runtime_state() const { return _state; }
 
     RowDescriptor* row_desc() { return &_row_desc; }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #6623

## Problem Summary(Required) ：

clear_data won't release string memory to heap, so we should call shrink_to_fit
to avoid OOM when rpc needs to send a large packet
