### PR TITLE
[StarRocks On ES] support ssl-secured ES

### DIFF
--- a/be/src/exec/es/es_scan_reader.h
+++ b/be/src/exec/es/es_scan_reader.h
@@ -43,6 +43,7 @@ public:
     static constexpr const char* KEY_BATCH_SIZE = "batch_size";
     static constexpr const char* KEY_TERMINATE_AFTER = "limit";
     static constexpr const char* KEY_DOC_VALUES_MODE = "doc_values_mode";
+    static constexpr const char* KEY_ES_NET_SSL = "es.net.ssl";
     ESScanReader(const std::string& target, const std::map<std::string, std::string>& props, bool doc_value_mode);
     ~ESScanReader();
 
@@ -100,5 +101,7 @@ private:
     bool _exactly_once;
 
     bool _doc_value_mode;
+
+    bool _ssl_enabled = false;
 };
 } // namespace starrocks

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -86,6 +86,10 @@ public:
 
     void set_timeout_ms(int64_t timeout_ms) { curl_easy_setopt(_curl, CURLOPT_TIMEOUT_MS, timeout_ms); }
 
+    void trust_all_ssl() {
+        curl_easy_setopt(_curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(_curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    }
     // used to get content length
     int64_t get_content_length() const {
         double cl = 0.0f;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -70,6 +70,7 @@ public class EsTable extends Table {
     public static final String MAX_DOCVALUE_FIELDS = "max_docvalue_fields";
 
     public static final String WAN_ONLY = "es.nodes.wan.only";
+    public static final String ES_NET_SSL = "es.net.ssl";
 
     private String hosts;
     private String[] seeds;
@@ -105,6 +106,7 @@ public class EsTable extends Table {
     private static final int DEFAULT_MAX_DOCVALUE_FIELDS = 20;
 
     private boolean wanOnly = false;
+    private boolean sslEnabled = false;
 
     // version would be used to be compatible with different ES Cluster
     public EsMajorVersion majorVersion = null;
@@ -148,6 +150,10 @@ public class EsTable extends Table {
 
     public boolean wanOnly() {
         return wanOnly;
+    }
+
+    public boolean sslEnabled() {
+        return sslEnabled;
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -248,6 +254,13 @@ public class EsTable extends Table {
                 wanOnly = false;
             }
         }
+        if (properties.containsKey(ES_NET_SSL)) {
+            try {
+                sslEnabled = Boolean.parseBoolean(properties.get(ES_NET_SSL).trim());
+            } catch (Exception e) {
+                sslEnabled = false;
+            }
+        }
         tableContext.put("hosts", hosts);
         tableContext.put("userName", userName);
         tableContext.put("passwd", passwd);
@@ -261,6 +274,7 @@ public class EsTable extends Table {
         tableContext.put("enableKeywordSniff", String.valueOf(enableKeywordSniff));
         tableContext.put("maxDocValueFields", String.valueOf(maxDocValueFields));
         tableContext.put("es.nodes.wan.only", String.valueOf(wanOnly));
+        tableContext.put(ES_NET_SSL, String.valueOf(sslEnabled));
     }
 
     @Override
@@ -363,6 +377,11 @@ public class EsTable extends Table {
             } else {
                 wanOnly = false;
             }
+            if (tableContext.containsKey(ES_NET_SSL)) {
+                sslEnabled = Boolean.parseBoolean(tableContext.get(ES_NET_SSL));
+            } else {
+                sslEnabled = false;
+            }
 
             PartitionType partType = PartitionType.valueOf(Text.readString(in));
             if (partType == PartitionType.UNPARTITIONED) {
@@ -398,6 +417,7 @@ public class EsTable extends Table {
             tableContext.put("enableDocValueScan", "false");
             tableContext.put(KEYWORD_SNIFF, "true");
             tableContext.put(WAN_ONLY, "false");
+            tableContext.put(ES_NET_SSL, "false");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRepository.java
@@ -59,7 +59,7 @@ public class EsRepository extends MasterDaemon {
         }
         esTables.put(esTable.getId(), esTable);
         esClients.put(esTable.getId(),
-                new EsRestClient(esTable.getSeeds(), esTable.getUserName(), esTable.getPasswd()));
+                new EsRestClient(esTable.getSeeds(), esTable.getUserName(), esTable.getPasswd(), esTable.sslEnabled()));
         LOG.info("register a new table [{}] to sync list", esTable);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRestClient.java
@@ -244,12 +244,17 @@ public class EsRestClient {
         }
         return sslNetworkClient;
     }
+
     private static class TrustAllCerts implements X509TrustManager {
-        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
 
-        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
 
-        public X509Certificate[] getAcceptedIssuers() {return new X509Certificate[0];}
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
     }
 
     private static class TrustAllHostnameVerifier implements HostnameVerifier {
@@ -257,11 +262,12 @@ public class EsRestClient {
             return true;
         }
     }
+
     private static SSLSocketFactory createSSLSocketFactory() {
         SSLSocketFactory ssfFactory;
         try {
             SSLContext sc = SSLContext.getInstance("TLS");
-            sc.init(null, new TrustManager[]{new TrustAllCerts()}, new SecureRandom());
+            sc.init(null, new TrustManager[] {new TrustAllCerts()}, new SecureRandom());
             ssfFactory = sc.getSocketFactory();
         } catch (Exception e) {
             throw new StarRocksESException("Errors happens when create ssl socket");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -157,6 +157,7 @@ public class EsScanNode extends ScanNode {
         Map<String, String> properties = Maps.newHashMap();
         properties.put(EsTable.USER, table.getUserName());
         properties.put(EsTable.PASSWORD, table.getPasswd());
+        properties.put(EsTable.ES_NET_SSL, String.valueOf(table.sslEnabled()));
         TEsScanNode esScanNode = new TEsScanNode(desc.getId().asInt());
         esScanNode.setProperties(properties);
         if (table.isDocValueScanEnable()) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/7160

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When creating an ES external table, add a parameter `es.net.ssl: "true"` to identify whether the ES cluster has HTTPS enabled 

```
CREATE EXTERNAL TABLE `wyf6` (
  `k1` bigint(20) NULL COMMENT "",
  `k2` varchar(20) NULL COMMENT "",
  `k3` varchar(20) NULL COMMENT "",
  `k4` bigint(20) NULL COMMENT ""
) ENGINE=ELASTICSEARCH 
COMMENT "ELASTICSEARCH"
PROPERTIES (
"hosts" = "https://127.0.01:9200",
"user" = "",
"password" = "",
"index" = "test",
"type" = "_doc",
"es.net.ssl" = "true"
);
```

es.net.ssl` is true to indicate that HTTPS is enabled for the ES cluster accessed; false indicates that HTTPS is not enabled, and ordinary HTTP requests are used

At this time, Starrocks both FE and BE  ignores all certificates and hostnames for now 

