### PR TITLE
[Enhancement] Support enable_show_all_variables flag && remove unused code

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowVariablesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowVariablesStmt.java
@@ -44,7 +44,7 @@ public class ShowVariablesStmt extends ShowStmt {
                     .build();
 
     private SetType type;
-    private String pattern;
+    private final String pattern;
     private Expr where;
 
     public ShowVariablesStmt(SetType type, String pattern) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -41,8 +42,10 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.util.List;
 
 // System variable
+@SuppressWarnings("FieldMayBeFinal")
 public class SessionVariable implements Serializable, Writable, Cloneable {
     private static final Logger LOG = LogManager.getLogger(SessionVariable.class);
 
@@ -62,9 +65,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     /**
      * The mem limit of query on BE. It takes effects only when enabling pipeline engine.
      * - If `query_mem_limit` > 0, use it to limit the memory of a query.
-     *   The memory a query able to be used is just `query_mem_limit`.
+     * The memory a query able to be used is just `query_mem_limit`.
      * - Otherwise, use `exec_mem_limit` to limit the memory of a query.
-     *   The memory a query able to be used is `exec_mem_limit * num_fragments * pipeline_dop`.
+     * The memory a query able to be used is `exec_mem_limit * num_fragments * pipeline_dop`.
      * To maintain compatibility, the default value is 0.
      */
     public static final String QUERY_MEM_LIMIT = "query_mem_limit";
@@ -229,6 +232,25 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String STATISTIC_COLLECT_PARALLEL = "statistic_collect_parallel";
 
+    public static final String ENABLE_SHOW_ALL_VARIABLES = "enable_show_all_variables";
+
+    public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
+            .add(CODEGEN_LEVEL)
+            .add(ENABLE_SPILLING)
+            .add(MAX_EXECUTION_TIME)
+            .add(PROFILING)
+            .add(BATCH_SIZE)
+            .add(DISABLE_BUCKET_JOIN)
+            .add(CBO_ENABLE_REPLICATED_JOIN)
+            .add(FOREIGN_KEY_CHECKS)
+            .add("enable_cbo")
+            .add("enable_vectorized_engine")
+            .add("vectorized_engine_enable")
+            .add("enable_vectorized_insert")
+            .add("vectorized_insert_enable")
+            .add("prefer_join_method")
+            .add("rewrite_count_distinct_to_bitmap_hll").build();
+
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
 
@@ -252,9 +274,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = QUERY_MEM_LIMIT)
     private long queryMemLimit = 0L;
 
-    @VariableMgr.VarAttr(name = ENABLE_SPILLING, flag = VariableMgr.INVISIBLE)
-    public boolean enableSpilling = false;
-
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     private int queryTimeoutS = 300;
@@ -266,17 +285,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = QUERY_DELIVERY_TIMEOUT)
     private int queryDeliveryTimeoutS = 300;
 
-    // query timeout in millisecond, currently nouse, only for compatible.
-    @VariableMgr.VarAttr(name = MAX_EXECUTION_TIME)
-    private long maxExecutionTime = 3000000;
-
     // if true, need report to coordinator when plan fragment execute successfully.
     @VariableMgr.VarAttr(name = IS_REPORT_SUCCESS)
     private boolean isReportSucc = false;
-    // only for Aliyun DTS, useless.
-    @Deprecated
-    @VariableMgr.VarAttr(name = PROFILING, flag = VariableMgr.INVISIBLE)
-    private boolean openProfile = false;
 
     // Default sqlMode is ONLY_FULL_GROUP_BY
     @VariableMgr.VarAttr(name = SQL_MODE_STORAGE_NAME, alias = SQL_MODE, show = SQL_MODE)
@@ -290,11 +301,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = AUTO_COMMIT)
     private boolean autoCommit = true;
 
-    // this is used to make c3p0 library happy
+    // ==================  this is used to make c3p0 library happy start ==================
     @VariableMgr.VarAttr(name = TX_ISOLATION)
     private String txIsolation = "REPEATABLE-READ";
-
-    // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)
     private String charsetClient = "utf8";
     @VariableMgr.VarAttr(name = CHARACTER_SET_CONNNECTION)
