### PR TITLE
[Enhancement] Optimize ingestion performance for table with materialized index STEP 1

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -738,6 +738,8 @@ CONF_mInt64(experimental_s3_min_upload_part_size, "16777216");
 
 CONF_Int64(max_load_dop, "16");
 
+CONF_Bool(enable_load_colocate_mv, "false");
+
 CONF_Int64(meta_threshold_to_manual_compact, "10737418240"); // 10G
 CONF_Bool(manual_compact_before_data_dir_load, "false");
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -130,11 +130,13 @@ private:
 
 class NodeChannel {
 public:
-    NodeChannel(OlapTableSink* parent, int64_t index_id, int64_t node_id);
+    NodeChannel(OlapTableSink* parent, int64_t node_id);
     ~NodeChannel() noexcept;
 
     // called before open, used to add tablet loacted in this backend
-    void add_tablet(const TTabletWithPartition& tablet) { _all_tablets.emplace_back(tablet); }
+    void add_tablet(const int64_t index_id, const TTabletWithPartition& tablet) {
+        _index_tablets_map[index_id].emplace_back(tablet);
+    }
 
     Status init(RuntimeState* state);
 
@@ -147,9 +149,13 @@ public:
 
     // async add chunk interface
     // if is_full() return false, add_chunk() will not block
-    Status add_chunk(vectorized::Chunk* chunk, const int64_t* tablet_ids, const uint32_t* indexes, uint32_t from,
-                     uint32_t size, bool eos);
     bool is_full();
+
+    Status add_chunk(vectorized::Chunk* input, const std::vector<int64_t>& tablet_ids,
+                     const std::vector<uint32_t>& indexes, uint32_t from, uint32_t size, bool eos);
+
+    Status add_chunks(vectorized::Chunk* input, const std::vector<std::vector<int64_t>>& tablet_ids,
+                      const std::vector<uint32_t>& indexes, uint32_t from, uint32_t size, bool eos);
 
     // async close interface: try_close() -> [is_close_done()] -> close_wait()
     // if is_close_done() return true, close_wait() will not block
@@ -171,6 +177,7 @@ public:
     const NodeInfo* node_info() const { return _node_info; }
     std::string print_load_info() const { return _load_info; }
     std::string name() const { return _name; }
+    bool enable_colocate_mv_index() const { return _enable_colocate_mv_index; }
 
 private:
     Status _wait_request(ReusableClosure<PTabletWriterAddBatchResult>* closure);
@@ -179,11 +186,14 @@ private:
     bool _check_prev_request_done();
     bool _check_all_prev_request_done();
     Status _serialize_chunk(const vectorized::Chunk* src, ChunkPB* dst);
+    void _open(int64_t index_id, RefCountClosure<PTabletWriterOpenResult>* open_closure);
+    Status _open_wait(RefCountClosure<PTabletWriterOpenResult>* open_closure);
+    Status _send_request(bool eos);
+    void _cancel(int64_t index_id, const Status& err_st);
 
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
     OlapTableSink* _parent = nullptr;
-    int64_t _index_id = -1;
     int64_t _node_id = -1;
     std::string _load_info;
     std::string _name;
@@ -208,9 +218,10 @@ private:
     std::unique_ptr<RowDescriptor> _row_desc;
 
     doris::PBackendService_Stub* _stub = nullptr;
-    RefCountClosure<PTabletWriterOpenResult>* _open_closure = nullptr;
+    std::vector<RefCountClosure<PTabletWriterOpenResult>*> _open_closures;
 
-    std::vector<TTabletWithPartition> _all_tablets;
+    std::map<int64_t, std::vector<TTabletWithPartition>> _index_tablets_map;
+
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
 
     AddBatchCounter _add_batch_counter;
@@ -218,17 +229,21 @@ private:
 
     size_t _max_parallel_request_size = 1;
     std::vector<ReusableClosure<PTabletWriterAddBatchResult>*> _add_batch_closures;
-    PTabletWriterAddChunkRequest _cur_request;
     std::unique_ptr<vectorized::Chunk> _cur_chunk;
-    using AddChunkReq = std::pair<std::unique_ptr<vectorized::Chunk>, PTabletWriterAddChunkRequest>;
-    std::deque<AddChunkReq> _chunk_queue;
+
+    PTabletWriterAddChunksRequest _rpc_request;
+    using AddMultiChunkReq = std::pair<std::unique_ptr<vectorized::Chunk>, PTabletWriterAddChunksRequest>;
+    std::deque<AddMultiChunkReq> _request_queue;
+
     size_t _current_request_index = 0;
-    size_t _max_chunk_queue_size = 8;
+    size_t _max_request_queue_size = 8;
 
     int64_t _actual_consume_ns = 0;
     Status _err_st = Status::OK();
 
     RuntimeState* _runtime_state = nullptr;
+
+    bool _enable_colocate_mv_index = config::enable_load_colocate_mv;
 };
 
 class IndexChannel {
@@ -254,8 +269,6 @@ private:
 
     // BeId -> channel
     std::unordered_map<int64_t, std::unique_ptr<NodeChannel>> _node_channels;
-    // map tablet_id to backend channel
-    std::unordered_map<int64_t, std::vector<NodeChannel*>> _channels_by_tablet;
     // map tablet_id to backend id
     std::unordered_map<int64_t, std::vector<int64_t>> _tablet_to_be;
     // BeId
@@ -316,6 +329,8 @@ private:
     // This method will change _validate_selection
     void _validate_data(RuntimeState* state, vectorized::Chunk* chunk);
 
+    Status _init_node_channels(RuntimeState* state);
+
     // When compute buckect hash, we should use real string for char column.
     // So we need to pad char column after compute buckect hash.
     void _padding_char_column(vectorized::Chunk* chunk);
@@ -324,8 +339,26 @@ private:
 
     static void _print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc);
 
