### PR TITLE
[Enhancement] Remove txn lock and add tracing for run_publish_version_task

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -8,6 +8,7 @@ DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include <bvar/bvar.h>
 DIAGNOSTIC_POP
 
+#include "common/tracer.h"
 #include "fmt/format.h"
 #include "gutil/strings/join.h"
 #include "storage/data_dir.h"
@@ -39,6 +40,10 @@ void run_publish_version_task(ThreadPool& threadpool, const TAgentTaskRequest& p
     int64_t start_ts = MonotonicMillis();
     auto& publish_version_req = publish_version_task.publish_version_req;
     int64_t transaction_id = publish_version_req.transaction_id;
+
+    auto span = Tracer::Instance().start_trace_txn("publish_version_task", transaction_id);
+    auto scoped = trace::Scope(span);
+
     size_t num_partition = publish_version_req.partition_version_infos.size();
     size_t num_tablet = 0;
     std::vector<std::map<TabletInfo, RowsetSharedPtr>> partitions(num_partition);
@@ -47,6 +52,8 @@ void run_publish_version_task(ThreadPool& threadpool, const TAgentTaskRequest& p
                 transaction_id, publish_version_req.partition_version_infos[i].partition_id, &partitions[i]);
         num_tablet += partitions[i].size();
     }
+    span->SetAttribute("num_partition", num_partition);
+    span->SetAttribute("num_tablet", num_tablet);
     std::vector<TabletPublishVersionTask> tablet_tasks(num_tablet);
     size_t tablet_idx = 0;
     for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
@@ -66,6 +73,11 @@ void run_publish_version_task(ThreadPool& threadpool, const TAgentTaskRequest& p
         while (retry_time++ < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
             st = threadpool.submit_func([&, i]() {
                 auto& task = tablet_tasks[i];
+                auto tablet_span = Tracer::Instance().add_span("tablet_publish_txn", span);
+                auto scoped_tablet_span = trace::Scope(tablet_span);
+                tablet_span->SetAttribute("txn_id", transaction_id);
+                tablet_span->SetAttribute("tablet_id", task.tablet_id);
+                tablet_span->SetAttribute("version", task.version);
                 if (!task.rowset) {
                     task.st = Status::NotFound(
                             fmt::format("rowset not found  of tablet: {}, txn_id: {}", task.tablet_id, task.txn_id));
@@ -102,6 +114,7 @@ void run_publish_version_task(ThreadPool& threadpool, const TAgentTaskRequest& p
                 LOG(WARNING) << "publish version threadpool is busy, retry in  " << retry_sleep_ms
                              << "ms. txn_id: " << transaction_id << ", tablet:" << tablet_tasks[i].tablet_id;
                 // In general, publish version is fast. A small sleep is needed here.
+                auto wait_span = Tracer::Instance().add_span("retry_wait", span);
                 SleepFor(MonoDelta::FromMilliseconds(retry_sleep_ms));
                 continue;
             } else {
@@ -112,7 +125,9 @@ void run_publish_version_task(ThreadPool& threadpool, const TAgentTaskRequest& p
             tablet_tasks[i].st = std::move(st);
         }
     }
+    span->AddEvent("all_task_submitted");
     threadpool.wait();
+    span->AddEvent("all_task_finished");
 
     Status st;
     finish_task.__isset.tablet_versions = true;

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -99,6 +99,7 @@ Status NodeChannel::init(RuntimeState* state) {
     // Initialize _cur_request
     _cur_request.set_allocated_id(&_parent->_load_id);
     _cur_request.set_index_id(_index_id);
+    _cur_request.set_txn_id(_parent->_txn_id);
     _cur_request.set_sender_id(_parent->_sender_id);
     _cur_request.set_eos(false);
 
@@ -484,6 +485,7 @@ void NodeChannel::cancel(const Status& err_st) {
     request.set_allocated_id(&_parent->_load_id);
     request.set_index_id(_index_id);
     request.set_sender_id(_parent->_sender_id);
+    request.set_txn_id(_parent->_txn_id);
 
     auto closure = new RefCountClosure<PTabletWriterCancelResult>();
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -49,8 +49,8 @@ Status RowsetUpdateState::load(Tablet* tablet, Rowset* rowset) {
 }
 
 Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
-    auto scoped_span = trace::Scope(Tracer::Instance().start_trace_txn_tablet("rowset_update_state_load",
-                                                                              rowset->txn_id(), tablet->tablet_id()));
+    auto span = Tracer::Instance().start_trace_txn_tablet("rowset_update_state_load", rowset->txn_id(),
+                                                          tablet->tablet_id());
     _tablet_id = tablet->tablet_id();
     auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <utility>
 
+#include "common/tracer.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "storage/compaction_candidate.h"
@@ -339,10 +340,23 @@ RowsetSharedPtr Tablet::_rowset_with_largest_size() {
 }
 
 // add inc rowset should not persist tablet meta, because it will be persisted when publish txn.
-Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
+Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     CHECK(!_updates) << "updatable tablet should not call add_inc_rowset";
     DCHECK(rowset != nullptr);
     std::unique_lock wrlock(_meta_lock);
+
+    // rowset is already set version here, memory is changed, if save failed it maybe a fatal error
+    rowset->make_visible({version, version});
+    auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
+    Status st = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), rowset_meta_pb);
+    if (!st.ok()) {
+        LOG(WARNING) << "Fail to save committed rowset. "
+                     << "tablet_id: " << tablet_id() << ", txn_id: " << rowset->txn_id()
+                     << ", rowset_id: " << rowset->rowset_id();
+        return Status::InternalError(fmt::format("Fail to save committed rowset. tablet_id: {}, txn_id: {}",
+                                                 tablet_id(), rowset->txn_id()));
+    }
+
     RETURN_IF_ERROR(_contains_version(rowset->version()));
     RETURN_IF_ERROR(_tablet_meta->add_rs_meta(rowset->rowset_meta()));
     RETURN_IF_ERROR(_tablet_meta->add_inc_rs_meta(rowset->rowset_meta()));
@@ -755,10 +769,10 @@ Version Tablet::_max_continuous_version_from_beginning_unlocked() const {
 }
 
 int64_t Tablet::max_continuous_version() const {
-    std::shared_lock rdlock(_meta_lock);
     if (_updates != nullptr) {
         return _updates->max_version();
     } else {
+        std::shared_lock rdlock(_meta_lock);
         int64_t v = _timestamped_version_tracker.get_max_continuous_version();
         DCHECK_EQ(v, _max_continuous_version_from_beginning_unlocked().second);
         return v;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -348,13 +348,13 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     // rowset is already set version here, memory is changed, if save failed it maybe a fatal error
     rowset->make_visible({version, version});
     auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
-    Status st = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), rowset_meta_pb);
+    auto st = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), rowset_meta_pb);
     if (!st.ok()) {
         LOG(WARNING) << "Fail to save committed rowset. "
                      << "tablet_id: " << tablet_id() << ", txn_id: " << rowset->txn_id()
                      << ", rowset_id: " << rowset->rowset_id();
-        return Status::InternalError(fmt::format("Fail to save committed rowset. tablet_id: {}, txn_id: {}",
-                                                 tablet_id(), rowset->txn_id()));
+        return Status::InternalError(
+                fmt::format("Fail to save committed rowset. tablet_id: {}, txn_id: {}", tablet_id(), rowset->txn_id()));
     }
 
     RETURN_IF_ERROR(_contains_version(rowset->version()));
@@ -370,7 +370,7 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     }
 
     // warm-up this rowset
-    auto st = rowset->load();
+    st = rowset->load();
     // ignore this error, only log load failure
     LOG_IF(WARNING, !st.ok()) << "ignore load rowset error tablet:" << tablet_id() << " rowset:" << rowset->rowset_id()
                               << " " << st;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -118,7 +118,7 @@ public:
 
     RowsetSharedPtr rowset_with_max_version() const;
 
-    Status add_inc_rowset(const RowsetSharedPtr& rowset);
+    Status add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version);
     void delete_expired_inc_rowsets();
 
     /// Delete stale rowset by timing. This delete policy uses now() munis

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -810,7 +810,6 @@ Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_i
                                               const PersistentIndexMetaPB& index_meta, bool enable_persistent_index) {
     auto span = Tracer::Instance().start_trace_tablet("apply_save_meta", tablet_id);
     span->SetAttribute("version", version.to_string());
-    auto scoped_span = trace::Scope(span);
     WriteBatch batch;
     auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     string logkey = encode_meta_log_key(tablet_id, logid);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -417,6 +417,8 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
 }
 
 Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
