### PR TITLE
[cherry-pick] [branch-2.1] [Enhancement] Don't output the unused log of RE2 (#7528)

### DIFF
--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -17,7 +17,7 @@ namespace starrocks::vectorized {
 
 // static const re2::RE2 JSON_PATTERN("^([a-zA-Z0-9_\\-\\:\\s#\\|\\.]*)(?:\\[([0-9]+)\\])?");
 // json path cannot contains: ", [, ]
-static const re2::RE2 JSON_PATTERN(R"(^([^\"\[\]]*)(?:\[([0-9]+|\*)\])?)");
+static const re2::RE2 JSON_PATTERN(R"(^([^\"\[\]]*)(?:\[([0-9]+|\*)\])?)", re2::RE2::Quiet);
 
 Status JsonFunctions::_get_parsed_paths(const std::vector<std::string>& path_exprs,
                                         std::vector<JsonPath>* parsed_paths) {

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -12,23 +12,23 @@
 namespace starrocks::vectorized {
 
 // A regex to match any regex pattern is equivalent to a substring search.
-static const RE2 SUBSTRING_RE(R"((?:\.\*)*([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)(?:\.\*)*)");
+static const RE2 SUBSTRING_RE(R"((?:\.\*)*([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)(?:\.\*)*)", re2::RE2::Quiet);
 
 // A regex to match any regex pattern which is equivalent to matching a constant string
 // at the end of the string values.
-static const RE2 ENDS_WITH_RE(R"((?:\.\*)*([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)\$)");
+static const RE2 ENDS_WITH_RE(R"((?:\.\*)*([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)\$)", re2::RE2::Quiet);
 
 // A regex to match any regex pattern which is equivalent to matching a constant string
 // at the end of the string values.
-static const RE2 STARTS_WITH_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)(?:\.\*)*)");
+static const RE2 STARTS_WITH_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)(?:\.\*)*)", re2::RE2::Quiet);
 
 // A regex to match any regex pattern which is equivalent to a constant string match.
-static const RE2 EQUALS_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)\$)");
+static const RE2 EQUALS_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)\$)", re2::RE2::Quiet);
 