-    // send chunk data to specific BE channel
-    Status _send_chunk_by_node(vectorized::Chunk* chunk, IndexChannel* channel, std::vector<uint16_t>& _selection_idx);
+    Status _send_chunk(vectorized::Chunk* chunk);
+
+    Status _send_chunk_with_colocate_index(vectorized::Chunk* chunk);
+
+    Status _send_chunk_by_node(vectorized::Chunk* chunk, IndexChannel* channel, std::vector<uint16_t>& selection_idx);
+
+    void mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
+    bool has_intolerable_failure() { return _failed_channels.size() >= ((_num_repicas + 1) / 2); }
+
+    void for_each_node_channel(const std::function<void(NodeChannel*)>& func) {
+        for (auto& it : _node_channels) {
+            func(it.second.get());
+        }
+    }
+
+    void for_each_index_channel(const std::function<void(NodeChannel*)>& func) {
+        for (auto& index_channel : _channels) {
+            index_channel->for_each_node_channel(func);
+        }
+    }
 
     friend class NodeChannel;
     friend class IndexChannel;
@@ -364,8 +397,6 @@ private:
     // index_channel
     std::vector<std::unique_ptr<IndexChannel>> _channels;
 
-    std::thread _sender_thread;
-
     std::vector<DecimalValue> _max_decimal_val;
     std::vector<DecimalValue> _min_decimal_val;
 
@@ -382,6 +413,7 @@ private:
     std::vector<uint32_t> _node_select_idx;
     std::vector<int64_t> _tablet_ids;
     vectorized::OlapTablePartitionParam* _vectorized_partition = nullptr;
+    std::vector<std::vector<int64_t>> _index_tablet_ids;
     // Store the output expr comput result column
     std::unique_ptr<vectorized::Chunk> _output_chunk;
 
@@ -414,6 +446,13 @@ private:
 
     bool _open_done = false;
     bool _close_done = false;
+
+    // BeId -> channel
+    std::unordered_map<int64_t, std::unique_ptr<NodeChannel>> _node_channels;
+    // BeId
+    std::set<int64_t> _failed_channels;
+    // enable colocate index
+    bool _colocate_mv_index = config::enable_load_colocate_mv;
 };
 
 } // namespace stream_load

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -31,7 +31,6 @@ DIAGNOSTIC_POP
 #include "storage/storage_engine.h"
 #include "util/compression/block_compression.h"
 #include "util/countdown_latch.h"
-#include "util/faststring.h"
 
 namespace starrocks {
 
@@ -46,10 +45,10 @@ public:
 
     const TabletsChannelKey& key() const { return _key; }
 
-    Status open(const PTabletWriterOpenRequest& params) override;
+    Status open(const PTabletWriterOpenRequest& params, std::shared_ptr<OlapTableSchemaParam> schema) override;
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) override;
+    void add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                   PTabletWriterAddBatchResult* response) override;
 
     void cancel() override;
 
@@ -106,7 +105,8 @@ private:
 
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
 
-    StatusOr<std::unique_ptr<WriteContext>> _create_write_context(const PTabletWriterAddChunkRequest& request,
+    StatusOr<std::unique_ptr<WriteContext>> _create_write_context(vectorized::Chunk* chunk,
+                                                                  const PTabletWriterAddChunkRequest& request,
                                                                   PTabletWriterAddBatchResult* response);
 
     int _close_sender(const int64_t* partitions, size_t partitions_size);
@@ -122,8 +122,7 @@ private:
     // initialized in open function
     int64_t _txn_id = -1;
     int64_t _index_id = -1;
-    std::unique_ptr<OlapTableSchemaParam> _schema;
-    std::unique_ptr<RowDescriptor> _row_desc;
+    std::shared_ptr<OlapTableSchemaParam> _schema;
 
     // next sequence we expect
     std::atomic<int> _num_remaining_senders;
@@ -141,26 +140,22 @@ private:
 };
 
 LakeTabletsChannel::LakeTabletsChannel(LoadChannel* load_channel, const TabletsChannelKey& key, MemTracker* mem_tracker)
