### PR TITLE
[BugFix] Fix merge limit error when subquery has limit with offset

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -37,11 +37,19 @@ public class LogicalLimitOperator extends LogicalOperator {
     }
 
     public static LogicalLimitOperator global(long limit) {
-        return new LogicalLimitOperator(limit, DEFAULT_OFFSET, Phase.GLOBAL);
+        return global(limit, DEFAULT_OFFSET);
+    }
+
+    public static LogicalLimitOperator global(long limit, long offset) {
+        return new LogicalLimitOperator(limit, offset, Phase.GLOBAL);
     }
 
     public static LogicalLimitOperator local(long limit) {
-        return new LogicalLimitOperator(limit, DEFAULT_OFFSET, Phase.LOCAL);
+        return local(limit, DEFAULT_OFFSET);
+    }
+
+    public static LogicalLimitOperator local(long limit, long offset) {
+        return new LogicalLimitOperator(limit, offset, Phase.LOCAL);
     }
 
     private LogicalLimitOperator(Builder builder) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
@@ -64,7 +64,6 @@ public class MergeLimitWithLimitRule extends TransformationRule {
         LogicalLimitOperator l2 = (LogicalLimitOperator) input.getInputs().get(0).getOp();
 
         Preconditions.checkState(!l1.hasOffset());
-        Preconditions.checkState(!l2.hasOffset());
 
         // l2 range
         long l2Max = l2.getLimit();
@@ -80,9 +79,9 @@ public class MergeLimitWithLimitRule extends TransformationRule {
 
         Operator result;
         if (l1.getLimit() <= l2.getLimit()) {
-            result = LogicalLimitOperator.local(limit);
+            result = LogicalLimitOperator.local(limit, l2.getOffset());
         } else {
-            result = LogicalLimitOperator.init(limit);
+            result = LogicalLimitOperator.init(limit, l2.getOffset());
         }
 
         return Lists.newArrayList(OptExpression.create(result, input.getInputs().get(0).getInputs()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
@@ -23,8 +23,9 @@ public class MergeLimitWithSortRule extends TransformationRule {
         LogicalTopNOperator topN = (LogicalTopNOperator) input.getInputs().get(0).getOp();
         LogicalLimitOperator limit = ((LogicalLimitOperator) input.getOp());
 
-        // only merge Init-Limit and Sort
-        return limit.isInit() && !topN.hasLimit();
+        // Merge Init-Limit/Local-limit and Sort
+        // Local-limit may be generate at MergeLimitWithLimitRule
+        return (limit.isInit() || limit.isLocal()) && !topN.hasLimit();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
@@ -46,7 +46,7 @@ public class MergeProjectWithChildRule extends TransformationRule {
                 Maps.newHashMap()));
 
         if (logicalProjectOperator.hasLimit()) {
-            builder.setLimit(logicalProjectOperator.getLimit());
+            builder.setLimit(Math.min(logicalProjectOperator.getLimit(), child.getLimit()));
         } else {
             builder.setLimit(child.getLimit());
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6871 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When subquery has limit with offset, the check in the MergeLimitWithLimitRule is not right,  l2 could has offset, we should deal with this situation