### PR TITLE
[BugFix] only concern primitive type when comparing ConstantOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -286,7 +286,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         ConstantOperator that = (ConstantOperator) obj;
         return isNull == that.isNull &&
                 Objects.equals(value, that.value) &&
-                Objects.equals(type.getPrimitiveType(), that.type.getPrimitiveType());
+                type.matchesType(that.getType());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -272,7 +272,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, type, isNull);
+        return Objects.hash(value, type.getPrimitiveType(), isNull);
     }
 
     @Override
@@ -286,7 +286,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         ConstantOperator that = (ConstantOperator) obj;
         return isNull == that.isNull &&
                 Objects.equals(value, that.value) &&
-                Objects.equals(type, that.type);
+                Objects.equals(type.getPrimitiveType(), that.type.getPrimitiveType());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RangeExtractTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RangeExtractTest.java
@@ -103,4 +103,11 @@ public class RangeExtractTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("PREDICATES: abs(4: v4) > 2, 4: v4 IN (1, 3)\n"));
     }
 
+    @Test
+    public void testRangePredicate12() throws Exception {
+        String sql = "select * from test_all_type where t1a = '12345' and t1a = 12345";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("PREDICATES: 1: t1a = '12345'\n"));
+    }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7276 
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Before calculating predicate range, we may apply `ImplicitCastRule` to cast constant value to specific type. In this case, `name=12345` will be casted to `name=cast(12345 as VARCHAR(1048576))` and `name='12345'` won't be casted, `''12345'`'s type is VARCHAR with default length 65533.

In `ScalarRangePredicateExtractor`, we use `LinkedHashSet<ConstantOperator>` to compute the intersection:
![image](https://user-images.githubusercontent.com/3675229/173771448-b47ee3ed-0faa-4b04-a0ec-d3844c687e2a.png)

In `ConstantOperator::equals` and `ConstantOperator::hashCode`, they're both care about `type`,so the length is considered. In fact, when comparing ConstantOperator, we don't need to care about the length of type, only value and primitive type are enough.


