### PR TITLE
[Enhancement] introduce query debug trace for BE

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -403,6 +403,14 @@ if (WITH_GCOV)
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
+if (ENABLE_QUERY_DEBUG_TRACE)
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DENABLE_QUERY_DEBUG_TRACE")
+    message(STATUS "enable query debug trace")
+endif()
+
+# to compresss debug section. https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -gz=zlib")
+
 # For CMAKE_BUILD_TYPE=Debug
 #   -ggdb: Enable gdb debugging
 # Debug information is stored as dwarf2 to be as compatible as possible

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -408,9 +408,6 @@ if (ENABLE_QUERY_DEBUG_TRACE)
     message(STATUS "enable query debug trace")
 endif()
 
-# to compresss debug section. https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
-set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -gz=zlib")
-
 # For CMAKE_BUILD_TYPE=Debug
 #   -ggdb: Enable gdb debugging
 # Debug information is stored as dwarf2 to be as compatible as possible

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -752,6 +752,9 @@ CONF_Int32(max_batch_publish_latency_ms, "100");
 // Config for opentelemetry tracing.
 CONF_String(jaeger_endpoint, "");
 
+// Config for query debug trace
+CONF_String(query_debug_trace_dir, "${STARROCKS_HOME}/query_debug_trace");
+
 #ifdef USE_STAROS
 CONF_Int32(starlet_port, "9070");
 // Root dir used for cache if cache enabled.

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -90,7 +90,7 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     // duplicate invocations of rpc exec_plan_fragment.
     const auto& params = request.common().params;
     const auto& query_id = params.query_id;
-    const auto& fragment_instance_id = params.fragment_instance_id;
+    const auto& fragment_instance_id = request.fragment_instance_id();
     const auto& query_options = request.common().query_options;
 
     auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
@@ -427,7 +427,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
     // The pipeline created later should be placed in the front
     runtime_state->runtime_profile()->reverse_childs();
     _fragment_ctx->set_drivers(std::move(drivers));
-    runtime_state->query_ctx()->query_trace()->register_drivers(fragment_instance_id, _fragment_ctx->drivers());
+    _query_ctx->query_trace()->register_drivers(fragment_instance_id, _fragment_ctx->drivers());
 
     // Acquire driver token to avoid overload
     auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(_fragment_ctx->drivers().size());

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -358,6 +358,9 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
                 }
             }
             QUERY_TRACE_END("finalize", "");
+            // @TODO(silverbullet233): if necessary, remove the dump from the execution thread
+            // considering that this feature is generally used for debugging,
+            // I think it should not have a big impact now
             query_trace->dump();
             return;
         }

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -354,6 +354,8 @@ public:
     inline bool is_in_ready_queue() const { return _in_ready_queue.load(std::memory_order_acquire); }
     void set_in_ready_queue(bool v) { _in_ready_queue.store(v, std::memory_order_release); }
 
+    inline std::string get_name() const { return strings::Substitute("PipelineDriver (id=$0)", _driver_id); }
+
 private:
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -97,11 +97,7 @@ Status QueryContext::init_query(workgroup::WorkGroup* wg) {
 }
 
 void QueryContext::set_query_trace(std::shared_ptr<starrocks::debug::QueryTrace> query_trace) {
-    bool expected = false;
-    // make sure _query_trace is initilized only once
-    if (_is_query_trace_inited.compare_exchange_strong(expected, true)) {
-        _query_trace = std::move(query_trace);
-    }
+    std::call_once(_query_trace_init_flag, [this, &query_trace]() { _query_trace = std::move(query_trace); });
 }
 
 QueryContextManager::QueryContextManager(size_t log2_num_slots)

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -96,6 +96,14 @@ Status QueryContext::init_query(workgroup::WorkGroup* wg) {
     return st;
 }
 
+void QueryContext::set_query_trace(std::shared_ptr<starrocks::debug::QueryTrace> query_trace) {
+    bool expected = false;
+    // make sure _query_trace is initilized only once
+    if (_is_query_trace_inited.compare_exchange_strong(expected, true)) {
+        _query_trace = std::move(query_trace);
+    }
+}
+
 QueryContextManager::QueryContextManager(size_t log2_num_slots)
         : _num_slots(1 << log2_num_slots),
           _slot_mask(_num_slots - 1),

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -12,6 +12,7 @@
 #include "gen_cpp/InternalService_types.h" // for TQueryOptions
 #include "gen_cpp/Types_types.h"           // for TUniqueId
 #include "runtime/runtime_state.h"
+#include "util/debug/query_trace.h"
 #include "util/hash_util.hpp"
 #include "util/time.h"
 
@@ -115,6 +116,11 @@ public:
 
     void set_scan_limit(int64_t scan_limit) { _scan_limit = scan_limit; }
     int64_t get_scan_limit() const { return _scan_limit; }
+    void set_query_trace(std::shared_ptr<starrocks::debug::QueryTrace> query_trace);
+
+    starrocks::debug::QueryTrace* query_trace() { return _query_trace.get(); }
+
+    std::shared_ptr<starrocks::debug::QueryTrace> shared_query_trace() { return _query_trace; }
 
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
@@ -136,6 +142,8 @@ private:
     std::shared_ptr<MemTracker> _mem_tracker;
     ObjectPool _object_pool;
     DescriptorTbl* _desc_tbl = nullptr;
