### PR TITLE
[Bugfix] fix BE crash when destroy pass-through buffer

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -80,7 +80,9 @@ void FragmentContext::prepare_pass_through_chunk_buffer() {
     _runtime_state->exec_env()->stream_mgr()->prepare_pass_through_chunk_buffer(_query_id);
 }
 void FragmentContext::destroy_pass_through_chunk_buffer() {
-    _runtime_state->exec_env()->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
+    if (_runtime_state) {
+        _runtime_state->exec_env()->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
+    }
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #7609 

## Problem Summary(Required) ：
when fragment context prepare failed before init runtime state
call destroy_pass_through_chunk_buffer in failed_cleanup will crash
