### PR TITLE
[Enhancement] assign tablets to each scan operator for some cases

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -50,6 +50,9 @@ public:
         return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id, driver_sequence);
     }
 
+    bool need_local_shuffle() const override;
+    TPartitionType::type partition_type() const override;
+
     std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state,
                                                          const std::shared_ptr<RuntimeProfile>& profile);
     void close_stream_recvr();

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -25,9 +25,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
         }
 
         auto it = _num_sinkers.find(instance_id.lo);
-        if (it != _num_sinkers.end()) {
-            it->second += num_sinkers;
-        } else {
+        if (it == _num_sinkers.end()) {
             _num_sinkers[instance_id.lo] = num_sinkers;
 
             _request_seqs[instance_id.lo] = -1;
@@ -46,10 +44,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
         }
     }
 
-    _num_remaining_eos = 0;
-    for (auto& [_, num] : _num_sinkers) {
-        _num_remaining_eos += num;
-    }
+    _num_remaining_eos = _num_sinkers.size() * num_sinkers;
 }
 
 SinkBuffer::~SinkBuffer() {

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -84,7 +84,7 @@ public:
 
     bool is_canceled() { return _runtime_state->is_cancelled(); }
 
-    MorselQueueMap& morsel_queues() { return _morsel_queues; }
+    MorselQueueFactoryMap& morsel_queue_factories() { return _morsel_queue_factories; }
 
     Status prepare_all_pipelines() {
         for (auto& pipe : _pipelines) {
@@ -134,10 +134,8 @@ private:
     Drivers _drivers;
 
     RuntimeFilterHub _runtime_filter_hub;
-    // _morsel_queues is mapping from an source_id to its corresponding
-    // MorselQueue that is shared among drivers created from the same pipeline,
-    // drivers contend for Morsels from MorselQueue.
-    MorselQueueMap _morsel_queues;
+
+    MorselQueueFactoryMap _morsel_queue_factories;
     // when _num_drivers counts down to zero, means all drivers has finished, then BE
     // can notify FE via reportExecStatus that fragment instance is done after which
     // FragmentContext can be unregistered safely.

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -237,6 +237,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
     const DescriptorTbl& desc_tbl = runtime_state->desc_tbl();
     const auto& params = request.params;
     const auto& fragment = request.fragment;
+    const auto dop = _calc_dop(exec_env, request);
 
     // Set up plan
     RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, desc_tbl, &_fragment_ctx->plan()));
@@ -257,6 +258,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;
     std::vector<TScanRangeParams> no_scan_ranges;
+    std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
     plan->collect_scan_nodes(&scan_nodes);
 
     bool enable_shared_scan = false;
@@ -264,14 +266,20 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
         enable_shared_scan = request.enable_shared_scan;
     }
 
