### PR TITLE
[BugFix]: Load txn commit failed while primary table using persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -662,7 +662,7 @@ public:
         return Status::OK();
     }
 
-    size_t dump_bound() { return _map.dump_bound(); }
+    size_t dump_bound() { return _map.empty() ? sizeof(size_t) : _map.dump_bound(); }
 
     bool dump(phmap::BinaryOutputArchive& ar_out) { return _map.dump(ar_out); }
 
@@ -1402,13 +1402,13 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         // be maybe crash after create index file during last commit
         // so we delete expired index file first to make sure no garbage left
         FileSystem::Default()->delete_file(file_name);
+        size_t snapshot_size = _dump_bound();
         phmap::BinaryOutputArchive ar_out(file_name.data());
         if (!_dump(ar_out)) {
             std::string err_msg = strings::Substitute("faile to dump snapshot to file $0", file_name);
             LOG(WARNING) << err_msg;
             return Status::InternalError(err_msg);
         }
-        size_t snapshot_size = _fs->get_file_size(file_name).value();
         // update PersistentIndexMetaPB
         index_meta->set_size(_size);
         _version.to_pb(index_meta->mutable_version());

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -663,7 +663,7 @@ public:
     }
 
     // return the dump file size if dump _map into a new file
-    // If _map is empty, _map.dump_bound() will  set empty hash set serialize_size larger 
+    // If _map is empty, _map.dump_bound() will  set empty hash set serialize_size larger
     // than sizeof(uint64_t) in order to improve count distinct streaming aggregate performance.
     // Howevevr, the real snapshot file will only wite a size_(type is size_t) into file. So we
     // will use `sizeof(size_t)` as return value.

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -662,6 +662,11 @@ public:
         return Status::OK();
     }
 
+    // return the dump file size if dump _map into a new file
+    // If _map is empty, _map.dump_bound() will  set empty hash set serialize_size larger 
+    // than sizeof(uint64_t) in order to improve count distinct streaming aggregate performance.
+    // Howevevr, the real snapshot file will only wite a size_(type is size_t) into file. So we
+    // will use `sizeof(size_t)` as return value.
     size_t dump_bound() { return _map.empty() ? sizeof(size_t) : _map.dump_bound(); }
 
     bool dump(phmap::BinaryOutputArchive& ar_out) { return _map.dump(ar_out); }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1402,13 +1402,13 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         // be maybe crash after create index file during last commit
         // so we delete expired index file first to make sure no garbage left
         FileSystem::Default()->delete_file(file_name);
-        size_t snapshot_size = _dump_bound();
         phmap::BinaryOutputArchive ar_out(file_name.data());
         if (!_dump(ar_out)) {
             std::string err_msg = strings::Substitute("faile to dump snapshot to file $0", file_name);
             LOG(WARNING) << err_msg;
             return Status::InternalError(err_msg);
         }
+        size_t snapshot_size = _fs->get_file_size(file_name).value();
         // update PersistentIndexMetaPB
         index_meta->set_size(_size);
         _version.to_pb(index_meta->mutable_version());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If the primary table using persistent index, we will create a `index.l0.x.x` to save the snapshot or log. However, after the first data load is successful, the second data load may fail. 

The reason is when we dump snapshot of the `hash_map` in memory, we use function `dump_bound()` to evaluate the snapshot file size. But when the map is empty, the return value of function `dump_bound()`  will be set as larger than sizeof(uint64_t) but the snapshot file only write `size_(uint64_t)`. It will cause the meta data error which leads to deserialize `index.l0.x.x` failed.

So the return value of function `dump_bound` is set to `sizeof(size_t)` when the `_map` is empty
