### PR TITLE
[BugFix] Fix wrong column order

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -224,6 +224,7 @@ void HdfsScannerContext::update_not_existed_columns_to_chunk(vectorized::ChunkPt
             col->append_default(row_count);
         }
     }
+    ck->set_num_rows(row_count);
 }
 
 void HdfsScannerContext::append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
@@ -265,7 +266,7 @@ void HdfsScannerContext::update_partition_column_to_chunk(vectorized::ChunkPtr* 
         DCHECK(partition_values[i]->is_constant());
         auto* const_column = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(partition_values[i]);
         ColumnPtr data_column = const_column->data_column();
-        auto chunk_part_column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+        auto chunk_part_column = ck->get_column_by_slot_id(slot_desc->id());
 
         if (row_count > 0) {
             if (data_column->is_nullable()) {
@@ -275,8 +276,8 @@ void HdfsScannerContext::update_partition_column_to_chunk(vectorized::ChunkPtr* 
             }
             chunk_part_column->assign(row_count, 0);
         }
-        ck->update_column(std::move(chunk_part_column), slot_desc->id());
     }
+    ck->set_num_rows(row_count);
 }
 
 bool HdfsScannerContext::can_use_dict_filter_on_slot(SlotDescriptor* slot) const {

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -213,7 +213,20 @@ void HdfsScannerContext::set_columns_from_file(const std::unordered_set<std::str
     }
 }
 
-void HdfsScannerContext::append_not_exised_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+void HdfsScannerContext::update_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+    if (not_existed_slots.size() == 0) return;
+
+    ChunkPtr& ck = (*chunk);
+    ck->set_num_rows(row_count);
+    for (auto* slot_desc : not_existed_slots) {
+        auto col = ck->get_column_by_slot_id(slot_desc->id());
+        if (row_count > 0) {
+            col->append_default(row_count);
+        }
+    }
+}
+
+void HdfsScannerContext::append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
     if (not_existed_slots.size() == 0) return;
 
     ChunkPtr& ck = (*chunk);
@@ -232,7 +245,7 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
 
     // build chunk for evaluation.
     ChunkPtr chunk = std::make_shared<Chunk>();
-    append_not_exised_columns_to_chunk(&chunk, 1);
+    append_not_existed_columns_to_chunk(&chunk, 1);
     // do evaluation.
     {
         SCOPED_RAW_TIMER(&stats->expr_filter_ns);
@@ -241,7 +254,7 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
     return !(chunk->has_rows());
 }
 
-void HdfsScannerContext::append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+void HdfsScannerContext::update_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
     if (partition_columns.size() == 0) return;
 
     ChunkPtr& ck = (*chunk);
@@ -262,7 +275,7 @@ void HdfsScannerContext::append_partition_column_to_chunk(vectorized::ChunkPtr* 
             }
             chunk_part_column->assign(row_count, 0);
         }
-        ck->append_column(std::move(chunk_part_column), slot_desc->id());
+        ck->update_column(std::move(chunk_part_column), slot_desc->id());
     }
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -159,15 +159,18 @@ struct HdfsScannerContext {
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void append_not_exised_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
 
     // other helper functions.
-    void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+
+private:
+    void append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
 };
 
 // if *lvalue == expect, swap(*lvalue,*rvalue)

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -512,7 +512,6 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                 ck->filter(_chunk_filter);
             }
         }
-        ck->set_num_rows(chunk_size);
 
         if (!_orc_reader->has_lazy_load_context()) {
             return Status::OK();

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -479,18 +479,17 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                 StatusOr<ChunkPtr> ret;
                 SCOPED_RAW_TIMER(&_stats.column_convert_ns);
                 if (!_orc_reader->has_lazy_load_context()) {
-                    ret = _orc_reader->get_chunk();
+                    ret = _orc_reader->get_chunk(chunk);
                 } else {
-                    ret = _orc_reader->get_active_chunk();
+                    ret = _orc_reader->get_active_chunk(chunk);
                 }
                 RETURN_IF_ERROR(ret);
-                *chunk = std::move(ret.value());
             }
 
             // important to add columns before evaluation
             // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _scanner_ctx.append_not_exised_columns_to_chunk(chunk, ck->num_rows());
