### PR TITLE
[Enhancement] parquet format to support coalesce reads.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -707,7 +707,7 @@ CONF_Bool(enable_orc_late_materialization, "true");
 CONF_Int32(orc_file_cache_max_size, "2097152");
 // parquet reader, each column will reserve X bytes for read
 CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");
-CONF_mBool(parquet_enable_coalesce_reads, "true");
+CONF_mBool(parquet_coalesce_read_enable, "true");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -707,6 +707,7 @@ CONF_Bool(enable_orc_late_materialization, "true");
 CONF_Int32(orc_file_cache_max_size, "2097152");
 // parquet reader, each column will reserve X bytes for read
 CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");
+CONF_mBool(parquet_enable_coalesce_reads, "true");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -70,11 +70,11 @@ Status HiveDataSource::open(RuntimeState* state) {
 Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (hdfs_scan_node.__isset.min_max_conjuncts) {
-        RETURN_IF_ERROR(Expr::create_expr_trees(_pool, hdfs_scan_node.min_max_conjuncts, &_min_max_conjunct_ctxs));
+        RETURN_IF_ERROR(Expr::create_expr_trees(&_pool, hdfs_scan_node.min_max_conjuncts, &_min_max_conjunct_ctxs));
     }
 
     if (hdfs_scan_node.__isset.partition_conjuncts) {
-        RETURN_IF_ERROR(Expr::create_expr_trees(_pool, hdfs_scan_node.partition_conjuncts, &_partition_conjunct_ctxs));
+        RETURN_IF_ERROR(Expr::create_expr_trees(&_pool, hdfs_scan_node.partition_conjuncts, &_partition_conjunct_ctxs));
         _has_partition_conjuncts = true;
     }
     RETURN_IF_ERROR(Expr::prepare(_min_max_conjunct_ctxs, state));
@@ -177,7 +177,6 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
 
     _profile.runtime_profile = _runtime_profile;
-    _profile.pool = _pool;
     _profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
     _profile.bytes_read_counter = ADD_COUNTER(_runtime_profile, "BytesRead", TUnit::BYTES);
 
@@ -228,7 +227,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     HdfsScannerParams scanner_params;
     scanner_params.runtime_filter_collector = _runtime_filters;
     scanner_params.scan_ranges = {&scan_range};
-    scanner_params.fs = _pool->add(fs.release());
+    scanner_params.fs = _pool.add(fs.release());
     scanner_params.path = native_file_path;
     scanner_params.tuple_desc = _tuple_desc;
     scanner_params.materialize_slots = _materialize_slots;
@@ -248,11 +247,11 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;
     if (format == THdfsFileFormat::PARQUET) {
-        scanner = _pool->add(new HdfsParquetScanner());
+        scanner = _pool.add(new HdfsParquetScanner());
     } else if (format == THdfsFileFormat::ORC) {
-        scanner = _pool->add(new HdfsOrcScanner());
+        scanner = _pool.add(new HdfsOrcScanner());
     } else if (format == THdfsFileFormat::TEXT) {
-        scanner = _pool->add(new HdfsTextScanner());
+        scanner = _pool.add(new HdfsTextScanner());
     } else {
         std::string msg = fmt::format("unsupported hdfs file format: {}", format);
         LOG(WARNING) << msg;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -58,8 +58,7 @@ private:
     Status _init_scanner(RuntimeState* state);
 
     // =====================================
-    ObjectPool _obj_pool;
-    ObjectPool* _pool = &_obj_pool;
+    ObjectPool _pool;
     RuntimeState* _runtime_state = nullptr;
     vectorized::HdfsScanner* _scanner = nullptr;
 

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -7,6 +7,43 @@
 
 namespace starrocks::vectorized {
 
+class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
+public:
+    explicit CountedSeekableInputStream(std::shared_ptr<io::SeekableInputStream> stream,
+                                        vectorized::HdfsScanStats* stats)
+            : io::SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership), _stream(stream), _stats(stats) {}
+
+    ~CountedSeekableInputStream() override = default;
+
+    StatusOr<int64_t> read(void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        ASSIGN_OR_RETURN(auto nread, _stream->read(data, size));
+        _stats->bytes_read += nread;
+        return nread;
+    }
+
+    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        ASSIGN_OR_RETURN(auto nread, _stream->read_at(offset, data, size));
+        _stats->bytes_read += nread;
+        return nread;
+    }
+
+    Status read_at_fully(int64_t offset, void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        RETURN_IF_ERROR(_stream->read_at_fully(offset, data, size));
+        _stats->bytes_read += size;
+        return Status::OK();
+    }
+
+private:
+    std::shared_ptr<io::SeekableInputStream> _stream;
+    vectorized::HdfsScanStats* _stats;
+};
+
 Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     _runtime_state = runtime_state;
     _scanner_params = scanner_params;
@@ -110,7 +147,9 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
         return Status::OK();
     }
     CHECK(_file == nullptr) << "File has already been opened";
-    ASSIGN_OR_RETURN(_file, _scanner_params.fs->new_random_access_file(_scanner_params.path));
+    ASSIGN_OR_RETURN(_raw_file, _scanner_params.fs->new_random_access_file(_scanner_params.path));
+    _file = std::make_unique<RandomAccessFile>(
+            std::make_shared<CountedSeekableInputStream>(_raw_file->stream(), &_stats), _raw_file->filename());
     _build_scanner_context();
     auto status = do_open(runtime_state);
     if (status.ok()) {
@@ -136,6 +175,7 @@ void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     }
     do_close(runtime_state);
     _file.reset(nullptr);
+    _raw_file.reset(nullptr);
     _is_closed = true;
     if (_is_open && _scanner_params.open_limit != nullptr) {
         _scanner_params.open_limit->fetch_sub(1, std::memory_order_relaxed);

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -164,9 +164,8 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
 
 void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     DCHECK(!has_pending_token());
-    if (_is_closed) {
-        return;
-    }
+    bool expect = false;
+    if (!_is_closed.compare_exchange_strong(expect, true)) return;
     update_counter();
     Expr::close(_conjunct_ctxs, runtime_state);
     Expr::close(_min_max_conjunct_ctxs, runtime_state);
@@ -176,13 +175,12 @@ void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     do_close(runtime_state);
     _file.reset(nullptr);
     _raw_file.reset(nullptr);
-    _is_closed = true;
     if (_is_open && _scanner_params.open_limit != nullptr) {
         _scanner_params.open_limit->fetch_sub(1, std::memory_order_relaxed);
     }
 }
 
