### PR TITLE
Incorrect ConnectContext for getting variable selectLimit in method visitQueryStatement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -160,7 +160,7 @@ public class Analyzer {
             new QueryAnalyzer(session).analyze(stmt);
 
             QueryRelation queryRelation = stmt.getQueryRelation();
-            long selectLimit = ConnectContext.get().getSessionVariable().getSqlSelectLimit();
+            long selectLimit = session.getSessionVariable().getSqlSelectLimit();
             if (!queryRelation.hasLimit() && selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
                 queryRelation.setLimit(new LimitElement(selectLimit));
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7443

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Incorrect ConnectContext for getting variable selectLimit in method visitQueryStatement