### PR TITLE
[cherry-pick] [branch-2.0] [BugFix] Fix the problem of estimate memtable size (#7316)

### DIFF
--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -85,6 +85,7 @@ bool MemTable::insert(Chunk* chunk, const uint32_t* indexes, uint32_t from, uint
         _chunk = ChunkHelper::new_chunk(_vectorized_schema, 0);
     }
 
+    size_t cur_row_count = _chunk->num_rows();
     // For schema change, FE will construct a shadow column.
     // The shadow column is not exist in _vectorized_schema
     // So the chunk can only be accessed by the subscript
@@ -97,7 +98,7 @@ bool MemTable::insert(Chunk* chunk, const uint32_t* indexes, uint32_t from, uint
 
     if (chunk->has_rows()) {
         _chunk_memory_usage += chunk->memory_usage() * size / chunk->num_rows();
-        _chunk_bytes_usage += chunk->bytes_usage() * size / chunk->num_rows();
+        _chunk_bytes_usage += _chunk->bytes_usage(cur_row_count, size);
     }
 
     // if memtable is full, push it to the flush executor,


### PR DESCRIPTION
The size calculation cost is relatively large for some types of `Column` such as `BitmapColumn`, so the estimation method of this `MemTable` Size is changed to the incremental before.

When importing, a `Chunk` will involve multiple Tablets. If there are large differences in length in different Tablets, for example, the average length of the string in `Tablet` 1 is 100 bytes, and the average length of string in `Tablet` 2 are small or is null. The estimated size of memtable is `chunk_bytes_usage += chunk.bytes_usage() * size / chunk.num_rows()`.

However, in extreme cases, due to incorrect estimation, the `MemTable` will be too large or too small, or even exceed 4G, resulting in crash or data confusion.

The new strategy is to Incremental calculate directly with chunk of `MemTable`

Before modification, MemTable Size

```
...
FLUSH:16949250
FLUSH:16983890
FLUSH:17078640
FLUSH:17270930
FLUSH:17073270
FLUSH:16934340
FLUSH:16890280
FLUSH:17088330
FLUSH:17014780
FLUSH:17002530
FLUSH:17299380
FLUSH:7911050
FLUSH:2497327728
FLUSH:2488632580
FLUSH:3305326048
FLUSH:3309594000
FLUSH:3303867992
FLUSH:1495277328
FLUSH:4116982500
...
```

After modification, MemTable size

```
...
FLUSH:104910526
FLUSH:104868988
FLUSH:104885820
FLUSH:104871402
FLUSH:104864160
FLUSH:104893658
FLUSH:104868340
FLUSH:104864715
FLUSH:104868988
FLUSH:104890714
FLUSH:104861746
FLUSH:104868356
FLUSH:104860294
FLUSH:104874798
FLUSH:104893900
FLUSH:104876775
FLUSH:104872573
FLUSH:104861746
FLUSH:104871402
FLUSH:104888300
FLUSH:104876720
...
```
