### PR TITLE
[BugFix] Fix throw ConcurrentModificationException use partition range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -23,6 +23,7 @@ package com.starrocks.planner;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
@@ -45,14 +46,14 @@ import java.util.Set;
 public class RangePartitionPruner implements PartitionPruner {
     private static final Logger LOG = LogManager.getLogger(RangePartitionPruner.class);
 
-    private Map<Long, Range<PartitionKey>> partitionRangeMap;
-    private List<Column> partitionColumns;
-    private Map<String, PartitionColumnFilter> partitionColumnFilters;
+    private final Map<Long, Range<PartitionKey>> partitionRangeMap;
+    private final List<Column> partitionColumns;
+    private final Map<String, PartitionColumnFilter> partitionColumnFilters;
 
     public RangePartitionPruner(Map<Long, Range<PartitionKey>> rangeMap,
                                 List<Column> columns,
                                 Map<String, PartitionColumnFilter> filters) {
-        partitionRangeMap = rangeMap;
+        partitionRangeMap = Maps.newHashMap(rangeMap);
         partitionColumns = columns;
         partitionColumnFilters = filters;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
```
java.util.ConcurrentModificationException
	at com.starrocks.planner.RangePartitionPruner.prune(RangePartitionPruner.java:189)
	at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRule.partitionPrune(PartitionPruneRule.java:93)
	at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRule.transform(PartitionPruneRule.java:57)
	at com.starrocks.sql.optimizer.task.TopDownRewriteTask.doExecute(TopDownRewriteTask.java:49)
	at com.starrocks.sql.optimizer.task.TopDownRewriteOnceTask.execute(TopDownRewriteOnceTask.java:31)
	at com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:42)
	at com.starrocks.sql.optimizer.Optimizer.ruleRewriteOnlyOnce(Optimizer.java:339)
	at com.starrocks.sql.optimizer.Optimizer.logicalRuleRewrite(Optimizer.java:258)
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:88)
	at com.starrocks.utframe.UtFrameUtils.getQueryExecPlan(UtFrameUtils.java:467)
	at com.starrocks.utframe.UtFrameUtils.getNewPlanAndFragmentFromDump(UtFrameUtils.java:496)
	at com.starrocks.sql.plan.ReplayFromDumpTest.getPlanFragment(ReplayFromDumpTest.java:136)
	at com.starrocks.sql.plan.ReplayFromDumpTest.testMultiCountDistinct(ReplayFromDumpTest.java:319)
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`keyRangeById = partitionInfo.getIdToRange(false);`

keyRangeById from partition meta, maybe change when modify partition

```
    private List<Long> partitionPrune(OlapTable olapTable, RangePartitionInfo partitionInfo,
                                      LogicalOlapScanOperator operator) {
        Map<Long, Range<PartitionKey>> keyRangeById;
        if (operator.getPartitionNames() != null) {
            keyRangeById = Maps.newHashMap();
            for (String partName : operator.getPartitionNames().getPartitionNames()) {
                Partition part = olapTable.getPartition(partName, operator.getPartitionNames().isTemp());
                if (part == null) {
                    continue;
                }
                keyRangeById.put(part.getId(), partitionInfo.getRange(part.getId()));
            }
        } else {
            keyRangeById = partitionInfo.getIdToRange(false);
        }
        PartitionPruner partitionPruner = new RangePartitionPruner(keyRangeById,
                partitionInfo.getPartitionColumns(), operator.getColumnFilters());
        try {

```