-        : TabletsChannel(), _load_channel(load_channel), _key(key), _mem_tracker(mem_tracker), _has_chunk_meta(false) {}
+        : TabletsChannel(), _load_channel(load_channel), _key(key), _mem_tracker(mem_tracker) {}
 
 LakeTabletsChannel::~LakeTabletsChannel() = default;
 
-Status LakeTabletsChannel::open(const PTabletWriterOpenRequest& params) {
+Status LakeTabletsChannel::open(const PTabletWriterOpenRequest& params, std::shared_ptr<OlapTableSchemaParam> schema) {
     _txn_id = params.txn_id();
     _index_id = params.index_id();
-    _schema = std::make_unique<OlapTableSchemaParam>();
-    RETURN_IF_ERROR(_schema->init(params.schema()));
-    _row_desc = std::make_unique<RowDescriptor>(_schema->tuple_desc(), false);
+    _schema = schema;
     _num_remaining_senders.store(params.num_senders(), std::memory_order_release);
     _senders = std::vector<Sender>(params.num_senders());
     RETURN_IF_ERROR(_create_delta_writers(params));
     return Status::OK();
 }
 
-void LakeTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
-    ClosureGuard done_guard(done);
-
+void LakeTabletsChannel::add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                                   PTabletWriterAddBatchResult* response) {
     auto t0 = std::chrono::steady_clock::now();
 
     if (UNLIKELY(!request.has_sender_id())) {
@@ -204,7 +199,7 @@ void LakeTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAd
         return;
     }
 
-    auto res = _create_write_context(request, response);
+    auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
         res.status().to_protobuf(response->mutable_status());
         return;
@@ -216,7 +211,7 @@ void LakeTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAd
     }
 
     auto context = std::move(res).value();
-    auto channel_size = request.has_chunk() ? _tablet_id_to_sorted_indexes.size() : 0;
+    auto channel_size = chunk != nullptr ? _tablet_id_to_sorted_indexes.size() : 0;
     auto tablet_ids = request.tablet_ids().data();
 
     // Maybe a nullptr
@@ -246,7 +241,7 @@ void LakeTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAd
             // Do NOT return
             break;
         }
-        dw->write(&context->_chunk, row_indexes + from, size, [&](const Status& st) {
+        dw->write(chunk, row_indexes + from, size, [&](const Status& st) {
             context->update_status(st);
             count_down_latch.count_down();
         });
@@ -309,21 +304,6 @@ void LakeTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAd
     }
 }
 
-Status LakeTabletsChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
-    if (_has_chunk_meta.load(std::memory_order_acquire)) {
-        return Status::OK();
-    }
-    std::lock_guard l(_chunk_meta_lock);
-    if (_has_chunk_meta.load(std::memory_order_acquire)) {
-        return Status::OK();
-    }
-    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, pb_chunk);
-    if (!res.ok()) return res.status();
-    _chunk_meta = std::move(res).value();
-    _has_chunk_meta.store(true, std::memory_order_release);
-    return Status::OK();
-}
-
 int LakeTabletsChannel::_close_sender(const int64_t* partitions, size_t partitions_size) {
     int n = _num_remaining_senders.fetch_sub(1);
     DCHECK_GE(n, 1);
@@ -368,64 +348,24 @@ void LakeTabletsChannel::cancel() {
     }
 }
 
