### PR TITLE
[BugFix] CTEAnchor must return child property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -354,12 +354,14 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
 
     @Override
     public PhysicalPropertySet visitPhysicalCTEAnchor(PhysicalCTEAnchorOperator node, ExpressionContext context) {
-        return requirements;
+        Preconditions.checkState(childrenOutputProperties.size() == 2);
+        return childrenOutputProperties.get(1);
     }
 
     @Override
     public PhysicalPropertySet visitPhysicalCTEProduce(PhysicalCTEProduceOperator node, ExpressionContext context) {
-        return requirements;
+        Preconditions.checkState(childrenOutputProperties.size() == 1);
+        return childrenOutputProperties.get(0);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -246,4 +246,29 @@ public class SubqueryTest extends PlanTestBase {
         }
         FeConstants.runningUnitTest = false;
     }
+
+
+    @Test
+    public void testCTEAnchorProperty() throws Exception {
+        String sql = "explain SELECT\n" +
+                "max (t0_2.v1 IN (SELECT t0_2.v1 FROM  t0 AS t0_2 where abs(2) < 1) )\n" +
+                "FROM\n" +
+                "  t0 AS t0_2\n" +
+                "GROUP BY\n" +
+                "  ( CAST(t0_2.v1 AS INT) - NULL ) IN (SELECT subt0.v1  FROM  t1 AS t1_3 RIGHT ANTI JOIN t0 subt0 ON t1_3.v5 = subt0.v1 ),\n" +
+                "  t0_2.v1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  30:HASH JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 16: v1 = 1: v1\n" +
+                "  |  \n" +
+                "  |----29:EXCHANGE\n" +
+                "  |    \n" +
+                "  5:AGGREGATE (merge finalize)\n" +
+                "  |  group by: 16: v1\n" +
+                "  |  \n" +
+                "  4:EXCHANGE");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6703 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
MySQL h0>  SELECT
max (t0_2.c_0_0 IN (SELECT t0_2.c_0_0 FROM  t0 AS t0_2 where abs(2) < 1) )
FROM
  t0 AS t0_2
GROUP BY
  ( CAST(t0_2.c_0_0 AS INT) - NULL ) IN (SELECT subt0.c_0_1  FROM  t1 AS t1_3 RIGHT ANTI JOIN t0 subt0 ON t1_3.c_1_9 = subt0.c_0_0 ),
  t0_2.c_0_0
+---------------------------------------------------------------------+
| max(c_0_0 IN (((SELECT c_0_0 FROM t0 AS t0_2 WHERE (abs(2)) < 1)))) |
+---------------------------------------------------------------------+
+---------------------------------------------------------------------+
```

The question plan, Join is BUCKET_SHUFFLE(S), but children wasn't re-shuffle
![QlbShvoV7a](https://user-images.githubusercontent.com/5609319/171360889-5d7bf31f-b05e-44d6-b03f-a6420f10f1b8.jpg)


CTEAnchor property return parent required property direct, will cause join check error in complex join.
Join operator need right children's property to update shuffle-relation