### PR TITLE
[Refactor] Reduce BitmapValue struct size

### DIFF
--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -28,6 +28,7 @@
 #define private public
 #include "types/bitmap_value.h"
 #include "types/bitmap_value_detail.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 
@@ -360,4 +361,24 @@ TEST(BitmapValueTest, bitmap_min) {
     bitmap.add(0);
     ASSERT_EQ(bitmap.min(), 0);
 }
+
+TEST(BitmapValueTest, bitmap_xor) {
+    // {3} ^ {1,2} = {1,2,3}
+    {
+        BitmapValue bm1;
+        bm1.add(3);
+        BitmapValue bm2;
+        bm2.add(1);
+        bm2.add(2);
+
+        bm1 ^= bm2;
+        ASSERT_EQ(3, bm1.cardinality());
+        ASSERT_EQ(3, bm1.max());
+        ASSERT_EQ(1, bm1.min());
+
+        // and b2 should not be changed
+        ASSERT_EQ(2, bm2.cardinality());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ x ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In this PR, I reduce the BitmapValue struct size by convert `_set` from struct to a `std::unique_ptr`. Besides this, I also changed the `operator^=` argument from reference to `const reference`. And keep the argument not be changed in the function. Which is more reasonable to understand.