-void HdfsScanner::cleanup() {
+void HdfsScanner::fianlize() {
     if (_runtime_state != nullptr) {
         close(_runtime_state);
     }

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -50,8 +50,6 @@ class HdfsParquetProfile;
 
 struct HdfsScanProfile {
     RuntimeProfile* runtime_profile = nullptr;
-    ObjectPool* pool = nullptr;
-
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* bytes_read_counter = nullptr;
     RuntimeProfile::Counter* scan_timer = nullptr;
@@ -67,7 +65,6 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* io_counter = nullptr;
     RuntimeProfile::Counter* column_read_timer = nullptr;
     RuntimeProfile::Counter* column_convert_timer = nullptr;
-    HdfsParquetProfile* parquet_profile = nullptr;
 };
 
 struct HdfsScannerParams {
@@ -189,7 +186,7 @@ public:
     void close(RuntimeState* runtime_state) noexcept;
     Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
     Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
-    void cleanup();
+    void fianlize();
 
     int64_t raw_rows_read() const { return _stats.raw_rows_read; }
     int64_t num_rows_read() const { return _stats.num_rows_read; }
@@ -231,7 +228,7 @@ public:
 
 private:
     bool _is_open = false;
-    bool _is_closed = false;
+    std::atomic<bool> _is_closed = false;
     bool _keep_priority = false;
     Status _build_scanner_context();
     MonotonicStopWatch _pending_queue_sw;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -252,6 +252,7 @@ protected:
     std::unordered_map<SlotId, std::vector<ExprContext*>> _conjunct_ctxs_by_slot;
     // predicate which havs min/max
     std::vector<ExprContext*> _min_max_conjunct_ctxs;
+    std::unique_ptr<RandomAccessFile> _raw_file;
     std::unique_ptr<RandomAccessFile> _file;
 };
 

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -14,7 +14,7 @@ class OrcRowReaderFilter;
 class HdfsOrcScanner final : public HdfsScanner {
 public:
     HdfsOrcScanner() = default;
-    ~HdfsOrcScanner() override { cleanup(); }
+    ~HdfsOrcScanner() override { fianlize(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -7,9 +7,13 @@
 
 namespace starrocks::vectorized {
 
-class HdfsParquetProfile {
-public:
-    // read & decode
+static const std::string kParquetProfileSectionPrefix = "Parquet";
+
+Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    return Status::OK();
+}
+
+void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
     RuntimeProfile::Counter* page_read_timer = nullptr;
@@ -23,12 +27,7 @@ public:
     RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
 
-    void init(RuntimeProfile* root);
-};
-
-static const std::string kParquetProfileSectionPrefix = "Parquet";
-
-void HdfsParquetProfile::init(RuntimeProfile* root) {
+    RuntimeProfile* root = profile->runtime_profile;
     ADD_TIMER(root, kParquetProfileSectionPrefix);
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
@@ -40,30 +39,15 @@ void HdfsParquetProfile::init(RuntimeProfile* root) {
     group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
-}
 
-Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
-    HdfsScanProfile* profile = scanner_params.profile;
-    // initialized once.
-    if (profile != nullptr && profile->parquet_profile == nullptr) {
-        profile->parquet_profile = profile->pool->add(new HdfsParquetProfile());
-        profile->parquet_profile->init(profile->runtime_profile);
-    }
-    return Status::OK();
-}
-
-void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
-    HdfsParquetProfile* parquet_profile = profile->parquet_profile;
-    if (parquet_profile != nullptr) {
-        COUNTER_UPDATE(parquet_profile->value_decode_timer, _stats.value_decode_ns);
-        COUNTER_UPDATE(parquet_profile->level_decode_timer, _stats.level_decode_ns);
-        COUNTER_UPDATE(parquet_profile->page_read_timer, _stats.page_read_ns);
-        COUNTER_UPDATE(parquet_profile->footer_read_timer, _stats.footer_read_ns);
-        COUNTER_UPDATE(parquet_profile->column_reader_init_timer, _stats.column_reader_init_ns);
-        COUNTER_UPDATE(parquet_profile->group_chunk_read_timer, _stats.group_chunk_read_ns);
-        COUNTER_UPDATE(parquet_profile->group_dict_filter_timer, _stats.group_dict_filter_ns);
-        COUNTER_UPDATE(parquet_profile->group_dict_decode_timer, _stats.group_dict_decode_ns);
-    }
+    COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
+    COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
+    COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);
+    COUNTER_UPDATE(footer_read_timer, _stats.footer_read_ns);
+    COUNTER_UPDATE(column_reader_init_timer, _stats.column_reader_init_ns);
+    COUNTER_UPDATE(group_chunk_read_timer, _stats.group_chunk_read_ns);
+    COUNTER_UPDATE(group_dict_filter_timer, _stats.group_dict_filter_ns);
+    COUNTER_UPDATE(group_dict_decode_timer, _stats.group_dict_decode_ns);
 }
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -9,7 +9,7 @@ namespace starrocks::vectorized {
 class HdfsParquetScanner final : public HdfsScanner {
 public:
     HdfsParquetScanner() = default;
-    ~HdfsParquetScanner() override { cleanup(); }
+    ~HdfsParquetScanner() override { fianlize(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -11,7 +11,7 @@ namespace starrocks::vectorized {
 class HdfsTextScanner final : public HdfsScanner {
 public:
     HdfsTextScanner() = default;
-    ~HdfsTextScanner() override { cleanup(); }
+    ~HdfsTextScanner() override { fianlize(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnPrinter.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnPrinter.cc
@@ -319,7 +319,7 @@ void LongColumnPrinter::printRow(uint64_t rowId) {
         writeString(buffer, "null");
     } else {
         char numBuffer[64];
-        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<int64_t>(data[rowId]));
+        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<long long int>(data[rowId]));
         writeString(buffer, numBuffer);
     }
 }
@@ -539,7 +539,7 @@ void UnionColumnPrinter::printRow(uint64_t rowId) {
     } else {
         writeString(buffer, "{\"tag\": ");
         char numBuffer[64];
-        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<int64_t>(tags[rowId]));
+        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<long long int>(tags[rowId]));
         writeString(buffer, numBuffer);
         writeString(buffer, ", \"value\": ");
         fieldPrinter[tags[rowId]]->printRow(offsets[rowId]);
@@ -680,7 +680,7 @@ void TimestampColumnPrinter::printRow(uint64_t rowId) {
         }
         char numBuffer[64];
         snprintf(numBuffer, sizeof(numBuffer), "%0*" INT64_FORMAT_STRING "d\"",
-                 static_cast<int>(NANO_DIGITS - zeroDigits), static_cast<int64_t>(nanos));
+                 static_cast<int>(NANO_DIGITS - zeroDigits), static_cast<long long int>(nanos));
         writeString(buffer, numBuffer);
     }
 }

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnPrinter.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnPrinter.cc
@@ -319,7 +319,7 @@ void LongColumnPrinter::printRow(uint64_t rowId) {
         writeString(buffer, "null");
     } else {
         char numBuffer[64];
-        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<long long int>(data[rowId]));
+        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<int64_t>(data[rowId]));
         writeString(buffer, numBuffer);
     }
 }
@@ -539,7 +539,7 @@ void UnionColumnPrinter::printRow(uint64_t rowId) {
     } else {
         writeString(buffer, "{\"tag\": ");
         char numBuffer[64];
-        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<long long int>(tags[rowId]));
+        snprintf(numBuffer, sizeof(numBuffer), "%" INT64_FORMAT_STRING "d", static_cast<int64_t>(tags[rowId]));
         writeString(buffer, numBuffer);
         writeString(buffer, ", \"value\": ");
         fieldPrinter[tags[rowId]]->printRow(offsets[rowId]);
@@ -680,7 +680,7 @@ void TimestampColumnPrinter::printRow(uint64_t rowId) {
         }
         char numBuffer[64];
         snprintf(numBuffer, sizeof(numBuffer), "%0*" INT64_FORMAT_STRING "d\"",
-                 static_cast<int>(NANO_DIGITS - zeroDigits), static_cast<long long int>(nanos));
+                 static_cast<int>(NANO_DIGITS - zeroDigits), static_cast<int64_t>(nanos));
         writeString(buffer, numBuffer);
     }
 }

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -17,44 +17,13 @@
 
 namespace starrocks::parquet {
 
-class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
-public:
-    explicit CountedSeekableInputStream(std::shared_ptr<io::SeekableInputStream> stream,
-                                        vectorized::HdfsScanStats* stats)
-            : io::SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership), _stream(stream), _stats(stats) {}
-
-    ~CountedSeekableInputStream() override = default;
-
-    StatusOr<int64_t> read(void* data, int64_t size) override {
-        SCOPED_RAW_TIMER(&_stats->io_ns);
-        _stats->io_count += 1;
-        ASSIGN_OR_RETURN(auto nread, _stream->read(data, size));
-        _stats->bytes_read += nread;
-        return nread;
-    }
-
-    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) override {
-        SCOPED_RAW_TIMER(&_stats->io_ns);
-        _stats->io_count += 1;
-        ASSIGN_OR_RETURN(auto nread, _stream->read_at(offset, data, size));
-        _stats->bytes_read += nread;
-        return nread;
-    }
-
-private:
-    std::shared_ptr<io::SeekableInputStream> _stream;
-    vectorized::HdfsScanStats* _stats;
-};
-
 ColumnChunkReader::ColumnChunkReader(level_t max_def_level, level_t max_rep_level, int32_t type_length,
-                                     const tparquet::ColumnChunk* column_chunk, RandomAccessFile* file,
-                                     const ColumnChunkReaderOptions& opts)
+                                     const tparquet::ColumnChunk* column_chunk, const ColumnReaderOptions& opts)
         : _max_def_level(max_def_level),
           _max_rep_level(max_rep_level),
           _type_length(type_length),
           _chunk_metadata(column_chunk),
-          _opts(opts),
-          _file(std::make_shared<CountedSeekableInputStream>(file->stream(), opts.stats), file->filename()) {}
+          _opts(opts) {}
 
 ColumnChunkReader::~ColumnChunkReader() = default;
 
@@ -65,8 +34,13 @@ Status ColumnChunkReader::init(int chunk_size) {
     } else {
         start_offset = metadata().data_page_offset;
     }
