### PR TITLE
[BugFix] Fix throw ConcurrentModificationException use partition range

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -34,6 +34,7 @@ import com.starrocks.analysis.SqlScanner;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.AnalysisException;
@@ -50,6 +51,7 @@ import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
@@ -488,10 +490,15 @@ public class UtFrameUtils {
     public static Pair<String, ExecPlan> getNewPlanAndFragmentFromDump(ConnectContext connectContext,
                                                                        QueryDumpInfo replayDumpInfo) throws Exception {
         String replaySql = initMockEnv(connectContext, replayDumpInfo);
+        Map<String, Database> dbs = null;
         try {
             StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(replaySql,
                     connectContext.getSessionVariable().getSqlMode()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, connectContext);
+
+            dbs = AnalyzerUtils.collectAllDatabase(connectContext, statementBase);
+            lock(dbs);
+
             if (statementBase instanceof QueryStatement) {
                 return getQueryExecPlan((QueryStatement) statementBase, connectContext);
             } else if (statementBase instanceof InsertStmt) {
@@ -501,6 +508,7 @@ public class UtFrameUtils {
                 return null;
             }
         } finally {
+            unLock(dbs);
             tearMockEnv();
         }
     }
@@ -527,5 +535,25 @@ public class UtFrameUtils {
 
     public static String getPlanThriftString(ConnectContext ctx, String queryStr) throws Exception {
         return UtFrameUtils.getThriftString(UtFrameUtils.getPlanAndFragment(ctx, queryStr).second.getFragments());
+    }
+
+    // Lock all database before analyze
+    private static void lock(Map<String, Database> dbs) {
+        if (dbs == null) {
+            return;
+        }
+        for (Database db : dbs.values()) {
+            db.readLock();
+        }
+    }
+
+    // unLock all database after analyze
+    private static void unLock(Map<String, Database> dbs) {
+        if (dbs == null) {
+            return;
+        }
+        for (Database db : dbs.values()) {
+            db.readUnlock();
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

```
java.util.ConcurrentModificationException
	at com.starrocks.planner.RangePartitionPruner.prune(RangePartitionPruner.java:189)
	at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRule.partitionPrune(PartitionPruneRule.java:93)
	at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRule.transform(PartitionPruneRule.java:57)
	at com.starrocks.sql.optimizer.task.TopDownRewriteTask.doExecute(TopDownRewriteTask.java:49)
	at com.starrocks.sql.optimizer.task.TopDownRewriteOnceTask.execute(TopDownRewriteOnceTask.java:31)
	at com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:42)
	at com.starrocks.sql.optimizer.Optimizer.ruleRewriteOnlyOnce(Optimizer.java:339)
	at com.starrocks.sql.optimizer.Optimizer.logicalRuleRewrite(Optimizer.java:258)
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:88)
	at com.starrocks.utframe.UtFrameUtils.getQueryExecPlan(UtFrameUtils.java:467)
	at com.starrocks.utframe.UtFrameUtils.getNewPlanAndFragmentFromDump(UtFrameUtils.java:496)
	at com.starrocks.sql.plan.ReplayFromDumpTest.getPlanFragment(ReplayFromDumpTest.java:136)
	at com.starrocks.sql.plan.ReplayFromDumpTest.testMultiCountDistinct(ReplayFromDumpTest.java:319)
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
