### PR TITLE
[BugFix] _compaction_running would not be reseted when _check_for_apply() can't submit task

### DIFF
--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -256,7 +256,7 @@ private:
 
     // check if needs submit an async apply task
     // assuming _lock is already hold
-    void _check_for_apply();
+    Status _check_for_apply();
 
     void _sync_apply_version_idx(const EditVersion& v);
 

--- a/be/test/storage/merge_iterator_test.cpp
+++ b/be/test/storage/merge_iterator_test.cpp
@@ -264,7 +264,6 @@ TEST_F(MergeIteratorTest, mask_merge) {
 }
 
 TEST_F(MergeIteratorTest, mask_merge_boundary_test) {
-
     std::vector<int32_t> v1;
     std::vector<int32_t> v2;
     std::vector<int32_t> v3;


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
bug

## Which issues of this PR fixes ：
Fixes:
TabletUpdates::compaction() will check _compaction_running and set it to true, so that only one compaction can run at the same time.  do_apply() of compaction_commit_task will change the _compaction_running to false, and then next compaction can run.
But when _check_for_apply() returned without submit the compaction_commmit_task because of _apply_running, do_apply would not execute, in this scenario,  _commit_compaction() would still return ok, and then _do_compaction() would execute _wait_for_version() and wait until timeout and then return ok, _do_compaction() would return ok and would not deal with _compaction_running, and compaction() finished and left _compaction_running = true, the next compaction can’t go on. 

## Problem Summary(Required) ：
fixed the bug
