### PR TITLE
[Enhancement] Estimate scan row bytes dynamically in time

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -29,16 +29,14 @@ void ConnectorScanOperatorFactory::do_close(RuntimeState* state) {
 }
 
 OperatorPtr ConnectorScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, _scan_node, _max_scan_concurrency,
-                                                   _num_committed_scan_tasks);
+    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, _scan_node, _num_committed_scan_tasks);
 }
 
 // ==================== ConnectorScanOperator ====================
 
 ConnectorScanOperator::ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence,
-                                             ScanNode* scan_node, int max_scan_concurrency,
-                                             std::atomic<int>& num_committed_scan_tasks)
-        : ScanOperator(factory, id, driver_sequence, scan_node, max_scan_concurrency, num_committed_scan_tasks) {}
+                                             ScanNode* scan_node, std::atomic<int>& num_committed_scan_tasks)
+        : ScanOperator(factory, id, driver_sequence, scan_node, num_committed_scan_tasks) {}
 
 Status ConnectorScanOperator::do_prepare(RuntimeState* state) {
     return Status::OK();
@@ -47,7 +45,7 @@ Status ConnectorScanOperator::do_prepare(RuntimeState* state) {
 void ConnectorScanOperator::do_close(RuntimeState* state) {}
 
 ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
-    vectorized::ConnectorScanNode* scan_node = down_cast<vectorized::ConnectorScanNode*>(_scan_node);
+    auto* scan_node = down_cast<vectorized::ConnectorScanNode*>(_scan_node);
     return std::make_shared<ConnectorChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel),
                                                   this, scan_node);
 }

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -27,7 +27,7 @@ public:
 class ConnectorScanOperator final : public ScanOperator {
 public:
     ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                          int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks);
+                          std::atomic<int>& num_committed_scan_tasks);
 
     ~ConnectorScanOperator() override = default;
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -63,6 +63,8 @@ private:
     // if it runs in the worker thread owned by other workgroup, which has running drivers.
     static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT = 20'000'000L;
 
+    static constexpr int UPDATE_AVG_ROW_BYTES_FREQUENCY = 8;
+
     Status _get_tablet(const TInternalScanRange* scan_range);
     Status _init_reader_params(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges,
                                const std::vector<uint32_t>& scanner_columns, std::vector<uint32_t>& reader_columns);
@@ -75,6 +77,8 @@ private:
     void _update_counter();
     void _update_realtime_counter(vectorized::Chunk* chunk);
     void _decide_chunk_size();
+
+    void _update_avg_row_bytes(vectorized::Chunk* chunk, size_t chunk_index, size_t batch_size);
 
 private:
     vectorized::TabletReaderParams _params{};
@@ -116,6 +120,9 @@ private:
     int64_t _raw_rows_read = 0;
     int64_t _compressed_bytes_read = 0;
     int64_t _last_spent_cpu_time_ns = 0;
+
+    size_t _local_sum_row_bytes = 0;
+    size_t _local_num_rows = 0;
 
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -72,4 +72,13 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
     return Status::OK();
 }
 
+void OlapScanContext::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _sum_row_bytes += added_sum_row_bytes;
+    _num_rows += added_num_rows;
+    if (_num_rows > 0) {
+        _avg_row_bytes = _sum_row_bytes / _num_rows;
+    }
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -39,6 +39,9 @@ public:
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
 
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
+    size_t avg_row_bytes() const { return _avg_row_bytes; }
+
 private:
     vectorized::OlapScanNode* _scan_node;
 
@@ -51,6 +54,11 @@ private:
     ObjectPool _obj_pool;
 
     std::atomic<bool> _is_prepare_finished{false};
+
+    std::mutex _mutex;
+    size_t _sum_row_bytes = 0;
+    size_t _num_rows = 0;
+    size_t _avg_row_bytes = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -28,17 +28,16 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _max_scan_concurrency,
-                                              _num_committed_scan_tasks, _ctx);
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _num_committed_scan_tasks, _ctx);
 }
 
 // ==================== OlapScanOperator ====================
 
 OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                                   int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks,
-                                   OlapScanContextPtr ctx)
-        : ScanOperator(factory, id, driver_sequence, scan_node, max_scan_concurrency, num_committed_scan_tasks),
-          _ctx(std::move(ctx)) {
+                                   std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx)
+        : ScanOperator(factory, id, driver_sequence, scan_node, num_committed_scan_tasks),
+          _ctx(std::move(ctx)),
+          _default_max_scan_concurrency(scan_node->max_scan_concurrency()) {
     _ctx->ref();
 }
 
@@ -75,15 +74,54 @@ bool OlapScanOperator::is_finished() const {
 }
 
 Status OlapScanOperator::do_prepare(RuntimeState*) {
+    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "DefaultMaxScanConcurrency", TUnit::UNIT);
+    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_default_max_scan_concurrency));
+
     return Status::OK();
 }
 
-void OlapScanOperator::do_close(RuntimeState* state) {}
+void OlapScanOperator::do_close(RuntimeState* state) {
+    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "AvgMaxScanConcurrency", TUnit::UNIT);
+    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_avg_max_scan_concurrency()));
+}
 
 ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);
     return std::make_shared<OlapChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel),
                                              olap_scan_node, _ctx.get());
