### PR TITLE
[Bugfix]support query external_catalog table when current_catalog is default_catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -179,6 +179,9 @@ public class TableName implements Writable {
 
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
+        if (catalog != null) {
+            stringBuilder.append("`").append(catalog).append("`.");
+        }
         if (db != null) {
             stringBuilder.append("`").append(db).append("`.");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -179,7 +179,7 @@ public class TableName implements Writable {
 
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
-        if (catalog != null) {
+        if (catalog != null && !CatalogMgr.isInternalCatalog(catalog)) {
             stringBuilder.append("`").append(catalog).append("`.");
         }
         if (db != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -707,6 +707,11 @@ public class GlobalStateMgr {
         return metadataMgr;
     }
 
+    @VisibleForTesting
+    public void setMetadataMgr(MetadataMgr metadataMgr) {
+        this.metadataMgr = metadataMgr;
+    }
+
     public TaskManager getTaskManager() {
         return taskManager;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -201,7 +201,7 @@ public class AnalyzerUtils {
             if (Strings.isNullOrEmpty(dbName)) {
                 dbName = session.getDatabase();
             } else {
-                if (CatalogMgr.isInternalCatalog(session.getCurrentCatalog())) {
+                if (CatalogMgr.isInternalCatalog(tableName.getCatalog())) {
                     dbName = ClusterNamespace.getFullName(session.getClusterName(), dbName);
                 } else {
                     return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2073,14 +2073,18 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new SlotRef(null, identifier.getValue(), identifier.getValue());
         } else {
             QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
-            if (qualifiedName.getParts().size() == 3) {
-                return new SlotRef(new TableName(qualifiedName.getParts().get(0), qualifiedName.getParts().get(1)),
-                        qualifiedName.getParts().get(2),
-                        qualifiedName.getParts().get(2));
-            } else if (qualifiedName.getParts().size() == 2) {
-                return new SlotRef(new TableName(null, qualifiedName.getParts().get(0)),
-                        qualifiedName.getParts().get(1),
-                        qualifiedName.getParts().get(1));
+            List<String> parts = qualifiedName.getParts();
+            TableName tableName;
+            if (parts.size() == 4) {
+                tableName = new TableName(qualifiedName.getParts().get(0),
+                        qualifiedName.getParts().get(1), qualifiedName.getParts().get(2));
+                return new SlotRef(tableName, parts.get(3), parts.get(3));
+            } else if (parts.size() == 3) {
+                tableName = new TableName(qualifiedName.getParts().get(0), qualifiedName.getParts().get(1));
+                return new SlotRef(tableName, parts.get(2), parts.get(2));
+            } else if (parts.size() == 2) {
+                tableName = new TableName(null, qualifiedName.getParts().get(0));
+                return new SlotRef(tableName, parts.get(1), parts.get(1));
             } else {
                 throw new ParsingException("Unqualified column reference " + qualifiedName);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
@@ -1,0 +1,65 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.server;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.DdlException;
+import com.starrocks.external.HiveMetaStoreTableUtils;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class CatalogLevelTest {
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        String createCatalog = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withCatalog(createCatalog);
+    }
+
+    @Test
+    public void testQueryExternalCatalogInDefaultCatalog(@Mocked MetadataMgr metadataMgr) throws DdlException {
+        List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "BIGINT", ""));
+        List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
+        String hdfsPath = "hdfs://127.0.0.1:10000/hive";
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setCols(unPartKeys);
+        sd.setLocation(hdfsPath);
+        Table msTable1 = new Table();
+        msTable1.setDbName("hive_db");
+        msTable1.setTableName("hive_table");
+        msTable1.setPartitionKeys(partKeys);
+        msTable1.setSd(sd);
+        msTable1.setTableType("MANAGED_TABLE");
+        com.starrocks.catalog.Table hiveTable = HiveMetaStoreTableUtils.convertToSRTable(msTable1, "thrift://127.0.0.1:9083");
+        GlobalStateMgr.getCurrentState().setMetadataMgr(metadataMgr);
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getDb("hive_catalog", "hive_db");
+                result = new Database(111, "hive_db");
+                minTimes = 0;
+
+                metadataMgr.getTable("hive_catalog", "hive_db", "hive_table");
+                result = hiveTable;
+            }
+        };
+        String sql_1 = "select col1 from hive_catalog.hive_db.hive_table";
+
+        AnalyzeTestUtil.analyzeSuccess(sql_1);
+
+    }
+}


### PR DESCRIPTION
support query external_catalog table when current_catalog is default_catalog

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- `TableName#tosql()` add `catalog` field
- `AstBuilder#visitColumnReference()` adapt to column names which has four level.