### PR TITLE
[BugFix] fix the bug of get_tablet with schema hash

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -108,7 +108,7 @@ Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_
     uint32_t schema_hash;
     RETURN_IF_ERROR(get_params(req, &tablet_id, &schema_hash));
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     RETURN_IF(tablet == nullptr,
               Status::InvalidArgument(fmt::format("Not Found tablet:{}, schema hash:{}", tablet_id, schema_hash)));
 

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -80,15 +80,13 @@ Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* 
     return Status::OK();
 }
 
-Status get_params(HttpRequest* req, uint64_t* tablet_id, uint32_t* schema_hash) {
+Status get_params(HttpRequest* req, uint64_t* tablet_id) {
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
-    std::string req_schema_hash = req->param(TABLET_SCHEMA_HASH_KEY);
 
     try {
         *tablet_id = std::stoull(req_tablet_id);
-        *schema_hash = std::stoul(req_schema_hash);
     } catch (const std::exception& e) {
-        std::string msg = fmt::format("invalid argument.tablet_id:{}, schema_hash:{}", req_tablet_id, req_schema_hash);
+        std::string msg = fmt::format("invalid argument.tablet_id:{}", req_tablet_id);
         LOG(WARNING) << msg;
         return Status::InvalidArgument(msg);
     }
@@ -105,12 +103,11 @@ Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_
     DeferOp defer([&]() { _running = false; });
 
     uint64_t tablet_id;
-    uint32_t schema_hash;
-    RETURN_IF_ERROR(get_params(req, &tablet_id, &schema_hash));
+    RETURN_IF_ERROR(get_params(req, &tablet_id));
 
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     RETURN_IF(tablet == nullptr,
-              Status::InvalidArgument(fmt::format("Not Found tablet:{}, schema hash:{}", tablet_id, schema_hash)));
+              Status::InvalidArgument(fmt::format("Not Found tablet:{}, schema hash:{}", tablet_id)));
 
     std::string compaction_type = req->param(PARAM_COMPACTION_TYPE);
     if (compaction_type != to_string(CompactionType::BASE_COMPACTION) &&

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -118,7 +118,7 @@ Status DeltaWriter::_init() {
         TabletSharedPtr new_tablet;
         if (!_tablet->is_migrating()) {
             // maybe migration just finish, get the tablet again
-            new_tablet = tablet_mgr->get_tablet(_opt.tablet_id, _opt.schema_hash);
+            new_tablet = tablet_mgr->get_tablet(_opt.tablet_id);
             if (new_tablet == nullptr) {
                 _set_state(kAborted);
                 return Status::NotFound(fmt::format("Not found tablet. tablet_id: {}", _opt.tablet_id));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7735 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
class TabletManager {
    TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false, std::string* err = nullptr);

    TabletSharedPtr get_tablet(TTabletId tablet_id, const TabletUid& tablet_uid, bool include_deleted = false,
                               std::string* err = nullptr);
}
```

our usage covert `schema hash` to `include_deleted`

which was introduced the the pr: https://github.com/StarRocks/starrocks/commit/3fd83add0a3a399d1a8235d7268d896d8c149516
