### PR TITLE
[BugFix] Allow skip authorization and reset root password

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -92,7 +93,9 @@ public class MysqlProto {
             return false;
         }
         context.setAuthDataSalt(randomString);
-        context.setCurrentUserIdentity(currentUserIdentity.get(0));
+        if (Config.enable_auth_check) {
+            context.setCurrentUserIdentity(currentUserIdentity.get(0));
+        }
         context.setQualifiedUser(qualifiedUser);
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -466,6 +466,9 @@ public class Auth implements Writable {
      * This method will check the given privilege levels
      */
     public boolean checkHasPriv(ConnectContext ctx, PrivPredicate priv, PrivLevel... levels) {
+        if (!Config.enable_auth_check) {
+            return true;
+        }
         // currentUser referred to the account that determines user's access privileges.
         return checkHasPrivInternal(ctx.getCurrentUserIdentity(), priv, levels);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7359 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
There must be other bugs somewhere once we set `enable_auth_check` to false, but this time I am only trying to make sure root password can be changed. The rest scenerios are off my consideration for now.