### PR TITLE
[Enhance] try to release chunks of operator when close

### DIFF
--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -27,6 +27,7 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
 }
 
 void AssertNumRowsOperator::close(RuntimeState* state) {
+    _cur_chunk.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.cpp
@@ -12,6 +12,11 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+
+void CrossJoinContext::close(RuntimeState* state) {
+    _build_chunks.clear();
+}
+
 Status CrossJoinContext::_init_runtime_filter(RuntimeState* state) {
     vectorized::ChunkPtr one_row_chunk = nullptr;
     size_t num_rows = 0;

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -35,7 +35,7 @@ public:
               _rf_hub(params.rf_hub),
               _rf_descs(std::move(params.rf_descs)) {}
 
-    void close(RuntimeState* state) override { _build_chunks.clear(); }
+    void close(RuntimeState* state) override;
 
     bool is_build_chunk_empty() const {
         return std::all_of(_build_chunks.begin(), _build_chunks.end(),

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -35,7 +35,7 @@ public:
               _rf_hub(params.rf_hub),
               _rf_descs(std::move(params.rf_descs)) {}
 
-    void close(RuntimeState* state) override {}
+    void close(RuntimeState* state) override { _build_chunks.clear(); }
 
     bool is_build_chunk_empty() const {
         return std::all_of(_build_chunks.begin(), _build_chunks.end(),

--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -14,6 +14,7 @@ Status DictDecodeOperator::prepare(RuntimeState* state) {
 }
 
 void DictDecodeOperator::close(RuntimeState* state) {
+    _cur_chunk.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -22,8 +22,6 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
 }
 
 void ExchangeMergeSortSourceOperator::close(RuntimeState* state) {
-    _stream_recvr->close();
-    _stream_recvr.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -22,6 +22,8 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
 }
 
 void ExchangeMergeSortSourceOperator::close(RuntimeState* state) {
+    _stream_recvr->close();
+    _stream_recvr.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -654,6 +654,7 @@ Status ExchangeSinkOperatorFactory::prepare(RuntimeState* state) {
 }
 
 void ExchangeSinkOperatorFactory::close(RuntimeState* state) {
+    _buffer.reset();
     Expr::close(_partition_expr_ctxs, state);
     OperatorFactory::close(state);
 }

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -15,6 +15,7 @@ Status ProjectOperator::prepare(RuntimeState* state) {
 }
 
 void ProjectOperator::close(RuntimeState* state) {
+    _cur_chunk.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -88,6 +88,7 @@ void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
     _closed = true;
     _data_source->close(state);
+    _chunk_buffer.clear();
 }
 
 bool ConnectorChunkSource::has_next_chunk() const {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -88,6 +88,7 @@ void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
     _closed = true;
     _data_source->close(state);
+    _chunk_buffer.shutdown();
     _chunk_buffer.clear();
 }
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -42,6 +42,8 @@ void OlapChunkSource::close(RuntimeState* state) {
     _prj_iter->close();
     _reader.reset();
     _predicate_free_pool.clear();
+    _chunk_buffer.clear();
+    _chunk_buffer.shutdown();
 }
 
 Status OlapChunkSource::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -42,8 +42,8 @@ void OlapChunkSource::close(RuntimeState* state) {
     _prj_iter->close();
     _reader.reset();
     _predicate_free_pool.clear();
-    _chunk_buffer.clear();
     _chunk_buffer.shutdown();
+    _chunk_buffer.clear();
 }
 
 Status OlapChunkSource::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -12,6 +12,8 @@ Status SelectOperator::prepare(RuntimeState* state) {
 }
 
 void SelectOperator::close(RuntimeState* state) {
+    _curr_chunk.reset();
+    _pre_output_chunk.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -21,6 +21,7 @@ Status ExceptContext::prepare(RuntimeState* state, const std::vector<ExprContext
 }
 
 void ExceptContext::close(RuntimeState* state) {
+    _hash_set.reset();
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -20,6 +20,7 @@ Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprCont
 }
 
 void IntersectContext::close(RuntimeState* state) {
+    _hash_set.reset();
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -25,6 +25,7 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
 
 void PartitionSortSinkOperator::close(RuntimeState* state) {
     _sort_context->unref(state);
+    _chunks_sorter.reset();
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -13,6 +13,11 @@ using vectorized::Columns;
 using vectorized::SortedRun;
 using vectorized::SortedRuns;
 
+void SortContext::close(RuntimeState* state) {
+    _chunks_sorter_partions.clear();
+    _merged_runs.clear();
+}
+
 StatusOr<ChunkPtr> SortContext::pull_chunk() {
     if (!_is_merge_finish) {
         _merge_inputs();

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -36,10 +36,7 @@ public:
         _chunks_sorter_partions.reserve(num_right_sinkers);
     }
 
-    void close(RuntimeState* state) override {
-        _chunks_sorter_partions.clear();
-        _merged_runs.clear();
-    }
+    void close(RuntimeState* state) override;
 
     void add_partition_chunks_sorter(std::shared_ptr<ChunksSorter> chunks_sorter) {
         _chunks_sorter_partions.push_back(chunks_sorter);

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -36,7 +36,10 @@ public:
         _chunks_sorter_partions.reserve(num_right_sinkers);
     }
 
-    void close(RuntimeState* state) override {}
+    void close(RuntimeState* state) override {
+        _chunks_sorter_partions.clear();
+        _merged_runs.clear();
+    }
 
     void add_partition_chunks_sorter(std::shared_ptr<ChunksSorter> chunks_sorter) {
         _chunks_sorter_partions.push_back(chunks_sorter);

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -275,6 +275,10 @@ void Aggregator::close(RuntimeState* state) {
     }
 
     _is_closed = true;
+    // Clear the buffer
+    while (!_buffer.empty()) {
+        _buffer.pop();
+    }
 
     auto agg_close = [this, state]() {
         // _mem_pool is nullptr means prepare phase failed

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -307,6 +307,10 @@ void Analytor::close(RuntimeState* state) {
         return;
     }
 
+    while (!_buffer.empty()) {
+        _buffer.pop();
+    }
+    _input_chunks.clear();
     _is_closed = true;
 
     auto agg_close = [this, state]() {

--- a/be/src/exec/vectorized/sorting/merge.h
+++ b/be/src/exec/vectorized/sorting/merge.h
@@ -92,6 +92,7 @@ struct SortedRuns {
         }
         return res;
     }
+    void clear();
 
     bool is_sorted(const SortDescs& sort_desc) const;
     ChunkPtr assemble() const;

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -385,6 +385,10 @@ void SortedRuns::resize(size_t size) {
     }
 }
 
+void SortedRuns::clear() {
+    chunks.clear();
+}
+
 bool SortedRuns::is_sorted(const SortDescs& sort_desc) const {
     for (int i = 0; i < chunks.size(); i++) {
         auto& run = chunks[i];

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -279,6 +279,11 @@ public:
         return _items.empty();
     }
 
+    void clear() {
+        std::lock_guard<Lock> l(_lock);
+        _items.clear();
+    }
+
 protected:
     mutable Lock _lock;
     CV _not_empty;

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -711,21 +711,17 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(JsonFunctionsTest, extract_from_object_test) {
     std::string output;
-    Status st;
 
-    st = test_extract_from_object(R"({"data" : 1})", "$.data", &output);
-    EXPECT_OK(st);
+    EXPECT_OK(test_extract_from_object(R"({"data" : 1})", "$.data", &output));
     EXPECT_STREQ(output.data(), "1");
 
-    st = test_extract_from_object(R"({"data" : 1})", "$.dataa", &output);
-    EXPECT_STATUS(Status::NotFound(""), st);
+    EXPECT_STATUS(Status::NotFound(""), test_extract_from_object(R"({"data" : 1})", "$.dataa", &output));
 
-    st = test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[1].key", &output);
-    EXPECT_OK(st);
+    EXPECT_OK(test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[1].key", &output));
     EXPECT_STREQ(output.data(), "2");
 
-    st = test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output);
-    EXPECT_STATUS(Status::NotFound(""), st);
+    EXPECT_STATUS(Status::NotFound(""),
+                  test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output));
 }
 
 } // namespace vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


When `Operator::close`, it could release the buffered chunk to avoid occupy too much memory.
