### PR TITLE
[Enhance] support shared scan operator

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -209,10 +209,6 @@ struct ColumnBuilder {
 
 ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size) {
     auto type = type_desc.type;
-    if (VLOG_ROW_IS_ON) {
-        VLOG_ROW << "PrimitiveType " << type << " nullable " << nullable << " is_const " << is_const;
-    }
-
     if (is_const && (nullable || type == TYPE_NULL)) {
         return ColumnHelper::create_const_null_column(size);
     } else if (type == TYPE_NULL) {

--- a/be/src/common/constexpr.h
+++ b/be/src/common/constexpr.h
@@ -10,7 +10,7 @@ constexpr const int DEFAULT_CHUNK_SIZE = 4096;
 // Chunk size for some huge type(HLL, JSON)
 constexpr inline int CHUNK_SIZE_FOR_HUGE_TYPE = 4096;
 
-// Lock is sharded input 32
+// Lock is sharded into 32 shards
 constexpr int NUM_LOCK_SHARD_LOG = 5;
 constexpr int NUM_LOCK_SHARD = 1 << NUM_LOCK_SHARD_LOG;
 

--- a/be/src/common/constexpr.h
+++ b/be/src/common/constexpr.h
@@ -10,4 +10,8 @@ constexpr const int DEFAULT_CHUNK_SIZE = 4096;
 // Chunk size for some huge type(HLL, JSON)
 constexpr inline int CHUNK_SIZE_FOR_HUGE_TYPE = 4096;
 
+// Lock is sharded input 32
+constexpr int NUM_LOCK_SHARD_LOG = 5;
+constexpr int NUM_LOCK_SHARD = 1 << NUM_LOCK_SHARD_LOG;
+
 } // namespace starrocks

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -140,6 +140,7 @@ set(EXEC_FILES
     pipeline/dict_decode_operator.cpp
     pipeline/result_sink_operator.cpp
     pipeline/olap_table_sink_operator.cpp
+    pipeline/scan/balanced_chunk_buffer.cpp
     pipeline/scan/morsel.cpp
     pipeline/scan/scan_operator.cpp
     pipeline/scan/olap_chunk_source.cpp

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -20,6 +20,7 @@
 #include "exec/scan_node.h"
 #include "exec/tablet_sink.h"
 #include "exec/vectorized/cross_join_node.h"
+#include "exec/vectorized/olap_scan_node.h"
 #include "exec/workgroup/work_group.h"
 #include "gen_cpp/doris_internal_service.pb.h"
 #include "gutil/casts.h"
@@ -258,6 +259,11 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
     std::vector<TScanRangeParams> no_scan_ranges;
     plan->collect_scan_nodes(&scan_nodes);
 
+    bool enable_shared_scan = false;
+    if (request.__isset.enable_shared_scan) {
+        enable_shared_scan = request.enable_shared_scan;
+    }
+
     MorselQueueMap& morsel_queues = _fragment_ctx->morsel_queues();
     for (auto& i : scan_nodes) {
         ScanNode* scan_node = down_cast<ScanNode*>(i);
@@ -266,6 +272,10 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
         ASSIGN_OR_RETURN(MorselQueuePtr morsel_queue,
                          scan_node->convert_scan_range_to_morsel_queue(scan_ranges, scan_node->id(), request));
         morsel_queues.emplace(scan_node->id(), std::move(morsel_queue));
+
+        if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
+            olap_scan->enable_shared_scan(enable_shared_scan);
+        }
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -17,10 +17,8 @@ BalancedChunkBuffer::BalancedChunkBuffer(BalanceStrategy strategy, int output_ru
 
 BalancedChunkBuffer::~BalancedChunkBuffer() {
     for (int i = 0; i < _output_runs; i++) {
-        if (!_sub_buffers[i]->empty()) {
-            LOG(INFO) << fmt::format("BalancedChunkBuffer destory but remained {} chunks in buffer {}",
-                                     _sub_buffers[i]->get_size(), i);
-        }
+        DCHECK(_sub_buffers[i]->empty()) << fmt::format(
+                "BalancedChunkBuffer destory but remained {} chunks in buffer {}", _sub_buffers[i]->get_size(), i);
     }
 }
 

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -1,0 +1,53 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/scan/balanced_chunk_buffer.h"
+
+#include "util/blocking_queue.hpp"
+
+namespace starrocks::pipeline {
+
+BalancedChunkBuffer::BalancedChunkBuffer(int output_runs) : _output_runs(output_runs) {
+    DCHECK_GT(output_runs, 0);
+    for (int i = 0; i < output_runs; i++) {
+        _sub_buffers.emplace_back(std::make_unique<QueueT>());
+    }
+}
+
+const BalancedChunkBuffer::SubBuffer& BalancedChunkBuffer::_get_sub_buffer(int index) const {
+    DCHECK_LT(index, _output_runs);
+    return _sub_buffers[index % _output_runs];
+}
+
+BalancedChunkBuffer::SubBuffer& BalancedChunkBuffer::_get_sub_buffer(int index) {
+    DCHECK_LT(index, _output_runs);
+    return _sub_buffers[index % _output_runs];
+}
+
+size_t BalancedChunkBuffer::size(int buffer_index) const {
+    return _get_sub_buffer(buffer_index)->get_size();
+}
+
+bool BalancedChunkBuffer::all_empty() const {
+    for (auto& buffer : _sub_buffers) {
+        if (!buffer->empty()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool BalancedChunkBuffer::empty(int buffer_index) const {
+    return _get_sub_buffer(buffer_index)->empty();
+}
+
+bool BalancedChunkBuffer::try_get(int buffer_index, vectorized::ChunkPtr* output_chunk) {
+    return _get_sub_buffer(buffer_index)->try_get(output_chunk);
+}
+
+bool BalancedChunkBuffer::put(vectorized::ChunkPtr chunk) {
+    int target_index = _output_index.fetch_add(1);
+    target_index %= _output_runs;
+    return _get_sub_buffer(target_index)->put(chunk);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -50,12 +50,10 @@ bool BalancedChunkBuffer::empty(int buffer_index) const {
 }
 
 bool BalancedChunkBuffer::try_get(int buffer_index, vectorized::ChunkPtr* output_chunk) {
-    LOG(INFO) << "BalancedChunkBuffer get chunk " << buffer_index;
     return _get_sub_buffer(buffer_index)->try_get(output_chunk);
 }
 
 bool BalancedChunkBuffer::put(int buffer_index, vectorized::ChunkPtr chunk) {
-    LOG(INFO) << "BalancedChunkBuffer put chunk " << buffer_index;
     if (_strategy == BalanceStrategy::kDirect) {
         return _get_sub_buffer(buffer_index)->put(chunk);
     } else if (_strategy == BalanceStrategy::kRoundRobin) {

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -19,7 +19,7 @@ enum BalanceStrategy {
 class BalancedChunkBuffer {
 public:
     BalancedChunkBuffer(BalanceStrategy strategy, int output_runs);
-    ~BalancedChunkBuffer() = default;
+    ~BalancedChunkBuffer();
 
     size_t size(int buffer_index) const;
     bool empty(int buffer_index) const;

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -11,21 +11,22 @@ namespace starrocks::pipeline {
 
 // TODO: support hash distribution instead of simple round-robin
 enum BalanceStrategy {
-    kDirect,
-    kRoundRobin,
+    kDirect,     // Assign chunks from input operator to output operator directly
+    kRoundRobin, // Assign chunks from input operator to output with round-robin strategy
 };
 
 // A chunk-buffer which try to balance output for each operator
 class BalancedChunkBuffer {
 public:
-    BalancedChunkBuffer(BalanceStrategy strategy, int output_runs);
+    BalancedChunkBuffer(BalanceStrategy strategy, int output_operators);
     ~BalancedChunkBuffer();
 
+    bool all_empty() const;
     size_t size(int buffer_index) const;
     bool empty(int buffer_index) const;
-    bool all_empty() const;
     bool try_get(int buffer_index, vectorized::ChunkPtr* output_chunk);
     bool put(int buffer_index, vectorized::ChunkPtr chunk);
+    void close();
 
 private:
     using QueueT = UnboundedBlockingQueue<vectorized::ChunkPtr>;
@@ -34,10 +35,10 @@ private:
     const SubBuffer& _get_sub_buffer(int index) const;
     SubBuffer& _get_sub_buffer(int index);
 
-    const int _output_runs;
+    const int _output_operators;
     const BalanceStrategy _strategy;
-    std::atomic_int64_t _output_index = 0;
     std::vector<SubBuffer> _sub_buffers;
+    std::atomic_int64_t _output_index = 0;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "column/chunk.h"
+#include "util/blocking_queue.hpp"
+
+namespace starrocks::pipeline {
+
+// A chunk-buffer which try to balance output for each operator
+// TODO: support hash distribution instead of simple round-robin
+class BalancedChunkBuffer {
+public:
+    BalancedChunkBuffer(int output_runs);
+    ~BalancedChunkBuffer() = default;
+
+    size_t size(int buffer_index) const;
+    bool empty(int buffer_index) const;
+    bool all_empty() const;
+    bool try_get(int buffer_index, vectorized::ChunkPtr* output_chunk);
+    bool put(vectorized::ChunkPtr chunk);
+
+private:
+    using QueueT = UnboundedBlockingQueue<vectorized::ChunkPtr>;
+    using SubBuffer = std::unique_ptr<QueueT>;
+
+    const SubBuffer& _get_sub_buffer(int index) const;
+    SubBuffer& _get_sub_buffer(int index);
+
+    const int _output_runs;
+    std::atomic_int64_t _output_index = 0;
+    std::vector<SubBuffer> _sub_buffers;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -34,7 +34,7 @@ public:
     // Whether cache is empty or not
     virtual bool has_output() const = 0;
 
-    virtual bool has_shared_output() const { return false; }
+    virtual bool has_shared_output() const = 0;
 
     virtual size_t get_buffer_size() const = 0;
 

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -18,8 +18,8 @@ namespace pipeline {
 
 class ChunkSource {
 public:
-    ChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel)
-            : _runtime_profile(runtime_profile), _morsel(std::move(morsel)){};
+    ChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel)
+            : _scan_operator_seq(scan_operator_id), _runtime_profile(runtime_profile), _morsel(std::move(morsel)) {}
 
     virtual ~ChunkSource() = default;
 
@@ -33,6 +33,8 @@ public:
 
     // Whether cache is empty or not
     virtual bool has_output() const = 0;
+
+    virtual bool has_shared_output() const { return false; }
 
     virtual size_t get_buffer_size() const = 0;
 
@@ -59,6 +61,7 @@ public:
     }
 
 protected:
+    const int32_t _scan_operator_seq;
     RuntimeProfile* _runtime_profile;
     // The morsel will own by pipeline driver
     MorselPtr _morsel;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -45,15 +45,16 @@ Status ConnectorScanOperator::do_prepare(RuntimeState* state) {
 void ConnectorScanOperator::do_close(RuntimeState* state) {}
 
 ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
-    auto* scan_node = down_cast<vectorized::ConnectorScanNode*>(_scan_node);
-    return std::make_shared<ConnectorChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel),
-                                                  this, scan_node);
+    vectorized::ConnectorScanNode* scan_node = down_cast<vectorized::ConnectorScanNode*>(_scan_node);
+    return std::make_shared<ConnectorChunkSource>(_driver_sequence, _chunk_source_profiles[chunk_source_index].get(),
+                                                  std::move(morsel), this, scan_node);
 }
 
 // ==================== ConnectorChunkSource ====================
-ConnectorChunkSource::ConnectorChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
+ConnectorChunkSource::ConnectorChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile,
+                                           MorselPtr&& morsel, ScanOperator* op,
                                            vectorized::ConnectorScanNode* scan_node)
-        : ChunkSource(runtime_profile, std::move(morsel)),
+        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel)),
           _scan_node(scan_node),
           _limit(scan_node->limit()),
           _runtime_in_filters(op->runtime_in_filters()),

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -72,6 +72,12 @@ bool ConnectorScanOperator::has_buffer_output() const {
     return !buffer.empty(_driver_sequence);
 }
 
+bool ConnectorScanOperator::has_available_buffer() const {
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    auto& buffer = factory->get_chunk_buffer();
+    return buffer.size(_driver_sequence) <= _buffer_size;
+}
+
 ChunkPtr ConnectorScanOperator::get_chunk_from_buffer() {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     auto& buffer = factory->get_chunk_buffer();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -53,17 +53,25 @@ ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int3
 }
 
 void ConnectorScanOperator::attach_chunk_source(int32_t source_index) {
-    DCHECK(!_active_inputs.contains(source_index));
-    _active_inputs.emplace(source_index);
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    auto& active_inputs = factory->get_active_inputs();
+    auto key = std::make_pair(_driver_sequence, source_index);
+    DCHECK(!active_inputs.contains(key));
+    active_inputs.emplace(key);
 }
 
 void ConnectorScanOperator::detach_chunk_source(int32_t source_index) {
-    DCHECK(_active_inputs.contains(source_index));
-    _active_inputs.erase(source_index);
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    auto& active_inputs = factory->get_active_inputs();
+    auto key = std::make_pair(_driver_sequence, source_index);
+    DCHECK(active_inputs.contains(key));
+    active_inputs.erase(key);
 }
 
 bool ConnectorScanOperator::has_shared_chunk_source() const {
-    return !_active_inputs.empty();
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    auto& active_inputs = factory->get_active_inputs();
+    return !active_inputs.empty();
 }
 
 bool ConnectorScanOperator::has_buffer_output() const {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -46,6 +46,7 @@ public:
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
     bool has_buffer_output() const override;
+    bool has_available_buffer() const override;
     ChunkPtr get_chunk_from_buffer() override;
 
 private:

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -40,8 +40,8 @@ private:
 
 class ConnectorChunkSource final : public ChunkSource {
 public:
-    ConnectorChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
-                         vectorized::ConnectorScanNode* scan_node);
+    ConnectorChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
+                         ScanOperator* op, vectorized::ConnectorScanNode* scan_node);
 
     ~ConnectorChunkSource() override;
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -26,7 +26,7 @@ public:
     BalancedChunkBuffer& get_chunk_buffer() { return _chunk_buffer; }
 
 private:
-    // TODO: support round-robin
+    // TODO: refactor the OlapScanContext, move them into the context
     BalancedChunkBuffer _chunk_buffer;
 };
 
@@ -41,7 +41,17 @@ public:
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
+    // TODO: refactor it into the base class
+    void attach_chunk_source(int32_t source_index) override;
+    void detach_chunk_source(int32_t source_index) override;
+    bool has_shared_chunk_source() const override;
+    bool has_buffer_output() const override;
+    ChunkPtr get_chunk_from_buffer() override;
+
 private:
+    using ActiveInputSet = phmap::flat_hash_set<int32_t>;
+
+    ActiveInputSet _active_inputs;
 };
 
 class ConnectorChunkSource final : public ChunkSource {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -43,8 +43,6 @@ void OlapChunkSource::close(RuntimeState* state) {
     _prj_iter->close();
     _reader.reset();
     _predicate_free_pool.clear();
-    // _chunk_buffer.shutdown();
-    // _chunk_buffer.clear();
 }
 
 Status OlapChunkSource::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -24,13 +24,14 @@
 namespace starrocks::pipeline {
 using namespace vectorized;
 
-OlapChunkSource::OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel,
+OlapChunkSource::OlapChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
                                  vectorized::OlapScanNode* scan_node, OlapScanContext* scan_ctx)
-        : ChunkSource(runtime_profile, std::move(morsel)),
+        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel)),
           _scan_node(scan_node),
           _scan_ctx(scan_ctx),
           _limit(scan_node->limit()),
-          _scan_range(down_cast<ScanMorsel*>(_morsel.get())->get_olap_scan_range()) {}
+          _scan_range(down_cast<ScanMorsel*>(_morsel.get())->get_olap_scan_range()),
+          _chunk_buffer(scan_ctx->get_chunk_buffer()) {}
 
 OlapChunkSource::~OlapChunkSource() {
     _reader.reset();
@@ -42,8 +43,8 @@ void OlapChunkSource::close(RuntimeState* state) {
     _prj_iter->close();
     _reader.reset();
     _predicate_free_pool.clear();
-    _chunk_buffer.shutdown();
-    _chunk_buffer.clear();
+    // _chunk_buffer.shutdown();
+    // _chunk_buffer.clear();
 }
 
 Status OlapChunkSource::prepare(RuntimeState* state) {
@@ -286,16 +287,20 @@ bool OlapChunkSource::has_next_chunk() const {
 }
 
 bool OlapChunkSource::has_output() const {
-    return !_chunk_buffer.empty();
+    return !_chunk_buffer.empty(_scan_operator_seq);
+}
+
+bool OlapChunkSource::has_shared_output() const {
+    return !_chunk_buffer.all_empty();
 }
 
 size_t OlapChunkSource::get_buffer_size() const {
-    return _chunk_buffer.get_size();
+    return _chunk_buffer.size(_scan_operator_seq);
 }
 
 StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     vectorized::ChunkPtr chunk = nullptr;
-    _chunk_buffer.try_get(&chunk);
+    _chunk_buffer.try_get(_scan_operator_seq, &chunk);
     return chunk;
 }
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -329,13 +329,13 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, Run
             // end of file is normal case, need process chunk
             if (_status.is_end_of_file()) {
                 _update_avg_row_bytes(chunk.get(), i, batch_size);
-                _chunk_buffer.put(std::move(chunk));
+                _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
             }
             break;
         }
 
         _update_avg_row_bytes(chunk.get(), i, batch_size);
-        _chunk_buffer.put(std::move(chunk));
+        _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
     }
 
     return _status;
@@ -362,14 +362,14 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t b
                 if (_status.is_end_of_file()) {
                     ++(*num_read_chunks);
                     _update_avg_row_bytes(chunk.get(), i, batch_size);
-                    _chunk_buffer.put(std::move(chunk));
+                    _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
                 }
                 break;
             }
 
             ++(*num_read_chunks);
             _update_avg_row_bytes(chunk.get(), i, batch_size);
-            _chunk_buffer.put(std::move(chunk));
+            _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
         }
 
         if (time_spent >= YIELD_MAX_TIME_SPENT) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -17,7 +17,6 @@
 #include "storage/conjunctive_predicates.h"
 #include "storage/tablet.h"
 #include "storage/tablet_reader.h"
-#include "util/json.h"
 
 namespace starrocks {
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -6,6 +6,7 @@
 
 #include "exec/olap_common.h"
 #include "exec/olap_utils.h"
+#include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "exec/pipeline/scan/chunk_source.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "exec/workgroup/work_group_fwd.h"
@@ -16,6 +17,7 @@
 #include "storage/conjunctive_predicates.h"
 #include "storage/tablet.h"
 #include "storage/tablet_reader.h"
+#include "util/json.h"
 
 namespace starrocks {
 
@@ -32,8 +34,8 @@ class OlapScanContext;
 
 class OlapChunkSource final : public ChunkSource {
 public:
-    OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, vectorized::OlapScanNode* scan_node,
-                    OlapScanContext* scan_ctx);
+    OlapChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
+                    vectorized::OlapScanNode* scan_node, OlapScanContext* scan_ctx);
 
     ~OlapChunkSource() override;
 
@@ -44,6 +46,8 @@ public:
     bool has_next_chunk() const override;
 
     bool has_output() const override;
+
+    bool has_shared_output() const override;
 
     virtual size_t get_buffer_size() const override;
 
@@ -89,7 +93,7 @@ private:
     TInternalScanRange* _scan_range;
 
     Status _status = Status::OK();
-    UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_buffer;
+    BalancedChunkBuffer& _chunk_buffer;
     vectorized::ConjunctivePredicates _not_push_down_predicates;
     std::vector<uint8_t> _selection;
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -12,16 +12,16 @@ using namespace vectorized;
 void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
     DCHECK(_active_inputs.count(key) == 0);
-    LOG(INFO) << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,
-                             _active_inputs.size());
+    VLOG_ROW << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,
+                            _active_inputs.size());
     _active_inputs.emplace(key);
 }
 
 void OlapScanContext::detach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
     DCHECK(_active_inputs.count(key) == 1);
-    LOG(INFO) << fmt::format("detach_shared_input ({}, {}), remain {}", operator_seq, source_index,
-                             _active_inputs.size());
+    VLOG_ROW << fmt::format("detach_shared_input ({}, {}), remain {}", operator_seq, source_index,
+                            _active_inputs.size());
     _active_inputs.erase(key);
 }
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -44,6 +44,7 @@ Status OlapScanContext::prepare(RuntimeState* state) {
 void OlapScanContext::close(RuntimeState* state) {
     const auto& conjunct_ctxs = _scan_node->conjunct_ctxs();
     Expr::close(conjunct_ctxs, state);
+    _chunk_buffer.close();
 }
 
 Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<ExprContext*>& runtime_in_filters,

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -29,6 +29,10 @@ bool OlapScanContext::has_active_input() const {
     return !_active_inputs.empty();
 }
 
+BalancedChunkBuffer& OlapScanContext::get_shared_buffer() {
+    return _chunk_buffer;
+}
+
 Status OlapScanContext::prepare(RuntimeState* state) {
     const auto& conjunct_ctxs = _scan_node->conjunct_ctxs();
     RETURN_IF_ERROR(Expr::prepare(conjunct_ctxs, state));

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -9,6 +9,26 @@ namespace starrocks::pipeline {
 
 using namespace vectorized;
 
+void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {
+    auto key = std::make_pair(operator_seq, source_index);
+    DCHECK(_active_inputs.count(key) == 0);
+    LOG(INFO) << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,
+                             _active_inputs.size());
+    _active_inputs.emplace(key);
+}
+
+void OlapScanContext::detach_shared_input(int32_t operator_seq, int32_t source_index) {
+    auto key = std::make_pair(operator_seq, source_index);
+    DCHECK(_active_inputs.count(key) == 1);
+    LOG(INFO) << fmt::format("detach_shared_input ({}, {}), remain {}", operator_seq, source_index,
+                             _active_inputs.size());
+    _active_inputs.erase(key);
+}
+
+bool OlapScanContext::has_active_input() const {
+    return !_active_inputs.empty();
+}
+
 Status OlapScanContext::prepare(RuntimeState* state) {
     const auto& conjunct_ctxs = _scan_node->conjunct_ctxs();
     RETURN_IF_ERROR(Expr::prepare(conjunct_ctxs, state));

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -71,15 +71,14 @@ private:
     ObjectPool _obj_pool;
 
     // For shared_scan mechanism
-    BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
-
     using ActiveInputKey = std::pair<int32_t, int32_t>;
     using ActiveInputSet = phmap::parallel_flat_hash_set<
             ActiveInputKey, typename phmap::Hash<ActiveInputKey>, typename phmap::EqualTo<ActiveInputKey>,
             typename std::allocator<ActiveInputKey>, NUM_LOCK_SHARD_LOG, std::mutex, true>;
-    ActiveInputSet _active_inputs;
-    bool _shared_scan; // Enable shared_scan
-    int32_t _scan_dop; // DOP of scan operator
+    BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
+    ActiveInputSet _active_inputs;     // Maintain the active chunksource
+    bool _shared_scan;                 // Enable shared_scan
+    int32_t _scan_dop;                 // DOP of scan operator
 
     std::atomic<bool> _is_prepare_finished{false};
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -24,8 +24,10 @@ using namespace vectorized;
 
 class OlapScanContext final : public ContextWithDependency {
 public:
-    explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop)
-            : _scan_node(scan_node), _chunk_buffer(dop), _scan_dop(dop) {}
+    explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop, bool shared_scan)
+            : _scan_node(scan_node),
+              _chunk_buffer(shared_scan ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect, dop),
+              _scan_dop(dop) {}
 
     Status prepare(RuntimeState* state);
     void close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -27,6 +27,7 @@ public:
     explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop, bool shared_scan)
             : _scan_node(scan_node),
               _chunk_buffer(shared_scan ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect, dop),
+              _shared_scan(shared_scan),
               _scan_dop(dop) {}
 
     Status prepare(RuntimeState* state);
@@ -43,6 +44,7 @@ public:
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
     BalancedChunkBuffer& get_chunk_buffer() { return _chunk_buffer; }
+    bool is_shared_scan() const { return _shared_scan; }
 
     void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
     size_t avg_row_bytes() const { return _avg_row_bytes; }
@@ -58,7 +60,9 @@ private:
     vectorized::DictOptimizeParser _dict_optimize_parser;
     ObjectPool _obj_pool;
     BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
-    int32_t _scan_dop;                 // DOP of scan operator
+
+    bool _shared_scan; // Enable shared_scan
+    int32_t _scan_dop; // DOP of scan operator
 
     std::atomic<bool> _is_prepare_finished{false};
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "exec/pipeline/context_with_dependency.h"
+#include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "runtime/global_dict/parser.h"
 
@@ -23,7 +24,8 @@ using namespace vectorized;
 
 class OlapScanContext final : public ContextWithDependency {
 public:
-    explicit OlapScanContext(vectorized::OlapScanNode* scan_node) : _scan_node(scan_node) {}
+    explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop)
+            : _scan_node(scan_node), _chunk_buffer(dop), _scan_dop(dop) {}
 
     Status prepare(RuntimeState* state);
     void close(RuntimeState* state) override;
@@ -38,6 +40,7 @@ public:
     vectorized::OlapScanConjunctsManager& conjuncts_manager() { return _conjuncts_manager; }
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
+    BalancedChunkBuffer& get_chunk_buffer() { return _chunk_buffer; }
 
     void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
     size_t avg_row_bytes() const { return _avg_row_bytes; }
@@ -52,6 +55,8 @@ private:
     std::vector<std::unique_ptr<OlapScanRange>> _key_ranges;
     vectorized::DictOptimizeParser _dict_optimize_parser;
     ObjectPool _obj_pool;
+    BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
+    int32_t _scan_dop;                 // DOP of scan operator
 
     std::atomic<bool> _is_prepare_finished{false};
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -2,10 +2,13 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "runtime/global_dict/parser.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 
@@ -44,7 +47,13 @@ public:
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
     BalancedChunkBuffer& get_chunk_buffer() { return _chunk_buffer; }
+
+    // Shared scan states
     bool is_shared_scan() const { return _shared_scan; }
+    // Attach and detach to account the active input for shared chunk buffer
+    void attach_shared_input(int32_t operator_seq, int32_t source_index);
+    void detach_shared_input(int32_t operator_seq, int32_t source_index);
+    bool has_active_input() const;
 
     void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
     size_t avg_row_bytes() const { return _avg_row_bytes; }
@@ -59,8 +68,15 @@ private:
     std::vector<std::unique_ptr<OlapScanRange>> _key_ranges;
     vectorized::DictOptimizeParser _dict_optimize_parser;
     ObjectPool _obj_pool;
+
+    // For shared_scan mechanism
     BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
 
+    using ActiveInputKey = std::pair<int32_t, int32_t>;
+    using ActiveInputSet = phmap::parallel_flat_hash_set<
+            ActiveInputKey, typename phmap::Hash<ActiveInputKey>, typename phmap::EqualTo<ActiveInputKey>,
+            typename std::allocator<ActiveInputKey>, NUM_LOCK_SHARD_LOG, std::mutex, true>;
+    ActiveInputSet _active_inputs;
     bool _shared_scan; // Enable shared_scan
     int32_t _scan_dop; // DOP of scan operator
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -54,6 +54,7 @@ public:
     void attach_shared_input(int32_t operator_seq, int32_t source_index);
     void detach_shared_input(int32_t operator_seq, int32_t source_index);
     bool has_active_input() const;
+    BalancedChunkBuffer& get_shared_buffer();
 
     void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
     size_t avg_row_bytes() const { return _avg_row_bytes; }

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -8,7 +8,7 @@
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "runtime/global_dict/parser.h"
-#include "util/phmap/phmap.h"
+#include "util/phmap/phmap_fwd_decl.h"
 
 namespace starrocks {
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -105,7 +105,7 @@ bool OlapScanOperator::has_shared_chunk_source() const {
     return _ctx->has_active_input();
 }
 
-bool OlapScanOperator::has_shared_output() const {
+bool OlapScanOperator::has_buffer_output() const {
     return !_ctx->get_chunk_buffer().empty(_driver_sequence);
 }
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -87,8 +87,8 @@ void OlapScanOperator::do_close(RuntimeState* state) {
 
 ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);
-    return std::make_shared<OlapChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel),
-                                             olap_scan_node, _ctx.get());
+    return std::make_shared<OlapChunkSource>(_driver_sequence, _chunk_source_profiles[chunk_source_index].get(),
+                                             std::move(morsel), olap_scan_node, _ctx.get());
 }
 
 size_t OlapScanOperator::max_scan_concurrency() const {

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -117,6 +117,11 @@ ChunkPtr OlapScanOperator::get_chunk_from_buffer() {
     return nullptr;
 }
 
+bool OlapScanOperator::has_available_buffer() const {
+    // TODO: consider the global buffer
+    return _ctx->get_chunk_buffer().size(_driver_sequence) <= _buffer_size;
+}
+
 size_t OlapScanOperator::max_scan_concurrency() const {
     int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -93,6 +93,18 @@ ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t c
                                              std::move(morsel), olap_scan_node, _ctx.get());
 }
 
+void OlapScanOperator::attach_chunk_source(int32_t source_index) {
+    _ctx->attach_shared_input(_driver_sequence, source_index);
+}
+
+void OlapScanOperator::detach_chunk_source(int32_t source_index) {
+    _ctx->detach_shared_input(_driver_sequence, source_index);
+}
+
+bool OlapScanOperator::has_shared_chunk_source() const {
+    return _ctx->has_active_input();
+}
+
 size_t OlapScanOperator::max_scan_concurrency() const {
     int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -105,6 +105,18 @@ bool OlapScanOperator::has_shared_chunk_source() const {
     return _ctx->has_active_input();
 }
 
+bool OlapScanOperator::has_shared_output() const {
+    return !_ctx->get_chunk_buffer().empty(_driver_sequence);
+}
+
+ChunkPtr OlapScanOperator::get_chunk_from_buffer() {
+    vectorized::ChunkPtr chunk = nullptr;
+    if (_ctx->get_chunk_buffer().try_get(_driver_sequence, &chunk)) {
+        return chunk;
+    }
+    return nullptr;
+}
+
 size_t OlapScanOperator::max_scan_concurrency() const {
     int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -76,6 +76,8 @@ bool OlapScanOperator::is_finished() const {
 Status OlapScanOperator::do_prepare(RuntimeState*) {
     auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "DefaultMaxScanConcurrency", TUnit::UNIT);
     COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_default_max_scan_concurrency));
+    bool shared_scan = _ctx->is_shared_scan();
+    _unique_metrics->add_info_string("SharedScan", shared_scan ? "True" : "False");
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -46,6 +46,8 @@ public:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
+    bool has_shared_output() const override;
+    ChunkPtr get_chunk_from_buffer() override;
 
     size_t max_scan_concurrency() const override;
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -43,13 +43,16 @@ public:
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
+
+    size_t max_scan_concurrency() const override;
+
+protected:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
     bool has_buffer_output() const override;
+    bool has_available_buffer() const override;
     ChunkPtr get_chunk_from_buffer() override;
-
-    size_t max_scan_concurrency() const override;
 
 private:
     size_t _avg_max_scan_concurrency() const;

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -43,6 +43,9 @@ public:
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
+    void attach_chunk_source(int32_t source_index) override;
+    void detach_chunk_source(int32_t source_index) override;
+    bool has_shared_chunk_source() const override;
 
     size_t max_scan_concurrency() const override;
 

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -46,7 +46,7 @@ public:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
-    bool has_shared_output() const override;
+    bool has_buffer_output() const override;
     ChunkPtr get_chunk_from_buffer() override;
 
     size_t max_scan_concurrency() const override;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -231,7 +231,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     if (!has_available_buffer()) {
         return Status::OK();
     }
-    
+
     // Check if exceed the concurrency limitation
     if (!_try_to_increase_committed_scan_tasks()) {
         return Status::OK();

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -227,6 +227,11 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
+    // Check if the buffer has available capacity to avoid occupy too much momory
+    if (!has_available_buffer()) {
+        return Status::OK();
+    }
+    // Check if exceed the concurrency limitation
     if (!_try_to_increase_committed_scan_tasks()) {
         return Status::OK();
     }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -173,19 +173,6 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     }
     eval_runtime_bloom_filters(res.get());
     return res;
-
-    /*
-    for (auto& chunk_source : _chunk_sources) {
-        if (chunk_source != nullptr && chunk_source->has_output()) {
-            auto&& chunk = chunk_source->get_next_chunk_from_buffer();
-            eval_runtime_bloom_filters(chunk.value().get());
-
-            return std::move(chunk);
-        }
-    }
-
-    return nullptr;
-    */
 }
 
 int64_t ScanOperator::global_rf_wait_timeout_ns() const {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -327,7 +327,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
         detach_chunk_source(chunk_source_index);
     }
 
-    // NOTE: attach a active source before really creating it, to avoid the race condition
+    // NOTE: attach an active source before really creating it, to avoid the race condition
     bool need_detach = true;
     attach_chunk_source(chunk_source_index);
     DeferOp defer([&]() {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -91,9 +91,6 @@ bool ScanOperator::has_output() const {
     if (!_get_scan_status().ok()) {
         return true;
     }
-    if (has_shared_chunk_source()) {
-        return true;
-    }
     if (has_buffer_output()) {
         return true;
     }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -221,9 +221,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
             continue;
         }
 
-        if (_chunk_sources[i] == nullptr) {
-            RETURN_IF_ERROR(_pickup_morsel(state, i));
-        } else if (_chunk_sources[i]->has_next_chunk()) {
+        if (_chunk_sources[i] != nullptr && _chunk_sources[i]->has_next_chunk()) {
             RETURN_IF_ERROR(_trigger_next_scan(state, i));
         } else {
             RETURN_IF_ERROR(_pickup_morsel(state, i));
@@ -304,13 +302,13 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                 }
 
                 _decrease_committed_scan_tasks();
-                _num_running_io_tasks--;
-                _is_io_task_running[chunk_source_index] = false;
                 // Close the chunk source if no more chunk
                 if (!_chunk_sources[chunk_source_index]->has_next_chunk()) {
                     _chunk_sources[chunk_source_index]->close(state);
                     _chunk_sources[chunk_source_index] = nullptr;
                 }
+                _num_running_io_tasks--;
+                _is_io_task_running[chunk_source_index] = false;
             }
         };
         // TODO(by satanson): set a proper priority

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -39,7 +39,6 @@ ScanOperator::~ScanOperator() {
         if (_chunk_sources[i] != nullptr) {
             _chunk_sources[i]->close(state);
             _chunk_sources[i] = nullptr;
-            detach_chunk_source(i);
         }
     }
 }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -91,7 +91,7 @@ bool ScanOperator::has_output() const {
     }
 
     for (const auto& chunk_source : _chunk_sources) {
-        if (chunk_source != nullptr && chunk_source->has_output()) {
+        if (chunk_source != nullptr && (chunk_source->has_output() || chunk_source->has_shared_output())) {
             return true;
         }
     }

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -77,6 +77,7 @@ private:
     Status _pickup_morsel(RuntimeState* state, int chunk_source_index);
     Status _trigger_next_scan(RuntimeState* state, int chunk_source_index);
     Status _try_to_trigger_next_scan(RuntimeState* state);
+    void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index);
     void _merge_chunk_source_profiles();
 
     inline void _set_scan_status(const Status& status) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -48,6 +48,9 @@ public:
     virtual Status do_prepare(RuntimeState* state) = 0;
     virtual void do_close(RuntimeState* state) = 0;
     virtual ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) = 0;
