### PR TITLE
[Enhancement] Generate key range when only having one conditional key column

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -600,7 +600,6 @@ private:
 
 Status OlapScanConjunctsManager::build_scan_keys(bool unlimited, int32_t max_scan_key_num) {
     int conditional_key_columns = 0;
-    scan_keys.set_is_convertible(unlimited);
     const std::vector<std::string>& ref_key_column_names = *key_column_names;
 
     for (const auto& key_column_name : ref_key_column_names) {
@@ -609,12 +608,15 @@ Status OlapScanConjunctsManager::build_scan_keys(bool unlimited, int32_t max_sca
         }
         conditional_key_columns++;
     }
-    if (conditional_key_columns > 1) {
-        for (int i = 0; i < conditional_key_columns && !scan_keys.has_range_value(); ++i) {
-            ExtendScanKeyVisitor visitor(&scan_keys, max_scan_key_num);
-            if (!std::visit(visitor, column_value_ranges[ref_key_column_names[i]]).ok()) {
-                break;
-            }
+
+    // When there is only one conditional key column,
+    // searching for range is better than searching for multiple points.
+    scan_keys.set_is_convertible(unlimited && conditional_key_columns > 1);
+
+    for (int i = 0; i < conditional_key_columns && !scan_keys.has_range_value(); ++i) {
+        ExtendScanKeyVisitor visitor(&scan_keys, max_scan_key_num);
+        if (!std::visit(visitor, column_value_ranges[ref_key_column_names[i]]).ok()) {
+            break;
         }
     }
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When there is only one conditional key column, searching for range is better than searching for multiple points.

However, we don't generate any key range when there is one conditional key column. 


## Test
### Environment
3 BE, each of which has 16 vCPUs and 64GB memory.

### Dataset
ssb 100g

### Query
```sql
-- Large range.
select count(1) from lineorder_flat where 492864069 <= LO_ORDERKEY  and LO_ORDERKEY<=592864069;
-- Small range.
select count(1) from lineorder_flat where 592864000 <= LO_ORDERKEY  and LO_ORDERKEY<=592864069;
-- In 10/100/500/1000/1025 values.
select count(1) from lineorder_flat where LO_ORDERKEY in (...);
```

### Summary
- For the range search, because there is zone map index for each short key block, this PR increases performance only a little.
- For the multiple points search, 
    - The number of points <= 500, this PR is better than before, because it can filter more rows by scan key range and read less rows to filter by predicates.
    - The number of points is 1000, this PR is worse than before, because init tablet reader need parse each scan key range for every tablet. It costs 100ms, while before costs 10ms. 
        - The number of points > max_scan_key_num will be converted to a range. Therefore, if we set `max_scan_key_num=100`, this PR isn't worse anymore.
    - The number of points > 1024, this PR is the same as before, because the number of points > 1024 will not push down to the storage level.

### Test Results


| Query                                         | Version | Latency   | Segment Read | Segment Init | ShortKey FilterRows | ZoneMap FilterRows | Scan  PullTotalTime |
| --------------------------------------------- | ------- | --------- | ------------ | ------------ | ------------------- | ------------------ | ------------------- |
| In 10 values                                  | main    | 6ms       | 1.387ms      | 102.203us    | 0                   | 28M                |                     |
| In 10 values                                  | PR      | 6ms       | 4.519us      | 357.351us    | 31M                 | 0                  |                     |
|                                               |         |           |              |              |                     |                    |                     |
| In 100 values                                 | main    | 55ms      | 35.18ms      | 1.20ms       | 0                   | 80M                |                     |
| In 100 values                                 | PR      | **20ms**  | 13.27us      | 4.35ms       | 156M                | 0                  |                     |
|                                               |         |           |              |              |                     |                    |                     |
| In 500 values                                 | main    | 114ms     | 72.193ms     | 975.870us    | 0                   | 22M                | 11.730ms            |
| In 500 values                                 | PR      | **91ms**  | 15.531us     | 44.969ms     | 600M                | 0                  | 58.519ms            |
|                                               |         |           |              |              |                     |                    |                     |
| In 1000 values                                | main    | **126ms** | 80.342ms     | 1.50ms       | 0                   | 1.66M              | 10.545ms            |
| In 1000 values                                | PR      | 175ms     | 28.927us     | 86.873ms     | 600M                | 0                  | **108.881ms**       |
| In 1000 values <br>set max_scan_ key_num=100; | PR      | **126ms** | 78.220ms     | 1.472ms      | 1.38M               | 1.65M              | 12.431ms            |
|                                               |         |           |              |              |                     |                    |                     |
| In 1025 values                                | main    | 122ms     | 73.651ms     | 225.888us    | 0                   | 0                  | 5.768ms             |
| In 1025 values                                | PR      | 120ms     | 75.706ms     | 282.998us    | 0                   | 0                  | 5.686ms             |
|                                               |         |           |              |              |                     |                    |                     |
| Large range                                   | main    | 138ms     | 6.308ms      | 189.899us    | 0                   | 494M               | 1.602ms             |
| Large range                                   | PR      | **133ms** | 1.873ms      | 280.628us    | 500M                | 0                  | 1.778ms             |
|                                               |         |           |              |              |                     |                    |                     |
| Small range                                   | main    | 8ms       | 95.278us     | 154.527us    | 0                   | 594M               | 658.541us           |
| Small range                                   | PR      | 8ms       | 1.518us      | 232.375us    | 600M                | 0                  | 737.655us           |