-    MorselQueueMap& morsel_queues = _fragment_ctx->morsel_queues();
+    MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
     for (auto& i : scan_nodes) {
-        ScanNode* scan_node = down_cast<ScanNode*>(i);
+        auto* scan_node = down_cast<ScanNode*>(i);
         const std::vector<TScanRangeParams>& scan_ranges =
                 FindWithDefault(params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
-        ASSIGN_OR_RETURN(MorselQueuePtr morsel_queue,
-                         scan_node->convert_scan_range_to_morsel_queue(scan_ranges, scan_node->id(), request));
-        morsel_queues.emplace(scan_node->id(), std::move(morsel_queue));
+        auto& scan_ranges_per_driver_seq = params.__isset.node_to_per_driver_seq_scan_ranges
+                                                   ? FindWithDefault(params.node_to_per_driver_seq_scan_ranges,
+                                                                     scan_node->id(), no_scan_ranges_per_driver_seq)
+                                                   : no_scan_ranges_per_driver_seq;
+
+        ASSIGN_OR_RETURN(auto morsel_queue_factory,
+                         scan_node->convert_scan_range_to_morsel_queue_factory(scan_ranges, scan_ranges_per_driver_seq,
+                                                                               scan_node->id(), request, dop));
+        morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
 
         if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
             olap_scan->enable_shared_scan(enable_shared_scan);
@@ -288,7 +296,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
     ExecNode* plan = _fragment_ctx->plan();
 
     Drivers drivers;
-    MorselQueueMap& morsel_queues = _fragment_ctx->morsel_queues();
+    MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
     auto* runtime_state = _fragment_ctx->runtime_state();
     const auto& pipelines = _fragment_ctx->pipelines();
 
@@ -324,15 +332,15 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
         setup_profile_hierarchy(runtime_state, pipeline);
         if (pipeline->source_operator_factory()->with_morsels()) {
             auto source_id = pipeline->get_op_factories()[0]->plan_node_id();
-            DCHECK(morsel_queues.count(source_id));
-            auto& morsel_queue = morsel_queues[source_id];
-            DCHECK(morsel_queue->num_morsels() == 0 || cur_pipeline_dop <= morsel_queue->num_morsels());
+            DCHECK(morsel_queue_factories.count(source_id));
+            auto& morsel_queue_factory = morsel_queue_factories[source_id];
+            DCHECK_EQ(cur_pipeline_dop, morsel_queue_factory->size());
 
             for (size_t i = 0; i < cur_pipeline_dop; ++i) {
                 auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);
                 DriverPtr driver = std::make_shared<PipelineDriver>(std::move(operators), _query_ctx,
                                                                     _fragment_ctx.get(), driver_id++);
-                driver->set_morsel_queue(morsel_queue.get());
+                driver->set_morsel_queue(morsel_queue_factory->create(i));
                 if (auto* scan_operator = driver->source_scan_operator()) {
                     if (_wg != nullptr) {
                         // Workgroup uses scan_executor instead of pipeline_scan_io_thread_pool.

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -58,7 +58,11 @@ public:
 
     FragmentContext* fragment_context() { return _fragment_context; }
 
-    MorselQueue* morsel_queue_of_source_operator(const SourceOperatorFactory* source_op);
+    size_t dop_of_source_operator(int source_node_id);
+    MorselQueueFactory* morsel_queue_factory_of_source_operator(int source_node_id);
+    MorselQueueFactory* morsel_queue_factory_of_source_operator(const SourceOperatorFactory* source_op);
+    // Whether the building pipeline `ops` need local shuffle for the next operator.
+    bool need_local_shuffle(OpFactories ops) const;
 
 private:
     static constexpr int kLocalExchangeBufferChunks = 8;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -146,6 +146,9 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
+    bool need_local_shuffle() const override { return _need_local_shuffle; }
+    void set_need_local_shuffle(bool need_local_shuffle) { _need_local_shuffle = need_local_shuffle; }
+
     // interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;
     virtual void do_close(RuntimeState* state) = 0;
@@ -153,6 +156,7 @@ public:
 
 protected:
     ScanNode* const _scan_node;
+    bool _need_local_shuffle = true;
 
     std::atomic<int> _num_committed_scan_tasks{0};
 };

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -31,6 +31,14 @@ public:
     }
     virtual size_t degree_of_parallelism() const { return _degree_of_parallelism; }
 
+    // When the pipeline of this source operator wants to insert a local shuffle for some complex operators,
+    // such as hash join and aggregate, use this method to decide whether really need to insert a local shuffle.
+    // There are two source operators returning false.
+    // - The scan operator, which has been assigned tablets with the specific bucket sequences.
+    // - The exchange source operator, partitioned by HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED.
+    virtual bool need_local_shuffle() const { return true; }
+    virtual TPartitionType::type partition_type() const { return TPartitionType::type::HASH_PARTITIONED; }
+
 protected:
     size_t _degree_of_parallelism = 1;
 };

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -54,8 +54,34 @@ Status ScanNode::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
+StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel_queue_factory(
+        const std::vector<TScanRangeParams>& global_scan_ranges,
+        const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
+        const TExecPlanFragmentParams& request, int pipeline_dop) {
+    if (scan_ranges_per_driver_seq.empty()) {
+        ASSIGN_OR_RETURN(auto morsel_queue, convert_scan_range_to_morsel_queue(global_scan_ranges, node_id, request,
+                                                                               global_scan_ranges.size()));
+        int scan_dop = std::min<int>(std::max<int>(1, morsel_queue->num_morsels()), pipeline_dop);
+        return std::make_unique<pipeline::SharedMorselQueueFactory>(std::move(morsel_queue), scan_dop);
+    } else {
+        size_t num_total_scan_ranges = 0;
+        for (const auto& [_, scan_ranges] : scan_ranges_per_driver_seq) {
+            num_total_scan_ranges += scan_ranges.size();
+        }
+
+        std::map<int, pipeline::MorselQueuePtr> queue_per_driver_seq;
+        for (const auto& [dop, scan_ranges] : scan_ranges_per_driver_seq) {
+            ASSIGN_OR_RETURN(auto queue,
+                             convert_scan_range_to_morsel_queue(scan_ranges, node_id, request, num_total_scan_ranges));
+            queue_per_driver_seq.emplace(dop, std::move(queue));
+        }
+
+        return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(queue_per_driver_seq));
+    }
+}
+
 StatusOr<pipeline::MorselQueuePtr> ScanNode::convert_scan_range_to_morsel_queue(
-        const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams&) {
+        const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams&, size_t) {
     pipeline::Morsels morsels;
     // If this scan node does not accept non-empty scan ranges, create a placeholder one.
     if (!accept_empty_scan_ranges() && scan_ranges.empty()) {

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -32,6 +32,8 @@ namespace starrocks {
 namespace pipeline {
 class MorselQueue;
 using MorselQueuePtr = std::unique_ptr<MorselQueue>;
+class MorselQueueFactory;
+using MorselQueueFactoryPtr = std::unique_ptr<MorselQueueFactory>;
 } // namespace pipeline
 
 class TScanRange;
@@ -63,8 +65,13 @@ public:
     // Convert scan_ranges into node-specific scan restrictions.  This should be
     // called after prepare()
     virtual Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) = 0;
+    virtual StatusOr<pipeline::MorselQueueFactoryPtr> convert_scan_range_to_morsel_queue_factory(
+            const std::vector<TScanRangeParams>& scan_ranges,
+            const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
+            const TExecPlanFragmentParams& request, int pipeline_dop);
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
-            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request);
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request,
+            size_t num_total_scan_ranges);
 
     // If this scan node accept empty scan ranges.
     virtual bool accept_empty_scan_ranges() const { return true; }

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -169,42 +169,24 @@ Status AggregateBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::decompose_to_pipeline(
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
-    OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
     auto& agg_node = _tnode.agg_node;
     if (agg_node.need_finalize) {
         // If finalize aggregate with group by clause, then it can be paralized
         if (agg_node.__isset.grouping_exprs && !_tnode.agg_node.grouping_exprs.empty()) {
-            // There are two ways of shuffle
-            // 1. If previous op is ExchangeSourceOperator and its partition type is HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED
-            // then pipeline level shuffle will be performed at sender side (ExchangeSinkOperator), so
-            // there is no need to perform local shuffle again at receiver side
-            // 2. Otherwise, add LocalExchangeOperator
-            // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into AggregateBlockingSinkOperator.
-            bool need_local_shuffle = true;
-            if (auto* exchange_op = dynamic_cast<ExchangeSourceOperatorFactory*>(operators_with_sink[0].get());
-                exchange_op != nullptr) {
-                auto& texchange_node = exchange_op->texchange_node();
-                DCHECK(texchange_node.__isset.partition_type);
-                if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||
-                    texchange_node.partition_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
-                    need_local_shuffle = false;
-                }
-            }
-            if (need_local_shuffle) {
+            if (context->need_local_shuffle(ops_with_sink)) {
                 std::vector<ExprContext*> group_by_expr_ctxs;
                 Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &group_by_expr_ctxs);
-                operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(
-                        runtime_state(), operators_with_sink, group_by_expr_ctxs);
+                ops_with_sink = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), ops_with_sink,
+                                                                                  group_by_expr_ctxs);
             }
         } else {
-            operators_with_sink =
-                    context->maybe_interpolate_local_passthrough_exchange(runtime_state(), operators_with_sink);
+            ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
         }
     }
     // We cannot get degree of parallelism from PipelineBuilderContext, of which is only a suggest value
     // and we may set other parallelism for source operator in many special cases
