### PR TITLE
[BugFix]: Change `enable_persistent_index` of primary table may cause be crash in ASAN mode

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -943,7 +943,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     // because the primary index is available in cache
                     // But it will be remove from index cache after apply is finished
                     auto manager = StorageEngine::instance()->update_manager();
-                    manager->index_cache().remove_by_key(tablet->tablet_id());
+                    manager->index_cache().try_remove_by_key(tablet->tablet_id());
                     break;
                 }
             }

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -161,14 +161,14 @@ public:
     }
 
     // try remove object by key
-    // return true if object exist and is removed
+    // return true if object not exist or be removed
     // if no one use this object, object will be removed
     // otherwise do not remove the object, return false
     bool try_remove_by_key(const Key& key) {
         std::lock_guard<std::mutex> lg(_lock);
         auto itr = _map.find(key);
         if (itr == _map.end()) {
-            return false;
+            return true;
         }
         auto v = itr->second;
         auto entry = *v;

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -173,7 +173,7 @@ public:
         auto v = itr->second;
         auto entry = *v;
         if (entry->_ref != 1) {
-            LOG(WARNING) << "try_remove_by_key() failed: cache entry ref != 1 " << entry->_value;
+            VLOG(1) << "try_remove_by_key() failed: cache entry ref != 1 " << entry->_value;
             return false;
         } else {
             _map.erase(itr);

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -174,6 +174,7 @@ public:
         auto entry = *v;
         if (entry->_ref != 1) {
             LOG(WARNING) << "try_remove_by_key() failed: cache entry ref != 1 " << entry->_value;
+            return false;
         } else {
             _map.erase(itr);
             _list.erase(v);

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -160,6 +160,31 @@ public:
         }
     }
 
+    // try remove object by key
+    // return true if object exist and is removed
+    // if no one use this object, object will be removed
+    // otherwise do not remove the object, return false
+    bool try_remove_by_key(const Key& key) {
+        std::lock_guard<std::mutex> lg(_lock);
+        auto itr = _map.find(key);
+        if (itr == _map.end()) {
+            return false;
+        }
+        auto v = itr->second;
+        auto entry = *v;
+        if (entry->_ref != 1) {
+            LOG(WARNING) << "try_remove_by_key() failed: cache entry ref != 1 " << entry->_value;
+        } else {
+            _map.erase(itr);
+            _list.erase(v);
+            _object_size--;
+            _size -= entry->_size;
+            if (_mem_tracker) _mem_tracker->release(entry->_size);
+            delete entry;
+        }
+        return true;
+    }
+
     // remove object by key
     // return true if object exist and is removed
     bool remove_by_key(const Key& key) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7761 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This is caused by concurrency between apply and modify enable_persistent_index. The reference of primary index may not equal 1, so it will cause crash when call function remove in ASAN mode.