@@ -307,28 +316,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private String collationConnection = "utf8_general_ci";
     @VariableMgr.VarAttr(name = COLLATION_DATABASE)
     private String collationDatabase = "utf8_general_ci";
-
     @VariableMgr.VarAttr(name = COLLATION_SERVER)
     private String collationServer = "utf8_general_ci";
-
-    // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = SQL_AUTO_IS_NULL)
     private boolean sqlAutoIsNull = false;
+    @VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET)
+    private int maxAllowedPacket = 1048576;
+    @VariableMgr.VarAttr(name = AUTO_INCREMENT_INCREMENT)
+    private int autoIncrementIncrement = 1;
+    @VariableMgr.VarAttr(name = QUERY_CACHE_TYPE)
+    private int queryCacheType = 0;
+    // ==================  this is used to make c3p0 library happy end ==================
 
     public static final long DEFAULT_SELECT_LIMIT = 9223372036854775807L;
     @VariableMgr.VarAttr(name = SQL_SELECT_LIMIT)
     private long sqlSelectLimit = DEFAULT_SELECT_LIMIT;
-
-    // this is used to make c3p0 library happy
-    @VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET)
-    private int maxAllowedPacket = 1048576;
-
-    @VariableMgr.VarAttr(name = AUTO_INCREMENT_INCREMENT)
-    private int autoIncrementIncrement = 1;
-
-    // this is used to make c3p0 library happy
-    @VariableMgr.VarAttr(name = QUERY_CACHE_TYPE)
-    private int queryCacheType = 0;
 
     // The number of seconds the server waits for activity on an interactive connection before closing it
     @VariableMgr.VarAttr(name = INTERACTIVE_TIMTOUT)
@@ -360,14 +362,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = NET_BUFFER_LENGTH, flag = VariableMgr.READ_ONLY)
     private int netBufferLength = 16384;
 
-    // if true, need report to coordinator when plan fragment execute successfully.
-    @Deprecated
-    @VariableMgr.VarAttr(name = CODEGEN_LEVEL, flag = VariableMgr.INVISIBLE)
-    private int codegenLevel = 0;
-
-    @VariableMgr.VarAttr(name = BATCH_SIZE, flag = VariableMgr.INVISIBLE)
-    private int batchSize = 0;
-
     @VariableMgr.VarAttr(name = CHUNK_SIZE, flag = VariableMgr.INVISIBLE)
     private int chunkSize = 4096;
 
@@ -382,17 +376,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;
 
-    @VariableMgr.VarAttr(name = DISABLE_BUCKET_JOIN, flag = VariableMgr.INVISIBLE)
-    private boolean disableBucketJoin = false;
-
-    @VariableMgr.VarAttr(name = CBO_USE_CORRELATED_JOIN_ESTIMATE)
+    @VariableMgr.VarAttr(name = CBO_USE_CORRELATED_JOIN_ESTIMATE, flag = VariableMgr.INVISIBLE)
     private boolean useCorrelatedJoinEstimate = true;
 
     @VariableMgr.VarAttr(name = CBO_USE_NTH_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private int useNthExecPlan = 0;
 
     @VarAttr(name = CBO_CTE_REUSE)
-    private boolean cboCteReuse = false;
+    private boolean cboCteReuse = true;
 
     @VarAttr(name = CBO_CTE_REUSE_RATE, flag = VariableMgr.INVISIBLE)
     private double cboCTERuseRatio = 1.2;
@@ -422,13 +413,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = FORWARD_TO_MASTER)
     private boolean forwardToMaster = false;
 
-    // compatible with some mysql client connect, say DataGrip of JetBrains
+    // ================= compatible with some mysql client connect, say DataGrip of JetBrains start ================
     @VariableMgr.VarAttr(name = EVENT_SCHEDULER)
     private String eventScheduler = "OFF";
     @VariableMgr.VarAttr(name = STORAGE_ENGINE)
     private String storageEngine = "olap";
     @VariableMgr.VarAttr(name = DIV_PRECISION_INCREMENT)
     private int divPrecisionIncrement = 4;
+    // ================= compatible with some mysql client connect, say DataGrip of JetBrains end ================
 
     // -1 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)
