### PR TITLE
[Bugfix] Fix init value of max_continuous if reconstruct_version_graph is not called

### DIFF
--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -238,14 +238,14 @@ void VersionGraph::construct_version_graph(const std::vector<RowsetMetaSharedPtr
 
 void VersionGraph::reconstruct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version) {
     _version_graph.clear();
-    _max_continuous_version = 0;
+    _max_continuous_version = -1;
     construct_version_graph(rs_metas, max_version);
 }
 
 void VersionGraph::add_version_to_graph(const Version& version) {
     _add_version_to_graph(version);
     if (version.first == _max_continuous_version + 1) {
-        _max_continuous_version = _get_max_continuous_version_from(_max_continuous_version);
+        _max_continuous_version = _get_max_continuous_version_from(_max_continuous_version + 1);
     }
 }
 

--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -80,8 +80,8 @@ private:
     // version.end_version + 1.
     // Use adjacency list to describe version graph.
     std::unordered_map<int64_t, std::unique_ptr<Vertex>> _version_graph;
-    // max continuous version from 0
-    int64_t _max_continuous_version{0};
+    // max continuous version from -1
+    int64_t _max_continuous_version{-1};
 };
 
 /// TimestampedVersion class which is implemented to maintain multi-version path of rowsets.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`reconstruct_version_graph` is not called when creating new tablet, so the value of `_max_continuous_version` is wrong, and causes misssed_version when report tablet info. This PR fix this.