### PR TITLE
[Enhancement] support prune shuffle columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -203,7 +203,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
-    public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
+    public static final String PRUNE_SHUFFLE_COLUMN_CARDINALITY_RATE = "prune_shuffle_column_cardinality_rate";
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -550,15 +550,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_SHOW_ALL_VARIABLES, flag = VariableMgr.INVISIBLE)
     private boolean enableShowAllVariables = false;
 
-    @VarAttr(name = CBO_PRUNE_SHUFFLE_COLUMN_RATE, flag = VariableMgr.INVISIBLE)
-    private double cboPruneShuffleColumnCardinality = 0.1;
+    @VarAttr(name = PRUNE_SHUFFLE_COLUMN_CARDINALITY_RATE, flag = VariableMgr.INVISIBLE)
+    private double pruneShuffleColumnCardinalityRate = 0.1;
 
-    public double getCboPruneShuffleColumnCardinality() {
-        return cboPruneShuffleColumnCardinality;
+    public double getPruneShuffleColumnCardinalityRate() {
+        return pruneShuffleColumnCardinalityRate;
     }
 
-    public void setCboPruneShuffleColumnCardinality(double cboPruneShuffleColumnCardinality) {
-        this.cboPruneShuffleColumnCardinality = cboPruneShuffleColumnCardinality;
+    public void setPruneShuffleColumnCardinalityRate(double pruneShuffleColumnCardinalityRate) {
+        this.pruneShuffleColumnCardinalityRate = pruneShuffleColumnCardinalityRate;
     }
 
     public boolean isEnableShowAllVariables() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -203,6 +203,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
+    public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -548,6 +549,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_SHOW_ALL_VARIABLES, flag = VariableMgr.INVISIBLE)
     private boolean enableShowAllVariables = false;
+
+    @VarAttr(name = CBO_PRUNE_SHUFFLE_COLUMN_RATE, flag = VariableMgr.INVISIBLE)
+    private double cboPruneShuffleColumnCardinality = 0.1;
+
+    public double getCboPruneShuffleColumnCardinality() {
+        return cboPruneShuffleColumnCardinality;
+    }
+
+    public void setCboPruneShuffleColumnCardinality(double cboPruneShuffleColumnCardinality) {
+        this.cboPruneShuffleColumnCardinality = cboPruneShuffleColumnCardinality;
+    }
 
     public boolean isEnableShowAllVariables() {
         return enableShowAllVariables;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -203,7 +203,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
-    public static final String PRUNE_SHUFFLE_COLUMN_CARDINALITY_RATE = "prune_shuffle_column_cardinality_rate";
+    public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -550,15 +550,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_SHOW_ALL_VARIABLES, flag = VariableMgr.INVISIBLE)
     private boolean enableShowAllVariables = false;
 
-    @VarAttr(name = PRUNE_SHUFFLE_COLUMN_CARDINALITY_RATE, flag = VariableMgr.INVISIBLE)
-    private double pruneShuffleColumnCardinalityRate = 0.1;
+    @VarAttr(name = CBO_PRUNE_SHUFFLE_COLUMN_RATE, flag = VariableMgr.INVISIBLE)
+    private double cboPruneShuffleColumnRate = 0.1;
 
-    public double getPruneShuffleColumnCardinalityRate() {
-        return pruneShuffleColumnCardinalityRate;
+    public double getCboPruneShuffleColumnRate() {
+        return cboPruneShuffleColumnRate;
     }
 
-    public void setPruneShuffleColumnCardinalityRate(double pruneShuffleColumnCardinalityRate) {
-        this.pruneShuffleColumnCardinalityRate = pruneShuffleColumnCardinalityRate;
+    public void setCboPruneShuffleColumnRate(double cboPruneShuffleColumnRate) {
+        this.cboPruneShuffleColumnRate = cboPruneShuffleColumnRate;
     }
 
     public boolean isEnableShowAllVariables() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -304,16 +304,16 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
 
             // 2.1 respect the hint
             if ("SHUFFLE".equalsIgnoreCase(hint)) {
-                if (leftDistributionDesc.isLocalShuffle()) {
+                if (leftDistributionDesc.isLocal()) {
                     enforceChildShuffleDistribution(leftShuffleColumns, leftChild, leftChildOutputProperty, 0);
                 }
-                if (rightDistributionDesc.isLocalShuffle()) {
+                if (rightDistributionDesc.isLocal()) {
                     enforceChildShuffleDistribution(rightShuffleColumns, rightChild, rightChildOutputProperty, 1);
                 }
                 return visitOperator(node, context);
             }
 
-            if (leftDistributionDesc.isLocalShuffle() && rightDistributionDesc.isLocalShuffle()) {
+            if (leftDistributionDesc.isLocal() && rightDistributionDesc.isLocal()) {
                 // colocate join
                 if ("BUCKET".equalsIgnoreCase(hint) ||
                         !canColocateJoin(leftDistributionSpec, rightDistributionSpec, leftShuffleColumns,
@@ -321,11 +321,11 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
                     transToBucketShuffleJoin(leftDistributionSpec, leftShuffleColumns, rightShuffleColumns);
                 }
                 return visitOperator(node, context);
-            } else if (leftDistributionDesc.isLocalShuffle() && rightDistributionDesc.isShuffle()) {
+            } else if (leftDistributionDesc.isLocal() && rightDistributionDesc.isShuffle()) {
                 // bucket join
                 transToBucketShuffleJoin(leftDistributionSpec, leftShuffleColumns, rightShuffleColumns);
                 return visitOperator(node, context);
-            } else if (leftDistributionDesc.isShuffle() && rightDistributionDesc.isLocalShuffle()) {
+            } else if (leftDistributionDesc.isShuffle() && rightDistributionDesc.isLocal()) {
                 // coordinator can not bucket shuffle data from left to right, so we need to adjust to shuffle join
                 enforceChildShuffleDistribution(rightShuffleColumns, rightChild, rightChildOutputProperty, 1);
                 return visitOperator(node, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
@@ -150,10 +150,14 @@ public abstract class OptExpressionVisitor<R, C> {
     }
 
     public R visitPhysicalHashJoin(OptExpression optExpression, C context) {
-        return visit(optExpression, context);
+        return visitPhysicalJoin(optExpression, context);
     }
 
     public R visitPhysicalMergeJoin(OptExpression optExpression, C context) {
+        return visitPhysicalJoin(optExpression, context);
+    }
+
+    public R visitPhysicalJoin(OptExpression optExpression, C context) {
         return visit(optExpression, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -175,6 +175,7 @@ public class Optimizer {
         // Rewrite Exchange on top of Sort to Final Sort
         result = new ExchangeSortToMergeRule().rewrite(result);
         result = new PruneAggregateNodeRule().rewrite(result, rootTaskContext);
+        result = new PruneShuffleColumnRule().rewrite(result, rootTaskContext);
         result = new AddDecodeNodeForDictStringRule().rewrite(result, rootTaskContext);
         // This rule should be last
         result = new ScalarOperatorsReuseRule().rewrite(result, rootTaskContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -80,7 +80,7 @@ public class Optimizer {
         context = new OptimizerContext(memo, columnRefFactory, connectContext);
         context.setTraceInfo(new OptimizerTraceInfo(connectContext.getQueryId()));
         TaskContext rootTaskContext =
-                new TaskContext(context, requiredProperty, (ColumnRefSet) requiredColumns.clone(), Double.MAX_VALUE);
+                new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
 
         // Note: root group of memo maybe change after rewrite,
         // so we should always get root group and root group expression

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -189,13 +189,13 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             HashDistributionDesc leftDistributionDesc = leftDistributionSpec.getHashDistributionDesc();
             HashDistributionDesc rightDistributionDesc = rightDistributionSpec.getHashDistributionDesc();
 
-            if (leftDistributionDesc.isLocalShuffle() && rightDistributionDesc.isLocalShuffle()) {
+            if (leftDistributionDesc.isLocal() && rightDistributionDesc.isLocal()) {
                 // colocate join
                 return computeHashJoinDistributionPropertyInfo(node,
                         computeColocateJoinOutputProperty(leftDistributionSpec, rightDistributionSpec),
                         leftOnPredicateColumns,
                         rightOnPredicateColumns, context);
-            } else if (leftDistributionDesc.isLocalShuffle() && rightDistributionDesc.isBucketJoin()) {
+            } else if (leftDistributionDesc.isLocal() && rightDistributionDesc.isBucketJoin()) {
                 // bucket join
                 return computeHashJoinDistributionPropertyInfo(node, leftChildOutputProperty, leftOnPredicateColumns,
                         rightOnPredicateColumns, context);
@@ -206,7 +206,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                         computeShuffleJoinOutputProperty(leftShuffleColumns),
                         leftOnPredicateColumns,
                         rightOnPredicateColumns, context);
-            } else if (leftDistributionDesc.isShuffle() && rightDistributionDesc.isLocalShuffle()) {
+            } else if (leftDistributionDesc.isShuffle() && rightDistributionDesc.isLocal()) {
                 // coordinator can not bucket shuffle data from left to right
                 Preconditions.checkState(false, "Children output property distribution error");
                 return PhysicalPropertySet.EMPTY;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PruneShuffleColumnRule.java
@@ -1,0 +1,197 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rewrite.PhysicalOperatorTreeRewriteRule;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PruneShuffleColumnRule implements PhysicalOperatorTreeRewriteRule {
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        PruneShuffleColumnVisitor visitor = new PruneShuffleColumnVisitor(taskContext);
+        visitor.rewrite(root);
+        return root;
+    }
+
+    private static class PruneShuffleColumnVisitor extends OptExpressionVisitor<OptExpression, DistributionContext> {
+        private final ColumnRefFactory factory;
+        private final SessionVariable sessionVariable;
+
+        public PruneShuffleColumnVisitor(TaskContext taskContext) {
+            this.factory = taskContext.getOptimizerContext().getColumnRefFactory();
+            this.sessionVariable = taskContext.getOptimizerContext().getSessionVariable();
+        }
+
+        public void rewrite(OptExpression root) {
+            DistributionContext rootContext = new DistributionContext();
+            root.getOp().accept(this, root, rootContext);
+            prune(rootContext);
+        }
+
+        @Override
+        public OptExpression visit(OptExpression optExpression, DistributionContext context) {
+            for (int i = 0; i < optExpression.arity(); ++i) {
+                optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), context);
+            }
+            return optExpression;
+        }
+
+        @Override
+        public OptExpression visitPhysicalCTEAnchor(OptExpression optExpression, DistributionContext context) {
+            optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), context);
+            return optExpression;
+        }
+
+        @Override
+        public OptExpression visitPhysicalDistribution(OptExpression optExpression, DistributionContext context) {
+            context.addDistribution(optExpression);
+
+            DistributionContext childContext = new DistributionContext();
+            visit(optExpression, childContext);
+
+            prune(childContext);
+            return optExpression;
+        }
+
+        private void prune(DistributionContext childContext) {
+            // only join can be return more distribution
+            if (childContext.distributionList.size() < 2) {
+                return;
+            }
+
+            Preconditions.checkState(childContext.distributionList.stream()
+                    .allMatch(s -> s.getDistributionSpec().getType() == DistributionSpec.DistributionType.SHUFFLE));
+
+            List<HashDistributionDesc> descs = childContext.distributionList.stream()
+                    .map(s -> ((HashDistributionSpec) s.getDistributionSpec()).getHashDistributionDesc()).collect(
+                            Collectors.toList());
+
+            Preconditions.checkState(descs.stream().mapToInt(d -> d.getColumns().size()).distinct().count() == 1);
+
+            if (descs.stream().mapToInt(d -> d.getColumns().size()).distinct().min().orElse(0) < 2) {
+                return;
+            }
+
+            // choose high cardinality column
+            int columnSize = descs.get(0).getColumns().size();
+            int maxColumnIndex = -1;
+            double maxRatio = -1;
+
+            for (int i = 0; i < columnSize; i++) {
+                for (int j = 0; j < descs.size(); j++) {
+                    ColumnRefOperator ref = factory.getColumnRef(descs.get(j).getColumns().get(i));
+                    ColumnStatistic cs = childContext.statistics.get(j).getColumnStatistic(ref);
+
+                    if (cs.isUnknown()) {
+                        continue;
+                    }
+
+                    double ratio =
+                            cs.getDistinctValuesCount() / childContext.statistics.get(j).getOutputRowCount();
+                    if ((cs.getDistinctValuesCount() <
+                            StatisticsEstimateCoefficient.DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT) ||
+                            (ratio < sessionVariable.getCboPruneShuffleColumnCardinality())) {
+                        continue;
+                    }
+
+                    if (ratio > maxRatio) {
+                        maxRatio = ratio;
+                        maxColumnIndex = i;
+                    }
+                }
+            }
+
+            if (maxColumnIndex > -1) {
+                for (HashDistributionDesc d : descs) {
+                    int x = d.getColumns().get(maxColumnIndex);
+                    d.getColumns().clear();
+                    d.getColumns().add(x);
+                }
+            }
+        }
+
+        @Override
+        public OptExpression visitPhysicalJoin(OptExpression optExpression, DistributionContext context) {
+            DistributionContext lc = new DistributionContext();
+            DistributionContext rc = new DistributionContext();
+
+            optExpression.getInputs().get(0).getOp().accept(this, optExpression.getInputs().get(0), lc);
+            optExpression.getInputs().get(1).getOp().accept(this, optExpression.getInputs().get(1), rc);
+
+            if (lc.distributionList.isEmpty() || rc.distributionList.isEmpty()) {
+                return optExpression;
+            }
+
+            if (canPrune(lc) && canPrune(rc)) {
+                context.add(lc);
+                context.add(rc);
+            }
+            return optExpression;
+        }
+
+        private boolean canPrune(DistributionContext context) {
+            for (PhysicalDistributionOperator d : context.distributionList) {
+                if (d.getDistributionSpec().getType() != DistributionSpec.DistributionType.SHUFFLE) {
+                    return false;
+                }
+
+                HashDistributionDesc desc = ((HashDistributionSpec) d.getDistributionSpec()).getHashDistributionDesc();
+                if (!desc.isShuffle() && !desc.isShuffleEnforce()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public OptExpression visitPhysicalUnion(OptExpression optExpression, DistributionContext context) {
+            visit(optExpression, new DistributionContext());
+            return optExpression;
+        }
+
+        @Override
+        public OptExpression visitPhysicalExcept(OptExpression optExpression, DistributionContext context) {
+            visit(optExpression, new DistributionContext());
+            return optExpression;
+        }
+
+        @Override
+        public OptExpression visitPhysicalIntersect(OptExpression optExpression, DistributionContext context) {
+            visit(optExpression, new DistributionContext());
+            return optExpression;
+        }
+    }
+
+    public static class DistributionContext {
+        public final List<PhysicalDistributionOperator> distributionList = Lists.newArrayList();
+        public final List<Statistics> statistics = Lists.newArrayList();
+
+        public void addDistribution(OptExpression optExpression) {
+            Preconditions.checkState(optExpression.getOp().getOpType() == OperatorType.PHYSICAL_DISTRIBUTION);
+            this.distributionList.add((PhysicalDistributionOperator) optExpression.getOp());
+            this.statistics.add(optExpression.getStatistics());
+        }
+
+        public void add(DistributionContext other) {
+            this.distributionList.addAll(other.distributionList);
+            this.statistics.addAll(other.statistics);
+        }
+
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PruneShuffleColumnRule.java
@@ -127,7 +127,7 @@ public class PruneShuffleColumnRule implements PhysicalOperatorTreeRewriteRule {
                             cs.getDistinctValuesCount() / childContext.statistics.get(j).getOutputRowCount();
                     if ((cs.getDistinctValuesCount() <
                             StatisticsEstimateCoefficient.DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT) ||
-                            (ratio < sessionVariable.getPruneShuffleColumnCardinalityRate())) {
+                            (ratio < sessionVariable.getCboPruneShuffleColumnRate())) {
                         continue;
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -74,7 +74,7 @@ public class HashDistributionDesc {
         return this.columns.equals(item.columns);
     }
 
-    public boolean isLocalShuffle() {
+    public boolean isLocal() {
         return this.sourceType == SourceType.LOCAL;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
@@ -76,15 +76,15 @@ public class PreAggregateTurnOnRule {
             ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(projection.getColumnRefMap());
 
             context.aggregations = context.aggregations.stream()
-                    .map(d -> rewriter.rewrite(d))
+                    .map(rewriter::rewrite)
                     .collect(Collectors.toList());
 
             context.groupings = context.groupings.stream()
-                    .map(d -> rewriter.rewrite(d))
+                    .map(rewriter::rewrite)
                     .collect(Collectors.toList());
 
             context.joinPredicates = context.joinPredicates.stream().filter(Objects::nonNull)
-                    .map(d -> rewriter.rewrite(d))
+                    .map(rewriter::rewrite)
                     .collect(Collectors.toList());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -32,6 +32,8 @@ public class StatisticsEstimateCoefficient {
     // if after aggregate row count < (input row count * DEFAULT_AGGREGATE_EFFECT_COEFFICIENT),
     // the aggregate has good effect.
     public static final double DEFAULT_AGGREGATE_EFFECT_COEFFICIENT = 0.001;
-    // default selectivity for anti jion
+    // default selectivity for anti join
     public static final double DEFAULT_ANTI_JOIN_SELECTIVITY_COEFFICIENT = 0.4;
+    // default shuffle column row count limit
+    public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -12,6 +12,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
+        connectContext.getSessionVariable().setCboPruneShuffleColumnCardinality(0);
     }
 
     @After
@@ -92,6 +93,24 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     @Test
     public void testTPCHQ5EnumPlan() {
         runFileUnitTest("enumerate-plan/tpch-q5");
+    }
+
+    @Test
+    public void test() throws Exception {
+        String sql = "select SUM(l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity) as amount\n" +
+                "from\n" +
+                "    part,\n" +
+                "    partsupp,\n" +
+                "    lineitem\n" +
+                "where\n" +
+                "    p_partkey = cast(l_partkey as bigint)\n" +
+                "    and ps_suppkey = l_suppkey\n" +
+                "    and ps_partkey = l_partkey\n" +
+                "    and p_name like '%peru%';\n";
+
+        // @haiu du
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -96,24 +96,6 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void test() throws Exception {
-        String sql = "select SUM(l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity) as amount\n" +
-                "from\n" +
-                "    part,\n" +
-                "    partsupp,\n" +
-                "    lineitem\n" +
-                "where\n" +
-                "    p_partkey = cast(l_partkey as bigint)\n" +
-                "    and ps_suppkey = l_suppkey\n" +
-                "    and ps_partkey = l_partkey\n" +
-                "    and p_name like '%peru%';\n";
-
-        // @haiu du
-        String plan = getFragmentPlan(sql);
-        System.out.println(plan);
-    }
-
-    @Test
     public void testTPCHQ6EnumPlan() {
         runFileUnitTest("enumerate-plan/tpch-q6");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -12,7 +12,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
-        connectContext.getSessionVariable().setCboPruneShuffleColumnCardinality(0);
+        connectContext.getSessionVariable().setPruneShuffleColumnCardinalityRate(0);
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -12,7 +12,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
-        connectContext.getSessionVariable().setPruneShuffleColumnCardinalityRate(0);
+        connectContext.getSessionVariable().setCboPruneShuffleColumnRate(0);
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1045,5 +1045,17 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 03\n" +
                 "    HASH_PARTITIONED: 6: v6");
+
+        sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6 " +
+                "               join[broadcast] t2 on t0.v2 = t2.v8";
+
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    HASH_PARTITIONED: 3: v3");
+
+        assertContains(plan, "STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    HASH_PARTITIONED: 6: v6");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1002,4 +1002,48 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         assertContains(plan, "  |  join op: INNER JOIN (COLOCATE)");
         assertContains(plan, "k3-->[NaN, NaN, 0.0, 4.0, 1.0] ESTIMATE");
     }
+
+    @Test
+    public void testPruneShuffleColumns() throws Exception {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getDb("default_cluster:test").getTable("t0");
+        OlapTable t1 = (OlapTable) globalStateMgr.getDb("default_cluster:test").getTable("t1");
+
+        StatisticStorage ss = globalStateMgr.getCurrentStatisticStorage();
+        new Expectations(ss) {
+            {
+                ss.getColumnStatistic(t0, "v1");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t0, "v2");
+                result = new ColumnStatistic(1, 4000000, 0, 4, 4000000);
+
+                ss.getColumnStatistic(t0, "v3");
+                result = new ColumnStatistic(1, 2000000, 0, 4, 2000000);
+
+                ss.getColumnStatistic(t1, "v4");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t1, "v5");
+                result = new ColumnStatistic(1, 100000, 0, 4, 100000);
+
+                ss.getColumnStatistic(t1, "v6");
+                result = new ColumnStatistic(1, 200000, 0, 4, 200000);
+            }
+        };
+
+        setTableStatistics(t0, 4000000);
+        setTableStatistics(t1, 100000);
+
+        String sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6";
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan, "STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    HASH_PARTITIONED: 3: v3");
+
+        assertContains(plan, "STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    HASH_PARTITIONED: 6: v6");
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -51,9 +51,9 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
                 SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE SHUFFLE[37]
                 INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[19, 18]
+                    EXCHANGE SHUFFLE[18]
                         SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
-                    EXCHANGE SHUFFLE[12, 11]
+                    EXCHANGE SHUFFLE[11]
                         SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-5]
@@ -106,25 +106,25 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
     EXCHANGE GATHER
         INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-            EXCHANGE SHUFFLE[19, 18]
+            EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                     SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
                     EXCHANGE BROADCAST
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-            EXCHANGE SHUFFLE[12, 11]
+            EXCHANGE SHUFFLE[11]
                 SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-10]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
     EXCHANGE GATHER
         INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-            EXCHANGE SHUFFLE[19, 18]
+            EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                     EXCHANGE SHUFFLE[37]
                         SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
                     EXCHANGE SHUFFLE[36]
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-            EXCHANGE SHUFFLE[12, 11]
+            EXCHANGE SHUFFLE[11]
                 SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-11]
@@ -173,9 +173,9 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                 EXCHANGE SHUFFLE[37]
                     INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[19, 18]
+                        EXCHANGE SHUFFLE[18]
                             SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
-                        EXCHANGE SHUFFLE[12, 11]
+                        EXCHANGE SHUFFLE[11]
                             SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-15]
@@ -233,12 +233,12 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                EXCHANGE SHUFFLE[19, 18]
+                EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                         SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                EXCHANGE SHUFFLE[12, 11]
+                EXCHANGE SHUFFLE[11]
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-20]
@@ -246,12 +246,12 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                EXCHANGE SHUFFLE[19, 18]
+                EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                         EXCHANGE SHUFFLE[37]
                             SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
                         EXCHANGE SHUFFLE[36]
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                EXCHANGE SHUFFLE[12, 11]
+                EXCHANGE SHUFFLE[11]
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -72,9 +72,9 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
     EXCHANGE GATHER
         INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
             INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                EXCHANGE SHUFFLE[19, 18]
+                EXCHANGE SHUFFLE[18]
                     SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
-                EXCHANGE SHUFFLE[12, 11]
+                EXCHANGE SHUFFLE[11]
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
             EXCHANGE BROADCAST
                 SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
@@ -196,9 +196,9 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                 INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[19, 18]
+                    EXCHANGE SHUFFLE[18]
                         SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
-                    EXCHANGE SHUFFLE[12, 11]
+                    EXCHANGE SHUFFLE[11]
                         SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q5.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q5.sql
@@ -121,7 +121,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -135,7 +135,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                     SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
                             EXCHANGE SHUFFLE[10]
                                 SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-6]
@@ -144,7 +144,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -159,7 +159,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                     SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
                             EXCHANGE SHUFFLE[10]
                                 SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-7]
@@ -168,7 +168,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -183,7 +183,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                     SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
                             EXCHANGE SHUFFLE[10]
                                 SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-8]
@@ -192,7 +192,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -208,7 +208,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                     SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
                             EXCHANGE SHUFFLE[10]
                                 SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-9]
@@ -401,7 +401,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -415,7 +415,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                             SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE BROADCAST
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-18]
@@ -424,7 +424,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -438,7 +438,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                             SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE BROADCAST
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-19]
@@ -447,7 +447,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -462,7 +462,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                 SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE SHUFFLE[50]
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-20]
@@ -471,7 +471,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -486,7 +486,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                 SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE SHUFFLE[50]
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-21]
@@ -495,7 +495,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -510,7 +510,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                             SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE BROADCAST
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-22]
@@ -519,7 +519,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -534,7 +534,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                             SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE BROADCAST
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-23]
@@ -543,7 +543,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -559,7 +559,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                 SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE SHUFFLE[50]
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-24]
@@ -568,7 +568,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[11, 40]
+                    EXCHANGE SHUFFLE[11]
                         INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
                             INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
@@ -584,7 +584,7 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
                                                 SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
                                             EXCHANGE SHUFFLE[50]
                                                 SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-                    EXCHANGE SHUFFLE[1, 4]
+                    EXCHANGE SHUFFLE[1]
                         SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]
 [plan-25]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
@@ -38,7 +38,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
                                 INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
                                     INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
@@ -52,7 +52,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                                 EXCHANGE SHUFFLE[42]
                                     SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-2]
