### PR TITLE
[MaterializedView] Partition based on non-existing table throws NPE when creating mv (#7733)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -469,11 +469,6 @@ public class Database extends MetaObject implements Writable {
             } else {
                 idToTable.put(materializedView.getId(), materializedView);
                 nameToTable.put(materializedView.getName(), materializedView);
-                // ref base table with mv
-                Set<Long> baseTableIds = materializedView.getBaseTableIds();
-                for (Long baseTableId : baseTableIds) {
-                    ((OlapTable) idToTable.get(baseTableId)).addRelatedMaterializedView(materializedView.getId());
-                }
                 if (!isReplay) {
                     // Write edit log
                     CreateTableInfo info = new CreateTableInfo(fullQualifiedName, materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -413,7 +413,7 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
                 new Scope(RelationId.anonymous(),
                         new RelationFields(this.getBaseSchema().stream()
                                 .map(col -> new Field(col.getName(), col.getType(),
-                                        new TableName(null, this.name), null))
+                                        new TableName(db.getFullName(), this.name), null))
                                 .collect(Collectors.toList()))), connectContext);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -210,6 +210,10 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
     @SerializedName(value = "mvTablePartitionNameRefMap")
     private Map<String, Set<String>> mvTablePartitionNameRefMap = new HashMap<>();
 
+    // record expression table column
+    @SerializedName(value = "partitionRefTableExprs")
+    private List<Expr> partitionRefTableExprs;
+
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
         this.clusterId = GlobalStateMgr.getCurrentState().getClusterId();
@@ -254,6 +258,14 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
 
     public void setBaseTableIds(Set<Long> baseTableIds) {
         this.baseTableIds = baseTableIds;
+    }
+
+    public void setPartitionRefTableExprs(List<Expr> partitionRefTableExprs) {
+        this.partitionRefTableExprs = partitionRefTableExprs;
+    }
+
+    public List<Expr> getPartitionRefTableExprs() {
+        return partitionRefTableExprs;
     }
 
     public MvRefreshScheme getRefreshScheme() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -426,6 +426,11 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
                                 .map(col -> new Field(col.getName(), col.getType(),
                                         new TableName(db.getFullName(), this.name), null))
                                 .collect(Collectors.toList()))), connectContext);
+        // if replay , partitions maybe not empty
+        Collection<Partition> partitions = this.getPartitions();
+        for (Partition partition : partitions) {
+            addPartitionRef(partition);
+        }
     }
 
     public void addPartitionRef(Partition mvPartition) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RangeUtils.java
@@ -48,6 +48,15 @@ public class RangeUtils {
         }
     }
 