+    virtual void attach_chunk_source(int32_t source_index) {}
+    virtual void detach_chunk_source(int32_t source_index) {}
+    virtual bool has_shared_chunk_source() const { return false; }
 
     virtual int64_t get_last_scan_rows_num() {
         int64_t scan_rows_num = _last_scan_rows_num;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -49,7 +49,6 @@ public:
     virtual void do_close(RuntimeState* state) = 0;
     virtual ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) = 0;
 
-
     virtual int64_t get_last_scan_rows_num() {
         int64_t scan_rows_num = _last_scan_rows_num;
         _last_scan_rows_num = 0;
@@ -119,7 +118,6 @@ protected:
     std::atomic<int>& _num_committed_scan_tasks;
 
 private:
-
     int32_t _io_task_retry_cnt = 0;
     PriorityThreadPool* _io_threads = nullptr;
     std::atomic<int> _num_running_io_tasks = 0;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -48,11 +48,13 @@ public:
     virtual Status do_prepare(RuntimeState* state) = 0;
     virtual void do_close(RuntimeState* state) = 0;
     virtual ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) = 0;
-    virtual void attach_chunk_source(int32_t source_index) {}
-    virtual void detach_chunk_source(int32_t source_index) {}
-    virtual bool has_shared_chunk_source() const { return false; }
-    virtual bool has_buffer_output() const { return false; }
-    virtual ChunkPtr get_chunk_from_buffer() { return nullptr; }
+
+    // Shared scan
+    virtual void attach_chunk_source(int32_t source_index) = 0;
+    virtual void detach_chunk_source(int32_t source_index) = 0;
+    virtual bool has_shared_chunk_source() const = 0;
+    virtual bool has_buffer_output() const = 0;
+    virtual ChunkPtr get_chunk_from_buffer() = 0;
 
     virtual int64_t get_last_scan_rows_num() {
         int64_t scan_rows_num = _last_scan_rows_num;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -51,7 +51,7 @@ public:
     virtual void attach_chunk_source(int32_t source_index) {}
     virtual void detach_chunk_source(int32_t source_index) {}
     virtual bool has_shared_chunk_source() const { return false; }
-    virtual bool has_shared_output() const { return false; }
+    virtual bool has_buffer_output() const { return false; }
     virtual ChunkPtr get_chunk_from_buffer() { return nullptr; }
 
     virtual int64_t get_last_scan_rows_num() {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -51,6 +51,8 @@ public:
     virtual void attach_chunk_source(int32_t source_index) {}
     virtual void detach_chunk_source(int32_t source_index) {}
     virtual bool has_shared_chunk_source() const { return false; }
+    virtual bool has_shared_output() const { return false; }
+    virtual ChunkPtr get_chunk_from_buffer() { return nullptr; }
 
     virtual int64_t get_last_scan_rows_num() {
         int64_t scan_rows_num = _last_scan_rows_num;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -51,7 +51,7 @@ public:
 
     // Shared scan
     virtual void attach_chunk_source(int32_t source_index) = 0;
-    virtual void detach_chunk_source(int32_t source_index) = 0;
+    virtual void detach_chunk_source(int32_t source_index) {}
     virtual bool has_shared_chunk_source() const = 0;
     virtual bool has_buffer_output() const = 0;
     virtual ChunkPtr get_chunk_from_buffer() = 0;

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -129,7 +129,8 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 }
 
 pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this);
+    size_t dop = context->degree_of_parallelism();
+    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop);
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -129,7 +129,12 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 }
 
 pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    size_t dop = context->degree_of_parallelism();