-
-    _page_reader = std::make_unique<PageReader>(&_file, start_offset, metadata().total_compressed_size);
+    size_t size = metadata().total_compressed_size;
+    IBufferedInputStream* stream = _opts.sb_stream;
+    if (!_opts.use_sb_stream) {
+        _default_stream = std::make_unique<DefaultBufferedInputStream>(_opts.file, start_offset, size);
+        stream = _default_stream.get();
+    }
+    _page_reader = std::make_unique<PageReader>(stream, start_offset, size);
 
     // seek to the first page
     _page_reader->seek_to_offset(start_offset);
@@ -129,7 +103,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
         RETURN_IF_ERROR(_compress_codec->decompress(com_slice, &_data));
     } else {
         _data.size = uncompressed_size;
-        _page_reader->read_bytes((const uint8_t**)&_data.data, _data.size);
+        RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&_data.data, _data.size));
     }
 
     return Status::OK();

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "exec/vectorized/hdfs_scanner.h"
+#include "formats/parquet/column_reader.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/encoding_dict.h"
 #include "formats/parquet/page_reader.h"

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -9,7 +9,6 @@
 
 #include "column/column.h"
 #include "common/status.h"
-#include "formats/parquet/column_reader.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/level_codec.h"
 #include "fs/fs.h"
