### PR TITLE
[SparkDpp] Support loading materialized view that aggregates on duplicate key columns

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/MinimumCoverageRollupTreeBuilder.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/MinimumCoverageRollupTreeBuilder.java
@@ -21,7 +21,9 @@ import com.starrocks.load.loadv2.etl.EtlJobConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 // Build RollupTree by using minimum coverage strategy,
 // which is to find the index with the minimum columns that
@@ -36,12 +38,12 @@ import java.util.List;
 // then the result tree is:
 //          index1
 //      |     \      \
-//  index2  index4   index5
-//    |
-//  index3
+//  index2  index5   index4
+//            |
+//          index3
 // Now, if there are more than one indexes meet the column coverage requirement,
 // have the same column size(eg: index2 vs index5), child rollup is preferred
-// builded from the front index(eg: index3 is the child of index2). This can be
+// builded from the back index(eg: index3 is the child of index5). This can be
 // further optimized based on the row number of the index.
 public class MinimumCoverageRollupTreeBuilder implements RollupTreeBuilder {
     public RollupTreeNode build(EtlJobConfig.EtlTable tableMeta) {
@@ -108,7 +110,10 @@ public class MinimumCoverageRollupTreeBuilder implements RollupTreeBuilder {
         }
 
         // find suitable parent rollup from current node
-        if (root.keyColumnNames.containsAll(keyColumns) && root.valueColumnNames.containsAll(valueColumns)) {
+        Set<String> allColumnNames = new HashSet<>();
+        allColumnNames.addAll(root.keyColumnNames);
+        allColumnNames.addAll(root.valueColumnNames);
+        if (allColumnNames.containsAll(keyColumns) && allColumnNames.containsAll(valueColumns)) {
             if (root.children == null) {
                 root.children = new ArrayList<>();
             }

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -373,12 +373,16 @@ public final class SparkDpp implements java.io.Serializable {
                                                                     List<String> parentRollupKeyColumns,
                                                                     List<String> parentRollupValueColumns)
             throws SparkDppException {
+        List<String> parentRollupColumns = new ArrayList<>();
+        parentRollupColumns.addAll(parentRollupKeyColumns);
+        parentRollupColumns.addAll(parentRollupValueColumns);
+
         List<Integer> keyMap = new ArrayList<>();
         List<Integer> valueMap = new ArrayList<>();
         // find column index in parent rollup schema
         for (int i = 0; i < childRollupKeyColumns.size(); i++) {
-            for (int j = 0; j < parentRollupKeyColumns.size(); j++) {
-                if (StringUtils.equalsIgnoreCase(childRollupKeyColumns.get(i), parentRollupKeyColumns.get(j))) {
+            for (int j = 0; j < parentRollupColumns.size(); j++) {
+                if (StringUtils.equalsIgnoreCase(childRollupKeyColumns.get(i), parentRollupColumns.get(j))) {
                     keyMap.add(j);
                     break;
                 }
@@ -386,8 +390,8 @@ public final class SparkDpp implements java.io.Serializable {
         }
 
         for (int i = 0; i < childRollupValueColumns.size(); i++) {
-            for (int j = 0; j < parentRollupValueColumns.size(); j++) {
-                if (StringUtils.equalsIgnoreCase(childRollupValueColumns.get(i), parentRollupValueColumns.get(j))) {
+            for (int j = 0; j < parentRollupColumns.size(); j++) {
+                if (StringUtils.equalsIgnoreCase(childRollupValueColumns.get(i), parentRollupColumns.get(j))) {
                     valueMap.add(j);
                     break;
                 }

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
@@ -191,14 +191,24 @@ class EncodeRollupAggregateTableFunction
         List<Object> keys = new ArrayList();
         Object[] values = new Object[valueColumnIndexMap.length];
 
+        int parentRollupKeysSize = parentRollupKeyValuePair._1.size() - 1;
+
         // deal bucket_id column
         keys.add(parentRollupKeyValuePair._1().get(0));
         for (int i = 0; i < keyColumnIndexMap.length; i++) {
-            keys.add(parentRollupKeyValuePair._1().get(keyColumnIndexMap[i] + 1));
+            if (keyColumnIndexMap[i] < parentRollupKeysSize) {
+                keys.add(parentRollupKeyValuePair._1().get(keyColumnIndexMap[i] + 1));
+            } else {
+                keys.add(parentRollupKeyValuePair._2()[keyColumnIndexMap[i] - parentRollupKeysSize]);
+            }
         }
 
         for (int i = 0; i < valueColumnIndexMap.length; i++) {
-            values[i] = parentRollupKeyValuePair._2()[valueColumnIndexMap[i]];
+            if (valueColumnIndexMap[i] < parentRollupKeysSize) {
+                values[i] = parentRollupKeyValuePair._1().get(valueColumnIndexMap[i] + 1);
+            } else {
+                values[i] = parentRollupKeyValuePair._2()[valueColumnIndexMap[i] - parentRollupKeysSize];
+            }
         }
         return new Tuple2<>(keys, values);
     }

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/MinimumCoverageRollupTreeBuilderTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/MinimumCoverageRollupTreeBuilderTest.java
@@ -74,11 +74,23 @@ public class MinimumCoverageRollupTreeBuilderTest {
         EtlJobConfig.EtlIndex roll3Index = new EtlJobConfig.EtlIndex(10003,
                 roll3Columns, 12348, "AGGREGATE", false);
 
+        List<EtlJobConfig.EtlColumn> roll4Columns = new ArrayList<>();
+        roll4Columns.add(column1);
+        EtlJobConfig.EtlColumn newColumn2 = new EtlJobConfig.EtlColumn(
+                "column2", "SMALLINT",
+                true, false,
+                "SUM", "0",
+                0, 0, 0);
+        roll4Columns.add(newColumn2);
+        EtlJobConfig.EtlIndex roll4Index = new EtlJobConfig.EtlIndex(10004,
+                roll4Columns, 12349, "AGGREGATE", false);
+
         List<EtlJobConfig.EtlIndex> indexes = new ArrayList<>();
         indexes.add(baseIndex);
         indexes.add(roll1Index);
         indexes.add(roll2Index);
         indexes.add(roll3Index);
+        indexes.add(roll4Index);
         EtlJobConfig.EtlTable table = new EtlJobConfig.EtlTable(indexes, null);
 
         MinimumCoverageRollupTreeBuilder builder = new MinimumCoverageRollupTreeBuilder();
@@ -92,7 +104,7 @@ public class MinimumCoverageRollupTreeBuilderTest {
         Assert.assertEquals(index1Node.parent.indexId, 10000);
         Assert.assertEquals(index1Node.indexId, 10001);
         Assert.assertEquals(index1Node.level, 1);
-        Assert.assertEquals(index1Node.children.size(), 1);
+        Assert.assertEquals(index1Node.children.size(), 2);
 
         RollupTreeNode index3Node = resultNode.children.get(1);
         Assert.assertEquals(index3Node.parent.indexId, 10000);
@@ -105,5 +117,11 @@ public class MinimumCoverageRollupTreeBuilderTest {
         Assert.assertEquals(index2Node.indexId, 10002);
         Assert.assertEquals(index2Node.level, 2);
         Assert.assertEquals(index2Node.children, null);
+
+        RollupTreeNode index4Node = index1Node.children.get(1);
+        Assert.assertEquals(index4Node.parent.indexId, 10001);
+        Assert.assertEquals(index4Node.indexId, 10004);
+        Assert.assertEquals(index4Node.level, 2);
+        Assert.assertEquals(index4Node.children, null);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7018 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently spark load only supports the materialized view which the columns key value type is the same as the base table.
For duplicate key tables, users can create a materialized view that aggregates on duplicate key columns,
so we support this case.
