### PR TITLE
[BugFix] change exception type in IntLiteral constructor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -91,7 +91,7 @@ public class IntLiteral extends LiteralExpr {
         }
 
         if (!valid) {
-            throw new SemanticException("Number out of range[" + value + "]. type: " + type);
+            throw new ArithmeticException("Number out of range[" + value + "]. type: " + type);
         }
 
         this.value = longValue;


### PR DESCRIPTION

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6931

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If overflow happens when constructing IntLiteral, it couldn't  give a correct error message because the parameter passed in may not the same as the user input, so we change the type of exception type  and let the upper layer handle it.

![image](https://user-images.githubusercontent.com/3675229/173777038-ea3cd379-ba4c-4d2c-b6a0-6b469e493627.png)
