### PR TITLE
[Refactor] Make FE UT work under JDK 17

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -49,7 +49,7 @@ public class TableProperty implements Writable {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
-    private DynamicPartitionProperty dynamicPartitionProperty = new DynamicPartitionProperty(Maps.newHashMap());
+    private transient DynamicPartitionProperty dynamicPartitionProperty = new DynamicPartitionProperty(Maps.newHashMap());
     // table's default replication num
     private Short replicationNum = FeConstants.default_replication_num;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
@@ -26,7 +26,7 @@ public class InsertOverwriteJob {
     @SerializedName(value = "targetTableId")
     private long targetTableId;
 
-    private InsertStmt insertStmt;
+    private transient InsertStmt insertStmt;
 
     public InsertOverwriteJob(long jobId, InsertStmt insertStmt, long targetDbId, long targetTableId) {
         this.jobId = jobId;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobManager.java
@@ -41,13 +41,13 @@ public class InsertOverwriteJobManager implements Writable, GsonPostProcessable 
     @SerializedName(value = "tableToOverwriteJobs")
     private Map<Long, List<Long>> tableToOverwriteJobs;
 
-    private ExecutorService cancelJobExecutorService;
+    private transient ExecutorService cancelJobExecutorService;
 
     // store the jobs which are still running after FE restart
     // it is used when replay, so no need to add concurrent control for it
-    private List<InsertOverwriteJob> runningJobs;
+    private transient List<InsertOverwriteJob> runningJobs;
 
-    private ReentrantReadWriteLock lock;
+    private transient ReentrantReadWriteLock lock;
 
     public InsertOverwriteJobManager() {
         this.overwriteJobMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadAppHandle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadAppHandle.java
@@ -41,7 +41,7 @@ public class SparkLoadAppHandle implements Writable {
     // 5min
     private static final long SUBMIT_APP_TIMEOUT_MS = 300 * 1000;
 
-    private Process process;
+    private transient Process process;
 
     @SerializedName("appId")
     private String appId;
@@ -60,7 +60,7 @@ public class SparkLoadAppHandle implements Writable {
     @SerializedName("logPath")
     private String logPath;
 
-    private List<Listener> listeners;
+    private transient List<Listener> listeners;
 
     public interface Listener {
         void stateChanged(SparkLoadAppHandle handle);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/PrivEntry.java
@@ -43,12 +43,12 @@ public abstract class PrivEntry implements Comparable<PrivEntry>, Writable {
     protected static final String ANY_USER = "%";
 
     // host is not case sensitive
-    protected PatternMatcher hostPattern;
+    protected transient PatternMatcher hostPattern;
     @SerializedName("origHost")
     protected String origHost;
     protected boolean isAnyHost = false;
     // user name is case sensitive
-    protected PatternMatcher userPattern;
+    protected transient PatternMatcher userPattern;
     @SerializedName("origUser")
     protected String origUser;
     protected boolean isAnyUser = false;
@@ -66,7 +66,7 @@ public abstract class PrivEntry implements Comparable<PrivEntry>, Writable {
     // see PrivEntry.read() for more details.
     protected boolean isClassNameWrote = false;
 
-    private UserIdentity userIdentity;
+    private transient UserIdentity userIdentity;
 
     protected PrivEntry() {}
 


### PR DESCRIPTION
Since Java 16 applications can by default no longer access JDK internals
using reflection, see JDK-8256358.

So I make some field transient to make GSON work.
Refer to https://github.com/google/gson/issues/1898

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
