### PR TITLE
[BugFix] Fix Enforcer record error required property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -334,8 +334,8 @@ public class RuleSet {
     }
 
     public void addAutoJoinImplementationRule() {
-        this.implementRules.add(MergeJoinImplementationRule.getInstance());
         this.implementRules.add(HashJoinImplementationRule.getInstance());
+        this.implementRules.add(MergeJoinImplementationRule.getInstance());
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -458,7 +458,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         curTotalCost += CostModel.calculateCost(enforcer);
 
         if (enforcer.updatePropertyWithCost(newOutputProperty, Lists.newArrayList(oldOutputProperty), curTotalCost)) {
-            enforcer.setOutputPropertySatisfyRequiredProperty(newOutputProperty, context.getRequiredProperty());
+            enforcer.setOutputPropertySatisfyRequiredProperty(newOutputProperty, newOutputProperty);
         }
         groupExpression.getGroup().setBestExpression(enforcer, curTotalCost, newOutputProperty);
         if (ConnectContext.get().getSessionVariable().isSetUseNthExecPlan()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeJoinTest.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.plan;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MergeJoinTest extends PlanTestBase {
@@ -13,19 +12,21 @@ public class MergeJoinTest extends PlanTestBase {
         PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("merge");
         String sql = "SELECT * from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 = 1;";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 = 1"));
+        assertContains(planFragment, "PREDICATES: 1: v1 = 1");
     }
 
     @Test
     public void testJoinColumnsPrune() throws Exception {
         PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("merge");
         String sql = " select count(a.v3) from t0 a join t0 b on a.v3 = b.v3;";
-        getFragmentPlan(sql);
+        String planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, " 8:MERGE JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)");
 
         sql = " select a.v2 from t0 a join t0 b on a.v3 = b.v3;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("Project\n"
-                + "  |  <slot 2> : 2: v2"));
+        planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "Project\n"
+                + "  |  <slot 2> : 2: v2");
     }
 
     @Test
@@ -33,7 +34,29 @@ public class MergeJoinTest extends PlanTestBase {
         PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("merge");
         String sql = "SELECT * from t0 join test_all_type where t0.v1 = 2;";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 = 2"));
+        assertContains(planFragment, "PREDICATES: 1: v1 = 2");
+    }
+
+    @Test
+    public void testJoinWithAutoMode() throws Exception {
+        PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
+        String sql = "SELECT * from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 = 1;";
+        String planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "PREDICATES: 1: v1 = 1");
+
+        sql = " select count(a.v3) from t0 a join t0 b on a.v3 = b.v3;";
+        planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, " 3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)");
+
+        sql = " select a.v2 from t0 a join t0 b on a.v3 = b.v3;";
+        planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "Project\n"
+                + "  |  <slot 2> : 2: v2");
+
+        sql = "SELECT * from t0 join test_all_type where t0.v1 = 2;";
+        planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "PREDICATES: 1: v1 = 2");
     }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7012 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The group expression  need to record itselft output property and required property by parent, but for enforcer, the property of output and required should be same