@@ -62,7 +62,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
                                 INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
                                     INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
@@ -77,7 +77,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                                 EXCHANGE SHUFFLE[42]
                                     SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-3]
@@ -87,7 +87,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [42: O_ORDERKEY = 19: L_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
                                 EXCHANGE SHUFFLE[19]
@@ -101,7 +101,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                                 SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
                                                 EXCHANGE BROADCAST
                                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-4]
@@ -111,7 +111,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [42: O_ORDERKEY = 19: L_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
                                 EXCHANGE SHUFFLE[19]
@@ -126,7 +126,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                                     SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
                                                 EXCHANGE SHUFFLE[52]
                                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-5]
@@ -136,7 +136,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [42: O_ORDERKEY = 19: L_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
                                 EXCHANGE SHUFFLE[19]
@@ -151,7 +151,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                                 SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
                                                 EXCHANGE BROADCAST
                                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-6]
@@ -161,7 +161,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
             EXCHANGE SHUFFLE[53, 57]
                 AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
                     INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[21, 20]
+                        EXCHANGE SHUFFLE[20]
                             INNER JOIN (join-predicate [42: O_ORDERKEY = 19: L_ORDERKEY] post-join-predicate [null])
                                 SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
                                 EXCHANGE SHUFFLE[19]
