### PR TITLE
[BugFix] Find wrong node when node not set fqdn

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -820,7 +820,7 @@ public class NodeMgr {
         try {
             targetPair = NetUtils.getIpAndFqdnByHost(ipOrFqdn);
         } catch (UnknownHostException e) {
-            LOG.info("faild to get address by fqdn {}", e.getMessage());
+            LOG.info("failed to get right ip by fqdn {}", e.getMessage());
             return null;
         }
         for (Frontend fe : frontends.values()) {
@@ -828,10 +828,16 @@ public class NodeMgr {
             try {
                 curPair = NetUtils.getIpAndFqdnByHost(fe.getHost());
             } catch (UnknownHostException e) {
-                LOG.info("faild to get address by fqdn {}", e.getMessage());
+                LOG.info("failed to get right ip by by fqdn {}", e.getMessage());
                 continue;
             }
-            if (targetPair.first.equals(curPair.first) || targetPair.second.equals(curPair.second)) {
+            boolean hostOk = false;
+            if (targetPair.second.equals("") && curPair.second.equals("")) {
+                hostOk = targetPair.first.equals(curPair.first);
+            } else {
+                hostOk = (targetPair.first.equals(curPair.first) || targetPair.second.equals(curPair.second));
+            }
+            if (hostOk) {
                 return fe;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -361,7 +361,7 @@ public class SystemInfoService {
         try {
             targetPair = NetUtils.getIpAndFqdnByHost(host);
         } catch (UnknownHostException e) {
-            LOG.info("faild to get address by fqdn {}", e.getMessage());
+            LOG.info("failed to get right ip by fqdn {}", e.getMessage());
             return null;
         }
 
@@ -371,10 +371,15 @@ public class SystemInfoService {
             try {
                 curPair = NetUtils.getIpAndFqdnByHost(backend.getHost());
             } catch (UnknownHostException e) {
-                LOG.info("faild to get address by fqdn {}", e.getMessage());
+                LOG.info("failed to get right ip by fqdn {}", e.getMessage());
                 continue;
             }
-            boolean hostOk = (targetPair.first.equals(curPair.first) || targetPair.second.equals(curPair.second));
+            boolean hostOk = false;
+            if (targetPair.second.equals("") && curPair.second.equals("")) {
+                hostOk = targetPair.first.equals(curPair.first);
+            } else {
+                hostOk = (targetPair.first.equals(curPair.first) || targetPair.second.equals(curPair.second));
+            }
             if (hostOk && (backend.getBePort() == bePort)) {
                 return backend;
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6940

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
[BugFix] Find wrong node when node not set fqdn