### PR TITLE
[BugFix]: Potential data errors in primary tables using persistent indexes

### DIFF
--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -103,8 +103,11 @@ private:
 
     Status _do_load(Tablet* tablet);
 
-    Status _build_persistent_values(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                    uint32_t idx_begin, uint32_t idx_end, std::vector<uint64_t>* values);
+    Status _build_persistent_values(uint32_t rssid, uint32_t rowid_start, uint32_t idx_begin, uint32_t idx_end,
+                                    std::vector<uint64_t>* values);
+
+    Status _build_persistent_values(uint32_t rssid, const vector<uint32_t>& rowids, uint32_t idx_begin,
+                                    uint32_t idx_end, std::vector<uint64_t>* values);
 
     Status _insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const vectorized::Column& pks);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7416 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In function `PrimaryIndex::_insert_into_persistent_index()`, if values in `rowids` is not continuous, we will get error value after call function `PrimaryIndex::_build_persistent_values` which may cause data error of primary table using persistent index.