-            _scanner_ctx.append_partition_column_to_chunk(chunk, ck->num_rows());
+            _scanner_ctx.update_not_existed_columns_to_chunk(chunk, ck->num_rows());
+            _scanner_ctx.update_partition_column_to_chunk(chunk, ck->num_rows());
             chunk_size = ck->num_rows();
             // do stats before we filter rows which does not match.
             _stats.raw_rows_read += chunk_size;
@@ -534,10 +533,8 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                 _orc_reader->lazy_filter_on_cvb(&_dict_filter);
             }
             _orc_reader->lazy_filter_on_cvb(&_chunk_filter);
-            StatusOr<ChunkPtr> ret = _orc_reader->get_lazy_chunk();
+            StatusOr<ChunkPtr> ret = _orc_reader->get_lazy_chunk(chunk);
             RETURN_IF_ERROR(ret);
-            Chunk& ret_ck = *(ret.value());
-            ck->merge(std::move(ret_ck));
         }
         return Status::OK();
     }

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1487,6 +1487,7 @@ StatusOr<ChunkPtr> OrcChunkReader::get_active_chunk(ChunkPtr* chunk) {
 void OrcChunkReader::lazy_filter_on_cvb(Filter* filter) {
     size_t true_size = SIMD::count_nonzero(*filter);
     if (filter->size() != true_size) {
+        std::cout<< "XXXXXXXXXXX: " << true_size << "       " << __LINE__ <<std::endl;
         _batch->filterOnFields(filter->data(), filter->size(), true_size, _lazy_load_ctx->lazy_load_orc_positions,
                                true);
     }

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1458,7 +1458,6 @@ ChunkPtr OrcChunkReader::_cast_chunk(ChunkPtr* chunk, const std::vector<SlotDesc
         ColumnPtr col = _cast_exprs[src_index]->evaluate(nullptr, src.get());
         col = ColumnHelper::unfold_const_column(slot->type(), chunk_size, col);
         DCHECK_LE(col->size(), chunk_size);
-        cast_chunk->append_column(std::move(col), slot->id());
     }
     return cast_chunk;
 }
@@ -1474,17 +1473,15 @@ ChunkPtr OrcChunkReader::cast_chunk(ChunkPtr* chunk) {
     return _cast_chunk(chunk, _src_slot_descriptors, nullptr);
 }
 
-StatusOr<ChunkPtr> OrcChunkReader::get_chunk() {
-    ChunkPtr ptr = create_chunk();
-    RETURN_IF_ERROR(fill_chunk(&ptr));
-    ChunkPtr ret = cast_chunk(&ptr);
+StatusOr<ChunkPtr> OrcChunkReader::get_chunk(ChunkPtr* chunk) {
+    RETURN_IF_ERROR(fill_chunk(chunk));
+    ChunkPtr ret = cast_chunk(chunk);
     return ret;
 }
 
-StatusOr<ChunkPtr> OrcChunkReader::get_active_chunk() {
-    ChunkPtr ptr = _create_chunk(_lazy_load_ctx->active_load_slots, &_lazy_load_ctx->active_load_indices);
-    RETURN_IF_ERROR(_fill_chunk(&ptr, _lazy_load_ctx->active_load_slots, &_lazy_load_ctx->active_load_indices));
-    ChunkPtr ret = _cast_chunk(&ptr, _lazy_load_ctx->active_load_slots, &_lazy_load_ctx->active_load_indices);
+StatusOr<ChunkPtr> OrcChunkReader::get_active_chunk(ChunkPtr* chunk) {
+    RETURN_IF_ERROR(_fill_chunk(chunk, _lazy_load_ctx->active_load_slots, &_lazy_load_ctx->active_load_indices));
+    ChunkPtr ret = _cast_chunk(chunk, _lazy_load_ctx->active_load_slots, &_lazy_load_ctx->active_load_indices);
     return ret;
 }
 
@@ -1496,10 +1493,9 @@ void OrcChunkReader::lazy_filter_on_cvb(Filter* filter) {
     }
 }
 
-StatusOr<ChunkPtr> OrcChunkReader::get_lazy_chunk() {
-    ChunkPtr ptr = _create_chunk(_lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices);
-    RETURN_IF_ERROR(_fill_chunk(&ptr, _lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices));
-    ChunkPtr ret = _cast_chunk(&ptr, _lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices);
+StatusOr<ChunkPtr> OrcChunkReader::get_lazy_chunk(ChunkPtr* chunk) {
+    RETURN_IF_ERROR(_fill_chunk(chunk, _lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices));
+    ChunkPtr ret = _cast_chunk(chunk, _lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices);
     return ret;
 }
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1487,7 +1487,6 @@ StatusOr<ChunkPtr> OrcChunkReader::get_active_chunk(ChunkPtr* chunk) {
 void OrcChunkReader::lazy_filter_on_cvb(Filter* filter) {
     size_t true_size = SIMD::count_nonzero(*filter);
     if (filter->size() != true_size) {
-        std::cout<< "XXXXXXXXXXX: " << true_size << "       " << __LINE__ <<std::endl;
         _batch->filterOnFields(filter->data(), filter->size(), true_size, _lazy_load_ctx->lazy_load_orc_positions,
                                true);
     }

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1444,7 +1444,6 @@ ChunkPtr OrcChunkReader::_cast_chunk(ChunkPtr* chunk, const std::vector<SlotDesc
                                      const std::vector<int>* indices) {
     ChunkPtr& src = (*chunk);
     size_t chunk_size = src->num_rows();
-    ChunkPtr cast_chunk = std::make_shared<Chunk>();
     int column_size = src_slot_descriptors.size();
     for (int column_pos = 0; column_pos < column_size; ++column_pos) {
         auto slot = src_slot_descriptors[column_pos];
@@ -1459,7 +1458,7 @@ ChunkPtr OrcChunkReader::_cast_chunk(ChunkPtr* chunk, const std::vector<SlotDesc
         col = ColumnHelper::unfold_const_column(slot->type(), chunk_size, col);
         DCHECK_LE(col->size(), chunk_size);
     }
-    return cast_chunk;
+    return src;
 }
 
 ChunkPtr OrcChunkReader::create_chunk() {

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -106,12 +106,12 @@ public:
 
     void set_lazy_load_context(LazyLoadContext* ctx) { _lazy_load_ctx = ctx; }
     bool has_lazy_load_context() { return _lazy_load_ctx != nullptr; }
-    StatusOr<ChunkPtr> get_chunk();
-    StatusOr<ChunkPtr> get_active_chunk();
+    StatusOr<ChunkPtr> get_chunk(ChunkPtr* chunk);
+    StatusOr<ChunkPtr> get_active_chunk(ChunkPtr* chunk);
     void lazy_read_next(size_t numValues);
     void lazy_seek_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
-    StatusOr<ChunkPtr> get_lazy_chunk();
+    StatusOr<ChunkPtr> get_lazy_chunk(ChunkPtr* chunk);
 
 private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -411,8 +411,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->append_not_exised_columns_to_chunk(chunk, row_count);
-                _scanner_ctx->append_partition_column_to_chunk(chunk, row_count);
+                _scanner_ctx->update_not_existed_columns_to_chunk(chunk, row_count);
+                _scanner_ctx->update_partition_column_to_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {
@@ -430,8 +430,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->append_not_exised_columns_to_chunk(chunk, read_size);
-        _scanner_ctx->append_partition_column_to_chunk(chunk, read_size);
+        _scanner_ctx->update_not_existed_columns_to_chunk(chunk, read_size);
+        _scanner_ctx->update_partition_column_to_chunk(chunk, read_size);
         _scan_row_count += read_size;
         return Status::OK();
     }

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -287,6 +287,7 @@ static void extend_partition_values(ObjectPool* pool, HdfsScannerParams* params,
         auto chunk = vectorized::ChunkHelper::new_chunk(*tuple_desc, 0);               \
         uint64_t records = 0;                                                          \
         for (;;) {                                                                     \
+            chunk->reset();                                                            \
             status = scanner->get_next(_runtime_state, &chunk);                        \
             if (status.is_end_of_file()) {                                             \
                 break;                                                                 \


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6028  https://github.com/StarRocks/starrocks/issues/7177  https://github.com/StarRocks/starrocks/issues/7330 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since `DataStreamRecvr::SenderQueue::_build_chunk_meta` is only called for the first chunk it receive, so the subsequent chunk should remain the same column order as the first chunk, otherwise, the deserialize might get wrong   type from chunk meta.