@@ -177,6 +177,6 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                                     SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
                                                 EXCHANGE SHUFFLE[52]
                                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
-                        EXCHANGE SHUFFLE[37, 36]
+                        EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q20.sql
@@ -47,10 +47,10 @@ TOP-N (order by [[2: S_NAME ASC NULLS FIRST]])
                     EXCHANGE SHUFFLE[15]
                         INNER JOIN (join-predicate [32: L_PARTKEY = 14: PS_PARTKEY AND 33: L_SUPPKEY = 15: PS_SUPPKEY AND cast(16: PS_AVAILQTY as double) > multiply(0.5, 48: sum)] post-join-predicate [null])
                             AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(48: sum)}] group by [[33: L_SUPPKEY, 32: L_PARTKEY]] having [null]
-                                EXCHANGE SHUFFLE[32, 33]
+                                EXCHANGE SHUFFLE[32]
                                     AGGREGATE ([LOCAL] aggregate [{48: sum=sum(35: L_QUANTITY)}] group by [[33: L_SUPPKEY, 32: L_PARTKEY]] having [null]
                                         SCAN (columns[33: L_SUPPKEY, 35: L_QUANTITY, 41: L_SHIPDATE, 32: L_PARTKEY] predicate[41: L_SHIPDATE >= 1993-01-01 AND 41: L_SHIPDATE < 1994-01-01])
-                            EXCHANGE SHUFFLE[14, 15]
+                            EXCHANGE SHUFFLE[14]
                                 LEFT SEMI JOIN (join-predicate [14: PS_PARTKEY = 20: P_PARTKEY] post-join-predicate [null])
                                     SCAN (columns[14: PS_PARTKEY, 15: PS_SUPPKEY, 16: PS_AVAILQTY] predicate[null])
                                     EXCHANGE SHUFFLE[20]

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
@@ -168,7 +168,7 @@ column statistics:
 
 PLAN FRAGMENT 4(F01)
 
-Input Partition: HASH_PARTITIONED: 32: L_PARTKEY, 33: L_SUPPKEY
+Input Partition: HASH_PARTITIONED: 32: L_PARTKEY
 OutPut Partition: HASH_PARTITIONED: 15: PS_SUPPKEY
 OutPut Exchange Id: 14
 
@@ -218,7 +218,7 @@ probe runtime filters:
 PLAN FRAGMENT 5(F02)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 14: PS_PARTKEY, 15: PS_SUPPKEY
+OutPut Partition: HASH_PARTITIONED: 14: PS_PARTKEY
 OutPut Exchange Id: 11
 
 10:Project
@@ -289,7 +289,7 @@ column statistics:
 PLAN FRAGMENT 7(F00)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 32: L_PARTKEY, 33: L_SUPPKEY
+OutPut Partition: HASH_PARTITIONED: 32: L_PARTKEY
 OutPut Exchange Id: 03
 
 2:AGGREGATE (update serialize)

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q9.sql
@@ -60,7 +60,7 @@ UNPARTITIONED
 
 PLAN FRAGMENT 2
 OUTPUT EXPRS:
-PARTITION: HASH_PARTITIONED: 21: L_SUPPKEY, 20: L_PARTKEY
+PARTITION: HASH_PARTITIONED: 20: L_PARTKEY
 
 STREAM DATA SINK
 EXCHANGE ID: 24
@@ -126,7 +126,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: supplier
 tabletRatio=1/1
-tabletList=10111
 cardinality=1000000
 avgRowSize=8.0
 numNodes=0
@@ -145,7 +144,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: nation
 tabletRatio=1/1
-tabletList=10185
 cardinality=25
 avgRowSize=29.0
 numNodes=0
@@ -156,7 +154,7 @@ PARTITION: RANDOM
 
 STREAM DATA SINK
 EXCHANGE ID: 12
-HASH_PARTITIONED: 37: PS_SUPPKEY, 36: PS_PARTKEY
+HASH_PARTITIONED: 36: PS_PARTKEY
 
 11:OlapScanNode
 TABLE: partsupp
@@ -164,7 +162,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: partsupp
 tabletRatio=10/10
-tabletList=10116,10118,10120,10122,10124,10126,10128,10130,10132,10134
 cardinality=80000000
 avgRowSize=24.0
 numNodes=0
@@ -175,7 +172,7 @@ PARTITION: RANDOM
 
 STREAM DATA SINK
 EXCHANGE ID: 10
-HASH_PARTITIONED: 21: L_SUPPKEY, 20: L_PARTKEY
+HASH_PARTITIONED: 20: L_PARTKEY
 
 9:Project
 |  <slot 20> : 20: L_PARTKEY
@@ -213,7 +210,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: lineitem
 tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
 cardinality=600000000
 avgRowSize=44.0
 numNodes=0
@@ -232,7 +228,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: orders
 tabletRatio=10/10
-tabletList=10139,10141,10143,10145,10147,10149,10151,10153,10155,10157
 cardinality=150000000
 avgRowSize=12.0
 numNodes=0
@@ -255,7 +250,6 @@ PREDICATES: 2: P_NAME LIKE '%peru%'
 partitions=1/1
 rollup: part
 tabletRatio=10/10
-tabletList=10190,10192,10194,10196,10198,10200,10202,10204,10206,10208
 cardinality=5000000
 avgRowSize=63.0
 numNodes=0


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

like sql:
```
select * from t0 join[shuffle] t1 on t0.v2 = t1.v2 and t0.v3 = t1.v3;
```

multi join on-clause predicate, we need shuffle by all columns now, the plan:

```
MySQL td> explain select * from t0 join[shuffle] t1 on t0.v2 = t1.v2 and t0.v3 = t1.v3;
+-------------------------------------------------------------+
| Explain String                                              |
+-------------------------------------------------------------+
| .............                                               |
| PLAN FRAGMENT 1                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: HASH_PARTITIONED: 2: v2, 3:v3                  |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 05                                         |
|     UNPARTITIONED                                           |
|                                                             |
|   4:HASH JOIN                                               |
|   |  join op: INNER JOIN (PARTITIONED)                      |
|   |  hash predicates:                                       |
|   |  colocate: false, reason:                               |
|   |  equal join conjunct: 2: v2 = 5: v2                     |
|   |  equal join conjunct: 3: v3 = 6: v3                     |
|   |                                                         |
|   |----3:EXCHANGE                                           |
|   |                                                         |
|   1:EXCHANGE                                                |
|                                                             |
| PLAN FRAGMENT 2                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: RANDOM                                         |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 03                                         |
|     HASH_PARTITIONED: 5: v2, 6: v3                          |
|                                                             |
|   2:OlapScanNode                                            |
|      TABLE: t1                                              |
| .............                                               |
|                                                             |
| PLAN FRAGMENT 3                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: RANDOM                                         |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 01                                         |
|     HASH_PARTITIONED: 2: v2, 3.v3                           |
|                                                             |
|   0:OlapScanNode                                            |
|      TABLE: t0                                              |
```

the enhance:
1. don't need compute multi-columns hash
2. imporve global runtime filter effect

after
```
MySQL td> explain select * from t0 join[shuffle] t1 on t0.v2 = t1.v2 and t0.v3 = t1.v3;
+-------------------------------------------------------------+
| Explain String                                              |
+-------------------------------------------------------------+
| .............                                               |
| PLAN FRAGMENT 1                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: HASH_PARTITIONED: 2: v2                        |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 05                                         |
|     UNPARTITIONED                                           |
|                                                             |
|   4:HASH JOIN                                               |
|   |  join op: INNER JOIN (PARTITIONED)                      |
|   |  hash predicates:                                       |
|   |  colocate: false, reason:                               |
|   |  equal join conjunct: 2: v2 = 5: v2                     |
|   |  equal join conjunct: 3: v3 = 6: v3                     |
|   |                                                         |
|   |----3:EXCHANGE                                           |
|   |                                                         |
|   1:EXCHANGE                                                |
|                                                             |
| PLAN FRAGMENT 2                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: RANDOM                                         |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 03                                         |
|     HASH_PARTITIONED: 5: v2                                 |
|                                                             |
|   2:OlapScanNode                                            |
|      TABLE: t1                                              |
| .............                                               |
|                                                             |
| PLAN FRAGMENT 3                                             |
|  OUTPUT EXPRS:                                              |
|   PARTITION: RANDOM                                         |
|                                                             |
|   STREAM DATA SINK                                          |
|     EXCHANGE ID: 01                                         |
|     HASH_PARTITIONED: 2: v2                                 |
|                                                             |
|   0:OlapScanNode                                            |
|      TABLE: t0                                              |
```


