### PR TITLE
[Enhancement] Fix UT RoutineLoadManagerTest.testExpired 2

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -838,6 +838,9 @@ public class RoutineLoadManagerTest {
         loadManager.replayChangeRoutineLoadJob(new RoutineLoadOperation(goodJob.getId(), RoutineLoadJob.JobState.CANCELLED));
         Assert.assertEquals(2, idToRoutineLoadJob.size());
 
+        // 3. make sure it can not be clean
+        idToRoutineLoadJob.get(goodJob.getId()).endTimestamp = System.currentTimeMillis() + 100000L;
+
         // 5. save image
         File tempFile = File.createTempFile("RoutineLoadManagerTest", ".image");
         System.err.println("write image " + tempFile.getAbsolutePath());
@@ -845,9 +848,6 @@ public class RoutineLoadManagerTest {
         long checksum = 0;
         long saveChecksum = loadManager.saveRoutineLoadJobs(dos, checksum);
         dos.close();
-
-        // make sure it can not be clean
-        idToRoutineLoadJob.get(goodJob.getId()).endTimestamp = System.currentTimeMillis() + 100000L;
 
         // 6. clean expire
         loadManager.cleanOldRoutineLoadJobs();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This UT failed because the time setting was not good. The time was changed after the metadata was saved, and there was a logic to re-read the metadata. At this time, the previously set time was invalid, which caused the UT to always fail. so. Just put this setup time before the save element.