### PR TITLE
[BugFix] Fix backend number assert

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1591,13 +1591,12 @@ public class Coordinator {
     }
 
     public void updateFragmentExecStatus(TReportExecStatusParams params) {
-        if (!backendExecStates.containsKey(params.backend_num)) {
+        BackendExecState execState = backendExecStates.get(params.backend_num);
+        if (execState == null) {
             LOG.warn("unknown backend number: {}, valid backend numbers: {}", params.backend_num,
-                    backendExecStates.keySet().toString());
+                    backendExecStates.keySet());
             return;
         }
-
-        BackendExecState execState = backendExecStates.get(params.backend_num);
         lock();
         try {
             if (!execState.updateProfile(params)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -490,7 +490,7 @@ public class Coordinator {
                 List<List<FInstanceExecParam>> infightFInstanceExecParamList = new LinkedList<>();
 
                 // Fragment instances' ordinals in FragmentExecParams.instanceExecParams determine
-                // shuffle partitions'ordinals in DataStreamSink. backendIds of Fragment instances that
+                // shuffle partitions' ordinals in DataStreamSink. backendIds of Fragment instances that
                 // contains shuffle join determine the ordinals of GRF components in the GRF. For a
                 // shuffle join, its shuffle partitions and corresponding one-map-one GRF components
                 // should have the same ordinals. so here assign monotonic unique backendIds to
@@ -1338,6 +1338,7 @@ public class Coordinator {
     }
 
     static final int BUCKET_ABSENT = 2147483647;
+
     public void computeBucketSeq2InstanceOrdinal(FragmentExecParams params, int numBuckets) {
         Integer[] bucketSeq2InstanceOrdinal = new Integer[numBuckets];
         // some buckets are pruned, so set the corresponding instance ordinal to BUCKET_ABSENT to indicate
@@ -1590,9 +1591,9 @@ public class Coordinator {
     }
 
     public void updateFragmentExecStatus(TReportExecStatusParams params) {
-        if (params.backend_num >= backendExecStates.size()) {
-            LOG.warn("unknown backend number: {}, expected less than: {}",
-                    params.backend_num, backendExecStates.size());
+        if (!backendExecStates.containsKey(params.backend_num)) {
+            LOG.warn("unknown backend number: {}, valid backend numbers: {}", params.backend_num,
+                    backendExecStates.keySet().toString());
             return;
         }
 
@@ -2076,7 +2077,6 @@ public class Coordinator {
             return this.rpcParams.params.getFragment_instance_id();
         }
     }
-
 
     // execution parameters for a single fragment,
     // per-fragment can have multiple FInstanceExecParam,


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
1. https://github.com/StarRocks/StarRocksTest/issues/464
2. https://github.com/StarRocks/StarRocksTest/issues/471

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Considering the following execution sequences

1. process fragment 0, which contains 1 instances, it's `backend_num=0`
    1. add `backend_num=0`  to `backendExecStates` of which size is up to 1
3. process fragment 1, which contains 3 instances, `backend_num` range from `1` to `3`. And the these 3 instances are divided into two parts,  first part contains `backend_num=2` and `backend_num=3`, second part contains `backend_num=1`
    1. we first process the first part, add `backend_num=2` and `backend_num=3` to `backendExecStates` of which size is up to 3
    3. execute `instance(backend_num=2)` and `instance(backend_num=3)` asynchronously
    4. `instance(backend_num=3)` is finished very soon, but the exec state is discarded, because the assertion `params.backend_num < backendExecStates.size()` is not satisfied
    5. then we process the second part, add `backend_num=1` to `backendExecStates` of which size is up to 4
    6. other steps...


Here are the logs corresponding to the above explanation.
```
2022-06-02 12:11:44,894 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():401] exec begin, this=com.starrocks.qe.Coordinator@25b7e1c5
2022-06-02 12:11:44,895 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():558] put backendExecStates backend_num=0, this=com.starrocks.qe.Coordinator@25b7e1c5
2022-06-02 12:11:44,897 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():558] put backendExecStates backend_num=2, this=com.starrocks.qe.Coordinator@25b7e1c5
2022-06-02 12:11:44,897 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():558] put backendExecStates backend_num=3, this=com.starrocks.qe.Coordinator@25b7e1c5
2022-06-02 12:11:44,907 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():558] put backendExecStates backend_num=1, this=com.starrocks.qe.Coordinator@25b7e1c5
2022-06-02 12:11:44,909 WARN (starrocks-mysql-nio-pool-0|99) [Coordinator.exec():617] exec end, this=com.starrocks.qe.Coordinator@25b7e1c5
```

So, the solution is straightforward, we only need to check whether the reported `backend_num` exists in the `backendExecStates` instead of assuming the size relation.