### PR TITLE
[Prototype] Add `JavaProxy/JP` to access HDFS

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -122,8 +122,10 @@ if [[ $(ulimit -n) -lt 60000 ]]; then
   ulimit -n 65535
 fi
 
+BE_OPTS="--h2_client_connection_window_size=67108864"
+
 if [ ${RUN_DAEMON} -eq 1 ]; then
-    nohup ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
+    nohup ${STARROCKS_HOME}/lib/starrocks_be $BE_OPTS "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
 else
-    ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null
+    ${STARROCKS_HOME}/lib/starrocks_be $BE_OPTS "$@" >> $LOG_DIR/be.out 2>&1 </dev/null
 fi

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -45,4 +45,10 @@ service PBackendService {
     rpc transmit_chunk(starrocks.PTransmitChunkParams) returns (starrocks.PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc transmit_runtime_filter(starrocks.PTransmitRuntimeFilterParams) returns (starrocks.PTransmitRuntimeFilterResult);
+
+rpc HdfsOpen (starrocks.HdfsRequest) returns (starrocks.HdfsResponse) {}
+  rpc HdfsClose (starrocks.HdfsRequest) returns (starrocks.HdfsResponse) {}
+  rpc HdfsRead (starrocks.HdfsRequest) returns (starrocks.HdfsResponse) {}
+  rpc HdfsGetSize (starrocks.HdfsRequest) returns (starrocks.HdfsResponse) {}
+  rpc HdfsGetStats (starrocks.HdfsRequest) returns (starrocks.HdfsResponse) {}
 };

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -297,6 +297,26 @@ message PProxyResult {
     optional PKafkaOffsetBatchProxyResult kafka_offset_batch_result = 102;
 };
 
+message HdfsRequest {
+  optional string path = 1;
+  optional string session_id = 2;
+  optional int32 offset = 3;
+  optional int32 size = 4;
+}
+
+message HdfsStats {
+  optional int64 total_bytes_read = 1;
+  optional int64 total_local_bytes_read = 2 ;
+  optional int64 total_short_circuit_bytes_read = 3;
+}
+
+message HdfsResponse {
+  optional string session_id = 1;
+  optional bytes data = 2;
+  optional int64 size = 3;
+  optional HdfsStats stats = 4;
+}
+
 // NOTE(zc): If you want to add new method here,
 // you must add same method to 'doris_internal_service.proto'.
 service PInternalService {
@@ -314,5 +334,11 @@ service PInternalService {
     rpc transmit_chunk(PTransmitChunkParams) returns (PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns (PTransmitRuntimeFilterResult);
+
+  rpc HdfsOpen (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsClose (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsRead (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsGetSize (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsGetStats (HdfsRequest) returns (HdfsResponse) {}
 };
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -315,6 +315,7 @@ message HdfsResponse {
   optional bytes data = 2;
   optional int64 size = 3;
   optional HdfsStats stats = 4;
+  optional string mmapFilePath = 5;
 }
 
 // NOTE(zc): If you want to add new method here,

--- a/java-extensions/java-proxy/pom.xml
+++ b/java-extensions/java-proxy/pom.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>java-extensions</artifactId>
+        <groupId>com.starrocks</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>java-proxy</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <java-extensions.home>${basedir}/../</java-extensions.home>
+        <grpc.version>1.48.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+        <protobuf.version>3.19.2</protobuf.version>
+        <protoc.version>3.19.2</protoc.version>
+        <hadoop.version>2.8.5</hadoop.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.clearspring.analytics</groupId>
+            <artifactId>stream</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>1.45.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.45.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>1.45.1</version>
+        </dependency>
+        <dependency> <!-- necessary for Java 9+ -->
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>annotations-api</artifactId>
+            <version>6.0.53</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version> <!-- prevent downgrade via protobuf-java-util -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>annotations-api</artifactId>
+            <version>6.0.53</version>
+            <scope>provided</scope> <!-- not needed at runtime -->
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.17.155</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aliyun.oss</groupId>
+            <artifactId>aliyun-sdk-oss</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.6.2</version>
+            </extension>
+        </extensions>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/HdfsRpcClient.java
+++ b/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/HdfsRpcClient.java
@@ -1,0 +1,72 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.javaproxy;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.TimeUnit;
+
+public class HdfsRpcClient {
+
+    private static final Logger logger = LogManager.getLogger(HdfsRpcClient.class.getName());
+
+    private final PBackendServiceGrpc.PBackendServiceBlockingStub blockingStub;
+
+    public HdfsRpcClient(Channel channel) {
+        blockingStub = PBackendServiceGrpc.newBlockingStub(channel);
+    }
+
+    public void test(String path) {
+        HdfsRequest request = HdfsRequest.newBuilder().setPath(path).build();
+        HdfsResponse resp = blockingStub.hdfsOpen(request);
+        String sessionId = resp.getSessionId();
+        logger.info(String.format("Session Id = " + sessionId));
+
+        // get size, read, get stats
+        {
+            request = HdfsRequest.newBuilder().setSessionId(sessionId).setOffset(0).build();
+            resp = blockingStub.hdfsGetSize(request);
+            logger.info(String.format("size = %d", resp.getSize()));
+            long size = resp.getSize();
+
+            long blockSize = 1024 * 1024;
+            long offset = 0;
+            while (offset < size) {
+                blockSize = Math.min(blockSize, size - offset);
+                request = HdfsRequest.newBuilder().setSessionId(sessionId).setOffset((int) offset)
+                        .setSize((int) blockSize).build();
+                resp = blockingStub.hdfsRead(request);
+                logger.info(String.format("read bytes = %d", resp.getData().size()));
+                offset += blockSize;
+            }
+            resp = blockingStub.hdfsGetStats(request);
+            logger.info(String.format("stats = %d", resp.getStats().getTotalBytesRead()));
+        }
+
+        request = HdfsRequest.newBuilder().setSessionId(sessionId).build();
+        blockingStub.hdfsClose(request);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String target = "localhost:50051";
+        String path = "file:///Users/dirlt/.ssh/id_rsa.pub";
+        if (args.length > 0) {
+            path = args[0];
+        }
+        ManagedChannel channel = ManagedChannelBuilder.forTarget(target)
+                .usePlaintext().build();
+        try {
+            HdfsRpcClient client = new HdfsRpcClient(channel);
+            client.test(path);
+        } finally {
+            // ManagedChannels use resources like threads and TCP connections. To prevent leaking these
+            // resources the channel should be shut down when it will no longer be used. If it may be used
+            // again leave it running.
+            channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/HdfsRpcHandler.java
+++ b/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/HdfsRpcHandler.java
@@ -1,0 +1,230 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.javaproxy;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSInputStream;
+import org.apache.hadoop.hdfs.client.HdfsDataInputStream;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class HdfsRpcHandler extends PBackendServiceGrpc.PBackendServiceImplBase {
+    private final Logger logger = LogManager.getLogger(HdfsRpcHandler.class.getCanonicalName());
+    private final AtomicLong rpcOnFly = new AtomicLong();
+
+    private static class CacheValue {
+        public FileSystem fs;
+        public Path path;
+        public FSDataInputStream inputStream;
+        public ByteBuffer buffer;
+    }
+
+    private Configuration configuration;
+    private Cache<String, CacheValue> cache;
+
+    public HdfsRpcHandler() {
+        Configuration conf = new Configuration();
+        conf.set("fs.hdfs.impl", org.apache.hadoop.hdfs.DistributedFileSystem.class.getName());
+        conf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+        configuration = conf;
+
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(128 * 1024)
+                .concurrencyLevel(32)
+                .expireAfterAccess(Duration.ofMinutes(5))
+                .removalListener(new RemovalListener<String, CacheValue>() {
+                    @Override
+                    public void onRemoval(RemovalNotification<String, CacheValue> notification) {
+                        CacheValue cv = notification.getValue();
+                        logger.info(String.format("release session %s", notification.getKey()));
+                        cv.buffer.clear();
+                        try {
+                            cv.inputStream.close();
+                        } catch (IOException e) {
+                        }
+                    }
+                })
+                .build();
+    }
+
+    // ============================================================
+    private ByteBuffer newBuffer(int size) {
+        int cap = 1024;
+        while (cap < size) {
+            cap *= 2;
+        }
+        return ByteBuffer.allocate(cap);
+    }
+
+    private ByteBuffer resizeBuffer(ByteBuffer buffer, int size) {
+        int cap = buffer.capacity();
+        if (cap >= size) {
+            return buffer;
+        }
+        while (cap < size) {
+            cap *= 2;
+        }
+        buffer.clear();
+        return ByteBuffer.allocate(cap);
+    }
+
+    private HdfsResponse doOpen(HdfsRequest request)
+            throws IOException {
+        String requestPath = request.getPath();
+        Path path = new Path(requestPath);
+
+        FileSystem fs = FileSystem.get(URI.create(requestPath), configuration);
+        fs.setWorkingDirectory(new Path("/"));
+
+        CacheValue cv = new CacheValue();
+        cv.fs = fs;
+        cv.path = path;
+        cv.inputStream = fs.open(path);
+        cv.buffer = newBuffer(1024 * 1024);
+
+        String sessionId = UUID.randomUUID().toString();
+        cache.put(sessionId, cv);
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setSessionId(sessionId).build();
+        return resp;
+    }
+
+    private HdfsResponse doClose(HdfsRequest request) {
+        cache.invalidate(request.getSessionId());
+        return HdfsResponse.getDefaultInstance();
+    }
+
+    private CacheValue getCacheValue(String sessionId) throws IOException {
+        CacheValue cv = cache.getIfPresent(sessionId);
+        if (cv == null) {
+            throw new IOException(String.format("session id %s not found", sessionId));
+        }
+        return cv;
+    }
+
+    private HdfsResponse doRead(HdfsRequest request)
+            throws IOException {
+        int size = request.getSize();
+        CacheValue cv = getCacheValue(request.getSessionId());
+
+        cv.buffer = resizeBuffer(cv.buffer, request.getSize());
+        cv.inputStream.readFully(request.getOffset(), cv.buffer.array(), 0, size);
+        ByteString bs = ByteString.copyFrom(cv.buffer.array(), 0, size);
+        //        ByteString bs = ByteString.copyFrom(cv.buffer, size);
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setData(bs).build();
+        return resp;
+    }
+
+    private HdfsResponse doGetSize(HdfsRequest request)
+            throws IOException {
+        CacheValue cv = getCacheValue(request.getSessionId());
+        FileStatus st = cv.fs.getFileStatus(cv.path);
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setSize(st.getLen()).build();
+        return resp;
+    }
+
+    private HdfsResponse doGetStats(HdfsRequest request)
+            throws IOException {
+        CacheValue cv = getCacheValue(request.getSessionId());
+        HdfsStats.Builder stats = HdfsStats.newBuilder();
+
+        if (cv.inputStream instanceof HdfsDataInputStream) {
+            HdfsDataInputStream inputStream = (HdfsDataInputStream) cv.inputStream;
+            DFSInputStream.ReadStatistics st = inputStream.getReadStatistics();
+            stats.setTotalBytesRead(st.getTotalBytesRead())
+                    .setTotalLocalBytesRead(st.getTotalLocalBytesRead())
+                    .setTotalShortCircuitBytesRead(st.getTotalShortCircuitBytesRead());
+        }
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setStats(stats).build();
+        return resp;
+    }
+
+    // ============================================================
+
+    @Override
+    public void hdfsOpen(HdfsRequest request,
+                         StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            logger.info(
+                    String.format("[%d][SS] hdfsOpen", rpcOnFly.incrementAndGet()));
+            responseObserver.onNext(doOpen(request));
+            responseObserver.onCompleted();
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        } finally {
+            logger.info(
+                    String.format("[%d][EE] hdfsOpen", rpcOnFly.decrementAndGet()));
+        }
+    }
+
+    @Override
+    public void hdfsClose(HdfsRequest request,
+                          StreamObserver<HdfsResponse> responseObserver) {
+        logger.info(
+                String.format("[%d][SS] hdfsClose", rpcOnFly.incrementAndGet()));
+        responseObserver.onNext(doClose(request));
+        responseObserver.onCompleted();
+        logger.info(
+                String.format("[%d][EE] hdfsClose", rpcOnFly.decrementAndGet()));
+    }
+
+    @Override
+    public void hdfsRead(HdfsRequest request,
+                         StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            logger.info(
+                    String.format("[%d][SS] hdfsRead", rpcOnFly.incrementAndGet()));
+            responseObserver.onNext(doRead(request));
+            responseObserver.onCompleted();
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        } finally {
+            logger.info(
+                    String.format("[%d][EE] hdfsRead", rpcOnFly.decrementAndGet()));
+        }
+    }
+
+    @Override
+    public void hdfsGetSize(HdfsRequest request,
+                            StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            responseObserver.onNext(doGetSize(request));
+            responseObserver.onCompleted();
+
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void hdfsGetStats(HdfsRequest request,
+                             StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            responseObserver.onNext(doGetStats(request));
+            responseObserver.onCompleted();
+
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/JavaProxyServer.java
+++ b/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/JavaProxyServer.java
@@ -1,0 +1,73 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.javaproxy;
+
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class JavaProxyServer {
+
+    private static final Logger logger =
+            LogManager.getLogger(JavaProxyServer.class.getCanonicalName());
+
+    private Server server;
+
+    private void start() throws IOException {
+        /* The port on which the server should run */
+        int port = 50051;
+        int windowSize = 64 * 1024 * 1024;
+        server = NettyServerBuilder.forPort(port)
+                .addService(new HdfsRpcHandler())
+                .flowControlWindow(windowSize)
+                .initialFlowControlWindow(windowSize)
+                .executor(Executors.newFixedThreadPool(128))
+                .build()
+                .start();
+
+        logger.info("Server started, listening on " + port);
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    JavaProxyServer.this.stop();
+                } catch (InterruptedException e) {
+                    e.printStackTrace(System.err);
+                }
+                System.err.println("*** server shut down");
+            }
+        });
+    }
+
+    private void stop() throws InterruptedException {
+        if (server != null) {
+            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Await termination on the main thread since the grpc library uses daemon threads.
+     */
+    private void blockUntilShutdown() throws InterruptedException {
+        if (server != null) {
+            server.awaitTermination();
+        }
+    }
+
+    /**
+     * Main launches the server from the command line.
+     */
+    public static void main(String[] args) throws IOException, InterruptedException {
+        final JavaProxyServer server = new JavaProxyServer();
+        server.start();
+        server.blockUntilShutdown();
+    }
+
+}

--- a/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/JavaProxyServer.java
+++ b/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/JavaProxyServer.java
@@ -23,7 +23,7 @@ public class JavaProxyServer {
         int port = 50051;
         int windowSize = 64 * 1024 * 1024;
         server = NettyServerBuilder.forPort(port)
-                .addService(new HdfsRpcHandler())
+                .addService(new MmapHdfsRpcHandler())
                 .flowControlWindow(windowSize)
                 .initialFlowControlWindow(windowSize)
                 .executor(Executors.newFixedThreadPool(128))

--- a/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/MmapHdfsRpcHandler.java
+++ b/java-extensions/java-proxy/src/main/java/com/starrocks/javaproxy/MmapHdfsRpcHandler.java
@@ -1,0 +1,254 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.javaproxy;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import io.grpc.stub.StreamObserver;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSInputStream;
+import org.apache.hadoop.hdfs.client.HdfsDataInputStream;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MmapHdfsRpcHandler extends PBackendServiceGrpc.PBackendServiceImplBase {
+    private final Logger logger = LogManager.getLogger(MmapHdfsRpcHandler.class.getCanonicalName());
+    private final AtomicLong rpcOnFly = new AtomicLong();
+    private final int maxReadSize = 64 * 1024 * 1024;
+
+    private static class CacheValue {
+        public FileSystem fs;
+        public Path path;
+        public FSDataInputStream inputStream;
+        public File mmapFile;
+        public FileChannel fc;
+        public ByteBuffer buffer;
+        public ByteBuffer tmpBuffer;
+    }
+
+    private Configuration configuration;
+    private Cache<String, CacheValue> cache;
+
+    public MmapHdfsRpcHandler() {
+        Configuration conf = new Configuration();
+        conf.set("fs.hdfs.impl", org.apache.hadoop.hdfs.DistributedFileSystem.class.getName());
+        conf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+        configuration = conf;
+
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(128 * 1024)
+                .concurrencyLevel(32)
+                .expireAfterAccess(Duration.ofMinutes(5))
+                .removalListener(new RemovalListener<String, CacheValue>() {
+                    @Override
+                    public void onRemoval(RemovalNotification<String, CacheValue> notification) {
+                        CacheValue cv = notification.getValue();
+                        logger.info(String.format("release session %s", notification.getKey()));
+                        cv.buffer.clear();
+                        try {
+                            cv.inputStream.close();
+                        } catch (IOException e) {
+                        }
+                        try {
+                            cv.fc.close();
+                        } catch (IOException e) {
+
+                        }
+                        cv.mmapFile.delete();
+                    }
+                })
+                .build();
+    }
+
+    private HdfsResponse doOpen(HdfsRequest request)
+            throws IOException {
+        String requestPath = request.getPath();
+        Path path = new Path(requestPath);
+
+        FileSystem fs = FileSystem.get(URI.create(requestPath), configuration);
+        fs.setWorkingDirectory(new Path("/"));
+
+        String sessionId = UUID.randomUUID().toString();
+        CacheValue cv = new CacheValue();
+        cv.fs = fs;
+        cv.path = path;
+        cv.inputStream = fs.open(path);
+        //        cv.buffer = newBuffer(1024 * 1024);
+
+        String mmapFilePath = String.format("/tmp/jp-mmap-%s.dat", sessionId);
+        File mmapFile = new File(mmapFilePath);
+        FileChannel fc =
+                FileChannel.open(mmapFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.CREATE,
+                        StandardOpenOption.READ,
+                        StandardOpenOption.TRUNCATE_EXISTING);
+        MappedByteBuffer buffer = fc.map(FileChannel.MapMode.READ_WRITE, 0, maxReadSize);
+        cv.buffer = buffer;
+        cv.tmpBuffer = newBuffer(1024 * 1024);
+        cv.fc = fc;
+        cv.mmapFile = mmapFile;
+
+        cache.put(sessionId, cv);
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setSessionId(sessionId).setSize(maxReadSize).setMmapFilePath(mmapFilePath)
+                        .build();
+        return resp;
+    }
+
+    private HdfsResponse doClose(HdfsRequest request) {
+        cache.invalidate(request.getSessionId());
+        return HdfsResponse.getDefaultInstance();
+    }
+
+    private CacheValue getCacheValue(String sessionId) throws IOException {
+        CacheValue cv = cache.getIfPresent(sessionId);
+        if (cv == null) {
+            throw new IOException(String.format("session id %s not found", sessionId));
+        }
+        return cv;
+    }
+
+    private ByteBuffer newBuffer(int size) {
+        int cap = 1024;
+        while (cap < size) {
+            cap *= 2;
+        }
+        return ByteBuffer.allocate(cap);
+    }
+
+    private ByteBuffer resizeBuffer(ByteBuffer buffer, int size) {
+        int cap = buffer.capacity();
+        if (cap >= size) {
+            return buffer;
+        }
+        while (cap < size) {
+            cap *= 2;
+        }
+        buffer.clear();
+        return ByteBuffer.allocate(cap);
+    }
+
+    private HdfsResponse doRead(HdfsRequest request)
+            throws IOException {
+        int size = request.getSize();
+        CacheValue cv = getCacheValue(request.getSessionId());
+        cv.tmpBuffer = resizeBuffer(cv.tmpBuffer, size);
+        cv.inputStream.readFully(request.getOffset(), cv.tmpBuffer.array(), 0, size);
+        // FIXME: still a memory copy.
+        cv.buffer.rewind();
+        cv.buffer.put(cv.tmpBuffer.array(), 0, size);
+        HdfsResponse resp = HdfsResponse.newBuilder().setSize(size).build();
+        return resp;
+    }
+
+    private HdfsResponse doGetSize(HdfsRequest request)
+            throws IOException {
+        CacheValue cv = getCacheValue(request.getSessionId());
+        FileStatus st = cv.fs.getFileStatus(cv.path);
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setSize(st.getLen()).build();
+        return resp;
+    }
+
+    private HdfsResponse doGetStats(HdfsRequest request)
+            throws IOException {
+        CacheValue cv = getCacheValue(request.getSessionId());
+        HdfsStats.Builder stats = HdfsStats.newBuilder();
+
+        if (cv.inputStream instanceof HdfsDataInputStream) {
+            HdfsDataInputStream inputStream = (HdfsDataInputStream) cv.inputStream;
+            DFSInputStream.ReadStatistics st = inputStream.getReadStatistics();
+            stats.setTotalBytesRead(st.getTotalBytesRead())
+                    .setTotalLocalBytesRead(st.getTotalLocalBytesRead())
+                    .setTotalShortCircuitBytesRead(st.getTotalShortCircuitBytesRead());
+        }
+        HdfsResponse resp =
+                HdfsResponse.newBuilder().setStats(stats).build();
+        return resp;
+    }
+
+    // ============================================================
+
+    @Override
+    public void hdfsOpen(HdfsRequest request,
+                         StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            logger.info(
+                    String.format("[%d][SS] hdfsOpen", rpcOnFly.incrementAndGet()));
+            responseObserver.onNext(doOpen(request));
+            responseObserver.onCompleted();
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        } finally {
+            logger.info(
+                    String.format("[%d][EE] hdfsOpen", rpcOnFly.decrementAndGet()));
+        }
+    }
+
+    @Override
+    public void hdfsClose(HdfsRequest request,
+                          StreamObserver<HdfsResponse> responseObserver) {
+        logger.info(
+                String.format("[%d][SS] hdfsClose", rpcOnFly.incrementAndGet()));
+        responseObserver.onNext(doClose(request));
+        responseObserver.onCompleted();
+        logger.info(
+                String.format("[%d][EE] hdfsClose", rpcOnFly.decrementAndGet()));
+    }
+
+    @Override
+    public void hdfsRead(HdfsRequest request,
+                         StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            logger.info(
+                    String.format("[%d][SS] hdfsRead", rpcOnFly.incrementAndGet()));
+            responseObserver.onNext(doRead(request));
+            responseObserver.onCompleted();
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        } finally {
+            logger.info(
+                    String.format("[%d][EE] hdfsRead", rpcOnFly.decrementAndGet()));
+        }
+    }
+
+    @Override
+    public void hdfsGetSize(HdfsRequest request,
+                            StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            responseObserver.onNext(doGetSize(request));
+            responseObserver.onCompleted();
+
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        }
+    }
+
+    @Override
+    public void hdfsGetStats(HdfsRequest request,
+                             StreamObserver<HdfsResponse> responseObserver) {
+        try {
+            responseObserver.onNext(doGetStats(request));
+            responseObserver.onCompleted();
+
+        } catch (IOException e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/java-extensions/java-proxy/src/main/proto/javaproxy.proto
+++ b/java-extensions/java-proxy/src/main/proto/javaproxy.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+
+option java_multiple_files = true;
+option java_package = "com.starrocks.javaproxy";
+option java_outer_classname = "JavaProxyProto";
+
+package doris;
+
+message HdfsRequest {
+  optional string path = 1;
+  optional string session_id = 2;
+  optional int32 offset = 3;
+  optional int32 size = 4;
+}
+
+message HdfsStats {
+  optional int64 total_bytes_read = 1;
+  optional int64 total_local_bytes_read = 2 ;
+  optional int64 total_short_circuit_bytes_read = 3;
+}
+
+message HdfsResponse {
+  optional string session_id = 1;
+  optional bytes data = 2;
+  optional int64 size = 3;
+  optional HdfsStats stats = 4;
+}
+
+service PBackendService {
+
+  rpc HdfsOpen (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsClose (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsRead (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsGetSize (HdfsRequest) returns (HdfsResponse) {}
+  rpc HdfsGetStats (HdfsRequest) returns (HdfsResponse) {}
+}

--- a/java-extensions/java-proxy/src/main/proto/javaproxy.proto
+++ b/java-extensions/java-proxy/src/main/proto/javaproxy.proto
@@ -24,6 +24,7 @@ message HdfsResponse {
   optional bytes data = 2;
   optional int64 size = 3;
   optional HdfsStats stats = 4;
+  optional string mmapFilePath = 5;
 }
 
 service PBackendService {

--- a/java-extensions/java-proxy/src/main/resources/log4j.properties
+++ b/java-extensions/java-proxy/src/main/resources/log4j.properties
@@ -1,0 +1,18 @@
+#log4j.logger.org.apache.http=WARN
+
+log4j.rootLogger=INFO, stdout, logfile
+
+log4j.category.org.springframework=ERROR
+log4j.category.org.apache=INFO
+log4j.catagory.org.apache.http=WARN
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p %t [%c] - %m%n
+#
+#log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+#log4j.appender.logfile.File=log4j.log
+#log4j.appender.logfile.MaxFileSize=100MB
+#log4j.appender.logfile.MaxBackupIndex=5
+#log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
+#log4j.appender.logfile.layout.ConversionPattern=%d %p %t [%c] - %m%n

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -11,6 +11,7 @@
     <modules>
         <module>jdbc-bridge</module>
         <module>udf-extensions</module>
+        <module>java-proxy</module>
     </modules>
     <name>starrocks-java-extensions</name>
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are currently a number of operations on BE that involve manipulating Java systems/components, including but not limited to
- Accessing HDFS
- Accessing Hudi MOR tables
- Java UDF
- Access to JDBC
- More Connectors in the future

-----

Currently these implementations are based on JNI。 But JNI implementation has the following problems.
- Stability: The team needs to have people who are proficient in JNI implementation, as well as debugging JVM core issues.
- Development costs: Big data ecosystem is more friendly to Java, and many implementations are available on Java. The cost of porting all these components to JNI is high.
- Development friendly: We will have more connectors in the future. Comparing to C++, Java is more friendly and less error-prone.

-----
So it is proposed to add a separate service `Java Proxy/JP`.
- This Java Proxy is the side car of BE, the purpose is to facilitate BE to access Java system/components.
- Since BE and JP are deployed on same machine, the communication between the two can even bypass serialization or copy. (shared memory or mmap can exchange data between the control flow can use rpc)
- The disadvantage is that it increases the cost of deployment (or BE can fork JP by calling JNI. The good side of this forking way is easy deployment, and the downside is it's hard for monitor and diagnosis by Java tools like jvisualvm)

----
Details & Perf:
- gRPC on Java side
- bRPC on BE side
- http2 as transfer protocol(`h2:grpc`)
- you *have to* increase `h2_client_connection_window_size` (default 1MB, now 64MB), otherwise some RPCs will be blocked

I don't implement bypassing serialization/deser/memcpy between BE & JP now. And I test tpch-100G/Q1 on local machine:
- Direct => 5.14 seconds
- JP => 6.27 seconds
-  JP(mmap) => 5.40 seconds

I guess with some optimization, there is almost no perf penalty.