### PR TITLE
[Enhancement] move the destructor of TabletsChannel out of lock

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -60,11 +60,14 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
 
     Status st;
     {
+        // We will `bthread::execution_queue_join()` in the destructor of AsnycDeltaWriter,
+        // the function will block the bthread, so we put its destructor outside the lock.
+        scoped_refptr<TabletsChannel> channel;
         std::lock_guard<std::mutex> l(_lock);
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
             TabletsChannelKey key(request.id(), index_id);
-            auto channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker.get())
-                                          : new_local_tablets_channel(this, key, _mem_tracker.get());
+            channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker.get())
+                                     : new_local_tablets_channel(this, key, _mem_tracker.get());
             if (st = channel->open(request); st.ok()) {
                 _tablets_channels.insert({index_id, std::move(channel)});
             }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -61,7 +61,7 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
     Status st;
     {
         // We will `bthread::execution_queue_join()` in the destructor of AsnycDeltaWriter,
-        // the function will block the bthread, so we put its destructor outside the lock.
+        // it will block the bthread, so we put its destructor outside the lock.
         scoped_refptr<TabletsChannel> channel;
         std::lock_guard<std::mutex> l(_lock);
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7763 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We will `bthread::execution_queue_join()` in the destructor of AsnycDeltaWriter, the function will block the bthread, so we put its destructor of `TabletsChannel` outside the lock.
