### PR TITLE
Fix tinyint/int/decimal may overflow in AGG SUM storage layer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
@@ -225,6 +225,11 @@ public class ColumnDef {
             throw new AnalysisException("charset name " + charsetName + " is not supported yet in column definition");
         }
 
+        if (getAggregateType() == AggregateType.SUM) {
+            // For the decimal type we extend to decimal128 to avoid overflow
+            typeDef.setType(AggregateType.extendedPrecision(typeDef.getType()));
+        }
+
         typeDef.analyze(null);
 
         Type type = typeDef.getType();

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
@@ -419,7 +419,6 @@ public class CreateTableStmt extends DdlStmt {
 
         boolean hasHll = false;
         boolean hasBitmap = false;
-        boolean hasJson = false;
         Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         for (ColumnDef columnDef : columnDefs) {
             columnDef.analyze(isOlapOrLakeEngine());
@@ -430,10 +429,6 @@ public class CreateTableStmt extends DdlStmt {
 
             if (columnDef.getAggregateType() == BITMAP_UNION) {
                 hasBitmap = columnDef.getType().isBitmapType();
-            }
-
-            if (columnDef.getType().isJsonType()) {
-                hasJson = true;
             }
 
             if (!columnSet.add(columnDef.getName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
@@ -31,7 +31,7 @@ import com.starrocks.common.AnalysisException;
  * Represents an anonymous type definition, e.g., used in DDL and CASTs.
  */
 public class TypeDef implements ParseNode {
-    private final Type parsedType;
+    private Type parsedType;
     private boolean isAnalyzed;
 
     public TypeDef(Type parsedType) {
@@ -148,6 +148,10 @@ public class TypeDef implements ParseNode {
 
     public Type getType() {
         return parsedType;
+    }
+
+    public void setType(Type type) {
+        this.parsedType = type;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
@@ -51,6 +51,7 @@ public enum AggregateType {
         primitiveTypeList.add(PrimitiveType.FLOAT);
         primitiveTypeList.add(PrimitiveType.DOUBLE);
         primitiveTypeList.add(PrimitiveType.DECIMALV2);
+        primitiveTypeList.add(PrimitiveType.DECIMAL64);
         primitiveTypeList.add(PrimitiveType.DECIMAL128);
         compatibilityMap.put(SUM, EnumSet.copyOf(primitiveTypeList));
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
@@ -45,16 +45,12 @@ public enum AggregateType {
         compatibilityMap = new EnumMap<>(AggregateType.class);
         List<PrimitiveType> primitiveTypeList = Lists.newArrayList();
 
-        primitiveTypeList.add(PrimitiveType.TINYINT);
-        primitiveTypeList.add(PrimitiveType.SMALLINT);
         primitiveTypeList.add(PrimitiveType.INT);
         primitiveTypeList.add(PrimitiveType.BIGINT);
         primitiveTypeList.add(PrimitiveType.LARGEINT);
         primitiveTypeList.add(PrimitiveType.FLOAT);
         primitiveTypeList.add(PrimitiveType.DOUBLE);
         primitiveTypeList.add(PrimitiveType.DECIMALV2);
-        primitiveTypeList.add(PrimitiveType.DECIMAL32);
-        primitiveTypeList.add(PrimitiveType.DECIMAL64);
         primitiveTypeList.add(PrimitiveType.DECIMAL128);
         compatibilityMap.put(SUM, EnumSet.copyOf(primitiveTypeList));
 
@@ -146,6 +142,13 @@ public enum AggregateType {
     public boolean checkCompatibility(Type type) {
         return checkPrimitiveTypeCompatibility(this, type.getPrimitiveType()) ||
                 (this.isReplaceFamily() && type.isArrayType());
+    }
+
+    public static Type extendedPrecision(Type type) {
+        if (type.isDecimalV3()) {
+            return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, ((ScalarType) type).getScalarScale());
+        }
+        return type;
     }
 
     public boolean isReplaceFamily() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -78,8 +78,8 @@ public class CreateMaterializedViewTest {
                         "                        `k1` date,\n" +
                         "                        `v2` datetime MAX,\n" +
                         "                        `v3` char(20) MIN,\n" +
-                        "                        `v4` tinyint SUM,\n" +
-                        "                        `v8` tinyint SUM,\n" +
+                        "                        `v4` bigint SUM,\n" +
+                        "                        `v8` bigint SUM,\n" +
                         "                        `v5` HLL HLL_UNION,\n" +
                         "                        `v6` BITMAP BITMAP_UNION,\n" +
                         "                        `v7` PERCENTILE PERCENTILE_UNION\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #6382
Fixes #6384

## Problem Summary(Required) ：
Some types using sum aggregation at the storage level may lead to overflow, so for these types will report a error.
decimal(x, scale) -> decimal(38, scale)

