### PR TITLE
[Refactor] Remove Cluster.java read access interface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -545,7 +545,6 @@ public class RestoreJob extends AbstractJob {
                                     // this partition can be added to this table, set ids
                                     Partition restorePart = resetPartitionForRestore(localOlapTbl, remoteOlapTbl,
                                             backupPartInfo.name,
-                                            db.getClusterName(),
                                             restoreReplicationNum);
                                     if (restorePart == null) {
                                         return;
@@ -799,7 +798,7 @@ public class RestoreJob extends AbstractJob {
     // reset remote partition.
     // reset all id in remote partition, but DO NOT modify any exist globalStateMgr objects.
     private Partition resetPartitionForRestore(OlapTable localTbl, OlapTable remoteTbl, String partName,
-                                               String clusterName, int restoreReplicationNum) {
+                                               int restoreReplicationNum) {
         Preconditions.checkState(localTbl.getPartition(partName) == null);
         Partition remotePart = remoteTbl.getPartition(partName);
         Preconditions.checkNotNull(remotePart);
@@ -843,7 +842,7 @@ public class RestoreJob extends AbstractJob {
                 // replicas
                 List<Long> beIds =
                         GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(restoreReplicationNum, true,
-                                true, clusterName);
+                                true);
                 if (beIds == null) {
                     status = new Status(ErrCode.COMMON_ERROR,
                             "failed to get enough backends for creating replica of tablet "

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -531,8 +531,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                     // replicas
                     List<Long> beIds = GlobalStateMgr.getCurrentSystemInfo()
                             .seqChooseBackendIds(partitionInfo.getReplicationNum(entry.getKey()),
-                                    true, true,
-                                    db.getClusterName());
+                                    true, true);
                     if (beIds == null) {
                         return new Status(ErrCode.COMMON_ERROR, "failed to find "
                                 + partitionInfo.getReplicationNum(entry.getKey())
@@ -1370,7 +1369,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
     }
 
     public boolean isStable(SystemInfoService infoService, TabletScheduler tabletScheduler, String clusterName) {
-        List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(clusterName, true);
+        List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
         for (Partition partition : idToPartition.values()) {
             long visibleVersion = partition.getVisibleVersion();
             short replicationNum = partitionInfo.getReplicationNum(partition.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -159,10 +159,6 @@ public class BackendLoadStatistic {
         return beId;
     }
 
-    public String getClusterName() {
-        return clusterName;
-    }
-
     public boolean isAvailable() {
         return isAvailable;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BeLoadRebalancer.java
@@ -106,7 +106,7 @@ public class BeLoadRebalancer extends Rebalancer {
                 b -> b.getAvailPathNum(medium)).sum();
         LOG.info("get number of low load paths: {}, with medium: {}", numOfLowPaths, medium);
 
-        int clusterAvailableBEnum = infoService.getClusterBackendIds(clusterName, true).size();
+        int clusterAvailableBEnum = infoService.getBackendIds(true).size();
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentColocateIndex();
         // choose tablets from high load backends.
         // BackendLoadStatistic is sorted by load score in ascend order,

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
@@ -49,8 +49,6 @@ public class ClusterLoadStatistic {
     private SystemInfoService infoService;
     private TabletInvertedIndex invertedIndex;
 
-    private String clusterName;
-
     private Map<TStorageMedium, Long> totalCapacityMap = Maps.newHashMap();
     private Map<TStorageMedium, Long> totalUsedCapacityMap = Maps.newHashMap();
     private Map<TStorageMedium, Long> totalReplicaNumMap = Maps.newHashMap();
@@ -61,15 +59,13 @@ public class ClusterLoadStatistic {
     private Map<TStorageMedium, Integer> backendNumMap = Maps.newHashMap();
     private List<BackendLoadStatistic> beLoadStatistics = Lists.newArrayList();
 
-    public ClusterLoadStatistic(String clusterName, SystemInfoService infoService,
-                                TabletInvertedIndex invertedIndex) {
-        this.clusterName = clusterName;
+    public ClusterLoadStatistic(SystemInfoService infoService, TabletInvertedIndex invertedIndex) {
         this.infoService = infoService;
         this.invertedIndex = invertedIndex;
     }
 
     public void init() {
-        ImmutableMap<Long, Backend> backends = infoService.getBackendsInCluster(clusterName);
+        ImmutableMap<Long, Backend> backends = infoService.getIdToBackend();
         for (Backend backend : backends.values()) {
             BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(),
                     backend.getOwnerClusterName(), infoService, invertedIndex);
@@ -308,8 +304,8 @@ public class ClusterLoadStatistic {
         sortBeStats(mid, medium);
         sortBeStats(high, medium);
 
-        LOG.debug("after adjust, cluster {} backend classification low/mid/high: {}/{}/{}, medium: {}",
-                clusterName, low.size(), mid.size(), high.size(), medium);
+        LOG.debug("after adjust, backend classification low/mid/high: {}/{}/{}, medium: {}",
+                low.size(), mid.size(), high.size(), medium);
     }
 
     public List<BackendLoadStatistic> getSortedBeLoadStats(TStorageMedium medium) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -521,7 +521,7 @@ public class ColocateTableBalancer extends MasterDaemon {
     private List<Long> getAvailableBeIds(String cluster, SystemInfoService infoService) {
         // get all backends to allBackendIds, and check be availability using checkBackendAvailable
         // backend stopped for a short period of time is still considered available
-        List<Long> allBackendIds = infoService.getClusterBackendIds(cluster, false);
+        List<Long> allBackendIds = infoService.getBackendIds(false);
         List<Long> availableBeIds = Lists.newArrayList();
         for (Long backendId : allBackendIds) {
             if (checkBackendAvailable(backendId, infoService)) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -391,7 +391,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         // cache selected tablets to avoid select same tablet
         Set<Long> selectedTablets = Sets.newHashSet();
         // aliveBeIds to check tablet health
-        List<Long> aliveBeIds = infoService.getClusterBackendIds(clusterName, true);
+        List<Long> aliveBeIds = infoService.getBackendIds(true);
         Map<String, List<Long>> hostGroups = getHostGroups(aliveBeIds);
         int srcBEIndex = beStats.size() - 1;
         int destBEIndex = 0;
@@ -609,7 +609,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         Preconditions.checkArgument(pathStats != null && pathStats.size() > 1 && beId > -1 && beNum > 0);
 
         // aliveBeIds to check tablet health
-        List<Long> aliveBeIds = infoService.getClusterBackendIds(clusterName, true);
+        List<Long> aliveBeIds = infoService.getBackendIds(true);
 
         // src|dest path stat
         int srcPathIndex = pathStats.size() - 1;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -211,7 +211,7 @@ public class TabletChecker extends MasterDaemon {
 
             db.readLock();
             try {
-                List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(db.getClusterName(), true);
+                List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
                 for (Table table : globalStateMgr.getTablesIncludeRecycleBin(db)) {
                     if (!table.needSchedule(false)) {
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -960,7 +960,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
     private void unprotectedFinishClone(TFinishTaskRequest request, Database db, Partition partition,
                                         short replicationNum) throws SchedException {
-        List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(db.getClusterName(), true);
+        List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
         Pair<TabletStatus, TabletSchedCtx.Priority> pair = tablet.getHealthStatusWithPriority(
                 infoService, db.getClusterName(), visibleVersion, replicationNum,
                 aliveBeIdsInCluster);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.starrocks.alter.DecommissionBackendJob.DecommissionType;
-import com.starrocks.cluster.Cluster;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
@@ -78,7 +77,7 @@ public class BackendsProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        final List<List<String>> backendInfos = getClusterBackendInfos(null);
+        final List<List<String>> backendInfos = getClusterBackendInfos();
         for (List<String> backendInfo : backendInfos) {
             List<String> oneInfo = new ArrayList<>(backendInfo.size());
             oneInfo.addAll(backendInfo);
@@ -93,22 +92,12 @@ public class BackendsProcDir implements ProcDirInterface {
      * @param clusterName
      * @return
      */
-    public static List<List<String>> getClusterBackendInfos(String clusterName) {
+    public static List<List<String>> getClusterBackendInfos() {
         final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentSystemInfo();
         List<List<String>> backendInfos = new LinkedList<>();
-        List<Long> backendIds;
-        if (!Strings.isNullOrEmpty(clusterName)) {
-            final Cluster cluster = GlobalStateMgr.getCurrentState().getCluster(clusterName);
-            // root not in any cluster
-            if (null == cluster) {
-                return backendInfos;
-            }
-            backendIds = cluster.getBackendIdList();
-        } else {
-            backendIds = clusterInfoService.getBackendIds(false);
-            if (backendIds == null) {
-                return backendInfos;
-            }
+        List<Long> backendIds = clusterInfoService.getBackendIds(false);
+        if (backendIds == null) {
+            return backendInfos;
         }
 
         long start = System.currentTimeMillis();
@@ -127,12 +116,10 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(String.valueOf(backendId));
             backendInfo.add(backend.getOwnerClusterName());
             backendInfo.add(backend.getHost());
-            if (Strings.isNullOrEmpty(clusterName)) {
-                backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
-                backendInfo.add(String.valueOf(backend.getBePort()));
-                backendInfo.add(String.valueOf(backend.getHttpPort()));
-                backendInfo.add(String.valueOf(backend.getBrpcPort()));
-            }
+            backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
+            backendInfo.add(String.valueOf(backend.getBePort()));
+            backendInfo.add(String.valueOf(backend.getHttpPort()));
+            backendInfo.add(String.valueOf(backend.getBrpcPort()));
             backendInfo.add(TimeUtils.longToTimeString(backend.getLastStartTime()));
             backendInfo.add(TimeUtils.longToTimeString(backend.getLastUpdateMs()));
             backendInfo.add(String.valueOf(backend.isAlive()));

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
@@ -111,7 +111,7 @@ public class StatisticProcDir implements ProcDirInterface {
             }
 
             ++totalDbNum;
-            List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(db.getClusterName(), true);
+            List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
             db.readLock();
             try {
                 int dbTableNum = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
@@ -219,7 +219,7 @@ public class ColocateMetaService {
             }
 
             List<Long> clusterBackendIds =
-                    GlobalStateMgr.getCurrentSystemInfo().getClusterBackendIds(clusterName, true);
+                    GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
             //check the Backend id
             for (List<Long> backendIds : backendsPerBucketSeq) {
                 if (backendIds.size() != groupSchema.getReplicationNum()) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -84,7 +84,7 @@ public class LoadAction extends RestBaseAction {
         checkTblAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, tableName, PrivPredicate.LOAD);
 
         // Choose a backend sequentially.
-        List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false, clusterName);
+        List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
         if (backendIds == null) {
             throw new DdlException("No backend alive.");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -22,13 +22,11 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TNetworkAddress;
@@ -64,18 +62,10 @@ public class TransactionLoadAction extends RestBaseAction {
 
     @Override
     public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
-
-        final String clusterName = ConnectContext.get().getClusterName();
-        if (Strings.isNullOrEmpty(clusterName)) {
-            throw new DdlException("No cluster selected.");
-        }
-
         String dbName = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("No database selected.");
         }
-
-        String fullDbName = ClusterNamespace.getFullName(clusterName, dbName);
 
         String label = request.getRequest().headers().get(LABEL_KEY);
         String op = request.getSingleParameter(TXN_OP_KEY);
@@ -84,7 +74,7 @@ public class TransactionLoadAction extends RestBaseAction {
         synchronized (this) {
             if (op.equalsIgnoreCase(TXN_BEGIN)) {
                 // Choose a backend sequentially.
-                List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false, clusterName);
+                List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
                 if (backendIds == null) {
                     throw new DdlException("No backend alive.");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -173,7 +173,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                         }
                     }
                     long timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;
-                    KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(), id, clusterName,
+                    KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(), id,
                             taskSchedIntervalS * 1000,
                             timeToExecuteMs, taskKafkaProgress);
                     routineLoadTaskInfoList.add(kafkaTaskInfo);
@@ -196,7 +196,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public int calculateCurrentConcurrentTaskNum() throws MetaNotFoundException {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        int aliveBeNum = systemInfoService.getClusterBackendIds(clusterName, true).size();
+        int aliveBeNum = systemInfoService.getBackendIds(true).size();
         int partitionNum = currentKafkaPartitions.size();
         if (desireTaskConcurrentNum == 0) {
             desireTaskConcurrentNum = Config.max_routine_load_task_concurrent_num;
@@ -382,7 +382,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         // init kafka routine load job
         long id = GlobalStateMgr.getCurrentState().getNextId();
         KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(id, stmt.getName(),
-                db.getClusterName(), db.getId(), tableId,
+                SystemInfoService.DEFAULT_CLUSTER, db.getId(), tableId,
                 stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
         kafkaRoutineLoadJob.setOptional(stmt);
         kafkaRoutineLoadJob.checkCustomProperties();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -59,14 +59,14 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     // offset is the latest existing message offset + 1
     private Map<Integer, Long> latestPartOffset;
 
-    public KafkaTaskInfo(UUID id, long jobId, String clusterName, long taskScheduleIntervalMs, long timeToExecuteMs,
+    public KafkaTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs, long timeToExecuteMs,
                          Map<Integer, Long> partitionIdToOffset) {
-        super(id, jobId, clusterName, taskScheduleIntervalMs, timeToExecuteMs);
+        super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs);
         this.partitionIdToOffset = partitionIdToOffset;
     }
 
     public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset) {
-        super(UUID.randomUUID(), kafkaTaskInfo.getJobId(), kafkaTaskInfo.getClusterName(),
+        super(UUID.randomUUID(), kafkaTaskInfo.getJobId(),
                 kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs, kafkaTaskInfo.getBeId());
         this.partitionIdToOffset = partitionIdToOffset;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -56,7 +56,6 @@ public abstract class RoutineLoadTaskInfo {
     protected UUID id;
     protected long txnId = -1L;
     protected long jobId;
-    protected String clusterName;
 
     private final long createTimeMs;
     // The time when the task is actually executed
@@ -84,20 +83,19 @@ public abstract class RoutineLoadTaskInfo {
     // record task schedule info
     protected String msg;
 
-    public RoutineLoadTaskInfo(UUID id, long jobId, String clusterName, long taskScheduleIntervalMs,
+    public RoutineLoadTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs,
                                long timeToExecuteMs) {
         this.id = id;
         this.jobId = jobId;
-        this.clusterName = clusterName;
         this.createTimeMs = System.currentTimeMillis();
         this.taskScheduleIntervalMs = taskScheduleIntervalMs;
         this.timeoutMs = 1000 * Config.routine_load_task_timeout_second;
         this.timeToExecuteMs = timeToExecuteMs;
     }
 
-    public RoutineLoadTaskInfo(UUID id, long jobId, String clusterName, long taskSchedulerIntervalMs,
+    public RoutineLoadTaskInfo(UUID id, long jobId, long taskSchedulerIntervalMs,
                                long timeToExecuteMs, long previousBeId) {
-        this(id, jobId, clusterName, taskSchedulerIntervalMs, timeToExecuteMs);
+        this(id, jobId, taskSchedulerIntervalMs, timeToExecuteMs);
         this.previousBeId = previousBeId;
     }
 
@@ -107,10 +105,6 @@ public abstract class RoutineLoadTaskInfo {
 
     public long getJobId() {
         return jobId;
-    }
-
-    public String getClusterName() {
-        return clusterName;
     }
 
     public void setExecuteStartTimeMs(long executeStartTimeMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
@@ -32,8 +32,8 @@ public class ScheduleRule {
 
     private static int deadBeCount(String clusterName) {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        int total = systemInfoService.getClusterBackendIds(clusterName, false).size();
-        int alive = systemInfoService.getClusterBackendIds(clusterName, true).size();
+        int total = systemInfoService.getBackendIds(false).size();
+        int alive = systemInfoService.getBackendIds(true).size();
         return total - alive;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -1175,8 +1175,7 @@ public class MasterImpl {
             }
 
             List<TBackendMeta> backends = new ArrayList<>();
-            for (Backend backend : GlobalStateMgr.getCurrentState().getCurrentSystemInfo()
-                    .getClusterBackends(db.getClusterName())) {
+            for (Backend backend : GlobalStateMgr.getCurrentState().getCurrentSystemInfo().getBackends()) {
                 TBackendMeta backendMeta = new TBackendMeta();
                 backendMeta.setBackend_id(backend.getId());
                 backendMeta.setHost(backend.getHost());

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -1203,7 +1203,7 @@ public class ReportHandler extends Daemon {
                 }
             }
 
-            List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(db.getClusterName(), true);
+            List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
             Pair<TabletStatus, TabletSchedCtx.Priority> status = tablet.getHealthStatusWithPriority(infoService,
                     db.getClusterName(), visibleVersion,
                     replicationNum, aliveBeIdsInCluster);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1293,7 +1293,7 @@ public class ShowExecutor {
 
     private void handleShowBackends() {
         final ShowBackendsStmt showStmt = (ShowBackendsStmt) stmt;
-        List<List<String>> backendInfos = BackendsProcDir.getClusterBackendInfos(showStmt.getClusterName());
+        List<List<String>> backendInfos = BackendsProcDir.getClusterBackendInfos();
         resultSet = new ShowResultSet(showStmt.getMetaData(), backendInfos);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1760,11 +1760,6 @@ public class GlobalStateMgr {
         localMetastore.unprotectCreateDb(db);
     }
 
-    // for test
-    public void addCluster(Cluster cluster) {
-        localMetastore.addCluster(cluster);
-    }
-
     public void replayCreateDb(Database db) {
         localMetastore.replayCreateDb(db);
     }
@@ -2331,10 +2326,6 @@ public class GlobalStateMgr {
 
     public List<String> getDbNames() {
         return localMetastore.listDbNames();
-    }
-
-    public List<String> getClusterDbNames(String clusterName) throws AnalysisException {
-        return localMetastore.getClusterDbNames(clusterName);
     }
 
     public List<Long> getDbIds() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -147,10 +147,6 @@ public class AccessTestUtil {
                     minTimes = 0;
                     result = new Load();
 
-                    globalStateMgr.getClusterDbNames("testCluster");
-                    minTimes = 0;
-                    result = Lists.newArrayList("testCluster:testDb");
-
                     globalStateMgr.changeCatalogDb((ConnectContext) any, "blockDb");
                     minTimes = 0;
                     result = new DdlException("failed");
@@ -165,8 +161,6 @@ public class AccessTestUtil {
             };
             return globalStateMgr;
         } catch (DdlException e) {
-            return null;
-        } catch (AnalysisException e) {
             return null;
         }
     }
@@ -301,10 +295,6 @@ public class AccessTestUtil {
                     minTimes = 0;
                     result = Lists.newArrayList("testCluster:testDb");
 
-                    globalStateMgr.getClusterDbNames("testCluster");
-                    minTimes = 0;
-                    result = Lists.newArrayList("testCluster:testDb");
-
                     globalStateMgr.getDb("emptyCluster");
                     minTimes = 0;
                     result = null;
@@ -312,8 +302,6 @@ public class AccessTestUtil {
             };
             return globalStateMgr;
         } catch (DdlException e) {
-            return null;
-        } catch (AnalysisException e) {
             return null;
         }
     }
@@ -363,26 +351,6 @@ public class AccessTestUtil {
                 analyzer.getDefaultDb();
                 minTimes = 0;
                 result = "testCluster:testDb";
-
-                analyzer.getQualifiedUser();
-                minTimes = 0;
-                result = "testCluster:testUser";
-
-                analyzer.getClusterName();
-                minTimes = 0;
-                result = "testCluster";
-            }
-        };
-        return analyzer;
-    }
-
-    public static Analyzer fetchEmptyDbAnalyzer() {
-        Analyzer analyzer = new Analyzer(fetchBlockCatalog(), new ConnectContext(null));
-        new Expectations(analyzer) {
-            {
-                analyzer.getDefaultDb();
-                minTimes = 0;
-                result = "";
 
                 analyzer.getQualifiedUser();
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -82,14 +82,6 @@ public class ShowDbStmtTest {
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getClusterDbNames("testCluster");
-                minTimes = 0;
-                result = Lists.newArrayList("testCluster:testDb");
-
-                globalStateMgr.getClusterDbNames("");
-                minTimes = 0;
-                result = Lists.newArrayList("");
-
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -159,7 +159,7 @@ public class RestoreJobTest {
 
         new Expectations() {
             {
-                systemInfoService.seqChooseBackendIds(anyInt, anyBoolean, anyBoolean, anyString);
+                systemInfoService.seqChooseBackendIds(anyInt, anyBoolean, anyBoolean);
                 minTimes = 0;
                 result = new Delegate() {
                     public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAlive,

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -144,8 +144,7 @@ public class ClusterLoadStatisticsTest {
 
     @Test
     public void test() {
-        ClusterLoadStatistic loadStatistic = new ClusterLoadStatistic(SystemInfoService.DEFAULT_CLUSTER,
-                systemInfoService, invertedIndex);
+        ClusterLoadStatistic loadStatistic = new ClusterLoadStatistic(systemInfoService, invertedIndex);
         loadStatistic.init();
         List<List<String>> infos = loadStatistic.getClusterStatistic(TStorageMedium.HDD);
         System.out.println(infos);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -389,7 +389,7 @@ public class ColocateTableBalancerTest {
         List<Long> clusterBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L);
         new Expectations() {
             {
-                infoService.getClusterBackendIds("cluster1", false);
+                infoService.getBackendIds(false);
                 result = clusterBackendIds;
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -100,7 +100,7 @@ public class DiskAndTabletLoadReBalancerTest {
                 30006L, beId2,
                 tabletDataSize, pathHash2);
 
-        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(cluster, infoService, invertedIndex);
+        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(infoService, invertedIndex);
         clusterLoadStatistic.init();
 
         PartitionInfo partitionInfo = new PartitionInfo();
@@ -252,7 +252,7 @@ public class DiskAndTabletLoadReBalancerTest {
                 30009L, beId3,
                 tabletDataSize, pathHash3);
 
-        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(cluster, infoService, invertedIndex);
+        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(infoService, invertedIndex);
         clusterLoadStatistic.init();
 
         PartitionInfo partitionInfo = new PartitionInfo();
@@ -424,7 +424,7 @@ public class DiskAndTabletLoadReBalancerTest {
         addTablet(invertedIndex, materializedIndex, TStorageMedium.SSD, dbId, tableId, partitionId2, indexId,
                 20010L, 30010L, beId2, tabletDataSize, pathHash21);
 
-        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(cluster, infoService, invertedIndex);
+        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(infoService, invertedIndex);
         clusterLoadStatistic.init();
 
         PartitionInfo partitionInfo = new PartitionInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -139,14 +139,13 @@ public class TabletSchedCtxTest {
         globalStateMgr.getIdToDb().put(DB_ID, db);
 
         // prepare clusterLoadStatistic
-        clusterLoadStatistic =
-                new ClusterLoadStatistic(SystemInfoService.DEFAULT_CLUSTER, systemInfoService, invertedIndex);
+        clusterLoadStatistic = new ClusterLoadStatistic(systemInfoService, invertedIndex);
         clusterLoadStatistic.init();
 
         // mock tabletScheduler
         tabletScheduler = new TabletScheduler(globalStateMgr, systemInfoService, invertedIndex, stat);
         tabletScheduler.getStatisticMap().put(SystemInfoService.DEFAULT_CLUSTER, clusterLoadStatistic);
-        systemInfoService.getClusterBackends(SystemInfoService.DEFAULT_CLUSTER).forEach(be -> {
+        systemInfoService.getBackends().forEach(be -> {
             List<Long> pathHashes =
                     be.getDisks().values().stream().map(DiskInfo::getPathHash).collect(Collectors.toList());
             TabletScheduler.PathSlot slot = new TabletScheduler.PathSlot(pathHashes, Config.schedule_slot_num_per_path);

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -240,10 +240,6 @@ abstract public class StarRocksHttpTestCase {
                     minTimes = 0;
                     result = editLog;
 
-                    globalStateMgr.getClusterDbNames("default_cluster");
-                    minTimes = 0;
-                    result = Lists.newArrayList("default_cluster:testDb");
-
                     globalStateMgr.changeCatalogDb((ConnectContext) any, "blockDb");
                     minTimes = 0;
 
@@ -257,8 +253,6 @@ abstract public class StarRocksHttpTestCase {
 
             return globalStateMgr;
         } catch (DdlException e) {
-            return null;
-        } catch (AnalysisException e) {
             return null;
         }
     }
@@ -313,10 +307,6 @@ abstract public class StarRocksHttpTestCase {
                     minTimes = 0;
                     result = editLog;
 
-                    globalStateMgr.getClusterDbNames("default_cluster");
-                    minTimes = 0;
-                    result = Lists.newArrayList("default_cluster:testDb");
-
                     globalStateMgr.changeCatalogDb((ConnectContext) any, "blockDb");
                     minTimes = 0;
 
@@ -338,8 +328,6 @@ abstract public class StarRocksHttpTestCase {
 
             return globalStateMgr;
         } catch (DdlException e) {
-            return null;
-        } catch (AnalysisException e) {
             return null;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -110,10 +110,10 @@ public class KafkaRoutineLoadJobTest {
                 GlobalStateMgr.getCurrentSystemInfo();
                 minTimes = 0;
                 result = systemInfoService;
-                systemInfoService.getClusterBackendIds(clusterName1, true);
+                systemInfoService.getBackendIds(true);
                 minTimes = 0;
                 result = beIds1;
-                systemInfoService.getClusterBackendIds(clusterName2, true);
+                systemInfoService.getBackendIds(true);
                 result = beIds2;
                 minTimes = 0;
             }
@@ -209,7 +209,7 @@ public class KafkaRoutineLoadJobTest {
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = new ArrayList<>();
         Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
         partitionIdsToOffset.put(100, 0L);
-        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L, "default_cluster",
+        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
                 maxBatchIntervalS * 2 * 1000, System.currentTimeMillis(), partitionIdsToOffset);
         kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
         routineLoadTaskInfoList.add(kafkaTaskInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -111,23 +111,13 @@ public class KafkaRoutineLoadJobTest {
                 minTimes = 0;
                 result = systemInfoService;
                 systemInfoService.getBackendIds(true);
-                minTimes = 0;
-                result = beIds1;
-                systemInfoService.getBackendIds(true);
                 result = beIds2;
                 minTimes = 0;
             }
         };
 
-        // 2 partitions, 1 be
-        RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName1, 1L,
-                        1L, "127.0.0.1:9020", "topic1");
-        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList1);
-        Assert.assertEquals(1, routineLoadJob.calculateCurrentConcurrentTaskNum());
-
         // 3 partitions, 4 be
-        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
                 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList2);
         Assert.assertEquals(3, routineLoadJob.calculateCurrentConcurrentTaskNum());

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -43,7 +43,6 @@ public class KafkaTaskInfoTest {
         offset1.put(0, 99L);
         KafkaTaskInfo kafkaTaskInfo1 = new KafkaTaskInfo(UUID.randomUUID(),
                 1L,
-                "cluster",
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 offset1);
@@ -53,7 +52,6 @@ public class KafkaTaskInfoTest {
         offset1.put(0, 100L);
         KafkaTaskInfo kafkaTaskInfo2 = new KafkaTaskInfo(UUID.randomUUID(),
                 1L,
-                "cluster",
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 offset2);
@@ -85,7 +83,6 @@ public class KafkaTaskInfoTest {
         offset.put(0, 99L);
         KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(),
                 1L,
-                "cluster",
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 offset);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -98,7 +98,7 @@ public class RoutineLoadSchedulerTest {
                 database.getTable(1L);
                 minTimes = 0;
                 result = olapTable;
-                systemInfoService.getClusterBackendIds(clusterName, true);
+                systemInfoService.getBackendIds(true);
                 minTimes = 0;
                 result = beIds;
                 routineLoadManager.getSizeOfIdToRoutineLoadTask();

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -53,7 +53,7 @@ public class RoutineLoadTaskSchedulerTest {
         Deencapsulation.setField(kafkaProgress, "partitionIdToOffset", partitionIdToOffset);
 
         Queue<RoutineLoadTaskInfo> routineLoadTaskInfoQueue = Queues.newLinkedBlockingQueue();
-        KafkaTaskInfo routineLoadTaskInfo1 = new KafkaTaskInfo(new UUID(1, 1), 1l, "default_cluster", 20000,
+        KafkaTaskInfo routineLoadTaskInfo1 = new KafkaTaskInfo(new UUID(1, 1), 1l, 20000,
                 System.currentTimeMillis(), partitionIdToOffset);
         routineLoadTaskInfoQueue.add(routineLoadTaskInfo1);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -232,14 +232,6 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getClusterDbNames("testCluster");
-                minTimes = 0;
-                result = Lists.newArrayList("testCluster:testDb");
-
-                globalStateMgr.getClusterDbNames("");
-                minTimes = 0;
-                result = Lists.newArrayList("");
-
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -338,7 +338,7 @@ public class GlobalTransactionMgrTest {
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), 1L, "defualt_cluster", 20000, System.currentTimeMillis(),
+                new KafkaTaskInfo(UUID.randomUUID(), 1L, 20000, System.currentTimeMillis(),
                         partitionIdToOffset);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
@@ -411,7 +411,7 @@ public class GlobalTransactionMgrTest {
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), 1L, "defualt_cluster", 20000, System.currentTimeMillis(),
+                new KafkaTaskInfo(UUID.randomUUID(), 1L, 20000, System.currentTimeMillis(),
                         partitionIdToOffset);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);


### PR DESCRIPTION
Because we need to be compatible with old version StarRocks, we can't change
the format of image and log. So we don't change the write interface of Cluster.java.
Then the old version binary can work normally when downgrade.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
