### PR TITLE
[FixBug] Fix lose of meta data bug after alter routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
@@ -125,7 +125,7 @@ public class RoutineLoadDesc {
         return String.join(", ", subSQLs);
     }
 
-    public String pack(String str) {
+    private String pack(String str) {
         return "`" + str + "`";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
@@ -22,18 +22,21 @@
 package com.starrocks.load;
 
 import com.starrocks.analysis.ColumnSeparator;
+import com.starrocks.analysis.ImportColumnDesc;
 import com.starrocks.analysis.ImportColumnsStmt;
 import com.starrocks.analysis.ImportWhereStmt;
 import com.starrocks.analysis.PartitionNames;
 import com.starrocks.analysis.RowDelimiter;
 
+import java.util.List;
+
 public class RoutineLoadDesc {
-    private final ColumnSeparator columnSeparator;
-    private final RowDelimiter rowDelimiter;
-    private final ImportColumnsStmt columnsInfo;
-    private final ImportWhereStmt wherePredicate;
+    private ColumnSeparator columnSeparator;
+    private RowDelimiter rowDelimiter;
+    private ImportColumnsStmt columnsInfo;
+    private ImportWhereStmt wherePredicate;
     // nullable
-    private final PartitionNames partitionNames;
+    private PartitionNames partitionNames;
 
     public RoutineLoadDesc(ColumnSeparator columnSeparator, RowDelimiter rowDelimiter, ImportColumnsStmt columnsInfo,
                            ImportWhereStmt wherePredicate, PartitionNames partitionNames) {
@@ -48,20 +51,68 @@ public class RoutineLoadDesc {
         return columnSeparator;
     }
 
+    public void setColumnSeparator(ColumnSeparator columnSeparator) {
+        this.columnSeparator = columnSeparator;
+    }
+
     public RowDelimiter getRowDelimiter() {
         return rowDelimiter;
+    }
+
+    public void setRowDelimiter(RowDelimiter rowDelimiter) {
+        this.rowDelimiter = rowDelimiter;
     }
 
     public ImportColumnsStmt getColumnsInfo() {
         return columnsInfo;
     }
 
+    public void setColumnsInfo(ImportColumnsStmt importColumnsStmt) {
+        this.columnsInfo = importColumnsStmt;
+    }
+
     public ImportWhereStmt getWherePredicate() {
         return wherePredicate;
+    }
+
+    public void setWherePredicate(ImportWhereStmt wherePredicate) {
+        this.wherePredicate = wherePredicate;
     }
 
     // nullable
     public PartitionNames getPartitionNames() {
         return partitionNames;
+    }
+
+    public void setPartitionNames(PartitionNames partitionNames) {
+        this.partitionNames = partitionNames;
+    }
+
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        if (columnSeparator != null) {
+            sb.append("COLUMNS TERMINATED BY ").append(columnSeparator.toSql());
+        }
+        if (rowDelimiter != null) {
+            sb.append("ROWS TERMINATED BY ").append(rowDelimiter.toSql());
+        }
+        if (columnsInfo != null) {
+            sb.append("COLUMNS (");
+            List<ImportColumnDesc> columns = columnsInfo.getColumns();
+            for (int i = 0; i < columns.size(); i++) {
+                sb.append(columns.get(i).toString());
+                if (i < columns.size() - 1) {
+                    sb.append(", ");
+                }
+            }
+            sb.append(")");
+        }
+        if (partitionNames != null) {
+            sb.append(partitionNames.toSql());
+        }
+        if (wherePredicate != null) {
+            sb.append("WHERE ").append(wherePredicate.getExpr().toSql());
+        }
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1554,11 +1554,19 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             originLoadDesc.setPartitionNames(routineLoadDesc.getPartitionNames());
         }
 
+        String tableName = null;
+        try {
+            tableName = getTableName();
+        } catch (Exception e) {
+            LOG.warn("get table name failed", e);
+            tableName = "unknown";
+        }
+
         // we use sql to persist the load properties, so we just put the load properties to sql.
-        String sql = "CREATE ROUTINE LOAD job ON tbl "
-                + originLoadDesc.toSql()
-                + " PROPERTIES (\"desired_concurrent_number\"=\"1\")"
-                + " FROM KAFKA (\"kafka_topic\" = \"my_topic\")";
+        String sql = String.format("CREATE ROUTINE LOAD %s ON %s %s" +
+                " PROPERTIES (\"desired_concurrent_number\"=\"1\")" +
+                " FROM KAFKA (\"kafka_topic\" = \"my_topic\")",
+                name, tableName, originLoadDesc.toSql());
         LOG.debug("merge result: {}", sql);
         origStmt = new OriginStatement(sql, 0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -576,24 +576,7 @@ public class RoutineLoadManager implements Writable {
         // NOTE: we use the origin statement to get the RoutineLoadDesc
         RoutineLoadDesc routineLoadDesc = null;
         if (log.getOriginStatement() != null) {
-            long sqlMode;
-            if (job.getSessionVariables() != null && job.getSessionVariables().containsKey(SessionVariable.SQL_MODE)) {
-                sqlMode = Long.parseLong(job.getSessionVariables().get(SessionVariable.SQL_MODE));
-            } else {
-                sqlMode = SqlModeHelper.MODE_DEFAULT;
-            }
-            try {
-                SqlParser parser = new SqlParser(
-                        new SqlScanner(new StringReader(log.getOriginStatement().originStmt), sqlMode));
-                AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) SqlParserUtils.getStmt(
-                        parser, log.getOriginStatement().idx);
-                if (stmt.getLoadPropertyList() != null) {
-                    routineLoadDesc = CreateRoutineLoadStmt.buildLoadDesc(stmt.getLoadPropertyList());
-                }
-            } catch (Exception e) {
-                throw new IOException("error happens when parsing alter routine load stmt: "
-                        + log.getOriginStatement().originStmt, e);
-            }
+            routineLoadDesc = job.getLoadDesc(log.getOriginStatement(), job.getSessionVariables());
         }
         job.modifyJob(routineLoadDesc, log.getJobProperties(),
                 log.getDataSourceProperties(), log.getOriginStatement(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -29,8 +29,6 @@ import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.CreateRoutineLoadStmt;
 import com.starrocks.analysis.PauseRoutineLoadStmt;
 import com.starrocks.analysis.ResumeRoutineLoadStmt;
-import com.starrocks.analysis.SqlParser;
-import com.starrocks.analysis.SqlScanner;
 import com.starrocks.analysis.StopRoutineLoadStmt;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.AnalysisException;
@@ -45,14 +43,11 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
-import com.starrocks.common.util.SqlParserUtils;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +58,6 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -576,7 +570,8 @@ public class RoutineLoadManager implements Writable {
         // NOTE: we use the origin statement to get the RoutineLoadDesc
         RoutineLoadDesc routineLoadDesc = null;
         if (log.getOriginStatement() != null) {
-            routineLoadDesc = job.getLoadDesc(log.getOriginStatement(), job.getSessionVariables());
+            routineLoadDesc = CreateRoutineLoadStmt.getLoadDesc(
+                    log.getOriginStatement(), job.getSessionVariables());
         }
         job.modifyJob(routineLoadDesc, log.getJobProperties(),
                 log.getDataSourceProperties(), log.getOriginStatement(), true);

--- a/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
@@ -1,0 +1,49 @@
+package com.starrocks.load;
+
+import com.starrocks.analysis.CreateRoutineLoadStmt;
+import com.starrocks.qe.OriginStatement;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RoutineLoadDescTest {
+    @Test
+    public void testToSql() throws Exception {
+        RoutineLoadDesc originLoad = CreateRoutineLoadStmt.getLoadDesc(new OriginStatement("CREATE ROUTINE LOAD job ON tbl " +
+                "COLUMNS TERMINATED BY ';', " +
+                "ROWS TERMINATED BY '\n', " +
+                "COLUMNS(`a`, `b`, `c`=1), " +
+                "TEMPORARY PARTITION(`p1`, `p2`), " +
+                "WHERE a = 1 " +
+                "PROPERTIES (\"desired_concurrent_number\"=\"3\") " +
+                "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", 0), null);
+
+        RoutineLoadDesc desc = new RoutineLoadDesc();
+        // set column separator and check
+        desc.setColumnSeparator(originLoad.getColumnSeparator());
+        Assert.assertEquals("COLUMNS TERMINATED BY ';'", desc.toSql());
+        // set row delimiter and check
+        desc.setRowDelimiter(originLoad.getRowDelimiter());
+        Assert.assertEquals("COLUMNS TERMINATED BY ';', " +
+                "ROWS TERMINATED BY '\n'", desc.toSql());
+        // set columns and check
+        desc.setColumnsInfo(originLoad.getColumnsInfo());
+        Assert.assertEquals("COLUMNS TERMINATED BY ';', " +
+                "ROWS TERMINATED BY '\n', " +
+                "COLUMNS(`a`, `b`, `c` = 1)", desc.toSql());
+        // set partitions and check
+        desc.setPartitionNames(originLoad.getPartitionNames());
+        Assert.assertEquals("COLUMNS TERMINATED BY ';', " +
+                "ROWS TERMINATED BY '\n', " +
+                "COLUMNS(`a`, `b`, `c` = 1), " +
+                "TEMPORARY PARTITION(`p1`, `p2`)",
+                desc.toSql());
+        // set where and check
+        desc.setWherePredicate(originLoad.getWherePredicate());
+        Assert.assertEquals("COLUMNS TERMINATED BY ';', " +
+                        "ROWS TERMINATED BY '\n', " +
+                        "COLUMNS(`a`, `b`, `c` = 1), " +
+                        "TEMPORARY PARTITION(`p1`, `p2`), " +
+                        "WHERE `a` = 1",
+                desc.toSql());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -351,8 +351,9 @@ public class RoutineLoadJobTest {
 
     @Test
     public void testMergeLoadDescToOriginStatement() throws Exception {
-        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        String originStmt = "CREATE ROUTINE LOAD job ON tbl " +
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                "default_cluster", 2L, 3L, "192.168.1.2:10000", "topic");
+        String originStmt = "CREATE ROUTINE LOAD job ON unknown " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")";
         routineLoadJob.setOrigStmt(new OriginStatement(originStmt, 0));
@@ -362,7 +363,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY ';'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY ';' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
@@ -372,7 +373,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY '\n'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
@@ -383,7 +384,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`, `b`, `c`=1)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1) " +
@@ -395,7 +396,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "TEMPORARY PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -408,7 +409,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 1", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -422,7 +423,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY '\t'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -436,7 +437,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY 'a'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -450,7 +451,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -463,7 +464,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         " PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -477,7 +478,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 5", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assert.assertEquals("CREATE ROUTINE LOAD job ON tbl " +
+        Assert.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6936

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When routine load serializes the load properties(columns/rows separator, column list, partitions, where filter), it stores the sql statement, and get the load properties by parsing the sql for deserialization. But after `alter routine load` is done, it will only keep the alter statement, this will cause the loss of metadata. We should merge the alter sql with the origin create sql to retain all load properties.