### PR TITLE
[Bugfix] fix decimal overflow problem in Sum and Add

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -141,8 +141,30 @@ public class ArithmeticExpr extends Expr {
         }
     }
 
+    public static void getAddReturnTypeOfDecimal(TypeTriple triple, ScalarType lhsType, ScalarType rhsType) {
+        final int lhsPrecision = lhsType.getPrecision();
+        final int rhsPrecision = rhsType.getPrecision();
+        final int lhsScale = lhsType.getScalarScale();
+        final int rhsScale = rhsType.getScalarScale();
+
+        // decimal(p1, s1) - decimal(p2, s2)
+        //  result type = decimal(max(p1 - s1, p2 - s2) + max(s1, s2), max(s1, s2)) + 1
+        int maxIntLength = Math.max(lhsPrecision - lhsScale, rhsPrecision - rhsScale);
+        int retPrecision = maxIntLength + Math.max(lhsScale, rhsScale) + 1;
+        int retScale = Math.max(lhsScale, rhsScale);
+        // precision
+        retPrecision = Math.min(retPrecision, 38);
+        PrimitiveType decimalType = PrimitiveType.getDecimalPrimitiveType(retPrecision);
+        decimalType = PrimitiveType.getWiderDecimalV3Type(decimalType, lhsType.getPrimitiveType());
+        decimalType = PrimitiveType.getWiderDecimalV3Type(decimalType, rhsType.getPrimitiveType());
+
+        triple.lhsTargetType = ScalarType.createDecimalV3Type(decimalType, retPrecision, lhsScale);
+        triple.rhsTargetType = ScalarType.createDecimalV3Type(decimalType, retPrecision, rhsScale);
+        triple.returnType = ScalarType.createDecimalV3Type(decimalType, retPrecision, retScale);
+    }
+
     public static TypeTriple getReturnTypeOfDecimal(Operator op, ScalarType lhsType, ScalarType rhsType)
