### PR TITLE
[BugFix] push worker thread can not pop NORMAL Priority task

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -78,7 +78,8 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
     CREATE_AND_START_POOL(PUBLISH_VERSION, _publish_version_workers, 1);
     CREATE_AND_START_POOL(CLEAR_TRANSACTION_TASK, _clear_transaction_task_workers,
                           config::clear_transaction_task_worker_count);
-    CREATE_AND_START_POOL(DELETE, _delete_workers, config::delete_worker_count);
+    CREATE_AND_START_POOL(DELETE, _delete_workers,
+                          config::delete_worker_count_normal_priority + config::delete_worker_count_high_priority);
     CREATE_AND_START_POOL(ALTER_TABLE, _alter_tablet_workers, config::alter_tablet_worker_count);
     CREATE_AND_START_POOL(CLONE, _clone_workers, config::clone_worker_count);
     CREATE_AND_START_POOL(STORAGE_MEDIUM_MIGRATE, _storage_medium_migrate_workers,

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -95,6 +95,7 @@ private:
     static void* _create_tablet_worker_thread_callback(void* arg_this);
     static void* _drop_tablet_worker_thread_callback(void* arg_this);
     static void* _push_worker_thread_callback(void* arg_this);
+    static void* _delete_worker_thread_callback(void* arg_this);
     static void* _publish_version_worker_thread_callback(void* arg_this);
     static void* _clear_transaction_task_worker_thread_callback(void* arg_this);
     static void* _alter_tablet_worker_thread_callback(void* arg_this);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -89,7 +89,9 @@ CONF_Int32(transaction_publish_version_worker_count, "8");
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");
 // The count of thread to delete.
-CONF_Int32(delete_worker_count, "3");
+CONF_Int32(delete_worker_count_normal_priority, "2");
+// The count of thread to high priority delete.
+CONF_Int32(delete_worker_count_high_priority, "1");
 // The count of thread to alter table.
 CONF_Int32(alter_tablet_worker_count, "3");
 // The count of thread to clone.


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7627 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the current implementation, the push worker thread can only pop the HIGH Priority tasks, it can not pop the NORMAL priority tasks.

I fix this bug in this pr, also I split the delete_workers from the _push_worker_thread_callback,
I add a stand-alone function _delete_worker_thread_callback for delete_workers