### PR TITLE
Global rf should not take place of local rf when all the runtime-filters' selectivity >0.01 and < 0.5

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -366,7 +366,14 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
             } else {
                 auto it = eval_context.selectivity.end();
                 it--;
-                if (selectivity < it->first) {
+                // In case of  all the runtime filters' selectivity is above 0.01 and below 0.5,
+                // the top 3 runtime filters of the highest selectivity are chosen to filter data, but if we have
+                // more than 3 runtime filters, the 4th, 5th, etc. can take place of the chosen runtime-filter of
+                // the lowest selectivity only in two cases:
+                // 1. current rf is a local rf;
+                // 2. current rf is a global rf and the chosen rf of the lowest selectivity is also a global rf.
+                // A global rf should not take place of local rf since global rf costs more time than local rf.
+                if (selectivity < it->first && (rf_desc->is_local() || !it->second->is_local())) {
                     eval_context.selectivity.erase(it);
                     eval_context.selectivity.emplace(selectivity, rf_desc);
                 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you -->


In case of  all the runtime filters' selectivity is above 0.01 and below 0.5, the top 3 runtime filters of the highest selectivity are chosen to filter data, but if we have more than 3 runtime filters, the 4th, 5th, etc. can take place of the chosen runtime-filter of the lowest selectivity only in two cases:
1. current rf is a local rf;
2. current rf is a global rf and the chosen rf of the lowest selectivity is also a global rf.

A global rf should not take place of local rf since global rf costs more time than local rf.

TEST
```
+===================================+=======================+=========+
| query                             | commit before this PR | this PR |
+===================================+=======================+=========+
| join.18_ssb_inner.q4.q_18_4_4.sql | 0.276s                | 0.275s  |
| join.19_ssb_left.q4.q_19_4_4.sql  | 0.274s                | 0.274s  |
+-----------------------------------+-----------------------+---------+
```