### PR TITLE
[cherry-pick] [Enhancement] Support column groups for final merge (#7333)

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -37,9 +37,11 @@
 #include "storage/chunk_helper.h"
 #include "storage/merge_iterator.h"
 #include "storage/olap_define.h"
+#include "storage/row_source_mask.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
 #include "storage/type_utils.h"
 #include "util/pretty_printer.h"
 
@@ -400,10 +402,14 @@ StatusOr<RowsetSharedPtr> HorizontalBetaRowsetWriter::build() {
     if (!_tmp_segment_files.empty()) {
         RETURN_IF_ERROR(_final_merge());
     }
-    // When building a rowset, we must ensure that the current _segment_writer has been
-    // flushed, that is, the current _segment_wirter is nullptr
-    DCHECK(_segment_writer == nullptr) << "segment must be null when build rowset";
-    return BetaRowsetWriter::build();
+    if (_vertical_beta_rowset_writer) {
+        return _vertical_beta_rowset_writer->build();
+    } else {
+        // When building a rowset, we must ensure that the current _segment_writer has been
+        // flushed, that is, the current _segment_writer is nullptr
+        DCHECK(_segment_writer == nullptr) << "segment must be null when build rowset";
+        return BetaRowsetWriter::build();
+    }
 }
 
 // why: when the data is large, multi segment files created, may be OVERLAPPINGed.
@@ -422,10 +428,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     MonotonicStopWatch timer;
     timer.start();
 
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*_context.tablet_schema);
-
-    std::vector<vectorized::ChunkIteratorPtr> seg_iterators;
-    seg_iterators.reserve(_num_segment);
+    std::vector<std::shared_ptr<Segment>> segments;
 
     vectorized::SegmentReadOptions seg_options;
     seg_options.fs = _fs;
@@ -434,95 +437,294 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     seg_options.stats = &stats;
 
     for (int seg_id = 0; seg_id < _num_segment; ++seg_id) {
+        if (_num_rows_of_tmp_segment_files[seg_id] == 0) {
+            continue;
+        }
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-
         auto segment_ptr = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), _fs, tmp_segment_file,
                                          seg_id, _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();
         }
-        if ((*segment_ptr)->num_rows() == 0) {
-            continue;
-        }
-        auto res = (*segment_ptr)->new_iterator(schema, seg_options);
-        if (res.status().is_end_of_file()) {
-            continue;
-        } else if (!res.ok()) {
-            return res.status();
-        } else if (res.value() == nullptr) {
-            continue;
-        } else {
+        segments.emplace_back(segment_ptr.value());
+    }
+
+    std::vector<vectorized::ChunkIteratorPtr> seg_iterators;
+    seg_iterators.reserve(segments.size());
+
+    if (CompactionUtils::choose_compaction_algorithm(_context.tablet_schema->num_columns(),
+                                                     config::vertical_compaction_max_columns_per_group,
+                                                     segments.size()) == VERTICAL_COMPACTION) {
+        std::vector<std::vector<uint32_t>> column_groups;
+        CompactionUtils::split_column_into_groups(_context.tablet_schema->num_columns(),
+                                                  _context.tablet_schema->num_key_columns(),
+                                                  config::vertical_compaction_max_columns_per_group, &column_groups);
+
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*_context.tablet_schema, column_groups[0]);
+
+        for (const auto& segment : segments) {
+            auto res = segment->new_iterator(schema, seg_options);
+            if (!res.ok()) {
+                return res.status();
+            }
             seg_iterators.emplace_back(res.value());
         }
-    }
 
-    ChunkIteratorPtr itr = nullptr;
-    // schema change vectorized
-    // schema change with sorting create temporary segment files first
-    // merge them and create final segment files if _context.write_tmp is true
-    if (_context.write_tmp) {
-        if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS) {
-            itr = new_heap_merge_iterator(seg_iterators);
-        } else if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS ||
-                   _context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
-            itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), 0);
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
+        RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", _context.tablet_id)));
+        auto mask_buffer =
+                std::make_unique<vectorized::RowSourceMaskBuffer>(_context.tablet_id, tablet->data_dir()->path());
+        auto source_masks = std::make_unique<std::vector<vectorized::RowSourceMask>>();
+
+        ChunkIteratorPtr itr;
+        // create temporary segment files at first, then merge them and create final segment files if schema change with sorting
+        if (_context.write_tmp) {
+            if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS) {
+                itr = new_heap_merge_iterator(seg_iterators);
+            } else if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS ||
+                       _context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
+                itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), true);
+            } else {
+                return Status::NotSupported(
+                        fmt::format("final merge: schema change with sorting do not support {} type",
+                                    KeysType_Name(_context.tablet_schema->keys_type())));
+            }
         } else {
-            return Status::NotSupported(fmt::format("HorizontalBetaRowsetWriter not support {} key type final merge",
-                                                    _context.tablet_schema->keys_type()));
+            itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), true);
         }
