### PR TITLE
[Cherry-Pick-2.3][BugFix] Fix load jobs hang with error: current running txns on db xxx is 100, larger than limit 100

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -151,7 +151,7 @@ public class MasterImpl {
     public TMasterResult finishTask(TFinishTaskRequest request) {
         // if current node is not master, reject the request
         TMasterResult result = new TMasterResult();
-        if (!Catalog.getCurrentCatalog().isMaster()) {
+        if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
             result.setStatus(status);
@@ -921,7 +921,7 @@ public class MasterImpl {
     public TMasterResult report(TReportRequest request) throws TException {
         // if current node is not master, reject the request
         TMasterResult result = new TMasterResult();
-        if (!Catalog.getCurrentCatalog().isMaster()) {
+        if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
             result.setStatus(status);

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -149,7 +149,14 @@ public class MasterImpl {
     }
 
     public TMasterResult finishTask(TFinishTaskRequest request) {
+        // if current node is not master, reject the request
         TMasterResult result = new TMasterResult();
+        if (!Catalog.getCurrentCatalog().isMaster()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
         TStatus tStatus = new TStatus(TStatusCode.OK);
         result.setStatus(tStatus);
         // check task status
@@ -912,6 +919,14 @@ public class MasterImpl {
     }
 
     public TMasterResult report(TReportRequest request) throws TException {
+        // if current node is not master, reject the request
+        TMasterResult result = new TMasterResult();
+        if (!Catalog.getCurrentCatalog().isMaster()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
         return reportHandler.handleReport(request);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -767,7 +767,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         TLoadTxnBeginResult result = new TLoadTxnBeginResult();
         // if current node is not master, reject the request
-        if (!Catalog.getCurrentCatalog().isMaster()) {
+        if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
             result.setStatus(status);
@@ -843,7 +843,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         TLoadTxnCommitResult result = new TLoadTxnCommitResult();
         // if current node is not master, reject the request
-        if (!Catalog.getCurrentCatalog().isMaster()) {
+        if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
             result.setStatus(status);
@@ -953,7 +953,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         TLoadTxnRollbackResult result = new TLoadTxnRollbackResult();
         // if current node is not master, reject the request
-        if (!Catalog.getCurrentCatalog().isMaster()) {
+        if (!GlobalStateMgr.getCurrentState().isMaster()) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.setError_msgs(Lists.newArrayList("current fe is not master"));
             result.setStatus(status);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -766,6 +766,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn begin request: {}", request);
 
         TLoadTxnBeginResult result = new TLoadTxnBeginResult();
+        // if current node is not master, reject the request
+        if (!Catalog.getCurrentCatalog().isMaster()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
+
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
         try {
@@ -834,6 +842,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn commit request: {}", request);
 
         TLoadTxnCommitResult result = new TLoadTxnCommitResult();
+        // if current node is not master, reject the request
+        if (!Catalog.getCurrentCatalog().isMaster()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
+
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
         try {
@@ -936,6 +952,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         LOG.debug("txn rollback request: {}", request);
 
         TLoadTxnRollbackResult result = new TLoadTxnRollbackResult();
+        // if current node is not master, reject the request
+        if (!Catalog.getCurrentCatalog().isMaster()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
+
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
         try {


### PR DESCRIPTION
After transferring the master, the master address recorded in be is still the address of the old master(the time before it reaches the new master's heartbeat). The txnCommit rpc executed on non-master fe will cause some metadata inconsistency issues (described in https://github.com/StarRocks/starrocks/issues/7350). So we should reject those request if current node is not master.