@@ -463,15 +455,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CBO_ENABLE_GREEDY_JOIN_REORDER, flag = VariableMgr.INVISIBLE)
     private boolean cboEnableGreedyJoinReorder = true;
 
-    @VariableMgr.VarAttr(name = CBO_ENABLE_REPLICATED_JOIN, flag = VariableMgr.INVISIBLE)
-    private boolean enableReplicationJoin = true;
-
     @VariableMgr.VarAttr(name = TRANSACTION_VISIBLE_WAIT_TIMEOUT)
     private long transactionVisibleWaitTimeout = 10;
-
-    // only for Aliyun DTS, useless.
-    @VariableMgr.VarAttr(name = FOREIGN_KEY_CHECKS)
-    private boolean foreignKeyChecks = true;
 
     @VariableMgr.VarAttr(name = FORCE_SCHEDULE_LOCAL)
     private boolean forceScheduleLocal = false;
@@ -529,33 +514,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             show = ENABLE_EXCHANGE_PASS_THROUGH)
     private boolean enableExchangePassThrough = false;
 
-    // The following variables are deprecated and invisible //
-    // ----------------------------------------------------------------------------//
-
     @VariableMgr.VarAttr(name = ALLOW_DEFAULT_PARTITION, flag = VariableMgr.INVISIBLE)
     private boolean allowDefaultPartition = false;
-
-    @VariableMgr.VarAttr(name = "enable_cbo", flag = VariableMgr.INVISIBLE)
-    @Deprecated
-    private boolean enableCbo = true;
-
-    @VariableMgr.VarAttr(name = "enable_vectorized_engine", alias = "vectorized_engine_enable",
-            flag = VariableMgr.INVISIBLE)
-    @Deprecated
-    private boolean vectorizedEngineEnable = true;
-
-    @VariableMgr.VarAttr(name = "enable_vectorized_insert", alias = "vectorized_insert_enable",
-            flag = VariableMgr.INVISIBLE)
-    @Deprecated
-    private boolean vectorizedInsertEnable = true;
-
-    @VariableMgr.VarAttr(name = "prefer_join_method", flag = VariableMgr.INVISIBLE)
-    @Deprecated
-    private String preferJoinMethod = "broadcast";
-
-    @VariableMgr.VarAttr(name = "rewrite_count_distinct_to_bitmap_hll", flag = VariableMgr.INVISIBLE)
-    @Deprecated
-    private boolean rewriteCountDistinct = true;
 
     @VariableMgr.VarAttr(name = SINGLE_NODE_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private boolean singleNodeExecPlan = false;
@@ -572,16 +532,19 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = STATISTIC_COLLECT_PARALLEL)
     private int statisticCollectParallelism = 1;
 
+    @VarAttr(name = ENABLE_SHOW_ALL_VARIABLES, flag = VariableMgr.INVISIBLE)
+    private boolean enableShowAllVariables = false;
+
+    public boolean isEnableShowAllVariables() {
+        return enableShowAllVariables;
+    }
+
+    public void setEnableShowAllVariables(boolean enableShowAllVariables) {
+        this.enableShowAllVariables = enableShowAllVariables;
+    }
+
     public int getStatisticCollectParallelism() {
         return statisticCollectParallelism;
-    }
-
-    public void setStatisticCollectParallelism(int statisticCollectParallelism) {
-        this.statisticCollectParallelism = statisticCollectParallelism;
-    }
-
-    public long getRuntimeFilterScanWaitTime() {
-        return runtimeFilterScanWaitTime;
     }
 
     public boolean enableHiveColumnStats() {
@@ -618,26 +581,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSqlMode(long sqlMode) {
         this.sqlMode = sqlMode;
-    }
-
-    public String getCharsetClient() {
-        return charsetClient;
-    }
-
-    public String getCharsetConnection() {
-        return charsetConnection;
-    }
-
-    public String getCharsetResults() {
-        return charsetResults;
-    }
-
-    public String getCollationDatabase() {
-        return collationDatabase;
-    }
-
-    public String getCollationServer() {
-        return collationServer;
     }
 
     public long getSqlSelectLimit() {
@@ -917,10 +860,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return pipelineProfileLevel;
     }
 
-    public void setPipelineProfileLevel(int pipelineProfileLevel) {
-        this.pipelineProfileLevel = pipelineProfileLevel;
-    }
-
     public boolean isEnableReplicationJoin() {
         return false;
     }
@@ -938,7 +877,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setEnableReplicationJoin(boolean enableReplicationJoin) {
-        this.enableReplicationJoin = enableReplicationJoin;
+
     }
 
     public boolean isUseCorrelatedJoinEstimate() {
@@ -1033,7 +972,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setQuery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryTimeoutS));
         tResult.setQuery_delivery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryDeliveryTimeoutS));
         tResult.setIs_report_success(isReportSucc);
