### PR TITLE
[compile] fix compile error with -Werror

### DIFF
--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -143,8 +143,8 @@ static ColumnPtr cast_from_json_fn(ColumnPtr& column) {
 
         JsonValue* json = viewer.value(row);
         if constexpr (pt_is_arithmetic<ToType>) {
-            constexpr auto min = RunTimeTypeLimits<ToType>::min_value();
-            constexpr auto max = RunTimeTypeLimits<ToType>::max_value();
+            [[maybe_unused]] constexpr auto min = RunTimeTypeLimits<ToType>::min_value();
+            [[maybe_unused]] constexpr auto max = RunTimeTypeLimits<ToType>::max_value();
             RunTimeCppType<ToType> cpp_value{};
             bool ok = true;
             if constexpr (pt_is_integer<ToType>) {

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -24,6 +24,8 @@
 // Note: Why does this file exist rather than in bitmap_value.cpp? Because we have some unittest for
 // the detail class such as Roaring64Map.
 // So other files should not include this file except bitmap_value.cpp.
+#include <cstdint>
+#include <optional>
 namespace starrocks {
 
 // serialized bitmap := TypeCode(1), Payload
@@ -183,7 +185,7 @@ public:
                 return uniteBytes(roaring_iter->first, roaring_iter->second.maximum());
             }
         }
-        return {};
+        return std::nullopt;
     }
 
     /**
@@ -196,7 +198,7 @@ public:
                 return uniteBytes(roaring.first, roaring.second.minimum());
             }
         }
-        return {};
+        return std::nullopt;
     }
 
     /**


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：


```
In file included from ../src/types/bitmap_value.cpp:24:
../src/types/bitmap_value_detail.h: In member function ‘std::optional<long unsigned int> starrocks::BitmapValue::max() const’:
../src/types/bitmap_value_detail.h:186:17: error: ‘<anonymous>’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  186 |         return {};
      |                 ^
../src/types/bitmap_value_detail.h: In member function ‘std::optional<long unsigned int> starrocks::BitmapValue::min() const’:
../src/types/bitmap_value_detail.h:199:17: error: ‘<anonymous>’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  199 |         return {};


../src/exprs/vectorized/cast_expr.cpp:210:1:   required from here
../src/exprs/vectorized/cast_expr.cpp:146:28: error: variable ‘min’ set but not used [-Werror=unused-but-set-variable]
  146 |             constexpr auto min = RunTimeTypeLimits<ToType>::min_value();
      |                            ^~~
../src/exprs/vectorized/cast_expr.cpp:147:28: error: variable ‘max’ set but not used [-Werror=unused-but-set-variable]
  147 |             constexpr auto max = RunTimeTypeLimits<ToType>::max_value();
```