+    public static boolean isRangeIntersect(Range<PartitionKey> range1, Range<PartitionKey> range2) {
+        if (range2.isConnected(range1)) {
+            if (!range2.intersection(range1).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /*
      * Pass only if the 2 range lists are exactly same
      * What is "exactly same"?

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RangeUtils.java
@@ -49,12 +49,7 @@ public class RangeUtils {
     }
 
     public static boolean isRangeIntersect(Range<PartitionKey> range1, Range<PartitionKey> range2) {
-        if (range2.isConnected(range1)) {
-            if (!range2.intersection(range1).isEmpty()) {
-                return true;
-            }
-        }
-        return false;
+        return range2.isConnected(range1) && !range2.intersection(range1).isEmpty();
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -77,7 +77,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
                 for (Partition partition : partitions) {
                     if (materializedView.needRefreshPartition(baseTableId, partition)) {
                         needRefresh = true;
-                        materializedView.addOrUpdateBasePartition(baseTableId, partition);
+                        materializedView.updateBasePartition(baseTableId, partition);
                     }
                 }
             }
@@ -160,7 +160,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             if (!materializedView.needAddBasePartition(baseTableId, basePartition)) {
                 continue;
             }
-            materializedView.addOrUpdateBasePartition(baseTableId, basePartition);
+            materializedView.addBasePartition(baseTableId, basePartition);
             Range<PartitionKey> basePartitionRange = baseRangePartitionInfo.getRange(basePartitionId);
             List<Column> basePartitionColumns = baseRangePartitionInfo.getPartitionColumns();
             int basePartitionIndex = -1;
@@ -210,7 +210,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             if (materializedView.needRefreshPartition(baseTableId, partition)) {
                 needRefreshPartitionNames.addAll(
                         materializedView.getMvPartitionNameByTable(basePartitionName));
-                materializedView.addOrUpdateBasePartition(baseTableId, partition);
+                materializedView.updateBasePartition(baseTableId, partition);
             }
         }
     }
@@ -222,7 +222,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         for (Partition basePartition : basePartitions) {
             if (materializedView.needRefreshPartition(baseTableId, basePartition)) {
                 refreshAllPartitions = true;
-                materializedView.addOrUpdateBasePartition(baseTableId, basePartition);
+                materializedView.updateBasePartition(baseTableId, basePartition);
             }
         }
         return refreshAllPartitions;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -92,11 +92,11 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
                 ((ExpressionRangePartitionInfo) partitionInfo);
         // currently, mv only supports one expression
         Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
-        Expr partitionExpr = expressionRangePartitionInfo.getPartitionExprs().get(0);
-        Column partitionColumn = expressionRangePartitionInfo.getPartitionColumns().get(0);
         // 1. scan base table, get table id which used in partition
+        Expr partitionExpr = materializedView.getPartitionRefTableExprs().get(0);
         Map<Long, OlapTable> olapTables = Maps.newHashMap();
         OlapTable partitionTable = null;
+        Column partitionColumn = null;
         List<SlotRef> slotRefs = Lists.newArrayList();
         partitionExpr.collect(SlotRef.class, slotRefs);
         // if partitionExpr is FunctionCallExpr, get first SlotRef
@@ -106,6 +106,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             OlapTable olapTable = (OlapTable) database.getTable(baseTableId);
             if (slotRef.getTblNameWithoutAnalyzed().getTbl().equals(olapTable.getName())) {
                 partitionTable = olapTable;
+                partitionColumn = partitionTable.getColumn(slotRef.getColumnName());
             }
             olapTables.put(baseTableId, olapTable);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -71,8 +71,8 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         Database database = GlobalStateMgr.getCurrentState().getDb(context.ctx.getDatabase());
         MaterializedView materializedView = (MaterializedView) database.getTable(mvId);
         if (!materializedView.isActive()) {
-            LOG.warn("Materialized view: " + mvId + "is not active, " +
-                    "skip sync partition and data with base tables");
+            LOG.warn("Materialized view: {} is not active, " +
+                    "skip sync partition and data with base tables", mvId);
             return;
         }
         Set<Long> baseTableIds = materializedView.getBaseTableIds();
@@ -145,7 +145,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         if (refreshAllPartitions) {
             refreshMv(context, materializedView);
         } else {
-            if (needRefreshPartitionNames.size() > 0) {
+            if (!needRefreshPartitionNames.isEmpty()) {
                 refreshMv(context, materializedView, partitionTable, needRefreshPartitionNames);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.scheduler;
 
-
 import com.clearspring.analytics.util.Lists;
 import com.clearspring.analytics.util.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -13,7 +12,6 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.QueryableReentrantLock;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
@@ -33,7 +31,6 @@ import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -120,10 +117,13 @@ public class TaskManager {
                 continue;
             }
 
-            LocalDateTime startTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(taskSchedule.getStartTime()),
-                    TimeUtils.getTimeZone().toZoneId());
+            LocalDateTime startTime = Utils.getDatetimeFromLong(taskSchedule.getStartTime());
             Duration duration = Duration.between(LocalDateTime.now(), startTime);
             long initialDelay = duration.getSeconds();
+            // if startTime < now, start scheduling now
+            if (initialDelay < 0) {
+                initialDelay = 0;
+            }
             ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() ->
                             executeTask(task.getName()), initialDelay, taskSchedule.getPeriod(),
                     taskSchedule.getTimeUnit());

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2943,6 +2943,7 @@ public class LocalMetastore implements ConnectorMetadata {
                             TimeUtils.convertUnitIdentifierToTimeUnit(asyncRefreshContext.getTimeUnit()));
                     task.setSchedule(taskSchedule);
                     task.setType(Constants.TaskType.PERIODICAL);
+                    task.setState(Constants.TaskState.ACTIVE);
                 }
                 TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
                 taskManager.createTask(task, false);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -298,7 +298,7 @@ public class LocalMetastore implements ConnectorMetadata {
             idToDb.put(db.getId(), db);
             fullNameToDb.put(db.getFullName(), db);
             stateMgr.getGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());
-            db.getMaterializedViews().stream().forEach(mv -> mv.onCreate());
+            db.getMaterializedViews().stream().forEach(Table::onCreate);
         }
         LOG.info("finished replay databases from image");
         return newChecksum;
@@ -2845,7 +2845,7 @@ public class LocalMetastore implements ConnectorMetadata {
         // set viewDefineSql
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         // set partitionRefTableExprs
-        materializedView.setPartitionRefTableExprs(Lists.newArrayList(stmt.getPartitionRefTableExprs()));
+        materializedView.setPartitionRefTableExprs(Lists.newArrayList(stmt.getPartitionRefTableExpr()));
         // set base index id
         long baseIndexId = getNextId();
         materializedView.setBaseIndexId(baseIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2949,7 +2949,6 @@ public class LocalMetastore implements ConnectorMetadata {
                             TimeUtils.convertUnitIdentifierToTimeUnit(asyncRefreshContext.getTimeUnit()));
                     task.setSchedule(taskSchedule);
                     task.setType(Constants.TaskType.PERIODICAL);
-                    task.setState(Constants.TaskState.ACTIVE);
                 }
                 TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
                 taskManager.createTask(task, false);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2797,7 +2797,7 @@ public class LocalMetastore implements ConnectorMetadata {
         PartitionInfo partitionInfo;
         if (partitionDesc != null) {
             partitionInfo = partitionDesc.toPartitionInfo(
-                    Arrays.asList(stmt.getBasePartitionColumn()),
+                    Arrays.asList(stmt.getPartitionColumn()),
                     Maps.newHashMap(), false);
         } else {
             partitionInfo = new SinglePartitionInfo();
@@ -2831,14 +2831,15 @@ public class LocalMetastore implements ConnectorMetadata {
         long mvId = GlobalStateMgr.getCurrentState().getNextId();
         MaterializedView materializedView =
                 new MaterializedView(mvId, db.getId(), mvName, baseSchema, stmt.getKeysType(), partitionInfo,
-                        distributionInfo,
-                        mvRefreshScheme);
+                        distributionInfo, mvRefreshScheme);
         // set comment
         materializedView.setComment(stmt.getComment());
         // set baseTableIds
         materializedView.setBaseTableIds(stmt.getBaseTableIds());
         // set viewDefineSql
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
+        // set partitionRefTableExprs
+        materializedView.setPartitionRefTableExprs(Lists.newArrayList(stmt.getPartitionRefTableExprs()));
         // set base index id
         long baseIndexId = getNextId();
         materializedView.setBaseIndexId(baseIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3141,7 +3141,9 @@ public class LocalMetastore implements ConnectorMetadata {
             OlapTable table = (OlapTable) db.getTable(tableId);
             Partition partition = table.getPartition(partitionId);
             table.renamePartition(partition.getName(), newPartitionName);
-
+            if (table.getType() == Table.TableType.MATERIALIZED_VIEW) {
+                ((MaterializedView) table).addPartitionRef(partition);
+            }
             LOG.info("replay rename partition[{}] to {}", partition.getName(), newPartitionName);
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1138,9 +1138,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 partitionInfo.addPartition(
                         partition.getId(), info.getDataProperty(), info.getReplicationNum(), info.isInMemory());
             }
-            if (olapTable.getType() == Table.TableType.MATERIALIZED_VIEW && !info.isTempPartition()) {
-                ((MaterializedView) olapTable).addPartitionRef(partition);
-            }
+            replayMvAddPartition(info, olapTable, partition);
             if (!isCheckpointThread()) {
                 // add to inverted index
                 TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
@@ -1160,6 +1158,12 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         } finally {
             db.writeUnlock();
+        }
+    }
+
+    private void replayMvAddPartition(PartitionPersistInfo info, OlapTable olapTable, Partition partition) {
+        if (olapTable.getType() == Table.TableType.MATERIALIZED_VIEW && !info.isTempPartition()) {
+            ((MaterializedView) olapTable).addPartitionRef(partition);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -318,7 +318,7 @@ public class AnalyzerUtils {
         }
     }
 
-    private static class TableAndViewCollectorWithAlias extends TableCollector {
+    private static class TableAndViewCollectorWithAlias extends TableCollectorWithAlias {
         public TableAndViewCollectorWithAlias(Map<TableName, Table> dbs) {
             super(dbs);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -313,7 +313,7 @@ public class MaterializedViewAnalyzer {
                 List<SlotRef> slotRefs = Lists.newArrayList();
                 expr.collect(SlotRef.class, slotRefs);
                 Preconditions.checkState(slotRefs.size() == 1);
-                return slotRefs.size() > 0 ? slotRefs.get(0) : null;
+                return slotRefs.get(0);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -443,11 +443,7 @@ public class MaterializedViewAnalyzer {
                 SlotRef slotRef = (SlotRef) fnExpr.getChild(1);
                 PrimitiveType primitiveType = slotRef.getType().getPrimitiveType();
                 // must check slotRef type, because function analyze don't check it.
-                if ((primitiveType == PrimitiveType.DATETIME || primitiveType == PrimitiveType.DATE)) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return primitiveType == PrimitiveType.DATETIME || primitiveType == PrimitiveType.DATE;
             } else {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -133,14 +133,6 @@ public class MaterializedViewAnalyzer {
                 checkPartitionExpParams(statement);
                 // check partition column must be base table's partition column
                 checkPartitionColumnWithBaseTable(statement, tableNameTableMap);
-                // analyze partition by expression
-                ExpressionAnalyzer.analyzeExpression(statement.getPartitionExpDesc().getExpr(),
-                        new AnalyzeState(),
-                        new Scope(RelationId.anonymous(),
-                                new RelationFields(statement.getMvColumnItems().stream()
-                                        .map(col -> new Field(col.getName(), col.getType(),
-                                                statement.getTableName(), null))
-                                        .collect(Collectors.toList()))), context);
             }
             // check and analyze distribution
             checkDistribution(statement, tableNameTableMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -18,6 +19,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
@@ -112,18 +114,25 @@ public class MaterializedViewAnalyzer {
             }
             // analyze query statement, can check whether tables and columns exist in catalog
             Analyzer.analyze(queryStatement, context);
+            // convert queryStatement to sql and set
+            statement.setInlineViewDef(ViewDefBuilder.build(queryStatement));
             // collect table from query statement
             Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllTableAndViewWithAlias(queryStatement);
             Set<Long> baseTableIds = Sets.newHashSet();
+            Database db = context.getGlobalStateMgr().getDb(statement.getTableName().getDb());
+            if (db == null) {
+                throw new SemanticException("Can not find database:" + statement.getTableName().getDb());
+            }
             tableNameTableMap.forEach((tableName, table) -> {
-                if (!tableName.getDb().equals(statement.getTableName().getDb())) {
+                if (db.getTable(table.getId()) == null) {
                     throw new SemanticException(
-                            "Materialized view do not support table which is in other database:" + tableName.getDb());
+                            "Materialized view do not support table: " + table.getName() +
+                                    " which is in other database");
                 }
                 if (!(table instanceof OlapTable)) {
                     throw new SemanticException(
-                            "Materialized view only support olap table:" + tableName.getTbl() + " type:" +
-                                    table.getType().name());
+                            "Materialized view only support olap table:" + table.getName() +
+                                    " type:" + table.getType().name());
                 }
                 baseTableIds.add(table.getId());
             });
@@ -142,13 +151,9 @@ public class MaterializedViewAnalyzer {
                 checkPartitionExpParams(statement);
                 // check partition column must be base table's partition column
                 checkPartitionColumnWithBaseTable(statement, tableNameTableMap);
-                // analyze expression
-                analyzeExp(statement.getPartitionExpDesc().getExpr(), statement.getQueryStatement(), context);
             }
             // check and analyze distribution
             checkDistribution(statement, tableNameTableMap);
-            // convert queryStatement to sql and set
-            statement.setInlineViewDef(ViewDefBuilder.build(queryStatement));
             return null;
         }
 
@@ -215,42 +220,54 @@ public class MaterializedViewAnalyzer {
                                       Map<Column, Expr> columnExprMap) {
             ExpressionPartitionDesc expressionPartitionDesc = statement.getPartitionExpDesc();
             List<Column> columns = statement.getMvColumnItems();
-            SlotRef slotRef = expressionPartitionDesc.getSlotRef();
-            boolean hasColumn = false;
+            SlotRef slotRef = getSlotRef(expressionPartitionDesc.getExpr());
+            if (slotRef.getTblNameWithoutAnalyzed() != null) {
+                throw new SemanticException("Materialized view partition exp: "
+                        + slotRef.toSql() + " must related to column");
+            }
             for (Column column : columns) {
                 if (slotRef.getColumnName().equals(column.getName())) {
-                    hasColumn = true;
-                    Expr refExpr = columnExprMap.get(column);
-                    // check exp with ref expr which in columnExprMap
-                    checkExpWithRefExpr(expressionPartitionDesc, refExpr);
+                    statement.setPartitionColumn(column);
                     break;
                 }
             }
-            if (!hasColumn) {
-                throw new SemanticException("Materialized view partition exp column is not found in query statement");
+            if (statement.getPartitionColumn() == null) {
+                throw new SemanticException("Materialized view partition exp column:"
+                        + slotRef.getColumnName() + " is not found in query statement");
             }
+            checkExpWithRefExpr(statement, columnExprMap);
         }
 
-        private void checkExpWithRefExpr(ExpressionPartitionDesc expressionPartitionDesc, Expr refExpr) {
+        private void checkExpWithRefExpr(CreateMaterializedViewStatement statement,
+                                         Map<Column, Expr> columnExprMap) {
+            ExpressionPartitionDesc expressionPartitionDesc = statement.getPartitionExpDesc();
+            Column partitionColumn = statement.getPartitionColumn();
+            Expr refExpr = columnExprMap.get(partitionColumn);
             if (expressionPartitionDesc.isFunction()) {
+                // e.g. partition by date_trunc(ss)
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) expressionPartitionDesc.getExpr();
                 if (!(refExpr instanceof SlotRef)) {
                     throw new SemanticException("Materialized view partition function " +
                             functionCallExpr.getFnName().getFunction() +
                             " must related with column");
                 }
-                ArrayList<Expr> children = functionCallExpr.getChildren();
-                for (int i = 0; i < children.size(); i++) {
-                    if (children.get(i) instanceof SlotRef) {
-                        functionCallExpr.setChild(i, refExpr);
-                        break;
-                    }
-                }
+                SlotRef slotRef = getSlotRef(functionCallExpr);
+                slotRef.setType(partitionColumn.getType());
                 // analyze function, must after update child
                 FunctionAnalyzer.analyze(functionCallExpr);
+                // copy function and set it into partitionRefTableExprs
+                Expr partitionRefTableExprs = functionCallExpr.clone();
+                List<Expr> children = partitionRefTableExprs.getChildren();
+                for (int i = 0; i < children.size(); i++) {
+                    if (children.get(i) instanceof SlotRef) {
+                        partitionRefTableExprs.setChild(i, refExpr);
+                    }
+                }
+                statement.setPartitionRefTableExprs(partitionRefTableExprs);
             } else {
+                // e.g. partition by date_trunc('day',ss) or partition by ss
                 if (refExpr instanceof FunctionCallExpr || refExpr instanceof SlotRef) {
-                    expressionPartitionDesc.setExpr(refExpr);
+                    statement.setPartitionRefTableExprs(refExpr);
                 } else {
                     throw new SemanticException(
                             "Materialized view partition function must related with column");
@@ -259,7 +276,7 @@ public class MaterializedViewAnalyzer {
         }
 
         private void checkPartitionExpParams(CreateMaterializedViewStatement statement) {
-            Expr expr = statement.getPartitionExpDesc().getExpr();
+            Expr expr = statement.getPartitionRefTableExprs();
             if (expr instanceof FunctionCallExpr) {
                 FunctionCallExpr functionCallExpr = ((FunctionCallExpr) expr);
                 String functionName = functionCallExpr.getFnName().getFunction();
@@ -278,8 +295,7 @@ public class MaterializedViewAnalyzer {
 
         private void checkPartitionColumnWithBaseTable(CreateMaterializedViewStatement statement,
                                                        Map<TableName, Table> tableNameTableMap) {
-            SlotRef slotRef = statement.getPartitionExpDesc().getSlotRef();
-            // must have table
+            SlotRef slotRef = getSlotRef(statement.getPartitionRefTableExprs());
             Table table = tableNameTableMap.get(slotRef.getTblNameWithoutAnalyzed());
             PartitionInfo partitionInfo = ((OlapTable) table).getPartitionInfo();
             if (partitionInfo instanceof SinglePartitionInfo) {
@@ -296,7 +312,6 @@ public class MaterializedViewAnalyzer {
                 for (Column basePartitionColumn : partitionColumns) {
                     if (basePartitionColumn.getName().equals(slotRef.getColumnName())) {
                         isInPartitionColumns = true;
-                        statement.setBasePartitionColumn(basePartitionColumn);
                         break;
                     }
                 }
@@ -307,6 +322,28 @@ public class MaterializedViewAnalyzer {
             } else {
                 throw new SemanticException("Materialized view related base table partition type:" +
                         partitionInfo.getType().name() + "not supports");
+            }
+            replaceTableAlias(slotRef, statement, tableNameTableMap);
+        }
+
+        private SlotRef getSlotRef(Expr expr) {
+            if (expr instanceof SlotRef) {
+                return ((SlotRef) expr);
+            } else {
+                List<SlotRef> slotRefs = Lists.newArrayList();
+                expr.collect(SlotRef.class, slotRefs);
+                Preconditions.checkState(slotRefs.size() == 1);
+                return slotRefs.size() > 0 ? slotRefs.get(0) : null;
+            }
+        }
+
+        private void replaceTableAlias(SlotRef slotRef,
+                                       CreateMaterializedViewStatement statement,
+                                       Map<TableName, Table> tableNameTableMap) {
+            if (slotRef.getTblNameWithoutAnalyzed().getDb() == null) {
+                TableName tableName = slotRef.getTblNameWithoutAnalyzed();
+                OlapTable table = ((OlapTable) tableNameTableMap.get(tableName));
+                slotRef.setTblName(new TableName(null, statement.getTableName().getDb(), table.getName()));
             }
         }
 
@@ -426,8 +463,7 @@ public class MaterializedViewAnalyzer {
                 SlotRef slotRef = (SlotRef) fnExpr.getChild(1);
                 PrimitiveType primitiveType = slotRef.getType().getPrimitiveType();
                 // must check slotRef type, because function analyze don't check it.
-                if ((primitiveType == PrimitiveType.DATETIME || primitiveType == PrimitiveType.DATE)
-                        && slotRef.getTblNameWithoutAnalyzed() != null) {
+                if ((primitiveType == PrimitiveType.DATETIME || primitiveType == PrimitiveType.DATE)) {
                     return true;
                 } else {
                     return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -235,15 +235,15 @@ public class MaterializedViewAnalyzer {
                 }
                 SlotRef slotRef = getSlotRef(functionCallExpr);
                 slotRef.setType(partitionColumn.getType());
-                // copy function and set it into partitionRefTableExprs
-                Expr partitionRefTableExprs = functionCallExpr.clone();
-                List<Expr> children = partitionRefTableExprs.getChildren();
+                // copy function and set it into partitionRefTableExpr
+                Expr partitionRefTableExpr = functionCallExpr.clone();
+                List<Expr> children = partitionRefTableExpr.getChildren();
                 for (int i = 0; i < children.size(); i++) {
                     if (children.get(i) instanceof SlotRef) {
-                        partitionRefTableExprs.setChild(i, refExpr);
+                        partitionRefTableExpr.setChild(i, refExpr);
                     }
                 }
-                statement.setPartitionRefTableExpr(partitionRefTableExprs);
+                statement.setPartitionRefTableExpr(partitionRefTableExpr);
             } else {
                 // e.g. partition by date_trunc('day',ss) or partition by ss
                 if (refExpr instanceof FunctionCallExpr || refExpr instanceof SlotRef) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewDefBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewDefBuilder.java
@@ -119,7 +119,7 @@ public class ViewDefBuilder {
             sqlBuilder.append(node.getName().toSql());
             if (node.getPartitionNames() != null) {
                 List<String> partitionNames = node.getPartitionNames().getPartitionNames();
-                if (partitionNames != null && partitionNames.size() > 0) {
+                if (partitionNames != null && !partitionNames.isEmpty()) {
                     sqlBuilder.append(" PARTITION(");
                 }
                 for (String partitionName : partitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewDefBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewDefBuilder.java
@@ -117,7 +117,17 @@ public class ViewDefBuilder {
         public String visitTable(TableRelation node, Void outerScope) {
             StringBuilder sqlBuilder = new StringBuilder();
             sqlBuilder.append(node.getName().toSql());
-
+            if (node.getPartitionNames() != null) {
+                List<String> partitionNames = node.getPartitionNames().getPartitionNames();
+                if (partitionNames != null && partitionNames.size() > 0) {
+                    sqlBuilder.append(" PARTITION(");
+                }
+                for (String partitionName : partitionNames) {
+                    sqlBuilder.append("`").append(partitionName).append("`").append(",");
+                }
+                sqlBuilder.deleteCharAt(sqlBuilder.length() - 1);
+                sqlBuilder.append(")");
+            }
             if (node.getAlias() != null) {
                 sqlBuilder.append(" AS ");
                 sqlBuilder.append("`").append(node.getAlias()).append("`");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -43,7 +43,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private Set<Long> baseTableIds;
     private Column partitionColumn;
     // record expression which related with partition by clause
-    private Expr partitionRefTableExprs;
+    private Expr partitionRefTableExpr;
 
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists, String comment,
                                            RefreshSchemeDesc refreshSchemeDesc, ExpressionPartitionDesc expressionPartitionDesc,
@@ -163,12 +163,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.partitionColumn = partitionColumn;
     }
 
-    public Expr getPartitionRefTableExprs() {
-        return partitionRefTableExprs;
+    public Expr getPartitionRefTableExpr() {
+        return partitionRefTableExpr;
     }
 
-    public void setPartitionRefTableExprs(Expr partitionRefTableExprs) {
-        this.partitionRefTableExprs = partitionRefTableExprs;
+    public void setPartitionRefTableExpr(Expr partitionRefTableExpr) {
+        this.partitionRefTableExpr = partitionRefTableExpr;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -5,6 +5,7 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.DdlStmt;
 import com.starrocks.analysis.DistributionDesc;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.KeysType;
@@ -40,7 +41,9 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     // for create column in mv
     private List<Column> mvColumnItems = Lists.newArrayList();
     private Set<Long> baseTableIds;
-    private Column basePartitionColumn;
+    private Column partitionColumn;
+    // record expression which related with partition by clause
+    private Expr partitionRefTableExprs;
 
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists, String comment,
                                            RefreshSchemeDesc refreshSchemeDesc, ExpressionPartitionDesc expressionPartitionDesc,
@@ -152,12 +155,20 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.baseTableIds = baseTableIds;
     }
 
-    public Column getBasePartitionColumn() {
-        return basePartitionColumn;
+    public Column getPartitionColumn() {
+        return partitionColumn;
     }
 
-    public void setBasePartitionColumn(Column basePartitionColumn) {
-        this.basePartitionColumn = basePartitionColumn;
+    public void setPartitionColumn(Column partitionColumn) {
+        this.partitionColumn = partitionColumn;
+    }
+
+    public Expr getPartitionRefTableExprs() {
+        return partitionRefTableExprs;
+    }
+
+    public void setPartitionRefTableExprs(Expr partitionRefTableExprs) {
+        this.partitionRefTableExprs = partitionRefTableExprs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ExpressionPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ExpressionPartitionUtil.java
@@ -15,7 +15,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -85,9 +84,7 @@ public class ExpressionPartitionUtil {
                             Collections.singletonList(new PartitionValue(upperLiteralExpr.getStringValue())),
                             Collections.singletonList(partitionColumn));
                     Range<PartitionKey> partitionKeyRange = Range.closedOpen(lowerPartitionKey, upperPartitionKey);
-                    try {
-                        RangeUtils.checkRangeIntersect(partitionKeyRange, existPartitionKeyRange);
-                    } catch (DdlException e) {
+                    if (RangeUtils.isRangeIntersect(partitionKeyRange, existPartitionKeyRange)) {
                         PartitionKey existLowerPartitionKey = existPartitionKeyRange.lowerEndpoint();
                         PartitionKey existUpperPartitionKey = existPartitionKeyRange.upperEndpoint();
                         if (existLowerPartitionKey.compareTo(lowerPartitionKey) <= 0 &&

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -516,7 +516,7 @@ public class CreateMaterializedViewTest {
             Assert.assertFalse(partitionExpDesc.isFunction());
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "ss");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed(), null);
+            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -540,7 +540,7 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
             Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "ss");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed(), null);
+            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -564,7 +564,7 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
             Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "k1");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed(), null);
+            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -588,7 +588,7 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
             Assert.assertEquals(partitionExpDesc.getExpr(), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "k1");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed(), null);
+            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1111,8 +1111,8 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals(e.getMessage(),
-                    "Materialized view do not support table: tbl3 which is in other database");
+            Assert.assertEquals("Materialized view do not support table: tbl3 " +
+                    "do not exist in database: default_cluster:test",e.getMessage());
         }
     }
 
@@ -1129,7 +1129,8 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals(e.getMessage(), "Materialized view only support olap table:mysql_external_table type:MYSQL");
+            Assert.assertEquals("Materialized view only supports olap table, " +
+                    "but the type of table: mysql_external_table is: MYSQL", e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -23,10 +23,15 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AST2SQL;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.ViewDefBuilder;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RefreshSchemeDesc;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -38,6 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class CreateMaterializedViewTest {
@@ -206,14 +212,14 @@ public class CreateMaterializedViewTest {
         testDb = currentState.getDb("default_cluster:test");
     }
 
-    // ========== full test ==========
-
     private void dropMv(String mvName) throws Exception {
         String sql ="drop materialized view " + mvName;
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
         stmtExecutor.execute();
     }
+
+    // ========== full test ==========
 
     @Test
     public void testFullCreate() throws Exception {
@@ -516,7 +522,6 @@ public class CreateMaterializedViewTest {
             Assert.assertFalse(partitionExpDesc.isFunction());
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "ss");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -540,7 +545,6 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
             Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "ss");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -564,7 +568,6 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
             Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "k1");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -588,7 +591,6 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
             Assert.assertEquals(partitionExpDesc.getExpr(), partitionExpDesc.getSlotRef());
             Assert.assertEquals(partitionExpDesc.getSlotRef().getColumnName(), "k1");
-            Assert.assertEquals(partitionExpDesc.getSlotRef().getTblNameWithoutAnalyzed().getTbl(), "mv1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -297,7 +297,7 @@ public class MaterializedViewTest {
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
         List<Expr> exprs = Lists.newArrayList();
-        TableName tableName = new TableName(database.getFullName(), baseTable.getName());
+        TableName tableName = new TableName(database.getFullName(), "mv_name");
         SlotRef slotRef1 = new SlotRef(tableName, "k1");
         StringLiteral quarterStringLiteral = new StringLiteral("quarter");
         FunctionCallExpr quarterFunctionCallExpr =

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunProcessorTest.java
@@ -62,7 +62,7 @@ public class MvTaskRunProcessorTest {
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');")
                 .withNewMaterializedView("create materialized view test.mv1\n" +
-                        "partition by date_trunc('week',tbl1.k1) \n" +
+                        "partition by date_trunc('week',k1) \n" +
                         "distributed by hash(k2)\n" +
                         "refresh manual\n" +
                         "properties('replication_num' = '1')\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -156,7 +156,7 @@ public class TaskManagerTest {
             public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {}
         };
         String sql = "create materialized view test.mv1\n" +
-                "partition by date_trunc('month',tbl1.k1)\n" +
+                "partition by date_trunc('month',k1)\n" +
                 "distributed by hash(k2)\n" +
                 "refresh manual\n" +
                 "properties('replication_num' = '1')\n" +
@@ -204,7 +204,7 @@ public class TaskManagerTest {
             }
         };
         String sql = "create materialized view test.mv1\n" +
-                "partition by date_trunc('month',tbl1.k1)\n" +
+                "partition by date_trunc('month',k1)\n" +
                 "distributed by hash(k2)\n" +
                 "refresh async every(interval 5 second)\n" +
                 "properties('replication_num' = '1')\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7733 

## Problem Summary(Required) ：

1. Fix `npe` Which cause by partition by clause related with base table column.
2. Fix mv period task no scheduling after restart fe.
3. Fix mv task no sync partitions in first time.
4. Fix partition no pruned if output column in query statement has alias.
5. Fix mv can't use after `fe` restarted.
6. Fix `insert overwrite` multi-tables failed in mv sync task.