-static const re2::RE2 LIKE_SUBSTRING_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+)(?:%+))");
-static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))");
-static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))");
-static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))");
+static const re2::RE2 LIKE_SUBSTRING_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
 
 Status LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
                                                    starrocks_udf::FunctionContext* context, const Slice& slice) {
@@ -390,6 +390,7 @@ ColumnPtr LikePredicate::regex_match_full(FunctionContext* context, const starro
     RE2::Options opts;
     opts.set_never_nl(false);
     opts.set_dot_nl(true);
+    opts.set_log_errors(false);
 
     for (int row = 0; row < value_viewer.size(); ++row) {
         if (value_viewer.is_null(row) || pattern_viewer.is_null(row)) {
@@ -436,6 +437,7 @@ ColumnPtr LikePredicate::regex_match_partial(FunctionContext* context, const sta
     RE2::Options opts;
     opts.set_never_nl(false);
     opts.set_dot_nl(true);
+    opts.set_log_errors(false);
 
     for (int row = 0; row < value_viewer.size(); ++row) {
         if (value_viewer.is_null(row) || pattern_viewer.is_null(row)) {

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -2504,7 +2504,7 @@ Status StringFunctions::regexp_prepare(starrocks_udf::FunctionContext* context,
         return Status::OK();
     }
 
-    StringFunctionsState* state = new StringFunctionsState();
+    auto* state = new StringFunctionsState();
     context->set_function_state(scope, state);
 
     state->options = std::make_unique<re2::RE2::Options>();
@@ -2535,7 +2535,7 @@ Status StringFunctions::regexp_prepare(starrocks_udf::FunctionContext* context,
 
 Status StringFunctions::regexp_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
-        StringFunctionsState* state =
+        auto* state =
                 reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         delete state;
     }

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -62,7 +62,7 @@ static uint32_t calc_days_in_year(uint32_t year) {
 
 DateTimeValue DateTimeValue::_s_min_datetime_value(0, TIME_DATETIME, 0, 0, 0, 0, 0, 1, 1);
 DateTimeValue DateTimeValue::_s_max_datetime_value(0, TIME_DATETIME, 23, 59, 59, 0, 9999, 12, 31);
-RE2 DateTimeValue::time_zone_offset_format_reg(R"(^[+-]{1}\d{2}\:\d{2}$)");
+RE2 DateTimeValue::time_zone_offset_format_reg(R"(^[+-]{1}\d{2}\:\d{2}$)", re2::RE2::Quiet);
 
 bool DateTimeValue::check_range() const {
     return _year > 9999 || _month > 12 || _day > 31 || _hour > (_type == TIME_TIME ? TIME_MAX_HOUR : 23) ||
@@ -457,12 +457,12 @@ int64_t DateTimeValue::to_datetime_int64() const {
 }
 
 int64_t DateTimeValue::to_date_int64() const {
-    return _year * 10000 + _month * 100 + _day;
+    return _year * 10000L + _month * 100 + _day;
 }
 
 int64_t DateTimeValue::to_time_int64() const {
     int sign = _neg == 0 ? 1 : -1;
-    return sign * (_hour * 10000 + _minute * 100 + _second);
+    return sign * (_hour * 10000L + _minute * 100 + _second);
 }
 
 int64_t DateTimeValue::to_int64() const {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -479,7 +479,7 @@ TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, const TabletUid& 
 
 bool TabletManager::get_tablet_id_and_schema_hash_from_path(const std::string& path, TTabletId* tablet_id,
                                                             TSchemaHash* schema_hash) {
-    static re2::RE2 normal_re(R"(/data/\d+/(\d+)/(\d+)($|/))");
+    static re2::RE2 normal_re(R"(/data/\d+/(\d+)/(\d+)($|/))", re2::RE2::Quiet);
     // match tablet schema hash data path, for example, the path is /data/1/16791/29998
     // 1 is shard id , 16791 is tablet id, 29998 is schema hash
     if (RE2::PartialMatch(path, normal_re, tablet_id, schema_hash)) {
@@ -489,7 +489,7 @@ bool TabletManager::get_tablet_id_and_schema_hash_from_path(const std::string& p
     // If we can't match normal path pattern, this may be a path which is a empty tablet
     // directory. Use this pattern to match empty tablet directory. In this case schema_hash
     // will be set to zero.
-    static re2::RE2 empty_tablet_re("/data/\\d+/(\\d+)($|/$)");
+    static re2::RE2 empty_tablet_re("/data/\\d+/(\\d+)($|/$)", re2::RE2::Quiet);
     if (!RE2::PartialMatch(path, empty_tablet_re, tablet_id)) {
         return false;
     }
@@ -498,7 +498,7 @@ bool TabletManager::get_tablet_id_and_schema_hash_from_path(const std::string& p
 }
 
 bool TabletManager::get_rowset_id_from_path(const std::string& path, RowsetId* rowset_id) {
-    static re2::RE2 re(R"(/data/\d+/\d+/\d+/([A-Fa-f0-9]+)_.*)");
+    static re2::RE2 re(R"(/data/\d+/\d+/\d+/([A-Fa-f0-9]+)_.*)", re2::RE2::Quiet);
     std::string id_str;
     bool ret = RE2::PartialMatch(path, re, &id_str);
     if (ret) {

--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -24,7 +24,7 @@
 
 namespace starrocks {
 
-RE2 TimezoneUtils::time_zone_offset_format_reg(R"(^[+-]{1}\d{2}\:\d{2}$)");
+RE2 TimezoneUtils::time_zone_offset_format_reg(R"(^[+-]{1}\d{2}\:\d{2}$)", re2::RE2::Quiet);
 
 const std::string TimezoneUtils::default_time_zone = "+08:00";
 


### PR DESCRIPTION
```
      if (!prog_->SearchDFA(subtext, text, anchor, kind,
                            matchp, &dfa_failed, NULL)) {
        if (dfa_failed) {
          if (options_.log_errors())
            LOG(ERROR) << "DFA out of memory: size " << prog_->size() << ", "
                       << "bytemap range " << prog_->bytemap_range() << ", "
                       << "list count " << prog_->list_count();
          // Fall back to NFA below.
          skipped_test = true;
          break;
        }
        return false;
```

If search failed with `DFA`, we will use the `NFA` algorithm, so the log may be useless for us.