+    std::atomic<bool> _is_query_trace_inited{false};
+    std::shared_ptr<starrocks::debug::QueryTrace> _query_trace;
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -142,7 +142,7 @@ private:
     std::shared_ptr<MemTracker> _mem_tracker;
     ObjectPool _object_pool;
     DescriptorTbl* _desc_tbl = nullptr;
-    std::atomic<bool> _is_query_trace_inited{false};
+    std::once_flag _query_trace_init_flag;
     std::shared_ptr<starrocks::debug::QueryTrace> _query_trace;
 
     std::once_flag _init_query_once;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -12,6 +12,7 @@
 #include "exec/workgroup/work_group.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "util/debug/query_trace.h"
 
 namespace starrocks::pipeline {
 
@@ -280,12 +281,15 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     if (is_uninitialized(_query_ctx)) {
         _query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
     }
+    starrocks::debug::QueryTraceContext query_trace_ctx = starrocks::debug::tls_trace_ctx;
+    query_trace_ctx.id = reinterpret_cast<int64_t>(_chunk_sources[chunk_source_index].get());
     if (_workgroup != nullptr) {
         workgroup::ScanTask task =
-                workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index](int worker_id) {
+                workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx](int worker_id) {
                     if (auto sp = wp.lock()) {
                         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-
+                        // @TODO add scoped?
+                        QUERY_TRACE_ASYNC_START(get_name(), "io_task", query_trace_ctx);
                         auto& chunk_source = _chunk_sources[chunk_source_index];
                         size_t num_read_chunks = 0;
                         int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
@@ -306,6 +310,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                         _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
                                                   chunk_source->get_scan_rows() - prev_scan_rows,
                                                   chunk_source->get_scan_bytes() - prev_scan_bytes);
+                        QUERY_TRACE_ASYNC_FINISH(get_name(), "io_task", query_trace_ctx);
                     }
                 });
         if (dynamic_cast<ConnectorScanOperator*>(this) != nullptr) {
@@ -315,10 +320,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
         }
     } else {
         PriorityThreadPool::Task task;
-        task.work_function = [wp = _query_ctx, this, state, chunk_source_index]() {
+        task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx]() {
             if (auto sp = wp.lock()) {
                 SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-
+                // @TODO
+                QUERY_TRACE_ASYNC_START(get_name(), "io_task", query_trace_ctx);
                 auto& chunk_source = _chunk_sources[chunk_source_index];
                 int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
                 int64_t prev_scan_rows = chunk_source->get_scan_rows();
@@ -334,6 +340,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                 _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
                                           chunk_source->get_scan_rows() - prev_scan_rows,
                                           chunk_source->get_scan_bytes() - prev_scan_bytes);
+                QUERY_TRACE_ASYNC_FINISH(get_name(), "io_task", query_trace_ctx);
             }
         };
         // TODO(by satanson): set a proper priority

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -284,8 +284,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     starrocks::debug::QueryTraceContext query_trace_ctx = starrocks::debug::tls_trace_ctx;
     query_trace_ctx.id = reinterpret_cast<int64_t>(_chunk_sources[chunk_source_index].get());
     if (_workgroup != nullptr) {
-        workgroup::ScanTask task =
-                workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx](int worker_id) {
+        workgroup::ScanTask task = workgroup::ScanTask(
+                _workgroup, [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx](int worker_id) {
                     if (auto sp = wp.lock()) {
                         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
                         // @TODO add scoped?

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -104,6 +104,7 @@ set(UTIL_FILES
   sha.cpp
   lru_cache.cpp
   tdigest.cpp
+  debug/query_trace_impl.cpp
 )
 
 # simdjson Runtime Implement Dispatch: https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md#runtime-cpu-detection

--- a/be/src/util/debug/query_trace.h
+++ b/be/src/util/debug/query_trace.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "util/debug/query_trace_impl.h"
+
+#ifdef ENABLE_QUERY_DEBUG_TRACE
+#define SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr) \
+    starrocks::debug::QueryTrace::set_tls_trace_context(query_trace, fragment_instance_id,  \
+                                                        reinterpret_cast<std::uintptr_t>(driver))
+
+#define QUERY_TRACE_BEGIN(category, name)        \
+    INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER( \
+            INTERNAL_CREATE_EVENT_WITH_CTX(category, name, 'B', starrocks::debug::tls_trace_ctx))
+
+#define QUERY_TRACE_END(category, name)          \
+    INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER( \
+            INTERNAL_CREATE_EVENT_WITH_CTX(category, name, 'E', starrocks::debug::tls_trace_ctx))
+
+#define QUERY_TRACE_SCOPED(category, name) starrocks::debug::ScopedTracer _scoped_tracer(category, name)
+
+#define QUERY_TRACE_ASYNC_START(category, name, ctx)                                                            \
+    do {                                                                                                        \
+        INTERNAL_ADD_EVENT_INFO_BUFFER(ctx.event_buffer,                                                        \
+                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, ctx.id, 'b', ctx)); \
+    } while (0);
+
+#define QUERY_TRACE_ASYNC_FINISH(category, name, ctx)                                                           \
+    do {                                                                                                        \
+        INTERNAL_ADD_EVENT_INFO_BUFFER(ctx.event_buffer,                                                        \
+                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, ctx.id, 'e', ctx)); \
+    } while (0);
+#else
+#define SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr)
+#define QUERY_TRACE_BEGIN(category, name)
+#define QUERY_TRACE_END(category, name)
+#define QUERY_TRACE_SCOPED(category, name)
+#define QUERY_TRACE_ASYNC_START(category, name, ctx)
+#define QUERY_TRACE_ASYNC_FINISH(category, name, ctx)
+#endif

--- a/be/src/util/debug/query_trace.h
+++ b/be/src/util/debug/query_trace.h
@@ -25,7 +25,7 @@
 // }
 // It should be noted that these QUERY_TRACE_* macros rely on thread local trace context to read some information,
 // remember to set it before use.
-// The asynv event is a bit different, It may record the start and finish in different threads.
+// The async event is a bit different, It may record the start and finish in different threads.
 // Each event needs to be identified with a different id, so you need to pass a context when using it.
 // In many cases, you can directly use the pointer address of an object as id, because it must be unique within the same process.
 // An example is as follows

--- a/be/src/util/debug/query_trace.h
+++ b/be/src/util/debug/query_trace.h
@@ -1,6 +1,44 @@
 #pragma once
 
 #include "util/debug/query_trace_impl.h"
+// A lightweight tool for analyzing query performance under the pipeline engine.
+// The basic background and usage can refer to the description of https://github.com/StarRocks/starrocks/pull/7649
+// How to add trace point?
+// Currently only duration events and async events are supported.
+// An example of adding duration event is as follows
+// void doSomething() {
+//     SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr);
+//     QUERY_TRACE_BEGIN("category", "name");
+//     process_function();
+//     QUERY_TRACE_END("category", "name");
+// }
+// or just use QUERY_TRACE_SCOPED
+// void process_function () {
+//     QUERY_TRACE_SCOPED("category", "name");
+//     do something
+// }
+// void doSomething() {
+//     SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr);
+//     process_function();
+// }
+// It should be noted that these QUERY_TRACE_* macros rely on thread local trace context to read some information,
+// remember to set it before use.
+// The asynv event is a bit different, It may record the start and finish in different threads.
+// Each event needs to be identified with a different id, so you need to pass a context when using it.
+// In many cases, you can directly use the pointer address of an object as id, because it must be unique within the same process.
+// An example is as follows
+// Thread 1
+// void doSomethingAsync() {
+//     starrocks::debug::QueryTraceContext ctx;
+//     init ctx
+//     QUERY_TRACE_ASYNC_START("category", "name", ctx);
+//     async_process(ctx);
+// }
+// Thread 2
+// void async_process(ctx) {
+//    do something...
+//    QUERY_TRACE_ASYNC_FINISH("category", "name", ctx);
+// }
 
 #ifdef ENABLE_QUERY_DEBUG_TRACE
 #define SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr) \

--- a/be/src/util/debug/query_trace.h
+++ b/be/src/util/debug/query_trace.h
@@ -47,32 +47,32 @@
     starrocks::debug::QueryTrace::set_tls_trace_context(query_trace, fragment_instance_id,  \
                                                         reinterpret_cast<std::uintptr_t>(driver))
 
-#define QUERY_TRACE_BEGIN(category, name)        \
+#define QUERY_TRACE_BEGIN(name, category)        \
     INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER( \
-            INTERNAL_CREATE_EVENT_WITH_CTX(category, name, 'B', starrocks::debug::tls_trace_ctx))
+            INTERNAL_CREATE_EVENT_WITH_CTX(name, category, 'B', starrocks::debug::tls_trace_ctx))
 
-#define QUERY_TRACE_END(category, name)          \
+#define QUERY_TRACE_END(name, category)          \
     INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER( \
-            INTERNAL_CREATE_EVENT_WITH_CTX(category, name, 'E', starrocks::debug::tls_trace_ctx))
+            INTERNAL_CREATE_EVENT_WITH_CTX(name, category, 'E', starrocks::debug::tls_trace_ctx))
 
