### PR TITLE
[Bugfix] Fix bug defineExpr is not set use old Analyzer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -823,15 +823,14 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         // parse the define stmt to schema
         SqlParser parser = new SqlParser(new SqlScanner(new StringReader(origStmt.originStmt),
                 SqlModeHelper.MODE_DEFAULT));
-        CreateMaterializedViewStmt stmt = null;
+        CreateMaterializedViewStmt stmt;
         try {
             stmt = (CreateMaterializedViewStmt) SqlParserUtils.getStmt(parser, origStmt.idx);
             stmt.setIsReplay(true);
             Map<String, Expr> columnNameToDefineExpr = stmt.parseDefineExprWithoutAnalyze();
             setColumnsDefineExpr(columnNameToDefineExpr);
         } catch (Exception e) {
-            // Under normal circumstances, the stmt will not fail to analyze.
-            throw new IOException("error happens when parsing create materialized view stmt: " + stmt, e);
+            throw new IOException("error happens when parsing create materialized view stmt: " + origStmt.originStmt, e);
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -122,7 +122,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     private void setColumnsDefineExpr(Map<String, Expr> columnNameToDefineExpr) {
         for (Map.Entry<String, Expr> entry : columnNameToDefineExpr.entrySet()) {
             for (Column column : schema) {
-                if (column.getName().equals(entry.getKey())) {
+                if (column.getName().equalsIgnoreCase(entry.getKey())) {
                     column.setDefineExpr(entry.getValue());
                     break;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -326,7 +326,7 @@ public class RollupJobV2Test {
     }
 
     @Test
-    public void testSerializeOfRollupJob(@Mocked CreateMaterializedViewStmt stmt) throws IOException,
+    public void testSerializeOfRollupJob() throws IOException,
             AnalysisException {
         Config.enable_materialized_view = true;
         // prepare file
@@ -336,7 +336,7 @@ public class RollupJobV2Test {
 
         short keysCount = 1;
         List<Column> columns = Lists.newArrayList();
-        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "to_bitmap_" + "c1";
+        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "bitmap_union_" + "c1";
         Column column = new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
         columns.add(column);
@@ -350,20 +350,6 @@ public class RollupJobV2Test {
         rollupJobV2.write(out);
         out.flush();
         out.close();
-
-        List<Expr> params = Lists.newArrayList();
-        SlotRef param1 = new SlotRef(new TableName(null, "test"), "c1");
-        params.add(param1);
-        MVColumnItem mvColumnItem = new MVColumnItem(mvColumnName, Type.BITMAP);
-        mvColumnItem.setDefineExpr(new FunctionCallExpr(new FunctionName("to_bitmap"), params));
-        List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
-        mvColumnItemList.add(mvColumnItem);
-        new Expectations() {
-            {
-                stmt.getMVColumnItemList();
-                result = mvColumnItemList;
-            }
-        };
 
         // read objects from file
         MetaContext metaContext = new MetaContext();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7198

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
this because #6459 remove old analyze method but defineExpr need use old Analyzer to generated.