### PR TITLE
[StarRocks On ES] Wrong _id type causes table creation to fail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -261,6 +261,11 @@ public class EsTable extends Table {
                 sslEnabled = false;
             }
         }
+        Column idColumn = getColumn("_id");
+        if (idColumn != null && !(idColumn.getPrimitiveType() == PrimitiveType.VARCHAR
+                || idColumn.getPrimitiveType() == PrimitiveType.CHAR)) {
+            throw new DdlException("Type of _id (ES Primary-Key) Column must be Char/Varchar");
+        }
         tableContext.put("hosts", hosts);
         tableContext.put("userName", userName);
         tableContext.put("passwd", passwd);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/StarRocks/starrocks/issues/7490

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Some users want to get _id, but set the wrong type, resulting in some unexpected errors.  
Therefore, it may be necessary for us to add verification when creating the table

