### PR TITLE
[BugFix] Modify the RedirectStatus of ShowRestoreStmt form FORWARD_NO_SYNC to NO_FORWARD

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRestoreStmt.java
@@ -107,7 +107,7 @@ public class ShowRestoreStmt extends ShowStmt {
 
     @Override
     public RedirectStatus getRedirectStatus() {
-        return RedirectStatus.FORWARD_NO_SYNC;
+        return RedirectStatus.NO_FORWARD;
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRestoreStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRestoreStmtTest.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ShowRestoreStmtTest {
+    
+    @Test
+    public void checkShowRestoreStmtRedirectStatus() {
+        ShowRestoreStmt stmt = new ShowRestoreStmt("", null);
+        assertEquals(stmt.getRedirectStatus(), RedirectStatus.NO_FORWARD);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7009

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When querying the restore task on the follower, the forward policy used before is FORWARD_NO_SYNC, which causes the restore task to be completed on the master, but the status of the table on the follower is still restoring, so If you query the data on the follower, you will get an error.
Now we have two ways to fix it, NO_FORWARD and FORWARD_WITH_SYNC, but since the two operations, fe write metadata memory and  write  log, are not atomic, so the moment when the request get restore has been finished from master, the finished log may still not generated yet, so the follower actually waits for a log id lower than the finish one, so in this case the follower thinks that the restore has finished, but the state of these tables is still restoring, and does not change the state to normal by replaying the log，you will get an error too.
so we have to choose NO_FORWARD