-        tResult.setCodegen_level(codegenLevel);
+        tResult.setCodegen_level(0);
         tResult.setBatch_size(chunkSize);
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
@@ -1044,7 +983,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         if (maxPushdownConditionsPerColumn > -1) {
             tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
         }
-        tResult.setEnable_spilling(enableSpilling);
+        tResult.setEnable_spilling(false);
 
         // Compression Type
         TCompressionType compressionType = CompressionUtils.findTCompressionByName(transmissionCompressionType);
@@ -1114,7 +1053,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void readFields(DataInput in) throws IOException {
         if (GlobalStateMgr.getCurrentStateJournalVersion() < FeMetaVersion.VERSION_67) {
-            codegenLevel = in.readInt();
+            int codegenLevel = in.readInt();
             netBufferLength = in.readInt();
             sqlSafeUpdates = in.readInt();
             timeZone = Text.readString(in);
@@ -1152,7 +1091,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 collationServer = Text.readString(in);
             }
             if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_38) {
-                batchSize = in.readInt();
+                int batchSize = in.readInt();
                 disableStreamPreaggregations = in.readBoolean();
                 parallelExecInstanceNum = in.readInt();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -301,9 +301,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = AUTO_COMMIT)
     private boolean autoCommit = true;
 
-    // ==================  this is used to make c3p0 library happy start ==================
+    // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = TX_ISOLATION)
     private String txIsolation = "REPEATABLE-READ";
+
+    // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)
     private String charsetClient = "utf8";
     @VariableMgr.VarAttr(name = CHARACTER_SET_CONNNECTION)
@@ -318,19 +320,24 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private String collationDatabase = "utf8_general_ci";
     @VariableMgr.VarAttr(name = COLLATION_SERVER)
     private String collationServer = "utf8_general_ci";
+
+    // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = SQL_AUTO_IS_NULL)
     private boolean sqlAutoIsNull = false;
-    @VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET)
-    private int maxAllowedPacket = 1048576;
-    @VariableMgr.VarAttr(name = AUTO_INCREMENT_INCREMENT)
-    private int autoIncrementIncrement = 1;
-    @VariableMgr.VarAttr(name = QUERY_CACHE_TYPE)
-    private int queryCacheType = 0;
-    // ==================  this is used to make c3p0 library happy end ==================
 
     public static final long DEFAULT_SELECT_LIMIT = 9223372036854775807L;
     @VariableMgr.VarAttr(name = SQL_SELECT_LIMIT)
     private long sqlSelectLimit = DEFAULT_SELECT_LIMIT;
+
+    // this is used to make c3p0 library happy
+    @VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET)
+    private int maxAllowedPacket = 1048576;
+    @VariableMgr.VarAttr(name = AUTO_INCREMENT_INCREMENT)
+    private int autoIncrementIncrement = 1;
+
+    // this is used to make c3p0 library happy
+    @VariableMgr.VarAttr(name = QUERY_CACHE_TYPE)
+    private int queryCacheType = 0;
 
     // The number of seconds the server waits for activity on an interactive connection before closing it
     @VariableMgr.VarAttr(name = INTERACTIVE_TIMTOUT)
@@ -413,14 +420,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = FORWARD_TO_MASTER)
     private boolean forwardToMaster = false;
 
-    // ================= compatible with some mysql client connect, say DataGrip of JetBrains start ================
+    // compatible with some mysql client connect, say DataGrip of JetBrains
     @VariableMgr.VarAttr(name = EVENT_SCHEDULER)
     private String eventScheduler = "OFF";
     @VariableMgr.VarAttr(name = STORAGE_ENGINE)
     private String storageEngine = "olap";
     @VariableMgr.VarAttr(name = DIV_PRECISION_INCREMENT)
     private int divPrecisionIncrement = 4;
