### PR TITLE
[Enhancement] Consider key container memory usages for streaming aggregate

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -75,8 +75,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
         APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
 
-        _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
-                          _aggregator->mem_pool()->total_reserved_bytes());
+        _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
     }
     if (_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -63,8 +63,7 @@ Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, co
         APPLY_FOR_AGG_VARIANT_ALL(HASH_SET_METHOD)
 #undef HASH_SET_METHOD
 
-        _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
-                          _aggregator->mem_pool()->total_reserved_bytes());
+        _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
         _aggregator->update_num_input_rows(chunk->num_rows());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -74,7 +74,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregati
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-    _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+    _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
     return Status::OK();
@@ -85,9 +85,9 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
     size_t real_capacity = _aggregator->hash_set_variant().capacity() - _aggregator->hash_set_variant().capacity() / 8;
     size_t remain_size = real_capacity - _aggregator->hash_set_variant().size();
     bool ht_needs_expansion = remain_size < chunk_size;
+    size_t allocated_bytes = _aggregator->hash_set_variant().allocated_memory_usage(_aggregator->mem_pool());
     if (!ht_needs_expansion ||
-        _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size,
-                                                      _aggregator->mem_pool()->total_allocated_bytes(),
+        _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size, allocated_bytes,
                                                       _aggregator->hash_set_variant().size())) {
         // hash table is not full or allow expand the hash table according reduction rate
         SCOPED_TIMER(_aggregator->agg_compute_timer());
@@ -106,8 +106,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
 
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-        _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
-                          _aggregator->mem_pool()->total_reserved_bytes());
+        _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
     } else {
         {

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -312,6 +312,7 @@ struct AggHashMapWithOneNullableNumberKey {
 
 template <typename HashMap>
 struct AggHashMapWithOneStringKey {
+    using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
     using ResultVector = typename std::vector<Slice>;
     HashMap hash_map;
@@ -400,6 +401,7 @@ struct AggHashMapWithOneStringKey {
 
 template <typename HashMap>
 struct AggHashMapWithOneNullableStringKey {
+    using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
     using ResultVector = typename std::vector<Slice>;
     HashMap hash_map;
@@ -527,6 +529,7 @@ struct AggHashMapWithOneNullableStringKey {
 
 template <typename HashMap>
 struct AggHashMapWithSerializedKey {
+    using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
     using ResultVector = typename std::vector<Slice>;
     HashMap hash_map;
@@ -643,6 +646,7 @@ struct AggHashMapWithSerializedKey {
 
 template <typename HashMap>
 struct AggHashMapWithSerializedKeyFixedSize {
+    using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
     using FixedSizeSliceKey = typename HashMap::key_type;
     using ResultVector = typename std::vector<FixedSizeSliceKey>;

--- a/be/src/exec/vectorized/aggregate/agg_hash_variant.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_variant.h
@@ -402,14 +402,29 @@ struct AggHashMapVariant {
         return 0;
     }
 
-    size_t memory_usage() const {
+    size_t reserved_memory_usage(const MemPool* pool) const {
         switch (type) {
 #define M(NAME)      \
     case Type::NAME: \
-        return NAME->hash_map.dump_bound();
+        return NAME->hash_map.dump_bound() + pool->total_reserved_bytes();
+
             APPLY_FOR_AGG_VARIANT_ALL(M)
 #undef M
         }
+
+        return 0;
+    }
+
+    size_t allocated_memory_usage(const MemPool* pool) const {
+        switch (type) {
+#define M(NAME)      \
+    case Type::NAME: \
+        return sizeof(decltype(NAME)::element_type::KeyType) * NAME->hash_map.size() + pool->total_allocated_bytes();
+
+            APPLY_FOR_AGG_VARIANT_ALL(M)
+#undef M
+        }
+
         return 0;
     }
 };
@@ -676,14 +691,27 @@ struct AggHashSetVariant {
         return 0;
     }
 
-    size_t memory_usage() const {
+    size_t reserved_memory_usage(const MemPool* pool) const {
         switch (type) {
 #define M(NAME)      \
     case Type::NAME: \
-        return NAME->hash_set.dump_bound();
+        return NAME->hash_set.dump_bound() + pool->total_reserved_bytes();
             APPLY_FOR_AGG_VARIANT_ALL(M)
 #undef M
         }
+        return 0;
+    }
+
+    size_t allocated_memory_usage(const MemPool* pool) const {
+        switch (type) {
+#define M(NAME)      \
+    case Type::NAME: \
+        return sizeof(decltype(NAME)::element_type::KeyType) * NAME->hash_set.size() + pool->total_allocated_bytes();
+
+            APPLY_FOR_AGG_VARIANT_ALL(M)
+#undef M
+        }
+
         return 0;
     }
 };

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -68,8 +68,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
                 APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
 
-                _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
-                                  _aggregator->mem_pool()->total_reserved_bytes());
+                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
                 TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
             }
             if (_aggregator->is_none_group_by_exprs()) {
@@ -119,7 +118,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
 
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
-    _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+    _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -88,8 +88,7 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
                     _aggregator->compute_batch_agg_states(input_chunk_size);
                 }
 
-                _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
-                                  _aggregator->mem_pool()->total_reserved_bytes());
+                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
                 TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
@@ -136,8 +135,7 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
                         _aggregator->compute_batch_agg_states(input_chunk_size);
                     }
 
-                    _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
-                                      _aggregator->mem_pool()->total_reserved_bytes());
+                    _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
                     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
                     continue;

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -59,8 +59,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
             APPLY_FOR_AGG_VARIANT_ALL(HASH_SET_METHOD)
 #undef HASH_SET_METHOD
 
-            _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
-                              _aggregator->mem_pool()->total_reserved_bytes());
+            _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
             TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
             _aggregator->update_num_input_rows(chunk->num_rows());
@@ -90,7 +89,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
 
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
-    _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+    _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -80,8 +80,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-                _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
-                                  _aggregator->mem_pool()->total_reserved_bytes());
+                _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
                 TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
                 continue;
@@ -114,8 +113,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-                    _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
-                                      _aggregator->mem_pool()->total_reserved_bytes());
+                    _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
                     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
                     continue;

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -71,7 +71,7 @@ public:
 
     void close(RuntimeState* state) override;
 
-    std::unique_ptr<MemPool>& mem_pool() { return _mem_pool; };
+    const MemPool* mem_pool() const { return _mem_pool.get(); }
     bool is_none_group_by_exprs() { return _group_by_expr_ctxs.empty(); }
     const std::vector<ExprContext*>& conjunct_ctxs() { return _conjunct_ctxs; }
     const std::vector<ExprContext*>& group_by_expr_ctxs() { return _group_by_expr_ctxs; }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR relates：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Closes #6212.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Streaming Agg decides whether to PreAgg according to the memory usage of Hash Table and the aggregation degree. When the HT memory is less than 256KB, PreAgg will be always used.

For now, HT memory only counts the memory allocated by `MemPool`. However, in some scenarios, in order to optimize performance, HT's keys don't allocate from MemPool, such as `AggHashSetOfSerializedKeyFixedSize`, which will cause `MemPool` to be always 0. Therefore, even if there is no degree of aggregation, PreAgg will always be used.

Therefore, this PR consider the key memory used for streaming aggregate.
- If keys are allocated from `MemPool`, the key memory usage is the pointer of the key.
- Otherwise, the key memory usage is the real key memory usage.


## Test Result
### Environment
- 3BE with 64GB memory and 16vCPUs.

### Query
```sql
-- Q1 Stremaing Distinct Aggregate
select count(distinct lo_orderkey*10+lo_linenumber) from lineorder;

-- Q2 Stremaing Distinct Aggregate
select count(*) from (
    SELECT LO_CUSTKEY, LO_SUPPKEY, sum(LO_REVENUE) 
    FROM lineorder_flat 
    GROUP BY LO_CUSTKEY, LO_SUPPKEY
) AS a;

-- Q3 Stremaing Distinct Aggregate
select count(*) from (
    SELECT LO_PARTKEY, LO_LINENUMBER, LO_DISCOUNT, sum(LO_REVENUE) 
    FROM lineorder_flat 
    GROUP BY LO_PARTKEY, LO_LINENUMBER, LO_DISCOUNT 
) AS a;

-- Q4 Stremaing Aggregate
select sum(LO_REVENUE) 
from lineorder 
group by LO_PARTKEY, LO_LINENUMBER, LO_DISCOUNT 
limit 10;
```

### Result
| Name    | Before (s) | After (s) | After/Before |
| ------- | ---------- | --------- | ------------ |
| query01 | 10.01      | 6.36      | 0.64         |
| query02 | 9.77       | 6.17      | 0.63         |
| query03 | 5.99       | 3.51      | 0.59         |
| query04 | 4.02       | 3.72      | 0.93         |
| SUM     | 29.79      | 19.76     | 0.66         |