+    int node_id = id();
+    auto& morsel_queues = context->fragment_context()->morsel_queues();
+    DCHECK_GT(morsel_queues.count(node_id), 0);
+    auto& morsel_queue = morsel_queues[node_id];
+    size_t dop = std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
+
     auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop);
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -751,7 +751,7 @@ void OlapScanNode::_close_pending_scanners() {
 }
 
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this);
+    auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this, context->degree_of_parallelism());
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     // scan_prepare_op.

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -755,9 +755,11 @@ void OlapScanNode::_close_pending_scanners() {
 }
 
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    // TODO(mofei) simplify it
+    // Set the dop according to requested parallelism and number of morsels
+    int node_id = id();
     auto& morsel_queues = context->fragment_context()->morsel_queues();
-    auto* morsel_queue = morsel_queues[id()].get();
+    DCHECK_GT(morsel_queues.count(node_id), 0);
+    auto& morsel_queue = morsel_queues[node_id];
     size_t dop = std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
 
     auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this, dop, _enable_shared_scan);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -335,6 +335,10 @@ Status OlapScanNode::set_scan_ranges(const std::vector<TScanRangeParams>& scan_r
     return Status::OK();
 }
 
+void OlapScanNode::enable_shared_scan(bool enable) {
+    _enable_shared_scan = enable;
+}
+
 StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request) {
     pipeline::Morsels morsels;
@@ -751,7 +755,8 @@ void OlapScanNode::_close_pending_scanners() {
 }
 
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this, context->degree_of_parallelism());
+    auto scan_ctx =
+            std::make_shared<pipeline::OlapScanContext>(this, context->degree_of_parallelism(), _enable_shared_scan);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     // scan_prepare_op.

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -66,6 +66,9 @@ public:
 
     Status set_scan_range(const TInternalScanRange& range);
 
