### PR TITLE
[BugFix] fix issue 6954 of base64_to_bitmap function generate wrong data

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/Roaring64Map.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/Roaring64Map.java
@@ -1295,8 +1295,10 @@ public class Roaring64Map {
         out.write(BitmapValue.BITMAP64);
         Codec.encodeVarint64(highToBitmap.size(), out);
 
+        // The key should be the same little endian with BE deserialized process
+        // which is decode_fixed32_le called by Roaring64Map read method.
         for (Map.Entry<Integer, BitmapDataProvider> entry : highToBitmap.entrySet()) {
-            out.writeInt(entry.getKey().intValue());
+            out.writeInt(Integer.reverseBytes(entry.getKey().intValue()));
             entry.getValue().serialize(out);
         }
     }
@@ -1329,7 +1331,8 @@ public class Roaring64Map {
 
         long nbHighs = Codec.decodeVarint64(in);
         for (int i = 0; i < nbHighs; i++) {
-            int high = in.readInt();
+            // The key should be the same little endian with serialize.
+            int high = Integer.reverseBytes(in.readInt());
             RoaringBitmap provider = new RoaringBitmap();
             provider.deserialize(in);
             highToBitmap.put(high, provider);


### PR DESCRIPTION
error about byte order is not the same between java and be(c++),
java serialize use big endian but c++ deserilize use little endian.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #6954

## Problem Summary(Required) ：
when we generate BitmapValue data in java, we use little endian in key, because in be(c++) deserialize, use little endian.
