### PR TITLE
[Bugfix]fix BE crash in hash join when probe stage set_finishing before build stage

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -435,6 +435,8 @@ void FragmentExecutor::_fail_cleanup() {
     if (_query_ctx) {
         if (_fragment_ctx) {
             _query_ctx->fragment_mgr()->unregister(_fragment_ctx->fragment_instance_id());
+            _fragment_ctx->destroy_pass_through_chunk_buffer();
+            _fragment_ctx.reset();
         }
         if (_query_ctx->count_down_fragments()) {
             auto query_id = _query_ctx->query_id();

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -192,6 +192,11 @@ private:
     }
 
     void _short_circuit_break() {
+        if (_phase == HashJoinPhase::EOS) {
+            set_builder_finished();
+            return;
+        }
+
         // special cases of short-circuit break.
         if (_ht.get_row_count() == 0 &&
             (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN ||
@@ -199,6 +204,7 @@ private:
              _join_type == TJoinOp::RIGHT_OUTER_JOIN)) {
             _phase = HashJoinPhase::EOS;
             set_builder_finished();
+            return;
         }
 
         if (_ht.get_row_count() > 0) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #7154

## Problem Summary(Required) ：
If the sink operator above the driver of the probe performs set_finishing for some reason (limit/cancel/RF), the probe operator performs set_finishing over the build operator. this causes the build operator to skip building the build hash table's key_column, which causes BE crash

in this case if _phase was EOS, hash_joiner will skip build hash table. 
later hash_joiner will access key_columns in `_short_circuit_break`
```
Status HashJoiner::build_ht(RuntimeState* state) {
    if (_phase == HashJoinPhase::BUILD) {
        RETURN_IF_ERROR(_build(state));
        COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
    }

    return Status::OK();
}
```