-        _context.write_tmp = false;
-    } else {
-        itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), 0);
-    }
-    itr->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
+        itr->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
 
-    auto chunk_shared_ptr = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
-    auto chunk = chunk_shared_ptr.get();
+        _context.max_rows_per_segment = CompactionUtils::get_segment_max_rows(config::max_segment_file_size,
+                                                                              _num_rows_written, _total_data_size);
 
-    _num_segment = 0;
-    _num_delfile = 0;
-    _num_rows_written = 0;
-    _num_rows_del = 0;
-    _total_data_size = 0;
-    _total_index_size = 0;
-    if (_rowset_txn_meta_pb) {
-        _rowset_txn_meta_pb->clear_partial_rowset_footers();
-    }
+        auto chunk_shared_ptr = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto chunk = chunk_shared_ptr.get();
 
-    // since the segment already NONOVERLAPPING here, make the _create_segment_writer
-    // method to create segment data files, rather than temporary segment files.
-    _context.segments_overlap = NONOVERLAPPING;
+        _num_segment = 0;
+        _num_delfile = 0;
+        _num_rows_written = 0;
+        _num_rows_del = 0;
+        _total_row_size = 0;
+        _total_data_size = 0;
+        _total_index_size = 0;
 
-    auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+        // If BetaRowsetWriter has final merge, it will produce new partial rowset footers and append them to partial_rowset_footers array,
+        // but this array already have old entries, should clear those entries before write new segments for final merge.
+        if (_rowset_txn_meta_pb) {
+            _rowset_txn_meta_pb->clear_partial_rowset_footers();
+        }
 
-    size_t total_rows = 0;
-    size_t total_chunk = 0;
-    while (true) {
-        chunk->reset();
-        auto st = itr->get_next(chunk);
-        if (st.is_end_of_file()) {
-            break;
-        } else if (st.ok()) {
-            vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, *_context.tablet_schema, chunk);
-            total_rows += chunk->num_rows();
-            total_chunk++;
-            add_chunk(*chunk);
-        } else {
+        // since the segment already NONOVERLAPPING here, make the _create_segment_writer
+        // method to create segment data files, rather than temporary segment files.
+        _context.segments_overlap = NONOVERLAPPING;
+
+        _vertical_beta_rowset_writer = std::make_unique<VerticalBetaRowsetWriter>(_context);
+        if (auto st = _vertical_beta_rowset_writer->init(); !st.ok()) {
+            std::stringstream ss;
+            ss << "Fail to create rowset writer. tablet_id=" << _context.tablet_id << " err=" << st;
+            LOG(WARNING) << ss.str();
+            return Status::InternalError(ss.str());
+        }
+
+        auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+
+        size_t total_rows = 0;
+        size_t total_chunk = 0;
+        while (true) {
+            chunk->reset();
+            auto st = itr->get_next(chunk, source_masks.get());
+            if (st.is_end_of_file()) {
+                break;
+            } else if (st.ok()) {
+                vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, *_context.tablet_schema,
+                                                              chunk);
+                total_rows += chunk->num_rows();
+                total_chunk++;
+                if (auto st = _vertical_beta_rowset_writer->add_columns(*chunk, column_groups[0], true); !st.ok()) {
+                    LOG(WARNING) << "writer add_columns error. tablet=" << _context.tablet_id << ", err=" << st;
+                    return st;
+                }
+            } else {
+                return st;
+            }
+            if (!source_masks->empty()) {
+                RETURN_IF_ERROR(mask_buffer->write(*source_masks));
+                source_masks->clear();
+            }
+        }
+        itr->close();
+        if (auto st = _vertical_beta_rowset_writer->flush_columns(); !st.ok()) {
+            LOG(WARNING) << "failed to flush_columns group, tablet=" << _context.tablet_id << ", err=" << st;
             return st;
         }
-    }
-    itr->close();
-    flush();
+        RETURN_IF_ERROR(mask_buffer->flush());
 
