### PR TITLE
[BugFix] Fix result sink fragment has multi instance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1166,7 +1166,7 @@ public class Coordinator {
                 continue;
             }
 
-            if (fragment.getDataPartition() == DataPartition.UNPARTITIONED) {
+            if (fragment.getDataPartition() == DataPartition.UNPARTITIONED || fragment.getSink() instanceof ResultSink) {
                 Reference<Long> backendIdRef = new Reference<>();
                 TNetworkAddress execHostport = SimpleScheduler.getHost(this.idToBackend, backendIdRef);
                 if (execHostport == null) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/587

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

As the plan:

union will use all children's node, so union will be multi-instances, aggregate(merge finalized) use children's node, then bomb
```
+-------------------------------------------------------------------------------------+
| Explain String                                                                      |
+-------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                     |
|  OUTPUT EXPRS:58: k1 | 59: k2 | 60: cast                                            |
|   PARTITION: HASH_PARTITIONED: 58: k1, 59: k2, 60: cast                             |
|                                                                                     |
|   RESULT SINK                                                                       |
|                                                                                     |
|   9:AGGREGATE (merge finalize)                                                      |
|   |  group by: 58: k1, 59: k2, 60: cast                                             |
|   |                                                                                 |
|   8:EXCHANGE                                                                        |
|                                                                                     |
| PLAN FRAGMENT 1                                                                     |
|  OUTPUT EXPRS:                                                                      |
|   PARTITION: RANDOM                                                                 |
|                                                                                     |
|   STREAM DATA SINK                                                                  |
|     EXCHANGE ID: 08                                                                 |
|     HASH_PARTITIONED: 58: k1, 59: k2, 60: cast                                      |
|                                                                                     |
|   7:AGGREGATE (update serialize)                                                    |
|   |  STREAMING                                                                      |
|   |  group by: 58: k1, 59: k2, 60: cast                                             |
|   |                                                                                 |
|   0:UNION                                                                           |
|   |                                                                                 |
|   |----6:EXCHANGE                                                                   |
|   |                                                                                 |
|   3:EXCHANGE                                                                        |
|                                                                                     |
| PLAN FRAGMENT 2                                                                     |
|  OUTPUT EXPRS:                                                                      |
|   PARTITION: RANDOM                                                                 |
```