### PR TITLE
[Feature] Add PipelineColumnPool for pipeline engine

### DIFF
--- a/be/src/column/type_column_traits.h
+++ b/be/src/column/type_column_traits.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "column/type_traits.h"
+
+namespace starrocks {
+namespace vectorized {
+// NOTE(zc): now CppColumnTraits is only used for this class, so I move it here.
+// Someday if it is used by others, please move it into a single file.
+// CppColumnTraits
+// Infer ColumnType from FieldType
+
+template <FieldType ftype>
+struct CppColumnTraits {
+    using CppType = typename CppTypeTraits<ftype>::CppType;
+    using ColumnType = typename vectorized::ColumnTraits<CppType>::ColumnType;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_BOOL> {
+    using ColumnType = vectorized::UInt8Column;
+};
+
+// deprecated
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_DATE> {
+    using ColumnType = vectorized::FixedLengthColumn<uint24_t>;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_DATE_V2> {
+    using ColumnType = vectorized::DateColumn;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_TIMESTAMP> {
+    using ColumnType = vectorized::TimestampColumn;
+};
+
+// deprecated
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_DECIMAL> {
+    using ColumnType = vectorized::FixedLengthColumn<decimal12_t>;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_HLL> {
+    using ColumnType = vectorized::HyperLogLogColumn;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_PERCENTILE> {
+    using ColumnType = vectorized::PercentileColumn;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_OBJECT> {
+    using ColumnType = vectorized::BitmapColumn;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_UNSIGNED_INT> {
+    using ColumnType = vectorized::UInt32Column;
+};
+
+template <>
+struct CppColumnTraits<OLAP_FIELD_TYPE_JSON> {
+    using ColumnType = vectorized::JsonColumn;
+};
+
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -190,6 +190,7 @@ set(EXEC_FILES
     pipeline/set/intersect_build_sink_operator.cpp
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
+    pipeline/pipeline_column_pool.cpp
     workgroup/work_group.cpp
     workgroup/scan_executor.cpp
     workgroup/scan_task_queue.cpp

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -323,6 +323,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
                                                                     _fragment_ctx.get(), driver_id++);
                 driver->set_morsel_queue(morsel_queue.get());
                 if (auto* scan_operator = driver->source_scan_operator()) {
+                    scan_operator->set_pipeline_driver(driver.get());
                     if (_wg != nullptr) {
                         // Workgroup uses scan_executor instead of pipeline_scan_io_thread_pool.
                         scan_operator->set_workgroup(_wg);

--- a/be/src/exec/pipeline/pipeline_column_pool.cpp
+++ b/be/src/exec/pipeline/pipeline_column_pool.cpp
@@ -1,0 +1,208 @@
+
+#include "exec/pipeline/pipeline_column_pool.h"
+
+#include "column/chunk.h"
+#include "column/column_pool.h"
+#include "column/schema.h"
+#include "column/type_column_traits.h"
+#include "storage/olap_type_infra.h"
+#include "storage/tablet_schema.h"
+#include "storage/type_utils.h"
+#include "storage/types.h"
+#include "util/metrics.h"
+#include "util/percentile_value.h"
+
+namespace starrocks {
+namespace pipeline {
+template <typename T, bool force>
+T* PipelineColumnPool::get_column() {
+    if constexpr (false) {
+    }
+#define DISPATCH_DIFFERENT_COLUMN(NAME)                       \
+    else if constexpr (std::is_same_v<T, vectorized::NAME>) { \
+        auto& buffer = NAME##Buffer;                          \
+        auto& blocks = buffer.blocks;                         \
+        std::lock_guard<std::mutex> l(buffer.mtx);            \
+        while (!blocks.empty()) {                             \
+            auto block = blocks.back();                       \
+            if (block->nfree > 0) {                           \
+                T* column = block->ptrs[--block->nfree];      \
+                auto bytes = column_bytes(column);            \
+                block->bytes -= bytes;                        \
+                return column;                                \
+            } else {                                          \
+                blocks.pop_back();                            \
+                free(block);                                  \
+            }                                                 \
+        }                                                     \
+        if constexpr (force) {                                \
+            return new (std::nothrow) T();                    \
+        } else {                                              \
+            return nullptr;                                   \
+        }                                                     \
+    }
+    APPLY_FOR_ALL_SUPPORT_COLUMNS(DISPATCH_DIFFERENT_COLUMN)
+#undef DISPATCH_DIFFERENT_COLUMN
+}
+
+template <typename T>
+void PipelineColumnPool::return_column(T* ptr, size_t chunk_size) {
+    using FreeBlock = PipelineColumnPool::ColumnPoolFreeBlock<T, PipelineColumnPool::kBufferSize>;
+    ptr->reset_column();
+    if constexpr (false) {
+    }
+#define DISPATCH_DIFFERENT_COLUMN(NAME)                               \
+    else if constexpr (std::is_same_v<T, vectorized::NAME>) {         \
+        auto& buffer = NAME##Buffer;                                  \
+        auto& blocks = buffer.blocks;                                 \
+        auto bytes = column_bytes(ptr);                               \
+        auto append_block = [&blocks, ptr, bytes](FreeBlock* block) { \
+            block->nfree = 1;                                         \
+            block->ptrs[0] = ptr;                                     \
+            block->bytes = bytes;                                     \
+            blocks.push_back(block);                                  \
+        };                                                            \
+        std::lock_guard<std::mutex> l(buffer.mtx);                    \
+        if (blocks.empty()) {                                         \
+            auto block = (FreeBlock*)malloc(sizeof(FreeBlock));       \
+            if (UNLIKELY(block == nullptr)) {                         \
+                delete ptr;                                           \
+                return;                                               \
+            }                                                         \
+            append_block(block);                                      \
+        } else {                                                      \
+            auto block = blocks.back();                               \
+            if (block->nfree < kBufferSize) {                         \
+                block->ptrs[block->nfree++] = ptr;                    \
+                block->bytes += bytes;                                \
+            } else {                                                  \
+                auto block = (FreeBlock*)malloc(sizeof(FreeBlock));   \
+                if (UNLIKELY(block == nullptr)) {                     \
+                    delete ptr;                                       \
+                    return;                                           \
+                }                                                     \
+                append_block(block);                                  \
+            }                                                         \
+        }                                                             \
+    }
+    APPLY_FOR_ALL_SUPPORT_COLUMNS(DISPATCH_DIFFERENT_COLUMN)
+#undef DISPATCH_DIFFERENT_COLUMN
+}
+
+template <typename T, bool force>
+std::shared_ptr<T> PipelineColumnPool::get_column_ptr(size_t chunk_size) {
+    if constexpr (std::negation_v<HasPipelineColumnPool<T>>) {
+        return std::make_shared<T>();
+    } else {
+        T* ptr = get_column<T, force>();
+        if (LIKELY(ptr != nullptr)) {
+            return std::shared_ptr<T>(ptr, PipelineColumnPool::PipelineColumnDeleter<T>(this, chunk_size));
+        } else {
+            return std::make_shared<T>();
+        }
+    }
+}
+
+template <typename T, bool force>
+std::shared_ptr<vectorized::DecimalColumnType<T>> PipelineColumnPool::get_decimal_column_ptr(int precision, int scale,
+                                                                                             size_t chunk_size) {
+    auto column = get_column_ptr<T, force>(chunk_size);
+    column->set_precision(precision);
+    column->set_scale(scale);
+    return column;
+}
+
+template <bool force>
+PipelineColumnPool::PipelineColumnPtrBuild<force>::PipelineColumnPtrBuild(PipelineColumnPool* column_pool) {
+    _column_pool = column_pool;
+}
+
+template <bool force>
+template <FieldType ftype>
+vectorized::ColumnPtr PipelineColumnPool::PipelineColumnPtrBuild<force>::operator()(size_t chunk_size,
+                                                                                    const vectorized::Field& field,
+                                                                                    int precision, int scale) {
+    auto nullable = [this, chunk_size, field, precision, scale](vectorized::ColumnPtr c) -> vectorized::ColumnPtr {
+        return field.is_nullable()
+                       ? vectorized::NullableColumn::create(
+                                 std::move(c), _column_pool->get_column_ptr<vectorized::NullColumn, force>(chunk_size))
+                       : c;
+    };
+
+    if constexpr (ftype == OLAP_FIELD_TYPE_ARRAY) {
+        auto elements = field.sub_field(0).create_column();
+        auto offsets = _column_pool->get_column_ptr<vectorized::UInt32Column, force>(chunk_size);
+        auto array = vectorized::ArrayColumn::create(std::move(elements), offsets);
+        return nullable(array);
+    } else {
+        switch (ftype) {
+        case OLAP_FIELD_TYPE_DECIMAL32:
+            return nullable(_column_pool->get_decimal_column_ptr<vectorized::Decimal32Column, force>(precision, scale,
+                                                                                                     chunk_size));
+        case OLAP_FIELD_TYPE_DECIMAL64:
+            return nullable(_column_pool->get_decimal_column_ptr<vectorized::Decimal64Column, force>(precision, scale,
+                                                                                                     chunk_size));
+        case OLAP_FIELD_TYPE_DECIMAL128:
+            return nullable(_column_pool->get_decimal_column_ptr<vectorized::Decimal128Column, force>(precision, scale,
+                                                                                                      chunk_size));
+        default: {
+            return nullable(
+                    _column_pool->get_column_ptr<typename vectorized::CppColumnTraits<ftype>::ColumnType, force>(
+                            chunk_size));
+        }
+        }
+    }
+}
+
+template <bool force>
+vectorized::ColumnPtr PipelineColumnPool::column_from_pool(const vectorized::Field& field, size_t chunk_size) {
+    auto precision = field.type()->precision();
+    auto scale = field.type()->scale();
+    return field_type_dispatch_column(field.type()->type(), PipelineColumnPool::PipelineColumnPtrBuild<force>(this),
+                                      chunk_size, field, precision, scale);
+}
+
+/*
+ * new_chunk_pooled, column_from_pool and so on, are like same method in non-pipeline's column pool,
+ * except that need a columnpool instance.
+ *
+ */
+vectorized::Chunk* PipelineColumnPool::new_chunk_pooled(const vectorized::Schema& schema, size_t chunk_size,
+                                                        bool force) {
+    vectorized::Columns columns;
+    columns.reserve(schema.num_fields());
+    for (size_t i = 0; i < schema.num_fields(); i++) {
+        const vectorized::FieldPtr& f = schema.field(i);
+        auto column = (force && !config::disable_column_pool) ? column_from_pool<true>(*f, chunk_size)
+                                                              : column_from_pool<false>(*f, chunk_size);
+        column->reserve(chunk_size);
+        columns.emplace_back(std::move(column));
+    }
+    return new vectorized::Chunk(std::move(columns), std::make_shared<vectorized::Schema>(schema));
+}
+
+PipelineColumnPool* PipelineColumnPoolManager::get_or_register(const TUniqueId& fragment_id) {
+    std::lock_guard<std::mutex> lock(_lock);
+    auto it = _pipeline_column_pool_contexts.find(fragment_id);
+    if (it != _pipeline_column_pool_contexts.end()) {
+        return it->second.get();
+    } else {
+        auto&& ctx = std::make_unique<PipelineColumnPool>();
+        auto* raw_ctx = ctx.get();
+        _pipeline_column_pool_contexts.emplace(fragment_id, std::move(ctx));
+        return raw_ctx;
+    }
+}
+
+PipelineColumnPoolPtr PipelineColumnPoolManager::get(const TUniqueId& fragment_id) {
+    std::lock_guard<std::mutex> lock(_lock);
+    auto it = _pipeline_column_pool_contexts.find(fragment_id);
+    if (it != _pipeline_column_pool_contexts.end()) {
+        return it->second;
+    } else {
+        return nullptr;
+    }
+}
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_column_pool.h
+++ b/be/src/exec/pipeline/pipeline_column_pool.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <memory>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/const_column.h"
+#include "column/decimalv3_column.h"
+#include "column/field.h"
+#include "column/nullable_column.h"
+#include "column/object_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/type_list.h"
+#include "storage/olap_type_infra.h"
+#include "storage/schema.h"
+
+namespace starrocks {
+namespace pipeline {
+class PipelineColumnPool {
+private:
+    template <typename T, size_t NITEM>
+    struct ColumnPoolFreeBlock {
+        int64_t nfree;
+        int64_t bytes;
+        T* ptrs[NITEM];
+    };
+
+    template <typename T, size_t NITEM>
+    struct ColumnPoolBuffer {
+        std::mutex mtx;
+        std::vector<ColumnPoolFreeBlock<T, NITEM>*> blocks;
+    };
+
+#define APPLY_FOR_ALL_SUPPORT_COLUMNS(M) \
+    M(Int8Column)                        \
+    M(UInt8Column)                       \
+    M(Int16Column)                       \
+    M(Int32Column)                       \
+    M(UInt32Column)                      \
+    M(Int64Column)                       \
+    M(Int128Column)                      \
+    M(FloatColumn)                       \
+    M(DoubleColumn)                      \
+    M(BinaryColumn)                      \
+    M(DateColumn)                        \
+    M(TimestampColumn)                   \
+    M(DecimalColumn)                     \
+    M(Decimal32Column)                   \
+    M(Decimal64Column)                   \
+    M(Decimal128Column)
+
+    static constexpr int kBufferSize = 128;
+    /*
+     * All column types that support by PipelineColumnPool.
+     */
+    ColumnPoolBuffer<vectorized::Int8Column, kBufferSize> Int8ColumnBuffer;
+    ColumnPoolBuffer<vectorized::UInt8Column, kBufferSize> UInt8ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Int16Column, kBufferSize> Int16ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Int32Column, kBufferSize> Int32ColumnBuffer;
+    ColumnPoolBuffer<vectorized::UInt32Column, kBufferSize> UInt32ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Int64Column, kBufferSize> Int64ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Int128Column, kBufferSize> Int128ColumnBuffer;
+    ColumnPoolBuffer<vectorized::FloatColumn, kBufferSize> FloatColumnBuffer;
+    ColumnPoolBuffer<vectorized::DoubleColumn, kBufferSize> DoubleColumnBuffer;
+    ColumnPoolBuffer<vectorized::BinaryColumn, kBufferSize> BinaryColumnBuffer;
+    ColumnPoolBuffer<vectorized::DateColumn, kBufferSize> DateColumnBuffer;
+    ColumnPoolBuffer<vectorized::TimestampColumn, kBufferSize> TimestampColumnBuffer;
+    ColumnPoolBuffer<vectorized::DecimalColumn, kBufferSize> DecimalColumnBuffer;
+    ColumnPoolBuffer<vectorized::Decimal32Column, kBufferSize> Decimal32ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Decimal64Column, kBufferSize> Decimal64ColumnBuffer;
+    ColumnPoolBuffer<vectorized::Decimal128Column, kBufferSize> Decimal128ColumnBuffer;
+
+    template <typename T>
+    struct PipelineColumnDeleter {
+        PipelineColumnDeleter(PipelineColumnPool* pipeline_column_pool, uint32_t chunk_size)
+                : pipeline_column_pool(pipeline_column_pool), chunk_size(chunk_size) {}
+        void operator()(vectorized::Column* ptr) const {
+            pipeline_column_pool->return_column<T>(down_cast<T*>(ptr), chunk_size);
+        }
+        PipelineColumnPool* pipeline_column_pool;
+        uint32_t chunk_size;
+    };
+
+    template <typename T, bool force>
+    T* get_column();
+
+    template <typename T>
+    void return_column(T* ptr, size_t chunk_size);
+
+    template <typename T, bool force>
+    std::shared_ptr<T> get_column_ptr(size_t chunk_size);
+
+    template <typename T, bool force>
+    std::shared_ptr<vectorized::DecimalColumnType<T>> get_decimal_column_ptr(int precision, int scale,
+                                                                             size_t chunk_size);
+
+    template <bool force>
+    struct PipelineColumnPtrBuild {
+        PipelineColumnPtrBuild(PipelineColumnPool* column_pool);
+        template <FieldType ftype>
+        vectorized::ColumnPtr operator()(size_t chunk_size, const vectorized::Field& field, int precision, int scale);
+
+        PipelineColumnPool* _column_pool;
+    };
+
+    template <bool force>
+    vectorized::ColumnPtr column_from_pool(const vectorized::Field& field, size_t chunk_size);
+
+public:
+    vectorized::Chunk* new_chunk_pooled(const vectorized::Schema& schema, size_t chunk_size, bool force);
+
+    template <typename T>
+    static int64_t column_bytes(const T* col) {
+        static_assert(std::is_base_of_v<vectorized::Column, T>, "must_derived_of_Column");
+        return col->memory_usage();
+    }
+
+    // Returns the number of bytes freed to tcmalloc.
+    template <typename T>
+    static size_t release_large_column(T* col, size_t limit) {
+        auto old_usage = column_bytes(col);
+        if (old_usage < limit) {
+            return 0;
+        }
+        if constexpr (std::is_same_v<vectorized::BinaryColumn, T>) {
+            auto& bytes = col->get_bytes();
+            vectorized::BinaryColumn::Bytes tmp;
+            tmp.swap(bytes);
+        } else {
+            typename T::Container tmp;
+            tmp.swap(col->get_data());
+        }
+        auto new_usage = column_bytes(col);
+        DCHECK_LT(new_usage, old_usage);
+        return old_usage - new_usage;
+    }
+
+    template <typename T>
+    void release_large_columns(size_t limit) {
+        if constexpr (false) {
+        }
+#define DISPATCH_DIFFERENT_COLUMN(NAME)                                     \
+    else if constexpr (std::is_same_v<T, vectorized::NAME>) {               \
+        auto& buffer = NAME##Buffer;                                        \
+        auto& blocks = buffer.blocks;                                       \
+        std::lock_guard<std::mutex> l(buffer.mtx);                          \
+        for (int i = 0; i < blocks.size(); ++i) {                           \
+            auto block = blocks[i];                                         \
+            size_t freed_bytes = 0;                                         \
+            for (int j = 0; j < block->nfree; ++j) {                        \
+                freed_bytes += release_large_column(block->ptrs[j], limit); \
+            }                                                               \
+            if (freed_bytes > 0) {                                          \
+                block->bytes -= freed_bytes;                                \
+            }                                                               \
+        }                                                                   \
+    }
+        APPLY_FOR_ALL_SUPPORT_COLUMNS(DISPATCH_DIFFERENT_COLUMN)
+#undef DISPATCH_DIFFERENT_COLUMN
+    }
+};
+
+using PipelineColumnPoolPtr = std::shared_ptr<PipelineColumnPool>;
+
+class PipelineColumnPoolManager {
+public:
+    PipelineColumnPoolManager() = default;
+    ~PipelineColumnPoolManager() = default;
+
+    PipelineColumnPoolManager(const PipelineColumnPoolManager&) = delete;
+    PipelineColumnPoolManager(PipelineColumnPoolManager&&) = delete;
+
+    PipelineColumnPool* get_or_register(const TUniqueId& fragment_id);
+    PipelineColumnPoolPtr get(const TUniqueId& fragment_id);
+
+private:
+    std::mutex _lock;
+    std::unordered_map<TUniqueId, PipelineColumnPoolPtr> _pipeline_column_pool_contexts;
+};
+
+// All column types that support by PipelineColumnPool.
+using PipelineColumnPoolList =
+        vectorized::TypeList<vectorized::Int8Column, vectorized::UInt8Column, vectorized::Int16Column,
+                             vectorized::Int32Column, vectorized::UInt32Column, vectorized::Int64Column,
+                             vectorized::Int128Column, vectorized::FloatColumn, vectorized::DoubleColumn,
+                             vectorized::BinaryColumn, vectorized::DateColumn, vectorized::TimestampColumn,
+                             vectorized::DecimalColumn, vectorized::Decimal32Column, vectorized::Decimal64Column,
+                             vectorized::Decimal128Column>;
+
+template <typename T>
+struct HasPipelineColumnPool : public std::bool_constant<vectorized::InList<T, PipelineColumnPoolList>::value> {};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -10,6 +10,7 @@
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/operator_with_dependency.h"
+#include "exec/pipeline/pipeline_column_pool.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/runtime_filter_types.h"
@@ -354,6 +355,10 @@ public:
     inline bool is_in_ready_queue() const { return _in_ready_queue.load(std::memory_order_acquire); }
     void set_in_ready_queue(bool v) { _in_ready_queue.store(v, std::memory_order_release); }
 
+    void set_column_pool(PipelineColumnPool* column_pool) { _column_pool = column_pool; }
+
+    PipelineColumnPool* get_column_pool() { return _column_pool; }
+
 private:
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;
@@ -405,6 +410,9 @@ private:
     // The index of QuerySharedDriverQueue{WithoutLock}._queues which this driver belongs to.
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};
+
+    // Column Pool used by this driver, It choosed by runtime.
+    PipelineColumnPool* _column_pool;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "exec/pipeline/exec_state_reporter.h"
+#include "exec/pipeline/pipeline_column_pool.h"
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/pipeline_driver_poller.h"
 #include "exec/pipeline/pipeline_driver_queue.h"
@@ -54,8 +55,9 @@ public:
 
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;
-    void _worker_thread();
-    void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
+    void _worker_thread(int thread_id);
+    void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state,
+                          PipelineColumnPool* pipeline_column_pool);
     void _update_profile_by_level(FragmentContext* fragment_ctx, bool done);
     void _remove_non_core_metrics(FragmentContext* fragment_ctx, std::vector<RuntimeProfile*>& driver_profiles);
     void _simplify_common_metrics(RuntimeProfile* driver_profile);
@@ -74,6 +76,9 @@ private:
     // metrics
     std::unique_ptr<UIntGauge> _driver_queue_len;
     std::unique_ptr<UIntGauge> _driver_poller_block_queue_len;
+
+    // dispatch to different column pool.
+    std::unique_ptr<PipelineColumnPoolManager> _pipeline_column_pool_mgr;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/chunk_pool_manager.h
+++ b/be/src/exec/pipeline/scan/chunk_pool_manager.h
@@ -1,0 +1,44 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "column/chunk.h"
+
+namespace starrocks {
+namespace pipeline {
+template <typename T>
+class Stack {
+public:
+    void reserve(size_t n) { _items.reserve(n); }
+
+    void push(const T& p) { _items.push_back(p); }
+
+    void push(T&& v) { _items.emplace_back(std::move(v)); }
+
+    void clear() { _items.clear(); }
+
+    // REQUIRES: not empty.
+    T pop() {
+        DCHECK(!_items.empty());
+        T v = _items.back();
+        _items.pop_back();
+        return v;
+    }
+
+    size_t size() const { return _items.size(); }
+
+    bool empty() const { return _items.empty(); }
+
+    void reverse() { std::reverse(_items.begin(), _items.end()); }
+
+private:
+    std::vector<T> _items;
+};
+
+struct ChunkPoolManager {
+    std::mutex mtx;
+    Stack<vectorized::ChunkPtr> chunk_pool;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -6,6 +6,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
+#include "exec/pipeline/scan/chunk_pool_manager.h"
 #include "exec/pipeline/scan/morsel.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "util/exclusive_ptr.h"
@@ -38,7 +39,8 @@ public:
 
     virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
 
-    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state) = 0;
+    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state,
+                                                     ChunkPoolManager* chunk_pool_manager) = 0;
     virtual Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, RuntimeState* state,
                                                                    size_t* num_read_chunks, int worker_id,
                                                                    workgroup::WorkGroupPtr running_wg) = 0;
@@ -57,6 +59,8 @@ public:
         _last_scan_bytes = 0;
         return res;
     }
+
+    virtual size_t get_curr_buffer_size() { return 0; }
 
 protected:
     RuntimeProfile* _runtime_profile;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -33,7 +33,7 @@ public:
 
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
-    ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
+    Status create_chunk_source(RuntimeState* state, MorselPtr morsel, int32_t chunk_source_index) override;
 
 private:
 };
@@ -57,7 +57,8 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state,
+                                             ChunkPoolManager* chunk_pool_manager) override;
     Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, RuntimeState* state,
                                                            size_t* num_read_chunks, int worker_id,
                                                            workgroup::WorkGroupPtr running_wg) override;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -49,12 +49,15 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, RuntimeState* state,
+                                             ChunkPoolManager* chunk_pool_manager) override;
     Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, RuntimeState* state,
                                                            size_t* num_read_chunks, int worker_id,
                                                            workgroup::WorkGroupPtr running_wg) override;
 
     int64_t last_spent_cpu_time_ns() override;
+
+    vectorized::ChunkIterator* get_prj_iter() { return _prj_iter.get(); }
 
 private:
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
@@ -89,6 +92,11 @@ private:
     TInternalScanRange* _scan_range;
 
     Status _status = Status::OK();
+
+public:
+    size_t get_curr_buffer_size() override;
+
+private:
     UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_buffer;
     vectorized::ConjunctivePredicates _not_push_down_predicates;
     std::vector<uint8_t> _selection;

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -42,7 +42,7 @@ public:
 
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
-    ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
+    Status create_chunk_source(RuntimeState* state, MorselPtr morsel, int32_t chunk_source_index) override;
 
     size_t max_scan_concurrency() const override;
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -7,7 +7,7 @@
 #include "column/column_helper.h"
 #include "column/column_pool.h"
 #include "column/schema.h"
-#include "column/type_traits.h"
+#include "column/type_column_traits.h"
 #include "runtime/descriptors.h"
 #include "storage/olap_type_infra.h"
 #include "storage/tablet_schema.h"
@@ -17,69 +17,6 @@
 #include "util/percentile_value.h"
 
 namespace starrocks::vectorized {
-
-// NOTE(zc): now CppColumnTraits is only used for this class, so I move it here.
-// Someday if it is used by others, please move it into a single file.
-// CppColumnTraits
-// Infer ColumnType from FieldType
-template <FieldType ftype>
-struct CppColumnTraits {
-    using CppType = typename CppTypeTraits<ftype>::CppType;
-    using ColumnType = typename vectorized::ColumnTraits<CppType>::ColumnType;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_BOOL> {
-    using ColumnType = vectorized::UInt8Column;
-};
-
-// deprecated
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_DATE> {
-    using ColumnType = vectorized::FixedLengthColumn<uint24_t>;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_DATE_V2> {
-    using ColumnType = vectorized::DateColumn;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_TIMESTAMP> {
-    using ColumnType = vectorized::TimestampColumn;
-};
-
-// deprecated
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_DECIMAL> {
-    using ColumnType = vectorized::FixedLengthColumn<decimal12_t>;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_HLL> {
-    using ColumnType = vectorized::HyperLogLogColumn;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_PERCENTILE> {
-    using ColumnType = vectorized::PercentileColumn;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_OBJECT> {
-    using ColumnType = vectorized::BitmapColumn;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_UNSIGNED_INT> {
-    using ColumnType = vectorized::UInt32Column;
-};
-
-template <>
-struct CppColumnTraits<OLAP_FIELD_TYPE_JSON> {
-    using ColumnType = vectorized::JsonColumn;
-};
-
 vectorized::Field ChunkHelper::convert_field(ColumnId id, const TabletColumn& c) {
     TypeInfoPtr type_info = get_type_info(c);
     starrocks::vectorized::Field f(id, std::string(c.name()), type_info, c.is_nullable());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
We support PipelineColumnPool for scan operations with pipeline engine, 
It different from ColumnPool with following points:
- ColumnPool is singleton and columns used by only one fragment_thread, but columns from PipelineColumnPool are transfered througth many pipelinedrivers, so that used by many driver_threads.
- ColumnPool has a global mechanism to collect too many columns from all columnpool, and PipelineColumnPool not.

## Implementation ：
- For every pipline driver thread, we use unique thread_id to get columnpool from Manager, we get columns from columnpool, and that used by scan operators now.
- For every io task, we try to complement _chunk_buffer to **_buffer_size**, It better than get _buffer_size chunks for every io taske to memory usage.
- we release lager memory in finalize stage of pipeline_driver.

## TODO:
- find a better usage to release large memroy(maybe finalize stage is not good enough).
- release memory with ratio in thread's function.
- add mem_tracker.
- test it with workgroup.