### PR TITLE
[Feature] Support parallel scan on tablet for merge/agg table

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -294,7 +294,7 @@ StatusOr<MorselPtr> LogicalSplitMorselQueue::try_get() {
         if (num_taken_blocks < _sample_splitted_scan_blocks) {
             cur_num_taken_blocks = _sample_splitted_scan_blocks - num_taken_blocks;
         } else {
-            // If it has taken enough blocks but haven't found the _cur_range_lower different from _cur_range_lower,
+            // If it has taken enough blocks but hasn't found the _cur_range_lower different from _cur_range_lower,
             // just take quarter of _sample_splitted_scan_blocks once.
             cur_num_taken_blocks = std::max<int64_t>(_sample_splitted_scan_blocks / 4, 1);
         }
@@ -353,7 +353,7 @@ bool LogicalSplitMorselQueue::_valid_range(const vectorized::ShortKeyOptionPtr& 
     }
 
     Slice upper_key = upper->short_key;
-    // Empty short key of start ShortKeyOption means it is the last splitted key range,
+    // Empty short key of end ShortKeyOption means it is the last splitted key range,
     // so use end original short key to compare.
     if (upper_key.empty()) {
         auto end_iter = _block_ranges_per_seek_range[_range_idx].second;

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -399,10 +399,14 @@ bool LogicalSplitMorselQueue::_cur_tablet_finished() const {
 }
 
 Rowset* LogicalSplitMorselQueue::_find_largest_rowset(const std::vector<RowsetSharedPtr>& rowsets) {
-    Rowset* largest_rowset = nullptr;
-    for (const auto& rowset : rowsets) {
-        if (largest_rowset == nullptr || largest_rowset->num_rows() < rowset->num_rows()) {
-            largest_rowset = rowset.get();
+    if (rowsets.empty()) {
+        return nullptr;
+    }
+
+    Rowset* largest_rowset = rowsets[0].get();
+    for (int i = 1; i < rowsets.size(); ++i) {
+        if (largest_rowset->num_rows() < rowsets[i]->num_rows()) {
+            largest_rowset = rowsets[i].get();
         }
     }
 
@@ -411,10 +415,15 @@ Rowset* LogicalSplitMorselQueue::_find_largest_rowset(const std::vector<RowsetSh
 
 SegmentSharedPtr LogicalSplitMorselQueue::_find_largest_segment(Rowset* rowset) const {
     auto* beta_rowset = down_cast<BetaRowset*>(rowset);
-    SegmentSharedPtr largest_segment = nullptr;
-    for (const auto& segment : beta_rowset->segments()) {
-        if (largest_segment == nullptr || largest_segment->num_rows() < segment->num_rows()) {
-            largest_segment = segment;
+    const auto& segments = beta_rowset->segments();
+    if (segments.empty()) {
+        return nullptr;
+    }
+
+    SegmentSharedPtr largest_segment = segments[0];
+    for (int i = 1; i < segments.size(); ++i) {
+        if (largest_segment->num_rows() < segments[i]->num_rows()) {
+            largest_segment = segments[i];
         }
     }
 

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -64,8 +64,10 @@ void PhysicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<
             continue;
         }
 
-        _range_start_op = key_range->begin_include ? "ge" : "gt";
-        _range_end_op = key_range->end_include ? "le" : "lt";
+        _range_start_op = key_range->begin_include ? vectorized::TabletReaderParams::RangeStartOperation::GE
+                                                   : vectorized::TabletReaderParams::RangeStartOperation::GT;
+        _range_end_op = key_range->end_include ? vectorized::TabletReaderParams::RangeEndOperation::LE
+                                               : vectorized::TabletReaderParams::RangeEndOperation::LT;
 
         _range_start_key.emplace_back(key_range->begin_scan_range);
         _range_end_key.emplace_back(key_range->end_scan_range);
@@ -246,8 +248,10 @@ void LogicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<O
             continue;
         }
 
-        _range_start_op = key_range->begin_include ? "ge" : "gt";
-        _range_end_op = key_range->end_include ? "le" : "lt";
+        _range_start_op = key_range->begin_include ? vectorized::TabletReaderParams::RangeStartOperation::GE
+                                                   : vectorized::TabletReaderParams::RangeStartOperation::GT;
+        _range_end_op = key_range->end_include ? vectorized::TabletReaderParams::RangeEndOperation::LE
+                                               : vectorized::TabletReaderParams::RangeEndOperation::LT;
 
         _range_start_key.emplace_back(key_range->begin_scan_range);
         _range_end_key.emplace_back(key_range->end_scan_range);

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -3,9 +3,11 @@
 #include "exec/pipeline/scan/morsel.h"
 
 #include "exec/olap_utils.h"
+#include "storage/chunk_helper.h"
 #include "storage/range.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/short_key_range_option.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_reader_params.h"
@@ -16,6 +18,10 @@ namespace pipeline {
 /// Morsel.
 void PhysicalSplitScanMorsel::init_tablet_reader_params(vectorized::TabletReaderParams* params) {
     params->rowid_range_option = _rowid_range_option;
+}
+
+void LogicalSplitScanMorsel::init_tablet_reader_params(vectorized::TabletReaderParams* params) {
+    params->short_key_ranges = _short_key_ranges;
 }
 
 /// MorselQueue.
@@ -109,7 +115,8 @@ StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
     return morsel;
 }
 
-rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower) {
+rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key,
+                                                       bool lower) const {
     std::string index_key =
             key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
     uint32_t start_block_id;
@@ -132,7 +139,7 @@ rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const v
 }
 
 rowid_t PhysicalSplitMorselQueue::_upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower,
-                                                       rowid_t end) {
+                                                       rowid_t end) const {
     std::string index_key =
             key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
 
@@ -227,6 +234,305 @@ Status PhysicalSplitMorselQueue::_init_segment() {
     _num_segment_rest_rows = _segment_scan_range.span_size();
 
     return Status::OK();
+}
+
+std::vector<TInternalScanRange*> LogicalSplitMorselQueue::olap_scan_ranges() const {
+    return _convert_morsels_to_olap_scan_ranges(_morsels);
+}
+
+void LogicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) {
+    for (const auto& key_range : key_ranges) {
+        if (key_range->begin_scan_range.size() == 1 && key_range->begin_scan_range.get_value(0) == NEGATIVE_INFINITY) {
+            continue;
+        }
+
+        _range_start_op = key_range->begin_include ? "ge" : "gt";
+        _range_end_op = key_range->end_include ? "le" : "lt";
+
+        _range_start_key.emplace_back(key_range->begin_scan_range);
+        _range_end_key.emplace_back(key_range->end_scan_range);
+    }
+}
+
+StatusOr<MorselPtr> LogicalSplitMorselQueue::try_get() {
+    DCHECK(!_tablets.empty());
+    DCHECK(!_tablet_rowsets.empty());
+    DCHECK_EQ(_tablets.size(), _tablet_rowsets.size());
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_tablet_idx >= _tablets.size()) {
+        return nullptr;
+    }
+
+    // When it hasn't initialized any tablet,
+    // or the current tablet doesn't contain any segment,
+    // or all the key ranges of the current tablet has been finished,
+    // we should pick up the next tablet and init it.
+    while (!_has_init_any_tablet || _segment_group == nullptr || _cur_tablet_finished()) {
+        if (!_next_tablet()) {
+            return nullptr;
+        }
+        RETURN_IF_ERROR(_init_tablet());
+    }
+
+    size_t num_taken_blocks = 0;
+    std::vector<vectorized::ShortKeyRangeOptionPtr> short_key_ranges;
+    vectorized::ShortKeyOptionPtr _cur_range_lower = nullptr;
+    vectorized::ShortKeyOptionPtr _cur_range_upper = nullptr;
+    bool need_more_blocks = true;
+    while (!_cur_tablet_finished() &&      // One morsel only read data from one tablet.
+           (_cur_range_lower != nullptr || // Haven't found the _cur_range_lower different from _cur_range_lower.
+            (need_more_blocks && num_taken_blocks < _sample_splitted_scan_blocks))) {
+        auto& num_rest_blocks = _num_rest_blocks_per_seek_range[_range_idx];
+
+        if (_cur_range_lower == nullptr) {
+            _cur_range_lower = _create_range_lower();
+        }
+
+        size_t cur_num_taken_blocks = 0;
+        if (num_taken_blocks < _sample_splitted_scan_blocks) {
+            cur_num_taken_blocks = _sample_splitted_scan_blocks - num_taken_blocks;
+        } else {
+            // If it has taken enough blocks but haven't found the _cur_range_lower different from _cur_range_lower,
+            // just take quarter of _sample_splitted_scan_blocks once.
+            cur_num_taken_blocks = std::max<int64_t>(_sample_splitted_scan_blocks / 4, 1);
+        }
+        cur_num_taken_blocks = std::min(cur_num_taken_blocks, num_rest_blocks);
+
+        // As for the last key range, if there is not enough blocks after this time taking,
+        // take from the last key range at most half of the rest blocks.
+        if (_range_idx + 1 >= _block_ranges_per_seek_range.size() && num_rest_blocks > cur_num_taken_blocks &&
+            num_rest_blocks - cur_num_taken_blocks < _sample_splitted_scan_blocks) {
+            cur_num_taken_blocks = std::min(cur_num_taken_blocks, num_rest_blocks / 2);
+            need_more_blocks = false;
+        }
+
+        num_rest_blocks -= cur_num_taken_blocks;
+        num_taken_blocks += cur_num_taken_blocks;
+        _next_lower_block_iter += static_cast<ssize_t>(cur_num_taken_blocks);
+
+        _cur_range_upper = _create_range_upper();
+
+        if (num_rest_blocks == 0 || _valid_range(_cur_range_lower, _cur_range_upper)) {
+            short_key_ranges.emplace_back(std::make_shared<vectorized::ShortKeyRangeOption>(
+                    std::move(_cur_range_lower), std::move(_cur_range_upper)));
+        }
+
+        // The current key range has no more blocks, so move to next key range.
+        if (num_rest_blocks == 0) {
+            ++_range_idx;
+            if (!_cur_tablet_finished()) {
+                _next_lower_block_iter = _block_ranges_per_seek_range[_range_idx].first;
+            }
+        }
+    }
+    DCHECK(_cur_range_lower == nullptr);
+    DCHECK(_cur_range_upper == nullptr);
+
+    auto* scan_morsel = down_cast<ScanMorsel*>(_morsels[_tablet_idx].get());
+    auto morsel = std::make_unique<LogicalSplitScanMorsel>(
+            scan_morsel->get_plan_node_id(), *(scan_morsel->get_scan_range()), std::move(short_key_ranges));
+    return morsel;
+}
+
+// Validate that the splitted start short key and end short key shouldn't be the same.
+bool LogicalSplitMorselQueue::_valid_range(const vectorized::ShortKeyOptionPtr& lower,
+                                           const vectorized::ShortKeyOptionPtr& upper) const {
+    // It is validated that any of endpoint is infinite or the original short key range is a point.
+    if (lower->is_infinite() || upper->is_infinite() ||
+        _block_ranges_per_seek_range[_range_idx].first == _block_ranges_per_seek_range[_range_idx].second) {
+        return true;
+    }
+
+    Slice lower_key = lower->short_key;
+    // Empty short key of start ShortKeyOption means it is the first splitted key range,
+    // so use start original short key to compare.
+    if (lower_key.empty()) {
+        lower_key = *_block_ranges_per_seek_range[_range_idx].first;
+    }
+
+    Slice upper_key = upper->short_key;
+    // Empty short key of start ShortKeyOption means it is the last splitted key range,
+    // so use end original short key to compare.
+    if (upper_key.empty()) {
+        auto end_iter = _block_ranges_per_seek_range[_range_idx].second;
+        --end_iter;
+        upper_key = *end_iter;
+    }
+
+    return lower_key.compare(upper_key) != 0;
+}
+
+vectorized::ShortKeyOptionPtr LogicalSplitMorselQueue::_create_range_lower() const {
+    // If it is the first splitted key range, the start point is the original start key.
+    if (_next_lower_block_iter == _block_ranges_per_seek_range[_range_idx].first) {
+        if (_tablet_seek_ranges.empty()) {
+            return std::make_unique<vectorized::ShortKeyOption>();
+        } else {
+            return std::make_unique<vectorized::ShortKeyOption>(&_tablet_seek_ranges[_range_idx].lower(),
+                                                                _tablet_seek_ranges[_range_idx].inclusive_lower());
+        }
+    } else {
+        Slice short_key = *_next_lower_block_iter;
+        return std::make_unique<vectorized::ShortKeyOption>(_short_key_schema, short_key, true);
+    }
+}
+
+vectorized::ShortKeyOptionPtr LogicalSplitMorselQueue::_create_range_upper() const {
+    // If it is the last splitted key range, the end point is the original end key.
+    if (_next_lower_block_iter == _block_ranges_per_seek_range[_range_idx].second) {
+        if (_tablet_seek_ranges.empty()) {
+            return std::make_unique<vectorized::ShortKeyOption>();
+        } else {
+            return std::make_unique<vectorized::ShortKeyOption>(&_tablet_seek_ranges[_range_idx].upper(),
+                                                                _tablet_seek_ranges[_range_idx].inclusive_upper());
+        }
+    } else {
+        Slice short_key = *_next_lower_block_iter;
+        return std::make_unique<vectorized::ShortKeyOption>(_short_key_schema, short_key, false);
+    }
+}
+
+bool LogicalSplitMorselQueue::_cur_tablet_finished() const {
+    return _range_idx >= _block_ranges_per_seek_range.size();
+}
+
+Rowset* LogicalSplitMorselQueue::_find_largest_rowset(const std::vector<RowsetSharedPtr>& rowsets) {
+    Rowset* largest_rowset = nullptr;
+    for (const auto& rowset : rowsets) {
+        if (largest_rowset == nullptr || largest_rowset->num_rows() < rowset->num_rows()) {
+            largest_rowset = rowset.get();
+        }
+    }
+
+    return largest_rowset;
+}
+
+SegmentSharedPtr LogicalSplitMorselQueue::_find_largest_segment(Rowset* rowset) const {
+    auto* beta_rowset = down_cast<BetaRowset*>(rowset);
+    SegmentSharedPtr largest_segment = nullptr;
+    for (const auto& segment : beta_rowset->segments()) {
+        if (largest_segment == nullptr || largest_segment->num_rows() < segment->num_rows()) {
+            largest_segment = segment;
+        }
+    }
+
+    return largest_segment;
+}
+
+StatusOr<SegmentGroupPtr> LogicalSplitMorselQueue::_create_segment_group(Rowset* rowset) {
+    std::vector<SegmentSharedPtr> segments;
+    if (rowset->rowset_meta()->is_segments_overlapping()) {
+        segments.emplace_back(_find_largest_segment(rowset));
+    } else {
+        auto* beta_rowset = down_cast<BetaRowset*>(rowset);
+        segments = beta_rowset->segments();
+    }
+
+    for (const auto& segment : segments) {
+        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->tablet_meta_mem_tracker()));
+    }
+
+    return std::make_unique<SegmentGroup>(std::move(segments));
+}
+
+bool LogicalSplitMorselQueue::_next_tablet() {
+    if (!_has_init_any_tablet) {
+        _has_init_any_tablet = true;
+    } else {
+        ++_tablet_idx;
+    }
+
+    return _tablet_idx < _tablets.size();
+}
+
+Status LogicalSplitMorselQueue::_init_tablet() {
+    _largest_rowset = nullptr;
+    _segment_group = nullptr;
+    _short_key_schema = nullptr;
+    _block_ranges_per_seek_range.clear();
+    _num_rest_blocks_per_seek_range.clear();
+    _range_idx = 0;
+
+    if (_tablet_idx == 0) {
+        // All the tablets have the same schema, so parse seek range with the first table schema.
+        RETURN_IF_ERROR(vectorized::TabletReader::parse_seek_range(_tablets[_tablet_idx], _range_start_op,
+                                                                   _range_end_op, _range_start_key, _range_end_key,
+                                                                   &_tablet_seek_ranges, &_mempool));
+    }
+
+    _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);
+    if (_largest_rowset == nullptr || _largest_rowset->num_rows() == 0) {
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(_largest_rowset->load());
+    ASSIGN_OR_RETURN(_segment_group, _create_segment_group(_largest_rowset));
+
+    _short_key_schema = std::make_shared<vectorized::Schema>(
+            vectorized::ChunkHelper::get_short_key_schema_with_format_v2(_tablets[_tablet_idx]->tablet_schema()));
+    _sample_splitted_scan_blocks =
+            _splitted_scan_rows * _segment_group->num_blocks() / _tablets[_tablet_idx]->num_rows();
+    _sample_splitted_scan_blocks = std::max<int64_t>(_sample_splitted_scan_blocks, 1);
+
+    if (_tablet_seek_ranges.empty()) {
+        _block_ranges_per_seek_range.emplace_back(_segment_group->begin(), _segment_group->end());
+        _num_rest_blocks_per_seek_range.emplace_back(_segment_group->num_blocks());
+    } else {
+        for (const auto& range : _tablet_seek_ranges) {
+            ShortKeyIndexGroupIterator upper_block_iter;
+            if (!range.upper().empty()) {
+                upper_block_iter = _upper_bound_ordinal(range.upper(), !range.inclusive_upper());
+            } else {
+                upper_block_iter = _segment_group->end();
+            }
+
+            ShortKeyIndexGroupIterator lower_block_iter;
+            if (!range.lower().empty() && upper_block_iter.ordinal() > 0) {
+                lower_block_iter = _lower_bound_ordinal(range.lower(), range.inclusive_lower());
+            } else {
+                lower_block_iter = _segment_group->begin();
+            }
+
+            _num_rest_blocks_per_seek_range.emplace_back(upper_block_iter - lower_block_iter);
+            _block_ranges_per_seek_range.emplace_back(lower_block_iter, upper_block_iter);
+        }
+    }
+    _next_lower_block_iter = _block_ranges_per_seek_range[0].first;
+
+    return Status::OK();
+}
+
+ShortKeyIndexGroupIterator LogicalSplitMorselQueue::_lower_bound_ordinal(const vectorized::SeekTuple& key,
+                                                                         bool lower) const {
+    std::string index_key =
+            key.short_key_encode(_segment_group->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+
+    auto start_iter = _segment_group->lower_bound(index_key);
+    if (start_iter.valid()) {
+        // Because previous block may contain this key, so we should set rowid to
+        // last block's first row.
+        if (start_iter.ordinal() > 0) {
+            --start_iter;
+        }
+    } else {
+        // When we don't find a valid index item, which means all short key is
+        // smaller than input key, this means that this key may exist in the last
+        // row block. so we set the rowid to first row of last row block.
+        start_iter = _segment_group->back();
+    }
+
+    return start_iter;
+}
+
+ShortKeyIndexGroupIterator LogicalSplitMorselQueue::_upper_bound_ordinal(const vectorized::SeekTuple& key,
+                                                                         bool lower) const {
+    std::string index_key =
+            key.short_key_encode(_segment_group->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+
+    auto end_iter = _segment_group->upper_bound(index_key);
+    return end_iter;
 }
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -286,7 +286,7 @@ StatusOr<MorselPtr> LogicalSplitMorselQueue::try_get() {
     vectorized::ShortKeyOptionPtr _cur_range_upper = nullptr;
     bool need_more_blocks = true;
     while (!_cur_tablet_finished() &&      // One morsel only read data from one tablet.
-           (_cur_range_lower != nullptr || // Haven't found the _cur_range_lower different from _cur_range_lower.
+           (_cur_range_lower != nullptr || // Haven't found the _cur_range_upper different from _cur_range_lower.
             (need_more_blocks && num_taken_blocks < _sample_splitted_scan_blocks))) {
         auto& num_rest_blocks = _num_rest_blocks_per_seek_range[_range_idx];
 
@@ -298,7 +298,7 @@ StatusOr<MorselPtr> LogicalSplitMorselQueue::try_get() {
         if (num_taken_blocks < _sample_splitted_scan_blocks) {
             cur_num_taken_blocks = _sample_splitted_scan_blocks - num_taken_blocks;
         } else {
-            // If it has taken enough blocks but hasn't found the _cur_range_lower different from _cur_range_lower,
+            // If it has taken enough blocks but hasn't found the _cur_range_upper different from _cur_range_lower,
             // just take quarter of _sample_splitted_scan_blocks once.
             cur_num_taken_blocks = std::max<int64_t>(_sample_splitted_scan_blocks / 4, 1);
         }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -9,6 +9,7 @@
 #include "storage/range.h"
 #include "storage/rowset/segment_group.h"
 #include "storage/seek_range.h"
+#include "storage/tablet_reader_params.h"
 #include "storage/tuple.h"
 
 namespace starrocks {
@@ -196,10 +197,10 @@ private:
     const int64_t _splitted_scan_rows;
 
     /// Key ranges passed to the storage layer.
-    // Possible values are "gt", "ge", "eq".
-    std::string _range_start_op = "";
-    // Possible values are "lt", "le".
-    std::string _range_end_op = "";
+    vectorized::TabletReaderParams::RangeStartOperation _range_start_op =
+            vectorized::TabletReaderParams::RangeStartOperation::GT;
+    vectorized::TabletReaderParams::RangeEndOperation _range_end_op =
+            vectorized::TabletReaderParams::RangeEndOperation::LT;
     std::vector<OlapTuple> _range_start_key;
     std::vector<OlapTuple> _range_end_key;
 
@@ -270,10 +271,10 @@ private:
     const int64_t _splitted_scan_rows;
 
     /// Key ranges passed to the storage layer.
-    // Possible values are "gt", "ge", "eq".
-    std::string _range_start_op = "";
-    // Possible values are "lt", "le".
-    std::string _range_end_op = "";
+    vectorized::TabletReaderParams::RangeStartOperation _range_start_op =
+            vectorized::TabletReaderParams::RangeStartOperation::GT;
+    vectorized::TabletReaderParams::RangeEndOperation _range_end_op =
+            vectorized::TabletReaderParams::RangeEndOperation::LT;
     std::vector<OlapTuple> _range_start_key;
     std::vector<OlapTuple> _range_end_key;
 

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -7,6 +7,7 @@
 #include "gen_cpp/InternalService_types.h"
 #include "storage/olap_common.h"
 #include "storage/range.h"
+#include "storage/rowset/segment_group.h"
 #include "storage/seek_range.h"
 #include "storage/tuple.h"
 
@@ -19,12 +20,20 @@ class Rowset;
 using RowsetSharedPtr = std::shared_ptr<Rowset>;
 class BetaRowset;
 class Segment;
+using SegmentSharedPtr = std::shared_ptr<Segment>;
 
 namespace vectorized {
 class TabletReaderParams;
 class SeekTuple;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+struct ShortKeyRangeOption;
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
+struct ShortKeyOption;
+using ShortKeyOptionPtr = std::unique_ptr<vectorized::ShortKeyOption>;
+class Schema;
+using SchemaPtr = std::shared_ptr<Schema>;
+class Range;
 } // namespace vectorized
 
 namespace pipeline {
@@ -76,6 +85,18 @@ public:
 
 private:
     vectorized::RowidRangeOptionPtr _rowid_range_option;
+};
+
+class LogicalSplitScanMorsel final : public ScanMorsel {
+public:
+    LogicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range,
+                           std::vector<vectorized::ShortKeyRangeOptionPtr> short_key_ranges)
+            : ScanMorsel(plan_node_id, scan_range), _short_key_ranges(std::move(short_key_ranges)) {}
+
+    void init_tablet_reader_params(vectorized::TabletReaderParams* params) override;
+
+private:
+    std::vector<vectorized::ShortKeyRangeOptionPtr> _short_key_ranges;
 };
 
 /// MorselQueue.
@@ -150,8 +171,8 @@ public:
     bool need_rebalance() const override { return _num_original_morsels < _degree_of_parallelism; }
 
 private:
-    static rowid_t _lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower);
-    static rowid_t _upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower, rowid_t end);
+    rowid_t _lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower) const;
+    rowid_t _upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower, rowid_t end) const;
 
     ScanMorsel* _cur_scan_morsel();
     BetaRowset* _cur_rowset();
@@ -197,6 +218,84 @@ private:
     size_t _num_segment_rest_rows = 0;
 
     MemPool _mempool;
+};
+
+class LogicalSplitMorselQueue final : public MorselQueue {
+public:
+    explicit LogicalSplitMorselQueue(Morsels&& morsels, int64_t degree_of_parallelism, int64_t splitted_scan_rows)
+            : _morsels(std::move(morsels)),
+              _num_original_morsels(_morsels.size()),
+              _degree_of_parallelism(degree_of_parallelism),
+              _splitted_scan_rows(splitted_scan_rows) {}
+    ~LogicalSplitMorselQueue() override = default;
+
+    std::vector<TInternalScanRange*> olap_scan_ranges() const override;
+
+    void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) override;
+    void set_tablets(const std::vector<TabletSharedPtr>& tablets) override { _tablets = tablets; }
+    void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) override {
+        _tablet_rowsets = tablet_rowsets;
+    }
+
+    size_t num_morsels() const override { return _degree_of_parallelism; }
+    bool empty() const override { return _tablet_idx >= _tablets.size(); }
+    StatusOr<MorselPtr> try_get() override;
+
+    std::string name() const override { return "logical_split_morsel_queue"; }
+
+private:
+    bool _cur_tablet_finished() const;
+
+    Rowset* _find_largest_rowset(const std::vector<RowsetSharedPtr>& rowsets);
+    SegmentSharedPtr _find_largest_segment(Rowset* rowset) const;
+    StatusOr<SegmentGroupPtr> _create_segment_group(Rowset* rowset);
+    bool _next_tablet();
+    Status _init_tablet();
+
+    vectorized::ShortKeyOptionPtr _create_range_lower() const;
+    vectorized::ShortKeyOptionPtr _create_range_upper() const;
+    bool _valid_range(const vectorized::ShortKeyOptionPtr& lower, const vectorized::ShortKeyOptionPtr& upper) const;
+
+    ShortKeyIndexGroupIterator _lower_bound_ordinal(const vectorized::SeekTuple& key, bool lower) const;
+    ShortKeyIndexGroupIterator _upper_bound_ordinal(const vectorized::SeekTuple& key, bool lower) const;
+
+private:
+    std::mutex _mutex;
+
+    Morsels _morsels;
+    // The number of the morsels before split them to pieces.
+    const size_t _num_original_morsels;
+    const int64_t _degree_of_parallelism;
+    // The minimum number of rows picked up from a segment at one time.
+    const int64_t _splitted_scan_rows;
+
+    /// Key ranges passed to the storage layer.
+    // Possible values are "gt", "ge", "eq".
+    std::string _range_start_op = "";
+    // Possible values are "lt", "le".
+    std::string _range_end_op = "";
+    std::vector<OlapTuple> _range_start_key;
+    std::vector<OlapTuple> _range_end_key;
+
+    // _tablets[i] and _tablet_rowsets[i] represent the i-th tablet and its rowsets.
+    std::vector<TabletSharedPtr> _tablets;
+    std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
+
+    bool _has_init_any_tablet = false;
+    std::atomic<size_t> _tablet_idx = 0;
+
+    // Used to allocate memory for _tablet_seek_ranges.
+    MemPool _mempool;
+    std::vector<vectorized::SeekRange> _tablet_seek_ranges;
+    Rowset* _largest_rowset = nullptr;
+    SegmentGroupPtr _segment_group = nullptr;
+    vectorized::SchemaPtr _short_key_schema = nullptr;
+    int64_t _sample_splitted_scan_blocks = 0;
+
+    std::vector<std::pair<ShortKeyIndexGroupIterator, ShortKeyIndexGroupIterator>> _block_ranges_per_seek_range;
+    std::vector<size_t> _num_rest_blocks_per_seek_range;
+    size_t _range_idx = 0;
+    ShortKeyIndexGroupIterator _next_lower_block_iter;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -171,8 +171,10 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
             continue;
         }
 
-        _params.range = key_range->begin_include ? "ge" : "gt";
-        _params.end_range = key_range->end_include ? "le" : "lt";
+        _params.range = key_range->begin_include ? TabletReaderParams::RangeStartOperation::GE
+                                                 : TabletReaderParams::RangeStartOperation::GT;
+        _params.end_range = key_range->end_include ? TabletReaderParams::RangeEndOperation::LE
+                                                   : TabletReaderParams::RangeEndOperation::LT;
 
         _params.start_key.push_back(key_range->begin_scan_range);
         _params.end_key.push_back(key_range->end_scan_range);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -366,7 +366,7 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
     }
 
     // TODO: use LogicalSplitMorselQueue, when it can split tablet logically.
