### PR TITLE
[BugFix] Fix TimestampArithmeticExpr analyze bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TimestampArithmeticExpr.java
@@ -71,7 +71,7 @@ public class TimestampArithmeticExpr extends Expr {
 
     // C'tor for function-call like arithmetic, e.g., 'date_add(a, interval b year)'.
     public TimestampArithmeticExpr(String funcName, Expr e1, Expr e2, String timeUnitIdent) {
-        this.funcName = funcName;
+        this.funcName = funcName.toLowerCase();
         this.timeUnitIdent = timeUnitIdent;
         this.intervalFirst = false;
         children.add(e1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -365,7 +365,7 @@ public class ExpressionAnalyzer {
         List<String> addDateFunctions = Lists.newArrayList(FunctionSet.DATE_ADD,
                 FunctionSet.ADDDATE, FunctionSet.DAYS_ADD, FunctionSet.TIMESTAMPADD);
         List<String> subDateFunctions = Lists.newArrayList(FunctionSet.DATE_SUB, FunctionSet.SUBDATE,
-                FunctionSet.DATE_SUB);
+                FunctionSet.DAYS_SUB);
 
         @Override
         public Void visitTimestampArithmeticExpr(TimestampArithmeticExpr node, Scope scope) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1771,7 +1771,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new IsNullPredicate(params.get(0), false);
         }
 
-        FunctionCallExpr functionCallExpr = new FunctionCallExpr(getQualifiedName(context.qualifiedName()).toString(),
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(functionName,
                 new FunctionParams(false, visit(context.expression(), Expr.class)));
 
         if (context.over() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -127,7 +127,7 @@ public class AnalyzeFunctionTest {
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess("select timestampadd(day, 2, '2022-01-01')");
-        Assert.assertEquals("SELECT TIMESTAMPADD(DAY, 2, '2022-01-01 00:00:00')",
+        Assert.assertEquals("SELECT timestampadd(DAY, 2, '2022-01-01 00:00:00')",
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess("select date_add('2022-01-01', 2)");
@@ -151,21 +151,21 @@ public class AnalyzeFunctionTest {
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess("select timestampdiff(day, '2020-01-01', '2020-01-03')");
-        Assert.assertEquals("SELECT TIMESTAMPDIFF(DAY, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
+        Assert.assertEquals("SELECT timestampdiff(DAY, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess(
                 "select timestampdiff(day, '2020-01-01 00:00:00', '2020-01-03 00:00:00')");
-        Assert.assertEquals("SELECT TIMESTAMPDIFF(DAY, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
+        Assert.assertEquals("SELECT timestampdiff(DAY, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess("select timestampdiff(minute, '2020-01-01', '2020-01-03')");
-        Assert.assertEquals("SELECT TIMESTAMPDIFF(MINUTE, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
+        Assert.assertEquals("SELECT timestampdiff(MINUTE, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
                 AST2SQL.toString(queryStatement.getQueryRelation()));
 
         queryStatement = (QueryStatement) analyzeSuccess(
                 "select timestampdiff(minute, '2020-01-01 00:00:00', '2020-01-03 00:00:00')");
-        Assert.assertEquals("SELECT TIMESTAMPDIFF(MINUTE, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
+        Assert.assertEquals("SELECT timestampdiff(MINUTE, '2020-01-01 00:00:00', '2020-01-03 00:00:00')",
                 AST2SQL.toString(queryStatement.getQueryRelation()));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1001,4 +1001,19 @@ public class ExpressionTest extends PlanTestBase {
         String sql3 = "select * from test_all_type, json_each(parse_json('{}'))";
         getFragmentPlan(sql3);
     }
+
+    @Test
+    public void testTimestampadd() throws Exception {
+        String sql = "select timestampadd(YEAR,1,'2022-04-02 13:21:03')";
+        String plan =  getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("<slot 2> : '2023-04-02 13:21:03'"));
+    }
+
+    @Test
+    public void testDaysSub() throws Exception {
+        String sql = "select days_sub('2010-11-30 23:59:59', 0)";
+        String plan =  getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("<slot 2> : '2010-11-30 23:59:59'"));
+    }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

https://github.com/StarRocks/starrocks/pull/6951 introduced some bugs:



### Steps to reproduce the behavior (Required)
`select days_sub('2010-11-30 23:59:59', 0) `

### Expected behavior (Required)
`2010-11-30 23:59:59`
### Real behavior (Required)
`null`


### Steps to reproduce the behavior (Required)
`select timestampadd(YEAR,1,'2022-04-02 13:21:03'); `

### Expected behavior (Required)
`2023-04-02 13:21:03`
### Real behavior (Required)
`null`


