### PR TITLE
[BugFix] Fix the bitmap index for bool

### DIFF
--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -169,20 +169,13 @@ private:
     template <FieldType type, EncodingTypePB encoding_type, bool optimize_value_seek = false>
     void _add_map() {
         auto key = std::make_pair(type, encoding_type);
-        auto it = _encoding_map.find(key);
-        if (it != _encoding_map.end()) {
-            return;
-        }
+        DCHECK(_encoding_map.count(key) == 0);
 
-        EncodingTraits<type, encoding_type> traits;
-        std::unique_ptr<EncodingInfo> encoding(new EncodingInfo(traits));
-        if (_default_encoding_type_map.find(type) == std::end(_default_encoding_type_map)) {
-            _default_encoding_type_map[type] = encoding_type;
-        }
-        if (optimize_value_seek && _value_seek_encoding_map.find(type) == _value_seek_encoding_map.end()) {
+        _default_encoding_type_map[type] = encoding_type;
+        if (optimize_value_seek) {
             _value_seek_encoding_map[type] = encoding_type;
         }
-        _encoding_map.emplace(key, encoding.release());
+        _encoding_map.emplace(key, new EncodingInfo(EncodingTraits<type, encoding_type>()));
     }
 
     std::unordered_map<FieldType, EncodingTypePB, std::hash<int>> _default_encoding_type_map;

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -248,11 +248,9 @@ EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<OLAP_FIELD_TYPE_TIMESTAMP, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_TIMESTAMP, FOR_ENCODING, true>();
 
-    _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE, true>();
 
-    _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, BIT_SHUFFLE, true>();
 

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -230,7 +230,6 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_BOOL, RLE>();
     _add_map<OLAP_FIELD_TYPE_BOOL, BIT_SHUFFLE>();
-    _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING, true>();
 
     _add_map<OLAP_FIELD_TYPE_DATE, BIT_SHUFFLE>();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6746
Fixes #7002

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


The map should not be add twice, otherwise the second attempt would fail to insert into the map.