### PR TITLE
[BugFix] flush memtable when delta writer is not inited will cause be crash

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -395,6 +395,11 @@ Status TabletsChannel::reduce_mem_usage_async(const std::set<int64_t>& flush_tab
                 // barely not happend, just return OK
                 return Status::OK();
             }
+
+            if (!writer->memtable_inited()) {
+                // writer's memtable not inited, just return OK
+                return Status::OK();
+            }
             VLOG(3) << "pick the delta writer to flush, with mem consumption: " << max_consume
                     << ", channel key: " << _key;
             *tablet_mem_consumption = max_consume;

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -46,6 +46,7 @@ DeltaWriter::DeltaWriter(WriteRequest* req, MemTracker* parent, StorageEngine* s
           _rowset_writer(nullptr),
           _tablet_schema(nullptr),
           _delta_written_success(false),
+          _mem_table(nullptr),
           _storage_engine(storage_engine) {
     _mem_tracker = std::make_unique<MemTracker>(-1, "delta writer", parent, true);
 }

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -84,6 +84,8 @@ public:
 
     int64_t mem_consumption() const;
 
+    bool memtable_inited() const { return _mem_table != nullptr; }
+
 private:
     DeltaWriter(WriteRequest* req, MemTracker* parent, StorageEngine* storage_engine);
 


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7720

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When load memory reaches the threshold, we will flush delta writer's memtable.
However, if delta writer is not inited, its memtable is nullptr, and flush the delta writer will cause be crash