### PR TITLE
[BugFix] Fix wrong column order (backport #7482)

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -159,15 +159,18 @@ struct HdfsScannerContext {
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void append_not_exised_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_not_existed_columns_of_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
 
     // other helper functions.
-    void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void update_partition_column_of_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+
+    void append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
+    void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
 };
 
 // if *lvalue == expect, swap(*lvalue,*rvalue)

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -454,7 +454,20 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
-    ChunkPtr& ck = *chunk;
+    ChunkPtr ck = std::make_shared<vectorized::Chunk>();
+    // The column order of chunk is required to be invariable. When a table performs schema change,
+    // says we want to add a new column to table A, the reader of old files of table A will append new
+    // column to the tail of the chunk, while the reader of new files of table A will put the new column
+    // in the chunk according to the order it's stored. This will lead two chunk from different file to
+    // different column order, so we need to adjust the column order according to the input chunk to make
+    // sure every chunk has same column order
+    auto convert_to_output = [chunk, &ck]() {
+        const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+        for (auto iter = slot_id_to_index_map.begin(); iter != slot_id_to_index_map.end(); iter++) {
+            (*chunk)->get_column_by_slot_id(iter->first)->swap_column(*ck->get_column_by_slot_id(iter->first));
+        }
+    };
+
     // this infinite for loop is for retry.
     for (;;) {
         orc::RowReader::ReadPosition position;
@@ -483,13 +496,13 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                     ret = _orc_reader->get_active_chunk();
                 }
                 RETURN_IF_ERROR(ret);
-                *chunk = std::move(ret.value());
+                ck = std::move(ret.value());
             }
 
             // important to add columns before evaluation
             // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _scanner_ctx.append_not_exised_columns_to_chunk(chunk, ck->num_rows());
-            _scanner_ctx.append_partition_column_to_chunk(chunk, ck->num_rows());
+            _scanner_ctx.append_not_existed_columns_to_chunk(&ck, ck->num_rows());
+            _scanner_ctx.append_partition_column_to_chunk(&ck, ck->num_rows());
             chunk_size = ck->num_rows();
             // do stats before we filter rows which does not match.
             _stats.raw_rows_read += chunk_size;
@@ -515,6 +528,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         ck->set_num_rows(chunk_size);
 
         if (!_orc_reader->has_lazy_load_context()) {
+            convert_to_output();
             return Status::OK();
         }
 
@@ -538,6 +552,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             Chunk& ret_ck = *(ret.value());
             ck->merge(std::move(ret_ck));
         }
+        convert_to_output();
         return Status::OK();
     }
     __builtin_unreachable();

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -411,8 +411,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->append_not_exised_columns_to_chunk(chunk, row_count);
-                _scanner_ctx->append_partition_column_to_chunk(chunk, row_count);
+                _scanner_ctx->update_not_existed_columns_of_chunk(chunk, row_count);
+                _scanner_ctx->update_partition_column_of_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {
@@ -430,8 +430,8 @@ Status FileReader::get_next(vectorized::ChunkPtr* chunk) {
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->append_not_exised_columns_to_chunk(chunk, read_size);
-        _scanner_ctx->append_partition_column_to_chunk(chunk, read_size);
+        _scanner_ctx->update_not_existed_columns_of_chunk(chunk, read_size);
+        _scanner_ctx->update_partition_column_of_chunk(chunk, read_size);
         _scan_row_count += read_size;
         return Status::OK();
     }

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -287,6 +287,7 @@ static void extend_partition_values(ObjectPool* pool, HdfsScannerParams* params,
         auto chunk = vectorized::ChunkHelper::new_chunk(*tuple_desc, 0);               \
         uint64_t records = 0;                                                          \
         for (;;) {                                                                     \
+            chunk->reset();                                                            \
             status = scanner->get_next(_runtime_state, &chunk);                        \
             if (status.is_end_of_file()) {                                             \
                 break;                                                                 \


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6028  https://github.com/StarRocks/starrocks/issues/7177  https://github.com/StarRocks/starrocks/issues/7330 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since `DataStreamRecvr::SenderQueue::_build_chunk_meta` is only called for the first chunk it receive, so the subsequent chunk should remain the same column order as the first chunk, otherwise, the deserialize might get wrong   type from chunk meta.