### PR TITLE
[Enhancement] Add short_key_ranges to segment options

### DIFF
--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -259,6 +259,7 @@ Status BetaRowset::get_segment_iterators(const vectorized::Schema& schema, const
         seg_options.meta = options.meta;
     }
     seg_options.rowid_range_option = options.rowid_range_option;
+    seg_options.short_key_ranges = options.short_key_ranges;
 
     auto segment_schema = schema;
     // Append the columns with delete condition to segment schema.

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -27,6 +27,8 @@ class DeletePredicates;
 class Schema;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+struct ShortKeyRangeOption;
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 
 class RowsetReadOptions {
 public:
@@ -60,6 +62,7 @@ public:
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
+    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/rowset/segment_options.cpp
+++ b/be/src/storage/rowset/segment_options.cpp
@@ -33,6 +33,7 @@ Status SegmentReadOptions::convert_to(SegmentReadOptions* dst, const std::vector
     dst->profile = profile;
     dst->global_dictmaps = global_dictmaps;
     dst->rowid_range_option = rowid_range_option;
+    dst->short_key_ranges = short_key_ranges;
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -24,6 +24,8 @@ namespace starrocks::vectorized {
 class ColumnPredicate;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+struct ShortKeyRangeOption;
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 
 class SegmentReadOptions {
 public:
@@ -61,6 +63,7 @@ public:
     bool has_delete_pred = false;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
+    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/rowset/short_key_range_option.h
+++ b/be/src/storage/rowset/short_key_range_option.h
@@ -1,0 +1,58 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "util/slice.h"
+
+namespace starrocks {
+namespace vectorized {
+
+class SeekTuple;
+class Schema;
+using SchemaPtr = std::shared_ptr<Schema>;
+struct ShortKeyOption;
+using ShortKeyOptionPtr = std::unique_ptr<ShortKeyOption>;
+
+// ShortKeyOption represents a sub key range endpoint splitted from a key range.
+// It could be a completed tuple key, or a short key with specific short_key_schema.
+struct ShortKeyOption {
+public:
+    ShortKeyOption() : tuple_key(nullptr), short_key_schema(nullptr), short_key(""), inclusive(false) {}
+
+    ShortKeyOption(const SeekTuple* tuple_key, bool inclusive)
+            : tuple_key(tuple_key), short_key_schema(nullptr), short_key(""), inclusive(inclusive) {}
+
+    ShortKeyOption(SchemaPtr short_key_schema, const Slice& short_key, bool inclusive)
+            : tuple_key(nullptr),
+              short_key_schema(std::move(short_key_schema)),
+              short_key(short_key),
+              inclusive(inclusive) {}
+
+    bool is_infinite() const { return tuple_key == nullptr && short_key.empty(); }
+
+public:
+    // Only one of tuple_key and short_key_schema has value.
+    const SeekTuple* const tuple_key;
+
+    const SchemaPtr short_key_schema;
+    const Slice short_key;
+
+    const bool inclusive;
+};
+
+// ShortKeyRangeOption represents a sub key range splitted from a key range.
+struct ShortKeyRangeOption {
+public:
+    ShortKeyRangeOption(ShortKeyOptionPtr lower, ShortKeyOptionPtr upper)
+            : lower(std::move(lower)), upper(std::move(upper)) {}
+
+public:
+    const ShortKeyOptionPtr lower;
+    const ShortKeyOptionPtr upper;
+};
+
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -120,6 +120,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
         rs_opts.meta = _tablet->data_dir()->get_meta();
     }
     rs_opts.rowid_range_option = params.rowid_range_option;
+    rs_opts.short_key_ranges = params.short_key_ranges;
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -21,6 +21,8 @@ namespace vectorized {
 class ColumnPredicate;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+struct ShortKeyRangeOption;
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 
 static inline std::unordered_set<uint32_t> EMPTY_FILTERED_COLUMN_IDS;
 
@@ -58,6 +60,7 @@ struct TabletReaderParams {
     const std::unordered_set<uint32_t>* unused_output_column_ids = &EMPTY_FILTERED_COLUMN_IDS;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
+    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
 public:
     std::string to_string() const;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR relates：
Relates #6110.

## Problem Summary:
As for parallel scan on the single tablet, it splits a key range into multiple small short key ranges. And each splitted point is a short key, not a completed `SeekTuple` key.

## Modification
- Make `SegmentIterator` able to find the rowid range of the short key range. 
- Add `short_key_ranges` to options of Segment, Rowset, and TabletReader.