@@ -24,6 +23,7 @@ class BlockCompressionCodec;
 namespace starrocks::parquet {
 
 class PageReader;
+class ColumnReaderOptions;
 
 class ColumnChunkReader {
 public:

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -9,34 +9,26 @@
 
 #include "column/column.h"
 #include "common/status.h"
+#include "formats/parquet/column_reader.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/level_codec.h"
 #include "fs/fs.h"
 #include "gen_cpp/parquet_types.h"
 #include "util/block_compression.h"
+#include "util/buffered_stream.h"
 
 namespace starrocks {
-class RandomAccessFile;
 class BlockCompressionCodec;
-namespace vectorized {
-class HdfsScanStats;
-}
-
 } // namespace starrocks
 
 namespace starrocks::parquet {
-
-struct ColumnChunkReaderOptions {
-    vectorized::HdfsScanStats* stats = nullptr;
-};
 
 class PageReader;
 
 class ColumnChunkReader {
 public:
     ColumnChunkReader(level_t max_def_level, level_t max_rep_level, int32_t type_length,
-                      const tparquet::ColumnChunk* column_chunk, RandomAccessFile* file,
-                      const ColumnChunkReaderOptions& opts);
+                      const tparquet::ColumnChunk* column_chunk, const ColumnReaderOptions& opts);
     ~ColumnChunkReader();
 
     Status init(int chunk_size);
@@ -121,10 +113,9 @@ private:
     level_t _max_rep_level = 0;
     int32_t _type_length = 0;
     const tparquet::ColumnChunk* _chunk_metadata = nullptr;
-    ColumnChunkReaderOptions _opts;
-    RandomAccessFile _file;
-
+    const ColumnReaderOptions& _opts;
     std::unique_ptr<PageReader> _page_reader;
+    std::unique_ptr<DefaultBufferedInputStream> _default_stream;
 
     const BlockCompressionCodec* _compress_codec = nullptr;
 

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -1,6 +1,6 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
-#include "column_converter.h"
+#include "formats/parquet/column_converter.h"
 
 #include <memory>
 #include <utility>
@@ -23,6 +23,231 @@
 #include "util/timezone_utils.h"
 
 namespace starrocks::parquet {
+
+// When doing decimal convert, source scale may not equal with destination scale,
+// when destination scale is greater than source, source unscaled data will be scaled up
+// to match destination scale.
+enum class DecimalScaleType { kNoScale, kScaleUp, kScaleDown };
+
+class Int32ToDateConverter : public ColumnConverter {
+public:
+    Int32ToDateConverter() = default;
+    ~Int32ToDateConverter() override = default;
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
+};
+
+class Int96ToDateTimeConverter : public ColumnConverter {
+public:
+    Int96ToDateTimeConverter() = default;
+    ~Int96ToDateTimeConverter() override = default;
+
+    Status init(const std::string& timezone);
+    // convert column from int96 to timestamp
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
+
+private:
+    // When Hive stores a timestamp value into Parquet format, it converts local time
+    // into UTC time, and when it reads data out, it should be converted to the time
+    // according to session variable "time_zone".
+    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
+        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
+    }
+
+private:
+    int _offset = 0;
+};
+
+class Int64ToDateTimeConverter : public ColumnConverter {
+public:
+    Int64ToDateTimeConverter() = default;
+    ~Int64ToDateTimeConverter() override = default;
+
+    Status init(const std::string& timezone, const tparquet::SchemaElement& schema_element);
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        return _convert_to_timestamp_column(src, dst);
+    }
+
+private:
+    // convert column from int64 to timestamp
+    Status _convert_to_timestamp_column(const vectorized::ColumnPtr& src, vectorized::Column* dst);
+    // When Hive stores a timestamp value into Parquet format, it converts local time
+    // into UTC time, and when it reads data out, it should be converted to the time
+    // according to session variable "time_zone".
+    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
+        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
+    }
+
+private:
+    bool _is_adjusted_to_utc = false;
+    int _offset = 0;
+
+    int64_t _second_mask = 0;
+    int64_t _scale_to_nano_factor = 0;
+};
+
+template <typename SourceType, typename DestType>
+class IntToIntConverter : public ColumnConverter {
+public:
+    IntToIntConverter() = default;
+    ~IntToIntConverter() override = default;
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
+                src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<DestType>>(
+                dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        size_t size = src_column->size();
+
+        for (size_t i = 0; i < size; i++) {
+            dst_null_data[i] = src_null_data[i];
+        }
+        for (size_t i = 0; i < size; i++) {
+            dst_data[i] = DestType(src_data[i]);
+        }
+
+        dst_nullable_column->set_has_null(src_nullable_column->has_null());
+        return Status::OK();
+    }
+};
+
+template <typename SourceType, PrimitiveType DestType>
+class PrimitiveToDecimalConverter : public ColumnConverter {
+public:
+    using DestDecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
+    using DestColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
+    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
+
+    PrimitiveToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
+        if (src_scale < dst_scale) {
+            _scale_type = DecimalScaleType::kScaleUp;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
+        } else if (src_scale > dst_scale) {
+            _scale_type = DecimalScaleType::kScaleDown;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
+        }
+    }
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
+                src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<DestColumnType>(dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        bool has_null = false;
+        size_t size = src_column->size();
+        for (size_t i = 0; i < size; i++) {
+            dst_null_data[i] = src_null_data[i];
+            if (dst_null_data[i]) {
+                has_null = true;
+                continue;
+            }
+            DestPrimitiveType value = src_data[i];
+            if (_scale_type == DecimalScaleType::kScaleUp) {
+                value *= _scale_factor;
+            } else if (_scale_type == DecimalScaleType::kScaleDown) {
+                value /= _scale_factor;
+            }
+            dst_data[i] = DestDecimalType(value);
+        }
+        dst_nullable_column->set_has_null(has_null);
+        return Status::OK();
+    }
+
+private:
+    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
+    DestPrimitiveType _scale_factor = 1;
+};
+
+template <PrimitiveType DestType>
+class BinaryToDecimalConverter : public ColumnConverter {
+public:
+    using DecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
+    using ColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
+    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
+
+    BinaryToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
+        if (src_scale < dst_scale) {
+            _scale_type = DecimalScaleType::kScaleUp;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
+        } else if (src_scale > dst_scale) {
+            _scale_type = DecimalScaleType::kScaleDown;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
+        }
+    }
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column =
+                vectorized::ColumnHelper::as_raw_column<vectorized::BinaryColumn>(src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<ColumnType>(dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        size_t size = src_column->size();
+        bool has_null = false;
+        for (size_t i = 0; i < size; i++) {
+            // If src_data[i].size > DestPrimitiveType, this means  we treat as null.
+            dst_null_data[i] = src_null_data[i] | (src_data[i].size > sizeof(DestPrimitiveType));
+            if (dst_null_data[i]) {
+                has_null = true;
+                continue;
+            }
+
+            // When Decimal in parquet is stored in byte arrays, binary and fixed,
+            // the unscaled number must be encoded as two's complement using big-endian byte order.
+            DestPrimitiveType value = src_data[i].data[0] & 0x80 ? -1 : 0;
+            memcpy(reinterpret_cast<char*>(&value) + sizeof(DestPrimitiveType) - src_data[i].size, src_data[i].data,
+                   src_data[i].size);
+            value = BitUtil::big_endian_to_host(value);
+
+            // scale up/down
+            if (_scale_type == DecimalScaleType::kScaleUp) {
+                value *= _scale_factor;
+            } else if (_scale_type == DecimalScaleType::kScaleDown) {
+                value /= _scale_factor;
+            }
+            dst_data[i] = DecimalType(value);
+        }
+        dst_nullable_column->set_has_null(has_null);
+        return Status::OK();
+    }
+
+private:
+    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
+    DestPrimitiveType _scale_factor = 1;
+};
+
 Status ColumnConverterFactory::create_converter(const ParquetField& field, const TypeDescriptor& typeDescriptor,
                                                 const std::string& timezone,
                                                 std::unique_ptr<ColumnConverter>* converter) {

--- a/be/src/formats/parquet/column_converter.h
+++ b/be/src/formats/parquet/column_converter.h
@@ -6,32 +6,20 @@
 #include "column/type_traits.h"
 #include "common/status.h"
 #include "formats/parquet/types.h"
+#include "formats/parquet/utils.h"
 #include "gen_cpp/parquet_types.h"
 #include "runtime/types.h"
 #include "util/bit_util.h"
-#include "utils.h"
 
 namespace starrocks {
-class RandomAccessFile;
 namespace vectorized {
 class Column;
-struct HdfsScanStats;
 } // namespace vectorized
 } // namespace starrocks
 
 namespace starrocks::parquet {
 
 class ParquetField;
-
-struct ColumnReaderOptions {
-    vectorized::HdfsScanStats* stats = nullptr;
-    std::string timezone;
-};
-
-// When doing decimal convert, source scale may not equal with destination scale,
-// when destination scale is greater than source, source unscaled data will be scaled up
-// to match destination scale.
-enum class DecimalScaleType { kNoScale, kScaleUp, kScaleDown };
 
 class ColumnConverter {
 public:
@@ -51,225 +39,6 @@ public:
 public:
     bool need_convert = false;
     tparquet::Type::type parquet_type;
-};
-
-class Int32ToDateConverter : public ColumnConverter {
-public:
-    Int32ToDateConverter() = default;
-    ~Int32ToDateConverter() override = default;
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
-};
-
-class Int96ToDateTimeConverter : public ColumnConverter {
-public:
-    Int96ToDateTimeConverter() = default;
-    ~Int96ToDateTimeConverter() override = default;
-
-    Status init(const std::string& timezone);
-    // convert column from int96 to timestamp
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
-
-private:
-    // When Hive stores a timestamp value into Parquet format, it converts local time
-    // into UTC time, and when it reads data out, it should be converted to the time
-    // according to session variable "time_zone".
-    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
-        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
-    }
-
-private:
-    int _offset = 0;
-};
-
-class Int64ToDateTimeConverter : public ColumnConverter {
-public:
-    Int64ToDateTimeConverter() = default;
-    ~Int64ToDateTimeConverter() override = default;
-
-    Status init(const std::string& timezone, const tparquet::SchemaElement& schema_element);
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        return _convert_to_timestamp_column(src, dst);
-    }
-
-private:
-    // convert column from int64 to timestamp
-    Status _convert_to_timestamp_column(const vectorized::ColumnPtr& src, vectorized::Column* dst);
-    // When Hive stores a timestamp value into Parquet format, it converts local time
-    // into UTC time, and when it reads data out, it should be converted to the time
-    // according to session variable "time_zone".
-    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
-        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
-    }
-
-private:
-    bool _is_adjusted_to_utc = false;
-    int _offset = 0;
-
-    int64_t _second_mask = 0;
-    int64_t _scale_to_nano_factor = 0;
-};
-
-template <typename SourceType, typename DestType>
-class IntToIntConverter : public ColumnConverter {
-public:
-    IntToIntConverter() = default;
-    ~IntToIntConverter() override = default;
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
-                src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<DestType>>(
-                dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        size_t size = src_column->size();
-
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-        }
-        for (size_t i = 0; i < size; i++) {
-            dst_data[i] = DestType(src_data[i]);
-        }
-
-        dst_nullable_column->set_has_null(src_nullable_column->has_null());
-        return Status::OK();
-    }
-};
-
-template <typename SourceType, PrimitiveType DestType>
-class PrimitiveToDecimalConverter : public ColumnConverter {
-public:
-    using DestDecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
-    using DestColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
-    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
-
-    PrimitiveToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
-        if (src_scale < dst_scale) {
-            _scale_type = DecimalScaleType::kScaleUp;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
-        } else if (src_scale > dst_scale) {
-            _scale_type = DecimalScaleType::kScaleDown;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
-        }
-    }
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
-                src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<DestColumnType>(dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        bool has_null = false;
-        size_t size = src_column->size();
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-            if (dst_null_data[i]) {
-                has_null = true;
-                continue;
-            }
-            DestPrimitiveType value = src_data[i];
-            if (_scale_type == DecimalScaleType::kScaleUp) {
-                value *= _scale_factor;
-            } else if (_scale_type == DecimalScaleType::kScaleDown) {
-                value /= _scale_factor;
-            }
-            dst_data[i] = DestDecimalType(value);
-        }
-        dst_nullable_column->set_has_null(has_null);
-        return Status::OK();
-    }
-
-private:
-    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
-    DestPrimitiveType _scale_factor = 1;
-};
-
-template <PrimitiveType DestType>
-class BinaryToDecimalConverter : public ColumnConverter {
-public:
-    using DecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
-    using ColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
-    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
-
-    BinaryToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
-        if (src_scale < dst_scale) {
-            _scale_type = DecimalScaleType::kScaleUp;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
-        } else if (src_scale > dst_scale) {
-            _scale_type = DecimalScaleType::kScaleDown;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
-        }
-    }
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column =
-                vectorized::ColumnHelper::as_raw_column<vectorized::BinaryColumn>(src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<ColumnType>(dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        size_t size = src_column->size();
-        bool has_null = false;
-        for (size_t i = 0; i < size; i++) {
-            // If src_data[i].size > DestPrimitiveType, this means  we treat as null.
-            dst_null_data[i] = src_null_data[i] | (src_data[i].size > sizeof(DestPrimitiveType));
-            if (dst_null_data[i]) {
-                has_null = true;
-                continue;
-            }
-
-            // When Decimal in parquet is stored in byte arrays, binary and fixed,
-            // the unscaled number must be encoded as two's complement using big-endian byte order.
-            DestPrimitiveType value = src_data[i].data[0] & 0x80 ? -1 : 0;
-            memcpy(reinterpret_cast<char*>(&value) + sizeof(DestPrimitiveType) - src_data[i].size, src_data[i].data,
-                   src_data[i].size);
-            value = BitUtil::big_endian_to_host(value);
-
-            // scale up/down
-            if (_scale_type == DecimalScaleType::kScaleUp) {
-                value *= _scale_factor;
-            } else if (_scale_type == DecimalScaleType::kScaleDown) {
-                value /= _scale_factor;
-            }
-            dst_data[i] = DecimalType(value);
-        }
-        dst_nullable_column->set_has_null(has_null);
-        return Status::OK();
-    }
-
-private:
-    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
-    DestPrimitiveType _scale_factor = 1;
 };
 
 class ColumnConverterFactory {

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -4,6 +4,7 @@
 
 #include "column/array_column.h"
 #include "exec/vectorized/hdfs_scanner.h"
+#include "formats/parquet/column_converter.h"
 #include "formats/parquet/stored_column_reader.h"
 #include "util/runtime_profile.h"
 
@@ -52,17 +53,13 @@ static void def_rep_to_offset(const LevelInfo& level_info, const level_t* def_le
 
 class ScalarColumnReader : public ColumnReader {
 public:
-    explicit ScalarColumnReader(ColumnReaderOptions opts) : _opts(std::move(opts)) {}
+    explicit ScalarColumnReader(const ColumnReaderOptions& opts) : _opts(opts) {}
     ~ScalarColumnReader() override = default;
 
-    Status init(int chunk_size, RandomAccessFile* file, const ParquetField* field,
-                const tparquet::ColumnChunk* chunk_metadata, const TypeDescriptor& col_type) {
-        StoredColumnReaderOptions opts;
-        opts.stats = _opts.stats;
-
+    Status init(const ParquetField* field, const TypeDescriptor& col_type,
+                const tparquet::ColumnChunk* chunk_metadata) {
         RETURN_IF_ERROR(ColumnConverterFactory::create_converter(*field, col_type, _opts.timezone, &converter));
-
-        return StoredColumnReader::create(file, field, chunk_metadata, opts, chunk_size, &_reader);
+        return StoredColumnReader::create(_opts, field, chunk_metadata, &_reader);
     }
 
     Status prepare_batch(size_t* num_records, ColumnContentType content_type, vectorized::Column* dst) override {
@@ -100,14 +97,14 @@ public:
     }
 
 private:
-    ColumnReaderOptions _opts;
+    const ColumnReaderOptions& _opts;
 
     std::unique_ptr<StoredColumnReader> _reader;
 };
 
 class ListColumnReader : public ColumnReader {
 public:
-    explicit ListColumnReader(ColumnReaderOptions opts) : _opts(std::move(opts)) {}
+    explicit ListColumnReader(const ColumnReaderOptions& opts) : _opts(opts) {}
     ~ListColumnReader() override = default;
 
     Status init(const ParquetField* field, std::unique_ptr<ColumnReader> element_reader) {
@@ -162,29 +159,26 @@ public:
     }
 
 private:
-    ColumnReaderOptions _opts;
+    const ColumnReaderOptions& _opts;
 
     const ParquetField* _field = nullptr;
     std::unique_ptr<ColumnReader> _element_reader;
 };
 
-Status ColumnReader::create(RandomAccessFile* file, const ParquetField* field, const tparquet::RowGroup& row_group,
-                            const TypeDescriptor& col_type, const ColumnReaderOptions& opts, int chunk_size,
+Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField* field, const TypeDescriptor& col_type,
                             std::unique_ptr<ColumnReader>* output) {
     if (field->type.type == TYPE_MAP || field->type.type == TYPE_STRUCT) {
         return Status::InternalError("not supported type");
     }
     if (field->type.type == TYPE_ARRAY) {
         std::unique_ptr<ColumnReader> child_reader;
-        RETURN_IF_ERROR(ColumnReader::create(file, &field->children[0], row_group, col_type.children[0], opts,
-                                             chunk_size, &child_reader));
+        RETURN_IF_ERROR(ColumnReader::create(opts, &field->children[0], col_type.children[0], &child_reader));
         std::unique_ptr<ListColumnReader> reader(new ListColumnReader(opts));
         RETURN_IF_ERROR(reader->init(field, std::move(child_reader)));
         *output = std::move(reader);
     } else {
         std::unique_ptr<ScalarColumnReader> reader(new ScalarColumnReader(opts));
-        RETURN_IF_ERROR(
-                reader->init(chunk_size, file, field, &row_group.columns[field->physical_column_index], col_type));
+        RETURN_IF_ERROR(reader->init(field, col_type, &opts.row_group_meta->columns[field->physical_column_index]));
         *output = std::move(reader);
     }
     return Status::OK();

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -1,19 +1,32 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 #pragma once
+#include "formats/parquet/column_converter.h"
 
-#include <memory>
-
-#include "column_converter.h"
+namespace starrocks {
+class RandomAccessFile;
+class SharedBufferedInputStream;
+namespace vectorized {
+class HdfsScanStats;
+}
+} // namespace starrocks
 
 namespace starrocks::parquet {
+struct ColumnReaderOptions {
+    std::string timezone;
+    int chunk_size = 0;
+    vectorized::HdfsScanStats* stats = nullptr;
+    RandomAccessFile* file = nullptr;
+    SharedBufferedInputStream* sb_stream = nullptr;
+    tparquet::RowGroup* row_group_meta = nullptr;
+    bool use_sb_stream = true;
+};
 
 class ColumnReader {
 public:
     // TODO(zc): review this,
     // create a column reader
-    static Status create(RandomAccessFile* file, const ParquetField* field, const tparquet::RowGroup& row_group,
-                         const TypeDescriptor& col_type, const ColumnReaderOptions& opts, int chunk_size,
+    static Status create(const ColumnReaderOptions& opts, const ParquetField* field, const TypeDescriptor& col_type,
                          std::unique_ptr<ColumnReader>* reader);
 
     virtual ~ColumnReader() = default;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -416,6 +416,7 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {
+                _row_group_readers[_cur_row_group_idx]->close();
                 _cur_row_group_idx++;
                 return Status::OK();
             }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -38,7 +38,7 @@ Status FileReader::init(vectorized::HdfsScannerContext* ctx) {
     if (_is_file_filtered) {
         return Status::OK();
     }
-    _init_group_reader();
+    RETURN_IF_ERROR(_init_group_reader());
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -16,6 +16,43 @@ namespace starrocks::parquet {
 constexpr static const PrimitiveType kDictCodePrimitiveType = TYPE_INT;
 constexpr static const FieldType kDictCodeFieldType = OLAP_FIELD_TYPE_INT;
 
+class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
+public:
+    explicit CountedSeekableInputStream(std::shared_ptr<io::SeekableInputStream> stream,
+                                        vectorized::HdfsScanStats* stats)
+            : io::SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership), _stream(stream), _stats(stats) {}
+
+    ~CountedSeekableInputStream() override = default;
+
+    StatusOr<int64_t> read(void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        ASSIGN_OR_RETURN(auto nread, _stream->read(data, size));
+        _stats->bytes_read += nread;
+        return nread;
+    }
+
+    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        ASSIGN_OR_RETURN(auto nread, _stream->read_at(offset, data, size));
+        _stats->bytes_read += nread;
+        return nread;
+    }
+
+    Status read_at_fully(int64_t offset, void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        RETURN_IF_ERROR(_stream->read_at_fully(offset, data, size));
+        _stats->bytes_read += size;
+        return Status::OK();
+    }
+
+private:
+    std::shared_ptr<io::SeekableInputStream> _stream;
+    vectorized::HdfsScanStats* _stats;
+};
+
 GroupReader::GroupReader(int chunk_size, RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number)
         : _chunk_size(chunk_size), _file(file), _file_metadata(file_metadata), _row_group_number(row_group_number) {
     _row_group_metadata =
@@ -26,7 +63,7 @@ Status GroupReader::init(const GroupReaderParam& param) {
     _param = param;
     // the calling order matters, do not change unless you know why.
     RETURN_IF_ERROR(_init_column_readers());
-    _pre_process_columns_and_conjunct_ctxs();
+    _process_columns_and_conjunct_ctxs();
     RETURN_IF_ERROR(_rewrite_dict_column_predicates());
     _init_read_chunk();
     return Status::OK();
@@ -78,7 +115,30 @@ Status GroupReader::get_next(vectorized::ChunkPtr* chunk, size_t* row_count) {
     return status;
 }
 
+void GroupReader::close() {
+    // to release memory ASAP.
+    _sb_stream->release();
+    _column_readers.clear();
+}
+
 Status GroupReader::_init_column_readers() {
+    _file_with_stats = _obj_pool.add(new RandomAccessFile(
+            std::make_shared<CountedSeekableInputStream>(_file->stream(), _param.stats), _file->filename()));
+    _sb_stream = _obj_pool.add(new SharedBufferedInputStream(_file_with_stats));
+
+    ColumnReaderOptions& opts = _column_reader_opts;
+    opts.timezone = _param.timezone;
+    opts.chunk_size = _chunk_size;
+    opts.stats = _param.stats;
+    opts.sb_stream = _sb_stream;
+    opts.file = _file_with_stats;
+    opts.row_group_meta = _row_group_metadata.get();
+    opts.use_sb_stream = config::parquet_enable_coalesce_reads;
+
+    if (opts.use_sb_stream) {
+        RETURN_IF_ERROR(_set_io_ranges());
+    }
+
     for (const auto& column : _param.read_cols) {
         RETURN_IF_ERROR(_create_column_reader(column));
     }
@@ -88,20 +148,16 @@ Status GroupReader::_init_column_readers() {
 Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column) {
     std::unique_ptr<ColumnReader> column_reader = nullptr;
     const auto* schema_node = _file_metadata->schema().get_stored_column_by_idx(column.col_idx_in_parquet);
-
-    ColumnReaderOptions opts;
-    opts.stats = _param.stats;
-    opts.timezone = _param.timezone;
     {
         SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
-        RETURN_IF_ERROR(ColumnReader::create(_file, schema_node, *_row_group_metadata, column.col_type_in_chunk, opts,
-                                             _chunk_size, &column_reader));
+        RETURN_IF_ERROR(
+                ColumnReader::create(_column_reader_opts, schema_node, column.col_type_in_chunk, &column_reader));
     }
     _column_readers[column.slot_id] = std::move(column_reader);
     return Status::OK();
 }
 
-void GroupReader::_pre_process_columns_and_conjunct_ctxs() {
+void GroupReader::_process_columns_and_conjunct_ctxs() {
     const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
     const auto& slots = _param.tuple_desc->slots();
     for (const auto& column : _param.read_cols) {
@@ -121,6 +177,25 @@ void GroupReader::_pre_process_columns_and_conjunct_ctxs() {
             }
         }
     }
+}
+
+Status GroupReader::_set_io_ranges() {
+    std::vector<SharedBufferedInputStream::IORange> ranges;
+
+    for (const auto& column : _param.read_cols) {
+        auto& rg = _row_group_metadata->columns[column.col_idx_in_parquet].meta_data;
+        int64_t offset = 0;
+        if (rg.__isset.dictionary_page_offset) {
+            offset = rg.dictionary_page_offset;
+        } else {
+            offset = rg.data_page_offset;
+        }
+        int64_t size = rg.total_compressed_size;
+        auto r = SharedBufferedInputStream::IORange{.offset = offset, .size = size};
+        ranges.emplace_back(r);
+    }
+
+    return _sb_stream->set_io_ranges(ranges);
 }
 
 bool GroupReader::_can_using_dict_filter(const SlotDescriptor* slot, const SlotIdExprContextsMap& conjunct_ctxs_by_slot,

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -10,8 +10,8 @@
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage/vectorized_column_predicate.h"
+#include "util/buffered_stream.h"
 #include "util/runtime_profile.h"
-
 namespace starrocks {
 class RandomAccessFile;
 
@@ -58,14 +58,16 @@ public:
 
     Status init(const GroupReaderParam& _param);
     Status get_next(vectorized::ChunkPtr* chunk, size_t* row_count);
+    void close();
 
 private:
     using SlotIdExprContextsMap = std::unordered_map<int, std::vector<ExprContext*>>;
 
     Status _init_column_readers();
     Status _create_column_reader(const GroupReaderParam::Column& column);
+    Status _set_io_ranges();
     // Extract dict filter columns and conjuncts
-    void _pre_process_columns_and_conjunct_ctxs();
+    void _process_columns_and_conjunct_ctxs();
     bool _can_using_dict_filter(const SlotDescriptor* slot, const SlotIdExprContextsMap& slot_conjunct_ctxs,
                                 const tparquet::ColumnMetaData& column_metadata);
     // Returns true if all of the data pages in the column chunk are dict encoded
@@ -80,6 +82,8 @@ private:
     int _chunk_size;
 
     RandomAccessFile* _file;
+    RandomAccessFile* _file_with_stats;
+    SharedBufferedInputStream* _sb_stream;
 
     // parquet file meta
     FileMetaData* _file_metadata;
@@ -114,6 +118,8 @@ private:
     GroupReaderParam _param;
 
     ObjectPool _obj_pool;
+
+    ColumnReaderOptions _column_reader_opts;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -82,7 +82,6 @@ private:
     int _chunk_size;
 
     RandomAccessFile* _file;
-    RandomAccessFile* _file_with_stats;
     SharedBufferedInputStream* _sb_stream;
 
     // parquet file meta

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -3,7 +3,7 @@
 #include "formats/parquet/page_reader.h"
 
 #include "common/config.h"
-#include "fs/fs.h"
+// #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
 #include "util/thrift_util.h"
 
@@ -12,10 +12,8 @@ namespace starrocks::parquet {
 static constexpr size_t kHeaderBufSize = 1024;
 static constexpr size_t kHeaderBufMaxSize = 16 * 1024;
 
-PageReader::PageReader(RandomAccessFile* file, uint64_t start_offset, uint64_t length)
-        : _stream(file, start_offset, length), _start_offset(start_offset), _finish_offset(start_offset + length) {
-    _stream.reserve(config::parquet_buffer_stream_reserve_size);
-}
+PageReader::PageReader(IBufferedInputStream* stream, uint64_t start_offset, uint64_t length)
+        : _stream(stream), _start_offset(start_offset), _finish_offset(start_offset + length) {}
 
 Status PageReader::next_header() {
     if (_offset != _next_header_pos) {
@@ -33,7 +31,7 @@ Status PageReader::next_header() {
     size_t nbytes = kHeaderBufSize;
 
     do {
-        RETURN_IF_ERROR(_stream.get_bytes(&page_buf, &nbytes, true));
+        RETURN_IF_ERROR(_stream->get_bytes(&page_buf, _offset, &nbytes));
 
         header_length = nbytes;
         auto st = deserialize_thrift_msg(page_buf, &header_length, TProtocolType::COMPACT, &_cur_header);
@@ -41,15 +39,13 @@ Status PageReader::next_header() {
             break;
         }
         nbytes <<= 2;
-        if (nbytes > kHeaderBufMaxSize) {
+        if ((nbytes > kHeaderBufMaxSize) || (_offset + nbytes) >= _finish_offset) {
             return Status::Corruption("Failed to decode parquet page header");
         }
     } while (true);
 
     _offset += header_length;
     _next_header_pos = _offset + _cur_header.compressed_page_size;
-    _stream.skip(header_length);
-
     return Status::OK();
 }
 
@@ -58,7 +54,7 @@ Status PageReader::read_bytes(const uint8_t** buffer, size_t size) {
         return Status::InternalError("Size to read exceed page size");
     }
     uint64_t nbytes = size;
-    RETURN_IF_ERROR(_stream.get_bytes(buffer, &nbytes));
+    RETURN_IF_ERROR(_stream->get_bytes(buffer, _offset, &nbytes));
     DCHECK_EQ(nbytes, size);
     _offset += nbytes;
     return Status::OK();

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -29,8 +29,9 @@ Status PageReader::next_header() {
 
     uint32_t header_length = 0;
     size_t nbytes = kHeaderBufSize;
-
+    size_t remaining = _finish_offset - _offset;
     do {
+        nbytes = std::min(nbytes, remaining);
         RETURN_IF_ERROR(_stream->get_bytes(&page_buf, _offset, &nbytes));
 
         header_length = nbytes;

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -18,7 +18,7 @@ namespace starrocks::parquet {
 // Used to parse page header of column chunk. This class don't parse page's type.
 class PageReader {
 public:
-    PageReader(RandomAccessFile* file, size_t start, size_t length);
+    PageReader(IBufferedInputStream* stream, size_t start, size_t length);
     ~PageReader() = default;
 
     // Try to parse header starts from current _offset. Caller should assure that
@@ -36,13 +36,12 @@ public:
 
     // seek to read position, this position must be a start of a page header.
     void seek_to_offset(uint64_t offset) {
-        _stream.seek_to(offset);
         _offset = offset;
         _next_header_pos = offset;
     }
 
 private:
-    BufferedInputStream _stream;
+    IBufferedInputStream* _stream;
     tparquet::PageHeader _cur_header;
 
     uint64_t _offset = 0;

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "column_reader.h"
 #include "common/status.h"
 #include "formats/parquet/column_chunk_reader.h"
 #include "formats/parquet/schema.h"
@@ -13,26 +14,18 @@
 #include "gen_cpp/parquet_types.h"
 
 namespace starrocks {
-class RandomAccessFile;
 namespace vectorized {
 class Column;
-class HdfsScanStats;
 } // namespace vectorized
 } // namespace starrocks
 
 namespace starrocks::parquet {
 
 class ColumnChunkReader;
-
-struct StoredColumnReaderOptions {
-    vectorized::HdfsScanStats* stats = nullptr;
-};
-
 class StoredColumnReader {
 public:
-    static Status create(RandomAccessFile* file, const ParquetField* field,
-                         const tparquet::ColumnChunk* _chunk_metadata, const StoredColumnReaderOptions& opts,
-                         int chunk_size, std::unique_ptr<StoredColumnReader>* out);
+    static Status create(const ColumnReaderOptions& opts, const ParquetField* field,
+                         const tparquet::ColumnChunk* _chunk_metadata, std::unique_ptr<StoredColumnReader>* out);
 
     virtual ~StoredColumnReader() = default;
 

--- a/be/src/util/bfd_parser.cpp
+++ b/be/src/util/bfd_parser.cpp
@@ -21,6 +21,8 @@
 
 #include "util/bfd_parser.h"
 
+#include <bfd.h>
+
 #include <memory>
 #include <utility>
 

--- a/be/src/util/bfd_parser.h
+++ b/be/src/util/bfd_parser.h
@@ -25,6 +25,10 @@
 #define PACKAGE_VERSION
 #endif
 
+// Following macros are redefined in bfd.h
+#undef DIAGNOSTIC_PUSH
+#undef DIAGNOSTIC_POP
+#undef DIAGNOSTIC_IGNORE
 #include <bfd.h>
 
 #include <mutex>

--- a/be/src/util/bfd_parser.h
+++ b/be/src/util/bfd_parser.h
@@ -25,11 +25,8 @@
 #define PACKAGE_VERSION
 #endif
 
-// Following macros are redefined in bfd.h
-#undef DIAGNOSTIC_PUSH
-#undef DIAGNOSTIC_POP
-#undef DIAGNOSTIC_IGNORE
-#include <bfd.h>
+class bfd;
+class bfd_symbol;
 
 #include <mutex>
 #include <string>

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -8,10 +8,12 @@
 
 namespace starrocks {
 
-BufferedInputStream::BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
+// ===================================================================================
+
+DefaultBufferedInputStream::DefaultBufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
         : _file(file), _offset(offset), _end_offset(offset + length) {}
 
-Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {
+Status DefaultBufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {
     if (*nbytes <= num_remaining()) {
         *buffer = _buf.get() + _buf_position;
         if (!peek) {
@@ -32,7 +34,7 @@ Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bo
     return Status::OK();
 }
 
-void BufferedInputStream::reserve(size_t nbytes) {
+void DefaultBufferedInputStream::reserve(size_t nbytes) {
     if (nbytes <= _buf_capacity - _buf_position) {
         return;
     }
@@ -55,13 +57,96 @@ void BufferedInputStream::reserve(size_t nbytes) {
     _buf_position = 0;
 }
 
-Status BufferedInputStream::_read_data() {
+Status DefaultBufferedInputStream::_read_data() {
     size_t bytes_read = std::min(left_capactiy(), _end_offset - _file_offset);
     Slice slice(_buf.get() + _buf_written, bytes_read);
     ASSIGN_OR_RETURN(slice.size, _file->read_at(_file_offset, slice.data, slice.size));
     _file_offset += slice.size;
     _buf_written += slice.size;
     return Status::OK();
+}
+
+Status DefaultBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) {
+    seek_to(offset);
+    return get_bytes(buffer, nbytes, false);
+}
+
+// ===================================================================================
+
+SharedBufferedInputStream::SharedBufferedInputStream(RandomAccessFile* file) : _file(file) {}
+
+Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges) {
+    if (ranges.size() == 0) {
+        return Status::OK();
+    }
+    std::vector<IORange> check(ranges);
+    std::sort(check.begin(), check.end());
+    // check io range is not overlapped.
+    for (size_t i = 1; i < ranges.size(); i++) {
+        if (check[i].offset < (check[i - 1].offset + check[i - 1].size)) {
+            return Status::RuntimeError("io ranges are overalpped");
+        }
+    }
+
+    std::vector<IORange> small_ranges;
+    for (const IORange& r : check) {
+        if (r.size > _options.max_buffer_size) {
+            SharedBuffer sb = SharedBuffer{.offset = r.offset, .size = r.size, .ref_count = 1};
+            _map.insert(std::make_pair(r.offset + r.size, sb));
+        } else {
+            small_ranges.emplace_back(r);
+        }
+    }
+
+    if (small_ranges.size() > 0) {
+        auto update_map = [&](size_t from, size_t to) {
+            // merge from [unmerge, i-1]
+            int64_t ref_count = (to - from + 1);
+            int64_t end = (small_ranges[to].offset + small_ranges[to].size);
+            SharedBuffer sb = SharedBuffer{.offset = small_ranges[from].offset,
+                                           .size = end - small_ranges[from].offset,
+                                           .ref_count = ref_count};
+            _map.insert(std::make_pair(sb.offset + sb.size, sb));
+        };
+
+        size_t unmerge = 0;
+        for (size_t i = 1; i < small_ranges.size(); i++) {
+            const auto& prev = small_ranges[i - 1];
+            const auto& now = small_ranges[i];
+            size_t now_end = now.offset + now.size;
+            size_t prev_end = prev.offset + prev.size;
+            if (((now_end - small_ranges[unmerge].offset) <= _options.max_read_size) &&
+                (now.offset - prev_end) <= _options.max_dist_size) {
+                continue;
+            } else {
+                update_map(unmerge, i - 1);
+                unmerge = i;
+            }
+        }
+        update_map(unmerge, small_ranges.size() - 1);
+    }
+    return Status::OK();
+}
+
+Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) {
+    auto iter = _map.upper_bound(offset);
+    if (iter == _map.end()) {
+        return Status::RuntimeError("failed to find shared buffer based on offset");
+    }
+    SharedBuffer& sb = iter->second;
+    if ((sb.offset > offset) || (sb.offset + sb.size) < (offset + *nbytes)) {
+        return Status::RuntimeError("bad construction of shared buffer");
+    }
+    if (sb.buffer.capacity() == 0) {
+        sb.buffer.reserve(sb.size);
+        RETURN_IF_ERROR(_file->read_at_fully(sb.offset, sb.buffer.data(), sb.size));
+    }
+    *buffer = sb.buffer.data() + offset - sb.offset;
+    return Status::OK();
+}
+
+void SharedBufferedInputStream::release() {
+    _map.clear();
 }
 
 } // namespace starrocks

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -12,11 +12,16 @@ namespace starrocks {
 
 class RandomAccessFile;
 
-class BufferedInputStream {
+class IBufferedInputStream {
 public:
-    BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length);
+    virtual Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) = 0;
+};
 
-    ~BufferedInputStream() = default;
+class DefaultBufferedInputStream : public IBufferedInputStream {
+public:
+    DefaultBufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length);
+
+    virtual ~DefaultBufferedInputStream() = default;
 
     void seek_to(uint64_t offset) {
         uint64_t current_file_offset = tell();
@@ -46,6 +51,8 @@ public:
 
     void reserve(size_t nbytes);
 
+    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) override;
+
 private:
     Status _read_data();
     size_t num_remaining() const { return _buf_written - _buf_position; }
@@ -62,6 +69,43 @@ private:
     size_t _buf_written = 0;
 
     uint64_t _file_offset = 0;
+};
+
+class SharedBufferedInputStream : public IBufferedInputStream {
+public:
+    struct IORange {
+        int64_t offset;
+        int64_t size;
+        bool operator<(const IORange& x) const { return offset < x.offset; }
+    };
+    struct CoalesceOptions {
+        static constexpr int64_t MB = 1024 * 1024;
+        int64_t max_read_size = 16 * MB;
+        int64_t max_dist_size = 1 * MB;
+        int64_t max_buffer_size = 8 * MB;
+    };
+
+    SharedBufferedInputStream(RandomAccessFile* file);
+
+    virtual ~SharedBufferedInputStream() = default;
+
+    Status set_io_ranges(const std::vector<IORange>& ranges);
+    Status remove_io_range(const IORange& range);
+
+    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) override;
+    void release();
+
+private:
+    struct SharedBuffer {
+    public:
+        int64_t offset;
+        int64_t size;
+        int64_t ref_count;
+        std::vector<uint8_t> buffer;
+    };
+    RandomAccessFile* _file;
+    std::map<int64_t, SharedBuffer> _map;
+    CoalesceOptions _options;
 };
 
 } // namespace starrocks

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -15,13 +15,14 @@ class RandomAccessFile;
 class IBufferedInputStream {
 public:
     virtual Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) = 0;
+    virtual ~IBufferedInputStream() {}
 };
 
 class DefaultBufferedInputStream : public IBufferedInputStream {
 public:
     DefaultBufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length);
 
-    virtual ~DefaultBufferedInputStream() = default;
+    ~DefaultBufferedInputStream() override = default;
 
     void seek_to(uint64_t offset) {
         uint64_t current_file_offset = tell();
@@ -87,7 +88,7 @@ public:
 
     SharedBufferedInputStream(RandomAccessFile* file);
 
-    virtual ~SharedBufferedInputStream() = default;
+    ~SharedBufferedInputStream() override = default;
 
     Status set_io_ranges(const std::vector<IORange>& ranges);
     Status remove_io_range(const IORange& range);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -167,7 +167,7 @@ set(EXEC_FILES
         ./storage/rowset/bloom_filter_index_reader_writer_test.cpp
         ./storage/rowset/column_reader_writer_test.cpp
         ./storage/rowset/encoding_info_test.cpp
-        #./storage/rowset/frame_of_reference_page_test.cpp
+        ./storage/rowset/frame_of_reference_page_test.cpp
         ./storage/rowset/ordinal_page_index_test.cpp
         ./storage/rowset/plain_page_test.cpp
         ./storage/rowset/rle_page_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -167,7 +167,7 @@ set(EXEC_FILES
         ./storage/rowset/bloom_filter_index_reader_writer_test.cpp
         ./storage/rowset/column_reader_writer_test.cpp
         ./storage/rowset/encoding_info_test.cpp
-        ./storage/rowset/frame_of_reference_page_test.cpp
+        #./storage/rowset/frame_of_reference_page_test.cpp
         ./storage/rowset/ordinal_page_index_test.cpp
         ./storage/rowset/plain_page_test.cpp
         ./storage/rowset/rle_page_test.cpp

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -198,7 +198,7 @@ static Permutation make_permutation(int len) {
     return perm;
 }
 
-static std::vector<ChunkPtr> consume_pages_from_sorter(ChunksSorter& sorter) {
+[[maybe_unused]] static std::vector<ChunkPtr> consume_pages_from_sorter(ChunksSorter& sorter) {
     std::vector<ChunkPtr> result;
 
     bool eos = false;

--- a/be/test/formats/parquet/page_reader_test.cpp
+++ b/be/test/formats/parquet/page_reader_test.cpp
@@ -57,8 +57,9 @@ TEST_F(ParquetPageReaderTest, Normal) {
     size_t total_size = buffer.size();
 
     RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
+    DefaultBufferedInputStream stream(&file, 0, total_size);
 
-    PageReader reader(&file, 0, total_size);
+    PageReader reader(&stream, 0, total_size);
 
     // read page 1
     auto st = reader.next_header();

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -59,7 +59,7 @@ TEST(CompactionUtilsTest, test_get_segment_max_rows) {
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
     ASSERT_EQ(2147483647, segment_max_rows);
 
-    max_segment_file_size = 1LL << 63;
+    max_segment_file_size = std::numeric_limits<int64_t>::max();
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
     ASSERT_EQ(2147483647, segment_max_rows);
 

--- a/be/test/util/buffered_stream_test.cpp
+++ b/be/test/util/buffered_stream_test.cpp
@@ -24,7 +24,7 @@ TEST_F(BufferedStreamTest, Normal) {
     }
     RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(test_str)), "string-file");
 
-    BufferedInputStream stream(&file, 0, 10);
+    DefaultBufferedInputStream stream(&file, 0, 10);
 
     ASSERT_EQ(0, stream.tell());
     {
@@ -60,7 +60,7 @@ TEST_F(BufferedStreamTest, Large) {
     test_str.resize(66 * 1024);
     RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(test_str)), "string-file");
 
-    BufferedInputStream stream(&file, 0, 66 * 1024);
+    DefaultBufferedInputStream stream(&file, 0, 66 * 1024);
 
     // get 1K
     {
@@ -92,7 +92,7 @@ TEST_F(BufferedStreamTest, Large2) {
     test_str.resize(65 * 1024);
     RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(test_str)), "string-file");
 
-    BufferedInputStream stream(&file, 0, 65 * 1024);
+    DefaultBufferedInputStream stream(&file, 0, 65 * 1024);
 
     // get 1K
     {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The reason why we need parquet_coalesce_reads is we found there are a lot of small reads in production cases. And small reads are very bad for remote storage like HDFS/S3, those filesystems prefer large reads like 8M ~ 16MB. So the idea of this PR is merge small reads into a large one(fit into 16MB)

This PR works in following way:
- when reading a row group, we know which columns we are going to read, and we know the io range of that column.
- Let's say we have 4 columns in a row group:
  - [4, 10]
  - [20,30]
  - [50,60]
  - [80,90]
- We can read [4,90] into a memory, and this memory can be shared by 4 column readers.

We mege io ranges in following way:
- we only merge small io ranges (< 8MB)
- the merged range can not exceed 16MB
- two consecutive ranges can not have large gap like 1MB

Those parameters can be tuned but now it's hardcoded.

```cpp
    struct CoalesceOptions {
        static constexpr int64_t MB = 1024 * 1024;
        int64_t max_read_size = 16 * MB;
        int64_t max_dist_size = 1 * MB;
        int64_t max_buffer_size = 8 * MB;
    };
```


----



Take SSB/Q4.1 for example 

```
-- Q4.1
select d_year, c_nation, sum(lo_revenue) - sum(lo_supplycost) as profit
from lineorder
join dates on lo_orderdate = d_datekey
join customer on lo_custkey = c_custkey
join supplier on lo_suppkey = s_suppkey
join part on lo_partkey = p_partkey
where c_region = 'AMERICA' and s_region = 'AMERICA' and (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2')
group by d_year, c_nation
order by d_year, c_nation;
```

Running on my local env with 100G on HDFS

- disable_coalesce_reads: IO=11790, Bytes=10833.9MB
- enable_coalesce_reads: IO=1800, Bytes=10844.2MB

```
mbp :: ~/Downloads » scan-node-io-stat --file enable.html --node 0
hosts: ( 172.31.32.94 172.31.38.245 172.31.45.105 ) => 3 hosts
IO bytes = 10844.2MB
IO counter = 1800
IO time = 335000ms
IO scan ranges = 900
IO scan files = 450
Rows = return 9994917, read 600037902
avg read size = 6169.144888888889KB
avg read lat = 186.11111111111111ms

mbp :: ~/Downloads » scan-node-io-stat --file disable.html --node 0
hosts: ( 172.31.32.94 172.31.38.245 172.31.45.105 ) => 3 hosts
IO bytes = 10833.9MB
IO counter = 11790
IO time = 676000ms
IO scan ranges = 900
IO scan files = 450
Rows = return 10019349, read 600037902
avg read size = 940.95959287531798KB
avg read lat = 57.336726039016114ms
```

----

Benchmark on SSB-100G, 3 BE nodes, 1 FE nodes. Coalesce-Reads does not hurt performance.

Parquet in Snappy

Query | SR(P=8) | Coalesce Reads | Ratio
-- | -- | -- | --
Q01 | 1533 | 1601 | 1.04
Q02 | 1509 | 1505 | 1
Q03 | 1444 | 1497 | 1.04
Q04 | 2737 | 2775 | 1.01
Q05 | 2653 | 2600 | 0.98
Q06 | 2802 | 2592 | 0.93
Q07 | 3248 | 3449 | 1.06
Q08 | 2717 | 2700 | 0.99
Q09 | 2661 | 2671 | 1
Q10 | 2731 | 2705 | 0.99
Q11 | 4034 | 4385 | 1.09
Q12 | 3738 | 3922 | 1.05
Q13 | 3912 | 3753 | 0.96
SUM | 35719 | 36155 | 1.01

Parquet in Zlib



Query | SR(P=8) | Coalesce Reads | Ratio
-- | -- | -- | --
Q01 | 1506 | 1574 | 1.05
Q02 | 1454 | 1507 | 1.04
Q03 | 1607 | 1504 | 0.94
Q04 | 2732 | 2832 | 1.04
Q05 | 2633 | 2611 | 0.99
Q06 | 2683 | 2586 | 0.96
Q07 | 3228 | 3407 | 1.06
Q08 | 2763 | 2834 | 1.03
Q09 | 2710 | 2641 | 0.97
Q10 | 2656 | 2571 | 0.97
Q11 | 4263 | 4499 | 1.06
Q12 | 3830 | 3894 | 1.02
Q13 | 3733 | 3696 | 0.99
SUM | 35798 | 36156 | 1.01