-Status LakeTabletsChannel::_deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk& chunk,
-                                              faststring* uncompressed_buffer) {
-    if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
-        TRY_CATCH_BAD_ALLOC({
-            serde::ProtobufChunkDeserializer des(_chunk_meta);
-            StatusOr<vectorized::Chunk> res = des.deserialize(pchunk.data());
-            if (!res.ok()) return res.status();
-            chunk = std::move(res).value();
-        });
-    } else {
-        [[maybe_unused]] size_t uncompressed_size;
-        {
-            const BlockCompressionCodec* codec = nullptr;
-            RETURN_IF_ERROR(get_block_compression_codec(pchunk.compress_type(), &codec));
-            uncompressed_size = pchunk.uncompressed_size();
-            TRY_CATCH_BAD_ALLOC(uncompressed_buffer->resize(uncompressed_size));
-            Slice output{uncompressed_buffer->data(), uncompressed_size};
-            RETURN_IF_ERROR(codec->decompress(pchunk.data(), &output));
-        }
-        {
-            TRY_CATCH_BAD_ALLOC({
-                std::string_view buff(reinterpret_cast<const char*>(uncompressed_buffer->data()), uncompressed_size);
-                serde::ProtobufChunkDeserializer des(_chunk_meta);
-                StatusOr<vectorized::Chunk> res = des.deserialize(buff);
-                if (!res.ok()) return res.status();
-                chunk = std::move(res).value();
-            });
-        }
-    }
-    return Status::OK();
-}
-
 StatusOr<std::unique_ptr<LakeTabletsChannel::WriteContext>> LakeTabletsChannel::_create_write_context(
-        const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
-    if (!request.has_chunk() && !request.eos()) {
+        vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
+    if (chunk == nullptr && !request.eos()) {
         return Status::InvalidArgument("PTabletWriterAddChunkRequest has no chunk or eos");
     }
 
     std::unique_ptr<WriteContext> context(new WriteContext(response));
 
-    if (!request.has_chunk()) {
+    if (chunk == nullptr) {
         return std::move(context);
     }
 
-    auto& pchunk = request.chunk();
-    RETURN_IF_ERROR(_build_chunk_meta(pchunk));
-
-    vectorized::Chunk& chunk = context->_chunk;
-
-    faststring uncompressed_buffer;
-    RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk, &uncompressed_buffer));
-
-    if (UNLIKELY(request.tablet_ids_size() != chunk.num_rows())) {
+    if (UNLIKELY(request.tablet_ids_size() != chunk->num_rows())) {
         return Status::InvalidArgument("request.tablet_ids_size() != chunk.num_rows()");
     }
 
     const auto channel_size = _tablet_id_to_sorted_indexes.size();
-    context->_row_indexes = std::make_unique<uint32_t[]>(chunk.num_rows());
+    context->_row_indexes = std::make_unique<uint32_t[]>(chunk->num_rows());
     context->_channel_row_idx_start_points = std::make_unique<uint32_t[]>(channel_size + 1);
 
     auto& row_indexes = context->_row_indexes;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -24,11 +24,24 @@
 #include <memory>
 
 #include "common/closure_guard.h"
+#include "fmt/format.h"
 #include "runtime/lake_tablets_channel.h"
 #include "runtime/load_channel_mgr.h"
 #include "runtime/local_tablets_channel.h"
 #include "runtime/mem_tracker.h"
+#include "util/compression/block_compression.h"
+#include "util/faststring.h"
 #include "util/lru_cache.h"
+
+#define RETURN_RESPONSE_IF_ERROR(stmt, response)                                      \
+    do {                                                                              \
+        auto&& status__ = (stmt);                                                     \
+        if (UNLIKELY(!status__.ok())) {                                               \
+            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR); \
+            response->mutable_status()->add_error_msgs(status__.to_string());         \
+            return;                                                                   \
+        }                                                                             \
+    } while (false)
 
 namespace starrocks {
 
@@ -37,6 +50,7 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, const UniqueId& load_id, const std
         : _load_mgr(mgr),
           _load_id(load_id),
           _timeout_s(timeout_s),
+          _has_chunk_meta(false),
           _mem_tracker(std::move(mem_tracker)),
           _last_updated_time(time(nullptr)) {
     _span = Tracer::Instance().start_trace_or_add_span("load_channel", txn_trace_parent);
@@ -64,11 +78,18 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
         // it will block the bthread, so we put its destructor outside the lock.
         std::shared_ptr<TabletsChannel> channel;
         std::lock_guard l(_lock);
+        if (_schema == nullptr) {
+            _schema.reset(new OlapTableSchemaParam());
+            RETURN_RESPONSE_IF_ERROR(_schema->init(request.schema()), response);
+        }
+        if (_row_desc == nullptr) {
+            _row_desc.reset(new RowDescriptor(_schema->tuple_desc(), false));
+        }
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
             TabletsChannelKey key(request.id(), index_id);
             channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker.get())
                                      : new_local_tablets_channel(this, key, _mem_tracker.get());
-            if (st = channel->open(request); st.ok()) {
+            if (st = channel->open(request, _schema); st.ok()) {
                 _tablets_channels.insert({index_id, std::move(channel)});
             }
         }
@@ -76,12 +97,15 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
     LOG_IF(WARNING, !st.ok()) << "Fail to open index " << index_id << " of load " << _load_id << ": " << st.to_string();
     response->mutable_status()->set_status_code(st.code());
     response->mutable_status()->add_error_msgs(st.get_error_msg());
+
+    if (config::enable_load_colocate_mv) {
+        response->set_is_repeated_chunk(true);
+    }
 }
 
-void LoadChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                            PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
+void LoadChannel::_add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                             PTabletWriterAddBatchResult* response) {
     _num_chunk++;
-    ClosureGuard done_guard(done);
     _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
     auto channel = get_tablets_channel(request.index_id());
     if (channel == nullptr) {
@@ -89,7 +113,52 @@ void LoadChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkR
         response->mutable_status()->add_error_msgs("cannot find the tablets channel associated with the index id");
         return;
     }
-    channel->add_chunk(cntl, request, response, done_guard.release());
+    channel->add_chunk(chunk, request, response);
+}
+
+void LoadChannel::add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
+    faststring uncompressed_buffer;
+    vectorized::Chunk chunk;
+    if (request.has_chunk()) {
+        auto& pchunk = request.chunk();
+        RETURN_RESPONSE_IF_ERROR(_build_chunk_meta(pchunk), response);
+        RETURN_RESPONSE_IF_ERROR(_deserialize_chunk(pchunk, chunk, &uncompressed_buffer), response);
+        _add_chunk(&chunk, request, response);
+    } else {
+        _add_chunk(nullptr, request, response);
+    }
+}
+
+void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWriterAddBatchResult* response) {
+    // only support repeated chunks
+    if (!req.is_repeated_chunk() || !config::enable_load_colocate_mv) {
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        response->mutable_status()->add_error_msgs("server not support repeated chunk");
+        return;
+    }
+    faststring uncompressed_buffer;
+    std::unique_ptr<vectorized::Chunk> chunk;
+    for (int i = 0; i < req.requests_size(); i++) {
+        auto& request = req.requests(i);
+        VLOG_RPC << "tablet writer add chunk, id=" << print_id(request.id()) << ", index_id=" << request.index_id()
+                 << ", sender_id=" << request.sender_id() << " request_index=" << i << " eos=" << request.eos();
+
+        if (i == 0 && request.has_chunk()) {
+            chunk.reset(new vectorized::Chunk());
+            auto& pchunk = request.chunk();
+            RETURN_RESPONSE_IF_ERROR(_build_chunk_meta(pchunk), response);
+            RETURN_RESPONSE_IF_ERROR(_deserialize_chunk(pchunk, *chunk, &uncompressed_buffer), response);
+        }
+        _add_chunk(chunk.get(), request, response);
+
+        if (response->status().status_code() != TStatusCode::OK) {
+            LOG(WARNING) << "tablet writer add chunk, id=" << print_id(request.id())
+                         << ", index_id=" << request.index_id() << ", sender_id=" << request.sender_id()
+                         << " request_index=" << i << " eos=" << request.eos()
+                         << " err=" << response->status().error_msgs(0);
+            return;
+        }
+    }
 }
 
 void LoadChannel::cancel() {
@@ -117,4 +186,50 @@ std::shared_ptr<TabletsChannel> LoadChannel::get_tablets_channel(int64_t index_i
     return (it != _tablets_channels.end()) ? it->second : nullptr;
 }
 
+Status LoadChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
+    if (_has_chunk_meta.load(std::memory_order_acquire)) {
+        return Status::OK();
+    }
+    std::lock_guard l(_chunk_meta_lock);
+    if (_has_chunk_meta.load(std::memory_order_acquire)) {
+        return Status::OK();
+    }
+    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, pb_chunk);
+    if (!res.ok()) return res.status();
+    _chunk_meta = std::move(res).value();
+    _has_chunk_meta.store(true, std::memory_order_release);
+    return Status::OK();
+}
+
+Status LoadChannel::_deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk& chunk,
+                                       faststring* uncompressed_buffer) {
+    if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
+        TRY_CATCH_BAD_ALLOC({
+            serde::ProtobufChunkDeserializer des(_chunk_meta);
+            StatusOr<vectorized::Chunk> res = des.deserialize(pchunk.data());
+            if (!res.ok()) return res.status();
+            chunk = std::move(res).value();
+        });
+    } else {
+        size_t uncompressed_size = 0;
+        {
+            const BlockCompressionCodec* codec = nullptr;
+            RETURN_IF_ERROR(get_block_compression_codec(pchunk.compress_type(), &codec));
+            uncompressed_size = pchunk.uncompressed_size();
+            TRY_CATCH_BAD_ALLOC(uncompressed_buffer->resize(uncompressed_size));
+            Slice output{uncompressed_buffer->data(), uncompressed_size};
+            RETURN_IF_ERROR(codec->decompress(pchunk.data(), &output));
+        }
+        {
+            TRY_CATCH_BAD_ALLOC({
+                std::string_view buff(reinterpret_cast<const char*>(uncompressed_buffer->data()), uncompressed_size);
+                serde::ProtobufChunkDeserializer des(_chunk_meta);
+                StatusOr<vectorized::Chunk> res = des.deserialize(buff);
+                if (!res.ok()) return res.status();
+                chunk = std::move(res).value();
+            });
+        }
+    }
+    return Status::OK();
+}
 } // namespace starrocks

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -65,8 +65,9 @@ public:
     void open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response,
               google::protobuf::Closure* done);
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
+    void add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
+
+    void add_chunks(const PTabletWriterAddChunksRequest& request, PTabletWriterAddBatchResult* response);
 
     void cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest& request, PTabletWriterCancelResult* response,
                 google::protobuf::Closure* done);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -61,10 +61,10 @@ public:
 
     const TabletsChannelKey& key() const { return _key; }
 
