### PR TITLE
[BugFix] fix #6782: make hdfs scan use individual WorkgroupOwner

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -161,7 +161,8 @@ Status ConnectorChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(siz
         }
 
         if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
-            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id, running_wg)) {
+            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(workgroup::TypeHdfsScanExecutor,
+                                                                               worker_id, running_wg)) {
             break;
         }
     }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -351,7 +351,8 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t b
         }
 
         if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
-            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id, running_wg)) {
+            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(workgroup::TypeOlapScanExecutor,
+                                                                               worker_id, running_wg)) {
             break;
         }
     }

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -7,8 +7,8 @@
 
 namespace starrocks::workgroup {
 
-ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool)
-        : _task_queue(std::make_unique<ScanTaskQueueWithWorkGroup>()), _thread_pool(std::move(thread_pool)) {}
+ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, ScanExecutorType type)
+        : _task_queue(std::make_unique<ScanTaskQueueWithWorkGroup>(type)), _thread_pool(std::move(thread_pool)) {}
 
 ScanExecutor::~ScanExecutor() {
     _task_queue->close();

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -13,7 +13,7 @@ class ScanTaskQueue;
 
 class ScanExecutor {
 public:
-    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool);
+    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, ScanExecutorType type);
     virtual ~ScanExecutor();
 
     void initialize(int32_t num_threads);

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -3,6 +3,7 @@
 #include "exec/workgroup/scan_task_queue.h"
 
 #include "exec/workgroup/work_group.h"
