### PR TITLE
[Bugfix] Check if tablet deleted after acquiring tabletupdates' lock

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1241,7 +1241,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     // The last is we find PersistentIndexMetaPB and it's version is equal to latest applied version. In this case,
     // we can load from index file directly
     EditVersion lastest_applied_version;
-    tablet->updates()->get_latest_applied_version(&lastest_applied_version);
+    RETURN_IF_ERROR(tablet->updates()->get_latest_applied_version(&lastest_applied_version));
     if (status.ok()) {
         // all applied rowsets has save in existing persistent index meta
         // so we can load persistent index according to PersistentIndexMetaPB

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -152,7 +152,7 @@ public:
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 
-    void get_latest_applied_version(EditVersion* latest_applied_version);
+    Status get_latest_applied_version(EditVersion* latest_applied_version);
 
     // Clear both in-memory cached and permanently stored meta data:
     //  - primary index
@@ -287,8 +287,6 @@ private:
     std::set<uint32_t> _active_rowsets();
 
     void _stop_and_wait_apply_done();
-
-    StatusOr<std::unique_ptr<CompactionInfo>> _get_compaction();
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo, bool wait_apply);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7293
Cherrypick #7304

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When deleting a primary key tablet, clear_meta will be called and _edit_version_infos will be cleared, this makes all other concurrent operations invalid, so these operations running in other threads should check state validity after acquiring lock.