### PR TITLE
[Cherry-Pick-2.3][BugFix] fix the npe bug when replaying the tablet consistency check data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MetaObject;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
@@ -231,7 +232,7 @@ public class ConsistencyChecker extends MasterDaemon {
      * we use a priority queue to sort db/table/partition/index/tablet by 'lastCheckTime'.
      * chose a tablet which has the smallest 'lastCheckTime'.
      */
-    private List<Long> chooseTablets() {
+    protected List<Long> chooseTablets() {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         MetaObject chosenOne = null;
 
@@ -266,7 +267,12 @@ public class ConsistencyChecker extends MasterDaemon {
                     List<Table> tables = db.getTables();
                     Queue<MetaObject> tableQueue = new PriorityQueue<>(Math.max(tables.size(), 1), COMPARATOR);
                     for (Table table : tables) {
-                        if (table.getType() != TableType.OLAP) {
+                        // Only check the OLAP table who is in NORMAL state.
+                        // Because some tablets of the not NORMAL table may just a temporary presence in memory,
+                        // if we check those tablets and log FinishConsistencyCheck to bdb,
+                        // it will throw NullPointerException when replaying the log.
+                        if (table.getType() != TableType.OLAP
+                                || ((OlapTable) table).getState() != OlapTableState.NORMAL) {
                             continue;
                         }
                         tableQueue.add(table);

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -1,0 +1,77 @@
+package com.starrocks.consistency;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConsistencyCheckerTest {
+
+    @Test
+    public void testChooseTablets(@Mocked GlobalStateMgr globalStateMgr) {
+        long dbId = 1L;
+        long tableId = 2L;
+        long partitionId = 3L;
+        long indexId = 4L;
+        long tabletId = 5L;
+        long replicaId = 6L;
+        long backendId = 7L;
+        TStorageMedium medium = TStorageMedium.HDD;
+
+        MaterializedIndex materializedIndex = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Replica replica = new Replica(replicaId, backendId, 2L, 1111,
+                10, 1000, Replica.ReplicaState.NORMAL, -1, 2);
+
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 1111, medium);
+        LocalTablet tablet = new LocalTablet(tabletId, Lists.newArrayList(replica));
+        materializedIndex.addTablet(tablet, tabletMeta, true);
+        PartitionInfo partitionInfo = new PartitionInfo();
+        DataProperty dataProperty = new DataProperty(medium);
+        partitionInfo.addPartition(partitionId, dataProperty, (short) 3, false);
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, Lists.newArrayList());
+        Partition partition = new Partition(partitionId, "partition", materializedIndex, distributionInfo);
+        partition.setVisibleVersion(2L, System.currentTimeMillis());
+        OlapTable table = new OlapTable(tableId, "table", Lists.newArrayList(), KeysType.AGG_KEYS, partitionInfo,
+                distributionInfo);
+        table.addPartition(partition);
+        Database database = new Database(dbId, "database");
+        database.createTable(table);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getDbIds();
+                result = Lists.newArrayList(dbId);
+                minTimes = 0;
+
+                globalStateMgr.getDb(dbId);
+                result = database;
+                minTimes = 0;
+            }
+        };
+
+        Assert.assertEquals(1, new ConsistencyChecker().chooseTablets().size());
+
+        // set table state to RESTORE, we will make sure checker will not choose its tablets.
+        table.setState(OlapTable.OlapTableState.RESTORE);
+        Assert.assertEquals(0, new ConsistencyChecker().chooseTablets().size());
+    }
+}


### PR DESCRIPTION
Only check the OLAP table who is in NORMAL state. Because some tablets of the not NORMAL table may just a temporary presence in memory, if we check those tablets and log FinishConsistencyCheck to bdb, it will throw NullPointerException when replaying the log.