### PR TITLE
[BugFix] Fix issue 7168 caused by wrong CMakelists.

### DIFF
--- a/be/src/formats/orc/apache-orc/CMakeLists.txt
+++ b/be/src/formats/orc/apache-orc/CMakeLists.txt
@@ -160,10 +160,6 @@ install(
   DESTINATION "share/doc/orc")
 endif()
 
-if (BUILD_JAVA)
-  add_subdirectory(java)
-endif()
-
 if (BUILD_TOOLS)
   add_subdirectory(tools)
 endif ()


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7168

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Building BE without -DBUILD_JAVA=0 option will not cause cmake failed.