### PR TITLE
[Bugfix] Fix unused size variable

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -1645,8 +1645,8 @@ ColumnPtr StringFunctions::upper(FunctionContext* context, const Columns& column
 
 static inline void ascii_reverse_per_slice(const char* src_begin, const char* src_end, char* dst_curr) {
     auto src_curr = src_begin;
+#if defined(__SSE3__) && defined(__SSE2__)
     auto const size = src_end - src_begin;
-#if defined(__SSSE3__) && defined(__SSE2__)
     constexpr auto SSE2_SIZE = sizeof(__m128i);
     const auto ctrl_masks = _mm_set_epi64((__m64)0x00'01'02'03'04'05'06'07ull, (__m64)0x08'09'0a'0b'0c'0d'0e'0full);
     const auto sse2_end = src_begin + (size & ~(SSE2_SIZE - 1));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix unused size variable in ascii_reverse_per_slice