-    Status open(const PTabletWriterOpenRequest& params) override;
+    Status open(const PTabletWriterOpenRequest& params, std::shared_ptr<OlapTableSchemaParam> schema) override;
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) override;
+    void add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                   PTabletWriterAddBatchResult* response) override;
 
     void cancel() override;
 
@@ -151,14 +151,11 @@ private:
 
     Status _open_all_writers(const PTabletWriterOpenRequest& params);
 
-    Status _build_chunk_meta(const ChunkPB& pb_chunk);
-
-    StatusOr<std::shared_ptr<WriteContext>> _create_write_context(const PTabletWriterAddChunkRequest& request,
+    StatusOr<std::shared_ptr<WriteContext>> _create_write_context(vectorized::Chunk* chunk,
+                                                                  const PTabletWriterAddChunkRequest& request,
                                                                   PTabletWriterAddBatchResult* response);
 
     int _close_sender(const int64_t* partitions, size_t partitions_size);
-
-    Status _deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk& chunk, faststring* uncompressed_buffer);
 
     LoadChannel* _load_channel;
 
@@ -169,8 +166,8 @@ private:
     // initialized in open function
     int64_t _txn_id = -1;
     int64_t _index_id = -1;
-    OlapTableSchemaParam* _schema = nullptr;
-    RowDescriptor* _row_desc = nullptr;
+    std::shared_ptr<OlapTableSchemaParam> _schema;
+    TupleDescriptor* _tuple_desc = nullptr;
 
     // next sequence we expect
     std::atomic<int> _num_remaining_senders;
