### PR TITLE
[BugFix] fix resource group metrics bug

### DIFF
--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -41,7 +41,10 @@ void ScanTaskQueueWithWorkGroup::_cal_wg_cpu_real_use_ratio() {
 
     int i = 0;
     for (auto& wg : _ready_wgs) {
-        double cpu_actual_use_ratio = ((double)growth_times[i] / (total_run_time));
+        double cpu_actual_use_ratio = 0.0;
+        if (total_run_time != 0) {
+            cpu_actual_use_ratio = ((double)growth_times[i] / (total_run_time));
+        }
         wg->set_cpu_actual_use_ratio(cpu_actual_use_ratio);
         i++;
     }

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -303,7 +303,7 @@ private:
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_concurrency_overflow_count;
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_bigquery_count;
 
-    void add_metrics(const WorkGroupPtr& wg);
+    void add_metrics_unlocked(const WorkGroupPtr& wg);
     void update_metrics_unlocked();
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -90,7 +90,6 @@ public class MetricCalculator extends TimerTask {
 
         // query latency
         List<QueryDetail> queryList = QueryDetailQueue.getQueryDetailsAfterTime(lastQueryEventTime);
-        ResourceGroupMetricMgr.updateQueryLatency(queryList);
         List<Long> latencyList = new ArrayList<>();
         double latencySum = 0L;
         for (QueryDetail queryDetail : queryList) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -499,6 +499,7 @@ public final class MetricRepo {
         for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
             visitor.visitHistogram(entry.getKey(), entry.getValue());
         }
+        ResourceGroupMetricMgr.visitQueryLatency();
 
         // collect routine load process metrics
         if (Config.enable_routine_load_lag_metrics) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -357,6 +357,12 @@ public class ConnectContext {
         this.errorCode = errorCode;
     }
 
+    public void setErrorCodeOnce(String errorCode) {
+        if (this.errorCode == null || this.errorCode.isEmpty()) {
+            this.errorCode = errorCode;
+        }
+    }
+
     public MysqlCapability getCapability() {
         return capability;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -162,6 +162,7 @@ public class ConnectProcessor {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);
+                ResourceGroupMetricMgr.updateQueryLatency(ctx, elapseMs);
                 if (elapseMs > Config.qe_slow_log_ms || ctx.getSessionVariable().isEnableSQLDigest()) {
                     MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
                     ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
@@ -424,6 +425,7 @@ public class ConnectProcessor {
         ctx.setCommand(command);
         ctx.setStartTime();
         ctx.setWorkGroup(null);
+        ctx.setErrorCodeOnce("");
 
         switch (command) {
             case COM_INIT_DB:

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1623,7 +1623,7 @@ public class Coordinator {
         if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
             ConnectContext ctx = connectContext;
             if (ctx != null) {
-                ctx.setErrorCode(Optional.ofNullable(status.getErrorCode()).map(Enum::toString).orElse("UNKNOWN"));
+                ctx.setErrorCodeOnce(Optional.ofNullable(status.getErrorCode()).map(Enum::toString).orElse("UNKNOWN"));
             }
             LOG.warn("one instance report fail {}, query_id={} instance_id={}",
                     status, DebugUtil.printId(queryId), DebugUtil.printId(params.getFragment_instance_id()));

--- a/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
@@ -34,33 +34,17 @@ public class ResourceGroupMetricTest {
         WorkGroup wg2 = new WorkGroup();
         wg2.setName("wg2");
 
-        List<QueryDetail> queryDetails = new ArrayList<>();
-        QueryDetail queryDetail1 = new QueryDetail();
-        queryDetail1.setWorkGroupName(wg1.getName());
-        queryDetail1.setQuery(true);
-        queryDetail1.setState(QueryDetail.QueryMemState.FINISHED);
-        queryDetail1.setLatency(10L);
-
-        QueryDetail queryDetail2 = new QueryDetail();
-        queryDetail2.setWorkGroupName(wg2.getName());
-        queryDetail2.setQuery(true);
-        queryDetail2.setState(QueryDetail.QueryMemState.FINISHED);
-        queryDetail2.setLatency(10L);
-
-        queryDetails.add(queryDetail1);
-        queryDetails.add(queryDetail2);
-
         ctx.setWorkGroup(wg1);
         ctx.getAuditEventBuilder().setResourceGroup(wg1.getName());
         ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
         ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
+        ResourceGroupMetricMgr.updateQueryLatency(ctx, 10L);
 
         ctx.setWorkGroup(wg2);
         ctx.getAuditEventBuilder().setResourceGroup(wg2.getName());
         ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
         ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
-
-        ResourceGroupMetricMgr.updateQueryLatency(queryDetails);
+        ResourceGroupMetricMgr.updateQueryLatency(ctx, 10L);
 
         List<Metric> metricsResourceGroup = MetricRepo.getMetricsByName("query_resource_group");
         List<Metric> metricsResourceGroupErr = MetricRepo.getMetricsByName("query_resource_group_err");
@@ -68,7 +52,7 @@ public class ResourceGroupMetricTest {
 
         Assert.assertEquals(2, metricsResourceGroup.size());
         Assert.assertEquals(2, metricsResourceGroupErr.size());
-        Assert.assertEquals(2*7, metricsResourceGroupLatency.size());
+        Assert.assertEquals(2*6, metricsResourceGroupLatency.size());
 
         for(Metric resourceGroupMetric : metricsResourceGroup){
             LongCounterMetric metric = (LongCounterMetric)resourceGroupMetric;
@@ -91,6 +75,8 @@ public class ResourceGroupMetricTest {
                 Assert.fail();
             }
         }
+
+        ResourceGroupMetricMgr.visitQueryLatency();
 
         for(Metric resourceGroupMetric : metricsResourceGroupLatency){
             GaugeMetricImpl<Double> metric = (GaugeMetricImpl<Double>)resourceGroupMetric;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
bug: 
1. When change resource group(create/alter/drop)，be metrics is wrong
2. When resource group has no query, starrocks_fe_query_resource_group_latency metrics cannot be reset to 0
3. ErrorCode in ConectContext cannot record the first error and will be overwritten as cancel 