### PR TITLE
[Bugfix] Check floating overflow for select and insert

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -48,6 +48,7 @@ public class IntLiteral extends LiteralExpr {
     public static final long INT_MIN = Integer.MIN_VALUE; // -2^31 ~ 2^31 - 1
     public static final long INT_MAX = Integer.MAX_VALUE;
     public static final long BIG_INT_MIN = Long.MIN_VALUE; // -2^63 ~ 2^63 - 1
+    public static final long BIG_INT_MAX = Long.MAX_VALUE;
     private long value;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -724,7 +724,15 @@ public abstract class Type implements Cloneable {
     }
 
     public boolean isFloatingPointType() {
-        return isScalarType(PrimitiveType.FLOAT) || isScalarType(PrimitiveType.DOUBLE);
+        return isFloatType() || isDoubleType();
+    }
+
+    public boolean isFloatType() {
+        return isScalarType(PrimitiveType.FLOAT);
+    }
+
+    public boolean isDoubleType() {
+        return isScalarType(PrimitiveType.DOUBLE);
     }
 
     public boolean isIntegerType() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.amazonaws.services.dynamodbv2.xspec.S;
 import com.starrocks.sql.parser.ParsingException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -347,5 +348,18 @@ public class ConstantExpressionTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  1:Project\n" +
                 "  |  <slot 2> : uuid()\n" +
                 "  |  <slot 3> : uuid()"));
+    }
+
+    @Test
+    public void testCastOverflowWithFloatLiteral() throws Exception {
+        Assert.assertThrows("Number out of range", UnsupportedOperationException.class,
+                () -> getFragmentPlan("SELECT CAST(3e39 as float)"));
+        Assert.assertThrows("Number out of range", ParsingException.class,
+                () -> getFragmentPlan("SELECT CAST(3e310 as double)"));
+
+        String plan = getFragmentPlan("SELECT CAST(3e39 as double)");
+        assertContains(plan, "3.0E39");
+        plan = getFragmentPlan("SELECT CAST(-3e39 as double)");
+        assertContains(plan, "-3.0E39");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -17,7 +17,6 @@
 
 package com.starrocks.sql.plan;
 
-import com.amazonaws.services.dynamodbv2.xspec.S;
 import com.starrocks.sql.parser.ParsingException;
 import org.junit.Assert;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -200,6 +200,25 @@ public class PlanTestBase {
                 "\"colocate_with\" = \"colocate_group_2\"" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `test_all_number_type` (\n" +
+                "  `k_str` varchar(20) NULL COMMENT \"\",\n" +
+                "  `c_ti` tinyint(4) NULL COMMENT \"\",\n" +
+                "  `c_si` smallint(6) NULL COMMENT \"\",\n" +
+                "  `c_i` int(11) NULL COMMENT \"\",\n" +
+                "  `c_bi` bigint(20) NULL COMMENT \"\",\n" +
+                "  `c_li` largeint NULL COMMENT \"\",\n" +
+                "  `c_f` float NULL COMMENT \"\",\n" +
+                "  `c_d` double NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k_str`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`k_str`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `test_all_type` (\n" +
                 "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
                 "  `t1b` smallint(6) NULL COMMENT \"\",\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6275.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- As for the double and float literal, the value will be `INF`, if the literal exceeds its range.
- When double and float literal cast to int, it doesn't check whether the double value exceeds the target range.

## Behaviour Modification
| Operation                                                    | Example                      | Before         | After         |
| ------------------------------------------------------------ | ---------------------------- | -------------- | ------------- |
| Insert overflow tinyint/smallint/int/bigint/largeint with FloatLiteral | insert into t1 values(3e39)  | Insert `NULL`. | Throw error.  |
| Insert overflow float with FloatLiteral                      | insert into t1 values(3e39)  | Insert `INF`.  | Throw error.  |
| Insert overflow double with FloatLiteral                     | insert into t1 values(3e310) | Insert `INF`.  | Throw error.  |
| Select overflow tinyint/smallint/int/bigint/largeint with FloatLiteral | select cast(3e39 as int)     | Output `NULL`. | Output `NULL` |
| Select overflow float with FloatLiteral                      | select cast(3e39 as float)   | Output `INF`   | Throw error   |
| Select overflow double with FloatLiteral                     | select cast(3e310 as double)  | Output `INF`   | Throw error   |



