### PR TITLE
[Enhancement] optimize aggregate group by single nullable(string)

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -206,7 +206,8 @@ struct AggHashMapWithOneNullableNumberKey {
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
             }
-        } else if (key_columns[0]->is_nullable()) {
+        } else {
+            DCHECK(key_columns[0]->is_nullable());
             auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
             auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
case: SSB100G lineorder

set parallel_fragment_exec_instance_num=1;
set enable_pipeline_engine=false;
set cbo_enable_low_cardinality_optimize=false;

```
select count(*) from lineorder group by lower(lo_orderpriority);
```
AGG costs:

baseline: 7s877
patched: 6s427

I did some benchmark for AggHashMapWithOneNullableNumberKey::compute_agg_states, but there is no significant performance improvement, benchmark is avaliable here(https://github.com/stdpain/starrocks-2/tree/agg_bench3)

```
Run on (104 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x52)
  L1 Instruction 32 KiB (x52)
  L2 Unified 1024 KiB (x52)
  L3 Unified 36608 KiB (x2)
Load Average: 2.15, 2.99, 3.65
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_agg_hash_map_8               99869 ns        99851 ns         7080
BM_agg_hash_new_map_8          100463 ns       100436 ns         7110
BM_agg_hash_map_1024           130580 ns       130544 ns         5349
BM_agg_hash_new_map_1024       131237 ns       131202 ns         5314
BM_agg_hash_map_4096           144640 ns       144610 ns         4858
BM_agg_hash_new_map_4096       145102 ns       145076 ns         4840
BM_agg_hash_map_16000          221778 ns       221711 ns         3173
BM_agg_hash_new_map_16000      229274 ns       229266 ns         3038
BM_agg_hash_map_160000         430434 ns       430572 ns         1826
BM_agg_hash_new_map_160000     456559 ns       456491 ns         1273
```



