### PR TITLE
[Enhancement] Imporve random exchange performance

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -84,6 +84,8 @@ public:
 
     bool use_pass_through() const { return _use_pass_through; }
 
+    bool is_local();
+
 private:
     Status _close_internal(RuntimeState* state, FragmentContext* fragment_ctx);
 
@@ -114,10 +116,7 @@ private:
     bool _use_pass_through = false;
 };
 
-bool ExchangeSinkOperator::Channel::_check_use_pass_through() {
-    if (!_enable_exchange_pass_through) {
-        return false;
-    }
+bool ExchangeSinkOperator::Channel::is_local() {
     if (BackendOptions::get_localhost() != _brpc_dest_addr.hostname) {
         return false;
     }
@@ -125,6 +124,13 @@ bool ExchangeSinkOperator::Channel::_check_use_pass_through() {
         return false;
     }
     return true;
+}
+
+bool ExchangeSinkOperator::Channel::_check_use_pass_through() {
+    if (!_enable_exchange_pass_through) {
+        return false;
+    }
+    return is_local();
 }
 
 void ExchangeSinkOperator::Channel::_prepare_pass_through() {
@@ -443,11 +449,22 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
         // Round-robin batches among channels. Wait for the current channel to finish its
         // rpc before overwriting its batch.
         // 1. Get request of that channel
-        auto& channel = _channels[_curr_random_channel_idx];
+        std::vector<std::shared_ptr<Channel>> local_channels;
+        for (const auto& channel : _channels) {
+            if (channel->is_local()) {
+                local_channels.emplace_back(channel);
+            }
+        }
+
+        if (local_channels.empty()) {
+            local_channels = _channels;
+        }
+
+        auto& channel = local_channels[_curr_random_channel_idx];
         bool real_sent = false;
         RETURN_IF_ERROR(channel->send_one_chunk(send_chunk, DEFAULT_DRIVER_SEQUENCE, false, &real_sent));
         if (real_sent) {
-            _curr_random_channel_idx = (_curr_random_channel_idx + 1) % _channels.size();
+            _curr_random_channel_idx = (_curr_random_channel_idx + 1) % local_channels.size();
         }
     } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
                _part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -109,7 +109,6 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalSchemaScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -2096,10 +2095,10 @@ public class PlanFragmentBuilder {
             }
 
             SetOperationNode setOperationNode;
-            boolean isUnionAll = false;
+            boolean isUnion = false;
             if (operatorType.equals(OperatorType.PHYSICAL_UNION)) {
+                isUnion = true;
                 setOperationNode = new UnionNode(context.getNextNodeId(), setOperationTuple.getId());
-                isUnionAll = ((PhysicalUnionOperator) setOperation).isUnionAll();
                 setOperationNode.setFirstMaterializedChildIdx_(optExpr.arity());
             } else if (operatorType.equals(OperatorType.PHYSICAL_EXCEPT)) {
                 setOperationNode = new ExceptNode(context.getNextNodeId(), setOperationTuple.getId());
@@ -2143,7 +2142,7 @@ public class PlanFragmentBuilder {
 
                 materializedResultExprLists.add(materializedExpressions);
 
-                if (isUnionAll) {
+                if (isUnion) {
                     fragment.setOutputPartition(DataPartition.RANDOM);
                 } else {
                     fragment.setOutputPartition(DataPartition.hashPartitioned(materializedExpressions));


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

now:
all chilren will send data to union node, the optimize point
1. union node always use max parallelism node which from chilren
3. union node just rename his chilren data, none other work
4. data need serialized/deserialized, and transform by network

<img width="396" alt="image" src="https://user-images.githubusercontent.com/5609319/173985304-94ee0461-4e0c-4379-8029-b1663d86a73c.png">


Enhancement
1. recompute union node host, always keep same with his chilren
2. update RANDOM choose channel strategy, only choose local node channel

<img width="396" alt="image" src="https://user-images.githubusercontent.com/5609319/173985318-38e30bb8-fd69-41b1-bc40-86b325aa713f.png">


test tpcds query02
before + pass_through: 8s ~ 11.213s,not stable
after: 9.803s
after + pass_through: 3.4s ~ 7.719s