-    timer.stop();
-    LOG(INFO) << "rowset writer final merge finished. tablet:" << _context.tablet_id
-              << " #key:" << schema.num_key_fields() << " input("
-              << "entry=" << seg_iterators.size() << " rows=" << stats.raw_rows_read
-              << " bytes=" << PrettyPrinter::print(stats.bytes_read, TUnit::UNIT) << ") output(rows=" << total_rows
-              << " chunk=" << total_chunk << " bytes=" << PrettyPrinter::print(total_data_size(), TUnit::UNIT)
-              << ") duration: " << timer.elapsed_time() / 1000000 << "ms";
+        for (size_t i = 1; i < column_groups.size(); ++i) {
+            mask_buffer->flip_to_read();
+
+            seg_iterators.clear();
+
+            auto schema =
+                    vectorized::ChunkHelper::convert_schema_to_format_v2(*_context.tablet_schema, column_groups[i]);
+
+            for (const auto& segment : segments) {
+                auto res = segment->new_iterator(schema, seg_options);
+                if (!res.ok()) {
+                    return res.status();
+                }
+                seg_iterators.emplace_back(res.value());
+            }
+
+            ChunkIteratorPtr itr;
+            // create temporary segment files at first, then merge them and create final segment files if schema change with sorting
+            if (_context.write_tmp) {
+                if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS) {
+                    itr = new_mask_merge_iterator(seg_iterators, mask_buffer.get());
+                } else if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS ||
+                           _context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
+                    itr = new_aggregate_iterator(new_mask_merge_iterator(seg_iterators, mask_buffer.get()), false);
+                } else {
+                    return Status::NotSupported(
+                            fmt::format("final merge: schema change with sorting do not support {} type",
+                                        KeysType_Name(_context.tablet_schema->keys_type())));
+                }
+            } else {
+                itr = new_aggregate_iterator(new_mask_merge_iterator(seg_iterators, mask_buffer.get()), false);
+            }
+            itr->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
+
+            auto chunk_shared_ptr = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+            auto chunk = chunk_shared_ptr.get();
+
+            auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+
+            while (true) {
+                chunk->reset();
+                auto st = itr->get_next(chunk, source_masks.get());
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (st.ok()) {
+                    vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, *_context.tablet_schema,
+                                                                  chunk);
+                    if (auto st = _vertical_beta_rowset_writer->add_columns(*chunk, column_groups[i], false);
+                        !st.ok()) {
+                        LOG(WARNING) << "writer add_columns error. tablet=" << _context.tablet_id << ", err=" << st;
+                        return st;
+                    }
+                } else {
+                    return st;
+                }
+                if (!source_masks->empty()) {
+                    source_masks->clear();
+                }
+            }
+            itr->close();
+            if (auto st = _vertical_beta_rowset_writer->flush_columns(); !st.ok()) {
+                LOG(WARNING) << "failed to flush_columns group, tablet=" << _context.tablet_id << ", err=" << st;
+                return st;
+            }
+        }
+
+        if (auto st = _vertical_beta_rowset_writer->final_flush(); !st.ok()) {
+            LOG(WARNING) << "failed to final flush rowset when final merge " << _context.tablet_id << ", err=" << st;
+            return st;
+        }
+        timer.stop();
+        LOG(INFO) << "rowset writer vertical final merge finished. tablet:" << _context.tablet_id
+                  << " #key:" << _context.tablet_schema->num_key_columns() << " input("
+                  << "entry=" << seg_iterators.size() << " rows=" << stats.raw_rows_read
+                  << " bytes=" << PrettyPrinter::print(stats.bytes_read, TUnit::UNIT) << ") output(rows=" << total_rows
+                  << " chunk=" << total_chunk << " bytes=" << PrettyPrinter::print(total_data_size(), TUnit::UNIT)
+                  << ") duration: " << timer.elapsed_time() / 1000000 << "ms";
+    } else {
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*_context.tablet_schema);
+
+        for (const auto& segment : segments) {
+            auto res = segment->new_iterator(schema, seg_options);
+            if (!res.ok()) {
+                return res.status();
+            }
+            seg_iterators.emplace_back(res.value());
+        }
+
+        ChunkIteratorPtr itr;
+        // create temporary segment files at first, then merge them and create final segment files if schema change with sorting
+        if (_context.write_tmp) {
+            if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS) {
+                itr = new_heap_merge_iterator(seg_iterators);
+            } else if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS ||
+                       _context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
+                itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), 0);
+            } else {
+                return Status::NotSupported(
+                        fmt::format("final merge: schema change with sorting do not support {} type",
+                                    KeysType_Name(_context.tablet_schema->keys_type())));
+            }
+            _context.write_tmp = false;
+        } else {
+            itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), 0);
+        }
+        itr->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
+
+        auto chunk_shared_ptr = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto chunk = chunk_shared_ptr.get();
+
+        _num_segment = 0;
+        _num_delfile = 0;
+        _num_rows_written = 0;
+        _num_rows_del = 0;
+        _total_row_size = 0;
+        _total_data_size = 0;
+        _total_index_size = 0;
+
+        // If BetaRowsetWriter has final merge, it will produce new partial rowset footers and append them to partial_rowset_footers array,
+        // but this array already have old entries, should clear those entries before write new segments for final merge.
+        if (_rowset_txn_meta_pb) {
+            _rowset_txn_meta_pb->clear_partial_rowset_footers();
+        }
+
+        // since the segment already NONOVERLAPPING here, make the _create_segment_writer
+        // method to create segment data files, rather than temporary segment files.
+        _context.segments_overlap = NONOVERLAPPING;
+
+        auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+
+        size_t total_rows = 0;
+        size_t total_chunk = 0;
+        while (true) {
+            chunk->reset();
+            auto st = itr->get_next(chunk);
+            if (st.is_end_of_file()) {
+                break;
+            } else if (st.ok()) {
+                vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, *_context.tablet_schema,
+                                                              chunk);
+                total_rows += chunk->num_rows();
+                total_chunk++;
+                if (auto st = add_chunk(*chunk); !st.ok()) {
+                    LOG(WARNING) << "writer add_chunk error: " << st;
+                    return st;
+                }
+            } else {
+                return st;
+            }
+        }
+        itr->close();
+        if (auto st = flush(); !st.ok()) {
+            LOG(WARNING) << "failed to flush, tablet=" << _context.tablet_id << ", err=" << st;
+            return st;
+        }
+
+        timer.stop();
+        LOG(INFO) << "rowset writer horizontal final merge finished. tablet:" << _context.tablet_id
+                  << " #key:" << _context.tablet_schema->num_key_columns() << " input("
+                  << "entry=" << seg_iterators.size() << " rows=" << stats.raw_rows_read
+                  << " bytes=" << PrettyPrinter::print(stats.bytes_read, TUnit::UNIT) << ") output(rows=" << total_rows
+                  << " chunk=" << total_chunk << " bytes=" << PrettyPrinter::print(total_data_size(), TUnit::UNIT)
+                  << ") duration: " << timer.elapsed_time() / 1000000 << "ms";
+    }
 
     for (const auto& tmp_segment_file : _tmp_segment_files) {
         auto st = _fs->delete_file(tmp_segment_file);
@@ -539,6 +741,8 @@ Status HorizontalBetaRowsetWriter::_flush_segment_writer(std::unique_ptr<Segment
     uint64_t index_size;
     uint64_t footer_position;
     RETURN_IF_ERROR((*segment_writer)->finalize(&segment_size, &index_size, &footer_position));
+    _num_rows_of_tmp_segment_files.push_back(_num_rows_written - _num_rows_flushed);
+    _num_rows_flushed = _num_rows_written;
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _context.partial_update_tablet_schema) {
         uint64_t footer_size = segment_size - footer_position;
         auto* partial_rowset_footer = _rowset_txn_meta_pb->add_partial_rowset_footers();

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -26,6 +26,7 @@
 
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
+#include "storage/compaction_utils.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/segment_writer.h"
 
@@ -68,6 +69,8 @@ protected:
 
     // counters and statistics maintained during data write
     int64_t _num_rows_written;
+    int64_t _num_rows_flushed = 0;
+    std::vector<int64_t> _num_rows_of_tmp_segment_files;
     int64_t _num_rows_del;
     int64_t _total_row_size;
     int64_t _total_data_size;
@@ -81,6 +84,8 @@ protected:
 
     FlushChunkState _flush_chunk_state = FlushChunkState::UNKNOWN;
 };
+
+class VerticalBetaRowsetWriter;
 
 // Chunk contains all schema columns data.
 class HorizontalBetaRowsetWriter final : public BetaRowsetWriter {
@@ -114,6 +119,7 @@ private:
     std::string _dump_mixed_segment_delfile_not_supported();
 
     std::unique_ptr<SegmentWriter> _segment_writer;
+    std::unique_ptr<VerticalBetaRowsetWriter> _vertical_beta_rowset_writer;
 };
 
 // Chunk contains partial columns data corresponding to column_indexes.

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -39,6 +39,7 @@
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
 #include "storage/tablet_schema.h"
 #include "storage/vectorized_column_predicate.h"
 #include "testutil/assert.h"
@@ -182,6 +183,53 @@ protected:
         tablet_schema->init_from_pb(tablet_schema_pb);
     }
 
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 2;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "k1";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "k2";
+        k2.__set_is_key(true);
+        k2.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn v1;
+        v1.column_name = "v1";
+        v1.__set_is_key(false);
+        v1.column_type.type = TPrimitiveType::INT;
+        v1.aggregation_type = TAggregationType::REPLACE;
+        request.tablet_schema.columns.push_back(v1);
+
+        TColumn v2;
+        v2.column_name = "v2";
+        v2.__set_is_key(false);
+        v2.column_type.type = TPrimitiveType::INT;
+        v1.aggregation_type = TAggregationType::REPLACE;
+        request.tablet_schema.columns.push_back(v2);
+
+        TColumn v3;
+        v3.column_name = "v3";
+        v3.__set_is_key(false);
+        v3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(v3);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
     void create_rowset_writer_context(const TabletSchema* tablet_schema, RowsetWriterContext* rowset_writer_context) {
         RowsetId rowset_id;
         rowset_id.init(10000);
@@ -299,6 +347,107 @@ TEST_F(BetaRowsetTest, FinalMergeTest) {
         }
         EXPECT_EQ(count, rows_per_segment * 2);
     }
