### PR TITLE
[BugFix] Remove duplicate limit operator

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -240,9 +240,6 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
                 context->next_operator_id(), id(), _texchange_node, _num_senders, _input_row_desc);
         exchange_source_op->set_degree_of_parallelism(context->degree_of_parallelism());
         operators.emplace_back(exchange_source_op);
-        if (limit() != -1) {
-            operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
-        }
     } else {
         auto exchange_merge_sort_source_operator = std::make_shared<ExchangeMergeSortSourceOperatorFactory>(
                 context->next_operator_id(), id(), _num_senders, _input_row_desc, &_sort_exec_exprs, _is_asc_order,

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -321,6 +321,7 @@ void RuntimeProfile::reverse_childs() {
 void RuntimeProfile::add_child_unlock(RuntimeProfile* child, bool indent, ChildVector::iterator pos) {
     DCHECK(child != nullptr);
     DCHECK(child->_parent == nullptr);
+    DCHECK(_child_map.find(child->_name) == _child_map.end());
     _child_map[child->_name] = child;
     _children.insert(pos, std::make_pair(child, indent));
     child->_parent = this;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

ExchagneNode may produce two same LimitOperators

The duplicate limitOperators will lead to the failure of profile merge mechanism, bacause the two limitOperator's profiles have exactly the same name. When calling `RuntimeProfile::add_child` to add these two profile, the filed `RuntimeProfile::_child_map` will be overwritten, so the size of `RuntimeProfile::_child_map` and `RuntimeProfile::_children` is not same

So, the following condition `i >= profile->num_children()`(`i` means the child index of `RuntimeProfile::_children` of profile A, `num_children()` will return the size of `RuntimeProfile::_child_map` of profile B) turns out to be true

```cpp
            ...
            for (auto j = 1; j < profiles.size(); j++) {
                auto* profile = profiles[j];
                if (i >= profile->num_children()) {
                    LOG(WARNING) << "find non-isomorphic children, profile_name=" << profile0->name()
                                 << ", children_names=" << profile0->get_children_name_string()
                                 << ", another profile_name=" << profile->name()
                                 << ", another children_names=" << profile->get_children_name_string();
                    return;
                }
                ...
           }
           ...
```