@@ -179,10 +176,6 @@ private:
 
     mutable bthread::Mutex _partitions_ids_lock;
     std::unordered_set<int64_t> _partition_ids;
-
-    mutable bthread::Mutex _chunk_meta_lock;
-    serde::ProtobufChunkMeta _chunk_meta;
-    std::atomic<bool> _has_chunk_meta;
 
     std::unordered_map<int64_t, uint32_t> _tablet_id_to_sorted_indexes;
     // tablet_id -> TabletChannel
@@ -200,7 +193,6 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
           _load_channel(load_channel),
           _key(key),
           _mem_tracker(mem_tracker),
-          _has_chunk_meta(false),
           _mem_pool(std::make_unique<MemPool>()) {
     static std::once_flag once_flag;
     std::call_once(once_flag, [] {
@@ -210,17 +202,14 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
 
 LocalTabletsChannel::~LocalTabletsChannel() {
     _s_tablet_writer_count -= _delta_writers.size();
-    delete _row_desc;
-    delete _schema;
     _mem_pool.reset();
 }
 
-Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params) {
+Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params, std::shared_ptr<OlapTableSchemaParam> schema) {
     _txn_id = params.txn_id();
     _index_id = params.index_id();
-    _schema = new OlapTableSchemaParam();
-    RETURN_IF_ERROR(_schema->init(params.schema()));
-    _row_desc = new RowDescriptor(_schema->tuple_desc(), false);
+    _schema = schema;
+    _tuple_desc = _schema->tuple_desc();
 
     _num_remaining_senders.store(params.num_senders(), std::memory_order_release);
     _senders = std::vector<Sender>(params.num_senders());
@@ -229,10 +218,8 @@ Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params) {
     return Status::OK();
 }
 
-void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                                    PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
-    ClosureGuard done_guard(done);
-
+void LocalTabletsChannel::add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                                    PTabletWriterAddBatchResult* response) {
     auto t0 = std::chrono::steady_clock::now();
 
     if (UNLIKELY(!request.has_sender_id())) {
@@ -298,7 +285,7 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
         }
     }
 
-    auto res = _create_write_context(request, response);
+    auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
         res.status().to_protobuf(response->mutable_status());
         return;
@@ -310,7 +297,7 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
     }
 
     auto context = std::move(res).value();
-    auto channel_size = request.has_chunk() ? _tablet_id_to_sorted_indexes.size() : 0;
+    auto channel_size = chunk != nullptr ? _tablet_id_to_sorted_indexes.size() : 0;
     auto tablet_ids = request.tablet_ids().data();
     auto channel_row_idx_start_points = context->_channel_row_idx_start_points.get(); // May be a nullptr
     auto row_indexes = context->_row_indexes.get();                                   // May be a nullptr
@@ -331,7 +318,7 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
         auto& delta_writer = it->second;
 
         AsyncDeltaWriterRequest req;
-        req.chunk = &context->_chunk;
+        req.chunk = chunk;
         req.indexes = row_indexes + from;
         req.indexes_size = size;
         req.commit_after_write = false;
@@ -390,8 +377,13 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
         }
     }
 
+    int64_t last_execution_time_us = 0;
+    if (response->has_execution_time_us()) {
+        last_execution_time_us = response->execution_time_us();
+    }
     auto t1 = std::chrono::steady_clock::now();
