### PR TITLE
[WIP][Enhancement] Support mapping varlen or long length primary keys into 128bit hash

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -745,7 +745,7 @@ CONF_String(jaeger_endpoint, "");
 // Although the probability is very small, but it is possible. Please make sure you can accept it before
 // enable this feature.
 // default: false
-CONF_Bool(enable_hash_key, "false");
+CONF_Bool(enable_mapping_pk_into_hash, "false");
 
 #ifdef USE_STAROS
 CONF_String(starmgr_addr, "");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -738,6 +738,13 @@ CONF_Int32(max_batch_publish_latency_ms, "100");
 // Config for opentelemetry tracing.
 CONF_String(jaeger_endpoint, "");
 
+// Support mapping varlen or long length primary keys into 128bit hash or not
+// If true, if key columns of primary key table contain varchar type, we will use a hash value(int128) to
+// replace the unqiue encoded key which can  save a lot of memory.
+// However, use fix length hash may encounter conflicts which can lead to the loss of some duplicate data.
+// Although the probability is very small, but it is possible. Please make sure you can accept it before
+// enable this feature.
+// default: false
 CONF_Bool(enable_hash_key, "false");
 
 #ifdef USE_STAROS

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -738,6 +738,8 @@ CONF_Int32(max_batch_publish_latency_ms, "100");
 // Config for opentelemetry tracing.
 CONF_String(jaeger_endpoint, "");
 
+CONF_Bool(enable_hash_key, "false");
+
 #ifdef USE_STAROS
 CONF_String(starmgr_addr, "");
 CONF_Int32(starlet_port, "9070");

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -263,14 +263,16 @@ bool PrimaryKeyEncoder::enable_hash_key(const vectorized::Schema& schema) {
     if (!config::enable_hash_key) {
         return false;
     }
+    size_t ret = 0;
     size_t n = schema.num_key_fields();
     for (size_t i = 0; i < n; i++) {
         auto t = schema.field(i)->type()->type();
         if (t == OLAP_FIELD_TYPE_VARCHAR || t == OLAP_FIELD_TYPE_CHAR) {
             return true;
         }
+        ret += TabletColumn::get_field_length_by_type(t, 0);
     }
-    return false;
+    return ret > 16 ? true : false;
 }
 
 FieldType PrimaryKeyEncoder::encoded_primary_key_type(const vectorized::Schema& schema) {

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -27,6 +27,8 @@ public:
 
     static bool is_supported(const vectorized::Schema& schema);
 
+    static bool enable_hash_key(const vectorized::Schema& schema);
+
     // Return |OLAP_FIELD_TYPE_NONE| if no primary key contained in |schema|.
     static FieldType encoded_primary_key_type(const vectorized::Schema& schema);
 

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -27,7 +27,7 @@ public:
 
     static bool is_supported(const vectorized::Schema& schema);
 
-    static bool enable_hash_key(const vectorized::Schema& schema);
+    static bool enable_mapping_pk_into_hash(const vectorized::Schema& schema);
 
     // Return |OLAP_FIELD_TYPE_NONE| if no primary key contained in |schema|.
     static FieldType encoded_primary_key_type(const vectorized::Schema& schema);

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -183,7 +183,7 @@ TEST(PrimaryKeyEncoderTest, testEnableHashKey) {
         tmp.set_uint8(i % 2);
         pchunk->columns()[3]->append_datum(tmp);
     }
-    
+
     vector<uint32_t> indexes;
     for (int i = 0; i < n; i++) {
         indexes.emplace_back(i);
@@ -204,7 +204,6 @@ TEST(PrimaryKeyEncoderTest, testEnableHashKey) {
         XXH128_hash_t val = XXH3_128bits(s.get_data(), s.get_size());
         ASSERT_EQ(keys[i], ((static_cast<int128_t>(val.high64)) << 64) + static_cast<int128_t>(val.low64));
     }
-
 }
 
 } // namespace starrocks

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -159,7 +159,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
 }
 
 TEST(PrimaryKeyEncoderTest, testEnableHashKey) {
-    config::enable_hash_key = true;
+    config::enable_mapping_pk_into_hash = true;
     auto sc = create_key_schema(
             {OLAP_FIELD_TYPE_INT, OLAP_FIELD_TYPE_VARCHAR, OLAP_FIELD_TYPE_SMALLINT, OLAP_FIELD_TYPE_BOOL});
     unique_ptr<vectorized::Column> dest;
@@ -190,7 +190,7 @@ TEST(PrimaryKeyEncoderTest, testEnableHashKey) {
     }
     PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), n, dest.get());
 
-    config::enable_hash_key = false;
+    config::enable_mapping_pk_into_hash = false;
     unique_ptr<vectorized::Column> bdest;
     PrimaryKeyEncoder::create_column(*sc, &bdest);
     ASSERT_TRUE(bdest->is_binary());

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -42,8 +42,9 @@ message PersistentIndexMetaPB {
     EditVersionPB version = 1;
     uint64 key_size = 2;
     uint64 size = 3;
-    MutableIndexMetaPB l0_meta = 4;
+    bool enable_hash_key = 4;
+    MutableIndexMetaPB l0_meta = 5;
     // l1's meta stored in l1 file
     // only store a version to get file name
-    EditVersionPB l1_version = 5;
+    EditVersionPB l1_version = 6;
 }

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -42,7 +42,7 @@ message PersistentIndexMetaPB {
     EditVersionPB version = 1;
     uint64 key_size = 2;
     uint64 size = 3;
-    bool enable_hash_key = 4;
+    bool enable_mapping_pk_into_hash = 4;
     MutableIndexMetaPB l0_meta = 5;
     // l1's meta stored in l1 file
     // only store a version to get file name


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3940

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This pr proposes the ability to store 128bit hashes instead of actual primary key binary string in PrimaryIndex, as a configurable property. Good quality 128bit hash should be practical to eliminate collisions for typical tablet primary index use cases.

Mapping varlen/long primary keys into fix length hashes can save a lot of memory & IO.
