### PR TITLE
[Bugfix] process returned status correctly

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -313,7 +313,7 @@ Status ExecNode::close(RuntimeState* state) {
         return Status::OK();
     }
     _is_closed = true;
-    RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::CLOSE));
+    exec_debug_action(TExecNodePhase::CLOSE);
 
     if (_rows_returned_counter != nullptr) {
         COUNTER_SET(_rows_returned_counter, _num_rows_returned);

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -53,7 +53,7 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSinkOperator::pull_chunk(Runtime
 }
 
 Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    _aggregator->evaluate_exprs(chunk.get());
+    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
     bool agg_group_by_with_limit =
             (!_aggregator->is_none_group_by_exprs() &&     // has group by

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -47,7 +47,7 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSinkOperator::pull_chunk
 
 Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     DCHECK_LE(chunk->num_rows(), state->chunk_size());
-    _aggregator->evaluate_exprs(chunk.get());
+    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
     {
         SCOPED_TIMER(_aggregator->agg_compute_timer());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -38,7 +38,7 @@ Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, c
     _aggregator->update_num_input_rows(chunk_size);
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
-    _aggregator->evaluate_exprs(chunk.get());
+    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
         return _push_chunk_by_force_streaming();

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -38,7 +38,7 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const vec
     _aggregator->update_num_input_rows(chunk_size);
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
-    _aggregator->evaluate_exprs(chunk.get());
+    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
         return _push_chunk_by_force_streaming();

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -86,7 +86,7 @@ Status PartitionExchanger::accept(const vectorized::ChunkPtr& chunk, const int32
     // and used later in pull_chunk() of source operator. If we reuse partition_row_indexes in partitioner,
     // it will be overwritten by the next time calling partitioner.partition_chunk().
     std::shared_ptr<std::vector<uint32_t>> partition_row_indexes = std::make_shared<std::vector<uint32_t>>(num_rows);
-    partitioner.partition_chunk(chunk, *partition_row_indexes);
+    RETURN_IF_ERROR(partitioner.partition_chunk(chunk, *partition_row_indexes));
 
     for (size_t i = 0; i < _source->get_sources().size(); ++i) {
         size_t from = partitioner.partition_begin_offset(i);

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -87,7 +87,11 @@ StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
             return nullptr;
         }
 
-        RETURN_IF_ERROR(_init_segment());
+        if (auto status = _init_segment(); !status.ok()) {
+            // Morsel_queue cannot generate morsels after errors occurring.
+            _tablet_idx = _tablets.size();
+            return status;
+        }
     }
 
     vectorized::SparseRange taken_range;

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -52,7 +52,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
 
         DCHECK_LE(chunk->num_rows(), runtime_state()->chunk_size());
 
-        _aggregator->evaluate_exprs(chunk.get());
+        RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
         size_t chunk_size = chunk->num_rows();
         {

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -58,7 +58,7 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
             size_t input_chunk_size = input_chunk->num_rows();
             _aggregator->update_num_input_rows(input_chunk_size);
             COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
-            _aggregator->evaluate_exprs(input_chunk.get());
+            RETURN_IF_ERROR(_aggregator->evaluate_exprs(input_chunk.get()));
 
             if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
                 // force execute streaming

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -45,7 +45,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
         }
         DCHECK_LE(chunk->num_rows(), runtime_state()->chunk_size());
 
-        _aggregator->evaluate_exprs(chunk.get());
+        RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -53,7 +53,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
             size_t input_chunk_size = input_chunk->num_rows();
             _aggregator->update_num_input_rows(input_chunk_size);
             COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
-            _aggregator->evaluate_exprs(input_chunk.get());
+            RETURN_IF_ERROR(_aggregator->evaluate_exprs(input_chunk.get()));
 
             if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
                 // force execute streaming

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -162,7 +162,7 @@ Status FileScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::CLOSE));
+    exec_debug_action(TExecNodePhase::CLOSE);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     _scan_finished.store(true);
     _queue_writer_cond.notify_all();

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -173,7 +173,7 @@ Status OlapScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::CLOSE));
+    exec_debug_action(TExecNodePhase::CLOSE);
     _update_status(Status::Cancelled("closed"));
     _result_chunks.shutdown();
     while (_running_threads.load(std::memory_order_acquire) > 0) {
@@ -193,8 +193,10 @@ Status OlapScanNode::close(RuntimeState* state) {
 
     _dict_optimize_parser.close(state);
 
-    // Reduce the memory usage if the the average string size is greater than 512.
-    release_large_columns<BinaryColumn>(runtime_state()->chunk_size() * 512);
+    if (runtime_state() != nullptr) {
+        // Reduce the memory usage if the the average string size is greater than 512.
+        release_large_columns<BinaryColumn>(runtime_state()->chunk_size() * 512);
+    }
 
     return ScanNode::close(state);
 }

--- a/be/src/exec/vectorized/project_node.cpp
+++ b/be/src/exec/vectorized/project_node.cpp
@@ -204,8 +204,8 @@ Status ProjectNode::close(RuntimeState* state) {
     Expr::close(_expr_ctxs, state);
     Expr::close(_common_sub_expr_ctxs, state);
     _dict_optimize_parser.close(state);
-    RETURN_IF_ERROR(ExecNode::close(state));
-    return Status::OK();
+
+    return ExecNode::close(state);
 }
 
 void ProjectNode::push_down_predicate(RuntimeState* state, std::list<ExprContext*>* expr_ctxs) {

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -265,7 +265,7 @@ Status SchemaScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::CLOSE));
+    exec_debug_action(TExecNodePhase::CLOSE);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     return ScanNode::close(state);

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -448,7 +448,9 @@ Status Expr::open(RuntimeState* state, ExprContext* context, FunctionContext::Fu
 
 void Expr::close(const std::vector<ExprContext*>& ctxs, RuntimeState* state) {
     for (auto ctx : ctxs) {
-        ctx->close(state);
+        if (ctx != nullptr) {
+            ctx->close(state);
+        }
     }
 }
 
@@ -479,6 +481,7 @@ Status Expr::clone_if_not_exists(const std::vector<ExprContext*>& ctxs, RuntimeS
         }
         return Status::OK();
     }
+
     new_ctxs->resize(ctxs.size());
     for (int i = 0; i < ctxs.size(); ++i) {
         RETURN_IF_ERROR(ctxs[i]->clone(state, &(*new_ctxs)[i]));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Don't add `RETURN_IF_ERROR` to `exec_debug_action` in `ExecNode::close()`. 
    Otherwise, the resource-released operations below `exec_debug_action` cannot be performed.
2. Add missed  `RETURN_IF_ERROR` to some methods.
3. Check whether `_runtime_state` is nullptr before using it in `ExecNode::close()`.
4. Make `Morsel::try_get()` not reenterable after it returns error.
5. Check whether each `ctx` is nullptr before closing it in `Expr::close(ctxs)`.
    Because in `Expr::clone_if_not_exists(ctxs, state, new_ctxs)`, if `ctxs[i]->clone` returns error, `ctxs[j]` where `j>=i` may be nullptr.

```C++
Status Expr::clone_if_not_exists(const std::vector<ExprContext*>& ctxs, RuntimeState* state,
                                 std::vector<ExprContext*>* new_ctxs) {
    // ....
    new_ctxs->resize(ctxs.size());
    for (int i = 0; i < ctxs.size(); ++i) {
        RETURN_IF_ERROR(ctxs[i]->clone(state, &(*new_ctxs)[i]));
    }
    return Status::OK();
}
```
