### PR TITLE
Fixup negative from days

### DIFF
--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -57,7 +57,7 @@ ColumnPtr date_valid(const ColumnPtr& v1) {
 
     if (v1->is_constant()) {
         auto value = ColumnHelper::get_const_value<Type>(v1);
-        if (value.is_valid()) {
+        if (value.is_valid_non_strict()) {
             return v1;
         } else {
             return ColumnHelper::create_const_null_column(v1->size());
@@ -74,7 +74,7 @@ ColumnPtr date_valid(const ColumnPtr& v1) {
         int size = v->size();
         for (int i = 0; i < size; ++i) {
             // if null or is invalid
-            null_result[i] = nulls[i] | (!values[i].is_valid());
+            null_result[i] = nulls[i] | (!values[i].is_valid_non_strict());
         }
 
         return NullableColumn::create(v->data_column(), null_column);
@@ -86,7 +86,7 @@ ColumnPtr date_valid(const ColumnPtr& v1) {
 
         int size = v1->size();
         for (int i = 0; i < size; ++i) {
-            nulls[i] = (!values[i].is_valid());
+            nulls[i] = (!values[i].is_valid_non_strict());
         }
 
         return NullableColumn::create(v1, null_column);
@@ -1164,9 +1164,14 @@ ColumnPtr TimeFunctions::from_unix_to_datetime_with_format(FunctionContext* cont
 
 // from_days
 DEFINE_UNARY_FN_WITH_IMPL(from_daysImpl, v) {
+    //return 00-00-00 if the argument is negative or too large, according to MySQL
     DateValue dv{date::BC_EPOCH_JULIAN + v};
+    if (!dv.is_valid()) {
+        return DateValue{date::ZERO_EPOCH_JULIAN};
+    }
     return dv;
 }
+
 ColumnPtr TimeFunctions::from_days(FunctionContext* context, const Columns& columns) {
     return date_valid<TYPE_DATE>(
             VectorizedStrictUnaryFunction<from_daysImpl>::evaluate<TYPE_INT, TYPE_DATE>(VECTORIZED_FN_ARGS(0)));

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -377,7 +377,7 @@ const constexpr uint32_t CACHE_JULIAN_DAYS = 200 * 366;
 extern JulianToDateEntry g_julian_to_date_cache[];
 
 inline void date::to_date(JulianDate julian, int* year, int* month, int* day) {
-    if (julian == ZERO_EPOCH_JULIAN) {
+    if (UNLIKELY(julian == ZERO_EPOCH_JULIAN)) {
         *year = 0;
         *month = 0;
         *day = 0;

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -131,6 +131,8 @@ public:
 public:
     // from_date(1970, 1, 1)
     static constexpr JulianDate UNIX_EPOCH_JULIAN = 2440588;
+    // from_date(0000, 0, 0)
+    static constexpr JulianDate ZERO_EPOCH_JULIAN = 1721028;
     // from_date(0000, 1, 1)
     static constexpr JulianDate BC_EPOCH_JULIAN = 1721060;
     // from_date(0001, 1, 1)
@@ -375,6 +377,13 @@ const constexpr uint32_t CACHE_JULIAN_DAYS = 200 * 366;
 extern JulianToDateEntry g_julian_to_date_cache[];
 
 inline void date::to_date(JulianDate julian, int* year, int* month, int* day) {
+    if (julian == ZERO_EPOCH_JULIAN) {
+        *year = 0;
+        *month = 0;
+        *day = 0;
+        return;
+    }
+
     int quad;
     int extra;
     int y;

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include "common/compiler_util.h"
+
 #pragma once
 
 namespace starrocks {

--- a/be/src/types/date_value.cpp
+++ b/be/src/types/date_value.cpp
@@ -132,6 +132,11 @@ bool DateValue::is_valid() const {
     return (_julian >= date::MIN_DATE) & (_julian <= date::MAX_DATE);
 }
 
+bool DateValue::is_valid_non_strict() const {
+    static const JulianDate zero_day = date::from_date(0, 0, 0);
+    return is_valid() || _julian == zero_day;
+}
+
 std::string DateValue::month_name() const {
     int year, month, day;
     date::to_date_with_cache(_julian, &year, &month, &day);

--- a/be/src/types/date_value.h
+++ b/be/src/types/date_value.h
@@ -69,6 +69,8 @@ public:
 
     bool is_valid() const;
 
+    bool is_valid_non_strict() const;
+
     std::string month_name() const;
 
     std::string day_name() const;

--- a/be/src/types/date_value.h
+++ b/be/src/types/date_value.h
@@ -69,6 +69,8 @@ public:
 
     bool is_valid() const;
 
+    // date_valid function needs this method, for DateValue '0000-00-00', is_valid_non_strict returns true but
+    // is_valid returns false.
     bool is_valid_non_strict() const;
 
     std::string month_name() const;

--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -883,6 +883,10 @@ bool TimestampValue::is_valid() const {
     return (_timestamp >= timestamp::MIN_TIMESTAMP) & (_timestamp <= timestamp::MAX_TIMESTAMP);
 }
 
+bool TimestampValue::is_valid_non_strict() const {
+    return is_valid();
+}
+
 std::string TimestampValue::to_string() const {
     return timestamp::to_string(_timestamp);
 }

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -109,6 +109,8 @@ public:
 
     bool is_valid() const;
 
+    bool is_valid_non_strict() const;
+
     // direct return microsecond will over int64
     int64_t diff_microsecond(TimestampValue other) const;
 

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -109,6 +109,7 @@ public:
 
     bool is_valid() const;
 
+    // date_valid function needs this method, in TimestampValue is_valid_non_strict is equivalent to is_valid.
     bool is_valid_non_strict() const;
 
     // direct return microsecond will over int64

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -1007,10 +1007,10 @@ TEST_F(TimeFunctionsTest, from_days) {
         columns.emplace_back(tc);
         ColumnPtr result = TimeFunctions::from_days(ctx, columns);
         ASSERT_TRUE(result->is_nullable());
-
-        NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
-        ASSERT_EQ(1, nullable_col->size());
-        ASSERT_TRUE(nullable_col->is_null(0));
+        auto col = ColumnHelper::as_column<NullableColumn>(result);
+        ASSERT_EQ(1,col->size());
+        ASSERT_FALSE(col->is_null(0));
+        ASSERT_EQ(col->get(0).get_date().to_string(), "0000-00-00");
     }
     // from_days(negative) return "0000-00-00"
     {
@@ -1024,11 +1024,11 @@ TEST_F(TimeFunctionsTest, from_days) {
         ColumnPtr result = TimeFunctions::from_days(ctx, columns);
         ASSERT_TRUE(result->is_nullable());
 
-        NullableColumn::Ptr nullable_column = ColumnHelper::as_column<NullableColumn>(result);
-        std::string zero_day("0000-00-00");
-        ASSERT_EQ(3, nullable_column->size());
+        auto col = ColumnHelper::as_column<NullableColumn>(result);
+        ASSERT_EQ(3, col->size());
         for (auto i = 0; i < 3; ++i) {
-            ASSERT_EQ(nullable_column->get(i).get_date().to_string(), zero_day);
+            ASSERT_FALSE(col->is_null(i));
+            ASSERT_EQ(col->get(i).get_date().to_string(), "0000-00-00");
         }
     }
 }

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -1012,6 +1012,25 @@ TEST_F(TimeFunctionsTest, from_days) {
         ASSERT_EQ(1, nullable_col->size());
         ASSERT_TRUE(nullable_col->is_null(0));
     }
+    // from_days(negative) return "0000-00-00"
+    {
+        auto tc = Int32Column::create();
+        tc->append(-1);
+        tc->append(-2);
+        tc->append(-2147483648);
+        Columns columns;
+        columns.push_back(tc);
+
+        ColumnPtr result = TimeFunctions::from_days(ctx, columns);
+        ASSERT_TRUE(result->is_nullable());
+
+        NullableColumn::Ptr nullable_column = ColumnHelper::as_column<NullableColumn>(result);
+        std::string zero_day("0000-00-00");
+        ASSERT_EQ(3, nullable_column->size());
+        for (auto i = 0; i < 3; ++i) {
+            ASSERT_EQ(nullable_column->get(i).get_date().to_string(), zero_day);
+        }
+    }
 }
 
 TEST_F(TimeFunctionsTest, to_days) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/4720

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In MySQL 8.0,  when the argument ranges from  0 ~ 3652424(include), from_days gives a valid date('0000-01-01') ~ ('9999-12-31'); otherwise(the argument below 0 or above 3652424), from_days gives date('0000-00-00');
i.e:
select from_days(-1) should return "0000-00-00"
select from_days(3652425) should return "0000-00-00"