+    // TODO: support more share_scan strategy
+    void enable_shared_scan(bool enable);
+
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;
 
@@ -175,6 +178,8 @@ private:
     // of the left table are compacted at building the right hash table. Therefore, reference
     // the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
+
+    bool _enable_shared_scan = false;
 
     // profile
     RuntimeProfile* _scan_profile = nullptr;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -123,7 +123,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected int pipelineDop = 1;
     protected boolean dopEstimated = false;
 
-    // Enable shared_scan for this fragment: OlapScanOperator could share the output data to avoid data ske
+    // Enable shared_scan for this fragment: OlapScanOperator could share the output data to avoid data skew
     protected boolean enableSharedScan = true;
 
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -123,6 +123,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected int pipelineDop = 1;
     protected boolean dopEstimated = false;
 
+    // Enable shared_scan for this fragment: OlapScanOperator could share the output data to avoid data ske
+    protected boolean enableSharedScan = true;
+
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
 
@@ -236,6 +239,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setPipelineDop(int dop) {
         this.pipelineDop = dop;
+    }
+
+    public void setEnableSharedScan(boolean enable) {
+        this.enableSharedScan = enable;
+    }
+
+    public boolean isEnableSharedScan() {
+        return enableSharedScan;
     }
 
     public void computeLocalRfWaitingSet(PlanNode root, boolean clearGlobalRuntimeFilter) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2310,7 +2310,7 @@ public class Coordinator {
                     if (isEnablePipelineEngine) {
                         params.setIs_pipeline(true);
                         params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
-                        params.setEnable_shared_scan(fragment.isEnableSharedScan());
+                        params.setEnable_shared_scan(sessionVariable.isEnableSharedScan() && fragment.isEnableSharedScan());
 
                         params.setPipeline_dop(fragment.getPipelineDop());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2310,6 +2310,7 @@ public class Coordinator {
                     if (isEnablePipelineEngine) {
                         params.setIs_pipeline(true);
                         params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
+                        params.setEnable_shared_scan(fragment.isEnableSharedScan());
 
                         params.setPipeline_dop(fragment.getPipelineDop());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -152,6 +152,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_RESOURCE_GROUP = "enable_resource_group";
 
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL = "enable_tablet_internal_parallel";
+    public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
@@ -270,6 +271,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_TABLET_INTERNAL_PARALLEL)
     private boolean enableTabletInternalParallel = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
+    private boolean enableSharedScan = false;
 
     // max memory used on every backend.
     public static final long DEFAULT_EXEC_MEM_LIMIT = 2147483648L;
@@ -880,6 +884,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public boolean isEnableSharedScan() {
+        return enableSharedScan;
     }
 
     public int getWorkGroupId() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -273,7 +273,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableTabletInternalParallel = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
-    private boolean enableSharedScan = false;
+    private boolean enableSharedScan = true;
 
     // max memory used on every backend.
     public static final long DEFAULT_EXEC_MEM_LIMIT = 2147483648L;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1581,6 +1581,7 @@ public class PlanFragmentBuilder {
                 return;
             }
             fragment.preferInstanceParallel();
+            fragment.setEnableSharedScan(false);
         }
 
         private void estimateDopOfOnePhaseAgg(PlanFragment fragment) {
@@ -1588,6 +1589,7 @@ public class PlanFragmentBuilder {
                 return;
             }
             fragment.preferInstanceParallel();
+            fragment.setEnableSharedScan(false);
         }
 
         // when enable_pipeline_engine=true and enable_global_runtime_filter=false, global runtime filter

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -296,6 +296,9 @@ struct TExecPlanFragmentParams {
   53: optional WorkGroup.TWorkGroup workgroup
   54: optional bool enable_resource_group
   55: optional i32 func_version
+  
+  // Some strategy of scan
+  56: optional bool enable_shared_scan
 }
 
 struct TExecPlanFragmentResult {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -297,7 +297,7 @@ struct TExecPlanFragmentParams {
   54: optional bool enable_resource_group
   55: optional i32 func_version
   
-  // Some strategy of scan
+  // Sharing data between drivers of same scan operator
   56: optional bool enable_shared_scan
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR tries to resolve the data skew problem in scan operator.

The main changes are:
1. Share the chunk buffer between scan operators
2. Introduce a `BalancedChunkBuffer` which try to balance data among scan operators
3. Modify the logic of `ScanOperator` to adapt to the shared chunk buffer

BTW, this mechanism has some limitation:
1. one-phase aggregation, colocate join, bucket-join could not leverage this mechanism 
2. Current `BalancedChunkBuffer` just balance chunks among scan operators but not the number of rows
3. Current `BalancedChunkBuffer` just balance outputchunks of IO-thread, but not the output of `ScanOperator`


## Experiment Result

On extremely skewed tpcds dataset, running the q38 query:
- With `enable_shared=false`, it costs 33.8s
- With `enable_shared=true`, it costs 13.7s

In addition to this, there's no obvious performance regression with this PR.
