### PR TITLE
[Enhancement] Reduce the size of TaskWorkerPool object

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -26,10 +26,13 @@
 #include <filesystem>
 #include <string>
 
+#include "agent/status.h"
 #include "agent/task_worker_pool.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "gen_cpp/MasterService_types.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
 #include "storage/snapshot_manager.h"
 #include "util/phmap/phmap.h"
@@ -43,9 +46,15 @@ const uint32_t REPORT_TASK_WORKER_COUNT = 1;
 const uint32_t REPORT_DISK_STATE_WORKER_COUNT = 1;
 const uint32_t REPORT_OLAP_TABLE_WORKER_COUNT = 1;
 const uint32_t REPORT_WORKGROUP_WORKER_COUNT = 1;
+const uint32_t TASK_FINISH_MAX_RETRY = 3;
+const uint32_t ALTER_FINISH_TASK_MAX_RETRY = 10;
+
+FrontendServiceClientCache g_master_service_client_cache;
 
 AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
-        : _exec_env(exec_env), _master_info(master_info) {
+        : _exec_env(exec_env),
+          _master_info(master_info),
+          _master_client(new MasterServerClient(master_info, &g_master_service_client_cache)) {
     for (auto& path : exec_env->store_paths()) {
         try {
             string dpp_download_path_str = path.path + DPP_PREFIX;
@@ -62,8 +71,8 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
     // to make code to be more readable.
 
 #ifndef BE_TEST
-#define CREATE_AND_START_POOL(type, pool_name, worker_num)                                                         \
-    pool_name.reset(new TaskWorkerPool(TaskWorkerPool::TaskWorkerType::type, _exec_env, master_info, worker_num)); \
+#define CREATE_AND_START_POOL(type, pool_name, worker_num)                                                  \
+    pool_name.reset(new TaskWorkerPool(this, TaskWorkerPool::TaskWorkerType::type, _exec_env, worker_num)); \
     pool_name->start();
 
 #else
@@ -334,6 +343,41 @@ void AgentServer::release_snapshot(TAgentResult& t_agent_result, const std::stri
 void AgentServer::publish_cluster_state(TAgentResult& t_agent_result, const TAgentPublishRequest& request) {
     Status status = Status::NotSupported("deprecated method(publish_cluster_state) was invoked");
     status.to_thrift(&t_agent_result.status);
+}
+
+void AgentServer::finish_task(const TFinishTaskRequest& finish_task_request) {
+    // Return result to FE
+    TMasterResult result;
+    uint32_t try_time = 0;
+    int32_t sleep_time_second = config::sleep_one_second;
+    int32_t max_retry_times = TASK_FINISH_MAX_RETRY;
+
+    while (try_time < max_retry_times) {
+        StarRocksMetrics::instance()->finish_task_requests_total.increment(1);
+        AgentStatus client_status = _master_client->finish_task(finish_task_request, &result);
+
+        if (client_status == STARROCKS_SUCCESS) {
+            // This means FE alter thread pool is full, all alter finish request to FE is meaningless
+            // so that we will sleep && retry 10 times
+            if (result.status.status_code == TStatusCode::TOO_MANY_TASKS &&
+                finish_task_request.task_type == TTaskType::ALTER) {
+                max_retry_times = ALTER_FINISH_TASK_MAX_RETRY;
+                sleep_time_second = sleep_time_second * 2;
+            } else {
+                break;
+            }
+        }
+        try_time += 1;
+        StarRocksMetrics::instance()->finish_task_requests_failed.increment(1);
+        LOG(WARNING) << "finish task failed retry: " << try_time << "/" << TASK_FINISH_MAX_RETRY
+                     << "client_status: " << client_status << " status_code: " << result.status.status_code;
+
+        sleep(sleep_time_second);
+    }
+}
+
+AgentStatus AgentServer::report_task(const TReportRequest& request, TMasterResult* result) {
+    return _master_client->report(request, result);
 }
 
 } // namespace starrocks

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -24,14 +24,18 @@
 #include <string>
 #include <vector>
 
+#include "agent/status.h"
 #include "gen_cpp/AgentService_types.h"
 
 namespace starrocks {
 
 class ExecEnv;
-class MultiWorkerPool;
+class MasterServerClient;
 class TaskWorkerPool;
+class TFinishTaskRequest;
 class TMasterInfo;
+class TMasterResult;
+class TReportRequest;
 
 // Each method corresponds to one RPC from FE Master, see BackendService.
 class AgentServer {
@@ -50,14 +54,21 @@ public:
     // TODO(lingbin): This method is deprecated, should be removed later.
     void publish_cluster_state(TAgentResult& agent_result, const TAgentPublishRequest& request);
 
-private:
+    void finish_task(const TFinishTaskRequest& finish_task_request);
+
+    AgentStatus report_task(const TReportRequest& request, TMasterResult* result);
+
+    const TMasterInfo& master_info() const { return _master_info; }
+
     AgentServer(const AgentServer&) = delete;
     const AgentServer& operator=(const AgentServer&) = delete;
 
+private:
     // Not Owned
     ExecEnv* _exec_env;
     // Reference to the ExecEnv::_master_info
     const TMasterInfo& _master_info;
+    std::unique_ptr<MasterServerClient> _master_client;
 
     std::unique_ptr<TaskWorkerPool> _create_tablet_workers;
     std::unique_ptr<TaskWorkerPool> _drop_tablet_workers;

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <string>
 
+#include "agent/agent_server.h"
 #include "agent/publish_version.h"
 #include "common/status.h"
 #include "exec/workgroup/work_group.h"
@@ -57,22 +58,17 @@
 
 namespace starrocks {
 
-const uint32_t TASK_FINISH_MAX_RETRY = 3;
-const uint32_t ALTER_FINISH_TASK_MAX_RETRY = 10;
 const size_t PUBLISH_VERSION_BATCH_SIZE = 10;
 
 std::atomic<int64_t> TaskWorkerPool::_s_report_version(time(nullptr) * 10000);
 std::mutex TaskWorkerPool::_s_task_signatures_locks[TTaskType::type::NUM_TASK_TYPE];
 std::set<int64_t> TaskWorkerPool::_s_task_signatures[TTaskType::type::NUM_TASK_TYPE];
-FrontendServiceClientCache TaskWorkerPool::_master_service_client_cache;
 
 using std::swap;
 
-TaskWorkerPool::TaskWorkerPool(TaskWorkerType task_worker_type, ExecEnv* env, const TMasterInfo& master_info,
+TaskWorkerPool::TaskWorkerPool(AgentServer* agent_server, TaskWorkerType task_worker_type, ExecEnv* env,
                                int worker_count)
-        : _master_info(master_info),
-          _agent_utils(new AgentUtils()),
-          _master_client(new MasterServerClient(_master_info, &_master_service_client_cache)),
+        : _agent_server(agent_server),
           _env(env),
           _worker_thread_condition_variable(new std::condition_variable()),
           _worker_count(worker_count),
@@ -307,37 +303,6 @@ void TaskWorkerPool::_spawn_callback_worker_thread(CALLBACK_FUNCTION callback_fu
     Thread::set_thread_name(_worker_threads.back(), "task_worker");
 }
 
-void TaskWorkerPool::_finish_task(const TFinishTaskRequest& finish_task_request) {
-    // Return result to FE
-    TMasterResult result;
-    uint32_t try_time = 0;
-    int32_t sleep_time_second = config::sleep_one_second;
-    int32_t max_retry_times = TASK_FINISH_MAX_RETRY;
-
-    while (try_time < max_retry_times) {
-        StarRocksMetrics::instance()->finish_task_requests_total.increment(1);
-        AgentStatus client_status = _master_client->finish_task(finish_task_request, &result);
-
-        if (client_status == STARROCKS_SUCCESS) {
-            // This means FE alter thread pool is full, all alter finish request to FE is meaningless
-            // so that we will sleep && retry 10 times
-            if (result.status.status_code == TStatusCode::TOO_MANY_TASKS &&
-                finish_task_request.task_type == TTaskType::ALTER) {
-                max_retry_times = ALTER_FINISH_TASK_MAX_RETRY;
-                sleep_time_second = sleep_time_second * 2;
-            } else {
-                break;
-            }
-        }
-        try_time += 1;
-        StarRocksMetrics::instance()->finish_task_requests_failed.increment(1);
-        LOG(WARNING) << "finish task failed retry: " << try_time << "/" << TASK_FINISH_MAX_RETRY
-                     << "client_status: " << client_status << " status_code: " << result.status.status_code;
-
-        sleep(sleep_time_second);
-    }
-}
-
 void* TaskWorkerPool::_create_tablet_worker_thread_callback(void* arg_this) {
     auto* worker_pool_this = (TaskWorkerPool*)arg_this;
 
@@ -387,7 +352,7 @@ void* TaskWorkerPool::_create_tablet_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_signature(agent_task_req->signature);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -431,7 +396,7 @@ void* TaskWorkerPool::_drop_tablet_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_signature(agent_task_req->signature);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -467,7 +432,7 @@ void* TaskWorkerPool::_alter_tablet_worker_thread_callback(void* arg_this) {
                 // pass
                 break;
             }
-            worker_pool_this->_finish_task(finish_task_request);
+            worker_pool_this->_agent_server->finish_task(finish_task_request);
         }
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
@@ -550,7 +515,7 @@ void TaskWorkerPool::_alter_tablet(TaskWorkerPool* worker_pool_this, const TAgen
     } else {
         LOG(WARNING) << process_name << " failed. signature: " << signature;
         error_msgs.push_back(process_name + " failed");
-        error_msgs.push_back("status: " + _agent_utils->print_agent_status(status));
+        error_msgs.push_back("status: " + AgentUtils::print_agent_status(status));
         task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
     }
 
@@ -640,7 +605,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
         finish_task_request.__set_report_version(_s_report_version.load(std::memory_order_relaxed));
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
 
@@ -760,7 +725,7 @@ void* TaskWorkerPool::_delete_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
         finish_task_request.__set_report_version(_s_report_version.load(std::memory_order_relaxed));
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
 
@@ -834,7 +799,7 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
             int64_t t1 = MonotonicMillis();
             // notify FE when all tasks of group have been finished.
             for (auto& finish_task_request : finish_task_requests) {
-                worker_pool_this->_finish_task(finish_task_request);
+                worker_pool_this->_agent_server->finish_task(finish_task_request);
                 worker_pool_this->_remove_task_info(finish_task_request.task_type, finish_task_request.signature);
             }
             int64_t t2 = MonotonicMillis();
@@ -893,7 +858,7 @@ void* TaskWorkerPool::_clear_transaction_task_worker_thread_callback(void* arg_t
         finish_task_request.__set_task_type(agent_task_req->task_type);
         finish_task_request.__set_signature(agent_task_req->signature);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -961,7 +926,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
         finish_task_request.__set_task_type(agent_task_req->task_type);
         finish_task_request.__set_signature(agent_task_req->signature);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -1021,7 +986,7 @@ void* TaskWorkerPool::_clone_worker_thread_callback(void* arg_this) {
             }
         } else {
             EngineCloneTask engine_task(ExecEnv::GetInstance()->clone_mem_tracker(), clone_req,
-                                        worker_pool_this->_master_info, agent_task_req->signature, &error_msgs,
+                                        worker_pool_this->master_info(), agent_task_req->signature, &error_msgs,
                                         &tablet_infos, &status);
             Status res = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
             if (!res.ok()) {
@@ -1046,7 +1011,7 @@ void* TaskWorkerPool::_clone_worker_thread_callback(void* arg_this) {
         task_status.__set_error_msgs(error_msgs);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
 
@@ -1135,7 +1100,7 @@ void* TaskWorkerPool::_storage_medium_migrate_worker_thread_callback(void* arg_t
         task_status.__set_error_msgs(error_msgs);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -1185,7 +1150,7 @@ void* TaskWorkerPool::_check_consistency_worker_thread_callback(void* arg_this) 
         finish_task_request.__set_tablet_checksum(static_cast<int64_t>(checksum));
         finish_task_request.__set_request_version(check_consistency_req.version);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return nullptr;
@@ -1197,7 +1162,7 @@ void* TaskWorkerPool::_report_task_worker_thread_callback(void* arg_this) {
     TReportRequest request;
 
     while ((!worker_pool_this->_stopped)) {
-        if (worker_pool_this->_master_info.network_address.port == 0) {
+        if (worker_pool_this->master_info().network_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
             LOG(INFO) << "Waiting to receive first heartbeat from frontend";
@@ -1216,12 +1181,12 @@ void* TaskWorkerPool::_report_task_worker_thread_callback(void* arg_this) {
 
         StarRocksMetrics::instance()->report_task_requests_total.increment(1);
         TMasterResult result;
-        AgentStatus status = worker_pool_this->_master_client->report(request, &result);
+        AgentStatus status = worker_pool_this->_agent_server->report_task(request, &result);
 
         if (status != STARROCKS_SUCCESS) {
             StarRocksMetrics::instance()->report_task_requests_failed.increment(1);
-            LOG(WARNING) << "Fail to report task to " << worker_pool_this->_master_info.network_address.hostname << ":"
-                         << worker_pool_this->_master_info.network_address.port << ", err=" << status;
+            LOG(WARNING) << "Fail to report task to " << worker_pool_this->master_info().network_address.hostname << ":"
+                         << worker_pool_this->master_info().network_address.port << ", err=" << status;
         }
 
         sleep(config::report_task_interval_seconds);
@@ -1236,7 +1201,7 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
     TReportRequest request;
 
     while ((!worker_pool_this->_stopped)) {
-        if (worker_pool_this->_master_info.network_address.port == 0) {
+        if (worker_pool_this->master_info().network_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
             LOG(INFO) << "Waiting to receive first heartbeat from frontend";
@@ -1271,12 +1236,12 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
 
         StarRocksMetrics::instance()->report_disk_requests_total.increment(1);
         TMasterResult result;
-        AgentStatus status = worker_pool_this->_master_client->report(request, &result);
+        AgentStatus status = worker_pool_this->_agent_server->report_task(request, &result);
 
         if (status != STARROCKS_SUCCESS) {
             StarRocksMetrics::instance()->report_disk_requests_failed.increment(1);
-            LOG(WARNING) << "Fail to report disk state to " << worker_pool_this->_master_info.network_address.hostname
-                         << ":" << worker_pool_this->_master_info.network_address.port << ", err=" << status;
+            LOG(WARNING) << "Fail to report disk state to " << worker_pool_this->master_info().network_address.hostname
+                         << ":" << worker_pool_this->master_info().network_address.port << ", err=" << status;
         }
 
         // wait for notifying until timeout
@@ -1294,7 +1259,7 @@ void* TaskWorkerPool::_report_tablet_worker_thread_callback(void* arg_this) {
     AgentStatus status = STARROCKS_SUCCESS;
 
     while ((!worker_pool_this->_stopped)) {
-        if (worker_pool_this->_master_info.network_address.port == 0) {
+        if (worker_pool_this->master_info().network_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
             LOG(INFO) << "Waiting to receive first heartbeat from frontend";
@@ -1318,13 +1283,13 @@ void* TaskWorkerPool::_report_tablet_worker_thread_callback(void* arg_this) {
         request.__set_backend(BackendOptions::get_localBackend());
 
         TMasterResult result;
-        status = worker_pool_this->_master_client->report(request, &result);
+        status = worker_pool_this->_agent_server->report_task(request, &result);
 
         if (status != STARROCKS_SUCCESS) {
             StarRocksMetrics::instance()->report_all_tablets_requests_failed.increment(1);
             LOG(WARNING) << "Fail to report olap table state to "
-                         << worker_pool_this->_master_info.network_address.hostname << ":"
-                         << worker_pool_this->_master_info.network_address.port << ", err=" << status;
+                         << worker_pool_this->master_info().network_address.hostname << ":"
+                         << worker_pool_this->master_info().network_address.port << ", err=" << status;
         }
 
         // wait for notifying until timeout
@@ -1341,7 +1306,7 @@ void* TaskWorkerPool::_report_workgroup_thread_callback(void* arg_this) {
     AgentStatus status = STARROCKS_SUCCESS;
 
     while ((!worker_pool_this->_stopped)) {
-        if (worker_pool_this->_master_info.network_address.port == 0) {
+        if (worker_pool_this->master_info().network_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
             LOG(INFO) << "Waiting to receive first heartbeat from frontend";
@@ -1355,12 +1320,12 @@ void* TaskWorkerPool::_report_workgroup_thread_callback(void* arg_this) {
         request.__set_active_workgroups(std::move(workgroups));
         request.__set_backend(BackendOptions::get_localBackend());
         TMasterResult result;
-        status = worker_pool_this->_master_client->report(request, &result);
+        status = worker_pool_this->_agent_server->report_task(request, &result);
 
         if (status != STARROCKS_SUCCESS) {
             StarRocksMetrics::instance()->report_workgroup_requests_failed.increment(1);
-            LOG(WARNING) << "Fail to report workgroup to " << worker_pool_this->_master_info.network_address.hostname
-                         << ":" << worker_pool_this->_master_info.network_address.port << ", err=" << status;
+            LOG(WARNING) << "Fail to report workgroup to " << worker_pool_this->master_info().network_address.hostname
+                         << ":" << worker_pool_this->master_info().network_address.port << ", err=" << status;
         }
         if (result.__isset.workgroup_ops) {
             workgroup::WorkGroupManager::instance()->apply(result.workgroup_ops);
@@ -1407,7 +1372,7 @@ void* TaskWorkerPool::_upload_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
         finish_task_request.__set_tablet_files(tablet_files);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 
         LOG(INFO) << "Uploaded task signature=" << agent_task_req->signature << " job id=" << upload_request.job_id;
@@ -1453,7 +1418,7 @@ void* TaskWorkerPool::_download_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
         finish_task_request.__set_downloaded_tablet_ids(downloaded_tablet_ids);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 
         LOG(INFO) << "Downloaded task signature=" << agent_task_req->signature << " job id=" << download_request.job_id;
@@ -1518,7 +1483,7 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
         finish_task_request.__set_snapshot_files(snapshot_files);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -1560,7 +1525,7 @@ void* TaskWorkerPool::_release_snapshot_thread_callback(void* arg_this) {
         finish_task_request.__set_signature(agent_task_req->signature);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -1618,7 +1583,7 @@ void* TaskWorkerPool::_move_dir_thread_callback(void* arg_this) {
         finish_task_request.__set_signature(agent_task_req->signature);
         finish_task_request.__set_task_status(task_status);
 
-        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_agent_server->finish_task(finish_task_request);
         worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
@@ -1644,6 +1609,10 @@ AgentStatus TaskWorkerPool::_move_dir(TTabletId tablet_id, TSchemaHash schema_ha
     }
 
     return STARROCKS_SUCCESS;
+}
+
+const TMasterInfo& TaskWorkerPool::master_info() {
+    return _agent_server->master_info();
 }
 
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -39,6 +39,7 @@
 
 namespace starrocks {
 
+class AgentServer;
 class ExecEnv;
 
 class TaskWorkerPool {
@@ -72,7 +73,7 @@ public:
 
     typedef void* (*CALLBACK_FUNCTION)(void*);
 
-    TaskWorkerPool(TaskWorkerType task_worker_type, ExecEnv* env, const TMasterInfo& master_info, int worker_num);
+    TaskWorkerPool(AgentServer* agent_server, TaskWorkerType task_worker_type, ExecEnv* env, int worker_num);
     ~TaskWorkerPool();
 
     // start the task worker callback thread
@@ -116,7 +117,6 @@ private:
     bool _register_task_info(TTaskType::type task_type, int64_t signature);
     void _remove_task_info(TTaskType::type task_type, int64_t signature);
     void _spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func);
-    void _finish_task(const TFinishTaskRequest& finish_task_request);
 
     using TAgentTaskRequestPtr = std::shared_ptr<TAgentTaskRequest>;
 
@@ -133,11 +133,10 @@ private:
     AgentStatus _move_dir(TTabletId tablet_id, TSchemaHash schema_hash, const std::string& src, int64_t job_id,
                           bool overwrite, std::vector<std::string>* error_msgs);
 
-    // Reference to the ExecEnv::_master_info
-    const TMasterInfo& _master_info;
+    const TMasterInfo& master_info();
+
+    AgentServer* _agent_server;
     TBackend _backend;
-    std::unique_ptr<AgentUtils> _agent_utils;
-    std::unique_ptr<MasterServerClient> _master_client;
     ExecEnv* _env;
 
     // Protect task queue
@@ -149,7 +148,6 @@ private:
     TaskWorkerType _task_worker_type;
     CALLBACK_FUNCTION _callback_function;
 
-    static FrontendServiceClientCache _master_service_client_cache;
     static std::atomic<int64_t> _s_report_version;
 
     static std::mutex _s_task_signatures_locks[TTaskType::type::NUM_TASK_TYPE];

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -81,7 +81,7 @@ public:
                                           const uint32_t transport_speed_limit_kbps, const uint32_t timeout_second);
 
     // Print AgentStatus as string
-    virtual std::string print_agent_status(AgentStatus status);
+    static std::string print_agent_status(AgentStatus status);
 
     // Execute shell cmd
     virtual bool exec_cmd(const std::string& command, std::string* errmsg);


### PR DESCRIPTION
Move some member variables to AgentServer to reduce the memory overhead of TaskWorkerPool.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