+}
+
+TEST_F(BetaRowsetTest, FinalMergeVerticalTest) {
+    auto tablet = create_tablet(12345, 1111);
+    RowsetSharedPtr rowset;
+    const uint32_t rows_per_segment = 1024;
+    config::vertical_compaction_max_columns_per_group = 1;
+    RowsetWriterContext writer_context(kDataFormatV2, kDataFormatV2);
+    create_rowset_writer_context(&tablet->tablet_schema(), &writer_context);
+    writer_context.segments_overlap = OVERLAP_UNKNOWN;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+
+    {
+        auto chunk = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = 0; i < rows_per_segment; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+            cols[4]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    {
+        auto chunk = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+            cols[4]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    {
+        auto chunk = vectorized::ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+            cols[4]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    rowset = rowset_writer->build().value();
+    ASSERT_TRUE(rowset != nullptr);
+    ASSERT_EQ(1, rowset->rowset_meta()->num_segments());
+    ASSERT_EQ(rows_per_segment * 2, rowset->rowset_meta()->num_rows());
+
+    vectorized::SegmentReadOptions seg_options;
+    ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
+    seg_options.stats = &_stats;
+
+    std::string segment_file =
+            BetaRowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
+    auto segment =
+            *Segment::open(_tablet_meta_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet->tablet_schema());
+    ASSERT_NE(segment->num_rows(), 0);
+    auto res = segment->new_iterator(schema, seg_options);
+    ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
+    auto seg_iterator = res.value();
+
+    seg_iterator->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
+
+    auto chunk = vectorized::ChunkHelper::new_chunk(seg_iterator->schema(), 100);
+    size_t count = 0;
+
+    while (true) {
+        auto st = seg_iterator->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_FALSE(!st.ok());
+        for (auto i = 0; i < chunk->num_rows(); i++) {
+            auto index = count + i;
+            if (0 <= index && index < rows_per_segment / 2) {
+                EXPECT_EQ(1, chunk->get(i)[2].get_int32());
+            } else if (rows_per_segment / 2 <= index && index < rows_per_segment) {
+                EXPECT_EQ(2, chunk->get(i)[2].get_int32());
+            } else if (rows_per_segment <= index && index < rows_per_segment * 2) {
+                EXPECT_EQ(3, chunk->get(i)[2].get_int32());
+            }
+        }
+        count += chunk->num_rows();
+        chunk->reset();
+    }
+    EXPECT_EQ(count, rows_per_segment * 2);
 }
 
 TEST_F(BetaRowsetTest, VerticalWriteTest) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7332

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
It will take up a lot of memory when merging temporary segment files in the final merge procedure, which may cause OOM. Support column groups when merging segment files.
There does exist some repetitive code, but other unrelated code will be influenced if refactor now, so let them go and refactor it in the next individual PR.

It will reduce memory 13~16 times and latency by 35%. A case like this one(5000 columns, 4.3G, 100000 rows), other data scales are the almost same ratio. will reduce more memory when more segments.
before this PR:
https://user-images.githubusercontent.com/16617323/175193201-3c82eddf-297f-429b-8e32-5f50fb509962.svg
after this PR:
https://user-images.githubusercontent.com/16617323/175193063-6aaae13a-4fa1-4ea7-8b42-bd37ef6c8a78.svg

36% performance improvement
before this PR:
https://user-images.githubusercontent.com/16617323/175211168-43d1912b-e652-4771-814b-b661956437ae.svg
after this PR:
https://user-images.githubusercontent.com/16617323/175211248-c25209e4-fc79-4536-a9f8-edd364291f67.svg