### PR TITLE
[BugFix] Fix the wrong type check of iceberg/hudi table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -312,9 +312,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
                 } else if (logicalType instanceof LogicalTypes.TimeMillis) {
                     return primitiveType == PrimitiveType.TIME;
                 } else {
-                    return primitiveType == PrimitiveType.INT ||
-                            primitiveType == PrimitiveType.TINYINT ||
-                            primitiveType == PrimitiveType.SMALLINT;
+                    return primitiveType == PrimitiveType.INT;
                 }
             case LONG:
                 if (logicalType instanceof LogicalTypes.TimeMicros) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -233,9 +233,7 @@ public class IcebergTable extends Table {
             case BOOLEAN:
                 return primitiveType == PrimitiveType.BOOLEAN;
             case INTEGER:
-                return primitiveType == PrimitiveType.INT ||
-                        primitiveType == PrimitiveType.TINYINT ||
-                        primitiveType == PrimitiveType.SMALLINT;
+                return primitiveType == PrimitiveType.INT;
             case LONG:
                 return primitiveType == PrimitiveType.BIGINT;
             case FLOAT:


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
Fix the wrong type check of iceberg/hudi table

The BE will crash if the integer type field of icebreg/hudi table is defined as tinyint/smallint in starrocks external table when complie type is DEBUG or ASAN
