### PR TITLE
[Enhance] change max_transmit_batched_bytes from 64KB to 256KB

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -587,8 +587,8 @@ CONF_Int32(late_materialization_ratio, "10");
 // `1000` will enable late materialization always select metric type.
 CONF_Int32(metric_late_materialization_ratio, "1000");
 
-// Max batched bytes for each transmit request.
-CONF_Int64(max_transmit_batched_bytes, "65536");
+// Max batched bytes for each transmit request. (256KB)
+CONF_Int64(max_transmit_batched_bytes, "262144");
 
 CONF_Int16(bitmap_max_filter_items, "30");
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -107,7 +107,6 @@ private:
     // Only used when broadcast
     PTransmitChunkParamsPtr _chunk_request;
     size_t _current_request_bytes = 0;
-    size_t _request_bytes_threshold = config::max_transmit_batched_bytes;
 
     bool _is_first_chunk = true;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`max_transmit_batched_bytes` affects the RPC packet size in exchange operator, but current value `64KB` is pretty small, and has some negative effects of performance.

If change it to `256KB`, the upside is we could reduce some RPC for network intensive workloads. And the buffer is pretty small, the memory overhead is not so significant.


## Experiment Result
| query | Before | After |
| ------| -------|-------|
| select d_year, s_city, p_brand, sum(lo_revenue) - sum(lo_supplycost) as profit from ssb_100g.lineorder join ssb_100g.dates on lo_orderdate = d_datekey join ssb_100g.customer on lo_custkey = c_custkey join ssb_100g.supplier on lo_suppkey = s_suppkey join ssb_100g.part on lo_partkey = p_partkey where c_region = 'AMERICA'and s_nation = 'UNITED STATES' and (d_year = 1997 or d_year = 1998) and p_category = 'MFGR#14' group by d_year, s_city, p_brand order by d_year, s_city, p_brand; | 490ms | 377ms |
|  select sum(p_size) from ssb_100g.part LEFT SEMI JOIN (select * from ssb_100g.lineorder WHERE lo_quantity<=15) as b on p_partkey=b.lo_partkey | 811ms | 642ms | 
