### PR TITLE
[feature] support sql_mode MODE_DOUBLE_LITERAL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
@@ -53,6 +53,7 @@ public class SqlModeHelper {
     public static final long MODE_ONLY_FULL_GROUP_BY = 1L << 5;
     public static final long MODE_NO_UNSIGNED_SUBTRACTION = 1L << 6;
     public static final long MODE_NO_DIR_IN_CREATE = 1L << 7;
+    public static final long MODE_DOUBLE_LITERAL = 1L << 17;
     public static final long MODE_ANSI = 1L << 18;
     public static final long MODE_NO_AUTO_VALUE_ON_ZERO = 1L << 19;
     public static final long MODE_NO_BACKSLASH_ESCAPES = 1L << 20;
@@ -78,7 +79,7 @@ public class SqlModeHelper {
     public static final long MODE_ALLOWED_MASK =
             (MODE_REAL_AS_FLOAT | MODE_PIPES_AS_CONCAT | MODE_ANSI_QUOTES |
                     MODE_IGNORE_SPACE | MODE_NOT_USED | MODE_ONLY_FULL_GROUP_BY |
-                    MODE_NO_UNSIGNED_SUBTRACTION | MODE_NO_DIR_IN_CREATE |
+                    MODE_NO_UNSIGNED_SUBTRACTION | MODE_NO_DIR_IN_CREATE | MODE_DOUBLE_LITERAL |
                     MODE_NO_AUTO_VALUE_ON_ZERO | MODE_NO_BACKSLASH_ESCAPES |
                     MODE_STRICT_TRANS_TABLES | MODE_STRICT_ALL_TABLES | MODE_NO_ZERO_IN_DATE |
                     MODE_NO_ZERO_DATE | MODE_INVALID_DATES | MODE_ERROR_FOR_DIVISION_BY_ZERO |
@@ -99,6 +100,7 @@ public class SqlModeHelper {
         sqlModeSet.put("ONLY_FULL_GROUP_BY", MODE_ONLY_FULL_GROUP_BY);
         sqlModeSet.put("NO_UNSIGNED_SUBTRACTION", MODE_NO_UNSIGNED_SUBTRACTION);
         sqlModeSet.put("NO_DIR_IN_CREATE", MODE_NO_DIR_IN_CREATE);
+        sqlModeSet.put("MODE_DOUBLE_LITERAL", MODE_DOUBLE_LITERAL);
         sqlModeSet.put("ANSI", MODE_ANSI);
         sqlModeSet.put("NO_AUTO_VALUE_ON_ZERO", MODE_NO_AUTO_VALUE_ON_ZERO);
         sqlModeSet.put("NO_BACKSLASH_ESCAPES", MODE_NO_BACKSLASH_ESCAPES);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
For accuracy, in the past our literal would give preference to the decimal type,
but in some cases we don't care about a precise value, so we provide a new SQL_MODE that gives preference to the float/double type for literals