+    auto span = Tracer::Instance().start_trace("rowset_commit");
+    auto scope_span = trace::Scope(span);
     if (_error) {
         return Status::InternalError(Substitute("rowset_commit failed, tablet updates is in error state: tablet:$0 $1",
                                                 _tablet.tablet_id(), _error_msg));
@@ -477,7 +479,8 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
 }
 
 Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetSharedPtr& rowset) {
-    auto span = Tracer::Instance().start_trace_txn_tablet("rowset_commit", rowset->txn_id(), _tablet.tablet_id());
+    auto span =
+            Tracer::Instance().start_trace_txn_tablet("rowset_commit_unlocked", rowset->txn_id(), _tablet.tablet_id());
     span->SetAttribute("version", version);
     auto scoped = trace::Scope(span);
     EditVersionMetaPB edit;

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -160,8 +160,6 @@ private:
 
     txn_partition_map_t& _get_txn_partition_map(TTransactionId transactionId);
 
-    std::mutex& _get_txn_lock(TTransactionId transactionId);
-
     // insert or remove (transaction_id, partition_id) from _txn_partition_map
     // get _txn_map_lock before calling
     void _insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
@@ -182,8 +180,6 @@ private:
 
     std::unique_ptr<std::shared_mutex[]> _txn_map_locks;
 
-    std::unique_ptr<std::mutex[]> _txn_mutex;
-
     TxnManager(const TxnManager&) = delete;
     const TxnManager& operator=(const TxnManager&) = delete;
 }; // TxnManager
@@ -198,10 +194,6 @@ inline TxnManager::txn_tablet_map_t& TxnManager::_get_txn_tablet_map(TTransactio
 
 inline TxnManager::txn_partition_map_t& TxnManager::_get_txn_partition_map(TTransactionId transactionId) {
     return _txn_partition_maps[transactionId & (_txn_map_shard_size - 1)];
-}
-
-inline std::mutex& TxnManager::_get_txn_lock(TTransactionId transactionId) {
-    return _txn_mutex[transactionId & (_txn_shard_size - 1)];
 }
 
 } // namespace starrocks

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -181,6 +181,7 @@ message PTabletWriterAddChunkRequest {
     // only valid when eos is true
     // valid partition ids that would write in this writer
     repeated int64 partition_ids = 8;
+    optional int64 txn_id = 9;
 };
 
 message PTabletWriterAddBatchResult {
@@ -195,6 +196,7 @@ message PTabletWriterCancelRequest {
     required PUniqueId id = 1;
     required int64 index_id = 2;
     required int32 sender_id = 3;
+    optional int64 txn_id = 4;
 };
 
 message PTabletWriterCancelResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7173

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For each tablet's publish_txn in a txn, they all request txn lock, which makes them run serially. This PR removes txn lock and adds some tracing for `run_publish_version_task`