### PR TITLE
[BugFix] fix the default encoding of largeint

### DIFF
--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -171,8 +171,10 @@ private:
         auto key = std::make_pair(type, encoding_type);
         DCHECK(_encoding_map.count(key) == 0);
 
-        _default_encoding_type_map[type] = encoding_type;
-        if (optimize_value_seek) {
+        if (_default_encoding_type_map.find(type) == _default_encoding_type_map.end()) {
+            _default_encoding_type_map[type] = encoding_type;
+        }
+        if (optimize_value_seek && _value_seek_encoding_map.find(type) == _value_seek_encoding_map.end()) {
             _value_seek_encoding_map[type] = encoding_type;
         }
         _encoding_map.emplace(key, new EncodingInfo(EncodingTraits<type, encoding_type>()));
@@ -241,11 +243,11 @@ EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<OLAP_FIELD_TYPE_TIMESTAMP, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_TIMESTAMP, FOR_ENCODING, true>();
 
-    _add_map<OLAP_FIELD_TYPE_DECIMAL, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE, true>();
+    _add_map<OLAP_FIELD_TYPE_DECIMAL, PLAIN_ENCODING>();
 
-    _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, PLAIN_ENCODING>();
     _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, BIT_SHUFFLE, true>();
+    _add_map<OLAP_FIELD_TYPE_DECIMAL_V2, PLAIN_ENCODING>();
 
     _add_map<OLAP_FIELD_TYPE_HLL, PLAIN_ENCODING>();
 

--- a/be/test/storage/rowset/encoding_info_test.cpp
+++ b/be/test/storage/rowset/encoding_info_test.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 
+#include "gen_cpp/segment.pb.h"
 #include "storage/olap_common.h"
 #include "storage/types.h"
 
@@ -49,6 +50,54 @@ TEST_F(EncodingInfoTest, no_encoding) {
     const EncodingInfo* encoding_info = nullptr;
     auto status = EncodingInfo::get(OLAP_FIELD_TYPE_BIGINT, DICT_ENCODING, &encoding_info);
     ASSERT_FALSE(status.ok());
+}
+
+TEST_F(EncodingInfoTest, default_encoding) {
+    std::map<FieldType, EncodingTypePB> default_expected = {
+            {OLAP_FIELD_TYPE_TINYINT, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_SMALLINT, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_INT, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_BIGINT, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_LARGEINT, BIT_SHUFFLE},
+
+            {OLAP_FIELD_TYPE_FLOAT, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_DOUBLE, BIT_SHUFFLE},
+
+            {OLAP_FIELD_TYPE_CHAR, DICT_ENCODING},
+            {OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING},
+
+            {OLAP_FIELD_TYPE_BOOL, RLE},
+
+            {OLAP_FIELD_TYPE_DATE, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_DATETIME, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE},
+
+            {OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE},
+            {OLAP_FIELD_TYPE_DECIMAL_V2, BIT_SHUFFLE},
+
+            {OLAP_FIELD_TYPE_HLL, PLAIN_ENCODING},
+            {OLAP_FIELD_TYPE_OBJECT, PLAIN_ENCODING},
+            {OLAP_FIELD_TYPE_PERCENTILE, PLAIN_ENCODING},
+            {OLAP_FIELD_TYPE_JSON, PLAIN_ENCODING},
+    };
+    std::map<FieldType, EncodingTypePB> value_seek_expected = {
+            {OLAP_FIELD_TYPE_TINYINT, FOR_ENCODING},    {OLAP_FIELD_TYPE_SMALLINT, FOR_ENCODING},
+            {OLAP_FIELD_TYPE_INT, FOR_ENCODING},        {OLAP_FIELD_TYPE_BIGINT, FOR_ENCODING},
+            {OLAP_FIELD_TYPE_LARGEINT, FOR_ENCODING},   {OLAP_FIELD_TYPE_CHAR, PREFIX_ENCODING},
+            {OLAP_FIELD_TYPE_VARCHAR, PREFIX_ENCODING}, {OLAP_FIELD_TYPE_BOOL, PLAIN_ENCODING},
+            {OLAP_FIELD_TYPE_DATE, FOR_ENCODING},       {OLAP_FIELD_TYPE_DATE_V2, FOR_ENCODING},
+            {OLAP_FIELD_TYPE_DATETIME, FOR_ENCODING},   {OLAP_FIELD_TYPE_TIMESTAMP, FOR_ENCODING},
+            {OLAP_FIELD_TYPE_DECIMAL_V2, BIT_SHUFFLE},  {OLAP_FIELD_TYPE_DECIMAL, BIT_SHUFFLE},
+    };
+    for (auto [type, encoding] : default_expected) {
+        auto default_encoding = EncodingInfo::get_default_encoding(type, false);
+        EXPECT_EQ(default_encoding, encoding);
+    }
+    for (auto [type, encoding] : value_seek_expected) {
+        auto default_encoding = EncodingInfo::get_default_encoding(type, true);
+        EXPECT_EQ(default_encoding, encoding);
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The default encoding of some type was changed by PR #7003 , and introduce some error.

So change it back and add some test case to make it more solid.