+}
+
+size_t OlapScanOperator::max_scan_concurrency() const {
+    int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
+
+    size_t avg_row_bytes = _ctx->avg_row_bytes();
+    if (avg_row_bytes == 0) {
+        return _default_max_scan_concurrency;
+    }
+
+    // Assume that the memory tried in the storage layer is the same as the output chunk.
+    size_t row_mem_usage = avg_row_bytes * 2;
+    size_t chunk_mem_usage = row_mem_usage * runtime_state()->chunk_size();
+    DCHECK_GT(chunk_mem_usage, 0);
+
+    // limit scan memory usage not greater than 1/4 query limit.
+    size_t concurrency = std::max<size_t>(query_limit * config::scan_use_query_mem_ratio / chunk_mem_usage, 1);
+
+    if (_prev_max_scan_concurrency != concurrency) {
+        _sum_max_scan_concurrency += concurrency;
+        ++_num_max_scan_concurrency;
+        _prev_max_scan_concurrency = concurrency;
+    }
+
+    return concurrency;
+}
+
+size_t OlapScanOperator::_avg_max_scan_concurrency() const {
+    if (_num_max_scan_concurrency > 0) {
+        return _sum_max_scan_concurrency / _num_max_scan_concurrency;
+    }
+
+    return 0;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -33,7 +33,7 @@ private:
 class OlapScanOperator final : public ScanOperator {
 public:
     OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                     int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx);
+                     std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx);
 
     ~OlapScanOperator() override;
 
@@ -44,8 +44,19 @@ public:
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
+    size_t max_scan_concurrency() const override;
+
+private:
+    size_t _avg_max_scan_concurrency() const;
+
 private:
     OlapScanContextPtr _ctx;
+
+    const size_t _default_max_scan_concurrency;
+    // These three fields are used to calculate the average of different `max_scan_concurrency`s for profile.
+    mutable size_t _prev_max_scan_concurrency = 0;
+    mutable size_t _sum_max_scan_concurrency = 0;
+    mutable size_t _num_max_scan_concurrency = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -16,7 +16,7 @@ namespace pipeline {
 class ScanOperator : public SourceOperator {
 public:
     ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                 int max_scan_concurrency, std::atomic<int>& num_committed_scan_tasks);
+                 std::atomic<int>& num_committed_scan_tasks);
 
     ~ScanOperator() override;
 
@@ -61,6 +61,11 @@ public:
         return res;
     }
 
+    virtual size_t max_scan_concurrency() const {
+        // It takes effect, only when it is positive.
+        return 0;
+    }
+
 private:
     // This method is only invoked when current morsel is reached eof
     // and all cached chunk of this morsel has benn read out
@@ -96,7 +101,6 @@ protected:
 
     bool _is_finished = false;
 
-    const int _max_scan_concurrency;
     // Shared by all the ScanOperators created by the same ScanOperatorFactory.
     std::atomic<int>& _num_committed_scan_tasks;
 
@@ -141,7 +145,6 @@ public:
 protected:
     ScanNode* const _scan_node;
 
-    const int _max_scan_concurrency;
     std::atomic<int> _num_committed_scan_tasks{0};
 };
 

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -59,8 +59,7 @@ const std::string RuntimeProfile::ROOT_COUNTER = ""; // NOLINT
 RuntimeProfile::PeriodicCounterUpdateState RuntimeProfile::_s_periodic_counter_update_state;
 
 const std::unordered_set<std::string> RuntimeProfile::NON_MERGE_COUNTER_NAMES = {
-        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum",
-        "PushdownPredicates",  "MemoryLimit",           "MaxScanConcurrency"};
+        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum", "PushdownPredicates", "MemoryLimit"};
 
 RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
         : _parent(nullptr),

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -55,7 +55,7 @@ public class RuntimeProfile {
     private static final String ROOT_COUNTER = "";
     private static final Set<String> NON_MERGE_COUNTER_NAMES =
             Sets.newHashSet("DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum", "PushdownPredicates",
-                    "MemoryLimit", "MaxScanConcurrency");
+                    "MemoryLimit");
 
     private final Counter counterTotalTime;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The current mechanism of estimating the scanning column bytes is to directly give a fixed estimated value. If the estimated value deviates greatly from the actual value, the parallelism will be too low.
For example, with a `Bitmap` estimate of 1MB, `query_mem_limit` of 32GB would limit the parallelism to 1.

Therefore, this PR adds the strategy of "adaptive row bytes estimation". 
During the scan tasks running, the `estimated_row_bytes` is adjusted in real time according to the read chunk bytes, and then the parallelism is adjusted.

In addition, there is a bug when `max_concurrency` < `dop`, which may lose reading some rows.
```C++
    for (int i = 0; i < MAX_IO_TASKS_PER_OP; ++i) {
        if (_chunk_sources[i] != nullptr && !_is_io_task_running[i] && _chunk_sources[i]->has_next_chunk()) { // A. 
            RETURN_IF_ERROR(_trigger_next_scan(state, i)); // B.
        }
    }
    // Secondly, find the unused position of _chunk_sources to pick up a new morsel.
    if (!_morsel_queue->empty()) {
        for (int i = 0; i < MAX_IO_TASKS_PER_OP; ++i) {
            // *** After limiting the scan concurrency from 2.3, `_trigger_next_scan` at B may failed. 
            // Therefore, should check `!_chunk_sources[i]->has_next_buffer()` again here. ***
            if (_chunk_sources[i] == nullptr || (!_is_io_task_running[i] && !_chunk_sources[i]->has_output())) {
                RETURN_IF_ERROR(_pickup_morsel(state, i));
            }
        }
    }
```
