### PR TITLE
[BugFix] showing unkonwn resource group should throw Exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -8,7 +8,10 @@ import com.starrocks.analysis.AlterWorkGroupStmt;
 import com.starrocks.analysis.CreateWorkGroupStmt;
 import com.starrocks.analysis.DropWorkGroupStmt;
 import com.starrocks.analysis.ShowWorkGroupStmt;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.WorkGroupOpEntry;
@@ -97,7 +100,11 @@ public class WorkGroupMgr implements Writable {
         }
     }
 
-    public List<List<String>> showWorkGroup(ShowWorkGroupStmt stmt) {
+    public List<List<String>> showWorkGroup(ShowWorkGroupStmt stmt) throws AnalysisException {
+        if (stmt.getName() != null && !workGroupMap.containsKey(stmt.getName())) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERROR_NO_WG_ERROR, stmt.getName());
+        }
+
         List<List<String>> rows;
         if (stmt.getName() != null) {
             rows = Catalog.getCurrentCatalog().getWorkGroupMgr().showOneWorkGroup(stmt.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -256,7 +256,9 @@ public enum ErrorCode {
     ERROR_SET_CONFIG_FAILED(5076, new byte[] {'4', '2', '0', '0', '0'},
             "set config failed: %s"),
     ERR_QUERY_EXCEPTION(5077, new byte[] {'4', '2', '0', '0', '0'},
-            "Query cancelled by crash of backends.");
+            "Query cancelled by crash of backends."),
+    ERROR_NO_WG_ERROR(5077, new byte[] {'4', '2', '0', '0', '0'},
+            "Unknown workgroup '%s' ");
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -257,7 +257,7 @@ public enum ErrorCode {
             "set config failed: %s"),
     ERR_QUERY_EXCEPTION(5077, new byte[] {'4', '2', '0', '0', '0'},
             "Query cancelled by crash of backends."),
-    ERROR_NO_WG_ERROR(5077, new byte[] {'4', '2', '0', '0', '0'},
+    ERROR_NO_WG_ERROR(5079, new byte[] {'4', '2', '0', '0', '0'},
             "Unknown workgroup '%s' ");
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1493,7 +1493,7 @@ public class ShowExecutor {
         resultSet = new ShowResultSet(stmt.getMetaData(), rows);
     }
 
-    private void handleShowWorkGroup() {
+    private void handleShowWorkGroup() throws AnalysisException {
         ShowWorkGroupStmt showWorkGroupStmt = (ShowWorkGroupStmt) stmt;
         List<List<String>> rows = Catalog.getCurrentCatalog().getWorkGroupMgr().showWorkGroup(showWorkGroupStmt);
         resultSet = new ShowResultSet(showWorkGroupStmt.getMetaData(), rows);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -36,6 +36,7 @@ import com.starrocks.analysis.ShowEnginesStmt;
 import com.starrocks.analysis.ShowProcedureStmt;
 import com.starrocks.analysis.ShowTableStmt;
 import com.starrocks.analysis.ShowVariablesStmt;
+import com.starrocks.analysis.ShowWorkGroupStmt;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
@@ -514,6 +515,16 @@ public class ShowExecutorTest {
         ShowResultSet resultSet = executor.execute();
 
         Assert.assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testShowUnknownWorkGroup() throws AnalysisException, DdlException{
+        ShowWorkGroupStmt stmt = new ShowWorkGroupStmt("abc", false);
+        ShowExecutor executor = new ShowExecutor(ctx, stmt);
+
+        expectedEx.expect(AnalysisException.class);
+        expectedEx.expectMessage("Unknown workgroup 'abc'");
+        executor.execute();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -36,7 +36,6 @@ import com.starrocks.analysis.ShowEnginesStmt;
 import com.starrocks.analysis.ShowProcedureStmt;
 import com.starrocks.analysis.ShowTableStmt;
 import com.starrocks.analysis.ShowVariablesStmt;
-import com.starrocks.analysis.ShowWorkGroupStmt;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
@@ -516,17 +515,6 @@ public class ShowExecutorTest {
 
         Assert.assertFalse(resultSet.next());
     }
-
-    @Test
-    public void testShowUnknownWorkGroup() throws AnalysisException, DdlException{
-        ShowWorkGroupStmt stmt = new ShowWorkGroupStmt("abc", false);
-        ShowExecutor executor = new ShowExecutor(ctx, stmt);
-
-        expectedEx.expect(AnalysisException.class);
-        expectedEx.expectMessage("Unknown workgroup 'abc'");
-        executor.execute();
-    }
-
     @Test
     public void testHelp() throws AnalysisException, IOException, UserException {
         HelpModule module = new HelpModule();


### PR DESCRIPTION
# What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #6813 

## Problem Summary(Required) ：
Showing a non-existent resource group should throw Exception，not return empty set.
cherry-pick to branch 2.2 due to error happen when auto merge.