### PR TITLE
[Enhancement] set query context expired timeout to query_delivery_timeout

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -60,7 +60,6 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFr
     const auto& params = request.params;
     const auto& query_id = params.query_id;
     const auto& fragment_instance_id = params.fragment_instance_id;
-    const auto& query_options = request.query_options;
 
     auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (existing_query_ctx) {
@@ -75,12 +74,8 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFr
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);
     }
-    if (query_options.__isset.query_timeout) {
-        _query_ctx->set_expire_seconds(std::max<int>(query_options.query_timeout, 1));
-    } else {
-        _query_ctx->set_expire_seconds(300);
-    }
 
+    _query_ctx->set_expire_seconds(_calc_query_ctx_expired_seconds(request));
     // initialize query's deadline
     _query_ctx->extend_lifetime();
 
@@ -202,6 +197,23 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const TExecPl
 int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const {
     int32_t degree_of_parallelism = request.__isset.pipeline_dop ? request.pipeline_dop : 0;
     return exec_env->calc_pipeline_dop(degree_of_parallelism);
+}
+
+int FragmentExecutor::_calc_query_ctx_expired_seconds(const TExecPlanFragmentParams& request) const {
+    const auto& query_options = request.query_options;
+
+    int expired_seconds = QueryContext::DEFAULT_EXPIRE_SECONDS;
+    if (query_options.__isset.query_delivery_timeout) {
+        if (query_options.__isset.query_timeout) {
+            expired_seconds = std::min(query_options.query_timeout, query_options.query_delivery_timeout);
+        } else {
+            expired_seconds = query_options.query_delivery_timeout;
+        }
+    } else if (query_options.__isset.query_timeout) {
+        expired_seconds = query_options.query_timeout;
+    }
+
+    return std::max<int>(1, expired_seconds);
 }
 
 Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -27,7 +27,8 @@ public:
 private:
     void _fail_cleanup();
     int32_t _calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const;
-    int _calc_query_ctx_expired_seconds(const TExecPlanFragmentParams& request) const;
+    int _calc_delivery_expired_seconds(const TExecPlanFragmentParams& request) const;
+    int _calc_query_expired_seconds(const TExecPlanFragmentParams& request) const;
 
     // Several steps of prepare a fragment
     // 1. query context

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -27,6 +27,7 @@ public:
 private:
     void _fail_cleanup();
     int32_t _calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const;
