### PR TITLE
[BugFix] wrong result of load with condition `IS NULL`/`IS NOT NULL`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IsNullPredicate.java
@@ -92,9 +92,9 @@ public class IsNullPredicate extends Predicate {
         super.analyzeImpl(analyzer);
 
         if (isNotNull) {
-            fn = isNullFN;
-        } else {
             fn = isNotNullFN;
+        } else {
+            fn = isNullFN;
         }
 
         // determine selectivity

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/IsNullPredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/IsNullPredicateTest.java
@@ -39,6 +39,7 @@ public class IsNullPredicateTest {
         } catch (AnalysisException e) {
             Assert.fail();
         }
+        Assert.assertEquals(isNullPredicate.getFn(), IsNullPredicate.isNullFN);
 
         IsNullPredicate isNotNullPredicate = new IsNullPredicate(new NullLiteral(), true);
 
@@ -47,6 +48,7 @@ public class IsNullPredicateTest {
         } catch (AnalysisException e) {
             Assert.fail();
         }
+        Assert.assertEquals(isNotNullPredicate.getFn(), IsNullPredicate.isNotNullFN);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7747

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR fix result of load with condition`IS NULL`/`IS NOT NULL`.