+#include "exec/workgroup/work_group_fwd.h"
 
 namespace starrocks::workgroup {
 
@@ -160,7 +161,7 @@ void ScanTaskQueueWithWorkGroup::_maybe_adjust_weight() {
 }
 
 WorkGroupPtr ScanTaskQueueWithWorkGroup::_select_next_wg(int worker_id) {
-    auto owner_wgs = workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id);
+    auto owner_wgs = workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(_type, worker_id);
 
     WorkGroupPtr max_owner_wg = nullptr;
     WorkGroupPtr max_other_wg = nullptr;

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -65,7 +65,7 @@ private:
 
 class ScanTaskQueueWithWorkGroup final : public ScanTaskQueue {
 public:
-    ScanTaskQueueWithWorkGroup() = default;
+    ScanTaskQueueWithWorkGroup(ScanExecutorType type) : _type(type) {}
     ~ScanTaskQueueWithWorkGroup() override = default;
 
     void close() override;
@@ -88,6 +88,7 @@ private:
     std::mutex _global_mutex;
     std::condition_variable _cv;
 
+    const ScanExecutorType _type;
     bool _is_closed = false;
 
     std::unordered_set<WorkGroupPtr> _ready_wgs;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -2,6 +2,8 @@
 
 #include "exec/workgroup/work_group.h"
 
+#include "common/config.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "glog/logging.h"
 #include "runtime/exec_env.h"
@@ -104,13 +106,16 @@ int64_t WorkGroup::mem_limit() const {
     return _memory_limit_bytes;
 }
 
-WorkGroupManager::WorkGroupManager()
-        : _driver_worker_owner_manager(std::make_unique<WorkerOwnerManager>(
-                  config::pipeline_exec_thread_pool_thread_num > 0 ? config::pipeline_exec_thread_pool_thread_num
-                                                                   : std::thread::hardware_concurrency())),
-          _scan_worker_owner_manager(std::make_unique<WorkerOwnerManager>(
-                  config::pipeline_scan_thread_pool_thread_num > 0 ? config::pipeline_scan_thread_pool_thread_num
-                                                                   : std::thread::hardware_concurrency())) {}
+WorkGroupManager::WorkGroupManager() {
+    _driver_worker_owner_manager = std::make_unique<WorkerOwnerManager>(
+            config::pipeline_exec_thread_pool_thread_num > 0 ? config::pipeline_exec_thread_pool_thread_num
+                                                             : std::thread::hardware_concurrency());
+    _scan_worker_owner_manager = std::make_unique<WorkerOwnerManager>(
+            config::pipeline_scan_thread_pool_thread_num > 0 ? config::pipeline_scan_thread_pool_thread_num
+                                                             : std::thread::hardware_concurrency());
+    _hdfs_scan_worker_owner_manager =
+            std::make_unique<WorkerOwnerManager>(config::pipeline_hdfs_scan_thread_pool_thread_num);
+}
 
 WorkGroupManager::~WorkGroupManager() {}
 void WorkGroupManager::destroy() {
@@ -118,6 +123,7 @@ void WorkGroupManager::destroy() {
 
     _driver_worker_owner_manager.reset(nullptr);
     _scan_worker_owner_manager.reset(nullptr);
+    _hdfs_scan_worker_owner_manager.reset(nullptr);
     update_metrics_unlocked();
     _workgroups.clear();
 }
@@ -450,6 +456,7 @@ std::vector<TWorkGroup> WorkGroupManager::list_all_workgroups() {
 void WorkGroupManager::reassign_worker_to_wgs() {
     _driver_worker_owner_manager->reassign_to_wgs(_workgroups, _sum_cpu_limit);
     _scan_worker_owner_manager->reassign_to_wgs(_workgroups, _sum_cpu_limit);
+    _hdfs_scan_worker_owner_manager->reassign_to_wgs(_workgroups, _sum_cpu_limit);
 }
 
 std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_driver_worker(int worker_id) {
@@ -460,12 +467,15 @@ bool WorkGroupManager::should_yield_driver_worker(int worker_id, WorkGroupPtr ru
     return _driver_worker_owner_manager->should_yield(worker_id, std::move(running_wg));
 }
 
-std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_scan_worker(int worker_id) {
-    return _scan_worker_owner_manager->get_owners(worker_id);
+std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_scan_worker(ScanExecutorType type, int worker_id) {
+    return type == TypeOlapScanExecutor ? _scan_worker_owner_manager->get_owners(worker_id)
+                                        : _hdfs_scan_worker_owner_manager->get_owners(worker_id);
 }
 
-bool WorkGroupManager::get_owners_of_scan_worker(int worker_id, WorkGroupPtr running_wg) {
-    return _scan_worker_owner_manager->should_yield(worker_id, std::move(running_wg));
+bool WorkGroupManager::get_owners_of_scan_worker(ScanExecutorType type, int worker_id, WorkGroupPtr running_wg) {
+    return type == TypeOlapScanExecutor
+                   ? _scan_worker_owner_manager->should_yield(worker_id, std::move(running_wg))
+                   : _hdfs_scan_worker_owner_manager->should_yield(worker_id, std::move(running_wg));
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -261,8 +261,8 @@ public:
     std::shared_ptr<WorkGroupPtrSet> get_owners_of_driver_worker(int worker_id);
     bool should_yield_driver_worker(int worker_id, WorkGroupPtr running_wg);
 
-    std::shared_ptr<WorkGroupPtrSet> get_owners_of_scan_worker(int worker_id);
-    bool get_owners_of_scan_worker(int worker_id, WorkGroupPtr running_wg);
+    std::shared_ptr<WorkGroupPtrSet> get_owners_of_scan_worker(ScanExecutorType type, int worker_id);
+    bool get_owners_of_scan_worker(ScanExecutorType type, int worker_id, WorkGroupPtr running_wg);
 
     int num_total_driver_workers() const { return _driver_worker_owner_manager->num_total_workers(); }
 
@@ -289,6 +289,7 @@ private:
 
     std::unique_ptr<WorkerOwnerManager> _driver_worker_owner_manager;
     std::unique_ptr<WorkerOwnerManager> _scan_worker_owner_manager;
+    std::unique_ptr<WorkerOwnerManager> _hdfs_scan_worker_owner_manager;
 
     std::once_flag init_metrics_once_flag;
     std::unordered_map<std::string, int128_t> _wg_metrics;

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -12,4 +12,10 @@ class ScanExecutor;
 
 using WorkGroupPtr = std::shared_ptr<WorkGroup>;
 
+// Two types of scan executor: OlapScan and HdfsScan
+enum ScanExecutorType {
+    TypeOlapScanExecutor,
+    TypeHdfsScanExecutor,
+};
+
 } // namespace starrocks::workgroup

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -188,6 +188,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _wg_driver_executor =
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
     _wg_driver_executor->initialize(_max_executor_threads);
+    starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
     _master_info = new TMasterInfo();
     _load_path_mgr = new LoadPathMgr(this);
@@ -315,7 +316,6 @@ Status ExecEnv::init_mem_tracker() {
     GlobalTabletSchemaMap::Instance()->set_mem_tracker(_tablet_meta_mem_tracker);
     SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     vectorized::ForEach<vectorized::ColumnPoolList>(op);
-    starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
     _init_storage_page_cache();
     return Status::OK();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6782

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

HdfsScanExecutor would use different number of thread with OlapScan, so it should use a individual WorkgroupOwner to calculate the workgroup of thread worker.