### PR TITLE
[BugFix]: Unexpected errors from primary table using persistent index

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -245,6 +245,8 @@ public:
 
     const Bytes& get_bytes() const { return _bytes; }
 
+    const uint8_t* continuous_data() const override { return reinterpret_cast<const uint8_t*>(_bytes.data()); }
+
     Offsets& get_offset() { return _offsets; }
     const Offsets& get_offset() const { return _offsets; }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -86,6 +86,8 @@ public:
 
     virtual uint8_t* mutable_raw_data() = 0;
 
+    virtual const uint8_t* continuous_data() const { return raw_data(); }
+
     // Return number of values in column.
     virtual size_t size() const = 0;
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1053,7 +1053,7 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowids[0], pks, 0, pks.size(), &values);
-    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.raw_data(), values.data(), true));
+    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(), values.data(), true));
     return Status::OK();
 }
 
@@ -1063,7 +1063,7 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
     values.reserve(pks.size());
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
     _build_persistent_values(rssid, rowid_start, pks, 0, pks.size(), &values);
-    _persistent_index->upsert(pks.size(), pks.raw_data(), values.data(), old_values.data());
+    _persistent_index->upsert(pks.size(), pks.continuous_data(), values.data(), old_values.data());
     for (uint32_t i = 0; i < old_values.size(); ++i) {
         uint64_t old = old_values[i];
         if ((old != NullIndexValue) && (old >> 32) == rssid) {
@@ -1077,7 +1077,7 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
 
 void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    Status st = _persistent_index->erase(key_col.size(), key_col.raw_data(), old_values.data());
+    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(), old_values.data());
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1090,7 +1090,7 @@ void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, De
 }
 
 void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
-    Status st = _persistent_index->get(key_col.size(), key_col.raw_data(), rowids->data());
+    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(), rowids->data());
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
@@ -1101,7 +1101,7 @@ void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_star
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, pks, 0, pks.size(), &values);
-    Status st = _persistent_index->try_replace(pks.size(), pks.raw_data(), values.data(), src_rssid, deletes);
+    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(), values.data(), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }


### PR DESCRIPTION

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7298

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 
If `enable_persistent_index` of primary table is true, and `encoded_key_column` is `BinaryColumn`.  The function `raw_data()` will return a vector of slice as `keys` of PersistentIndex .

However, PersistentIndex required the `keys` is real data because PersistentIndex will read data from `keys` directly. So we will get unexpected error when `encoded_key_column` is `BinaryColumn`
