### PR TITLE
[BugFix] Fix join reorder push project error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import com.starrocks.statistic.Constants;
 
@@ -26,8 +27,6 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public abstract class JoinOrder {
     /**
@@ -296,16 +295,24 @@ public abstract class JoinOrder {
             return;
         }
 
-        Map<ColumnRefOperator, ScalarOperator> projection = exprInfo.expr.getOutputColumns()
-                .getStream().mapToObj(context.getColumnRefFactory()::getColumnRef)
-                .collect(Collectors.toMap(Function.identity(), Function.identity()));
-        projection.putAll(expression);
+        Map<ColumnRefOperator, ScalarOperator> projection = Maps.newHashMap();
         if (exprInfo.expr.getOp().getProjection() != null) {
             projection.putAll(exprInfo.expr.getOp().getProjection().getColumnRefMap());
+        } else {
+            exprInfo.expr.getOutputColumns().getStream().mapToObj(context.getColumnRefFactory()::getColumnRef)
+                    .forEach(c -> projection.put(c, c));
         }
+
+        // merge two projection, keep same logical from MergeTwoProjectRule
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(projection);
+        Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : expression.entrySet()) {
+            resultMap.put(entry.getKey(), rewriter.rewrite(entry.getValue()));
+        }
+
         Operator.Builder builder = OperatorBuilderFactory.build(exprInfo.expr.getOp());
         exprInfo.expr = OptExpression.create(
-                builder.withOperator(exprInfo.expr.getOp()).setProjection(new Projection(projection)).build(),
+                builder.withOperator(exprInfo.expr.getOp()).setProjection(new Projection(resultMap)).build(),
                 exprInfo.expr.getInputs());
         exprInfo.expr.deriveLogicalPropertyItself();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -309,6 +309,7 @@ public abstract class JoinOrder {
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : expression.entrySet()) {
             resultMap.put(entry.getKey(), rewriter.rewrite(entry.getValue()));
         }
+        resultMap.putAll(projection);
 
         Operator.Builder builder = OperatorBuilderFactory.build(exprInfo.expr.getOp());
         exprInfo.expr = OptExpression.create(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -2,7 +2,9 @@
 
 package com.starrocks.sql.optimizer.rule.join;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -83,7 +85,6 @@ public class ReorderJoinRule extends Rule {
         for (OptExpression joinExpr : reorderTopKResult) {
             ColumnRefSet outputColumns = new ColumnRefSet();
             Map<ColumnRefOperator, ScalarOperator> projectMap = new HashMap<>();
-            Map<ColumnRefOperator, ScalarOperator> commonProjectMap = new HashMap<>();
             if (oldRoot.getProjection() == null) {
                 innerJoinRoot.getInputs().forEach(opt -> outputColumns.union(opt.getOutputColumns()));
 
@@ -93,7 +94,6 @@ public class ReorderJoinRule extends Rule {
             } else {
                 outputColumns.union(oldRoot.getProjection().getOutputColumns());
                 projectMap.putAll(oldRoot.getProjection().getColumnRefMap());
-                commonProjectMap.putAll(oldRoot.getProjection().getCommonSubOperatorMap());
             }
 
             ColumnRefSet newRootInputColumns = new ColumnRefSet();
@@ -118,7 +118,7 @@ public class ReorderJoinRule extends Rule {
                             replaceColumnRefRewriter.rewrite(scalarOperator));
                 }
             }
-            joinExpr.getOp().setProjection(new Projection(projectMap, commonProjectMap));
+            joinExpr.getOp().setProjection(new Projection(projectMap));
             ColumnRefSet requireInputColumns = ((LogicalJoinOperator) joinExpr.getOp()).getRequiredChildInputColumns();
             requireInputColumns.union(outputColumns);
 
@@ -177,23 +177,37 @@ public class ReorderJoinRule extends Rule {
             this.optimizerContext = optimizerContext;
         }
 
-        public OptExpression rewrite(OptExpression optExpression, ColumnRefSet pruneOutputColumns) {
+        public OptExpression rewrite(OptExpression optExpression, ColumnRefSet requiredColumns) {
             Operator operator = optExpression.getOp();
-            if (operator.getProjection() != null) {
+            if (operator.getProjection() != null && operator.getProjection().getColumnRefMap().size() > 1) {
                 Projection projection = operator.getProjection();
 
-                for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
-                    if (!entry.getValue().isColumnRef()) {
-                        return optExpression;
+                List<ColumnRefOperator> outputColumns = Lists.newArrayList();
+                for (ColumnRefOperator key : projection.getColumnRefMap().keySet()) {
+                    if (requiredColumns.contains(key)) {
+                        outputColumns.add(key);
+                    }
+                }
+
+                if (outputColumns.size() == 0) {
+                    outputColumns.add(Utils.findSmallestColumnRef(projection.getOutputColumns()));
+                }
+
+                if (outputColumns.size() != projection.getColumnRefMap().size()) {
+                    Map<ColumnRefOperator, ScalarOperator> newOutputProjections = Maps.newHashMap();
+                    for (ColumnRefOperator ref : outputColumns) {
+                        newOutputProjections.put(ref, projection.getColumnRefMap().get(ref));
                     }
 
-                    if (!entry.getKey().equals(entry.getValue())) {
-                        return optExpression;
-                    }
+                    optExpression.getOp().setProjection(new Projection(newOutputProjections));
+                }
+
+                for (ScalarOperator value : optExpression.getOp().getProjection().getColumnRefMap().values()) {
+                    requiredColumns.union(value.getUsedColumns());
                 }
             }
 
-            return optExpression.getOp().accept(this, optExpression, pruneOutputColumns);
+            return optExpression.getOp().accept(this, optExpression, requiredColumns);
         }
 
         @Override
@@ -212,12 +226,8 @@ public class ReorderJoinRule extends Rule {
             }
             requireColumns = ((LogicalJoinOperator) optExpression.getOp()).getRequiredChildInputColumns();
 
-            ColumnRefSet childInputColumns = new ColumnRefSet();
-            optExpression.getInputs().forEach(opt -> childInputColumns.union(
-                    ((LogicalOperator) opt.getOp()).getOutputColumns(new ExpressionContext(opt))));
-
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
-            if (!newOutputColumns.isEmpty()) {
+            if (joinOperator.getProjection() == null && !newOutputColumns.isEmpty()) {
                 joinOperator = new LogicalJoinOperator.Builder()
                         .withOperator((LogicalJoinOperator) optExpression.getOp())
                         .setProjection(new Projection(newOutputColumns.getStream()
@@ -225,6 +235,9 @@ public class ReorderJoinRule extends Rule {
                                 .collect(Collectors.toMap(Function.identity(), Function.identity())),
                                 new HashMap<>()))
                         .build();
+            } else if (joinOperator.getProjection() != null) {
+                Preconditions.checkState(
+                        joinOperator.getProjection().getColumnRefMap().size() >= newOutputColumns.cardinality());
             }
 
             requireColumns.union(newOutputColumns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -224,7 +224,6 @@ public class ReorderJoinRule extends Rule {
                     newOutputColumns.union(id);
                 }
             }
-            requireColumns = ((LogicalJoinOperator) optExpression.getOp()).getRequiredChildInputColumns();
 
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
             if (joinOperator.getProjection() == null && !newOutputColumns.isEmpty()) {
@@ -237,9 +236,10 @@ public class ReorderJoinRule extends Rule {
                         .build();
             } else if (joinOperator.getProjection() != null) {
                 Preconditions.checkState(
-                        joinOperator.getProjection().getColumnRefMap().size() >= newOutputColumns.cardinality());
+                        newOutputColumns.cardinality() >= joinOperator.getProjection().getColumnRefMap().size());
             }
 
+            requireColumns = ((LogicalJoinOperator) optExpression.getOp()).getRequiredChildInputColumns();
             requireColumns.union(newOutputColumns);
             OptExpression left = rewrite(optExpression.inputAt(0), (ColumnRefSet) requireColumns.clone());
             OptExpression right = rewrite(optExpression.inputAt(1), (ColumnRefSet) requireColumns.clone());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6805

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the test sql use 100+ tables join, and hard to simple, so I only print some wrong plan. the bug plan:

```
|   STREAM DATA SINK                                                                                                                                                                                                                         |
|     EXCHANGE ID: 78                                                                                                                                                                                                                        |
|     UNPARTITIONED                                                                                                                                                                                                                          |
|                                                                                                                                                                                                                                            |
|   77:Project                                                                                                                                                                                                                               |
|   |  <slot 1428> : 1407: c_1_0                                                                                                                                                                                                             |
|   |  <slot 1703> : 1428: c_1_0                                                                                                                                                                                                             |
|   |                                                                                                                                                                                                                                        |
|   76:HASH JOIN                                                                                                                                                                                                                             |
|   |  join op: LEFT ANTI JOIN (PARTITIONED)                                                                                                                                                                                                 |
|   |  hash predicates:                                                                                                                                                                                                                      |
|   |  colocate: false, reason:                                                                                                                                                                                                              |
|   |  equal join conjunct: 1409: c_1_2 = 1419: c_0_2                                                                                                                                                                                        |
|   |  other join predicates: 1409: c_1_2 <= 1419: c_0_2, CAST(1415: c_1_8 AS DOUBLE) >= CAST(1427: c_0_10 AS DOUBLE), CAST(1415: c_1_8 AS DOUBLE) < CAST(1427: c_0_10 AS DOUBLE), CAST(1414: c_1_7 AS DOUBLE) > CAST(1417: c_0_0 AS DOUBLE) |
|   |                                                                                                                                                                                                                                        
```

the project is error. I think the bug is related to push required column logical, and happend when merge projection.

the right plan:
```
|   STREAM DATA SINK                                                                                                                                                                                                                         |
|     EXCHANGE ID: 78                                                                                                                                                                                                                        |
|     UNPARTITIONED                                                                                                                                                                                                                          |
|                                                                                                                                                                                                                                            |
|   77:Project                                                                                                                                                                                                                               |
|   |  <slot 1703> : 1427: c_1_0                                                                                                                                                                                                             |
|   |                                                                                                                                                                                                                                        |
|   76:HASH JOIN                                                                                                                                                                                                                             |
|   |  join op: LEFT ANTI JOIN (PARTITIONED)                                                                                                                                                                                                 |
|   |  hash predicates:                                                                                                                                                                                                                      |
|   |  colocate: false, reason:                                                                                                                                                                                                              |
|   |  equal join conjunct: 1409: c_1_2 = 1419: c_0_2                                                                                                                                                                                        |
|   |  other join predicates: 1409: c_1_2 <= 1419: c_0_2, CAST(1415: c_1_8 AS DOUBLE) >= CAST(1427: c_0_10 AS DOUBLE), CAST(1415: c_1_8 AS DOUBLE) < CAST(1427: c_0_10 AS DOUBLE), CAST(1414: c_1_7 AS DOUBLE) > CAST(1417: c_0_0 AS DOUBLE) |
|   |                                                                                                                                                                                                                                        
```