### PR TITLE
[Bugfix] keep the aggregate expr order when rewrite aggregate operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -578,7 +578,8 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                                                                  DecodeContext context) {
             Map<Integer, Integer> newStringToDicts = Maps.newHashMap();
 
-            Map<ColumnRefOperator, CallOperator> newAggMap = Maps.newHashMap(aggOperator.getAggregations());
+            final List<Map.Entry<ColumnRefOperator, CallOperator>> newAggMapEntry = Lists.newArrayList();
+
             for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggOperator.getAggregations().entrySet()) {
                 boolean canApplyDictDecodeOpt = (kv.getValue().getUsedColumns().cardinality() > 0) &&
                         (PhysicalHashAggregateOperator.couldApplyLowCardAggregateFunction.contains(
@@ -597,7 +598,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                                 Collections.singletonList(dictColumn), newFunction,
                                 oldCall.isDistinct());
                         ColumnRefOperator outputColumn = kv.getKey();
-                        newAggMap.put(outputColumn, newCall);
+                        newAggMapEntry.add(Maps.immutableEntry(outputColumn, newCall));
                     } else if (context.stringColumnIdToDictColumnIds.containsKey(columnId)) {
                         Integer dictColumnId = context.stringColumnIdToDictColumnIds.get(columnId);
                         ColumnRefOperator dictColumn = context.columnRefFactory.getColumnRef(dictColumnId);
@@ -628,7 +629,6 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                             ColumnRefOperator outputStringColumn = kv.getKey();
                             final ColumnRefOperator newDictColumn = context.columnRefFactory.create(
                                     dictColumn.getName(), ID_TYPE, dictColumn.isNullable());
-                            newAggMap.remove(outputStringColumn);
                             newStringToDicts.put(outputStringColumn.getId(), newDictColumn.getId());
 
                             for (Pair<Integer, ColumnDict> globalDict : context.globalDicts) {
@@ -647,10 +647,15 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                                 newArguments, newFunction,
                                 oldCall.isDistinct());
 
-                        newAggMap.put(outputColumn, newCall);
+                        newAggMapEntry.add(Maps.immutableEntry(outputColumn, newCall));
+                    } else {
+                        newAggMapEntry.add(kv);
                     }
+                } else {
+                    newAggMapEntry.add(kv);
                 }
             }
+            Map<ColumnRefOperator, CallOperator> newAggMap = ImmutableMap.copyOf(newAggMapEntry);
 
             List<ColumnRefOperator> newGroupBys = Lists.newArrayList();
             for (ColumnRefOperator groupBy : aggOperator.getGroupBys()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -286,7 +286,7 @@ public class LowCardinalityTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertFalse(plan.contains("Decode"));
         Assert.assertTrue(plan.contains("7:AGGREGATE (merge finalize)\n" +
-                "  |  output: multi_distinct_count(13: count), multi_distinct_count(12: count)"));
+                "  |  output: multi_distinct_count(12: count), multi_distinct_count(13: count)"));
 
         sql = "select count(distinct S_ADDRESS), count(distinct S_COMMENT) from supplier;";
         plan = getFragmentPlan(sql);
@@ -872,7 +872,7 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select min(distinct S_ADDRESS), max(S_ADDRESS) from supplier_nullable";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update serialize)\n" +
-                "  |  output: max(11: S_ADDRESS), min(11: S_ADDRESS)"));
+                "  |  output: min(11: S_ADDRESS), max(11: S_ADDRESS)"));
         Assert.assertTrue(plan.contains("  3:AGGREGATE (merge finalize)\n" +
                 "  |  output: min(12: S_ADDRESS), max(13: S_ADDRESS)"));
         Assert.assertTrue(plan.contains("  4:Decode\n" +
@@ -914,7 +914,6 @@ public class LowCardinalityTest extends PlanTestBase {
     public void testHavingAggFunctionOnConstant() throws Exception {
         String sql = "select S_ADDRESS from supplier GROUP BY S_ADDRESS HAVING (cast(count(null) as string)) IN (\"\")";
         String plan = getCostExplain(sql);
-        System.out.println("plan = " + plan);
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
                 "  |  aggregate: count[(NULL); args: BOOLEAN; result: BIGINT; args nullable: true; result nullable: false]\n" +
                 "  |  group by: [10: S_ADDRESS, INT, false]\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #7659

## Problem Summary(Required) ：

we should keep the aggregate expr order when rewrite, because we will use
singleDistinctFunctionPos to decide call update or merge