-    response->set_execution_time_us(std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+    response->set_execution_time_us(last_execution_time_us +
+                                    std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
     response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
 
     if (close_channel) {
@@ -409,21 +401,6 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
         auto st = StorageEngine::instance()->txn_manager()->persist_tablet_related_txns(tablets);
         LOG_IF(WARNING, !st.ok()) << "failed to persist transactions: " << st;
     }
-}
-
-Status LocalTabletsChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
-    if (_has_chunk_meta.load(std::memory_order_acquire)) {
-        return Status::OK();
-    }
-    std::lock_guard l(_chunk_meta_lock);
-    if (_has_chunk_meta.load(std::memory_order_acquire)) {
-        return Status::OK();
-    }
-    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, pb_chunk);
-    if (!res.ok()) return res.status();
-    _chunk_meta = std::move(res).value();
-    _has_chunk_meta.store(true, std::memory_order_release);
-    return Status::OK();
 }
 
 int LocalTabletsChannel::_close_sender(const int64_t* partitions, size_t partitions_size) {
@@ -508,64 +485,24 @@ void LocalTabletsChannel::cancel() {
               << " tablet_ids:" << tablet_id_list_str;
 }
 
-Status LocalTabletsChannel::_deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk& chunk,
-                                               faststring* uncompressed_buffer) {
-    if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
-        TRY_CATCH_BAD_ALLOC({
-            serde::ProtobufChunkDeserializer des(_chunk_meta);
-            StatusOr<vectorized::Chunk> res = des.deserialize(pchunk.data());
-            if (!res.ok()) return res.status();
-            chunk = std::move(res).value();
-        });
-    } else {
-        [[maybe_unused]] size_t uncompressed_size;
-        {
-            const BlockCompressionCodec* codec = nullptr;
-            RETURN_IF_ERROR(get_block_compression_codec(pchunk.compress_type(), &codec));
-            uncompressed_size = pchunk.uncompressed_size();
-            TRY_CATCH_BAD_ALLOC(uncompressed_buffer->resize(uncompressed_size));
-            Slice output{uncompressed_buffer->data(), uncompressed_size};
-            RETURN_IF_ERROR(codec->decompress(pchunk.data(), &output));
-        }
-        {
-            TRY_CATCH_BAD_ALLOC({
-                std::string_view buff(reinterpret_cast<const char*>(uncompressed_buffer->data()), uncompressed_size);
-                serde::ProtobufChunkDeserializer des(_chunk_meta);
-                StatusOr<vectorized::Chunk> res = des.deserialize(buff);
-                if (!res.ok()) return res.status();
-                chunk = std::move(res).value();
-            });
-        }
-    }
-    return Status::OK();
-}
-
 StatusOr<std::shared_ptr<LocalTabletsChannel::WriteContext>> LocalTabletsChannel::_create_write_context(
-        const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
-    if (!request.has_chunk() && !request.eos()) {
+        vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
+    if (chunk == nullptr && !request.eos()) {
         return Status::InvalidArgument("PTabletWriterAddChunkRequest has no chunk or eos");
     }
 
     auto context = std::make_shared<WriteContext>(response);
 
-    if (!request.has_chunk()) {
+    if (chunk == nullptr) {
         return std::move(context);
     }
 
-    auto& pchunk = request.chunk();
-    RETURN_IF_ERROR(_build_chunk_meta(pchunk));
-
-    vectorized::Chunk& chunk = context->_chunk;
-
-    faststring uncompressed_buffer;
-    RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk, &uncompressed_buffer));
-
-    if (UNLIKELY(request.tablet_ids_size() != chunk.num_rows())) {
+    if (UNLIKELY(request.tablet_ids_size() != chunk->num_rows())) {
         return Status::InvalidArgument("request.tablet_ids_size() != chunk.num_rows()");
     }
 
     const auto channel_size = _tablet_id_to_sorted_indexes.size();
-    context->_row_indexes = std::make_unique<uint32_t[]>(chunk.num_rows());
+    context->_row_indexes = std::make_unique<uint32_t[]>(chunk->num_rows());
     context->_channel_row_idx_start_points = std::make_unique<uint32_t[]>(channel_size + 1);
 
     auto& row_indexes = context->_row_indexes;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -5,7 +5,9 @@
 #include <sstream>
 #include <string>
 
+#include "column/chunk.h"
 #include "common/status.h"
+#include "exec/tablet_info.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/types.pb.h"
 #include "gutil/ref_counted.h"
@@ -32,10 +34,11 @@ public:
     TabletsChannel() = default;
     virtual ~TabletsChannel() = default;
 
-    [[nodiscard]] virtual Status open(const PTabletWriterOpenRequest& params) = 0;
+    [[nodiscard]] virtual Status open(const PTabletWriterOpenRequest& params,
+                                      std::shared_ptr<OlapTableSchemaParam> schema) = 0;
 
-    virtual void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
-                           PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) = 0;
+    virtual void add_chunk(vectorized::Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+                           PTabletWriterAddBatchResult* response) = 0;
 
     virtual void cancel() = 0;
 };

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -207,6 +207,15 @@ void PInternalServiceImplBase<T>::tablet_writer_add_chunk(google::protobuf::RpcC
 }
 
 template <typename T>
