### PR TITLE
[BugFix] Fix load jobs hang with error: current running txns on db xxx is 100, larger than limit 100

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -919,7 +919,7 @@ public class MasterImpl {
     }
 
     public TMasterResult report(TReportRequest request) throws TException {
-        // if current node is follower, forward it to leader
+        // if current node is not master, reject the request
         TMasterResult result = new TMasterResult();
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -149,22 +149,12 @@ public class MasterImpl {
     }
 
     public TMasterResult finishTask(TFinishTaskRequest request) {
-        // if current node is follower, forward it to leader
+        // if current node is not master, reject the request
         TMasterResult result = new TMasterResult();
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
-            TNetworkAddress addr = masterAddr();
-            try {
-                LOG.info("finishTask as follower, forward it to master. master: {}", addr.toString());
-                result = FrontendServiceProxy.call(addr,
-                        Config.thrift_rpc_timeout_ms,
-                        Config.thrift_rpc_retry_times,
-                        client -> client.finishTask(request));
-            } catch (Exception e) {
-                LOG.warn("finishTask forward to master failed", e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
-                result.setStatus(status);
-            }
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
             return result;
         }
         TStatus tStatus = new TStatus(TStatusCode.OK);
@@ -932,19 +922,9 @@ public class MasterImpl {
         // if current node is follower, forward it to leader
         TMasterResult result = new TMasterResult();
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
-            TNetworkAddress addr = masterAddr();
-            try {
-                LOG.info("report as follower, forward it to master. master: {}", addr.toString());
-                result = FrontendServiceProxy.call(addr,
-                        Config.thrift_rpc_timeout_ms,
-                        Config.thrift_rpc_retry_times,
-                        client -> client.report(request));
-            } catch (Exception e) {
-                LOG.warn("report forward to master failed", e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
-                result.setStatus(status);
-            }
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
             return result;
         }
         return reportHandler.handleReport(request);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -765,7 +765,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn begin request: {}", request);
 
         TLoadTxnBeginResult result = new TLoadTxnBeginResult();
-        // if current node is follower, forward it to leader
+        // if current node is not master, reject the request
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
@@ -841,7 +841,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn commit request: {}", request);
 
         TLoadTxnCommitResult result = new TLoadTxnCommitResult();
-        // if current node is follower, forward it to leader
+        // if current node is not master, reject the request
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
@@ -951,7 +951,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn rollback request: {}", request);
 
         TLoadTxnRollbackResult result = new TLoadTxnRollbackResult();
-        // if current node is follower, forward it to leader
+        // if current node is not master, reject the request
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -69,7 +69,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.VariableMgr;
-import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -768,19 +767,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TLoadTxnBeginResult result = new TLoadTxnBeginResult();
         // if current node is follower, forward it to leader
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
-            TNetworkAddress addr = masterImpl.masterAddr();
-            try {
-                LOG.info("loadTxnBegin as follower, forward it to master. master: {}", addr.toString());
-                result = FrontendServiceProxy.call(addr,
-                        Config.thrift_rpc_timeout_ms,
-                        Config.thrift_rpc_retry_times,
-                        client -> client.loadTxnBegin(request));
-            } catch (Exception e) {
-                LOG.warn("loadTxnBegin forward to master failed", e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
-                result.setStatus(status);
-            }
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
             return result;
         }
 
@@ -854,19 +843,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TLoadTxnCommitResult result = new TLoadTxnCommitResult();
         // if current node is follower, forward it to leader
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
-            TNetworkAddress addr = masterImpl.masterAddr();
-            try {
-                LOG.info("loadTxnCommit as follower, forward it to master. master: {}", addr.toString());
-                result = FrontendServiceProxy.call(addr,
-                        Config.thrift_rpc_timeout_ms,
-                        Config.thrift_rpc_retry_times,
-                        client -> client.loadTxnCommit(request));
-            } catch (Exception e) {
-                LOG.warn("loadTxnCommit forward to master failed", e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
-                result.setStatus(status);
-            }
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
             return result;
         }
 
@@ -974,19 +953,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TLoadTxnRollbackResult result = new TLoadTxnRollbackResult();
         // if current node is follower, forward it to leader
         if (!GlobalStateMgr.getCurrentState().isMaster()) {
-            TNetworkAddress addr = masterImpl.masterAddr();
-            try {
-                LOG.info("loadTxnRollback as follower, forward it to master. master: {}", addr.toString());
-                result = FrontendServiceProxy.call(addr,
-                        Config.thrift_rpc_timeout_ms,
-                        Config.thrift_rpc_retry_times,
-                        client -> client.loadTxnRollback(request));
-            } catch (Exception e) {
-                LOG.warn("loadTxnRollback forward to master failed", e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
-                result.setStatus(status);
-            }
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
             return result;
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7350

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After transferring the master, the master address recorded in be is still the address of the old master(the time before it reaches the new master's heartbeat). The txnCommit rpc executed on non-master fe will cause some metadata inconsistency issues (described in https://github.com/StarRocks/starrocks/issues/7350). So we should reject those request if current node is not master.