### PR TITLE
[cherry-pick] [branch-2.0] [Enhancement] Add size check for memtable before flush (#6289)

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -225,8 +225,8 @@ public:
 
     std::string debug_string() const override;
 
-    bool reach_capacity_limit() const override {
-        return _elements->reach_capacity_limit() || _offsets->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _elements->reach_capacity_limit(msg) || _offsets->reach_capacity_limit(msg);
     }
 
 private:

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -436,4 +436,25 @@ std::string BinaryColumn::debug_item(uint32_t idx) const {
     return s;
 }
 
+bool BinaryColumn::reach_capacity_limit(std::string* msg) const {
+    // The size limit of a single element is 2^32 - 1.
+    // The size limit of all elements is 2^32 - 1.
+    // The number limit of elements is 2^32 - 1.
+    if (_bytes.size() >= Column::MAX_CAPACITY_LIMIT) {
+        if (msg != nullptr) {
+            msg->append("Total byte size of binary column exceed the limit: " +
+                        std::to_string(Column::MAX_CAPACITY_LIMIT));
+        }
+        return true;
+    } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
+        if (msg != nullptr) {
+            msg->append("Total row count of binary column exceed the limit: " +
+                        std::to_string(Column::MAX_CAPACITY_LIMIT));
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -277,10 +277,7 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _bytes.size() >= Column::MAX_CAPACITY_LIMIT || _offsets.size() >= Column::MAX_CAPACITY_LIMIT ||
-               _slices.size() >= Column::MAX_CAPACITY_LIMIT;
-    }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override;
 
 private:
     void _build_slices() const;

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -238,9 +238,9 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
-    bool reach_capacity_limit() const {
+    bool reach_capacity_limit(std::string* msg = nullptr) const {
         for (const auto& column : _columns) {
-            if (column->reach_capacity_limit()) {
+            if (column->reach_capacity_limit(msg)) {
                 return true;
             }
         }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -322,7 +322,7 @@ public:
 
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
-    virtual bool reach_capacity_limit() const = 0;
+    virtual bool reach_capacity_limit(std::string* msg = nullptr) const = 0;
 
 protected:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -5,6 +5,7 @@
 #include "column/column.h"
 #include "column/datum.h"
 #include "common/logging.h"
+#include "common/status.h"
 
 namespace starrocks::vectorized {
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -218,7 +218,16 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override { return _data->reach_capacity_limit(); }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        RETURN_IF_UNLIKELY(_data->reach_capacity_limit(msg), true);
+        if (_size > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Row count of const column reach limit: " + std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
 private:
     ColumnPtr _data;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -190,7 +190,18 @@ public:
         _data.clear();
     }
 
-    bool reach_capacity_limit() const override { return _data.size() >= Column::MAX_CAPACITY_LIMIT; }
+    // The `_data` support one size(> 2^32), but some interface such as update_rows() will use index of uint32_t to
+    // access the item, so we should use 2^32 as the limit
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_data.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of fixed length column exceend the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
 protected:
     Container _data;

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -278,8 +278,8 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _data_column->reach_capacity_limit() || _null_column->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _data_column->reach_capacity_limit(msg) || _null_column->reach_capacity_limit(msg);
     }
 
 private:

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -196,9 +196,15 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _pool.size() >= Column::MAX_CAPACITY_LIMIT || _cache.size() >= Column::MAX_CAPACITY_LIMIT ||
-               _slices.size() >= Column::MAX_CAPACITY_LIMIT || _buffer.size() >= Column::MAX_CAPACITY_LIMIT;
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_pool.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of object column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
     }
 
 private:

--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -189,6 +189,11 @@ OLAPStatus MemTable::flush() {
     if (_result_chunk == nullptr) {
         return OLAP_SUCCESS;
     }
+    std::string msg;
+    if (_result_chunk->reach_capacity_limit(&msg)) {
+        LOG(WARNING) << "memtable of tablet: " << _tablet_id << " reache the capacity limit, detail msg:" << msg;
+        return OLAP_ERR_OTHER_ERROR;
+    }
 
     int64_t duration_ns = 0;
     {


### PR DESCRIPTION
Currently BinaryColumn supports a maximum of 4G, and other column support a maximum of 2^32 rows. If it exceeds, it will write dirty data, so when memtable flush, should add a size check to prevent generation dirty data