### PR TITLE
[BugFix] Choose wrong compaction algorithm in some case 

### DIFF
--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -63,7 +63,13 @@ Status Compaction::do_compaction_impl() {
     _output_version = Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
 
     // choose vertical or horizontal compaction algorithm
-    size_t segment_iterator_num = Rowset::get_segment_num(_input_rowsets);
+    auto iterator_num_res = Rowset::get_segment_num(_input_rowsets);
+    if (!iterator_num_res.ok()) {
+        LOG(WARNING) << "fail to get segment iterator num. tablet=" << _tablet->tablet_id()
+                     << ", err=" << iterator_num_res.status().to_string();
+        return iterator_num_res.status();
+    }
+    size_t segment_iterator_num = iterator_num_res.value();
     int64_t max_columns_per_group = config::vertical_compaction_max_columns_per_group;
     size_t num_columns = _tablet->num_columns();
     CompactionAlgorithm algorithm =

--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -19,7 +19,13 @@
 namespace starrocks {
 
 std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() {
-    size_t segment_iterator_num = Rowset::get_segment_num(_input_rowsets);
+    auto iterator_num_res = Rowset::get_segment_num(_input_rowsets);
+    if (!iterator_num_res.ok()) {
+        LOG(WARNING) << "fail to get segment iterator num. tablet=" << _tablet->tablet_id()
+                     << ", err=" << iterator_num_res.status().to_string();
+        return nullptr;
+    }
+    size_t segment_iterator_num = iterator_num_res.value();
     int64_t max_columns_per_group = config::vertical_compaction_max_columns_per_group;
     size_t num_columns = _tablet->num_columns();
     CompactionAlgorithm algorithm =

--- a/be/src/storage/rowset/beta_rowset.h
+++ b/be/src/storage/rowset/beta_rowset.h
@@ -63,6 +63,9 @@ public:
     Status get_segment_iterators(const vectorized::Schema& schema, const vectorized::RowsetReadOptions& options,
                                  std::vector<vectorized::ChunkIteratorPtr>* seg_iterators) override;
 
+    // estimate the number of compaction segment iterator
+    StatusOr<int64_t> estimate_compaction_segment_iterator_num() override;
+
     // only used for updatable tablets' rowset
     // simply get iterators to iterate all rows without complex options like predicates
     // |schema| read schema


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7213 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When performing base compaction on the tablet with the following rowsets:

   "rowsets": [
        "[0-175183] 11 DATA NONOVERLAPPING",
        "[175184-175232] 0 DATA NONOVERLAPPING",
        "[175233-175278] 0 DATA NONOVERLAPPING",
        "[175279-175327] 0 DATA NONOVERLAPPING",
        "[175328-175369] 0 DATA NONOVERLAPPING"
    ]

Because there are 11 segments and columns num are more than 5, so it will choose the vertical compaction.
When creating tablet reader, it will merge 11 segment iterator into one union iterator, and create a HeapMaskIterator with only one union_iterator.
In the `new_heap_merge_iterator`, it will return the iterator immediately if the input iterators len is 1.
So here we will then call the get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) on the union_iterator,
However, the union_iterator doesn't implement get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks), and
we get the warning `get chunk with sources not supported`.

In fact, we should count the number of segment iterator after creating tablet reader, only one union iterator in this case,
and choose the horizontal compaction.