### PR TITLE
[Bugfix] Use original sql for task definition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -23,6 +23,7 @@ import com.starrocks.analysis.ShowStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.UpdateStmt;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.AnalyzeStmt;
 import com.starrocks.sql.ast.AstVisitor;
@@ -118,9 +119,8 @@ public class Analyzer {
             CreateTableAsSelectStmt createTableAsSelectStmt = statement.getCreateTableAsSelectStmt();
             QueryStatement queryStatement = createTableAsSelectStmt.getQueryStatement();
             Analyzer.analyze(queryStatement, context);
-            String sqlText = "CREATE TABLE " +
-                    createTableAsSelectStmt.getCreateTableStmt().getDbTbl().toSql() + " AS " +
-                    ViewDefBuilder.build(queryStatement);
+            OriginStatement origStmt = statement.getOrigStmt();
+            String sqlText = origStmt.originStmt.substring(statement.getSqlBeginIndex());
             statement.setSqlText(sqlText);
             TaskAnalyzer.analyzeSubmitTaskStmt(statement, context);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
@@ -15,15 +15,18 @@ public class SubmitTaskStmt extends DdlStmt {
 
     private Map<String, String> properties;
 
+    private int sqlBeginIndex;
+
     private String sqlText;
 
     private CreateTableAsSelectStmt createTableAsSelectStmt;
 
-    public SubmitTaskStmt(String dbName, String taskName, Map<String, String> properties,
+    public SubmitTaskStmt(String dbName, String taskName, Map<String, String> properties, int sqlBeginIndex,
                           CreateTableAsSelectStmt createTableAsSelectStmt) {
         this.dbName = dbName;
         this.taskName = taskName;
         this.properties = properties;
+        this.sqlBeginIndex = sqlBeginIndex;
         this.createTableAsSelectStmt = createTableAsSelectStmt;
     }
 
@@ -41,6 +44,14 @@ public class SubmitTaskStmt extends DdlStmt {
 
     public void setTaskName(String taskName) {
         this.taskName = taskName;
+    }
+
+    public int getSqlBeginIndex() {
+        return sqlBeginIndex;
+    }
+
+    public void setSqlBeginIndex(int sqlBeginIndex) {
+        this.sqlBeginIndex = sqlBeginIndex;
     }
 
     public Map<String, String> getProperties() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -601,16 +601,16 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         CreateTableAsSelectStmt createTableAsSelectStmt =
                 (CreateTableAsSelectStmt) visit(context.createTableAsSelectStatement());
-
+        int startIndex = context.createTableAsSelectStatement().start.getStartIndex();
         if (qualifiedName == null) {
             return new SubmitTaskStmt(null, null,
-                    properties, createTableAsSelectStmt);
+                    properties, startIndex, createTableAsSelectStmt);
         } else if (qualifiedName.getParts().size() == 1) {
             return new SubmitTaskStmt(null, qualifiedName.getParts().get(0),
-                    properties, createTableAsSelectStmt);
+                    properties, startIndex, createTableAsSelectStmt);
         } else if (qualifiedName.getParts().size() == 2) {
             return new SubmitTaskStmt(SystemInfoService.DEFAULT_CLUSTER + ":" + qualifiedName.getParts().get(0),
-                    qualifiedName.getParts().get(1), properties, createTableAsSelectStmt);
+                    qualifiedName.getParts().get(1), properties, startIndex, createTableAsSelectStmt);
         } else {
             throw new ParsingException("error task name ");
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7186

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
use ViewDefBuilder or AST2SQL can not convert execute sql correctly and user experience is not good.
Task have db session so it does not need to have cluster DB information, or other redundant transformations, so we only store raw SQL.