### PR TITLE
[Refactor] Refactor DdlExecutor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/execution/CreateDbExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/execution/CreateDbExecutor.java
@@ -1,0 +1,17 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.execution;
+
+import com.starrocks.analysis.CreateDbStmt;
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+
+public class CreateDbExecutor implements DataDefinitionExecutor {
+
+    public ShowResultSet execute(StatementBase stmt, ConnectContext context) throws DdlException {
+        context.getGlobalStateMgr().createDb((CreateDbStmt) stmt);
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutor.java
@@ -1,0 +1,14 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.execution;
+
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+
+public interface DataDefinitionExecutor {
+
+    ShowResultSet execute(StatementBase stmt, ConnectContext context) throws DdlException;
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutorFactory.java
@@ -1,0 +1,27 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.execution;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.analysis.CreateDbStmt;
+import com.starrocks.analysis.DdlStmt;
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DdlExecutor;
+import com.starrocks.qe.ShowResultSet;
+
+public class DataDefinitionExecutorFactory {
+    private final static ImmutableMap<Class<? extends StatementBase>, DataDefinitionExecutor> executorMap =
+            new ImmutableMap.Builder<Class<? extends StatementBase>, DataDefinitionExecutor>()
+                    .put(CreateDbStmt.class, new CreateDbExecutor()).
+                    build();
+
+    public static ShowResultSet execute(StatementBase stmt, ConnectContext context) throws Exception {
+        DataDefinitionExecutor executor = executorMap.get(stmt.getClass());
+        if (executor != null) {
+            return executor.execute(stmt, context);
+        } else {
+            return DdlExecutor.execute(context.getGlobalStateMgr(), (DdlStmt) stmt);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/execution/DataDefinitionExecutorFactory.java
@@ -11,7 +11,7 @@ import com.starrocks.qe.DdlExecutor;
 import com.starrocks.qe.ShowResultSet;
 
 public class DataDefinitionExecutorFactory {
-    private final static ImmutableMap<Class<? extends StatementBase>, DataDefinitionExecutor> executorMap =
+    private static final ImmutableMap<Class<? extends StatementBase>, DataDefinitionExecutor> executorMap =
             new ImmutableMap.Builder<Class<? extends StatementBase>, DataDefinitionExecutor>()
                     .put(CreateDbStmt.class, new CreateDbExecutor()).
                     build();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
@@ -41,7 +41,6 @@ import com.starrocks.analysis.CancelAlterTableStmt;
 import com.starrocks.analysis.CancelBackupStmt;
 import com.starrocks.analysis.CancelExportStmt;
 import com.starrocks.analysis.CancelLoadStmt;
-import com.starrocks.analysis.CreateDbStmt;
 import com.starrocks.analysis.CreateFileStmt;
 import com.starrocks.analysis.CreateFunctionStmt;
 import com.starrocks.analysis.CreateMaterializedViewStmt;
@@ -98,9 +97,7 @@ import com.starrocks.sql.ast.SubmitTaskStmt;
 
 public class DdlExecutor {
     public static ShowResultSet execute(GlobalStateMgr globalStateMgr, DdlStmt ddlStmt) throws Exception {
-        if (ddlStmt instanceof CreateDbStmt) {
-            globalStateMgr.createDb((CreateDbStmt) ddlStmt);
-        } else if (ddlStmt instanceof DropDbStmt) {
+        if (ddlStmt instanceof DropDbStmt) {
             globalStateMgr.dropDb((DropDbStmt) ddlStmt);
         } else if (ddlStmt instanceof CreateFunctionStmt) {
             globalStateMgr.createFunction((CreateFunctionStmt) ddlStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -68,6 +68,7 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.execution.DataDefinitionExecutorFactory;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.InsertOverwriteJob;
 import com.starrocks.load.InsertOverwriteJobManager;
@@ -928,7 +929,7 @@ public class StmtExecutor {
 
     private void handleDdlStmt() {
         try {
-            ShowResultSet resultSet = DdlExecutor.execute(context.getGlobalStateMgr(), (DdlStmt) parsedStmt);
+            ShowResultSet resultSet = DataDefinitionExecutorFactory.execute(parsedStmt, context);
             if (resultSet == null) {
                 context.getState().setOk();
             } else {


### PR DESCRIPTION
Now when executing a DDL statement, all DDL Statement will be checked, this is not efficient.
And what's more, all DDL execute entrance is GlobalStateMgr method, which makes it huge and hard to maintain.
But it is not necessary.
So I want to create multiple DDLExecutors for each statement, and offload work from GlobalStateMgr to new DDLExecutors.