### PR TITLE
[BugFix] Fixed inaccurate of WaitTime estimation

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -88,12 +88,15 @@ bool SinkBuffer::is_full() const {
     }
     bool is_full = buffer_size > max_buffer_size;
 
-    if (is_full && _last_full_timestamp == -1) {
-        _last_full_timestamp = MonotonicNanos();
+    int64_t last_full_timestamp = _last_full_timestamp;
+    int64_t full_time = _full_time;
+
+    if (is_full && last_full_timestamp == -1) {
+        _last_full_timestamp.compare_exchange_weak(last_full_timestamp, MonotonicNanos());
     }
-    if (!is_full && _last_full_timestamp != -1) {
-        _full_time += (MonotonicNanos() - _last_full_timestamp);
-        _last_full_timestamp = -1;
+    if (!is_full && last_full_timestamp != -1) {
+        _full_time.compare_exchange_weak(full_time, full_time + (MonotonicNanos() - last_full_timestamp));
+        _last_full_timestamp.compare_exchange_weak(last_full_timestamp, -1);
     }
 
     return is_full;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -157,8 +157,8 @@ private:
     std::atomic<int64_t> _request_sent = 0;
 
     int64_t _pending_timestamp = -1;
-    mutable int64_t _last_full_timestamp = -1;
-    mutable int64_t _full_time = 0;
+    mutable std::atomic<int64_t> _last_full_timestamp = -1;
+    mutable std::atomic<int64_t> _full_time = 0;
 }; // namespace starrocks::pipeline
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Multiply threads may invoke `SinkBuffer::is_full` simultaneously, and the `_full_time` maybe double counted