### PR TITLE
[Bugfix] Prevent JVM from handling signals

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -122,6 +122,10 @@ if [[ $(ulimit -n) -lt 60000 ]]; then
   ulimit -n 65535
 fi
 
+# Prevent JVM from handling any internally or externally generated signals.
+# Otherwise, JVM will overwrite the signal handlers for SIGINT and SIGTERM.
+export LIBHDFS_OPTS="$LIBHDFS_OPTS -Xrs"
+
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
 else


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/474

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the signal `SIGINT` or `SIGTERM` coming, the process `BE` captures it and performs graceful exit operations by order. For example, when a `SIGTERM` coming, 
1. The process captures `SIGTERM` to make `start_be()` can be returned.
2. The thread `TaskWorkerPool`, which uses `StarRocksMetrics::instance`, is desctructed, when the function `start_be()` returns.
3. `__run_exit_handlers` desctruct all the static variables including `StarRocksMetrics::instance`.

However, JVM overwrites the handlers of `SIGINT` and `SIGTERM`. Then,  the sequential graceful exit operations are breaked. `start_be()` has no chance to return, so `StarRocksMetrics::instance` will be desctructed while The thread `TaskWorkerPool` is running.

