### PR TITLE
[WIP][Bugfix] fix query context leak in when cancel multi times

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -349,6 +349,9 @@ public:
     inline bool is_in_ready_queue() const { return _in_ready_queue.load(std::memory_order_acquire); }
     void set_in_ready_queue(bool v) { _in_ready_queue.store(v, std::memory_order_release); }
 
+    bool in_pending_cancel_queue() const { return _in_pending_cancel_queue; }
+    void set_in_pending_cancel_queue(bool flag) { _in_pending_cancel_queue = flag; }
+
 private:
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;
@@ -400,6 +403,8 @@ private:
     // The index of QuerySharedDriverQueue{WithoutLock}._queues which this driver belongs to.
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};
+
+    bool _in_pending_cancel_queue = false;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -250,7 +250,8 @@ void SubQuerySharedDriverQueue::put(const DriverRawPtr driver) {
 }
 
 void SubQuerySharedDriverQueue::cancel(const DriverRawPtr driver) {
-    if (cancelled_set.count(driver) == 0) {
+    if (!driver->in_pending_cancel_queue()) {
+        driver->set_in_ready_queue(true);
         DCHECK(driver->is_in_ready_queue());
         pending_cancel_queue.emplace(driver);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #https://github.com/StarRocks/starrocks/issues/6160

## Problem Summary(Required) ：
#6161 have not fixed this issue, as it is possible that FE will send the cancel rpc multiple times. And at this time the driver has not been added to cancel_set. 

It's a little hard to reproduce through automated testing
