### PR TITLE
Fix project node map error when group by constant

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -371,7 +371,8 @@ public class SplitAggregateRule extends TransformationRule {
         // build projection for DISTINCT_GLOBAL aggregate node
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
         distinctGlobal.getGroupingKeys().forEach(k -> columnRefMap.put(k, k));
-        columnRefMap.putAll(distinctGlobal.getAggregations());
+        distinctGlobal.getAggregations().keySet().forEach(key -> columnRefMap.put(key, key));
+
         Projection childProjection = input.getInputs().get(0).getOp().getProjection();
         if (childProjection != null) {
             childProjection.getColumnRefMap().entrySet().stream()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1259,6 +1259,13 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, " 8:AGGREGATE (merge finalize)\n" +
                 "  |  output: count(20: count)\n" +
                 "  |  group by: 18: expr");
+
+        sql = "select count(distinct L_ORDERKEY), count(L_PARTKEY) from lineitem group by 1.0001";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 5:Project\n" +
+                "  |  <slot 1> : 1: L_ORDERKEY\n" +
+                "  |  <slot 18> : 1.0001\n" +
+                "  |  <slot 20> : 20: count");
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
mysql> explain  select count(d_date), count(distinct d_year) from dates group by 1.00001;
+-------------------------------------------------+
| Explain String                                  |
+-------------------------------------------------+
| PLAN FRAGMENT 0                                 |
|  OUTPUT EXPRS:19: count | 20: count             |
|   PARTITION: UNPARTITIONED                      |
|                                                 |
|   RESULT SINK                                   |
|                                                 |
|   9:Project                                     |
|   |  <slot 19> : 19: count                      |
|   |  <slot 20> : 20: count                      |
|   |                                             |
|   8:AGGREGATE (merge finalize)                  |
|   |  output: count(19: count), count(20: count) |
|   |  group by: 18: expr                         |
|   |                                             |
|   7:EXCHANGE                                    |
|                                                 |
| PLAN FRAGMENT 1                                 |
|  OUTPUT EXPRS:                                  |
|   PARTITION: HASH_PARTITIONED: 5: d_year        |
|                                                 |
|   STREAM DATA SINK                              |
|     EXCHANGE ID: 07                             |
|     UNPARTITIONED                               |
|                                                 |
|   6:AGGREGATE (update serialize)                |
|   |  STREAMING                                  |
|   |  output: count(19: count), count(5: d_year) |
|   |  group by: 18: expr                         |
|   |                                             |
|   5:Project                                     |
|   |  <slot 5> : 5: d_year                       |
|   |  <slot 18> : 1.00001                        |
|   |  <slot 19> : count(19: count)               |
|   |                                             |
|   4:AGGREGATE (merge serialize)                 |
|   |  output: count(19: count)                   |
|   |  group by: 5: d_year                        |
|   |                                             |
|   3:EXCHANGE                                    |
|                                                 |
| PLAN FRAGMENT 2                                 |
|  OUTPUT EXPRS:                                  |
|   PARTITION: RANDOM                             |
|                                                 |
|   STREAM DATA SINK                              |
|     EXCHANGE ID: 03                             |
|     HASH_PARTITIONED: 5: d_year                 |
|                                                 |
|   2:AGGREGATE (update serialize)                |
|   |  STREAMING                                  |
|   |  output: count(2: d_date)                   |
|   |  group by: 5: d_year                        |
|   |                                             |
|   1:Project                                     |
|   |  <slot 2> : 2: d_date                       |
|   |  <slot 5> : 5: d_year                       |
|   |  <slot 18> : 1.00001                        |
|   |                                             |
|   0:OlapScanNode                                |
|      TABLE: dates                               |
|      PREAGGREGATION: ON                         |
|      partitions=1/1                             |
|      rollup: dates                              |
|      tabletRatio=1/1                            |
|      tabletList=1586422                         |
|      cardinality=2556                           |
|      avgRowSize=6.0                             |
|      numNodes=0                                 |
+-------------------------------------------------+
```
project node 5 's map is wong, should be <slot 19> : 19: count