### PR TITLE
[Bugfix] Avoid using released resources for ContextWithDependency after closing (backport #7363)

### DIFF
--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -18,10 +18,7 @@ public:
 
     void close(RuntimeState* state) override { _build_chunks.clear(); }
 
-    bool is_build_chunk_empty() const {
-        return std::all_of(_build_chunks.begin(), _build_chunks.end(),
-                           [](const vectorized::ChunkPtr& chunk) { return chunk == nullptr || chunk->is_empty(); });
-    }
+    bool is_build_chunk_empty() const { return _is_build_chunk_empty; }
 
     int32_t num_build_chunks() const { return _num_right_sinkers; }
 
@@ -31,11 +28,16 @@ public:
         _build_chunks[sinker_id] = build_chunk;
     }
 
-    void finish_one_right_sinker() { _num_finished_right_sinkers.fetch_add(1, std::memory_order_release); }
-
-    bool is_right_finished() const {
-        return _num_finished_right_sinkers.load(std::memory_order_acquire) == _num_right_sinkers;
+    void finish_one_right_sinker() {
+        if (_num_right_sinkers - 1 == _num_finished_right_sinkers.fetch_add(1)) {
+            _is_build_chunk_empty = std::all_of(
+                    _build_chunks.begin(), _build_chunks.end(),
+                    [](const vectorized::ChunkPtr& chunk) { return chunk == nullptr || chunk->is_empty(); });
+            _all_right_finished.store(true, std::memory_order_release);
+        }
     }
+
+    bool is_right_finished() const { return _all_right_finished.load(std::memory_order_acquire); }
 
 private:
     const int32_t _num_right_sinkers;
@@ -44,9 +46,12 @@ private:
     // _num_finished_right_sinkers is used to ensure CrossJoinLeftOperator can see all the parts
     // of _build_chunks, when it sees all the CrossJoinRightSinkOperators are finished.
     std::atomic<int32_t> _num_finished_right_sinkers = 0;
+    std::atomic_bool _all_right_finished = false;
 
     // _build_chunks[i] contains all the rows from i-th CrossJoinRightSinkOperator.
     std::vector<vectorized::ChunkPtr> _build_chunks;
+
+    bool _is_build_chunk_empty = false;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -29,10 +29,12 @@ class ExceptContext final : public ContextWithDependency {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 
-    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
+    bool is_ht_empty() const { return _is_hash_set_empty; }
 
     void finish_build_ht() {
+        _is_hash_set_empty = _hash_set->empty();
         _next_processed_iter = _hash_set->begin();
+        _hash_set_end_iter = _hash_set->end();
         _finished_dependency_index.fetch_add(1, std::memory_order_release);
     }
 
@@ -42,7 +44,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _next_processed_iter == _hash_set_end_iter; }
 
     // Called in the preparation phase of ExceptBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
@@ -77,6 +79,8 @@ private:
     // Used for traversal on the hash set to get the undeleted keys to dest chunk.
     // Init when the hash set is finished building in finish_build_ht().
     vectorized::ExceptHashSerializeSet::Iterator _next_processed_iter;
+    vectorized::ExceptHashSerializeSet::Iterator _hash_set_end_iter;
+    bool _is_hash_set_empty = false;
 
     // The BUILD, PROBES, and OUTPUT operators execute sequentially.
     // BUILD -> 1-th PROBE -> 2-th PROBE -> ... -> n-th PROBE -> OUTPUT.

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -31,10 +31,12 @@ public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
 
-    bool is_ht_empty() const { return _hash_set == nullptr || _hash_set->empty(); }
+    bool is_ht_empty() const { return _is_hash_set_empty; }
 
     void finish_build_ht() {
+        _is_hash_set_empty = _hash_set->empty();
         _next_processed_iter = _hash_set->begin();
+        _hash_set_end_iter = _hash_set->end();
         _finished_dependency_index.fetch_add(1, std::memory_order_release);
     }
 
@@ -44,7 +46,7 @@ public:
         return _finished_dependency_index.load(std::memory_order_acquire) == dependency_index;
     }
 
-    bool is_output_finished() const { return _hash_set == nullptr || _next_processed_iter == _hash_set->end(); }
+    bool is_output_finished() const { return _next_processed_iter == _hash_set_end_iter; }
 
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
@@ -80,6 +82,8 @@ private:
     // Used for traversal on the hash set to get the undeleted keys to dest chunk.
     // Init when the hash set is finished building in finish_build_ht().
     vectorized::IntersectHashSerializeSet::Iterator _next_processed_iter;
+    vectorized::IntersectHashSerializeSet::Iterator _hash_set_end_iter;
+    bool _is_hash_set_empty = false;
 
     // The BUILD, PROBES, and OUTPUT operators execute sequentially.
     // BUILD -> 1-th PROBE -> 2-th PROBE -> ... -> n-th PROBE -> OUTPUT.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from #7363.

