### PR TITLE
[MaterializedView] The table related mv id is not cleared when dropping mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2990,6 +2990,13 @@ public class LocalMetastore implements ConnectorMetadata {
         }
         if (table != null && table instanceof MaterializedView) {
             db.dropTable(table.getName(), stmt.isSetIfExists(), true);
+            Set<Long> baseTableIds = ((MaterializedView) table).getBaseTableIds();
+            for (Long baseTableId : baseTableIds) {
+                OlapTable baseTable = ((OlapTable) db.getTable(baseTableId));
+                if (baseTable != null) {
+                    baseTable.removeRelatedMaterializedView(table.getId());
+                }
+            }
         } else {
             stateMgr.getAlterInstance().processDropMaterializedView(stmt);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
@@ -5,6 +5,7 @@ package com.starrocks.analysis;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -113,11 +114,16 @@ public class UseMaterializedViewTest {
             Assert.assertTrue(database != null);
             Table table = database.getTable("mv_to_drop");
             Assert.assertTrue(table != null);
+            MaterializedView materializedView = (MaterializedView) table;
+            long baseTableId = materializedView.getBaseTableIds().iterator().next();
+            OlapTable baseTable = ((OlapTable) database.getTable(baseTableId));
+            Assert.assertEquals(baseTable.getRelatedMaterializedViews().size(), 2);
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
             stmtExecutor.execute();
             table = database.getTable("mv_to_drop");
             Assert.assertTrue(table == null);
+            Assert.assertEquals(baseTable.getRelatedMaterializedViews().size(), 1);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7672

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
table property `relatedMaterializedViews` remove related mv id when dropping mv
