### PR TITLE
[BugFix] Support to access object storage in https

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -698,9 +698,9 @@ CONF_String(object_storage_endpoint, "");
 // Tencent cos needs to add region information
 CONF_String(object_storage_region, "");
 CONF_Int64(object_storage_max_connection, "102400");
-// Acccess object storage use https.
+// Acccess object storage using https.
 // this options is applicable only if `object_storage_endpoint` is not specified.
-CONF_Bool(object_storage_endpoint_use_ssl, "false");
+CONF_Bool(object_storage_endpoint_use_https, "false");
 
 
 CONF_Bool(enable_orc_late_materialization, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -702,7 +702,6 @@ CONF_Int64(object_storage_max_connection, "102400");
 // this options is applicable only if `object_storage_endpoint` is not specified.
 CONF_Bool(object_storage_endpoint_use_https, "false");
 
-
 CONF_Bool(enable_orc_late_materialization, "true");
 // orc reader, if RowGroup/Stripe/File size is less than this value, read all data.
 CONF_Int32(orc_file_cache_max_size, "2097152");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -698,6 +698,10 @@ CONF_String(object_storage_endpoint, "");
 // Tencent cos needs to add region information
 CONF_String(object_storage_region, "");
 CONF_Int64(object_storage_max_connection, "102400");
+// Acccess object storage use https.
+// this options is applicable only if `object_storage_endpoint` is not specified.
+CONF_Bool(object_storage_endpoint_use_ssl, "false");
+
 
 CONF_Bool(enable_orc_late_materialization, "true");
 // orc reader, if RowGroup/Stripe/File size is less than this value, read all data.

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -135,7 +135,7 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
     } else if (!config::object_storage_endpoint.empty()) {
         config.endpointOverride = config::object_storage_endpoint;
     } else if (config::object_storage_endpoint_use_https) {
-         config.scheme = Aws::Http::Scheme::HTTPS;
+        config.scheme = Aws::Http::Scheme::HTTPS;
     } else {
         config.scheme = Aws::Http::Scheme::HTTP;
     }

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -134,12 +134,10 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
         config.endpointOverride = uri.endpoint();
     } else if (!config::object_storage_endpoint.empty()) {
         config.endpointOverride = config::object_storage_endpoint;
+    } else if (config::object_storage_endpoint_use_https) {
+         config.scheme = Aws::Http::Scheme::HTTPS;
     } else {
-        // To use implicit endpoint.
         config.scheme = Aws::Http::Scheme::HTTP;
-        if (config::object_storage_endpoint_use_https) {
-            config.scheme = Aws::Http::Scheme::HTTPS;
-        }
     }
     if (!config::object_storage_region.empty()) {
         config.region = config::object_storage_region;

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -130,11 +130,16 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
 
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
     Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
-    config.scheme = Aws::Http::Scheme::HTTP; // TODO: use the scheme in uri
     if (!uri.endpoint().empty()) {
         config.endpointOverride = uri.endpoint();
     } else if (!config::object_storage_endpoint.empty()) {
         config.endpointOverride = config::object_storage_endpoint;
+    } else {
+        // To use implicit endpoint.
+        config.scheme = Aws::Http::Scheme::HTTP;
+        if (config::object_storage_endpoint_use_ssl) {
+            config.scheme = Aws::Http::Scheme::HTTPS;
+        }
     }
     if (!config::object_storage_region.empty()) {
         config.region = config::object_storage_region;

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -137,7 +137,7 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
     } else {
         // To use implicit endpoint.
         config.scheme = Aws::Http::Scheme::HTTP;
-        if (config::object_storage_endpoint_use_ssl) {
+        if (config::object_storage_endpoint_use_https) {
             config.scheme = Aws::Http::Scheme::HTTPS;
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7204 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When user running SR on ec2 and ec2 has proper IAM role, there is no need to specify 
- AK/SK
- endpoint

But when in that case, we are not sure if bucket/object can be accessed in http(perhaps there are policies there).  So we add a option `object_storage_endpoint_use_ssl`, to let user specify that.

So basically there are two ways of configuration. When running on non-ec2 instance

```
object_storage_access_key_id = xxx
object_storage_secret_access_key = xxx
object_storage_endpoint = https://s3.us-east-1.amazonaws.com
object_storage_max_connection = 102400
AWS_EC2_METADATA_DISABLED=true
```

When runing on ec2 instance

```
object_storage_max_connection = 102400
object_storage_endpoint_use_ssl = true/false
```