-#define QUERY_TRACE_SCOPED(category, name) starrocks::debug::ScopedTracer _scoped_tracer(category, name)
+#define QUERY_TRACE_SCOPED(name, category) starrocks::debug::ScopedTracer _scoped_tracer(name, category)
 
-#define QUERY_TRACE_ASYNC_START(category, name, ctx)                                                            \
+#define QUERY_TRACE_ASYNC_START(name, category, ctx)                                                            \
     do {                                                                                                        \
         INTERNAL_ADD_EVENT_INFO_BUFFER(ctx.event_buffer,                                                        \
-                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, ctx.id, 'b', ctx)); \
+                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(name, category, ctx.id, 'b', ctx)); \
     } while (0);
 
-#define QUERY_TRACE_ASYNC_FINISH(category, name, ctx)                                                           \
+#define QUERY_TRACE_ASYNC_FINISH(name, category, ctx)                                                           \
     do {                                                                                                        \
         INTERNAL_ADD_EVENT_INFO_BUFFER(ctx.event_buffer,                                                        \
-                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, ctx.id, 'e', ctx)); \
+                                       INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(name, category, ctx.id, 'e', ctx)); \
     } while (0);
 #else
 #define SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_trace, fragment_instance_id, driver_ptr)
-#define QUERY_TRACE_BEGIN(category, name)
-#define QUERY_TRACE_END(category, name)
-#define QUERY_TRACE_SCOPED(category, name)
-#define QUERY_TRACE_ASYNC_START(category, name, ctx)
-#define QUERY_TRACE_ASYNC_FINISH(category, name, ctx)
+#define QUERY_TRACE_BEGIN(name, category)
+#define QUERY_TRACE_END(name, category)
+#define QUERY_TRACE_SCOPED(name, category)
+#define QUERY_TRACE_ASYNC_START(name, category, ctx)
+#define QUERY_TRACE_ASYNC_FINISH(name, category, ctx)
 #endif

