### PR TITLE
[Bugfix] fix init database failed in QueryDetail when executing multiple statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -78,7 +78,11 @@ public class QueryDetail implements Serializable {
             this.database = "";
         } else {
             String[] stringPieces = database.split(":", -1);
-            this.database = stringPieces[1]; // eliminate cluster name
+            if (stringPieces.length == 1) {
+                this.database = stringPieces[0];
+            } else {
+                this.database = stringPieces[1]; // eliminate cluster name
+            }
         }
         this.sql = sql;
         this.user = user;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we send multiple external_catalog's queries by jdbc.  it will failed when init database in QueryDetail.
