### PR TITLE
 [Enhancement] delay creation of memtables in delta writer

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -188,7 +188,6 @@ Status DeltaWriter::_init() {
     }
     _mem_table_sink = std::make_unique<MemTableRowsetWriterSink>(_rowset_writer.get());
     _tablet_schema = writer_context.tablet_schema;
-    _reset_mem_table();
     _flush_token = _storage_engine->memtable_flush_executor()->create_flush_token();
     _set_state(kWriting);
     return Status::OK();
@@ -196,6 +195,11 @@ Status DeltaWriter::_init() {
 
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    // Delay the creation memtables until we write data.
+    // Because for the tablet which doesn't have any written data, we will not use their memtables.
+    if (_mem_table == nullptr) {
+        _reset_mem_table();
+    }
     auto state = _get_state();
     if (state != kWriting) {
         return Status::InternalError(


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6818

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Before sending data, we will first open all tablets, and init all tablet memtables. However, most of these memtables will not used lator. Suppose a table has 2500 tablets, and a stream load only covers 100 tablets, then 2400 memtables are not used in this stream load. These 2400 unused memtables consumes a lot of memory.
    
In this pr, i delay the creation of memtables until we write chunk.
In my test, if there are 3 concurrent stream load, before optimization, the load memory can reach to the upper bound 30G quickly, after optimization, the load memory is 0.5G.
