### PR TITLE
[BugFix] When the input_rows is larger, the overflow occurs when (#5609)

### DIFF
--- a/be/test/storage/table_schema_test.cpp
+++ b/be/test/storage/table_schema_test.cpp
@@ -59,4 +59,4 @@ TEST(TabletSchemaTest, test_estimate_row_size) {
     size_t row_size = tablet_schema.estimate_row_size(100);
     ASSERT_EQ(row_size, 134);
 }
-}
+} // namespace starrocks


### PR DESCRIPTION
When the input_rows is larger, the overflow occurs when calculating the output rows of every segment. 
Because of the overflow, the row in every segment will be one. It will generate thousands of files and reach the limit of the file descriptors.
```
I0428 00:12:07.176318 11782 compaction.cpp:86] start base compaction. tablet=940828, output version is=0-138715, max rows per segment=1, segment iterator num=100, algo
rithm=VERTICAL_COMPACTION, column group size=23, columns per group=5
W0428 00:12:35.023933 11782 compaction.cpp:106] fail to do base compaction. res=IO error: /home/disk8/starrocks/storage/be-c6e29739-05e6-4286-b850-33c5d97c8f8a/data/54
/940828/1092789729/0200000000000701e04e325abb82380c536e56bffe78afae_65040.dat: Too many open files
```
As well, config::max_segments_file_size is redesigned as a integer. This is the max size of a segment is 2GB and enough for all the cases.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5610 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
