### PR TITLE
[cherry-pick] [branch-2.3] [Enhancement] move the destructor of TabletsChannel out of lock (#7753)

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -48,10 +48,13 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
 
     Status st;
     {
+        // We will `bthread::execution_queue_join()` in the destructor of AsnycDeltaWriter,
+        // it will block the bthread, so we put its destructor outside the lock.
+        scoped_refptr<TabletsChannel> channel;
         std::lock_guard<std::mutex> l(_lock);
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
             TabletsChannelKey key(request.id(), index_id);
-            scoped_refptr<TabletsChannel> channel(new LocalTabletsChannel(this, key, _mem_tracker.get()));
+            channel.reset(new LocalTabletsChannel(this, key, _mem_tracker.get()));
             if (st = channel->open(request); st.ok()) {
                 _tablets_channels.insert({index_id, std::move(channel)});
             }


### PR DESCRIPTION
We will bthread::execution_queue_join() in the destructor of AsnycDeltaWriter, the function will block the bthread, so we put its destructor of TabletsChannel outside the lock.