### PR TITLE
[BugFix] window push down runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -32,6 +32,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.common.UserException;
 import com.starrocks.thrift.TAnalyticNode;
@@ -291,6 +292,36 @@ public class AnalyticEvalNode extends PlanNode {
 
     public void setSubstitutedPartitionExprs(List<Expr> substitutedPartitionExprs) {
         this.substitutedPartitionExprs = substitutedPartitionExprs;
+    }
+
+    @Override
+    public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
+        if (!canPushDownRuntimeFilter()) {
+            return false;
+        }
+
+        if (probeExpr.isBoundByTupleIds(getTupleIds())) {
+            if (probeExpr instanceof SlotRef) {
+                for (Expr pExpr : partitionExprs) {
+                    // push down only when both of them are slot ref and slot id match.
+                    if ((pExpr instanceof SlotRef) &&
+                            (((SlotRef) pExpr).getSlotId().asInt() == ((SlotRef) probeExpr).getSlotId().asInt())) {
+                        if (children.get(0).pushDownRuntimeFilters(description, pExpr)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            if (description.canProbeUse(this)) {
+                // can not push down to children.
+                // use runtime filter at this level.
+                description.addProbeExpr(id.asInt(), probeExpr);
+                probeRuntimeFilters.add(description);
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

window node support push down runtime filter

SQL1. window without partition by, can't push down any runtime filter
```
select * from
(select v1, sum(v2) over (order by v2 desc) as sum1 from t0) a, 
(select v1 from t0 where v1 = 1) b 
where a.v1 = b.v1
```


SQL2. window with partition by and runtime filter columns eqauls partition by columns, can push down
```
select * from
(select v1, sum(v2) over (partition by v1 order by v2 desc) as sum1 from t0) a, 
(select v1 from t0 where v1 = 1) b 
where a.v1 = b.v1
```


SQL3. window with partition by but runtime filter columns not eqauls partition by columns, can't push down
```
select * from
(select v1, v3, sum(v2) over (partition by v3 order by v2 desc) as sum1 from t0) a, 
(select v1 from t0 where v1 = 1) b 
where a.v1 = b.v1
```

