### PR TITLE
[Bugfix] Avoid using released resources for ContextWithDependency after closing

### DIFF
--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -29,10 +29,12 @@ class ExceptContext final : public ContextWithDependency {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 
-    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
+    bool is_ht_empty() const { return _is_hash_set_empty; }
 
     void finish_build_ht() {
+        _is_hash_set_empty = _hash_set->empty();
         _next_processed_iter = _hash_set->begin();
+        _hash_set_end_iter = _hash_set->end();
         _finished_dependency_index.fetch_add(1, std::memory_order_release);
     }
 
@@ -42,7 +44,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _next_processed_iter == _hash_set_end_iter; }
 
     // Called in the preparation phase of ExceptBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
@@ -77,6 +79,8 @@ private:
     // Used for traversal on the hash set to get the undeleted keys to dest chunk.
     // Init when the hash set is finished building in finish_build_ht().
     vectorized::ExceptHashSerializeSet::Iterator _next_processed_iter;
+    vectorized::ExceptHashSerializeSet::Iterator _hash_set_end_iter;
+    bool _is_hash_set_empty = false;
 
     // The BUILD, PROBES, and OUTPUT operators execute sequentially.
     // BUILD -> 1-th PROBE -> 2-th PROBE -> ... -> n-th PROBE -> OUTPUT.

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -31,10 +31,12 @@ public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
 
-    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
+    bool is_ht_empty() const { return _is_hash_set_empty; }
 
     void finish_build_ht() {
+        _is_hash_set_empty = _hash_set->empty();
         _next_processed_iter = _hash_set->begin();
+        _hash_set_end_iter = _hash_set->end();
         _finished_dependency_index.fetch_add(1, std::memory_order_release);
     }
 
@@ -44,7 +46,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _next_processed_iter == _hash_set_end_iter; }
 
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
@@ -80,6 +82,8 @@ private:
     // Used for traversal on the hash set to get the undeleted keys to dest chunk.
     // Init when the hash set is finished building in finish_build_ht().
     vectorized::IntersectHashSerializeSet::Iterator _next_processed_iter;
+    vectorized::IntersectHashSerializeSet::Iterator _hash_set_end_iter;
+    bool _is_hash_set_empty = false;
 
     // The BUILD, PROBES, and OUTPUT operators execute sequentially.
     // BUILD -> 1-th PROBE -> 2-th PROBE -> ... -> n-th PROBE -> OUTPUT.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others


## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
A `ContextWithDependency` may be used by multiple related drivers at the same time. Therefore, there will be race conditions, if the check status methods of operators use the resources, which will be releases after the context is closed. 

To solve this, record the status of these resources to the specific variables, including `is_ht_empty` and `ht_end_iter. 

For example, 
| Sequence ID | Threads 1                                                    | Threads 2                                             |
| ----------- | ------------------------------------------------------------ | ----------------------------------------------------- |
| 1           | Close CrossJoinLeft.                                         |                                                       |
| 2           | Start call CrossJoinLeft.is_finished() ⇨ ctx.is_build_chunk_empty() |                                                       |
| 3           | ctx.is_build_chunk_empty() takes `_build_chunks[0]`          |                                                       |
| 4           |                                                              | Close CrossJoinRight and release `ctx._build_chunks`. |
| 5           | ctx.is_build_chunk_empty() calls `_build_chunks[0]->empty()`, **crash by the raw pointer!** |                                                       |