-    size_t degree_of_parallelism =
-            down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
+    size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
 
     // shared by sink operator and source operator
     AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
@@ -215,8 +197,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
                                                                                 aggregator_factory);
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(sink_operator.get(), context, rc_rf_probe_collector);
-    operators_with_sink.push_back(std::move(sink_operator));
-    context->add_pipeline(operators_with_sink);
+    ops_with_sink.push_back(std::move(sink_operator));
+    context->add_pipeline(ops_with_sink);
 
     OpFactories operators_with_source;
     auto source_operator = std::make_shared<AggregateBlockingSourceOperatorFactory>(context->next_operator_id(), id(),

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -129,12 +129,7 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 }
 
 pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    int node_id = id();
-    auto& morsel_queues = context->fragment_context()->morsel_queues();
-    DCHECK_GT(morsel_queues.count(node_id), 0);
-    auto& morsel_queue = morsel_queues[node_id];
-    size_t dop = std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-
+    size_t dop = context->dop_of_source_operator(id());
     auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop);
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -54,8 +54,8 @@ public:
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
-            const std::vector<TScanRangeParams>& scan_ranges, int node_id,
-            const TExecPlanFragmentParams& request) override;
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request,
+            size_t num_total_scan_ranges) override;
 
     void debug_string(int indentation_level, std::stringstream* out) const override {
         *out << "vectorized::OlapScanNode";
@@ -137,8 +137,8 @@ private:
     void _estimate_scan_and_output_row_bytes();
 
     StatusOr<bool> _could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
-                                                   const TExecPlanFragmentParams& request, int64_t* scan_dop,
-                                                   int64_t* splitted_scan_rows) const;
+                                                   const TExecPlanFragmentParams& request, size_t num_total_scan_ranges,
+                                                   int64_t* scan_dop, int64_t* splitted_scan_rows) const;
     StatusOr<bool> _could_split_tablet_physically(const std::vector<TScanRangeParams>& scan_ranges) const;
 
 private:

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ListUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ListUtil.java
@@ -20,6 +20,7 @@ package com.starrocks.common.util;
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ListUtil {
@@ -39,6 +40,10 @@ public class ListUtil {
             throws NullPointerException, IllegalArgumentException {
         Preconditions.checkNotNull(list, "list must not be null");
         Preconditions.checkArgument(expectedSize > 0, "expectedSize must larger than 0");
+
+        if (1 == expectedSize) {
+            return Collections.singletonList(list);
+        }
 
         int splitSize = Math.min(expectedSize, list.size());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -337,6 +337,10 @@ public class Coordinator {
         this.queryOptions.setQuery_timeout(timeout);
     }
 
+    public void addReplicateScanId(Integer scanId) {
+        replicateScanIds.add(scanId);
+    }
+
     public void clearExportStatus() {
         lock.lock();
         try {
@@ -1067,10 +1071,12 @@ public class Coordinator {
                     dest.setBrpc_server(dummyServer);
 
                     for (FInstanceExecParam instanceExecParams : destParams.instanceExecParams) {
-                        if (instanceExecParams.bucketSeqSet.contains(bucketSeq)) {
+                        Integer driverSeq = instanceExecParams.bucketSeqToDriverSeq.get(bucketSeq);
+                        if (driverSeq != null) {
                             dest.fragment_instance_id = instanceExecParams.instanceId;
                             dest.server = toRpcHost(instanceExecParams.host);
                             dest.setBrpc_server(toBrpcHost(instanceExecParams.host));
+                            dest.setPipeline_driver_sequence(driverSeq);
                             break;
                         }
                     }
@@ -1132,10 +1138,12 @@ public class Coordinator {
                         dest.setBrpc_server(dummyServer);
 
                         for (FInstanceExecParam instanceExecParams : destParams.instanceExecParams) {
-                            if (instanceExecParams.bucketSeqSet.contains(bucketSeq)) {
+                            Integer driverSeq = instanceExecParams.bucketSeqToDriverSeq.get(bucketSeq);
+                            if (driverSeq != null) {
                                 dest.fragment_instance_id = instanceExecParams.instanceId;
                                 dest.server = toRpcHost(instanceExecParams.host);
                                 dest.setBrpc_server(toBrpcHost(instanceExecParams.host));
+                                dest.setPipeline_driver_sequence(driverSeq);
                                 break;
                             }
                         }
@@ -1206,9 +1214,11 @@ public class Coordinator {
             PlanFragment fragment = fragments.get(i);
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
 
-            boolean dopAdaptionEnabled = connectContext != null &&
-                    connectContext.getSessionVariable().isPipelineDopAdaptionEnabled() &&
+            boolean enablePipeline = connectContext != null &&
+                    connectContext.getSessionVariable().isEnablePipelineEngine() &&
                     fragment.getPlanRoot().canUsePipeLine();
+            boolean dopAdaptionEnabled = enablePipeline &&
+                    connectContext.getSessionVariable().isPipelineDopAdaptionEnabled();
 
             // If left child is MultiCastDataFragment(only support left now), will keep same instance with child.
             if (fragment.getChildren().size() > 0 && fragment.getChild(0) instanceof MultiCastPlanFragment) {
@@ -1347,13 +1357,16 @@ public class Coordinator {
             }
 
             int parallelExecInstanceNum = fragment.getParallelExecNum();
+            int pipelineDop = fragment.getPipelineDop();
             boolean hasColocate = (isColocateFragment(fragment.getPlanRoot()) &&
                     fragmentIdToSeqToAddressMap.containsKey(fragment.getFragmentId())
                     && fragmentIdToSeqToAddressMap.get(fragment.getFragmentId()).size() > 0);
             boolean hasBucketShuffle = isBucketShuffleJoin(fragment.getFragmentId().asInt());
 
             if (hasColocate || hasBucketShuffle) {
-                computeColocatedJoinInstanceParam(fragment.getFragmentId(), parallelExecInstanceNum, params);
+                computeColocatedJoinInstanceParam(fragmentIdToSeqToAddressMap.get(fragment.getFragmentId()),
+                        fragmentIdBucketSeqToScanRangeMap.get(fragment.getFragmentId()),
+                        parallelExecInstanceNum, pipelineDop, enablePipeline, params);
                 computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
             } else {
                 for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> tNetworkAddressMapEntry :
@@ -1445,7 +1458,7 @@ public class Coordinator {
         }
         for (int i = 0; i < params.instanceExecParams.size(); ++i) {
             FInstanceExecParam instance = params.instanceExecParams.get(i);
-            for (Integer bucketSeq : instance.bucketSeqSet) {
+            for (Integer bucketSeq : instance.bucketSeqToDriverSeq.keySet()) {
                 Preconditions.checkArgument(bucketSeq < numBuckets, "bucketSeq exceeds bucketNum in colocate Fragment");
                 bucketSeq2InstanceOrdinal[bucketSeq] = i;
             }
@@ -1573,60 +1586,78 @@ public class Coordinator {
         return value;
     }
 
-    private void computeColocatedJoinInstanceParam(PlanFragmentId fragmentId, int parallelExecInstanceNum,
-                                                   FragmentExecParams params) {
-        Map<Integer, TNetworkAddress> bucketSeqToAddress = fragmentIdToSeqToAddressMap.get(fragmentId);
-        BucketSeqToScanRange bucketSeqToScanRange = fragmentIdBucketSeqToScanRangeMap.get(fragmentId);
-
+    public void computeColocatedJoinInstanceParam(Map<Integer, TNetworkAddress> bucketSeqToAddress,
+                                                  BucketSeqToScanRange bucketSeqToScanRange,
+                                                  int parallelExecInstanceNum, int pipelineDop, boolean enablePipeline,
+                                                  FragmentExecParams params) {
         // 1. count each node in one fragment should scan how many tablet, gather them in one list
         Map<TNetworkAddress, List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>>> addressToScanRanges =
                 Maps.newHashMap();
-        for (Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>> scanRanges : bucketSeqToScanRange.entrySet()) {
-            TNetworkAddress address = bucketSeqToAddress.get(scanRanges.getKey());
+        for (Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>> bucketSeqAndScanRanges : bucketSeqToScanRange.entrySet()) {
+            TNetworkAddress address = bucketSeqToAddress.get(bucketSeqAndScanRanges.getKey());
 
             if (!addressToScanRanges.containsKey(address)) {
                 addressToScanRanges.put(address, Lists.newArrayList());
             }
-            addressToScanRanges.get(address).add(scanRanges);
+            addressToScanRanges.get(address).add(bucketSeqAndScanRanges);
         }
 
         for (Map.Entry<TNetworkAddress, List<Map.Entry<Integer, Map<Integer,
                 List<TScanRangeParams>>>>> addressScanRange : addressToScanRanges.entrySet()) {
             List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>> scanRange = addressScanRange.getValue();
+
             int expectedInstanceNum = 1;
             if (parallelExecInstanceNum > 1) {
-                //the scan instance num should not larger than the tablets num
+                // The scan instance num should not larger than the tablets num
                 expectedInstanceNum = Math.min(scanRange.size(), parallelExecInstanceNum);
             }
 
             // 2. split how many scanRange one instance should scan
-            List<List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>>> perInstanceScanRanges =
-                    ListUtil.splitBySize(scanRange,
-                            expectedInstanceNum);
+            List<List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>>> scanRangesPerInstance =
+                    ListUtil.splitBySize(scanRange, expectedInstanceNum);
 
             // 3.construct instanceExecParam add the scanRange should be scan by instance
-            for (List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>> perInstanceScanRange : perInstanceScanRanges) {
+            for (List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>> scanRangePerInstance : scanRangesPerInstance) {
                 FInstanceExecParam instanceParam = new FInstanceExecParam(null, addressScanRange.getKey(), 0, params);
                 // record each instance replicate scan id in set, to avoid add replicate scan range repeatedly when they are in different buckets
                 Set<Integer> instanceReplicateScanSet = new HashSet<>();
-                for (Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>> nodeScanRangeMap : perInstanceScanRange) {
-                    instanceParam.addBucketSeq(nodeScanRangeMap.getKey());
-                    for (Map.Entry<Integer, List<TScanRangeParams>> nodeScanRange : nodeScanRangeMap.getValue()
-                            .entrySet()) {
-                        int scanId = nodeScanRange.getKey();
-                        if (!instanceParam.perNodeScanRanges.containsKey(scanId)) {
-                            instanceParam.perNodeScanRanges.put(scanId, new ArrayList<>());
-                        }
-                        if (replicateScanIds.contains(scanId)) {
-                            if (!instanceReplicateScanSet.contains(scanId)) {
-                                instanceParam.perNodeScanRanges.get(scanId).addAll(nodeScanRange.getValue());
-                                instanceReplicateScanSet.add(scanId);
-                            }
-                        } else {
-                            instanceParam.perNodeScanRanges.get(scanId).addAll(nodeScanRange.getValue());
-                        }
-                    }
+
+                int expectedDop = 1;
+                if (pipelineDop > 1) {
+                    expectedDop = Math.min(scanRangePerInstance.size(), pipelineDop);
                 }
+                List<List<Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>>>> scanRangesPerDriverSeq =
+                        ListUtil.splitBySize(scanRangePerInstance, expectedDop);
+                instanceParam.pipelineDop = scanRangesPerDriverSeq.size();
+
+                for (int driverSeq = 0; driverSeq < scanRangesPerDriverSeq.size(); ++driverSeq) {
+                    final int finalDriverSeq = driverSeq;
+                    scanRangesPerDriverSeq.get(finalDriverSeq).forEach(bucketSeqAndScanRanges -> {
+                        instanceParam.addBucketSeqAndDriverSeq(bucketSeqAndScanRanges.getKey(), finalDriverSeq);
+
+                        bucketSeqAndScanRanges.getValue().forEach((scanId, scanRanges) -> {
+                            List<TScanRangeParams> destScanRanges;
+                            if (!enablePipeline) {
+                                destScanRanges = instanceParam.perNodeScanRanges
+                                        .computeIfAbsent(scanId, k -> new ArrayList<>());
+                            } else {
+                                destScanRanges = instanceParam.nodeToPerDriverSeqScanRanges
+                                        .computeIfAbsent(scanId, k -> new HashMap<>())
+                                        .computeIfAbsent(finalDriverSeq, k -> new ArrayList<>());
+                            }
+
+                            if (replicateScanIds.contains(scanId)) {
+                                if (!instanceReplicateScanSet.contains(scanId)) {
+                                    destScanRanges.addAll(scanRanges);
+                                    instanceReplicateScanSet.add(scanId);
+                                }
+                            } else {
+                                destScanRanges.addAll(scanRanges);
+                            }
+                        });
+                    });
+                }
+
                 params.instanceExecParams.add(instanceParam);
             }
         }
@@ -1957,20 +1988,25 @@ public class Coordinator {
     // the per-instance TPlanFragmentExecParas, as a member of
     // FragmentExecParams
     static class FInstanceExecParam {
+        static final int ABSENT_PIPELINE_DOP = -1;
+
         TUniqueId instanceId;
         TNetworkAddress host;
         Map<Integer, List<TScanRangeParams>> perNodeScanRanges = Maps.newHashMap();
+        Map<Integer, Map<Integer, List<TScanRangeParams>>> nodeToPerDriverSeqScanRanges = Maps.newHashMap();
 
         int perFragmentInstanceIdx;
 
-        Set<Integer> bucketSeqSet = Sets.newHashSet();
+        Map<Integer, Integer> bucketSeqToDriverSeq = Maps.newHashMap();
 
         int backendId;
 
         FragmentExecParams fragmentExecParams;
 
-        public void addBucketSeq(int bucketSeq) {
-            this.bucketSeqSet.add(bucketSeq);
+        int pipelineDop = ABSENT_PIPELINE_DOP;
+
+        public void addBucketSeqAndDriverSeq(int bucketSeq, int driverSeq) {
+            this.bucketSeqToDriverSeq.putIfAbsent(bucketSeq, driverSeq);
         }
 
         public FInstanceExecParam(TUniqueId id, TNetworkAddress host,
@@ -1983,6 +2019,26 @@ public class Coordinator {
 
         public PlanFragment fragment() {
             return fragmentExecParams.fragment;
+        }
+
+        public boolean isSetPipelineDop() {
+            return pipelineDop != ABSENT_PIPELINE_DOP;
+        }
+
+        public int getPipelineDop() {
+            return pipelineDop;
+        }
+
+        public Map<Integer, Integer> getBucketSeqToDriverSeq() {
+            return bucketSeqToDriverSeq;
+        }
+
+        public Map<Integer, List<TScanRangeParams>> getPerNodeScanRanges() {
+            return perNodeScanRanges;
+        }
+
+        public Map<Integer, Map<Integer, List<TScanRangeParams>>> getNodeToPerDriverSeqScanRanges() {
+            return nodeToPerDriverSeqScanRanges;
         }
     }
 
@@ -2284,6 +2340,7 @@ public class Coordinator {
                 }
 
                 params.params.setPer_node_scan_ranges(scanRanges);
+                params.params.setNode_to_per_driver_seq_scan_ranges(instanceExecParam.nodeToPerDriverSeqScanRanges);
                 params.params.setPer_exch_num_senders(perExchNumSenders);
 
                 params.params.setDestinations(destinations);
@@ -2312,7 +2369,11 @@ public class Coordinator {
                         params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
                         params.setEnable_shared_scan(sessionVariable.isEnableSharedScan() && fragment.isEnableSharedScan());
 
-                        params.setPipeline_dop(fragment.getPipelineDop());
+                        if (instanceExecParam.isSetPipelineDop()) {
+                            params.setPipeline_dop(instanceExecParam.pipelineDop);
+                        } else {
+                            params.setPipeline_dop(fragment.getPipelineDop());
+                        }
 
                         boolean enableResourceGroup = sessionVariable.isEnableResourceGroup();
                         params.setEnable_resource_group(enableResourceGroup);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -2,7 +2,8 @@
 
 package com.starrocks.qe;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.EmptySetNode;
@@ -12,34 +13,51 @@ import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.thrift.TDescriptorTable;
+import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPartitionType;
+import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.commons.compress.utils.Lists;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
 public class CoordinatorTest {
-    private void testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode mode) throws IOException {
-        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+    ConnectContext ctx;
+    Coordinator coordinator;
+
+    @Before
+    public void setUp() throws IOException {
+        ctx = UtFrameUtils.createDefaultCtx();
         ctx.setExecutionId(new TUniqueId(0xdeadbeef, 0xdeadbeef));
         ConnectContext.threadLocalInfo.set(ctx);
-        Coordinator coordinator = new Coordinator(ctx, Lists.newArrayList(), Lists.newArrayList(), new TDescriptorTable());
+
+        coordinator = new Coordinator(ctx, Lists.newArrayList(), Lists.newArrayList(), new TDescriptorTable());
+    }
+
+    private void testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode mode) throws IOException {
+
         ArrayList<TupleId> tupleIdArrayList = new ArrayList<>();
         tupleIdArrayList.add(new TupleId(1));
-        PlanFragment fragment = new PlanFragment(new PlanFragmentId(1), new EmptySetNode(new PlanNodeId(1), tupleIdArrayList),
-                new DataPartition(TPartitionType.RANDOM));
+        PlanFragment fragment =
+                new PlanFragment(new PlanFragmentId(1), new EmptySetNode(new PlanNodeId(1), tupleIdArrayList),
+                        new DataPartition(TPartitionType.RANDOM));
         Coordinator.FragmentExecParams params = coordinator.new FragmentExecParams(fragment);
         Coordinator.FInstanceExecParam instance0 = new Coordinator.FInstanceExecParam(null, null, 0, params);
         Coordinator.FInstanceExecParam instance1 = new Coordinator.FInstanceExecParam(null, null, 1, params);
         Coordinator.FInstanceExecParam instance2 = new Coordinator.FInstanceExecParam(null, null, 2, params);
-        instance0.bucketSeqSet = Sets.newHashSet(2, 0);
-        instance1.bucketSeqSet = Sets.newHashSet(1, 4);
-        instance2.bucketSeqSet = Sets.newHashSet(3, 5);
+        instance0.bucketSeqToDriverSeq = ImmutableMap.of(2, -1, 0, -1);
+        instance1.bucketSeqToDriverSeq = ImmutableMap.of(1, -1, 4, -1);
+        instance2.bucketSeqToDriverSeq = ImmutableMap.of(3, -1, 5, -1);
         params.instanceExecParams.add(instance0);
         params.instanceExecParams.add(instance1);
         params.instanceExecParams.add(instance2);
@@ -60,5 +78,257 @@ public class CoordinatorTest {
     @Test
     public void testBucketShuffleRuntimeFilter() throws IOException {
         testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode.LOCAL_HASH_BUCKET);
+    }
+
+    private Map<Integer, List<TScanRangeParams>> createScanId2scanRanges(int scanId, int numScanRanges) {
+        List<TScanRangeParams> scanRanges = Lists.newArrayList();
+        for (int i = 0; i < numScanRanges; ++i) {
+            scanRanges.add(new TScanRangeParams());
+        }
+
+        return ImmutableMap.of(scanId, scanRanges);
+    }
+
+    private void testComputeColocatedJoinInstanceParamHelper(int scanId,
+                                                             Map<Integer, TNetworkAddress> bucketSeqToAddress,
+                                                             int parallelExecInstanceNum,
+                                                             int pipelineDop, boolean enablePipeline,
+                                                             int expectedInstances,
+                                                             List<TNetworkAddress> expectedParamAddresses,
+                                                             List<Integer> expectedPipelineDops,
+                                                             List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs,
+                                                             List<Integer> expectedNumScanRangesList,
+                                                             List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList) {
+        Coordinator.FragmentExecParams params = coordinator.new FragmentExecParams(null);
+        Coordinator.BucketSeqToScanRange bucketSeqToScanRange = new Coordinator.BucketSeqToScanRange();
+        for (Integer bucketSeq : bucketSeqToAddress.keySet()) {
+            bucketSeqToScanRange.put(bucketSeq, createScanId2scanRanges(scanId, 1));
+        }
+
+        coordinator.computeColocatedJoinInstanceParam(bucketSeqToAddress, bucketSeqToScanRange,
+                parallelExecInstanceNum, pipelineDop, enablePipeline, params);
+        params.instanceExecParams.sort(Comparator.comparing(param -> param.host));
+
+        Assert.assertEquals(expectedInstances, params.instanceExecParams.size());
+        for (int i = 0; i < expectedInstances; ++i) {
+            Coordinator.FInstanceExecParam param = params.instanceExecParams.get(i);
+            Assert.assertEquals(expectedParamAddresses.get(i), param.host);
+            Assert.assertEquals(expectedPipelineDops.get(i).intValue(), param.getPipelineDop());
+
+            Map<Integer, Integer> bucketSeqToDriverSeq = param.getBucketSeqToDriverSeq();
+            Map<Integer, Integer> expectedBucketSeqToDriverSeq = expectedBucketSeqToDriverSeqs.get(i);
+
+            Assert.assertEquals(expectedBucketSeqToDriverSeq.size(), bucketSeqToDriverSeq.size());
+            expectedBucketSeqToDriverSeq.forEach((expectedBucketSeq, expectedDriverSeq) -> {
+                Assert.assertEquals(expectedDriverSeq, bucketSeqToDriverSeq.get(expectedBucketSeq));
+            });
+
+            if (enablePipeline) {
+                Assert.assertTrue(param.getPerNodeScanRanges().isEmpty());
+
+                Map<Integer, Integer> expectedDriverSeq2NumScanRanges = expectedDriverSeq2NumScanRangesList.get(i);
+                Map<Integer, List<TScanRangeParams>> perDriverSeqScanRanges =
+                        param.getNodeToPerDriverSeqScanRanges().get(scanId);
+                Assert.assertEquals(expectedDriverSeq2NumScanRanges.size(), perDriverSeqScanRanges.size());
+                expectedDriverSeq2NumScanRanges.forEach((expectedDriverSeq, expectedNumScanRanges) -> {
+                    Assert.assertEquals(expectedNumScanRanges.intValue(),
+                            perDriverSeqScanRanges.get(expectedDriverSeq).size());
+                });
+
+            } else {
+                Assert.assertTrue(param.getNodeToPerDriverSeqScanRanges().isEmpty());
+                Assert.assertEquals(expectedNumScanRangesList.get(i).intValue(),
+                        param.getPerNodeScanRanges().get(scanId).size());
+            }
+        }
+    }
+
+    @Test
+    public void testComputeColocatedJoinInstanceParam() {
+        int scanId = 0;
+
+        // Bucket distribution:
+        // - addr1: 11, 12, 13, 14, 15.
+        // - addr2: 21, 22, 23.
+        // - addr3: 31
+        TNetworkAddress addr1 = new TNetworkAddress("host1", 8000);
+        TNetworkAddress addr2 = new TNetworkAddress("host2", 8000);
+        TNetworkAddress addr3 = new TNetworkAddress("host3", 8000);
+        Map<Integer, TNetworkAddress> bucketSeqToAddress = ImmutableMap.<Integer, TNetworkAddress>builder()
+                .put(11, addr1).put(12, addr1).put(13, addr1).put(14, addr1).put(15, addr1)
+                .put(21, addr2).put(22, addr2).put(23, addr2)
+                .put(31, addr3)
+                .build();
+
+        // Test case 1: numInstance=1, pipelineDop=3, enablePipeline.
+        // - addr1
+        //      - Instance#0
+        //          - DriverSequence#0: 11, 14.
+        //          - DriverSequence#1: 12, 15.
+        //          - DriverSequence#2: 13.
+        // - addr2
+        //      - Instance#0
+        //          - DriverSequence#0: 21.
+        //          - DriverSequence#1: 22.
+        //          - DriverSequence#2: 23.
+        // - addr3
+        //      - Instance#0
+        //          - DriverSequence#0: 31.
+        int expectedInstances = 3;
+        List<TNetworkAddress> expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
+        List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, 0, 12, 1, 13, 2, 14, 0, 15, 1),
+                ImmutableMap.of(21, 0, 22, 1, 23, 2),
+                ImmutableMap.of(31, 0)
+        );
+        List<Integer> expectedPipelineDops = ImmutableList.of(3, 3, 1);
+        List<Integer> expectedNumScanRangesList = null;
+        List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList = ImmutableList.of(
+                ImmutableMap.of(0, 2, 1, 2, 2, 1),
+                ImmutableMap.of(0, 1, 1, 1, 2, 1),
+                ImmutableMap.of(0, 1)
+        );
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
+        // Test case 2: numInstance=3, pipelineDop=2, enablePipeline.
+        // - addr1
+        //      - Instance#0
+        //          - DriverSequence#0: 11.
+        //          - DriverSequence#1: 14.
+        //      - Instance#1
+        //          - DriverSequence#0: 12.
+        //          - DriverSequence#1: 15.
+        //      - Instance#2
+        //          - DriverSequence#0: 13.
+        // - addr2
+        //      - Instance#0
+        //          - DriverSequence#0: 21.
+        //      - Instance#1
+        //          - DriverSequence#0: 22.
+        //      - Instance#2
+        //          - DriverSequence#0: 23.
+        // - addr3
+        //      - Instance#0
+        //          - DriverSequence#0: 31.
+        expectedInstances = 7;
+        expectedParamAddresses = ImmutableList.of(addr1, addr1, addr1, addr2, addr2, addr2, addr3, addr3);
+        expectedPipelineDops = ImmutableList.of(2, 2, 1, 1, 1, 1, 1);
+        expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, 0, 14, 1),
+                ImmutableMap.of(12, 0, 15, 1),
+                ImmutableMap.of(13, 0),
+                ImmutableMap.of(21, 0),
+                ImmutableMap.of(22, 0),
+                ImmutableMap.of(23, 0),
+                ImmutableMap.of(31, 0)
+        );
+        expectedDriverSeq2NumScanRangesList = ImmutableList.of(
+                ImmutableMap.of(0, 1, 1, 1),
+                ImmutableMap.of(0, 1, 1, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1)
+        );
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 2, true,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
+        // Test case 3: numInstance=3, pipelineDop=1, enablePipeline.
+        // - addr1
+        //      - Instance#0
+        //          - DriverSequence#0: 11, 14.
+        //      - Instance#1
+        //          - DriverSequence#0: 12, 15.
+        //      - Instance#2
+        //          - DriverSequence#0: 13.
+        // - addr2
+        //      - Instance#0
+        //          - DriverSequence#0: 21.
+        //      - Instance#1
+        //          - DriverSequence#0: 22.
+        //      - Instance#2
+        //          - DriverSequence#0: 23.
+        // - addr3
+        //      - Instance#0
+        //          - DriverSequence#0: 31.
+        expectedInstances = 7;
+        expectedParamAddresses = ImmutableList.of(addr1, addr1, addr1, addr2, addr2, addr2, addr3, addr3);
+        expectedPipelineDops = Collections.nCopies(expectedInstances, 1);
+        expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, 0, 14, 0),
+                ImmutableMap.of(12, 0, 15, 0),
+                ImmutableMap.of(13, 0),
+                ImmutableMap.of(21, 0),
+                ImmutableMap.of(22, 0),
+                ImmutableMap.of(23, 0),
+                ImmutableMap.of(31, 0)
+        );
+        expectedDriverSeq2NumScanRangesList = ImmutableList.of(
+                ImmutableMap.of(0, 2),
+                ImmutableMap.of(0, 2),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1),
+                ImmutableMap.of(0, 1)
+        );
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 1, true,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
+        // Test case 4: numInstance=3, pipelineDop=1, disablePipeline.
+        // - addr1
+        //      - Instance#0: 11, 14.
+        //      - Instance#1: 12, 15.
+        //      - Instance#2: 13.
+        // - addr2
+        //      - Instance#0: 21.
+        //      - Instance#1: 22.
+        //      - Instance#2: 23.
+        // - addr3
+        //      - Instance#0: 31.
+        expectedNumScanRangesList = ImmutableList.of(2, 2, 1, 1, 1, 1, 1);
+        expectedDriverSeq2NumScanRangesList = null;
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 1, false,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
+        // Test case 5: numInstance=1, pipelineDop=3, enablePipeline, the scan node is replicated scan.
+        // - addr1
+        //      - Instance#0
+        //          - DriverSequence#0: 11.
+        //          - DriverSequence#1: empty.
+        //          - DriverSequence#2: empty.
+        // - addr2
+        //      - Instance#0
+        //          - DriverSequence#0: 21.
+        //          - DriverSequence#1: empty.
+        //          - DriverSequence#2: empty.
+        // - addr3
+        //      - Instance#0
+        //          - DriverSequence#0: 31.
+        coordinator.addReplicateScanId(scanId);
+        expectedInstances = 3;
+        expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
+        expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, 0, 12, 1, 13, 2, 14, 0, 15, 1),
+                ImmutableMap.of(21, 0, 22, 1, 23, 2),
+                ImmutableMap.of(31, 0)
+        );
+        expectedPipelineDops = ImmutableList.of(3, 3, 1);
+        expectedNumScanRangesList = null;
+        expectedDriverSeq2NumScanRangesList = ImmutableList.of(
+                ImmutableMap.of(0, 1, 1, 0, 2, 0),
+                ImmutableMap.of(0, 1, 1, 0, 2, 0),
+                ImmutableMap.of(0, 1)
+        );
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -205,8 +205,8 @@ public class AggregateTest extends PlanTestBase {
                         + "  |  group by: 2: v2\n"
                         + "  |  \n"
                         + "  0:OlapScanNode"));
-                Assert.assertEquals(expectedTotalDop, aggPlan.getParallelExecNum());
-                Assert.assertEquals(1, aggPlan.getPipelineDop());
+                Assert.assertEquals(expectedTotalDop, aggPlan.getPipelineDop());
+                Assert.assertEquals(1, aggPlan.getParallelExecNum());
             }
 
             // Manually set dop

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2114,8 +2114,8 @@ public class JoinTest extends PlanTestBase {
             ExecPlan plan = getExecPlan(sql);
             PlanFragment fragment = plan.getFragments().get(1);
             assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
-            Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
-            Assert.assertEquals(1, fragment.getPipelineDop());
+            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+            Assert.assertEquals(1, fragment.getParallelExecNum());
 
             // Case 2: colocate join should use fragment instance parallel.
             sql = "select * from colocate1 left join colocate2 " +
@@ -2123,16 +2123,16 @@ public class JoinTest extends PlanTestBase {
             plan = getExecPlan(sql);
             fragment = plan.getFragments().get(1);
             assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
-            Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
-            Assert.assertEquals(1, fragment.getPipelineDop());
+            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+            Assert.assertEquals(1, fragment.getParallelExecNum());
 
             // Case 3: broadcast join should use pipeline parallel.
             sql = "select a.v1 from t0 a join [broadcast] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
             plan = getExecPlan(sql);
             fragment = plan.getFragments().get(1);
             assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BROADCAST)");
-            Assert.assertEquals(1, fragment.getParallelExecNum());
             Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+            Assert.assertEquals(1, fragment.getParallelExecNum());
 
             // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
             sql = "select a.v1 from t0 a " +
@@ -2143,8 +2143,8 @@ public class JoinTest extends PlanTestBase {
             String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);
             assertContains(fragmentString, "join op: INNER JOIN (BROADCAST)");
             assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
-            Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
-            Assert.assertEquals(1, fragment.getPipelineDop());
+            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+            Assert.assertEquals(1, fragment.getParallelExecNum());
         } finally {
             sessionVariable.setEnablePipelineEngine(enablePipeline);
             sessionVariable.setPipelineDop(pipelineDop);

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -67,6 +67,8 @@ struct TPlanFragmentDestination {
   // ... which is being executed on this server
   2: required Types.TNetworkAddress server
   3: optional Types.TNetworkAddress brpc_server
+
+  4: optional i32 pipeline_driver_sequence
 }
 
 // Sink which forwards data to a remote plan fragment,

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -217,6 +217,8 @@ struct TPlanFragmentExecParams {
   51: optional i32 instances_number
   // To enable pass through chunks between sink/exchange if they are in the same process.
   52: optional bool enable_exchange_pass_through
+
+  53: optional map<Types.TPlanNodeId, map<i32, list<TScanRangeParams>>> node_to_per_driver_seq_scan_ranges
 }
 
 // Global query parameters assigned by the coordinator.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Assign tablets to each scan operator for colocate join, local bucket shuffle join, and one-phase aggregate with scan node.
In this way, we can use pipeline parallel for all the scenarios.

## Modification
FE
- Consider pipeline dop when assigning `bucketSeq` to fragment instance in `Coordinate::computeColocatedJoinInstanceParam`, and add `node_to_per_driver_seq_scan_ranges` to `TPlanFragmentExecParams`.
- Set destination with driver_sequence for local bucket shuffle join.


BE
- Introduce `MorselQueueFactory`.
    - If `node_to_per_driver_seq_scan_ranges` is set, then use `IndividualMorselQueueFactory`; otherwise, use `SharedMorselQueueFactory`.
- `ExchangeSinkOperator` considers whether each channel has been bound to the specific driver sequence.

