### PR TITLE
[Bugfix] Avoid NPE for operator status method after closing (#7255)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -371,11 +371,11 @@ bool ExchangeSinkOperator::is_finished() const {
 }
 
 bool ExchangeSinkOperator::need_input() const {
-    return !is_finished() && !_buffer->is_full();
+    return !is_finished() && _buffer != nullptr && !_buffer->is_full();
 }
 
 bool ExchangeSinkOperator::pending_finish() const {
-    return !_buffer->is_finished();
+    return _buffer != nullptr && !_buffer->is_finished();
 }
 
 Status ExchangeSinkOperator::set_cancelled(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -29,7 +29,7 @@ class ExceptContext final : public ContextWithDependency {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 
-    bool is_ht_empty() const { return _hash_set->empty(); }
+    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
 
     void finish_build_ht() {
         _next_processed_iter = _hash_set->begin();
@@ -42,7 +42,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
 
     // Called in the preparation phase of ExceptBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -31,7 +31,7 @@ public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
 
-    bool is_ht_empty() const { return _hash_set->empty(); }
+    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
 
     void finish_build_ht() {
         _next_processed_iter = _hash_set->begin();
@@ -44,7 +44,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
 
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7203.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from #7255.
