### PR TITLE
[BugFix] Fix wrong column order

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -491,8 +491,8 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
             // important to add columns before evaluation
             // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _file_read_param.append_not_exised_columns_to_chunk(chunk, ck->num_rows());
-            _file_read_param.append_partition_column_to_chunk(chunk, ck->num_rows());
+            _file_read_param.append_not_exised_columns_to_chunk(&ck, ck->num_rows());
+            _file_read_param.append_partition_column_to_chunk(&ck, ck->num_rows());
             chunk_size = ck->num_rows();
             // do stats before we filter rows which does not match.
             _stats.raw_rows_read += chunk_size;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -444,7 +444,20 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
-    ChunkPtr& ck = *chunk;
+    ChunkPtr ck = std::make_shared<vectorized::Chunk>();
+    // The column order of chunk is required to be invariable. When a table performs schema change,
+    // says we want to add a new column to table A, the reader of old files of table A will append new
+    // column to the tail of the chunk, while the reader of new files of table A will put the new column
+    // in the chunk according to the order it's stored. This will lead two chunk from different file to
+    // different column order, so we need to adjust the column order according to the input chunk to make
+    // sure every chunk has same column order
+    auto convert_to_output = [chunk, &ck]() {
+        const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+        for (auto iter = slot_id_to_index_map.begin(); iter != slot_id_to_index_map.end(); iter++) {
+            (*chunk)->get_column_by_slot_id(iter->first)->swap_column(*ck->get_column_by_slot_id(iter->first));
+        }
+    };
+
     // this infinite for loop is for retry.
     for (;;) {
         orc::RowReader::ReadPosition position;
@@ -473,7 +486,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                     ret = _orc_adapter->get_active_chunk();
                 }
                 RETURN_IF_ERROR(ret);
-                *chunk = std::move(ret.value());
+                ck = std::move(ret.value());
             }
 
             // important to add columns before evaluation
@@ -505,6 +518,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         ck->set_num_rows(chunk_size);
 
         if (!_orc_adapter->has_lazy_load_context()) {
+            convert_to_output();
             return Status::OK();
         }
 
@@ -528,6 +542,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             Chunk& ret_ck = *(ret.value());
             ck->merge(std::move(ret_ck));
         }
+        convert_to_output();
         return Status::OK();
     }
     __builtin_unreachable();


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/6028  https://github.com/StarRocks/starrocks/issues/7177  https://github.com/StarRocks/starrocks/issues/7330 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since `DataStreamRecvr::SenderQueue::_build_chunk_meta` is only called for the first chunk it receive, so the subsequent chunk should remain the same column order as the first chunk, otherwise, the deserialize might get wrong   type from chunk meta.