### PR TITLE
[BugFix]: Use PrimaryIndex in memory when key columns contains variable length column

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -927,7 +927,8 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     // load persistent index if enable persistent index meta
     size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
 
-    if (tablet->get_enable_persistent_index() && fix_size <= 64) {
+    // persistent_index does't support variable length columns(varchar/char) as key column for now
+    if (tablet->get_enable_persistent_index() && (fix_size <= 64 && fix_size > 0)) {
         // TODO
         // PersistentIndex and tablet data are currently stored in the same directory
         // We may need to support the separation of PersistentIndex and Tablet data


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7252 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
PersistentIndex doesn't support variable length columns(varchar/char) as key column for now. If we enable PersitentIndex and the key columns contains varchar type, all load will fail.

Use PrimaryIndex in memory when key columns contains variable length column.
