### PR TITLE
Fix Malformed packet error when Result Package greater than 16M

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -37,7 +37,7 @@ import java.nio.channels.SocketChannel;
 public class MysqlChannel {
     // max length which one MySQL physical can hold, if one logical packet is bigger than this,
     // one packet will split to many packets
-    protected static final int MAX_PHYSICAL_PACKET_LENGTH = 0xffffff - 1;
+    protected static final int MAX_PHYSICAL_PACKET_LENGTH = 0xffffff;
     // MySQL packet header length
     protected static final int PACKET_HEADER_LEN = 4;
     protected static final int DEFAULT_BUFFER_SIZE = 16 * 1024;

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
@@ -162,7 +162,7 @@ public class MysqlChannelTest {
                 minTimes = 0;
                 result = new Delegate() {
                     int fakeRead(ByteBuffer buffer) {
-                        int maxLen = 0xffffff - 1;
+                        int maxLen = MysqlChannel.MAX_PHYSICAL_PACKET_LENGTH;
                         MysqlSerializer serializer = MysqlSerializer.newInstance();
                         if (readIdx == 0) {
                             // packet

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
@@ -99,7 +99,7 @@ public class MysqlChannelTest {
                 minTimes = 0;
                 result = new Delegate() {
                     int fakeRead(ByteBuffer buffer) {
-                        int maxLen = 0xffffff - 1;
+                        int maxLen = MysqlChannel.MAX_PHYSICAL_PACKET_LENGTH;
                         MysqlSerializer serializer = MysqlSerializer.newInstance();
                         if (readIdx == 0) {
                             // packet
@@ -147,7 +147,7 @@ public class MysqlChannelTest {
         MysqlChannel channel1 = new MysqlChannel(channel);
 
         ByteBuffer buf = channel1.fetchOnePacket();
-        Assert.assertEquals(0xffffff - 1 + 10, buf.remaining());
+        Assert.assertEquals(MysqlChannel.MAX_PHYSICAL_PACKET_LENGTH + 10, buf.remaining());
         for (int i = 0; i < 0xffffff - 1 + 10; ++i) {
             Assert.assertEquals('a' + (i % 26), buf.get());
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #6842

according to https://dev.mysql.com/doc/internals/en/sending-more-than-16mbyte.html
if the payload is larger than or equal to 2^24−1 bytes the length is set to 2^24−1 (ff ff ff)

then we need change the mysql client behaviour:
https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
```
mysql --max_allowed_packet=32M
```
