### PR TITLE
[Enhancement] clearer json parsing error

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -645,8 +645,9 @@ Status JsonReader::_build_slot_descs() {
 
     // get the first row of json.
     simdjson::ondemand::object obj;
-    if (!_parser->get_current(&obj).ok()) {
-        return Status::DataQualityError("can not get first row of json");
+    auto st = _parser->get_current(&obj);
+    if (!st.ok()) {
+        return Status::DataQualityError(fmt::format("can not get first row of json, err: {}", st.get_error_msg()));
     }
     std::ostringstream oss;
     simdjson::ondemand::raw_json_string json_str;

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -645,10 +645,7 @@ Status JsonReader::_build_slot_descs() {
 
     // get the first row of json.
     simdjson::ondemand::object obj;
-    auto st = _parser->get_current(&obj);
-    if (!st.ok()) {
-        return Status::DataQualityError(fmt::format("can not get first row of json, err: {}", st.get_error_msg()));
-    }
+    RETURN_IF_ERROR(_parser->get_current(&obj));
     std::ostringstream oss;
     simdjson::ondemand::raw_json_string json_str;
 
@@ -658,7 +655,7 @@ Status JsonReader::_build_slot_descs() {
             json_str = field.key();
         } catch (simdjson::simdjson_error& e) {
             // Nothing would be done if got any error.
-            return Status::DataQualityError("parse invalid field key");
+            return Status::DataQualityError(Slice{simdjson::error_message(e.error())});
         }
 
         oss << json_str;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7532

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR attaches the error returned by json parser to the `Message`.
```
{
    "TxnId": 115,
    "Label": "a2a415c5-4ba5-4249-a8a2-343f63737ad9",
    "Status": "Fail",
    "Message": "Failed to iterate document stream as object. error: Within strings, some characters must be escaped, we found unescaped characters",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 49,
    "LoadTimeMs": 2,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 0,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 0,
    "CommitAndPublishTimeMs": 0
}
```