### PR TITLE
[BugFix]: compaction error when enable persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -657,7 +657,10 @@ public:
             const auto& key = fkeys[replace_idxes[i]];
             const auto v = values[replace_idxes[i]];
             uint64_t hash = FixedKeyHash<KeySize>()(key);
-            _map.emplace_with_hash(hash, key, v);
+            auto p = _map.emplace_with_hash(hash, key, v);
+            if (!p.second) {
+                p.first->second = v;
+            }
         }
         return Status::OK();
     }
@@ -1538,7 +1541,7 @@ Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue
     uint32_t rowid_start = (uint32_t)(values[0] & 0xFFFFFFFF);
     std::vector<size_t> replace_idxes;
     for (size_t i = 0; i < n; ++i) {
-        if (values[i] != NullIndexValue && ((uint32_t)(found_values[i] >> 32)) == src_rssid[i]) {
+        if (found_values[i] != NullIndexValue && ((uint32_t)(found_values[i] >> 32)) == src_rssid[i]) {
             replace_idxes.emplace_back(i);
         } else {
             failed->emplace_back(rowid_start + i);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7244 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In function `PersistentIndex::try_replace()`, new value is not update if find same key in hash map. So it will cause data error in compaction of primary key table.