--- a/be/src/util/debug/query_trace.h
+++ b/be/src/util/debug/query_trace.h
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
 #pragma once
 
 #include "util/debug/query_trace_impl.h"

--- a/be/src/util/debug/query_trace_impl.cpp
+++ b/be/src/util/debug/query_trace_impl.cpp
@@ -176,9 +176,11 @@ ScopedTracer::ScopedTracer(const std::string& name, const std::string& category)
 }
 
 ScopedTracer::~ScopedTracer() {
-    _duration = MonotonicMicros() - _start_ts;
-    tls_trace_ctx.event_buffer->add(QueryTraceEvent::create_with_ctx(
-            _name, _category, -1, 'X', _start_ts - tls_trace_ctx.start_ts, _duration, tls_trace_ctx));
+    if (tls_trace_ctx.event_buffer != nullptr) {
+        _duration = MonotonicMicros() - _start_ts;
+        tls_trace_ctx.event_buffer->add(QueryTraceEvent::create_with_ctx(
+                _name, _category, -1, 'X', _start_ts - tls_trace_ctx.start_ts, _duration, tls_trace_ctx));
+    }
 }
 
 } // namespace debug

--- a/be/src/util/debug/query_trace_impl.cpp
+++ b/be/src/util/debug/query_trace_impl.cpp
@@ -171,7 +171,7 @@ void QueryTrace::set_tls_trace_context(QueryTrace* query_trace, TUniqueId fragme
 #endif
 }
 
