### PR TITLE
[BugFix] fix memory statistic in local passthrough

### DIFF
--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -24,4 +24,8 @@ starrocks::MemTracker* CurrentThread::mem_tracker() {
     return tls_mem_tracker;
 }
 
+CurrentThread& CurrentThread::current() {
+    return tls_thread_status;
+}
+
 } // namespace starrocks

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -89,7 +89,7 @@ public:
     void mem_consume(int64_t size) {
         MemTracker* cur_tracker = mem_tracker();
         _cache_size += size;
-        _consumed_bytes += size;
+        _total_consumed_bytes += size;
         if (cur_tracker != nullptr && _cache_size >= BATCH_SIZE) {
             cur_tracker->consume(_cache_size);
             _cache_size = 0;
@@ -99,7 +99,7 @@ public:
     bool try_mem_consume(int64_t size) {
         MemTracker* cur_tracker = mem_tracker();
         _cache_size += size;
-        _consumed_bytes += size;
+        _total_consumed_bytes += size;
         if (cur_tracker != nullptr && _cache_size >= BATCH_SIZE) {
             MemTracker* limit_tracker = cur_tracker->try_consume(_cache_size);
             if (LIKELY(limit_tracker == nullptr)) {
@@ -158,20 +158,20 @@ public:
         return res;
     }
 
-    int64_t get_consumed_bytes() const { return _consumed_bytes; }
+    int64_t get_consumed_bytes() const { return _total_consumed_bytes; }
 
 private:
     const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
 
-    int64_t _cache_size = 0;
-    int64_t _consumed_bytes = 0;
+    int64_t _cache_size = 0;           // Allocated but not committed memory bytes
+    int64_t _total_consumed_bytes = 0; // Totally consumed memory bytes
+    int64_t _try_consume_mem_size = 0; // Last time tried to consumed bytes
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
     int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;
-    int64_t _try_consume_mem_size = 0;
 };
 
 inline thread_local CurrentThread tls_thread_status;

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -16,7 +16,7 @@ public:
 
     ~PassThroughSenderChannel() {
         if (_physical_bytes > 0) {
-            CurrentThread::mem_tracker()->consume(_physical_bytes);
+            CurrentThread::current().mem_consume(_physical_bytes);
         }
     }
 
@@ -26,7 +26,7 @@ public:
         auto clone = chunk->clone_unique();
         int64_t physical_bytes = CurrentThread::current().get_consumed_bytes() - before_bytes;
         DCHECK_GE(physical_bytes, 0);
-        CurrentThread::mem_tracker()->release(physical_bytes);
+        CurrentThread::current().mem_release(physical_bytes);
 
         std::unique_lock lock(_mutex);
         _buffer.emplace_back(std::make_pair(std::move(clone), driver_sequence));
@@ -39,7 +39,7 @@ public:
         bytes->swap(_bytes);
 
         // Consume physical bytes in current MemTracker, since later it would be released
-        CurrentThread::mem_tracker()->consume(_physical_bytes);
+        CurrentThread::current().mem_consume(_physical_bytes);
         _physical_bytes = 0;
     }
 

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -12,6 +12,14 @@ namespace starrocks {
 // channel per [sender_id]
 class PassThroughSenderChannel {
 public:
+    PassThroughSenderChannel() = default;
+
+    ~PassThroughSenderChannel() {
+        if (_physical_bytes > 0) {
+            CurrentThread::mem_tracker()->consume(_physical_bytes);
+        }
+    }
+
     void append_chunk(const vectorized::Chunk* chunk, size_t chunk_size, int32_t driver_sequence) {
         // Release allocated bytes in current MemTracker, since it would not be released at current MemTracker
         int64_t before_bytes = CurrentThread::current().get_consumed_bytes();

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -18,7 +18,7 @@ public:
         auto clone = chunk->clone_unique();
         int64_t physical_bytes = CurrentThread::current().get_consumed_bytes() - before_bytes;
         DCHECK_GE(physical_bytes, 0);
-        CurrentThread::current().mem_release(physical_bytes);
+        CurrentThread::mem_tracker()->release(physical_bytes);
 
         std::unique_lock lock(_mutex);
         _buffer.emplace_back(std::make_pair(std::move(clone), driver_sequence));
@@ -31,7 +31,7 @@ public:
         bytes->swap(_bytes);
 
         // Consume physical bytes in current MemTracker, since later it would be released
-        tls_thread_status.mem_consume(_physical_bytes);
+        CurrentThread::mem_tracker()->consume(_physical_bytes);
         _physical_bytes = 0;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7181

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Problem:
- Chunks are transferred from one fragment to the other, but not be accounted at `MemTracker`

Solution:
- Release in `MemTracker` at sender fragment
- Allocate in MemTracker in receiver fragment

Considerations:
- The passthrough memory is not accounted at the global `MemTracker` ? 
  - Total memory of passthrough memory is limited by the `max_transmit_batched_bytes`, and it's not a large part
- What if the `PassThroughSenderChannel` destruct without `pull_chunk`, will be lead to memory leak at `MemTracker`?
  - It could not, cause we have accounted the memory at `~PassThroughSenderChannel()`.