+void PInternalServiceImplBase<T>::tablet_writer_add_chunks(google::protobuf::RpcController* cntl_base,
+                                                           const PTabletWriterAddChunksRequest* request,
+                                                           PTabletWriterAddBatchResult* response,
+                                                           google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
+
+template <typename T>
 void PInternalServiceImplBase<T>::tablet_writer_cancel(google::protobuf::RpcController* cntl_base,
                                                        const PTabletWriterCancelRequest* request,
                                                        PTabletWriterCancelResult* response,

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -85,6 +85,10 @@ public:
                                  const PTabletWriterAddChunkRequest* request, PTabletWriterAddBatchResult* response,
                                  google::protobuf::Closure* done) override;
 
+    void tablet_writer_add_chunks(google::protobuf::RpcController* controller,
+                                  const PTabletWriterAddChunksRequest* request, PTabletWriterAddBatchResult* response,
+                                  google::protobuf::Closure* done) override;
+
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override;
 

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -63,10 +63,19 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::Rp
                                                             const PTabletWriterAddChunkRequest* request,
                                                             PTabletWriterAddBatchResult* response,
                                                             google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
     VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", sender_id=" << request->sender_id();
-    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(static_cast<brpc::Controller*>(cntl_base),
-                                                                          *request, response, done);
+    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(*request, response);
+}
+
+template <typename T>
+void BackendInternalServiceImpl<T>::tablet_writer_add_chunks(google::protobuf::RpcController* cntl_base,
+                                                             const PTabletWriterAddChunksRequest* request,
+                                                             PTabletWriterAddBatchResult* response,
+                                                             google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*request, response);
 }
 
 template <typename T>

--- a/be/src/service/service_be/internal_service.h
+++ b/be/src/service/service_be/internal_service.h
@@ -50,6 +50,10 @@ public:
                                  const PTabletWriterAddChunkRequest* request, PTabletWriterAddBatchResult* response,
                                  google::protobuf::Closure* done) override;
 
+    void tablet_writer_add_chunks(google::protobuf::RpcController* controller,
+                                  const PTabletWriterAddChunksRequest* request, PTabletWriterAddBatchResult* response,
+                                  google::protobuf::Closure* done) override;
+
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override;
 };

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -45,5 +45,6 @@ service PBackendService {
     // Transmit vectorized data between backends
     rpc transmit_chunk(starrocks.PTransmitChunkParams) returns (starrocks.PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc transmit_runtime_filter(starrocks.PTransmitRuntimeFilterParams) returns (starrocks.PTransmitRuntimeFilterResult);
 };

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -147,6 +147,7 @@ message PTabletWriterOpenRequest {
 
 message PTabletWriterOpenResult {
     required StatusPB status = 1;
+    optional bool is_repeated_chunk = 2 [default = false];
 };
 
 // Add batch to tablet writer.
@@ -184,6 +185,14 @@ message PTabletWriterAddChunkRequest {
     repeated int64 partition_ids = 8;
     optional int64 txn_id = 9;
 };
+
+message PTabletWriterAddChunksRequest {
+    optional PUniqueId id = 1;
+    repeated PTabletWriterAddChunkRequest requests = 2;
+    // all request's chunk are repeated if true
+    // only first request's chunk will be set
+    optional bool is_repeated_chunk = 3 [default = false];
+}
 
 message PTabletWriterAddBatchResult {
     required StatusPB status = 1;
@@ -330,6 +339,7 @@ service PInternalService {
     // Transmit vectorized data between backends.
     rpc transmit_chunk(PTransmitChunkParams) returns (PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns (PTransmitRuntimeFilterResult);
 };
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7717

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When a table has multiple materialized views, StarRocks will send the chunks to the tablets corresponding to the materialized views, which leads to the enlargement of network transmission bandwidth and unnecessary data serialization and transmission overhead. Since the materialized view and the base table use the same partition column and distribute in the same node when using `colocate mv` #7451, we can reuse the chunk data of the base table.


| materialized index num| main branch | optimize branch|SpeedUp|
|---|---|---|---|
|0|1314MB/s|1310MB/s||
|1|780MB/s|1274Mb/s|1.6x|
|3|420MB/s|1241MB/s|2.9x|
| 5 |286MB/s |1213MB/s|4.2x|

> using [github_events](https://ghe.clickhouse.tech/) data, 16 parallel
> 3 BE with 1.5GB/s network bandwidth
> create two columns of materialized view; materialized view computation is relatively small; ensure the bottleneck is network bandwidth and serialization.

`NOTE` We will enable it after colocate mv index implementation.