### PR TITLE
canonicalize decimal types when desc table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DescribeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DescribeStmt.java
@@ -148,7 +148,7 @@ public class DescribeStmt extends ShowStmt {
                                     String extraStr = StringUtils.join(extras, ",");
                                     List<String> row = Arrays.asList(
                                             column.getDisplayName(),
-                                            column.getType().toString(),
+                                            column.getType().canonicalName(),
                                             column.isAllowNull() ? "Yes" : "No",
                                             ((Boolean) column.isKey()).toString(),
                                             defaultStr,
@@ -221,7 +221,7 @@ public class DescribeStmt extends ShowStmt {
                             List<String> row = Arrays.asList("",
                                     "",
                                     column.getDisplayName(),
-                                    column.getType().toString(),
+                                    column.getType().canonicalName(),
                                     column.isAllowNull() ? "Yes" : "No",
                                     ((Boolean) column.isKey()).toString(),
                                     defaultStr,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -811,4 +811,14 @@ public class ScalarType extends Type implements Cloneable {
     public ScalarType clone() {
         return (ScalarType) super.clone();
     }
+
+    @Override
+    public String canonicalName() {
+        if (isDecimalOfAnyVersion()) {
+            Preconditions.checkArgument(!isWildcardDecimal());
+            return String.format("DECIMAL(%d,%d)", precision, scale);
+        } else {
+            return toString();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1420,4 +1420,8 @@ public abstract class Type implements Cloneable {
         }
         throw new AnalysisException("Cannot get innermost type of '" + type + "'");
     }
+
+    public String canonicalName() {
+        return toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexSchemaProcNode.java
@@ -76,7 +76,7 @@ public class IndexSchemaProcNode implements ProcNodeInterface {
             String extraStr = StringUtils.join(extras, ",");
 
             List<String> rowList = Arrays.asList(column.getName(),
-                    column.getType().toString(),
+                    column.getType().canonicalName(),
                     column.isAllowNull() ? "Yes" : "No",
                     ((Boolean) column.isKey()).toString(),
                     defaultStr,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -667,7 +667,7 @@ public class ShowExecutor {
                             continue;
                         }
                         final String columnName = col.getName();
-                        final String columnType = col.getType().toString().toLowerCase();
+                        final String columnType = col.getType().canonicalName().toLowerCase();
                         final String isAllowNull = col.isAllowNull() ? "YES" : "NO";
                         final String isKey = col.isKey() ? "YES" : "NO";
                         final String defaultValue = col.getMetaDefaultValue(Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -125,4 +125,23 @@ public class TypeTest {
         Assert.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assert.assertEquals(33, type.getMysqlResultSetFieldCharsetIndex());
     }
+
+    @Test
+    public void testCanonicalName() {
+        Object[][] testCases = new Object[][]{
+                {ScalarType.createDecimalV3NarrowestType(9, 2), "DECIMAL(9,2)"},
+                {ScalarType.createDecimalV3NarrowestType(18, 4), "DECIMAL(18,4)"},
+                {ScalarType.createDecimalV3NarrowestType(38, 6), "DECIMAL(38,6)"},
+                {ScalarType.createVarchar(16), "VARCHAR(16)"},
+                {ScalarType.createCharType(16), "CHAR(16)"},
+                {ScalarType.createType(PrimitiveType.INT), "INT"},
+                {ScalarType.createType(PrimitiveType.FLOAT), "FLOAT"},
+        };
+
+        for (Object[] tc : testCases) {
+            ScalarType type = (ScalarType) tc[0];
+            String name = (String) tc[1];
+            Assert.assertEquals(name, type.canonicalName());
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
decimal32(p,s)/decimal64(p,s)/decimal128(p,s) should show as decimal(p,s) in stmts as follow:
```
mysql> desc t0;
+-------+--------------+------+-------+---------+-------+
| Field | Type         | Null | Key   | Default | Extra |
+-------+--------------+------+-------+---------+-------+
| k0    | INT          | No   | true  | NULL    |       |
| c0    | DECIMAL(9,2) | No   | false | NULL    |       |
| c1    | DECIMAL(9,2) | No   | false | NULL    |       |
| c2    | DECIMAL(9,2) | No   | false | NULL    |       |
+-------+--------------+------+-------+---------+-------+
4 rows in set (0.00 sec)

mysql> desc t0 all;
+-----------+---------------+-------+--------------+------+-------+---------+-------+
| IndexName | IndexKeysType | Field | Type         | Null | Key   | Default | Extra |
+-----------+---------------+-------+--------------+------+-------+---------+-------+
| t0        | DUP_KEYS      | k0    | INT          | No   | true  | NULL    |       |
|           |               | c0    | DECIMAL(9,2) | No   | false | NULL    | NONE  |
|           |               | c1    | DECIMAL(9,2) | No   | false | NULL    | NONE  |
|           |               | c2    | DECIMAL(9,2) | No   | false | NULL    | NONE  |
+-----------+---------------+-------+--------------+------+-------+---------+-------+
4 rows in set (0.00 sec)

mysql> show columns from t0;
+-------+--------------+------+------+---------+-------+
| Field | Type         | Null | Key  | Default | Extra |
+-------+--------------+------+------+---------+-------+
| k0    | int          | NO   | YES  | NULL    |       |
| c0    | decimal(9,2) | NO   | NO   | NULL    |       |
| c1    | decimal(9,2) | NO   | NO   | NULL    |       |
| c2    | decimal(9,2) | NO   | NO   | NULL    |       |
+-------+--------------+------+------+---------+-------+
4 rows in set (0.00 sec)

```