### PR TITLE
[Refactor] Support specified thrift in pom.xml

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -38,11 +38,22 @@ under the License.
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.5</jacoco.version>
-        <starrocks.thridparty>${basedir}/../../thirdparty</starrocks.thridparty>
+        <starrocks.thrift>thrift</starrocks.thrift>
         <iceberg.version>0.12.1</iceberg.version>
     </properties>
 
     <profiles>
+        <profile>
+            <id>thrift</id>
+            <activation>
+                <property>
+                    <name>env.THRIFT</name>
+                </property>
+            </activation>
+            <properties>
+                <starrocks.thrift>${env.THRIFT}</starrocks.thrift>
+            </properties>
+        </profile>
         <profile>
             <id>thirdparty</id>
             <activation>
@@ -51,7 +62,7 @@ under the License.
                 </property>
             </activation>
             <properties>
-                <starrocks.thridparty>${env.STARROCKS_THIRDPARTY}</starrocks.thridparty>
+                <starrocks.thrift>${env.STARROCKS_THIRDPARTY}/installed/bin/thrift</starrocks.thrift>
             </properties>
         </profile>
     </profiles>
@@ -610,7 +621,7 @@ under the License.
                 <artifactId>maven-thrift-plugin</artifactId>
                 <version>0.1.11</version>
                 <configuration>
-                    <thriftExecutable>${starrocks.thridparty}/installed/bin/thrift</thriftExecutable>
+                    <thriftExecutable>${starrocks.thrift}</thriftExecutable>
                     <thriftSourceRoot>${starrocks.home}/gensrc/thrift</thriftSourceRoot>
                     <generator>java</generator>
                 </configuration>


### PR DESCRIPTION
Now StarRocks needs thrift binary locate thirdparty/installed/bin, which
is not friendly for our developers.
After applying this PR, when building SR fronted, if both THRIFT and
STARROCKS_THIRDPARTY enviroment variables are not provided, default
'thrift' binary will be used. If there are 'thrift' is installed, then
the FE can be built successfully.
If STARROCKS_THIRDPARTY is specified,
   ${STARROCKS_THIRDPARTY}/installed/bin/thrift will be used. And this
can be compatible with current build method.
If users don't have STARROCKS_THIRDPARTY, they only have a thrift, they
can pass the right binary by executing 'THRIFT=/path/to/thrift mvn package'
to build Frontend.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