-    return std::make_unique<pipeline::FixedMorselQueue>(std::move(morsels));
+    return std::make_unique<pipeline::LogicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
 }
 
 StatusOr<bool> OlapScanNode::_could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -365,7 +365,6 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
         return std::make_unique<pipeline::PhysicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
     }
 
-    // TODO: use LogicalSplitMorselQueue, when it can split tablet logically.
     return std::make_unique<pipeline::LogicalSplitMorselQueue>(std::move(morsels), scan_dop, splitted_scan_rows);
 }
 

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -154,8 +154,10 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
             continue;
         }
 
-        _params.range = key_range->begin_include ? "ge" : "gt";
-        _params.end_range = key_range->end_include ? "le" : "lt";
+        _params.range = key_range->begin_include ? TabletReaderParams::RangeStartOperation::GE
+                                                 : TabletReaderParams::RangeStartOperation::GT;
+        _params.end_range = key_range->end_include ? TabletReaderParams::RangeEndOperation::LE
+                                                   : TabletReaderParams::RangeEndOperation::LT;
 
         _params.start_key.push_back(key_range->begin_scan_range);
         _params.end_key.push_back(key_range->end_scan_range);

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(Storage STATIC
     rowset/segment.cpp
     rowset/segment_writer.cpp
     rowset/segment_rewriter.cpp
+    rowset/segment_group.cpp
     rowset/storage_page_decoder.cpp
     rowset/block_split_bloom_filter.cpp
     rowset/bloom_filter_index_reader.cpp

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -88,6 +88,15 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
     return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
 }
 
+starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {
+    starrocks::vectorized::Fields fields;
+    for (ColumnId cid = 0; cid < schema.num_short_key_columns(); ++cid) {
+        auto f = convert_field_to_format_v2(cid, schema.column(cid));
+        fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
+    }
+    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
+}
+
 ColumnId ChunkHelper::max_column_id(const starrocks::vectorized::Schema& schema) {
     ColumnId id = 0;
     for (const auto& field : schema.fields()) {

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -48,6 +48,9 @@ public:
     static vectorized::Schema convert_schema_to_format_v2(const starrocks::TabletSchema& schema,
                                                           const std::vector<ColumnId>& cids);
 
+    // Get schema with format v2 type containing short key columns from TabletSchema.
+    static vectorized::Schema get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema);
+
     static ColumnId max_column_id(const vectorized::Schema& schema);
 
     // Create an empty chunk according to the |schema| and reserve it of size |n|.

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -257,6 +257,10 @@ Status Segment::load_index(MemTracker* mem_tracker) {
     });
 }
 
+bool Segment::has_loaded_index() const {
+    return _load_index_once.has_called();
+}
+
 Status Segment::_create_column_readers(MemTracker* mem_tracker, SegmentFooterPB* footer) {
     std::unordered_map<uint32_t, uint32_t> column_id_to_footer_ordinal;
     for (uint32_t ordinal = 0, sz = footer->columns().size(); ordinal < sz; ++ordinal) {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -148,6 +148,9 @@ public:
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.
     Status load_index(MemTracker* mem_tracker);
+    bool has_loaded_index() const;
+
+    const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 
 private:
     Segment(const Segment&) = delete;

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -1,0 +1,93 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/rowset/segment_group.h"
+
+namespace starrocks {
+
+/// ShortKeyIndexGroupIterator
+ShortKeyIndexGroupIterator::ShortKeyIndexGroupIterator(const ShortKeyIndexDecoderGroup* decoder_group, ssize_t ordinal)
+        : _decoder_group(decoder_group), _ordinal(ordinal) {}
+
+bool ShortKeyIndexGroupIterator::valid() const {
+    return _ordinal >= 0 && _ordinal < _decoder_group->num_blocks();
+}
+
+Slice ShortKeyIndexGroupIterator::operator*() const {
+    DCHECK(valid());
+    return _decoder_group->key(_ordinal);
+}
+
+/// ShortKeyIndexDecoderGroup
+ShortKeyIndexDecoderGroup::ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*> sk_index_decoders)
+        : _sk_index_decoders(std::move(sk_index_decoders)) {
+    _decoder_start_ordinals.reserve(_sk_index_decoders.size() + 1);
+    ssize_t num_total_items = 0;
+    _decoder_start_ordinals.emplace_back(num_total_items);
+    for (auto* decoder : _sk_index_decoders) {
+        num_total_items += decoder->num_items();
+        _decoder_start_ordinals.emplace_back(num_total_items);
+    }
+}
+
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::begin() const {
+    return {this, 0};
+}
+
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::end() const {
+    return {this, num_blocks()};
+}
+
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::back() const {
+    return {this, num_blocks() - 1};
+}
+
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::lower_bound(const Slice& key) const {
+    return _seek<true>(key);
+}
+
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::upper_bound(const Slice& key) const {
+    return _seek<false>(key);
+}
+
+Slice ShortKeyIndexDecoderGroup::key(ssize_t ordinal) const {
+    ssize_t decoder_id;
+    ssize_t block_id_in_decoder;
+    _find_position(ordinal, &decoder_id, &block_id_in_decoder);
+
+    return _sk_index_decoders[size_t(decoder_id)]->key(block_id_in_decoder);
+}
+
+template <bool lower_bound>
+ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::_seek(const Slice& key) const {
+    auto comparator = [](const Slice& lhs, const Slice& rhs) { return lhs.compare(rhs) < 0; };
+    if (lower_bound) {
+        return std::lower_bound(begin(), end(), key, comparator);
+    } else {
+        return std::upper_bound(begin(), end(), key, comparator);
+    }
+}
+
+void ShortKeyIndexDecoderGroup::_find_position(ssize_t ordinal, ssize_t* decoder_id,
+                                               ssize_t* block_id_in_decoder) const {
+    auto it = std::upper_bound(_decoder_start_ordinals.begin(), _decoder_start_ordinals.end(), ordinal);
+
+    *decoder_id = it - _decoder_start_ordinals.begin() - 1;
+    if (*decoder_id < _sk_index_decoders.size()) {
+        *block_id_in_decoder = ordinal - _decoder_start_ordinals[size_t(*decoder_id)];
+    } else {
+        *block_id_in_decoder = 0;
+    }
+}
+
+/// SegmentGroup
+SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr> segments) : _segments(std::move(segments)) {
+    std::vector<const ShortKeyIndexDecoder*> sk_index_decoders;
+    sk_index_decoders.reserve(_segments.size());
+    for (const auto& segment : _segments) {
+        DCHECK(segment->has_loaded_index());
+        sk_index_decoders.emplace_back(segment->decoder());
+    }
+    _decoder_group = std::make_unique<ShortKeyIndexDecoderGroup>(std::move(sk_index_decoders));
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -18,7 +18,7 @@ Slice ShortKeyIndexGroupIterator::operator*() const {
 }
 
 /// ShortKeyIndexDecoderGroup
-ShortKeyIndexDecoderGroup::ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*> sk_index_decoders)
+ShortKeyIndexDecoderGroup::ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*>&& sk_index_decoders)
         : _sk_index_decoders(std::move(sk_index_decoders)) {
     _decoder_start_ordinals.reserve(_sk_index_decoders.size() + 1);
     ssize_t num_total_items = 0;

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -9,12 +9,12 @@ ShortKeyIndexGroupIterator::ShortKeyIndexGroupIterator(const ShortKeyIndexDecode
         : _decoder_group(decoder_group), _ordinal(ordinal) {}
 
 bool ShortKeyIndexGroupIterator::valid() const {
-    return _ordinal >= 0 && _ordinal < _decoder_group.num_blocks();
+    return _ordinal >= 0 && _ordinal < _decoder_group->num_blocks();
 }
 
 Slice ShortKeyIndexGroupIterator::operator*() const {
     DCHECK(valid());
-    return _decoder_group.key(_ordinal);
+    return _decoder_group->key(_ordinal);
 }
 
 /// ShortKeyIndexDecoderGroup

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -67,7 +67,7 @@ Slice ShortKeyIndexDecoderGroup::key(ssize_t ordinal) const {
 template <bool lower_bound>
 ShortKeyIndexGroupIterator ShortKeyIndexDecoderGroup::_seek(const Slice& key) const {
     auto comparator = [](const Slice& lhs, const Slice& rhs) { return lhs.compare(rhs) < 0; };
-    if (lower_bound) {
+    if constexpr (lower_bound) {
         return std::lower_bound(begin(), end(), key, comparator);
     } else {
         return std::upper_bound(begin(), end(), key, comparator);
@@ -87,7 +87,7 @@ void ShortKeyIndexDecoderGroup::_find_position(ssize_t ordinal, ssize_t* decoder
 }
 
 /// SegmentGroup
-SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr> segments)
+SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr>&& segments)
         : _segments(std::move(segments)), _decoder_group(_segments) {}
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -64,6 +64,7 @@ private:
     ssize_t _ordinal;
 };
 
+// ShortKeyIndexDecoderGroup contains decoders for each segment of SegmentGroup.
 class ShortKeyIndexDecoderGroup {
 public:
     explicit ShortKeyIndexDecoderGroup(const std::vector<SegmentSharedPtr>& segments);
@@ -92,9 +93,11 @@ private:
     std::vector<ssize_t> _decoder_start_ordinals;
 };
 
+// SegmentGroup contains multiple non-overlapping segments incremented by the key columns.
+// It is used to perform binary search on the short keys of all the segments.
 class SegmentGroup {
 public:
-    SegmentGroup(std::vector<SegmentSharedPtr> segments);
+    SegmentGroup(std::vector<SegmentSharedPtr>&& segments);
 
     ShortKeyIndexGroupIterator lower_bound(const Slice& key) const { return _decoder_group.lower_bound(key); }
 

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -66,7 +66,7 @@ private:
 
 class ShortKeyIndexDecoderGroup {
 public:
-    explicit ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*>&& sk_index_decoders);
+    explicit ShortKeyIndexDecoderGroup(const std::vector<SegmentSharedPtr>& segments);
 
     ShortKeyIndexGroupIterator begin() const;
     ShortKeyIndexGroupIterator end() const;
@@ -86,7 +86,7 @@ private:
 
 private:
     // The short keys among decoders are increasing.
-    const std::vector<const ShortKeyIndexDecoder*> _sk_index_decoders;
+    std::vector<const ShortKeyIndexDecoder*> _sk_index_decoders;
     // _decoder_start_ordinals[i] represents the start ordinal of _sk_index_decoder[i].
     // _decoder_start_ordinals[_sk_index_decoders.size()] represents the total number of rows among decoders.
     std::vector<ssize_t> _decoder_start_ordinals;
@@ -96,17 +96,17 @@ class SegmentGroup {
 public:
     SegmentGroup(std::vector<SegmentSharedPtr> segments);
 
-    ShortKeyIndexGroupIterator lower_bound(const Slice& key) const { return _decoder_group->lower_bound(key); }
+    ShortKeyIndexGroupIterator lower_bound(const Slice& key) const { return _decoder_group.lower_bound(key); }
 
-    ShortKeyIndexGroupIterator upper_bound(const Slice& key) const { return _decoder_group->upper_bound(key); }
+    ShortKeyIndexGroupIterator upper_bound(const Slice& key) const { return _decoder_group.upper_bound(key); }
 
-    ShortKeyIndexGroupIterator begin() const { return _decoder_group->begin(); }
+    ShortKeyIndexGroupIterator begin() const { return _decoder_group.begin(); }
 
-    ShortKeyIndexGroupIterator end() const { return _decoder_group->end(); }
+    ShortKeyIndexGroupIterator end() const { return _decoder_group.end(); }
 
-    ShortKeyIndexGroupIterator back() const { return _decoder_group->back(); }
+    ShortKeyIndexGroupIterator back() const { return _decoder_group.back(); }
 
-    ssize_t num_blocks() const { return _decoder_group->num_blocks(); }
+    ssize_t num_blocks() const { return _decoder_group.num_blocks(); }
 
     uint32_t num_rows_per_block() const {
         if (_segments.empty()) {
@@ -124,7 +124,7 @@ public:
 
 private:
     std::vector<SegmentSharedPtr> _segments;
-    std::unique_ptr<ShortKeyIndexDecoderGroup> _decoder_group = nullptr;
+    ShortKeyIndexDecoderGroup _decoder_group;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -66,7 +66,7 @@ private:
 
 class ShortKeyIndexDecoderGroup {
 public:
-    explicit ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*> sk_index_decoders);
+    explicit ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*>&& sk_index_decoders);
 
     ShortKeyIndexGroupIterator begin() const;
     ShortKeyIndexGroupIterator end() const;

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -1,0 +1,130 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "storage/rowset/segment.h"
+
+namespace starrocks {
+
+class ShortKeyIndexGroupIterator;
+class ShortKeyIndexDecoderGroup;
+class SegmentGroup;
+using SegmentGroupPtr = std::unique_ptr<SegmentGroup>;
+
+class ShortKeyIndexGroupIterator {
+public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = Slice;
+    using pointer = Slice*;
+    using reference = Slice&;
+    using difference_type = ssize_t;
+
+    ShortKeyIndexGroupIterator() : _decoder_group(nullptr), _ordinal(0) {}
+
+    ShortKeyIndexGroupIterator(const ShortKeyIndexDecoderGroup* decoder_group, ssize_t ordinal);
+
+    ShortKeyIndexGroupIterator& operator-=(ssize_t step) {
+        _ordinal -= step;
+        return *this;
+    }
+
+    ShortKeyIndexGroupIterator& operator+=(ssize_t step) {
+        _ordinal += step;
+        return *this;
+    }
+
+    ShortKeyIndexGroupIterator& operator++() {
+        ++_ordinal;
+        return *this;
+    }
+
+    ShortKeyIndexGroupIterator& operator--() {
+        --_ordinal;
+        return *this;
+    }
+
+    bool operator!=(const ShortKeyIndexGroupIterator& rhs) const {
+        return _ordinal != rhs._ordinal || _decoder_group != rhs._decoder_group;
+    }
+
+    bool operator==(const ShortKeyIndexGroupIterator& rhs) const {
+        return _ordinal == rhs._ordinal && _decoder_group == rhs._decoder_group;
+    }
+
+    ssize_t operator-(const ShortKeyIndexGroupIterator& rhs) const { return _ordinal - rhs._ordinal; }
+
+    bool valid() const;
+
+    Slice operator*() const;
+
+    ssize_t ordinal() const { return _ordinal; }
+
+private:
+    const ShortKeyIndexDecoderGroup* _decoder_group;
+    ssize_t _ordinal;
+};
+
+class ShortKeyIndexDecoderGroup {
+public:
+    explicit ShortKeyIndexDecoderGroup(std::vector<const ShortKeyIndexDecoder*> sk_index_decoders);
+
+    ShortKeyIndexGroupIterator begin() const;
+    ShortKeyIndexGroupIterator end() const;
+    ShortKeyIndexGroupIterator back() const;
+
+    ShortKeyIndexGroupIterator lower_bound(const Slice& key) const;
+    ShortKeyIndexGroupIterator upper_bound(const Slice& key) const;
+
+    Slice key(ssize_t ordinal) const;
+
+    ssize_t num_blocks() const { return _decoder_start_ordinals.back(); }
+
+private:
+    template <bool lower_bound>
+    ShortKeyIndexGroupIterator _seek(const Slice& key) const;
+    void _find_position(ssize_t ordinal, ssize_t* decoder_id, ssize_t* block_id_in_decoder) const;
+
+private:
+    // The short keys among decoders are increasing.
+    const std::vector<const ShortKeyIndexDecoder*> _sk_index_decoders;
+    // _decoder_start_ordinals[i] represents the start ordinal of _sk_index_decoder[i].
+    // _decoder_start_ordinals[_sk_index_decoders.size()] represents the total number of rows among decoders.
+    std::vector<ssize_t> _decoder_start_ordinals;
+};
+
+class SegmentGroup {
+public:
+    SegmentGroup(std::vector<SegmentSharedPtr> segments);
+
+    ShortKeyIndexGroupIterator lower_bound(const Slice& key) const { return _decoder_group->lower_bound(key); }
+
+    ShortKeyIndexGroupIterator upper_bound(const Slice& key) const { return _decoder_group->upper_bound(key); }
+
+    ShortKeyIndexGroupIterator begin() const { return _decoder_group->begin(); }
+
+    ShortKeyIndexGroupIterator end() const { return _decoder_group->end(); }
+
+    ShortKeyIndexGroupIterator back() const { return _decoder_group->back(); }
+
+    ssize_t num_blocks() const { return _decoder_group->num_blocks(); }
+
+    uint32_t num_rows_per_block() const {
+        if (_segments.empty()) {
+            return 0;
+        }
+        return _segments[0]->num_rows_per_block();
+    }
+
+    size_t num_short_keys() const {
+        if (_segments.empty()) {
+            return 0;
+        }
+        return _segments[0]->num_short_keys();
+    }
+
+private:
+    std::vector<SegmentSharedPtr> _segments;
+    std::unique_ptr<ShortKeyIndexDecoderGroup> _decoder_group = nullptr;
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -376,16 +376,20 @@ Status TabletReader::_to_seek_tuple(const TabletSchema& tablet_schema, const Ola
 }
 
 // convert vector<OlapTuple> to vector<SeekRange>
-Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet, const std::string& range_start_op,
-                                      const std::string& range_end_op, const std::vector<OlapTuple>& range_start_key,
+Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet,
+                                      TabletReaderParams::RangeStartOperation range_start_op,
+                                      TabletReaderParams::RangeEndOperation range_end_op,
+                                      const std::vector<OlapTuple>& range_start_key,
                                       const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
                                       MemPool* mempool) {
     if (range_start_key.empty()) {
         return {};
     }
 
-    bool lower_inclusive = range_start_op == "ge" || range_start_op == "eq";
-    bool upper_inclusive = range_end_op == "le" || range_end_op == "eq";
+    bool lower_inclusive = range_start_op == TabletReaderParams::RangeStartOperation::GE ||
+                           range_start_op == TabletReaderParams::RangeStartOperation::EQ;
+    bool upper_inclusive = range_end_op == TabletReaderParams::RangeEndOperation::LE ||
+                           range_end_op == TabletReaderParams::RangeEndOperation::EQ;
 
     CHECK_EQ(range_start_key.size(), range_end_key.size());
     size_t n = range_start_key.size();

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -41,8 +41,10 @@ public:
 
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
-    static Status parse_seek_range(const TabletSharedPtr& tablet, const std::string& range_start_op,
-                                   const std::string& range_end_op, const std::vector<OlapTuple>& range_start_key,
+    static Status parse_seek_range(const TabletSharedPtr& tablet,
+                                   TabletReaderParams::RangeStartOperation range_start_op,
+                                   TabletReaderParams::RangeEndOperation range_end_op,
+                                   const std::vector<OlapTuple>& range_start_key,
                                    const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
                                    MemPool* mempool);
 

--- a/be/src/storage/tablet_reader_params.cpp
+++ b/be/src/storage/tablet_reader_params.cpp
@@ -24,4 +24,40 @@ std::string TabletReaderParams::to_string() const {
     return ss.str();
 }
 
+std::string to_string(TabletReaderParams::RangeStartOperation range_start_op) {
+    switch (range_start_op) {
+    case TabletReaderParams::RangeStartOperation::GT:
+        return "GT";
+    case TabletReaderParams::RangeStartOperation::GE:
+        return "GE";
+    case TabletReaderParams::RangeStartOperation::EQ:
+        return "EQ";
+    default:
+        return "Unknown";
+    }
+}
+
+std::string to_string(TabletReaderParams::RangeEndOperation range_end_op) {
+    switch (range_end_op) {
+    case TabletReaderParams::RangeEndOperation::LT:
+        return "LT";
+    case TabletReaderParams::RangeEndOperation::LE:
+        return "LE";
+    case TabletReaderParams::RangeEndOperation::EQ:
+        return "EQ";
+    default:
+        return "Unknown";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, TabletReaderParams::RangeStartOperation range_start_op) {
+    os << to_string(range_start_op);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, TabletReaderParams::RangeEndOperation range_end_op) {
+    os << to_string(range_end_op);
+    return os;
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -28,6 +28,9 @@ static inline std::unordered_set<uint32_t> EMPTY_FILTERED_COLUMN_IDS;
 
 // Params for TabletReader
 struct TabletReaderParams {
+    enum class RangeStartOperation { GT = 0, GE, EQ };
+    enum class RangeEndOperation { LT = 0, LE, EQ };
+
     TabletReaderParams();
 
     ReaderType reader_type = READER_QUERY;
@@ -42,10 +45,8 @@ struct TabletReaderParams {
     //     if config::disable_storage_page_cache is false, we use page cache
     bool use_page_cache = false;
 
-    // possible values are "gt", "ge", "eq"
-    std::string range;
-    // possible values are "lt", "le"
-    std::string end_range;
+    RangeStartOperation range = RangeStartOperation::GT;
+    RangeEndOperation end_range = RangeEndOperation::LT;
     std::vector<OlapTuple> start_key;
     std::vector<OlapTuple> end_key;
     std::vector<const ColumnPredicate*> predicates;
@@ -65,6 +66,11 @@ struct TabletReaderParams {
 public:
     std::string to_string() const;
 };
+
+std::string to_string(TabletReaderParams::RangeStartOperation range_start_op);
+std::string to_string(TabletReaderParams::RangeEndOperation range_end_op);
+std::ostream& operator<<(std::ostream& os, TabletReaderParams::RangeStartOperation range_start_op);
+std::ostream& operator<<(std::ostream& os, TabletReaderParams::RangeEndOperation range_end_op);
 
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR relates：
Closes #6110.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for parallel scan on the single tablet, it splits a key range into multiple small short key ranges. Add a new `LogicalSplitMorselQueue` to implement this.

## Modification
- `MorselQueue` creates multiple morsels from a tablet.
- As for a tablet, it splits each key range into small short key ranges.
- It uses short key blocks on the non-overlapping segments of the largest segment for the current tablet to split each key range.