-ScopedTracer::ScopedTracer(const std::string& category, const std::string& name) : _category(category), _name(name) {
+ScopedTracer::ScopedTracer(const std::string& name, const std::string& category) : _name(name), _category(category) {
     _start_ts = MonotonicMicros();
 }
 

--- a/be/src/util/debug/query_trace_impl.cpp
+++ b/be/src/util/debug/query_trace_impl.cpp
@@ -1,0 +1,169 @@
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+
+#include "common/config.h"
+#include "exec/pipeline/pipeline_driver.h"
+#include "fmt/printf.h"
+#include "io/fd_output_stream.h" // write trace to file
+#include "util/debug/query_trace.h"
+#include "util/time.h"
+#include "util/uid_util.h"
+
+namespace starrocks {
+namespace debug {
+
+QueryTraceEvent QueryTraceEvent::create(const std::string& name, const std::string& category, int64_t id, char phase,
+                                        int64_t timestamp, int64_t instance_id, std::uintptr_t driver,
+                                        std::vector<std::pair<std::string, std::string>>&& args) {
+    QueryTraceEvent event;
+    event.name = name;
+    event.category = category;
+    event.id = id;
+    event.phase = phase;
+    event.timestamp = timestamp;
+    event.instance_id = instance_id;
+    event.driver = driver;
+    event.args = std::move(args);
+    return event;
+}
+
+QueryTraceEvent QueryTraceEvent::create_with_ctx(const std::string& name, const std::string& category, int64_t id,
+                                                 char phase, const QueryTraceContext& ctx) {
+    return create(name, category, id, phase, MonotonicMicros() - ctx.start_ts, ctx.fragment_instance_id, ctx.driver,
+                  {});
+}
+
+static const char* kSimpleEventFormat =
+        "{\"cat\":\"%s\",\"name\":\"%s\",\"pid\":\"%ld\",\"tid\":\"%ld\",\"id\":\"%ld\",\"ts\":%ld,\"ph\":\"%c\","
+        "\"args\":%s}";
+static const char* kCompleteEventFormat =
+        "{\"cat\":\"%s\",\"name\":\"%s\",\"pid\":\"%ld\",\"tid\":\"%ld\",\"id\":\"%ld\",\"ts\":%ld,\"dur\":%ld,\"ph\":"
+        "\"%c\",\"args\":%s}";
+[[maybe_unused]] static const char* kProcessNameMetaEventFormat =
+        "{\"name\":\"process_name\",\"ph\":\"M\",\"pid\":\"%ld\",\"args\":{\"name\":\"%s\"}}";
+[[maybe_unused]] static const char* kThreadNameMetaEventFormat =
+        "{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":\"%ld\",\"tid\":\"%ld\",\"args\":{\"name\":\"%s\"}}";
+
+std::string QueryTraceEvent::to_string() {
+    std::string args_str = args_to_string();
+    if (phase == 'X') {
+        return fmt::sprintf(kCompleteEventFormat, category.c_str(), name.c_str(), instance_id, (int64_t)driver, id,
+                            timestamp, duration, phase, args_str.c_str());
+    } else {
+        return fmt::sprintf(kSimpleEventFormat, category.c_str(), name.c_str(), instance_id, (int64_t)driver, id,
+                            timestamp, phase, args_str.c_str());
+    }
+}
+
+std::string QueryTraceEvent::args_to_string() {
+    std::ostringstream oss;
+    oss << "{";
+    for (size_t i = 0; i < args.size(); i++) {
+        if (i != 0) {
+            oss << ",";
+        }
+        oss << fmt::sprintf("\"%s\":\"%s\"", args[i].first.c_str(), args[i].second.c_str());
+    }
+    oss << "}";
+    return oss.str();
+}
+
+void EventBuffer::add(QueryTraceEvent&& event) {
+    std::lock_guard<SpinLock> l(_mutex);
+    _buffer.emplace_back(std::move(event));
+}
+
+QueryTrace::QueryTrace(const TUniqueId& query_id, bool is_enable) : _query_id(query_id), _is_enable(is_enable) {
+    _start_ts = MonotonicMicros();
+}
+
+void QueryTrace::register_drivers(TUniqueId fragment_instance_id, starrocks::pipeline::Drivers& drivers) {
+#ifdef ENABLE_QUERY_DEBUG_TRACE
+    if (!_is_enable) {
+        return;
+    }
+    std::unique_lock l(_mutex);
+    auto iter = _fragment_drivers.find(fragment_instance_id);
+    if (iter == _fragment_drivers.end()) {
+        _fragment_drivers.insert({fragment_instance_id, std::make_shared<std::unordered_set<std::uintptr_t>>()});
+        iter = _fragment_drivers.find(fragment_instance_id);
+    }
+    for (auto& driver : drivers) {
+        std::uintptr_t ptr = reinterpret_cast<std::uintptr_t>(driver.get());
+        iter->second->insert(ptr);
+        _buffers.insert({ptr, std::make_unique<EventBuffer>()});
+    }
+#endif
+}
+
+Status QueryTrace::dump() {
+#ifdef ENABLE_QUERY_DEBUG_TRACE
+    if (!_is_enable) {
+        return Status::OK();
+    }
+    try {
+        std::filesystem::create_directory(starrocks::config::query_debug_trace_dir);
+        std::string file_name =
+                fmt::format("{}/{}.json", starrocks::config::query_debug_trace_dir, print_id(_query_id));
+        std::ofstream oss(file_name.c_str(), std::ios::out | std::ios::binary);
+        oss << "{\"traceEvents\":[";
+        bool is_first = true;
+        for (auto& [fragment_id, driver_set] : _fragment_drivers) {
+            std::string fragment_id_str = print_id(fragment_id);
+            oss << (is_first ? "" : ",\n");
+            oss << fmt::sprintf(kProcessNameMetaEventFormat, fragment_id.lo, fragment_id_str.c_str());
+            is_first = false;
+            for (auto& driver : *driver_set) {
+                starrocks::pipeline::DriverRawPtr ptr = reinterpret_cast<starrocks::pipeline::DriverRawPtr>(driver);
+                oss << (is_first ? "" : ",\n");
+                oss << fmt::sprintf(kThreadNameMetaEventFormat, fragment_id.lo, (int64_t)driver,
+                                    ptr->get_name().c_str());
+            }
+        }
+
+        for (auto& [_, buffer_ptr] : _buffers) {
+            auto& buffer = buffer_ptr->_buffer;
+            for (auto iter : buffer) {
+                oss << (is_first ? "" : ",\n");
+                oss << iter.to_string();
+            }
+        }
+        oss << "]}";
+
+        oss.close();
+    } catch (std::exception& e) {
+        return Status::IOError(fmt::format("dump trace log error {}", e.what()));
+    }
+#endif
+    return Status::OK();
+}
+
+void QueryTrace::set_tls_trace_context(QueryTrace* query_trace, TUniqueId fragment_instance_id, std::uintptr_t driver) {
+#ifdef ENABLE_QUERY_DEBUG_TRACE
+    if (!query_trace->_is_enable) {
+        tls_trace_ctx.reset();
+        return;
+    }
+    {
+        std::shared_lock l(query_trace->_mutex);
+        auto iter = query_trace->_buffers.find(driver);
+        DCHECK(iter != query_trace->_buffers.end());
+        tls_trace_ctx.event_buffer = iter->second.get();
+    }
+    tls_trace_ctx.start_ts = query_trace->_start_ts;
+    tls_trace_ctx.fragment_instance_id = fragment_instance_id.lo;
+    tls_trace_ctx.driver = driver;
+#endif
+}
+
+ScopedTracer::ScopedTracer(const std::string& category, const std::string& name) : _category(category), _name(name) {
+    QUERY_TRACE_BEGIN(_category, _name);
+}
+
+ScopedTracer::~ScopedTracer() {
+    QUERY_TRACE_END(_category, _name);
+}
+
+} // namespace debug
+} // namespace starrocks

--- a/be/src/util/debug/query_trace_impl.cpp
+++ b/be/src/util/debug/query_trace_impl.cpp
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
 #include <filesystem>
 #include <fstream>
 #include <mutex>

--- a/be/src/util/debug/query_trace_impl.cpp
+++ b/be/src/util/debug/query_trace_impl.cpp
@@ -102,6 +102,10 @@ Status QueryTrace::dump() {
     if (!_is_enable) {
         return Status::OK();
     }
+    static const char* kProcessNameMetaEventFormat =
+            "{\"name\":\"process_name\",\"ph\":\"M\",\"pid\":\"%ld\",\"args\":{\"name\":\"%s\"}}";
+    static const char* kThreadNameMetaEventFormat =
+            "{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":\"%ld\",\"tid\":\"%ld\",\"args\":{\"name\":\"%s\"}}";
     try {
         std::filesystem::create_directory(starrocks::config::query_debug_trace_dir);
         std::string file_name =
@@ -160,7 +164,7 @@ void QueryTrace::set_tls_trace_context(QueryTrace* query_trace, TUniqueId fragme
 ScopedTracer::ScopedTracer(const std::string& category, const std::string& name) : _category(category), _name(name) {
     QUERY_TRACE_BEGIN(_category, _name);
 }
-
+// @TODO: just generate a compelete event to reduce the number of events
 ScopedTracer::~ScopedTracer() {
     QUERY_TRACE_END(_category, _name);
 }

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -99,7 +99,7 @@ private:
     std::string _name;
     std::string _category;
     int64_t _start_ts;
-    int64_t _duration;
+    int64_t _duration = -1;
 };
 
 struct QueryTraceContext {

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -20,14 +20,13 @@ namespace debug {
 
 class QueryTraceContext;
 
-// QueryTraceEvent
 struct QueryTraceEvent {
     std::string name;
     std::string category;
     int64_t id; // used for async event
     char phase;
     int64_t timestamp;
-    int64_t duration = -1; // for compelete event
+    int64_t duration = -1; // for compelete event, not used now
     // TUniqueId::hi is all the same in one query, so we use TUniqueId::lo to specific one fragment instance
     int64_t instance_id;
     // driver pointer address
@@ -62,7 +61,6 @@ private:
     std::deque<QueryTraceEvent> _buffer;
 };
 
-// QueryTrace
 class QueryTrace {
 public:
     QueryTrace(const TUniqueId& query_id, bool is_enable);

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -28,21 +28,24 @@ struct QueryTraceEvent {
     int64_t id; // used for async event
     char phase;
     int64_t timestamp;
-    int64_t duration = -1; // for compelete event, not used now
+    int64_t duration = -1; // used for compelete event
     // TUniqueId::hi is all the same in one query, so we use TUniqueId::lo to specific one fragment instance
     int64_t instance_id;
-    // driver pointer address
+    // driver pointer
     std::uintptr_t driver;
     std::vector<std::pair<std::string, std::string>> args;
 
     std::string to_string();
 
     static QueryTraceEvent create(const std::string& name, const std::string& category, int64_t id, char phase,
-                                  int64_t timestamp, int64_t instance_id, std::uintptr_t driver,
+                                  int64_t timestamp, int64_t duration, int64_t instance_id, std::uintptr_t driver,
                                   std::vector<std::pair<std::string, std::string>>&& args);
 
     static QueryTraceEvent create_with_ctx(const std::string& name, const std::string& category, int64_t id, char phase,
                                            const QueryTraceContext& ctx);
+
+    static QueryTraceEvent create_with_ctx(const std::string& name, const std::string& category, int64_t id, char phase,
+                                           int64_t start_ts, int64_t duration, const QueryTraceContext& ctx);
 
 private:
     std::string args_to_string();
@@ -95,6 +98,8 @@ public:
 private:
     std::string _category;
     std::string _name;
+    int64_t _start_ts;
+    int64_t _duration;
 };
 
 struct QueryTraceContext {

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -92,12 +92,12 @@ private:
 
 class ScopedTracer {
 public:
-    ScopedTracer(const std::string& category, const std::string& name);
+    ScopedTracer(const std::string& name, const std::string& category);
     ~ScopedTracer();
 
 private:
-    std::string _category;
     std::string _name;
+    std::string _category;
     int64_t _start_ts;
     int64_t _duration;
 };
@@ -120,11 +120,11 @@ struct QueryTraceContext {
 
 inline thread_local QueryTraceContext tls_trace_ctx;
 
-#define INTERNAL_CREATE_EVENT_WITH_CTX(category, name, phase, ctx) \
-    starrocks::debug::QueryTraceEvent::create_with_ctx(category, name, -1, phase, ctx)
+#define INTERNAL_CREATE_EVENT_WITH_CTX(name, category, phase, ctx) \
+    starrocks::debug::QueryTraceEvent::create_with_ctx(name, category, -1, phase, ctx)
 
-#define INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, id, phase, ctx) \
-    starrocks::debug::QueryTraceEvent::create_with_ctx(category, name, id, phase, ctx)
+#define INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(name, category, id, phase, ctx) \
+    starrocks::debug::QueryTraceEvent::create_with_ctx(name, category, id, phase, ctx)
 
 #define INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER(event) \
     INTERNAL_ADD_EVENT_INFO_BUFFER(starrocks::debug::tls_trace_ctx.event_buffer, event)

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
 #pragma once
 
 #include <deque>

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <deque>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_set>
+
+#include "common/status.h"
+#include "exec/pipeline/pipeline_fwd.h"
+#include "gen_cpp/Types_types.h"
+#include "util/hash_util.hpp"
+#include "util/spinlock.h"
+
+namespace starrocks {
+namespace debug {
+
+class QueryTraceContext;
+
+// QueryTraceEvent
+struct QueryTraceEvent {
+    std::string name;
+    std::string category;
+    int64_t id; // used for async event
+    char phase;
+    int64_t timestamp;
+    int64_t duration = -1; // for compelete event
+    // TUniqueId::hi is all the same in one query, so we use TUniqueId::lo to specific one fragment instance
+    int64_t instance_id;
+    // driver pointer address
+    std::uintptr_t driver;
+    std::vector<std::pair<std::string, std::string>> args;
+
+    std::string to_string();
+
+    static QueryTraceEvent create(const std::string& name, const std::string& category, int64_t id, char phase,
+                                  int64_t timestamp, int64_t instance_id, std::uintptr_t driver,
+                                  std::vector<std::pair<std::string, std::string>>&& args);
+
+    static QueryTraceEvent create_with_ctx(const std::string& name, const std::string& category, int64_t id, char phase,
+                                           const QueryTraceContext& ctx);
+
+private:
+    std::string args_to_string();
+};
+
+// event buffer for a single pipeline driver
+class EventBuffer {
+public:
+    EventBuffer() = default;
+    ~EventBuffer() = default;
+
+    void add(QueryTraceEvent&& event);
+
+private:
+    friend class QueryTrace;
+    typedef SpinLock Mutex;
+    Mutex _mutex;
+    std::deque<QueryTraceEvent> _buffer;
+};
+
+// QueryTrace
+class QueryTrace {
+public:
+    QueryTrace(const TUniqueId& query_id, bool is_enable);
+    ~QueryTrace() = default;
+
+    // init event buffer for all drivers in a single fragment instance
+    void register_drivers(TUniqueId fragment_instance_id, starrocks::pipeline::Drivers& drivers);
+
+    Status dump();
+
+    static void set_tls_trace_context(QueryTrace* query_trace, TUniqueId fragment_instance_id, std::uintptr_t driver);
+
+private:
+    TUniqueId _query_id;
+    bool _is_enable = false;
+    int64_t _start_ts = -1;
+
+    std::shared_mutex _mutex;
+    std::unordered_map<std::uintptr_t, std::unique_ptr<EventBuffer>> _buffers;
+
+    // fragment_instance_id => driver list, it will be used to generate meta event
+    std::unordered_map<TUniqueId, std::shared_ptr<std::unordered_set<std::uintptr_t>>> _fragment_drivers;
+};
+
+class ScopedTracer {
+public:
+    ScopedTracer(const std::string& category, const std::string& name);
+    ~ScopedTracer();
+
+private:
+    std::string _category;
+    std::string _name;
+};
+
+struct QueryTraceContext {
+    int64_t start_ts = -1;
+    int64_t fragment_instance_id = -1;
+    std::uintptr_t driver = 0;
+    int64_t id = -1; // used for async event
+    EventBuffer* event_buffer = nullptr;
+
+    void reset() {
+        start_ts = -1;
+        fragment_instance_id = -1;
+        driver = 0;
+        id = -1;
+        event_buffer = nullptr;
+    }
+};
+
+inline thread_local QueryTraceContext tls_trace_ctx;
+
+#define INTERNAL_CREATE_EVENT_WITH_CTX(category, name, phase, ctx) \
+    starrocks::debug::QueryTraceEvent::create_with_ctx(category, name, -1, phase, ctx)
+
+#define INTERNAL_CREATE_ASYNC_EVENT_WITH_CTX(category, name, id, phase, ctx) \
+    starrocks::debug::QueryTraceEvent::create_with_ctx(category, name, id, phase, ctx)
+
+#define INTERNAL_ADD_EVENT_INTO_THREAD_LOCAL_BUFFER(event) \
+    INTERNAL_ADD_EVENT_INFO_BUFFER(starrocks::debug::tls_trace_ctx.event_buffer, event)
+
+#define INTERNAL_ADD_EVENT_INFO_BUFFER(buffer, event) \
+    do {                                              \
+        if (buffer) {                                 \
+            buffer->add(event);                       \
+        }                                             \
+    } while (0);
+} // namespace debug
+} // namespace starrocks

--- a/build.sh
+++ b/build.sh
@@ -107,6 +107,9 @@ fi
 if [[ -z ${USE_SSE4_2} ]]; then
     USE_SSE4_2=ON
 fi
+if [[ -z ${ENABLE_QUERY_DEBUG_TRACE} ]]; then
+	ENABLE_QUERY_DEBUG_TRACE=OFF
+fi
 
 
 HELP=0
@@ -162,6 +165,7 @@ echo "Get params:
     USE_STAROS          -- $USE_STAROS
     USE_AVX2            -- $USE_AVX2
     PARALLEL            -- $PARALLEL
+    ENABLE_QUERY_DEBUG_TRACE -- $ENABLE_QUERY_DEBUG_TRACE
 "
 
 # Clean and build generated code
@@ -208,6 +212,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
                     -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}\
                     -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
+                    -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                     -DUSE_STAROS=${USE_STAROS} \
                     -Dprotobuf_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/protobuf \
@@ -222,6 +227,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
                     -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}\
                     -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
+                    -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
     fi
     time ${BUILD_SYSTEM} -j${PARALLEL}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1029,7 +1029,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isRuntimeFilterOnExchangeNode() {
         return runtimeFilterOnExchangeNode;
-	}
+    }
 
     public boolean isEnableQueryDebugTrace() {
         return enableQueryDebugTrace;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -240,6 +240,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SHOW_ALL_VARIABLES = "enable_show_all_variables";
 
+    public static final String ENABLE_QUERY_DEBUG_TRACE = "enable_query_debug_trace";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(ENABLE_SPILLING)
@@ -256,6 +258,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             .add("vectorized_insert_enable")
             .add("prefer_join_method")
             .add("rewrite_count_distinct_to_bitmap_hll").build();
+
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
@@ -559,6 +562,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_OPTIMIZER_TRACE_LOG, flag = VariableMgr.INVISIBLE)
     private boolean enableOptimizerTraceLog = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_DEBUG_TRACE, flag = VariableMgr.INVISIBLE)
+    private boolean enableQueryDebugTrace = false;
 
     @VarAttr(name = STATISTIC_COLLECT_PARALLEL)
     private int statisticCollectParallelism = 1;
@@ -1023,6 +1029,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isRuntimeFilterOnExchangeNode() {
         return runtimeFilterOnExchangeNode;
+	}
+
+    public boolean isEnableQueryDebugTrace() {
+        return enableQueryDebugTrace;
     }
 
     // Serialize to thrift object
@@ -1084,6 +1094,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
 
         tResult.setEnable_tablet_internal_parallel(enableTabletInternalParallel);
+        tResult.setEnable_query_debug_trace(enableQueryDebugTrace);
 
         return tResult;
     }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -169,6 +169,8 @@ struct TQueryOptions {
   59: optional bool enable_tablet_internal_parallel;
 
   60: optional i32 query_delivery_timeout;
+  
+  61: optional bool enable_query_debug_trace;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

# Background

Inspired by [minitrace](https://github.com/hrydgard/minitrace), I implemented a lightweight tool to analyze the performance of a single query.

When the query is executed, it will collect pre-set trace events and generate a json file compatible with Chrome's excellent built-in trace viewer.

Through it, we can fully understand the execution status of a query, know what each pipeline driver is doing at every time.

# Basic Usage

1. if you need to use this feature, you need to specify the `ENABLE_QUERY_DEBUG_TRACE` macro when BE compiles.I expect this feature to have no impact on production environments.
3. set environment variables before query starts
```sql
set enable_query_debug_trace=true;
```
4. initiate a query, here is an example of ssb-flat q4
```sql
set pipeline_dop=3;
select l_returnflag,l_linestatus,sum(l_quantity) as sum_qty,sum(l_extendedprice) as sum_base_price,sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,avg(l_quantity) as avg_qty,avg(l_extendedprice) as avg_price,avg(l_discount) as avg_disc,count(*) as count_order from lineitem where  l_shipdate <= date '1998-12-01' group by  l_returnflag,  l_linestatus order by  l_returnflag,  l_linestatus;
```
5. After the query is complete, you can find the json file named with the query id in the `${STARROCKS_HOME}/query_debug_trace`
6. open `chrome://tracing/` in Chrome, load this json file, you will see the execution time of all pipeline drivers during its lifetime.
![image](https://user-images.githubusercontent.com/3675229/174995385-13269139-63c2-4776-a83e-6a936e0ca0fa.png)

using chrome viewer, you can see the time-consuming of each operator every time the driver is processed
![image](https://user-images.githubusercontent.com/3675229/174996006-5b39c6f2-d7c8-42ca-a222-ffeba1572eb5.png)
you can also see the execution time of async io task triggerd by a pipeline driver
![image](https://user-images.githubusercontent.com/3675229/174996384-f349954e-5cf6-4f0b-a298-dc6ad7e205e2.png)

# Design and Implementation
All the implementations are in `query_trace_impl.h` and  `query_trace_impl.cpp`. The upper layer need to add the trace point through the macros in `query_trace.h`.The overall implementation is relatively simple, and you can directly see the code.

The format of trace event can refer to https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit

# Why not just use minitrace directly?

minitrace has the following problems: 
1. The interface it provides by default describes the timeline from the perspective of threads, so that the life cycle of the pipeline driver cannot be seen intuitively;
2. It needs to access the global lock when adding an event, which will have a relatively large performance overhead under multi-core. And my implementation will create a separate buffer for each pipeline driver, which can greatly reduce the chance of lock competition.

I look forward to using this tool to help us analyze some potential performance issues.

# TODO
1. support more types of trace events if necessary
2. support setting arguments for trace event.
3. add more trace point for pipeline driver, such as the waiting time in blocked driver and ready queue.