-            throws AnalysisException {
+            throws SemanticException {
         Preconditions.checkState(lhsType.isDecimalV3() && rhsType.isDecimalV3(),
                 "Types of lhs and rhs must be DecimalV3");
         final PrimitiveType lhsPtype = lhsType.getPrimitiveType();
@@ -165,6 +187,8 @@ public class ArithmeticExpr extends Expr {
         int returnPrecision = 0;
         switch (op) {
             case ADD:
+                getAddReturnTypeOfDecimal(result, lhsType, rhsType);
+                return result;
             case SUBTRACT:
             case MOD:
                 returnScale = Math.max(lhsScale, rhsScale);
@@ -202,7 +226,7 @@ public class ArithmeticExpr extends Expr {
                     return result;
                 } else {
                     // returnScale > 38, so it is cannot be represented as decimal.
-                    throw new AnalysisException(
+                    throw new SemanticException(
                             String.format(
                                     "Return scale(%d) exceeds maximum value(%d), please cast decimal type to low-precision one",
                                     returnScale, maxDecimalPrecision));
@@ -222,7 +246,7 @@ public class ArithmeticExpr extends Expr {
                 result.rhsTargetType = ScalarType.createDecimalV3Type(widerType, maxPrecision, rhsScale);
                 int adjustedScale = returnScale + rhsScale;
                 if (adjustedScale > maxPrecision) {
-                    throw new AnalysisException(
+                    throw new SemanticException(
                             String.format(
                                     "Dividend fails to adjust scale to %d that exceeds maximum value(%d)",
                                     adjustedScale,
@@ -247,6 +271,12 @@ public class ArithmeticExpr extends Expr {
     private void rewriteDecimalDecimalOperation() throws AnalysisException {
         final Type lhsOriginType = getChild(0).type;
         final Type rhsOriginType = getChild(1).type;
+        // TODO:
+
+        if (getChild(0).isImplicitCast() && getChild(1).isImplicitCast()) {
+            return;
+        }
+
         Type lhsTargetType = lhsOriginType;
         Type rhsTargetType = rhsOriginType;
 
@@ -613,9 +643,9 @@ public class ArithmeticExpr extends Expr {
     }
 
     public static class TypeTriple {
-        ScalarType returnType;
-        ScalarType lhsTargetType;
-        ScalarType rhsTargetType;
+        public ScalarType returnType;
+        public ScalarType lhsTargetType;
+        public ScalarType rhsTargetType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -317,6 +317,19 @@ public enum PrimitiveType {
         }
     }
 
+    public static PrimitiveType getDecimalPrimitiveType(int precision) {
+        PrimitiveType type = INVALID_TYPE;
+        if (precision > 0 && precision <= getMaxPrecisionOfDecimal(DECIMAL32)) {
+            return DECIMAL32;
+        } else if (precision <= getMaxPrecisionOfDecimal(DECIMAL64)) {
+            return DECIMAL64;
+        } else if (precision <= getMaxPrecisionOfDecimal(DECIMAL128)) {
+            return DECIMAL128;
+        }
+        Preconditions.checkState(type.isDecimalOfAnyVersion());
+        return type;
+    }
+
     public void setTimeType() {
         isTimeType = true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -20,24 +20,24 @@ import java.util.Set;
 
 public class DecimalV3FunctionAnalyzer {
     public static final Set<String> DECIMAL_UNARY_FUNCTION_SET =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .add(FunctionSet.ABS).add(FunctionSet.POSITIVE).add(FunctionSet.NEGATIVE)
                     .add(FunctionSet.MONEY_FORMAT).build();
 
     public static final Set<String> DECIMAL_IDENTICAL_TYPE_FUNCTION_SET =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .add(FunctionSet.LEAST).add(FunctionSet.GREATEST).add(FunctionSet.NULL_IF)
                     .add(FunctionSet.IF_NULL).add(FunctionSet.COALESCE).add(FunctionSet.MOD).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_SAME_TYPE =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .add(FunctionSet.MAX).add(FunctionSet.MIN)
                     .add(FunctionSet.LEAD).add(FunctionSet.LAG)
                     .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE)
                     .add(FunctionSet.ANY_VALUE).add(FunctionSet.ARRAY_AGG).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_WIDER_TYPE =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .add(FunctionSet.COUNT).add(FunctionSet.SUM).add(FunctionSet.SUM_DISTINCT)
                     .add(FunctionSet.MULTI_DISTINCT_SUM).add(FunctionSet.AVG).add(FunctionSet.VARIANCE)
                     .add(FunctionSet.VARIANCE_POP).add(FunctionSet.VAR_POP).add(FunctionSet.VARIANCE_SAMP)
@@ -45,7 +45,7 @@ public class DecimalV3FunctionAnalyzer {
                     .add(FunctionSet.STDDEV_SAMP).build();
 
     public static final Set<String> DECIMAL_AGG_VARIANCE_STDDEV_TYPE =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .add(FunctionSet.VARIANCE).add(FunctionSet.VARIANCE_POP).add(FunctionSet.VAR_POP)
                     .add(FunctionSet.VARIANCE_SAMP).add(FunctionSet.VAR_SAMP).add(FunctionSet.STD)
                     .add(FunctionSet.STDDEV).add(FunctionSet.STDDEV_POP).add(FunctionSet.STDDEV_SAMP).build();
@@ -55,7 +55,7 @@ public class DecimalV3FunctionAnalyzer {
                     .add(FunctionSet.SUM_DISTINCT).add(FunctionSet.MULTI_DISTINCT_SUM).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            new ImmutableSortedSet.Builder<>(String::compareTo)
                     .addAll(DECIMAL_AGG_FUNCTION_SAME_TYPE)
                     .addAll(DECIMAL_AGG_FUNCTION_WIDER_TYPE).build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -51,7 +51,7 @@ public class DecimalV3FunctionAnalyzer {
                     .add(FunctionSet.STDDEV).add(FunctionSet.STDDEV_POP).add(FunctionSet.STDDEV_SAMP).build();
 
     public static final Set<String> DECIMAL_SUM_FUNCTION_TYPE =
-            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER).add(FunctionSet.SUM)
+            new ImmutableSortedSet.Builder<>(String::compareTo).add(FunctionSet.SUM)
                     .add(FunctionSet.SUM_DISTINCT).add(FunctionSet.MULTI_DISTINCT_SUM).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION =

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
@@ -3,6 +3,7 @@ package com.starrocks.analysis;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,13 +22,13 @@ public class ArithmeticExprTest {
         ArithmeticExpr addExpr = new ArithmeticExpr(
                 ArithmeticExpr.Operator.ADD, lhsExpr, rhsExpr);
         try {
-            ScalarType decimal64p18s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2);
+            ScalarType decimal64p10s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
             addExpr.analyzeImpl(null);
-            Assert.assertEquals(addExpr.type, decimal64p18s2);
+            Assert.assertEquals(addExpr.type, decimal64p10s2);
             Assert.assertTrue(addExpr.getChild(0) instanceof CastExpr);
             Assert.assertTrue(addExpr.getChild(1) instanceof CastExpr);
-            Assert.assertEquals(addExpr.getChild(0).type, decimal64p18s2);
-            Assert.assertEquals(addExpr.getChild(1).type, decimal64p18s2);
+            Assert.assertEquals(addExpr.getChild(0).type, decimal64p10s2);
+            Assert.assertEquals(addExpr.getChild(1).type, decimal64p10s2);
         } catch (AnalysisException e) {
             Assert.fail("Should not throw exception");
         }
@@ -147,7 +148,7 @@ public class ArithmeticExprTest {
             try {
                 ArithmeticExpr.getReturnTypeOfDecimal(ArithmeticExpr.Operator.MULTIPLY, lhsType, rhsType);
                 Assert.fail("should throw exception");
-            } catch (AnalysisException ignored) {
+            } catch (SemanticException ignored) {
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -46,7 +46,13 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         starRocksAssert.withTable("CREATE TABLE `test_decimal_type6` (\n" +
                 "  `dec_1_2` decimal32(2, 1) NOT NULL COMMENT \"\",\n" +
                 "  `dec_18_0` decimal64(18, 0) NOT NULL COMMENT \"\",\n" +
-                "  `dec_18_18` decimal64(18, 18) NOT NULL COMMENT \"\"\n" +
+                "  `dec_18_18` decimal64(18, 18) NOT NULL COMMENT \"\",\n" +
+                "  `dec_10_2` decimal64(10, 2) NOT NULL COMMENT \"\",\n" +
+                "  `dec_12_10` decimal64(12, 10) NOT NULL COMMENT \"\",\n" +
+                "   dec_20_3 decimal128(20, 3),\n" +
+                "   dec_20_19 decimal128(20, 19)," +
+                "   dec_4_2 decimal64(4, 2),\n" +
+                "   dec_5_1 decimal64(5, 1)\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`dec_1_2`)\n" +
                 "COMMENT \"OLAP\"\n" +
@@ -95,7 +101,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String sql = " select  if(1, cast('3.14' AS decimal32(9, 2)), cast('1.9999' AS decimal32(5, 4))) " +
                 "AS res0 from db1.decimal_table;";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
-        System.out.println(thrift);
         Assert.assertTrue(thrift.contains(
                 "type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))"));
 
@@ -141,7 +146,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                         "integer_value:3A 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00), output_scale:-1, has_nullable_child:false, " +
                         "is_nullable:false, is_monotonic:true)])})";
         String plan = UtFrameUtils.getPlanThriftString(ctx, sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains(expectString));
     }
 
@@ -177,7 +181,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalInPredicates() throws Exception {
         String sql = "select * from db1.decimal_table where col_decimal64p13s0 in (0, 1, 9999, -9.223372E+18)";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        System.out.println(plan);
         String snippet = "CAST(3: col_decimal64p13s0 AS DECIMAL128(19,0))" +
                 " IN (0, 1, 9999, -9223372000000000000)";
         Assert.assertTrue(plan.contains(snippet));
@@ -187,7 +190,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalBetweenPredicates() throws Exception {
         String sql = "select * from db1.decimal_table where col_decimal64p13s0 between -9.223372E+18 and 9.223372E+18";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        System.out.println(plan);
         String snippet = "cast([3: col_decimal64p13s0, DECIMAL64(13,0), false] as DECIMAL128(19,0)) " +
                 ">= -9223372000000000000, " +
                 "cast([3: col_decimal64p13s0, DECIMAL64(13,0), false] as DECIMAL128(19,0)) " +
@@ -220,6 +222,10 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String snippet =
                 "sum[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); args: DECIMAL128; result: DECIMAL128(38,3)";
         Assert.assertTrue(plan.contains(snippet));
+
+        sql = "select sum(dec_20_19) from test_decimal_type6";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains("sum[(cast([7: dec_20_19, DECIMAL128(20,19), true] as DECIMAL128(38,18))); args: DECIMAL128; result: DECIMAL128(38,18); args nullable: true; result nullable: true]"));
     }
 
     @Test
@@ -304,7 +310,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalAddNULL() throws Exception {
         String sql = "select col_decimal32p9s2 + NULL from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) + NULL";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(10,2)) + NULL";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -320,7 +326,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalMulNULL() throws Exception {
         String sql = "select col_decimal32p9s2 * NULL from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        System.out.println(plan);
         String snippet = "6 <-> [2: col_decimal32p9s2, DECIMAL32(9,2), false] * NULL";
         Assert.assertTrue(plan.contains(snippet));
     }
@@ -361,8 +366,36 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalAddZero() throws Exception {
         String sql = "select col_decimal32p9s2 + 0.0 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) + 0";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(10,2)) + 0";
         Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalAddRule() throws Exception {
+        String sql;
+        String plan;
+
+        // decimal(10, 2) + decimal(10, 2) = decimal(11, 2)
+        sql = "select count(`dec_10_2` + dec_10_2) from `test_decimal_type6`;";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains("[12: cast, DECIMAL64(11,2), true] + [12: cast, DECIMAL64(11,2), true]"));
+
+        sql = "select count(`dec_10_2` + dec_12_10) from `test_decimal_type6`;";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        // decimal64(10, 2) + decimal64(12, 10) = decimal128(21, 10);
+        Assert.assertTrue(plan.contains("cast([4: dec_10_2, DECIMAL64(10,2), false] as DECIMAL128(19,2)) + cast([5: dec_12_10, DECIMAL64(12,10), false] as DECIMAL128(19,10))"));
+        // decimal64(18, 0) + decimal64(18, 18) = decimal(37, 18)
+        sql = "select count(dec_18_0 + dec_18_18) from `test_decimal_type6`";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains("cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
+        // const decimal64(18, 0) + decimal64(18, 18) = decimal128(37, 18) literal
+        sql = "select cast(1000000000000000000 as decimal(18, 0)) + cast(0.000000000000000001 as decimal(18, 18))";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains(" 2 <-> 1000000000000000000.000000000000000001"));
+
+        sql = "select dec_1_2 + dec_1_2 from test_decimal_type6";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains("[11: cast, DECIMAL32(3,1), true] + [11: cast, DECIMAL32(3,1), true]"));
     }
 
     @Test
@@ -377,7 +410,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalMulZero() throws Exception {
         String sql = "select col_decimal32p9s2 * 0.0 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        System.out.println(plan);
         String snippet = "6 <-> [2: col_decimal32p9s2, DECIMAL32(9,2), false] * 0";
         Assert.assertTrue(plan.contains(snippet));
     }
@@ -422,18 +454,18 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         // test decimal count(no-nullable decimal)
         sql = "select count(`dec_18_0`) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        System.out.println("plan = " + plan);
         Assert.assertTrue(plan.contains("aggregate: count[([2: dec_18_0, DECIMAL64(18,0), false]); args: DECIMAL64; result: BIGINT; args nullable: false; result nullable: true]"));
 
         // test decimal add return a nullable column
         sql = "select count(`dec_18_0` + `dec_18_18`) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("aggregate: count[([4: expr, DECIMAL64(18,18), true]); args: DECIMAL64; result: BIGINT; args nullable: true; result nullable: true]"));
+        Assert.assertTrue(plan.contains("cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
 
         // test decimal input function input no-nullable, output is nullable
         sql = "select round(`dec_18_0`) from `test_decimal_type6`";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("  |  4 <-> round[(cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(18,0))); args: DECIMAL128; result: DECIMAL128(38,0); args nullable: true; result nullable: true]"));
+        System.out.println("plan = " + plan);
+        Assert.assertTrue(plan.contains("round[(cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(18,0))); args: DECIMAL128; result: DECIMAL128(38,0); args nullable: true; result nullable: true]"));
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -98,7 +98,7 @@ public class AnalyzeDecimalV3Test {
         List<Expr> items = ((SelectRelation) queryRelation).getOutputExpr();
         Assert.assertTrue(items.size() == 2 && items.get(1) != null);
         Type type = items.get(1).getType();
-        Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2));
+        Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
     }
 
     @Test
@@ -218,13 +218,13 @@ public class AnalyzeDecimalV3Test {
         Type[] expectArgTypes = Arrays.asList(
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
         ).toArray(new Type[0]);
 
         Type[] expectReturnTypes = Arrays.asList(
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 4),
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
         ).toArray(new Type[0]);
         Assert.assertTrue(items.size() == 9);
         Assert.assertTrue(expectArgTypes.length == 3);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -136,8 +136,9 @@ public class ExpressionTest extends PlanTestBase {
     public void testExpression6() throws Exception {
         String sql = "select cast(v1 as decimal64(7,2)) + cast(v2 as decimal64(9,3)) from t0";
         String planFragment = getFragmentPlan(sql);
+        System.out.println("planFragment = " + planFragment);
         Assert.assertTrue(planFragment.contains("  1:Project\n" +
-                "  |  <slot 4> : CAST(CAST(1: v1 AS DECIMAL64(7,2)) AS DECIMAL64(18,2)) + CAST(CAST(2: v2 AS DECIMAL64(9,3)) AS DECIMAL64(18,3))\n"));
+                "  |  <slot 4> : CAST(CAST(1: v1 AS DECIMAL64(7,2)) AS DECIMAL64(10,2)) + CAST(CAST(2: v2 AS DECIMAL64(9,3)) AS DECIMAL64(10,3))\n"));
     }
 
     @Test
@@ -971,7 +972,7 @@ public class ExpressionTest extends PlanTestBase {
         String sql = "select id_decimal + 1, id_decimal + 2 from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "common expressions:\n" +
-                "  |  <slot 13> : CAST(10: id_decimal AS DECIMAL64(18,2))");
+                "  |  <slot 13> : CAST(10: id_decimal AS DECIMAL64(12,2))");
 
         sql = "select concat(cast(t1c as varchar(10)), 'a'), concat(cast(t1c as varchar(10)), 'b') from test_all_type";
         plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SmallestTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SmallestTypeTest.java
@@ -65,7 +65,7 @@ public class SmallestTypeTest extends PlanTestBase {
         sql = "select id_decimal + 1 from test_all_type";
         planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  1:Project\n" +
-                "  |  <slot 11> : CAST(10: id_decimal AS DECIMAL64(18,2)) + 1\n" +
+                "  |  <slot 11> : CAST(10: id_decimal AS DECIMAL64(12,2)) + 1\n" +
                 "  |  "));
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #7078

## Problem Summary(Required) ：

Before this commit, our decimal rule was decimal(a, b) + decimal(c, d) = decimal(max(a, b), max(c, d)), but that could lead to some potential overflow problems, especially if the scale is large, e.g. decimal(18, 0) + decimal(18, 18) = decimal(18, 18).

This PR adjusts the decimal addition rules a bit. It keeps the result as accurate as possible while avoiding overflow
decimal(p1, s1)+decimal(p2,s2) = decimal(max(p1-s1, p2-s2)+1+max(s1,s2), max(s1, s2))
so the result of decimal(18, 0) + decimal(18, 18) is decimal(37, 18).

For the behavior of the aggregation function sum, we take a fixed scale if scale is too big
Sum(Decimal(a, b)) -> Sum(Decimal(38, min(b, 18)))
