### PR TITLE
[BugFix] Fix Agg table use replace agg function when load_dop is not 1 will make data disorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -202,11 +202,11 @@ public class StreamLoadPlanner {
         queryOptions.setQuery_timeout(streamLoadTask.getTimeout());
         queryOptions.setTransmission_compression_type(streamLoadTask.getTransmisionCompressionType());
         if (streamLoadTask.getLoadParallelRequestNum() != 0) {
-            // primary key & unique key should not use parallel write since the order of write is important
-            if (destTable.getKeysType() == KeysType.PRIMARY_KEYS || destTable.getKeysType() == KeysType.UNIQUE_KEYS) {
-                queryOptions.setLoad_dop(1);
-            } else {
+            // only dup_keys can use parallel write since other table's the order of write is important
+            if (destTable.getKeysType() == KeysType.DUP_KEYS) {
                 queryOptions.setLoad_dop(streamLoadTask.getLoadParallelRequestNum());
+            } else {
+                queryOptions.setLoad_dop(1);
             }
         }
         // for stream load, we use exec_mem_limit to limit the memory usage of load channel.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7201

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Agg table use replace agg function when load_dop is not 1 will make data disorder