### PR TITLE
[Feature] Support preprocess in gson serialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -168,11 +168,8 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        // In the present, the fullSchema could be rebuilt by schema change while the properties is changed by MV.
-        // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
-        // So, here we need to rebuild the fullSchema to ensure the correctness of the properties.
-        rebuildFullSchema();
-        partitionInfo.postDeserialized();
+        super.gsonPostProcess();
+
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
         if (db == null) {
             LOG.warn("db:{} do not exist. materialized view id:{} name:{} should not exist", dbId, id, name);
@@ -197,7 +194,6 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
     public void write(DataOutput out) throws IOException {
         // write type first
         Text.writeString(out, type.name());
-        partitionInfo.preSerialize();
         Text.writeString(out, GsonUtils.GSON.toJson(this));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -27,6 +27,8 @@ import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
@@ -43,7 +45,7 @@ import java.util.Map;
 /*
  * Repository of a partition's related infos
  */
-public class PartitionInfo implements Writable {
+public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(PartitionInfo.class);
 
     @SerializedName(value = "type")
@@ -58,6 +60,7 @@ public class PartitionInfo implements Writable {
     @SerializedName(value = "isMultiColumnPartition")
     protected boolean isMultiColumnPartition = false;
 
+    @SerializedName(value = "idToInMemory")
     protected Map<Long, Boolean> idToInMemory;
 
     // partition id -> tablet type
@@ -117,13 +120,16 @@ public class PartitionInfo implements Writable {
     }
 
     public TTabletType getTabletType(long partitionId) {
-        if (!idToTabletType.containsKey(partitionId)) {
+        if (idToTabletType == null || !idToTabletType.containsKey(partitionId)) {
             return TTabletType.TABLET_TYPE_DISK;
         }
         return idToTabletType.get(partitionId);
     }
 
     public void setTabletType(long partitionId, TTabletType tabletType) {
+        if (idToTabletType == null) {
+            idToTabletType = new HashMap<>();
+        }
         idToTabletType.put(partitionId, tabletType);
     }
 
@@ -204,12 +210,12 @@ public class PartitionInfo implements Writable {
         }
     }
 
-    public void preSerialize() throws IOException {
-
+    @Override
+    public void gsonPreProcess() throws IOException {
     }
 
-    public void postDeserialized() throws IOException {
-
+    @Override
+    public void gsonPostProcess() throws IOException {
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -353,7 +353,7 @@ public class RangePartitionInfo extends PartitionInfo {
     }
 
     @Override
-    public void preSerialize() throws IOException {
+    public void gsonPreProcess() throws IOException {
         serializedIdToRange = Maps.newHashMap();
         for (Map.Entry<Long, Range<PartitionKey>> entry : idToRange.entrySet()) {
             byte[] serializedRange = serializeRange(entry.getValue());
@@ -368,7 +368,7 @@ public class RangePartitionInfo extends PartitionInfo {
     }
 
     @Override
-    public void postDeserialized() throws IOException {
+    public void gsonPostProcess() throws IOException {
         if (serializedIdToRange != null && !serializedIdToRange.isEmpty()) {
             for (Map.Entry<Long, byte[]> entry : serializedIdToRange.entrySet()) {
                 idToRange.put(entry.getKey(), deserializeRange(entry.getValue()));

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonPreProcessable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonPreProcessable.java
@@ -1,0 +1,9 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.persist.gson;
+
+import java.io.IOException;
+
+public interface GsonPreProcessable {
+    public void gsonPreProcess() throws IOException;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -426,8 +426,11 @@ public class GsonUtils {
             TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
 
             return new TypeAdapter<T>() {
-                public void write(JsonWriter out, T value) throws IOException {
-                    delegate.write(out, value);
+                public void write(JsonWriter out, T obj) throws IOException {
+                    if (obj instanceof GsonPreProcessable) {
+                        ((GsonPreProcessable) obj).gsonPreProcess();
+                    }
+                    delegate.write(out, obj);
                 }
 
                 public T read(JsonReader reader) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -199,7 +199,7 @@ public class GsonUtils {
             .enableComplexMapKeySerialization()
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
-            .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
+            .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
             .registerTypeAdapterFactory(columnTypeAdapterFactory)
             .registerTypeAdapterFactory(distributionInfoTypeAdapterFactory)
             .registerTypeAdapterFactory(resourceTypeAdapterFactory)
@@ -416,9 +416,9 @@ public class GsonUtils {
         }
     }
 
-    public static class PostProcessTypeAdapterFactory implements TypeAdapterFactory {
+    public static class ProcessHookTypeAdapterFactory implements TypeAdapterFactory {
 
-        public PostProcessTypeAdapterFactory() {
+        public ProcessHookTypeAdapterFactory() {
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonDerivedClassSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonDerivedClassSerializationTest.java
@@ -28,7 +28,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils.HiddenAnnotationExclusionStrategy;
-import com.starrocks.persist.gson.GsonUtils.PostProcessTypeAdapterFactory;
+import com.starrocks.persist.gson.GsonUtils.ProcessHookTypeAdapterFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -179,7 +179,7 @@ public class GsonDerivedClassSerializationTest {
             .enableComplexMapKeySerialization()
             // register the RuntimeTypeAdapterFactory
             .registerTypeAdapterFactory(runtimeTypeAdapterFactory)
-            .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
+            .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
             .create();
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Some objects are not easy to be persisted directly with JSON, like google collect Range.
Through the preprocess function, these objects can be converted into easily persistent
objects before persistence, like String.
Then complete the deserialization through the postprocess function.
This makes gson serialization easier to use.
