### PR TITLE
[Bugfix] fix call JNI in bthread in Java UDF

### DIFF
--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -102,8 +102,13 @@ ColumnPtr JavaFunctionCallExpr::evaluate(ExprContext* context, vectorized::Chunk
     for (int i = 0; i < _children.size(); ++i) {
         columns[i] = _children[i]->evaluate(context, ptr);
     }
-
-    return _call_helper->call(context->fn_context(_fn_context_index), columns, ptr != nullptr ? ptr->num_rows() : 1);
+    ColumnPtr res;
+    auto call_udf = [&]() {
+        _call_helper->call(context->fn_context(_fn_context_index), columns, ptr != nullptr ? ptr->num_rows() : 1);
+        return Status::OK();
+    };
+    call_function_in_pthread(_runtime_state, call_udf)->get_future().get();
+    return res;
 }
 
 JavaFunctionCallExpr::~JavaFunctionCallExpr() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #7083

## Problem Summary(Required) ：

evaluate_const method will call JavaFunctionCallExpr::evaluate .
In pipeline engine, evaluate_const maybe called in bthread. which will cause JNI crash

mini reproduce case:
```
select count(*) from dates where  upper(udf(1, 2)) is null;
```
