### PR TITLE
[BugFix] fix sorting of overflowed nullable column

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -440,6 +440,7 @@ Datum ArrayColumn::get(size_t idx) const {
 }
 
 size_t ArrayColumn::get_element_size(size_t idx) const {
+    DCHECK_LT(idx + 1, _offsets->size());
     return _offsets->get_data()[idx + 1] - _offsets->get_data()[idx];
 }
 

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -130,6 +130,18 @@ void ArrayColumn::append_default(size_t count) {
     _offsets->append_value_multiple_times(&offset, count);
 }
 
+void ArrayColumn::update_default(const Filter& filter) {
+    std::vector<uint32_t> indexes;
+    for (size_t i = 0; i < filter.size(); i++) {
+        if (filter[i] == 1 && get_element_size(i) > 0) {
+            indexes.push_back(i);
+        }
+    }
+    auto default_column = clone_empty();
+    default_column->append_default(indexes.size());
+    update_rows(*default_column, indexes.data());
+}
+
 Status ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& array_column = down_cast<const ArrayColumn&>(src);
 
@@ -425,6 +437,10 @@ Datum ArrayColumn::get(size_t idx) const {
         res[i] = _elements->get(offset + i);
     }
     return Datum(res);
+}
+
+size_t ArrayColumn::get_element_size(size_t idx) const {
+    return _offsets->get_data()[idx + 1] - _offsets->get_data()[idx];
 }
 
 bool ArrayColumn::set_null(size_t idx) {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -130,7 +130,7 @@ void ArrayColumn::append_default(size_t count) {
     _offsets->append_value_multiple_times(&offset, count);
 }
 
-void ArrayColumn::update_default(const Filter& filter) {
+void ArrayColumn::fill_default(const Filter& filter) {
     std::vector<uint32_t> indexes;
     for (size_t i = 0; i < filter.size(); i++) {
         if (filter[i] == 1 && get_element_size(i) > 0) {

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -80,7 +80,7 @@ public:
 
     void append_default(size_t count) override;
 
-    void update_default(const Filter& filter) override;
+    void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -80,6 +80,8 @@ public:
 
     void append_default(size_t count) override;
 
+    void update_default(const Filter& filter) override;
+
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     void remove_first_n_values(size_t count) override {}
@@ -118,6 +120,8 @@ public:
     std::string get_name() const override { return "array"; }
 
     Datum get(size_t idx) const override;
+
+    size_t get_element_size(size_t idx) const;
 
     bool set_null(size_t idx) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -213,8 +213,8 @@ template <typename T>
 void BinaryColumnBase<T>::fill_default(const Filter& filter) {
     std::vector<uint32_t> indexes;
     for (size_t i = 0; i < filter.size(); i++) {
-        Slice slice = get_slice(i);
-        if (filter[i] == 1 && slice.size > 0) {
+        size_t len = _offsets[i + 1] - _offsets[i];
+        if (filter[i] == 1 && len > 0) {
             indexes.push_back(i);
         }
     }

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -210,6 +210,23 @@ void BinaryColumnBase<T>::_build_slices() const {
 }
 
 template <typename T>
+void BinaryColumnBase<T>::update_default(const Filter& filter) {
+    std::vector<uint32_t> indexes;
+    for (size_t i = 0; i < filter.size(); i++) {
+        Slice slice = get_slice(i);
+        if (filter[i] == 1 && slice.size > 0) {
+            indexes.push_back(i);
+        }
+    }
+    if (indexes.empty()) {
+        return;
+    }
+    auto default_column = clone_empty();
+    default_column->append_default(indexes.size());
+    update_rows(*default_column, indexes.data());
+}
+
+template <typename T>
 Status BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     size_t replace_num = src.size();

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -210,7 +210,7 @@ void BinaryColumnBase<T>::_build_slices() const {
 }
 
 template <typename T>
-void BinaryColumnBase<T>::update_default(const Filter& filter) {
+void BinaryColumnBase<T>::fill_default(const Filter& filter) {
     std::vector<uint32_t> indexes;
     for (size_t i = 0; i < filter.size(); i++) {
         Slice slice = get_slice(i);

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -182,6 +182,8 @@ public:
         _slices_cache = false;
     }
 
+    void update_default(const Filter& filter) override;
+
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -182,7 +182,7 @@ public:
         _slices_cache = false;
     }
 
-    void update_default(const Filter& filter) override;
+    void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -148,6 +148,9 @@ public:
 
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
+    // Update elements to default value which hit by the filter
+    virtual void update_default(const Filter& filter) = 0;
+
     // This function will update data from src according to the input indexes. 'indexes' contains
     // the row index will be update
     // For example:

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -149,7 +149,7 @@ public:
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
     // Update elements to default value which hit by the filter
-    virtual void update_default(const Filter& filter) = 0;
+    virtual void fill_default(const Filter& filter) = 0;
 
     // This function will update data from src according to the input indexes. 'indexes' contains
     // the row index will be update

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -35,7 +35,7 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
-void ConstColumn::update_default(const Filter& filter) {
+void ConstColumn::fill_default(const Filter& filter) {
     CHECK(false) << "ConstColumn does not support update";
 }
 

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -35,6 +35,10 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
+void ConstColumn::update_default(const Filter& filter) {
+    CHECK(false) << "ConstColumn does not support update";
+}
+
 Status ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
     return Status::NotSupported("ConstColumn does not support update");
 }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -116,7 +116,7 @@ public:
 
     void append_default(size_t count) override { _size += count; }
 
-    void update_default(const Filter& filter) override;
+    void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -116,6 +116,8 @@ public:
 
     void append_default(size_t count) override { _size += count; }
 
+    void update_default(const Filter& filter) override;
+
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override { return _data->serialize(0, pos); }

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -10,6 +10,7 @@
 #include "storage/decimal12.h"
 #include "util/hash_util.hpp"
 #include "util/mysql_row_buffer.h"
+#include "util/value_generator.h"
 
 namespace starrocks::vectorized {
 
@@ -46,6 +47,16 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
     _data.resize(orig_size + size);
     for (size_t i = 0; i < size; ++i) {
         _data[orig_size + i] = src_data[index];
+    }
+}
+
+template <typename T>
+void FixedLengthColumnBase<T>::update_default(const Filter& filter) {
+    T val = DefaultValueGenerator<T>::next_value();
+    for (size_t i = 0; i < filter.size(); i++) {
+        if (filter[i] == 1) {
+            _data[i] = val;
+        }
     }
 }
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -51,7 +51,7 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::update_default(const Filter& filter) {
+void FixedLengthColumnBase<T>::fill_default(const Filter& filter) {
     T val = DefaultValueGenerator<T>::next_value();
     for (size_t i = 0; i < filter.size(); i++) {
         if (filter[i] == 1) {

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -131,7 +131,7 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
-    void update_default(const Filter& filter) override;
+    void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -131,6 +131,8 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
+    void update_default(const Filter& filter) override;
+
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     // The `_data` support one size(> 2^32), but some interface such as update_rows() will use uint32_t to

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -157,6 +157,13 @@ void NullableColumn::append_value_multiple_times(const void* value, size_t count
     null_column_data().insert(null_column_data().end(), count, 0);
 }
 
+void NullableColumn::update_null_as_default() {
+    if (null_count() == 0) {
+        return;
+    }
+    _data_column->update_default(_null_column->get_data());
+}
+
 Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t replace_num = src.size();

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -157,7 +157,7 @@ void NullableColumn::append_value_multiple_times(const void* value, size_t count
     null_column_data().insert(null_column_data().end(), count, 0);
 }
 
-void NullableColumn::fill_null_as_default() {
+void NullableColumn::fill_null_with_default() {
     if (null_count() == 0) {
         return;
     }

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -157,11 +157,11 @@ void NullableColumn::append_value_multiple_times(const void* value, size_t count
     null_column_data().insert(null_column_data().end(), count, 0);
 }
 
-void NullableColumn::update_null_as_default() {
+void NullableColumn::fill_null_as_default() {
     if (null_count() == 0) {
         return;
     }
-    _data_column->update_default(_null_column->get_data());
+    _data_column->fill_default(_null_column->get_data());
 }
 
 Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -52,7 +52,7 @@ public:
     void set_has_null(bool has_null) { _has_null = _has_null | has_null; }
 
     // Update null element to default value
-    void fill_null_as_default();
+    void fill_null_with_default();
 
     void fill_default(const Filter& filter) override {}
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -52,9 +52,9 @@ public:
     void set_has_null(bool has_null) { _has_null = _has_null | has_null; }
 
     // Update null element to default value
-    void update_null_as_default();
+    void fill_null_as_default();
 
-    void update_default(const Filter& filter) override {}
+    void fill_default(const Filter& filter) override {}
 
     void update_has_null() {
         const NullColumn::Container& v = _null_column->get_data();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -51,6 +51,11 @@ public:
 
     void set_has_null(bool has_null) { _has_null = _has_null | has_null; }
 
+    // Update null element to default value
+    void update_null_as_default();
+
+    void update_default(const Filter& filter) override {}
+
     void update_has_null() {
         const NullColumn::Container& v = _null_column->get_data();
         const auto* p = v.data();

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -129,7 +129,7 @@ void ObjectColumn<T>::append_default(size_t count) {
 }
 
 template <typename T>
-void ObjectColumn<T>::update_default(const Filter& filter) {
+void ObjectColumn<T>::fill_default(const Filter& filter) {
     for (size_t i = 0; i < filter.size(); i++) {
         if (filter[i] == 1) {
             _pool[i] = {};

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -129,6 +129,16 @@ void ObjectColumn<T>::append_default(size_t count) {
 }
 
 template <typename T>
+void ObjectColumn<T>::update_default(const Filter& filter) {
+    for (size_t i = 0; i < filter.size(); i++) {
+        if (filter[i] == 1) {
+            _pool[i] = {};
+        }
+    }
+    _cache_ok = false;
+}
+
+template <typename T>
 Status ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
     size_t replace_num = src.size();

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -104,7 +104,7 @@ public:
 
     void append_default(size_t count) override;
 
-    void update_default(const Filter& filter) override;
+    void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -104,6 +104,8 @@ public:
 
     void append_default(size_t count) override;
 
+    void update_default(const Filter& filter) override;
+
     Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override;

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -356,7 +356,7 @@ Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const boo
 Status sort_and_tie_column(const bool cancel, ColumnPtr& column, const bool is_asc_order, const bool is_null_first,
                            SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, bool build_tie) {
     if (column->is_nullable()) {
-        ColumnHelper::as_column<NullableColumn>(column)->fill_null_as_default();
+        ColumnHelper::as_column<NullableColumn>(column)->fill_null_with_default();
     }
     ColumnSorter column_sorter(cancel, is_asc_order, is_null_first, permutation, tie, range, build_tie);
     return column->accept(&column_sorter);
@@ -426,7 +426,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
 
     for (auto& col : columns) {
         if (col->is_nullable()) {
-            ColumnHelper::as_column<NullableColumn>(col)->fill_null_as_default();
+            ColumnHelper::as_column<NullableColumn>(col)->fill_null_with_default();
         }
     }
 

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -6,6 +6,7 @@
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
+#include "column/column_helper.h"
 #include "column/column_visitor_adapter.h"
 #include "column/const_column.h"
 #include "column/fixed_length_column_base.h"
@@ -352,6 +353,15 @@ Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const boo
     return column->accept(&column_sorter);
 }
 
+Status sort_and_tie_column(const bool cancel, ColumnPtr& column, const bool is_asc_order, const bool is_null_first,
+                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, bool build_tie) {
+    if (column->is_nullable()) {
+        ColumnHelper::as_column<NullableColumn>(column)->update_null_as_default();
+    }
+    ColumnSorter column_sorter(cancel, is_asc_order, is_null_first, permutation, tie, range, build_tie);
+    return column->accept(&column_sorter);
+}
+
 Status sort_and_tie_columns(const bool cancel, const Columns& columns, const std::vector<int>& sort_orders,
                             const std::vector<int>& null_firsts, Permutation* permutation) {
     if (columns.size() < 1) {
@@ -413,6 +423,13 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
                              std::pair<int, int> range, const bool build_tie, const size_t limit, size_t* limited) {
     DCHECK_GT(columns.size(), 0);
     DCHECK_GT(permutation.size(), 0);
+    
+    for (auto& col : columns) {
+        if (col->is_nullable()) {
+            ColumnHelper::as_column<NullableColumn>(col)->update_null_as_default();
+        }
+    }
+
     VerticalColumnSorter sorter(cancel, columns, is_asc_order, is_null_first, permutation, tie, range, build_tie,
                                 limit);
     RETURN_IF_ERROR(columns[0]->accept(&sorter));

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -356,7 +356,7 @@ Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const boo
 Status sort_and_tie_column(const bool cancel, ColumnPtr& column, const bool is_asc_order, const bool is_null_first,
                            SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, bool build_tie) {
     if (column->is_nullable()) {
-        ColumnHelper::as_column<NullableColumn>(column)->update_null_as_default();
+        ColumnHelper::as_column<NullableColumn>(column)->fill_null_as_default();
     }
     ColumnSorter column_sorter(cancel, is_asc_order, is_null_first, permutation, tie, range, build_tie);
     return column->accept(&column_sorter);
@@ -426,7 +426,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
 
     for (auto& col : columns) {
         if (col->is_nullable()) {
-            ColumnHelper::as_column<NullableColumn>(col)->update_null_as_default();
+            ColumnHelper::as_column<NullableColumn>(col)->fill_null_as_default();
         }
     }
 

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -423,7 +423,7 @@ Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<
                              std::pair<int, int> range, const bool build_tie, const size_t limit, size_t* limited) {
     DCHECK_GT(columns.size(), 0);
     DCHECK_GT(permutation.size(), 0);
-    
+
     for (auto& col : columns) {
         if (col->is_nullable()) {
             ColumnHelper::as_column<NullableColumn>(col)->update_null_as_default();

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -16,6 +16,8 @@ namespace starrocks::vectorized {
 // @param permutation input and output permutation
 // @param tie input and output tie
 // @param range sort range, {0, 0} means not build tie but sort data
+Status sort_and_tie_column(const bool cancel, ColumnPtr& column, const bool is_asc_order, const bool is_null_first,
+                           SmallPermutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie);
 Status sort_and_tie_column(const bool cancel, const ColumnPtr& column, const bool is_asc_order,
                            const bool is_null_first, SmallPermutation& permutation, Tie& tie, std::pair<int, int> range,
                            const bool build_tie);

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -101,14 +101,20 @@ public:
         col_mkt_sgmt_1->append_datum(Datum(Slice("HOUSEHOLD")));
 
         col_cust_key_2->append_datum(Datum(int32_t(69)));
-        col_nation_2->append_datum(Datum());
-        col_region_2->append_datum(Datum());
-        col_mkt_sgmt_2->append_datum(Datum());
+        col_nation_2->append_datum(Datum(Slice("null0")));
+        col_region_2->append_datum(Datum(Slice("null0")));
+        col_mkt_sgmt_2->append_datum(Datum(Slice("null0")));
+        col_nation_2->set_null(col_nation_2->size() - 1);
+        col_region_2->set_null(col_region_2->size() - 1);
+        col_mkt_sgmt_2->set_null(col_mkt_sgmt_2->size() - 1);
 
         col_cust_key_3->append_datum(Datum(int32_t(70)));
-        col_nation_3->append_datum(Datum());
-        col_region_3->append_datum(Datum());
-        col_mkt_sgmt_3->append_datum(Datum());
+        col_nation_3->append_datum(Datum(Slice("null1")));
+        col_region_3->append_datum(Datum(Slice("null1")));
+        col_mkt_sgmt_3->append_datum(Datum(Slice("null1")));
+        col_nation_3->set_null(col_nation_3->size() - 1);
+        col_region_3->set_null(col_region_3->size() - 1);
+        col_mkt_sgmt_3->set_null(col_mkt_sgmt_3->size() - 1);
 
         col_cust_key_1->append_datum(Datum(int32_t(71)));
         col_nation_1->append_datum(Datum());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6746

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


Problem:
- The sorting of nullable column is divided into two steps: at first partition the null elements and non-null element, then sort them individually 
- A basic assumption of sorting null element is, the datum of null element should be the same, so the sorting procedure does not need to differentiate null element and not-null element
- But the exception is, the `NullableColumn` could not ensure this property: value of null element are same
- For some special expression, it could generate a `NullableColumn` whose value are not default value

Solution:
1. `NullableColumn::update_null_as_default` before sorting a nullable column
2. `Column::update_default` would update the null element to default value if necessary