### PR TITLE
[Enhancement] Make UUID generator thread-local for better performance

### DIFF
--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -51,7 +51,7 @@ std::string print_id(const PUniqueId& id) {
 
 UniqueId UniqueId::gen_uid() {
     UniqueId uid(0, 0);
-    auto uuid = UUIDGenerator::instance()->next_uuid();
+    auto uuid = ThreadLocalUUIDGenerator::next_uuid();
     memcpy(&uid.hi, uuid.data, sizeof(int64_t));
     memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));
     return uid;
@@ -59,12 +59,12 @@ UniqueId UniqueId::gen_uid() {
 
 /// generates a 16 byte
 std::string generate_uuid_string() {
-    return boost::uuids::to_string(boost::uuids::basic_random_generator<boost::mt19937>()());
+    return boost::uuids::to_string(ThreadLocalUUIDGenerator::next_uuid());
 }
 
 /// generates a 16 byte UUID
 TUniqueId generate_uuid() {
-    auto uuid = boost::uuids::basic_random_generator<boost::mt19937>()();
+    auto uuid = ThreadLocalUUIDGenerator::next_uuid();
     TUniqueId uid;
     memcpy(&uid.hi, uuid.data, sizeof(int64_t));
     memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));

--- a/be/src/util/uuid_generator.h
+++ b/be/src/util/uuid_generator.h
@@ -24,29 +24,18 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <mutex>
-#include <ostream>
 #include <string>
-
-#include "util/spinlock.h"
 
 namespace starrocks {
 
-class UUIDGenerator {
+class ThreadLocalUUIDGenerator {
 public:
-    boost::uuids::uuid next_uuid() {
-        std::lock_guard<SpinLock> lock(_uuid_gen_lock);
-        return _boost_uuid_generator();
-    }
+    static boost::uuids::uuid next_uuid() { return s_tls_gen(); }
 
-    static UUIDGenerator* instance() {
-        static UUIDGenerator generator;
-        return &generator;
-    }
+    static std::string next_uuid_string() { return boost::uuids::to_string(next_uuid()); }
 
 private:
-    boost::uuids::basic_random_generator<boost::mt19937> _boost_uuid_generator;
-    SpinLock _uuid_gen_lock;
+    static inline thread_local boost::uuids::basic_random_generator<boost::mt19937> s_tls_gen;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
On my local machine, the time to generate and print 10000 UUIDs improved from 4788ms to 17ms

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