-    // ================= compatible with some mysql client connect, say DataGrip of JetBrains end ================
 
     // -1 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -106,13 +106,13 @@ public class VariableMgr {
 
     // Map variable name to variable context which have enough information to change variable value.
     // This map contains info of all session and global variables.
-    private static ImmutableMap<String, VarContext> ctxByVarName;
+    private static final ImmutableMap<String, VarContext> ctxByVarName;
 
-    private static ImmutableMap<String, String> aliases;
+    private static final ImmutableMap<String, String> aliases;
 
     // This variable is equivalent to the default value of session variables.
     // Whenever a new session is established, the value in this object is copied to the session-level variable.
-    private static SessionVariable defaultSessionVariable;
+    private static final SessionVariable defaultSessionVariable;
 
     // Global read/write lock to protect access of globalSessionVariable.
     private static final ReadWriteLock rwlock = new ReentrantReadWriteLock();
@@ -139,9 +139,8 @@ public class VariableMgr {
             }
 
             field.setAccessible(true);
-            ctxBuilder.put(attr.name(),
-                    new VarContext(field, defaultSessionVariable, SESSION | attr.flag(),
-                            getValue(defaultSessionVariable, field), attr));
+            ctxBuilder.put(attr.name(), new VarContext(field, defaultSessionVariable, SESSION | attr.flag(),
+                    getValue(defaultSessionVariable, field), attr));
 
             if (!attr.alias().isEmpty()) {
                 aliasBuilder.put(attr.alias(), attr.name());
@@ -261,6 +260,10 @@ public class VariableMgr {
     //      setVar: variable information that needs to be set
     public static void setVar(SessionVariable sessionVariable, SetVar setVar, boolean onlySetSessionVar)
             throws DdlException {
+        if (SessionVariable.DEPRECATED_VARIABLES.stream().anyMatch(c -> c.equalsIgnoreCase(setVar.getVariable()))) {
+            return;
+        }
+
         VarContext ctx = getVarContext(setVar.getVariable());
         if (ctx == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable());
@@ -492,7 +495,7 @@ public class VariableMgr {
 
                 // For session variables, the flag is VariableMgr.SESSION | VariableMgr.INVISIBLE
                 // For global variables, the flag is VariableMgr.GLOBAL | VariableMgr.INVISIBLE
-                if (ctx.getFlag() > VariableMgr.INVISIBLE) {
+                if ((ctx.getFlag() > VariableMgr.INVISIBLE) && !sessionVar.isEnableShowAllVariables()) {
                     continue;
                 }
 
@@ -506,7 +509,7 @@ public class VariableMgr {
                     row.add(getValue(ctx.getObj(), ctx.getField()));
                 }
 
-                if (row.size() > 1 && row.get(0).equalsIgnoreCase(SessionVariable.SQL_MODE)) {
+                if (row.get(0).equalsIgnoreCase(SessionVariable.SQL_MODE)) {
                     try {
                         row.set(1, SqlModeHelper.decode(Long.valueOf(row.get(1))));
                     } catch (DdlException e) {
@@ -542,7 +545,7 @@ public class VariableMgr {
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    public static @interface VarAttr {
+    public @interface VarAttr {
         // Name in show variables and set statement;
         String name();
 
@@ -552,11 +555,6 @@ public class VariableMgr {
         String show() default "";
 
         int flag() default 0;
-
-        // TODO(zhaochun): min and max is not used.
-        String minValue() default "0";
-
-        String maxValue() default "0";
     }
 
     private static class VarContext {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -106,13 +106,13 @@ public class VariableMgr {
 
     // Map variable name to variable context which have enough information to change variable value.
     // This map contains info of all session and global variables.
-    private static final ImmutableMap<String, VarContext> ctxByVarName;
+    private static ImmutableMap<String, VarContext> ctxByVarName;
 
-    private static final ImmutableMap<String, String> aliases;
+    private static ImmutableMap<String, String> aliases;
 
     // This variable is equivalent to the default value of session variables.
     // Whenever a new session is established, the value in this object is copied to the session-level variable.
-    private static final SessionVariable defaultSessionVariable;
+    private static SessionVariable defaultSessionVariable;
 
     // Global read/write lock to protect access of globalSessionVariable.
     private static final ReadWriteLock rwlock = new ReentrantReadWriteLock();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -226,5 +226,17 @@ public class VariableMgrTest {
         VariableMgr.setVar(null, setVar, false);
         Assert.fail("No exception throws.");
     }
+
+    @Test
+    public void testDumpInvisible() {
+        SessionVariable sv = new SessionVariable();
+        List<List<String>> vars = VariableMgr.dump(SetType.DEFAULT, sv, null);
+        Assert.assertFalse(vars.toString().contains("enable_show_all_variables"));
+        Assert.assertFalse(vars.toString().contains("cbo_use_correlated_join_estimate"));
+
+        sv.setEnableShowAllVariables(true);
+        vars = VariableMgr.dump(SetType.DEFAULT, sv, null);
+        Assert.assertTrue(vars.toString().contains("cbo_use_correlated_join_estimate"));
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -105,6 +105,7 @@ public class LowCardinalityTest extends PlanTestBase {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setCboCteReuse(false);
     }
 
     @AfterClass

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -78,6 +78,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Before
     public void before() {
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
+        connectContext.getSessionVariable().setCboCteReuse(false);
     }
 
     private static final String V1 = "v1";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -174,6 +174,7 @@ public class ReplayFromDumpTest {
         Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/tpcds02"));
         SessionVariable replaySessionVariable = replayPair.first.getSessionVariable();
         Assert.assertEquals(replaySessionVariable.getParallelExecInstanceNum(), 4);
+        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("  |----24:EXCHANGE\n" +
                 "  |       cardinality: 73049\n" +
                 "  |    \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -132,6 +132,7 @@ public class ReplayFromDumpTest {
             queryDumpInfo.setSessionVariable(sessionVariable);
         }
         queryDumpInfo.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        queryDumpInfo.getSessionVariable().setCboCteReuse(false);
         return new Pair<>(queryDumpInfo,
                 UtFrameUtils.getNewPlanAndFragmentFromDump(connectContext, queryDumpInfo).second.
                         getExplainString(level));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
@@ -13,6 +13,7 @@ public class TPCHPlanTest extends PlanTestBase {
         PlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        connectContext.getSessionVariable().setCboCteReuse(false);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Add enable_show_all_variables to show invisible variables
2. Remove deprecated variables

```
MySQL td> set enable_show_all_variables=true;
Query OK, 0 rows affected
Time: 0.002s
MySQL td> show variables;
+---------------------------------------------+---------------------------+
| Variable_name                               | Value                     |
+---------------------------------------------+---------------------------+
| ............                                                            |
| cbo_cte_reuse                               | true                      |
| cbo_cte_reuse_rate                          | 1.2                       |
| cbo_enable_dp_join_reorder                  | true                      |
| cbo_enable_greedy_join_reorder              | true                      |
| cbo_enable_low_cardinality_optimize         | true                      |
| cbo_max_reorder_node                        | 50                        |
| cbo_max_reorder_node_use_dp                 | 10                        |
| cbo_max_reorder_node_use_exhaustive         | 4                         |
| ............                                                            |
+---------------------------------------------+---------------------------+
97 rows in set
Time: 0.014s
MySQL td> set enable_show_all_variables=false;
Query OK, 0 rows affected
Time: 0.001s
MySQL td> show variables;
+--------------------------------------------+---------------------------+
| Variable_name                              | Value                     |
+--------------------------------------------+---------------------------+
| ................                                                       |
| broadcast_row_limit                        | 15000000                  |
| cbo_cte_reuse                              | true                      |
| cbo_enable_low_cardinality_optimize        | true                      |
| cbo_max_reorder_node_use_dp                | 10                        |
| cbo_max_reorder_node_use_exhaustive        | 4                         |
| character_set_client                       | utf8                      |
| character_set_connection                   | utf8                      |
| character_set_database                     | utf8                      |
| ................                                                       |
+--------------------------------------------+---------------------------+
80 rows in set
Time: 0.021s
MySQL td>
```