### PR TITLE
[Enhancement] Remove decimal column range extract limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -57,10 +57,6 @@ public class ScalarRangePredicateExtractor {
 
         Set<ScalarOperator> result = Sets.newLinkedHashSet();
         extractMap.keySet().stream().filter(k -> !onlyExtractColumnRef || k.isColumnRef())
-                // The decimal column is filtered out
-                // because the literal constants of the same Decimal may have different types,
-                // resulting in an error in the judgment of the equivalence of the constants
-                .filter(k -> !k.getType().isDecimalOfAnyVersion())
                 .map(extractMap::get)
                 .filter(d -> d.sourceCount > 1)
                 .map(ValueDescriptor::toScalarOperator).forEach(result::addAll);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
@@ -575,4 +575,48 @@ public class TPCDSPlanTest extends TPCDSPlanTestBase {
 
         Assert.assertTrue(plan.contains("dict_col=c_birth_country"));
     }
+
+    @Test
+    public void expressionExtract() throws Exception {
+        String sql = "\n" +
+                "select count(1)\n" +
+                " from store_sales\n" +
+                "     ,customer_demographics\n" +
+                "     ,customer_address\n" +
+                " where 1=1\n" +
+                " and((cd_demo_sk = ss_cdemo_sk\n" +
+                "  and cd_marital_status = 'M'\n" +
+                "  and cd_education_status = 'Advanced Degree'\n" +
+                "  and ss_sales_price between 100.00 and 150.00\n" +
+                "     )or\n" +
+                "     (cd_demo_sk = ss_cdemo_sk\n" +
+                "  and cd_marital_status = 'S'\n" +
+                "  and cd_education_status = 'College'\n" +
+                "  and ss_sales_price between 50.00 and 100.00\n" +
+                "     ) or\n" +
+                "     (cd_demo_sk = ss_cdemo_sk\n" +
+                "  and cd_marital_status = 'W'\n" +
+                "  and cd_education_status = '2 yr Degree'\n" +
+                "  and ss_sales_price between 150.00 and 200.00\n" +
+                "     ))\n" +
+                " and((ss_addr_sk = ca_address_sk\n" +
+                "  and ca_country = 'United States'\n" +
+                "  and ca_state in ('TX', 'OH', 'TX')\n" +
+                "  and ss_net_profit between 100 and 200\n" +
+                "     ) or\n" +
+                "     (ss_addr_sk = ca_address_sk\n" +
+                "  and ca_country = 'United States'\n" +
+                "  and ca_state in ('OR', 'NM', 'KY')\n" +
+                "  and ss_net_profit between 150 and 300\n" +
+                "     ) or\n" +
+                "     (ss_addr_sk = ca_address_sk\n" +
+                "  and ca_country = 'United States'\n" +
+                "  and ca_state in ('VA', 'TX', 'MS')\n" +
+                "  and ss_net_profit between 50 and 250\n" +
+                "     ));";
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan,
+                "PREDICATES: 14: ss_sales_price >= 50, 14: ss_sales_price <= 200, 23: ss_net_profit >= 50, 23: ss_net_profit <= 300");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

I think decimal constant which in an expression must be same type(same scale and precision), so we should fix type cast  when we meet question