### PR TITLE
[Refactor] Remove old partition level tablet type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -8,7 +8,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,10 +55,6 @@ public class CatalogUtils {
             }
         }
         return existPartitionNameSet;
-    }
-
-    public static boolean isUseStarOS(TStorageMedium storageMedium) {
-        return storageMedium == TStorageMedium.S3;
     }
 
     // Used to temporarily disable some command on StarOS table and remove later.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -23,7 +23,6 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.lake.LakeTablet;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -95,10 +94,6 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "tablets")
     // this is for keeping tablet order
     private List<Tablet> tablets;
-
-    // Not persist.
-    // If useStarOS is true, use StarOSTablet in |tablets|, otherwise use LocalTablet.
-    private boolean useStarOS = false;
 
     // for push after rollup index finished
     @SerializedName(value = "rollupIndexId")
@@ -186,14 +181,6 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         this.rowCount = rowCount;
     }
 
-    public boolean isUseStarOS() {
-        return useStarOS;
-    }
-
-    public void setUseStarOS(boolean useStarOS) {
-        this.useStarOS = useStarOS;
-    }
-
     public void setRollupIndexInfo(long rollupIndexId, long rollupFinishedVersion) {
         this.rollupIndexId = rollupIndexId;
         this.rollupFinishedVersion = rollupFinishedVersion;
@@ -221,10 +208,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public long getReplicaCount() {
-        if (useStarOS) {
-            return tablets.size();
-        }
-
+        // Support LakeTablet later.
         long replicaCount = 0;
         for (Tablet tablet : getTablets()) {
             LocalTablet localTablet = (LocalTablet) tablet;
@@ -273,12 +257,8 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
 
         int tabletCount = in.readInt();
         for (int i = 0; i < tabletCount; ++i) {
-            Tablet tablet = null;
-            if (useStarOS) {
-                tablet = LakeTablet.read(in);
-            } else {
-                tablet = LocalTablet.read(in);
-            }
+            // LakeTablet uses json serialization.
+            Tablet tablet = LocalTablet.read(in);
             tablets.add(tablet);
             idToTablets.put(tablet.getId(), tablet);
         }
@@ -287,15 +267,10 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         rollupFinishedVersion = in.readLong();
     }
 
-    public static MaterializedIndex read(DataInput in, boolean useStarOS) throws IOException {
+    public static MaterializedIndex read(DataInput in) throws IOException {
         MaterializedIndex materializedIndex = new MaterializedIndex();
-        materializedIndex.setUseStarOS(useStarOS);
         materializedIndex.readFields(in);
         return materializedIndex;
-    }
-
-    public static MaterializedIndex read(DataInput in) throws IOException {
-        return MaterializedIndex.read(in, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1168,7 +1168,7 @@ public class OlapTable extends Table {
 
         int partitionCount = in.readInt();
         for (int i = 0; i < partitionCount; ++i) {
-            Partition partition = Partition.read(in, partitionInfo);
+            Partition partition = Partition.read(in);
             idToPartition.put(partition.getId(), partition);
             nameToPartition.put(partition.getName(), partition);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -98,11 +98,6 @@ public class Partition extends MetaObject implements Writable {
     @SerializedName(value = "distributionInfo")
     private DistributionInfo distributionInfo;
 
-    // Not persist.
-    // Currently it is used to check whether the storage medium of the partition is S3.
-    // If storage medium is S3, use StarOSTablet in MaterializedIndex, otherwise use LocalTablet.
-    private PartitionInfo partitionInfo = null;
-
     private Partition() {
     }
 
@@ -200,12 +195,9 @@ public class Partition extends MetaObject implements Writable {
         return distributionInfo;
     }
 
-    public void setPartitionInfo(PartitionInfo partitionInfo) {
-        this.partitionInfo = partitionInfo;
-    }
-
+    // Remove this after LakeTable is merged.
     public boolean isUseStarOS() {
-        return partitionInfo != null && partitionInfo.isUseStarOS(id);
+        return false;
     }
 
     public void createRollupIndex(MaterializedIndex mIndex) {
@@ -348,15 +340,10 @@ public class Partition extends MetaObject implements Writable {
         return true;
     }
 
-    public static Partition read(DataInput in, PartitionInfo partitionInfo) throws IOException {
+    public static Partition read(DataInput in) throws IOException {
         Partition partition = new Partition();
-        partition.setPartitionInfo(partitionInfo);
         partition.readFields(in);
         return partition;
-    }
-
-    public static Partition read(DataInput in) throws IOException {
-        return Partition.read(in, null);
     }
 
     @Override
@@ -402,18 +389,18 @@ public class Partition extends MetaObject implements Writable {
         name = Text.readString(in);
         state = PartitionState.valueOf(Text.readString(in));
 
-        baseIndex = MaterializedIndex.read(in, isUseStarOS());
+        baseIndex = MaterializedIndex.read(in);
 
         int rollupCount = in.readInt();
         for (int i = 0; i < rollupCount; ++i) {
-            MaterializedIndex rollupTable = MaterializedIndex.read(in, isUseStarOS());
+            MaterializedIndex rollupTable = MaterializedIndex.read(in);
             idToVisibleRollupIndex.put(rollupTable.getId(), rollupTable);
         }
 
         if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_61) {
             int shadowIndexCount = in.readInt();
             for (int i = 0; i < shadowIndexCount; i++) {
-                MaterializedIndex shadowIndex = MaterializedIndex.read(in, isUseStarOS());
+                MaterializedIndex shadowIndex = MaterializedIndex.read(in);
                 idToShadowIndex.put(shadowIndex.getId(), shadowIndex);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -195,7 +195,7 @@ public class Partition extends MetaObject implements Writable {
         return distributionInfo;
     }
 
-    // Remove this after LakeTable is merged.
+    // TODO: Remove this after LakeTable is merged.
     public boolean isUseStarOS() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -92,14 +92,6 @@ public class PartitionInfo implements Writable {
         idToDataProperty.put(partitionId, newDataProperty);
     }
 
-    public boolean isUseStarOS(long partitionId) {
-        DataProperty dataProperty = getDataProperty(partitionId);
-        if (dataProperty == null) {
-            return false;
-        }
-        return CatalogUtils.isUseStarOS(dataProperty.getStorageMedium());
-    }
-
     public int getQuorumNum(long partitionId) {
         return getReplicationNum(partitionId) / 2 + 1;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -82,8 +82,9 @@ public class TabletMeta {
         this.storageMedium = storageMedium;
     }
 
+    // Remove this after LakeTable is merged.
     public boolean isUseStarOS() {
-        return CatalogUtils.isUseStarOS(storageMedium);
+        return false;
     }
 
     public int getNewSchemaHash() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -82,7 +82,7 @@ public class TabletMeta {
         this.storageMedium = storageMedium;
     }
 
-    // Remove this after LakeTable is merged.
+    // TODO: Remove this after LakeTable is merged.
     public boolean isUseStarOS() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -30,7 +30,6 @@ import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
 
@@ -43,16 +42,9 @@ import java.util.List;
  * show index's detail info within a partition
  */
 public class IndicesProcDir implements ProcDirInterface {
-    public static final ImmutableList<String> TITLE_NAMES;
-
-    static {
-        ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
-                .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime");
-        if (Config.use_staros) {
-            builder.add("UseStarOS");
-        }
-        TITLE_NAMES = builder.build();
-    }
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
+            .build();
 
     private Database db;
     private OlapTable olapTable;
@@ -81,9 +73,6 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(olapTable.getIndexNameById(materializedIndex.getId()));
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
-                if (Config.use_staros) {
-                    indexInfo.add(materializedIndex.isUseStarOS());
-                }
 
                 indexInfos.add(indexInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -113,8 +113,6 @@ public class PropertyAnalyzer {
                     storageMedium = TStorageMedium.SSD;
                 } else if (value.equalsIgnoreCase(TStorageMedium.HDD.name())) {
                     storageMedium = TStorageMedium.HDD;
-                } else if (value.equalsIgnoreCase(TStorageMedium.S3.name()) && Config.use_staros) {
-                    storageMedium = TStorageMedium.S3;
                 } else {
                     throw new AnalysisException("Invalid storage medium: " + value);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1350,13 +1350,11 @@ public class LocalMetastore implements ConnectorMetadata {
         Map<Long, MaterializedIndex> indexMap = new HashMap<>();
         for (long indexId : table.getIndexIdToMeta().keySet()) {
             MaterializedIndex rollup = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-            rollup.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
             indexMap.put(indexId, rollup);
         }
         DistributionInfo distributionInfo = table.getDefaultDistributionInfo();
         Partition partition =
                 new Partition(partitionId, partitionName, indexMap.get(table.getBaseIndexId()), distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
 
         // version
         if (version != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -24,15 +24,12 @@ package com.starrocks.catalog;
 import com.starrocks.analysis.AlterTableStmt;
 import com.starrocks.analysis.CreateDbStmt;
 import com.starrocks.analysis.CreateTableStmt;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -287,71 +284,6 @@ public class CreateTableTest {
         ));
         ExceptionChecker.expectThrowsNoException(
                 () -> alterTable("ALTER TABLE test.t_json_primary_key ADD COLUMN k3 JSON"));
-    }
-
-    private void checkOlapTableWithLakeTablet(String dbName, String tableName) {
-        String fullDbName = ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, dbName);
-        Database db = GlobalStateMgr.getCurrentState().getDb(fullDbName);
-        Table table = db.getTable(tableName);
-        Assert.assertTrue(table instanceof OlapTable);
-        OlapTable olapTable = (OlapTable) table;
-        for (Partition partition : olapTable.getAllPartitions()) {
-            Assert.assertTrue(partition.isUseStarOS());
-        }
-
-        boolean throwException = false;
-        try {
-            CatalogUtils.checkOlapTableHasStarOSPartition(fullDbName, tableName);
-        } catch (AnalysisException e) {
-            throwException = true;
-        }
-        Assert.assertTrue(throwException);
-    }
-
-    private void dropOlapTableWithLakeTablet(String dbName, String tableName) {
-        String fullDbName = ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, dbName);
-        Database db = GlobalStateMgr.getCurrentState().getDb(fullDbName);
-        Table table = db.getTable(tableName);
-        Assert.assertTrue(table != null);
-        db.dropTable(tableName);
-        table = db.getTable(tableName);
-        Assert.assertTrue(table == null);
-    }
-
-    @Test
-    public void testCreateOlapTableWithLakeTablet() throws DdlException {
-        Config.use_staros = true;
-
-        // normal
-        ExceptionChecker.expectThrowsNoException(() -> createTable(
-                "create table test.single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
-                        "distributed by hash(key1) buckets 3\n" +
-                        "properties('replication_num' = '1', 'storage_medium' = 's3');"));
-        checkOlapTableWithLakeTablet("test", "single_partition_duplicate_key");
-        dropOlapTableWithLakeTablet("test", "single_partition_duplicate_key");
-
-        ExceptionChecker.expectThrowsNoException(() -> createTable(
-                "create table test.multi_partition_aggregate_key (key1 date, key2 varchar(10), v bigint sum)\n" +
-                        "partition by range(key1)\n" +
-                        "(partition p1 values less than (\"2022-03-01\"),\n" +
-                        " partition p2 values less than (\"2022-04-01\"))\n" +
-                        "distributed by hash(key2) buckets 3\n" +
-                        "properties('replication_num' = '1', 'storage_medium' = 's3');"));
-        checkOlapTableWithLakeTablet("test", "multi_partition_aggregate_key");
-        dropOlapTableWithLakeTablet("test", "multi_partition_aggregate_key");
-
-        ExceptionChecker.expectThrowsNoException(() -> createTable(
-                "create table test.multi_partition_unique_key (key1 int, key2 varchar(10), v bigint)\n" +
-                        "unique key (key1, key2)\n" +
-                        "partition by range(key1)\n" +
-                        "(partition p1 values less than (\"10\"),\n" +
-                        " partition p2 values less than (\"20\"))\n" +
-                        "distributed by hash(key2) buckets 3\n" +
-                        "properties('replication_num' = '1', 'storage_medium' = 's3');"));
-        checkOlapTableWithLakeTablet("test", "multi_partition_unique_key");
-        dropOlapTableWithLakeTablet("test", "multi_partition_unique_key");
-
-        Config.use_staros = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -25,15 +25,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.IndexDef;
 import com.starrocks.catalog.Table.TableType;
-import com.starrocks.catalog.lake.LakeTablet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.FastByteArrayOutputStream;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UnitTestUtil;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.thrift.TStorageMedium;
-import com.starrocks.thrift.TStorageType;
-import com.starrocks.thrift.TTabletType;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
@@ -42,7 +37,6 @@ import org.junit.Test;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class OlapTableTest {
@@ -83,7 +77,6 @@ public class OlapTableTest {
             Partition partition = ((OlapTable) copiedTbl).getPartition(3L);
             Assert.assertFalse(partition.isUseStarOS());
             MaterializedIndex newIndex = partition.getIndex(4L);
-            Assert.assertFalse(newIndex.isUseStarOS());
             for (Tablet tablet : newIndex.getTablets()) {
                 Assert.assertTrue(tablet instanceof LocalTablet);
             }
@@ -96,87 +89,6 @@ public class OlapTableTest {
             Assert.assertEquals(Sets.newHashSet(30l), tbl.getRelatedMaterializedViews());
             tbl.removeRelatedMaterializedView(30l);
             Assert.assertEquals(Sets.newHashSet(), tbl.getRelatedMaterializedViews());
-        }
-    }
-
-    @Test
-    public void testTableWithLakeTablet() throws IOException {
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            int getCurrentStateJournalVersion() {
-                return FeConstants.meta_version;
-            }
-        };
-
-        long dbId = 1L;
-        long tableId = 2L;
-        long partitionId = 3L;
-        long indexId = 4L;
-        long tablet1Id = 10L;
-        long tablet2Id = 11L;
-
-        // Columns
-        List<Column> columns = new ArrayList<Column>();
-        Column k1 = new Column("k1", Type.INT, true, null, "", "");
-        columns.add(k1);
-        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
-        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
-
-        // Tablet
-        Tablet tablet1 = new LakeTablet(tablet1Id, 0L);
-        Tablet tablet2 = new LakeTablet(tablet2Id, 1L);
-
-        // Partition info and distribution info
-        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
-        PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.S3));
-        partitionInfo.setIsInMemory(partitionId, false);
-        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
-
-        // Index
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        index.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.S3);
-        index.addTablet(tablet1, tabletMeta);
-        index.addTablet(tablet2, tabletMeta);
-
-        // Partition
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
-
-        // Table
-        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
-        Deencapsulation.setField(table, "baseIndexId", indexId);
-        table.addPartition(partition);
-        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
-
-        // Serialize
-        FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
-        try (DataOutputStream out = new DataOutputStream(byteArrayOutputStream)) {
-            table.write(out);
-            out.flush();
-        }
-
-        // Deserialize
-        Table newTable = null;
-        try (DataInputStream in = new DataInputStream(byteArrayOutputStream.getInputStream())) {
-            newTable = Table.read(in);
-        }
-        byteArrayOutputStream.close();
-
-        // Check
-        Assert.assertTrue(newTable instanceof OlapTable);
-        OlapTable newOlapTable = (OlapTable) newTable;
-        Partition p1 = newOlapTable.getPartition(partitionId);
-        Assert.assertTrue(p1.isUseStarOS());
-        MaterializedIndex newIndex = p1.getBaseIndex();
-        Assert.assertTrue(newIndex.isUseStarOS());
-        long expectedShardId = 0L;
-        for (Tablet tablet : newIndex.getTablets()) {
-            Assert.assertTrue(tablet instanceof LakeTablet);
-            LakeTablet lakeTablet = (LakeTablet) tablet;
-            Assert.assertEquals(expectedShardId++, lakeTablet.getShardId());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
@@ -4,7 +4,6 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.lake.LakeTablet;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
@@ -28,7 +27,6 @@ public class TabletStatMgrTest {
         long tableId = 2L;
         long partitionId = 3L;
         long indexId = 4L;
-        long tablet1Id = 10L;
         long tablet2Id = 11L;
         long backendId = 20L;
         TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
@@ -40,9 +38,6 @@ public class TabletStatMgrTest {
         columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
 
-        // Tablet1 is LakeTablet
-        Tablet tablet1 = new LakeTablet(tablet1Id, 0L);
-
         // Tablet2 is LocalTablet
         TabletMeta tabletMeta2 = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD);
         invertedIndex.addTablet(tablet2Id, tabletMeta2);
@@ -52,23 +47,14 @@ public class TabletStatMgrTest {
         // Partition info and distribution info
         DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
         PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.S3));
+        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.HDD));
         partitionInfo.setIsInMemory(partitionId, false);
         partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
         partitionInfo.setReplicationNum(partitionId, (short) 3);
 
-        // Index
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        index.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
-        TabletMeta tabletMeta1 = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.S3);
-        index.addTablet(tablet1, tabletMeta1);
-        invertedIndex.addTablet(tablet1Id, tabletMeta1);
-
-        // Partition
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
-
         // Table
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
         OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
@@ -81,10 +67,6 @@ public class TabletStatMgrTest {
         TTabletStatResult result = new TTabletStatResult();
         Map<Long, TTabletStat> tabletsStats = Maps.newHashMap();
         result.setTablets_stats(tabletsStats);
-        TTabletStat tablet1Stat = new TTabletStat(tablet1Id);
-        tablet1Stat.setData_size(100L);
-        tablet1Stat.setRow_num(101L);
-        tabletsStats.put(tablet1Id, tablet1Stat);
         TTabletStat tablet2Stat = new TTabletStat(tablet2Id);
         tablet2Stat.setData_size(200L);
         tablet2Stat.setRow_num(201L);
@@ -92,12 +74,8 @@ public class TabletStatMgrTest {
 
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
                 GlobalStateMgr.getCurrentInvertedIndex();
                 result = invertedIndex;
-                globalStateMgr.getDb(dbId);
-                result = db;
             }
         };
 
@@ -105,8 +83,6 @@ public class TabletStatMgrTest {
         TabletStatMgr tabletStatMgr = new TabletStatMgr();
         Deencapsulation.invoke(tabletStatMgr, "updateTabletStat", backendId, result);
 
-        Assert.assertEquals(100L, tablet1.getDataSize(true));
-        Assert.assertEquals(101L, tablet1.getRowCount(0L));
         Assert.assertEquals(200L, replica.getDataSize());
         Assert.assertEquals(201L, replica.getRowCount());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletsProcDirTest.java
@@ -19,10 +19,8 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.SinglePartitionInfo;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
-import com.starrocks.catalog.lake.LakeTablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
@@ -41,83 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 public class TabletsProcDirTest {
-    @Test
-    public void testFetchResultLakeTablet(@Mocked GlobalStateMgr globalStateMgr,
-                                          @Mocked SystemInfoService systemInfoService) {
-        Map<Long, Backend> idToBackend = Maps.newHashMap();
-        long backendId = 1L;
-        idToBackend.put(backendId, new Backend(backendId, "127.0.0.1", 9050));
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentSystemInfo();
-                result = systemInfoService;
-                systemInfoService.getIdToBackend();
-                result = ImmutableMap.copyOf(idToBackend);
-            }
-        };
-
-        long dbId = 1L;
-        long tableId = 2L;
-        long partitionId = 3L;
-        long indexId = 4L;
-        long tablet1Id = 10L;
-        long tablet2Id = 11L;
-
-        // Columns
-        List<Column> columns = new ArrayList<Column>();
-        Column k1 = new Column("k1", Type.INT, true, null, "", "");
-        columns.add(k1);
-        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
-        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
-
-        // Tablet
-        Tablet tablet1 = new LakeTablet(tablet1Id, 0L);
-        Tablet tablet2 = new LakeTablet(tablet2Id, 1L);
-
-        // Partition info and distribution info
-        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
-        PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.S3));
-        partitionInfo.setIsInMemory(partitionId, false);
-        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
-
-        // Index
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        index.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.S3);
-        index.addTablet(tablet1, tabletMeta);
-        index.addTablet(tablet2, tabletMeta);
-
-        // Partition
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
-
-        // Table
-        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
-        Deencapsulation.setField(table, "baseIndexId", indexId);
-        table.addPartition(partition);
-        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
-
-        // Db
-        Database db = new Database(dbId, "test_db");
-        db.createTable(table);
-
-        // Check
-        Config.use_staros = true;
-        TabletsProcDir tabletsProcDir = new TabletsProcDir(db, partition, index);
-        List<List<Comparable>> result = tabletsProcDir.fetchComparableResult(-1, -1, null);
-        System.out.println(result);
-        Assert.assertEquals(2, result.size());
-        Assert.assertEquals((long) result.get(0).get(0), tablet1Id);
-        Assert.assertEquals(result.get(0).get(1), -1);
-        Assert.assertEquals((long) result.get(0).get(21), 0L);
-        Assert.assertEquals((long) result.get(1).get(0), tablet2Id);
-        Assert.assertEquals(result.get(1).get(1), -1);
-        Assert.assertEquals((long) result.get(1).get(21), 1L);
-        Config.use_staros = false;
-    }
 
     @Test
     public void testFetchResultWithLocalTablet(@Mocked GlobalStateMgr globalStateMgr,
@@ -177,7 +98,6 @@ public class TabletsProcDirTest {
 
         // Partition
         Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
 
         // Table
         OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -40,11 +40,8 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.SinglePartitionInfo;
-import com.starrocks.catalog.StarOSAgent;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
-import com.starrocks.catalog.lake.LakeTablet;
 import com.starrocks.common.Status;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -194,81 +191,6 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testCreateLocationWithLakeTablet(@Mocked GlobalStateMgr globalStateMgr, @Mocked StarOSAgent agent,
-                                                 @Mocked SystemInfoService systemInfoService) {
-        long dbId = 1L;
-        long tableId = 2L;
-        long partitionId = 3L;
-        long indexId = 4L;
-        long backendId = 5L;
-        long tablet1Id = 10L;
-        long tablet2Id = 11L;
-
-        // Columns
-        List<Column> columns = new ArrayList<Column>();
-        Column k1 = new Column("k1", Type.INT, true, null, "", "");
-        columns.add(k1);
-        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
-        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
-
-        // Tablet
-        Tablet tablet1 = new LakeTablet(tablet1Id, 0L);
-        Tablet tablet2 = new LakeTablet(tablet2Id, 1L);
-
-        // Partition info and distribution info
-        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
-        PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.S3));
-        partitionInfo.setIsInMemory(partitionId, false);
-        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
-
-        // Index
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        index.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.S3);
-        index.addTablet(tablet1, tabletMeta);
-        index.addTablet(tablet2, tabletMeta);
-
-        // Partition
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
-
-        // Table
-        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
-        Deencapsulation.setField(table, "baseIndexId", indexId);
-        table.addPartition(partition);
-        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentSystemInfo();
-                result = systemInfoService;
-                systemInfoService.checkExceedDiskCapacityLimit((Multimap<Long, Long>) any, anyBoolean);
-                result = Status.OK;
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-                globalStateMgr.getStarOSAgent();
-                result = agent;
-                agent.getPrimaryBackendIdByShard(anyLong);
-                result = backendId;
-            }
-        };
-
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId));
-        TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
-        System.out.println(param);
-
-        // Check
-        List<TTabletLocation> locations = param.getTablets();
-        Assert.assertEquals(2, locations.size());
-        TTabletLocation location = locations.get(0);
-        List<Long> nodes = location.getNode_ids();
-        Assert.assertEquals(1, nodes.size());
-        Assert.assertEquals(backendId, nodes.get(0).longValue());
-    }
-
-    @Test
     public void testCreateLocationWithLocalTablet(@Mocked GlobalStateMgr globalStateMgr,
                                                   @Mocked SystemInfoService systemInfoService) {
         long dbId = 1L;
@@ -312,7 +234,6 @@ public class OlapTableSinkTest {
 
         // Partition
         Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setPartitionInfo(partitionInfo);
 
         // Table
         OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -49,8 +49,7 @@ enum TStorageType {
 
 enum TStorageMedium {
     HDD,
-    SSD,
-    S3
+    SSD
 }
 
 enum TVarType {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. We will introduce StarRocks LakeTable, so remove partition level
useStarOS.
2. Remove S3 TStorageMedium that has been not used.
3. Remove old UTs and add news with LakeTable.
