### PR TITLE
[BugFix] Fix wrong column order

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -213,7 +213,19 @@ void HdfsScannerContext::set_columns_from_file(const std::unordered_set<std::str
     }
 }
 
-void HdfsScannerContext::append_not_exised_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+void HdfsScannerContext::update_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+    if (not_existed_slots.size() == 0) return;
+
+    ChunkPtr& ck = (*chunk);
+    for (auto* slot_desc : not_existed_slots) {
+        auto col = ck->get_column_by_slot_id(slot_desc->id());
+        if (row_count > 0) {
+            col->append_default(row_count);
+        }
+    }
+}
+
+void HdfsScannerContext::append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
     if (not_existed_slots.size() == 0) return;
 
     ChunkPtr& ck = (*chunk);
@@ -232,13 +244,35 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
 
     // build chunk for evaluation.
     ChunkPtr chunk = std::make_shared<Chunk>();
-    append_not_exised_columns_to_chunk(&chunk, 1);
+    append_not_existed_columns_to_chunk(&chunk, 1);
     // do evaluation.
     {
         SCOPED_RAW_TIMER(&stats->expr_filter_ns);
         RETURN_IF_ERROR(ExecNode::eval_conjuncts(conjunct_ctxs_of_non_existed_slots, chunk.get()));
     }
     return !(chunk->has_rows());
+}
+
+void HdfsScannerContext::update_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {
+    if (partition_columns.size() == 0) return;
+
+    ChunkPtr& ck = (*chunk);
+    for (size_t i = 0; i < partition_columns.size(); i++) {
+        SlotDescriptor* slot_desc = partition_columns[i].slot_desc;
+        DCHECK(partition_values[i]->is_constant());
+        auto* const_column = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(partition_values[i]);
+        ColumnPtr data_column = const_column->data_column();
+        auto chunk_part_column = ck->get_column_by_slot_id(slot_desc->id());
+
+        if (row_count > 0) {
+            if (data_column->is_nullable()) {
+                chunk_part_column->append_nulls(1);
+            } else {
+                chunk_part_column->append(*data_column, 0, 1);
+            }
+            chunk_part_column->assign(row_count, 0);
+        }
+    }
 }
 
 void HdfsScannerContext::append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count) {

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -159,14 +159,14 @@ struct HdfsScannerContext {
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void update_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_not_existed_columns_of_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
 
     // other helper functions.
-    void update_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_partition_column_of_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
 
     void append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -159,15 +159,18 @@ struct HdfsScannerContext {
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void append_not_exised_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
 
     // other helper functions.
-    void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+
+    void append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
 };
 
 // if *lvalue == expect, swap(*lvalue,*rvalue)

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -455,7 +455,14 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
-    ChunkPtr& ck = *chunk;
+    ChunkPtr ck = std::make_shared<vectorized::Chunk>();
+    auto convert_to_output = [chunk, &ck]() {
+        const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+        for (auto iter = slot_id_to_index_map.begin(); iter != slot_id_to_index_map.end(); iter++) {
+            (*chunk)->get_column_by_slot_id(iter->first)->swap_column(*ck->get_column_by_slot_id(iter->first));
+        }
+    };
+
     // this infinite for loop is for retry.
     for (;;) {
         orc::RowReader::ReadPosition position;
@@ -484,13 +491,13 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                     ret = _orc_reader->get_active_chunk();
                 }
                 RETURN_IF_ERROR(ret);
-                *chunk = std::move(ret.value());
+                ck = std::move(ret.value());
             }
 
             // important to add columns before evaluation
             // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _scanner_ctx.append_not_exised_columns_to_chunk(chunk, ck->num_rows());
-            _scanner_ctx.append_partition_column_to_chunk(chunk, ck->num_rows());
+            _scanner_ctx.append_not_existed_columns_to_chunk(&ck, ck->num_rows());
+            _scanner_ctx.append_partition_column_to_chunk(&ck, ck->num_rows());
             chunk_size = ck->num_rows();
             // do stats before we filter rows which does not match.
             _stats.raw_rows_read += chunk_size;
@@ -516,6 +523,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         ck->set_num_rows(chunk_size);
 
         if (!_orc_reader->has_lazy_load_context()) {
+            convert_to_output();
             return Status::OK();
         }
 
@@ -539,6 +547,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             Chunk& ret_ck = *(ret.value());
             ck->merge(std::move(ret_ck));
         }
+        convert_to_output();
         return Status::OK();
     }
     __builtin_unreachable();

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -411,8 +411,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->append_not_exised_columns_to_chunk(chunk, row_count);
-                _scanner_ctx->append_partition_column_to_chunk(chunk, row_count);
+                _scanner_ctx->update_not_existed_columns_to_chunk(chunk, row_count);
+                _scanner_ctx->update_partition_column_to_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {
@@ -430,8 +430,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->append_not_exised_columns_to_chunk(chunk, read_size);
-        _scanner_ctx->append_partition_column_to_chunk(chunk, read_size);
+        _scanner_ctx->update_not_existed_columns_to_chunk(chunk, read_size);
+        _scanner_ctx->update_partition_column_to_chunk(chunk, read_size);
         _scan_row_count += read_size;
         return Status::OK();
     }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -430,8 +430,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->update_not_existed_columns_to_chunk(chunk, read_size);
-        _scanner_ctx->update_partition_column_to_chunk(chunk, read_size);
+        _scanner_ctx->update_not_existed_columns_of_chunk(chunk, read_size);
+        _scanner_ctx->update_partition_column_of_chunk(chunk, read_size);
         _scan_row_count += read_size;
         return Status::OK();
     }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -411,8 +411,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->update_not_existed_columns_to_chunk(chunk, row_count);
-                _scanner_ctx->update_partition_column_to_chunk(chunk, row_count);
+                _scanner_ctx->update_not_existed_columns_of_chunk(chunk, row_count);
+                _scanner_ctx->update_partition_column_of_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -287,6 +287,7 @@ static void extend_partition_values(ObjectPool* pool, HdfsScannerParams* params,
         auto chunk = vectorized::ChunkHelper::new_chunk(*tuple_desc, 0);               \
         uint64_t records = 0;                                                          \
         for (;;) {                                                                     \
+            chunk->reset();                                                            \
             status = scanner->get_next(_runtime_state, &chunk);                        \
             if (status.is_end_of_file()) {                                             \
                 break;                                                                 \


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6028  https://github.com/StarRocks/starrocks/issues/7177  https://github.com/StarRocks/starrocks/issues/7330 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since `DataStreamRecvr::SenderQueue::_build_chunk_meta` is only called for the first chunk it receive, so the subsequent chunk should remain the same column order as the first chunk, otherwise, the deserialize might get wrong   type from chunk meta.