### PR TITLE
[Cherry-pick][Bugfix] Fix bug in some case failed to set DefineExpr for materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
@@ -119,10 +120,12 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         }
     }
 
-    private void setColumnsDefineExpr(Map<String, Expr> columnNameToDefineExpr) {
+    // The column names of the materialized view are all lowercase, but the column names may be uppercase
+    @VisibleForTesting
+    public void setColumnsDefineExpr(Map<String, Expr> columnNameToDefineExpr) {
         for (Map.Entry<String, Expr> entry : columnNameToDefineExpr.entrySet()) {
             for (Column column : schema) {
-                if (column.getName().equals(entry.getKey())) {
+                if (column.getName().equalsIgnoreCase(entry.getKey())) {
                     column.setDefineExpr(entry.getValue());
                     break;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
@@ -28,6 +28,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.OriginStatement;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
@@ -58,6 +58,20 @@ public class MaterializedIndexMetaTest {
     }
 
     @Test
+    public void testSetDefineExprCaseInsensitive() {
+        List<Column> schema = Lists.newArrayList();
+        Column column = new Column("UPPER", Type.ARRAY_VARCHAR);
+        schema.add(column);
+        MaterializedIndexMeta meta = new MaterializedIndexMeta(0, schema, 0, 0,
+                (short) 0, TStorageType.COLUMN, KeysType.DUP_KEYS, null);
+
+        Map<String, Expr> columnNameToDefineExpr = Maps.newHashMap();
+        columnNameToDefineExpr.put("upper", new StringLiteral());
+        meta.setColumnsDefineExpr(columnNameToDefineExpr);
+        Assert.assertNotNull(column.getDefineExpr());
+    }
+
+    @Test
     public void testSerializeMaterializedIndexMeta(@Mocked CreateMaterializedViewStmt stmt)
             throws IOException, AnalysisException {
         // 1. Write objects to file


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7362

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the user's table contains uppercase columns, then defineExpr may be processed in two cases when building a materialized view. One is that Log is processed through MVColumn, which is no problem. The second type of Image is directly compared to Column. This processing is problematic, which will cause defineExpr to be set to null, which will affect import and query.