+    int _calc_query_ctx_expired_seconds(const TExecPlanFragmentParams& request) const;
 
     // Several steps of prepare a fragment
     // 1. query context

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -53,7 +53,7 @@ void PipelineDriverPoller::run_internal() {
         while (driver_it != local_blocked_drivers.end()) {
             auto* driver = *driver_it;
 
-            if (driver->query_ctx()->is_expired()) {
+            if (driver->query_ctx()->is_query_expired()) {
                 // there are not any drivers belonging to a query context can make progress for an expiration period
                 // indicates that some fragments are missing because of failed exec_plan_fragment invocation. in
                 // this situation, query is failed finally, so drivers are marked PENDING_FINISH/FINISH.
@@ -63,7 +63,7 @@ void PipelineDriverPoller::run_internal() {
                 LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
                              << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
                 driver->fragment_ctx()->cancel(Status::TimedOut(fmt::format(
-                        "Query exceeded time limit of {} seconds", driver->query_ctx()->get_expire_seconds())));
+                        "Query exceeded time limit of {} seconds", driver->query_ctx()->get_query_expire_seconds())));
                 driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -16,8 +16,7 @@ QueryContext::QueryContext()
         : _fragment_mgr(new FragmentContextManager()),
           _total_fragments(0),
           _num_fragments(0),
-          _num_active_fragments(0),
-          _deadline(0) {}
+          _num_active_fragments(0) {}
 
 QueryContext::~QueryContext() {
     // When destruct FragmentContextManager, we use query-level MemTracker. since when PipelineDriver executor
@@ -123,7 +122,7 @@ void QueryContextManager::_clean_slot_unlocked(size_t i) {
     auto& sc_map = _second_chance_maps[i];
     auto sc_it = sc_map.begin();
     while (sc_it != sc_map.end()) {
-        if (sc_it->second->has_no_active_instances() && sc_it->second->is_expired()) {
+        if (sc_it->second->has_no_active_instances() && sc_it->second->is_delivery_expired()) {
             sc_it = sc_map.erase(sc_it);
         } else {
             ++sc_it;
@@ -261,7 +260,7 @@ bool QueryContextManager::remove(const TUniqueId& query_id) {
         // in the future, so extend the lifetime of query context and wait for some time till fragments on wire have
         // vanished
         auto ctx = std::move(it->second);
-        ctx->extend_lifetime();
+        ctx->extend_delivery_lifetime();
         context_map.erase(it);
         sc_map.emplace(query_id, std::move(ctx));
         return false;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -45,18 +45,28 @@ public:
     int num_active_fragments() const { return _num_active_fragments.load(); }
     bool has_no_active_instances() { return _num_active_fragments.load() == 0; }
 
-    void set_expire_seconds(int expire_seconds) { _expire_seconds = seconds(expire_seconds); }
-    inline int get_expire_seconds() { return _expire_seconds.count(); }
+    void set_delivery_expire_seconds(int expire_seconds) { _delivery_expire_seconds = seconds(expire_seconds); }
+    void set_query_expire_seconds(int expire_seconds) { _query_expire_seconds = seconds(expire_seconds); }
+    inline int get_query_expire_seconds() const { return _query_expire_seconds.count(); }
     // now time point pass by deadline point.
-    bool is_expired() {
+    bool is_delivery_expired() const {
         auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
-        return now > _deadline;
+        return now > _delivery_deadline;
+    }
+    bool is_query_expired() const {
+        auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+        return now > _query_deadline;
     }
 
     bool is_dead() { return _num_active_fragments == 0 && _num_fragments == _total_fragments; }
     // add expired seconds to deadline
-    void extend_lifetime() {
-        _deadline = duration_cast<milliseconds>(steady_clock::now().time_since_epoch() + _expire_seconds).count();
+    void extend_delivery_lifetime() {
+        _delivery_deadline =
+                duration_cast<milliseconds>(steady_clock::now().time_since_epoch() + _delivery_expire_seconds).count();
+    }
+    void extend_query_lifetime() {
+        _query_deadline =
+                duration_cast<milliseconds>(steady_clock::now().time_since_epoch() + _query_expire_seconds).count();
     }
 
     FragmentContextManager* fragment_mgr();
@@ -113,8 +123,10 @@ private:
     size_t _total_fragments;
     std::atomic<size_t> _num_fragments;
     std::atomic<size_t> _num_active_fragments;
-    int64_t _deadline;
-    seconds _expire_seconds = seconds(DEFAULT_EXPIRE_SECONDS);
+    int64_t _delivery_deadline = 0;
+    int64_t _query_deadline = 0;
+    seconds _delivery_expire_seconds = seconds(DEFAULT_EXPIRE_SECONDS);
+    seconds _query_expire_seconds = seconds(DEFAULT_EXPIRE_SECONDS);
     bool _is_runtime_filter_coordinator = false;
     std::once_flag _init_mem_tracker_once;
     std::shared_ptr<RuntimeProfile> _profile;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -103,6 +103,9 @@ public:
     int64_t query_begin_time() const { return _query_begin_time; }
     void init_query_begin_time() { _query_begin_time = MonotonicNanos(); }
 
+public:
+    static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
+
 private:
     ExecEnv* _exec_env = nullptr;
     TUniqueId _query_id;
@@ -111,7 +114,7 @@ private:
     std::atomic<size_t> _num_fragments;
     std::atomic<size_t> _num_active_fragments;
     int64_t _deadline;
-    seconds _expire_seconds;
+    seconds _expire_seconds = seconds(DEFAULT_EXPIRE_SECONDS);
     bool _is_runtime_filter_coordinator = false;
     std::once_flag _init_mem_tracker_once;
     std::shared_ptr<RuntimeProfile> _profile;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -506,7 +506,7 @@ static inline Status receive_total_runtime_filter_pipeline(
         return Status::OK();
     }
     // the query is already finished, so it is needless to cache rf.
-    if (query_ctx->has_no_active_instances() || query_ctx->is_expired()) {
+    if (query_ctx->has_no_active_instances() || query_ctx->is_query_expired()) {
         return Status::OK();
     }
 

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -62,8 +62,10 @@ void PipelineTestBase::_prepare() {
 
     _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
     _query_ctx->set_total_fragments(1);
-    _query_ctx->set_expire_seconds(60);
-    _query_ctx->extend_lifetime();
+    _query_ctx->set_delivery_expire_seconds(60);
+    _query_ctx->set_query_expire_seconds(60);
+    _query_ctx->extend_delivery_lifetime();
+    _query_ctx->extend_query_lifetime();
     _query_ctx->init_mem_tracker(_exec_env->query_pool_mem_tracker()->limit(), _exec_env->query_pool_mem_tracker());
 
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -151,8 +151,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         ASSERT_FALSE(query_ctx->is_dead());
         query_ctx_mgr->remove(query_id);
         ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
-        query_ctx->set_delivery_expire_seconds(60);
-        query_ctx->set_query_expire_seconds(300);
+        query_ctx->set_delivery_expire_seconds(1);
         query_ctx->extend_delivery_lifetime();
         query_ctx->extend_query_lifetime();
         sleep(2);

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -19,12 +19,15 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
             query_id.lo = i;
             auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
             ASSERT_TRUE(query_ctx != nullptr);
-            query_ctx->set_expire_seconds(300);
+            query_ctx->set_delivery_expire_seconds(60);
+            query_ctx->set_query_expire_seconds(300);
             query_ctx->set_total_fragments(1);
-            query_ctx->extend_lifetime();
+            query_ctx->extend_delivery_lifetime();
+            query_ctx->extend_query_lifetime();
             query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
             ASSERT_EQ(query_ctx->query_id(), query_id);
-            ASSERT_FALSE(query_ctx->is_expired());
+            ASSERT_FALSE(query_ctx->is_delivery_expired());
+            ASSERT_FALSE(query_ctx->is_query_expired());
             ASSERT_FALSE(query_ctx->has_no_active_instances());
             ASSERT_FALSE(query_ctx->is_dead());
         }
@@ -35,7 +38,8 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
             auto query_ctx = query_ctx_mgr->get(query_id);
             ASSERT_TRUE(query_ctx);
             ASSERT_EQ(query_ctx->query_id(), query_id);
-            ASSERT_FALSE(query_ctx->is_expired());
+            ASSERT_FALSE(query_ctx->is_delivery_expired());
+            ASSERT_FALSE(query_ctx->is_query_expired());
             ASSERT_FALSE(query_ctx->has_no_active_instances());
             ASSERT_FALSE(query_ctx->is_dead());
             query_ctx->count_down_fragments();
@@ -45,107 +49,114 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
             query_ctx = query_ctx_mgr->get(query_id);
             ASSERT_FALSE(query_ctx);
         }
+    }
 
-        {
-            auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
-            ASSERT_TRUE(query_ctx_mgr->init().ok());
-            TUniqueId query_id;
-            query_id.hi = 100;
-            query_id.lo = 1;
-            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
-            query_ctx->set_total_fragments(8);
-            query_ctx->set_expire_seconds(300);
-            query_ctx->extend_lifetime();
-            query_ctx->count_down_fragments();
-            query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+    {
+        auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
+        ASSERT_TRUE(query_ctx_mgr->init().ok());
+        TUniqueId query_id;
+        query_id.hi = 100;
+        query_id.lo = 1;
+        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        query_ctx->set_total_fragments(8);
+        query_ctx->set_delivery_expire_seconds(60);
+        query_ctx->set_query_expire_seconds(300);
+        query_ctx->extend_delivery_lifetime();
+        query_ctx->extend_query_lifetime();
+        query_ctx->count_down_fragments();
+        query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
 
-            for (int i = 0; i < 7; ++i) {
-                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
-                tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-                ASSERT_TRUE(tmp_query_ctx != nullptr);
-            }
-            for (int i = 0; i < 7; ++i) {
-                query_ctx->count_down_fragments();
-            }
-            ASSERT_TRUE(query_ctx->has_no_active_instances());
-            ASSERT_TRUE(query_ctx->is_dead());
-            query_ctx_mgr->remove(query_id);
-            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+        for (int i = 0; i < 7; ++i) {
+            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+            ASSERT_TRUE(tmp_query_ctx != nullptr);
         }
-
-        {
-            auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
-            ASSERT_TRUE(query_ctx_mgr->init().ok());
-            TUniqueId query_id;
-            query_id.hi = 100;
-            query_id.lo = 2;
-            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
-            query_ctx->set_total_fragments(8);
-            query_ctx->set_expire_seconds(300);
-            query_ctx->extend_lifetime();
+        for (int i = 0; i < 7; ++i) {
             query_ctx->count_down_fragments();
-            query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+        }
+        ASSERT_TRUE(query_ctx->has_no_active_instances());
+        ASSERT_TRUE(query_ctx->is_dead());
+        query_ctx_mgr->remove(query_id);
+        ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+    }
 
-            for (int i = 0; i < 3; ++i) {
-                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
-                tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-                ASSERT_TRUE(tmp_query_ctx != nullptr);
-            }
-            for (int i = 0; i < 3; ++i) {
-                query_ctx->count_down_fragments();
-            }
-            ASSERT_TRUE(query_ctx->has_no_active_instances());
-            ASSERT_FALSE(query_ctx->is_dead());
+    {
+        auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
+        ASSERT_TRUE(query_ctx_mgr->init().ok());
+        TUniqueId query_id;
+        query_id.hi = 100;
+        query_id.lo = 2;
+        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        query_ctx->set_total_fragments(8);
+        query_ctx->set_delivery_expire_seconds(60);
+        query_ctx->set_query_expire_seconds(300);
+        query_ctx->extend_delivery_lifetime();
+        query_ctx->extend_query_lifetime();
+        query_ctx->count_down_fragments();
+        query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+
+        for (int i = 0; i < 3; ++i) {
+            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+            ASSERT_TRUE(tmp_query_ctx != nullptr);
+        }
+        for (int i = 0; i < 3; ++i) {
+            query_ctx->count_down_fragments();
+        }
+        ASSERT_TRUE(query_ctx->has_no_active_instances());
+        ASSERT_FALSE(query_ctx->is_dead());
+        query_ctx_mgr->remove(query_id);
+        ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
+        for (int i = 0; i < 3; ++i) {
+            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+            ASSERT_TRUE(query_ctx != nullptr);
+            tmp_query_ctx->count_down_fragments();
             query_ctx_mgr->remove(query_id);
+            ASSERT_TRUE(tmp_query_ctx->has_no_active_instances());
+            ASSERT_FALSE(tmp_query_ctx->is_dead());
             ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
-            for (int i = 0; i < 3; ++i) {
-                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
-                tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-                ASSERT_TRUE(query_ctx != nullptr);
-                tmp_query_ctx->count_down_fragments();
-                query_ctx_mgr->remove(query_id);
-                ASSERT_TRUE(tmp_query_ctx->has_no_active_instances());
-                ASSERT_FALSE(tmp_query_ctx->is_dead());
-                ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
-            }
-            query_ctx = query_ctx_mgr->get_or_register(query_id);
-            query_ctx->count_down_fragments();
-            query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-            ASSERT_TRUE(query_ctx->is_dead());
-            query_ctx_mgr->remove(query_id);
-            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
         }
+        query_ctx = query_ctx_mgr->get_or_register(query_id);
+        query_ctx->count_down_fragments();
+        query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+        ASSERT_TRUE(query_ctx->is_dead());
+        query_ctx_mgr->remove(query_id);
+        ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+    }
 
-        {
-            auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
-            ASSERT_TRUE(query_ctx_mgr->init().ok());
-            TUniqueId query_id;
-            query_id.hi = 100;
-            query_id.lo = 3;
-            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
-            query_ctx->set_total_fragments(8);
-            query_ctx->set_expire_seconds(300);
-            query_ctx->extend_lifetime();
-            query_ctx->count_down_fragments();
-            query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-            for (int i = 0; i < 3; ++i) {
-                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
-                tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-                ASSERT_TRUE(tmp_query_ctx != nullptr);
-            }
-            for (int i = 0; i < 3; ++i) {
-                query_ctx->count_down_fragments();
-            }
-            ASSERT_TRUE(query_ctx->has_no_active_instances());
-            ASSERT_FALSE(query_ctx->is_dead());
-            query_ctx_mgr->remove(query_id);
-            ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
-            ASSERT_FALSE(query_ctx->is_expired());
-            query_ctx->set_expire_seconds(1);
-            query_ctx->extend_lifetime();
-            sleep(2);
-            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+    {
+        auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
+        ASSERT_TRUE(query_ctx_mgr->init().ok());
+        TUniqueId query_id;
+        query_id.hi = 100;
+        query_id.lo = 3;
+        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        query_ctx->set_total_fragments(8);
+        query_ctx->set_delivery_expire_seconds(60);
+        query_ctx->set_query_expire_seconds(300);
+        query_ctx->extend_delivery_lifetime();
+        query_ctx->extend_query_lifetime();
+        query_ctx->count_down_fragments();
+        query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+        for (int i = 0; i < 3; ++i) {
+            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+            ASSERT_TRUE(tmp_query_ctx != nullptr);
         }
+        for (int i = 0; i < 3; ++i) {
+            query_ctx->count_down_fragments();
+        }
+        ASSERT_TRUE(query_ctx->has_no_active_instances());
+        ASSERT_FALSE(query_ctx->is_dead());
+        query_ctx_mgr->remove(query_id);
+        ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
+        query_ctx->set_delivery_expire_seconds(60);
+        query_ctx->set_query_expire_seconds(300);
+        query_ctx->extend_delivery_lifetime();
+        query_ctx->extend_query_lifetime();
+        sleep(2);
+        ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
     }
 }
 
@@ -158,9 +169,11 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
     query_id.hi = 2;
     auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
     query_ctx->set_total_fragments(202);
-    query_ctx->set_expire_seconds(300);
+    query_ctx->set_delivery_expire_seconds(60);
+    query_ctx->set_query_expire_seconds(300);
     query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
-    query_ctx->extend_lifetime();
+    query_ctx->extend_delivery_lifetime();
+    query_ctx->extend_query_lifetime();
     query_ctx->count_down_fragments();
     query_ctx_mgr->remove(query_id);
     ASSERT_TRUE(query_ctx->has_no_active_instances());
@@ -174,7 +187,8 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
                 auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
                 query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
                 ASSERT_TRUE(query_ctx != nullptr);
-                ASSERT_FALSE(query_ctx->is_expired());
+                ASSERT_FALSE(query_ctx->is_delivery_expired());
+                ASSERT_FALSE(query_ctx->is_query_expired());
                 ASSERT_FALSE(query_ctx->is_dead());
                 std::this_thread::sleep_for(std::chrono::milliseconds(dist(rd)));
                 query_ctx->count_down_fragments();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -467,6 +467,7 @@ public class Coordinator {
         for (TUniqueId instanceId : instanceIds) {
             profileDoneSignal.addMark(instanceId, -1L /* value is meaningless */);
         }
+        long queryDeliveryTimeoutMs = Math.min(queryOptions.query_timeout, queryOptions.query_delivery_timeout) * 1000L;
         lock();
         try {
             // execute all instances from up to bottom
@@ -566,8 +567,8 @@ public class Coordinator {
                         TStatusCode code;
                         String errMsg = null;
                         try {
-                            PExecPlanFragmentResult result = pair.second.get(queryOptions.query_timeout * 1000L,
-                                    TimeUnit.MILLISECONDS);
+                            PExecPlanFragmentResult result =
+                                    pair.second.get(queryDeliveryTimeoutMs, TimeUnit.MILLISECONDS);
                             code = TStatusCode.findByValue(result.status.statusCode);
                             if (result.status.errorMsgs != null && !result.status.errorMsgs.isEmpty()) {
                                 errMsg = result.status.errorMsgs.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -70,6 +70,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_MEM_LIMIT = "query_mem_limit";
 
     public static final String QUERY_TIMEOUT = "query_timeout";
+
+    public static final String QUERY_DELIVERY_TIMEOUT = "query_delivery_timeout";
     public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String IS_REPORT_SUCCESS = "is_report_success";
     public static final String PROFILING = "profiling";
@@ -249,6 +251,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     private int queryTimeoutS = 300;
+
+    // Execution of a query contains two phase.
+    // 1. Deliver all the fragment instances to BEs.
+    // 2. Pull data from BEs, after all the fragments are prepared and ready to execute in BEs.
+    // queryDeliveryTimeoutS is the timeout of the first phase.
+    @VariableMgr.VarAttr(name = QUERY_DELIVERY_TIMEOUT)
+    private int queryDeliveryTimeoutS = 300;
 
     // query timeout in millisecond, currently nouse, only for compatible.
     @VariableMgr.VarAttr(name = MAX_EXECUTION_TIME)
@@ -1016,6 +1025,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setBuffer_pool_limit(maxExecMemByte);
         // Avoid integer overflow
         tResult.setQuery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryTimeoutS));
+        tResult.setQuery_delivery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryDeliveryTimeoutS));
         tResult.setIs_report_success(isReportSucc);
         tResult.setCodegen_level(codegenLevel);
         tResult.setBatch_size(chunkSize);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -167,6 +167,8 @@ struct TQueryOptions {
   58: optional i64 query_mem_limit;
 
   59: optional bool enable_tablet_internal_parallel;
+
+  60: optional i32 query_delivery_timeout;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In pipeline, `QueryContext` will be released, if there isn't active fragment in `_expired_seconds`.
It is useful when some fragments are not delivered successfully.
`_expired_seconds` is set to the session variables `query_timeout`. However, if users set `query_timeout` to a too large value, the query context cannot be released timely.

Therefore, introduce a new session variable `query_delivery_timeout`, and set `_expired_seconds` to it.

## Modification
- Add a new session variable `query_delivery_timeout`, 60s by default.
- `Coordinator::exec` only waits `query_delivery_timeout` before getting responses of the RPC request `execRemoteFragmentAsync`.
- Distinguish `_delivery_expired` and `_query_expired`.
    - Use `QueryContext::is_delivery_timeout` to decide whether cleaning the query contexts in the second map.
    - Use `QueryContext::is_query_timeout` in poller to decide whether the query is timeout.
    - set `_delivery_expired_seconds` to `min(query_delivery_timeout, query_timeout)`.
    - set `_query_expired_seconds` to `query_timeout`.
    - `extend_query_lifetime` in prepare fragment phase.
    - `extend_delivery_lifetime` in prepare fragment phase and when moving query_context to second map.