### PR TITLE
[cherry-pick] [branch-2.1] [Enhancement] Add size check for memtable before flush (#6289)

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -147,8 +147,8 @@ public:
 
     std::string debug_string() const override;
 
-    bool reach_capacity_limit() const override {
-        return _elements->reach_capacity_limit() || _offsets->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _elements->reach_capacity_limit(msg) || _offsets->reach_capacity_limit(msg);
     }
 
 private:

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -444,4 +444,25 @@ std::string BinaryColumn::debug_item(uint32_t idx) const {
     return s;
 }
 
+bool BinaryColumn::reach_capacity_limit(std::string* msg) const {
+    // The size limit of a single element is 2^32 - 1.
+    // The size limit of all elements is 2^32 - 1.
+    // The number limit of elements is 2^32 - 1.
+    if (_bytes.size() >= Column::MAX_CAPACITY_LIMIT) {
+        if (msg != nullptr) {
+            msg->append("Total byte size of binary column exceed the limit: " +
+                        std::to_string(Column::MAX_CAPACITY_LIMIT));
+        }
+        return true;
+    } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
+        if (msg != nullptr) {
+            msg->append("Total row count of binary column exceed the limit: " +
+                        std::to_string(Column::MAX_CAPACITY_LIMIT));
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -268,10 +268,7 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _bytes.size() >= Column::MAX_CAPACITY_LIMIT || _offsets.size() >= Column::MAX_CAPACITY_LIMIT ||
-               _slices.size() >= Column::MAX_CAPACITY_LIMIT;
-    }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override;
 
 private:
     void _build_slices() const;

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -220,9 +220,9 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
-    bool reach_capacity_limit() const {
+    bool reach_capacity_limit(std::string* msg = nullptr) const {
         for (const auto& column : _columns) {
-            if (column->reach_capacity_limit()) {
+            if (column->reach_capacity_limit(msg)) {
                 return true;
             }
         }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -316,7 +316,7 @@ public:
 
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
-    virtual bool reach_capacity_limit() const = 0;
+    virtual bool reach_capacity_limit(std::string* msg = nullptr) const = 0;
 
     virtual Status accept(ColumnVisitor* visitor) const = 0;
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -212,7 +212,16 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override { return _data->reach_capacity_limit(); }
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        RETURN_IF_UNLIKELY(_data->reach_capacity_limit(msg), true);
+        if (_size > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("Row count of const column reach limit: " + std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
 private:
     ColumnPtr _data;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -188,7 +188,18 @@ public:
         _data.clear();
     }
 
-    bool reach_capacity_limit() const override { return _data.size() >= Column::MAX_CAPACITY_LIMIT; }
+    // The `_data` support one size(> 2^32), but some interface such as update_rows() will use index of uint32_t to
+    // access the item, so we should use 2^32 as the limit
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_data.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of fixed length column exceend the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
+    }
 
 protected:
     Container _data;

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -272,8 +272,8 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _data_column->reach_capacity_limit() || _null_column->reach_capacity_limit();
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        return _data_column->reach_capacity_limit(msg) || _null_column->reach_capacity_limit(msg);
     }
 
 private:

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -194,9 +194,15 @@ public:
         return ss.str();
     }
 
-    bool reach_capacity_limit() const override {
-        return _pool.size() >= Column::MAX_CAPACITY_LIMIT || _cache.size() >= Column::MAX_CAPACITY_LIMIT ||
-               _slices.size() >= Column::MAX_CAPACITY_LIMIT || _buffer.size() >= Column::MAX_CAPACITY_LIMIT;
+    bool reach_capacity_limit(std::string* msg = nullptr) const override {
+        if (_pool.size() > Column::MAX_CAPACITY_LIMIT) {
+            if (msg != nullptr) {
+                msg->append("row count of object column exceed the limit: " +
+                            std::to_string(Column::MAX_CAPACITY_LIMIT));
+            }
+            return true;
+        }
+        return false;
     }
 
 private:

--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -216,6 +216,11 @@ Status MemTable::flush() {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
+    std::string msg;
+    if (_result_chunk->reach_capacity_limit(&msg)) {
+        return Status::InternalError(
+                fmt::format("memtable of tablet {} reache the capacity limit, detail msg: {}", _tablet_id, msg));
+    }
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);


### PR DESCRIPTION
Currently BinaryColumn supports a maximum of 4G, and other column support a maximum of 2^32 rows. If it exceeds, it will write dirty data, so when memtable flush, should add a size check to prevent generation dirty data

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
