### PR TITLE
[Enhancement] optimize vectorized schema 

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -34,7 +34,8 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
     _build_index_map(_fields);
 }
 
-// if we use the constructor, we must make sure that input (Schema* schema) is read_only
+// if we use this constructor and share the name_to_index with another schema,
+// we must make sure another shema is read only!!!
 Schema::Schema(Schema* schema)
         : _num_keys(schema->_num_keys), _name_to_index_append_buffer(nullptr), _keys_type(schema->_keys_type) {
     DCHECK(schema->_name_to_index_append_buffer == nullptr);
@@ -43,7 +44,7 @@ Schema::Schema(Schema* schema)
         _fields[i] = schema->_fields[i];
     }
     if (schema->_name_to_index_append_buffer == nullptr) {
-        // share the name_to_index with schema&, later append fields will be added to _name_to_index_append_buffer
+        // share the name_to_index with schema, later append fields will be added to _name_to_index_append_buffer
         schema->_share_name_to_index = true;
         _share_name_to_index = true;
         _name_to_index = schema->_name_to_index;
@@ -53,7 +54,8 @@ Schema::Schema(Schema* schema)
     }
 }
 
-// if we use the constructor, we must make sure that input (Schema& schema) is read_only
+// if we use this constructor and share the name_to_index with another schema,
+// we must make sure another shema is read only!!!
 Schema::Schema(const Schema& schema)
         : _num_keys(schema._num_keys), _name_to_index_append_buffer(nullptr), _keys_type(schema._keys_type) {
     _fields.resize(schema.num_fields());
@@ -71,7 +73,8 @@ Schema::Schema(const Schema& schema)
     }
 }
 
-// if we use the schema, we must make sure that input (Schema& schema) is read_only
+// if we use this constructor and share the name_to_index with another schema,
+// we must make sure another shema is read only!!!
 Schema& Schema::operator=(const Schema& other) {
     this->_num_keys = other._num_keys;
     this->_name_to_index_append_buffer = nullptr;

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -13,45 +13,95 @@ Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS) {}
 #endif
 
 Schema::Schema(Fields fields, KeysType keys_type)
-        : _fields(std::move(fields)), _keys_type(static_cast<uint8_t>(keys_type)) {
+        : _fields(std::move(fields)),
+          _name_to_index_append_buffer(nullptr),
+          _read_append_only(false),
+          _keys_type(static_cast<uint8_t>(keys_type)) {
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
 }
 
+Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
+        : _name_to_index_append_buffer(nullptr), _read_append_only(false), _keys_type(schema->_keys_type) {
+    _fields.resize(cids.size());
+    for (int i = 0; i < cids.size(); i++) {
+        DCHECK_LT(cids[i], schema->_fields.size());
+        _fields[i] = schema->_fields[cids[i]];
+    }
+    auto is_key = [](const FieldPtr& f) { return f->is_key(); };
+    _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
+    _build_index_map(_fields);
+}
+
+// if we use the constructor, we must make sure that input (Schema* schema) is read_only
+Schema::Schema(Schema* schema)
+        : _num_keys(schema->_num_keys),
+          _name_to_index_append_buffer(nullptr),
+          _read_append_only(true),
+          _keys_type(schema->_keys_type) {
+    DCHECK(schema->_name_to_index_append_buffer == nullptr);
+    _fields.resize(schema->num_fields());
+    for (int i = 0; i < schema->_fields.size(); i++) {
+        _fields[i] = schema->_fields[i];
+    }
+    // share the name_to_index with schema*, lator append fields will be added to _name_to_index_append_buffer
+    _name_to_index = schema->_name_to_index;
+}
+
 void Schema::append(const FieldPtr& field) {
     _fields.emplace_back(field);
-    _name_to_index.emplace(field->name(), _fields.size() - 1);
     _num_keys += field->is_key();
+    if (!_read_append_only) {
+        if (_name_to_index == nullptr) {
+            _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
+        }
+        _name_to_index->emplace(field->name(), _fields.size() - 1);
+    } else {
+        if (_name_to_index_append_buffer == nullptr) {
+            _name_to_index_append_buffer.reset(new std::unordered_map<std::string_view, size_t>());
+        }
+        _name_to_index_append_buffer->emplace(field->name(), _fields.size() - 1);
+    }
 }
 
 void Schema::insert(size_t idx, const FieldPtr& field) {
     DCHECK_LT(idx, _fields.size());
 
     _fields.emplace(_fields.begin() + idx, field);
-    _name_to_index.clear();
     _num_keys += field->is_key();
+
+    if (_read_append_only) {
+        // release the _name_to_index_append_buffer and rebuild the _name_to_index
+        _name_to_index_append_buffer.reset();
+        _read_append_only = false;
+    }
+
+    _name_to_index.reset();
     _build_index_map(_fields);
 }
 
 void Schema::remove(size_t idx) {
     DCHECK_LT(idx, _fields.size());
     _num_keys -= _fields[idx]->is_key();
-    if (idx == _fields.size() - 1) {
-        _name_to_index.erase(_fields[idx]->name());
+    if (_read_append_only && idx == _fields.size() - 1 && _name_to_index_append_buffer != nullptr &&
+        _name_to_index_append_buffer->size() > 0) {
+        // fastpath for the filed we want to remove is at the end of the _name_to_index_append_buffer
+        _name_to_index_append_buffer->erase(_fields[idx]->name());
         _fields.erase(_fields.begin() + idx);
     } else {
-        _fields.erase(_fields.begin() + idx);
-        _name_to_index.clear();
-        _build_index_map(_fields);
+        if (idx == _fields.size() - 1) {
+            DCHECK(_name_to_index != nullptr);
+            _name_to_index->erase(_fields[idx]->name());
+            _fields.erase(_fields.begin() + idx);
+        } else {
+            _fields.erase(_fields.begin() + idx);
+            _name_to_index.reset();
+            _build_index_map(_fields);
+        }
+        _name_to_index_append_buffer.reset();
+        _read_append_only = false;
     }
-}
-
-void Schema::set_fields(Fields fields) {
-    _fields = std::move(fields);
-    auto is_key = [](const FieldPtr& f) { return f->is_key(); };
-    _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
-    _build_index_map(_fields);
 }
 
 const FieldPtr& Schema::field(size_t idx) const {
@@ -75,17 +125,49 @@ FieldPtr Schema::get_field_by_name(const std::string& name) const {
 }
 
 void Schema::_build_index_map(const Fields& fields) {
+    _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
     for (size_t i = 0; i < fields.size(); i++) {
-        _name_to_index.emplace(fields[i]->name(), i);
+        _name_to_index->emplace(fields[i]->name(), i);
     }
 }
 
 size_t Schema::get_field_index_by_name(const std::string& name) const {
-    auto p = _name_to_index.find(name);
-    if (p == _name_to_index.end()) {
-        return -1;
+    DCHECK(_name_to_index != nullptr);
+    auto p = _name_to_index->find(name);
+    if (p == _name_to_index->end()) {
+        if (_name_to_index_append_buffer != nullptr) {
+            DCHECK(_read_append_only);
+            auto p2 = _name_to_index_append_buffer->find(name);
+            if (p2 == _name_to_index_append_buffer->end()) {
+                return -1;
+            } else {
+                return p2->second;
+            }
+        } else {
+            return -1;
+        }
     }
     return p->second;
+}
+
+void Schema::convert_to(Schema* new_schema, const std::vector<FieldType>& new_types) const {
+    int num_fields = _fields.size();
+    new_schema->_fields.resize(num_fields);
+    for (int i = 0; i < num_fields; ++i) {
+        auto cid = _fields[i]->id();
+        auto new_type = new_types[cid];
+        if (_fields[i]->type()->type() == new_type) {
+            new_schema->_fields[i] = _fields[i]->copy();
+        } else {
+            new_schema->_fields[i] = _fields[i]->convert_to(new_type);
+        }
+    }
+    new_schema->_num_keys = _num_keys;
+    if (!_read_append_only) {
+        new_schema->_name_to_index = _name_to_index;
+    } else {
+        new_schema->_build_index_map(new_schema->_fields);
+    }
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -24,16 +24,15 @@ public:
 
     explicit Schema(Schema* schema, const std::vector<ColumnId>& cids);
 
+    Schema(const Schema& schema);
+
+    Schema& operator=(const Schema& other);
+
     size_t num_fields() const { return _fields.size(); }
 
     size_t num_key_fields() const { return _num_keys; }
 
-    void reserve(size_t size) {
-        _fields.reserve(size);
-        if (_name_to_index != nullptr) {
-            _name_to_index->reserve(size);
-        }
-    }
+    void reserve(size_t size) { _fields.reserve(size); }
 
     void append(const FieldPtr& field);
     void insert(size_t idx, const FieldPtr& field);

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -20,23 +20,31 @@ public:
 
     explicit Schema(Fields fields, KeysType keys_type);
 
+    explicit Schema(Schema* schema);
+
+    explicit Schema(Schema* schema, const std::vector<ColumnId>& cids);
+
     size_t num_fields() const { return _fields.size(); }
 
     size_t num_key_fields() const { return _num_keys; }
 
     void reserve(size_t size) {
         _fields.reserve(size);
-        _name_to_index.reserve(size);
+        if (_name_to_index != nullptr) {
+            _name_to_index->reserve(size);
+        }
     }
 
     void append(const FieldPtr& field);
     void insert(size_t idx, const FieldPtr& field);
     void remove(size_t idx);
-    void set_fields(Fields fields);
+
     void clear() {
         _fields.clear();
         _num_keys = 0;
-        _name_to_index.clear();
+        _name_to_index.reset();
+        _name_to_index_append_buffer.reset();
+        _read_append_only = false;
     }
 
     const FieldPtr& field(size_t idx) const;
@@ -49,22 +57,7 @@ public:
 
     size_t get_field_index_by_name(const std::string& name) const;
 
-    void convert_to(Schema* new_schema, const std::vector<FieldType>& new_types) const {
-        // fields
-        int num_fields = _fields.size();
-        new_schema->_fields.resize(num_fields);
-        for (int i = 0; i < num_fields; ++i) {
-            auto cid = _fields[i]->id();
-            auto new_type = new_types[cid];
-            if (_fields[i]->type()->type() == new_type) {
-                new_schema->_fields[i] = _fields[i]->copy();
-            } else {
-                new_schema->_fields[i] = _fields[i]->convert_to(new_type);
-            }
-        }
-        new_schema->_num_keys = _num_keys;
-        new_schema->_name_to_index = _name_to_index;
-    }
+    void convert_to(Schema* new_schema, const std::vector<FieldType>& new_types) const;
 
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
 
@@ -73,7 +66,24 @@ private:
 
     Fields _fields;
     size_t _num_keys = 0;
-    std::unordered_map<std::string_view, size_t> _name_to_index;
+    std::shared_ptr<std::unordered_map<std::string_view, size_t>> _name_to_index;
+
+    // If we share the same _name_to_index with another vectorized schema,
+    // newly append(only append here) fields will be added directly to the
+    // _name_to_index_append_buffer. Reasons why we use this: because we share
+    // _name_to_index with another vectorized schema, we cannot directly append
+    // the newly fields to the shared _name_to_index. One possible solution is
+    // COW(copy on write), allocate a new _name_to_index and append the newly
+    // fields to it. However, in our scenario, usually we only need to append
+    // few fields(maybe only 1) to the new schema, there is not need to use COW
+    // to allocate a new _name_to_index, so here we saves new append fileds in
+    // _name_to_index_append_buffer.
+    std::shared_ptr<std::unordered_map<std::string_view, size_t>> _name_to_index_append_buffer;
+    // If _read_append_only is true, it means that we only perform read or
+    // append to the schema, the append field's name will be written to
+    // _name_to_index_append_buffer.
+    bool _read_append_only;
+
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
 };
 

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -20,12 +20,18 @@ public:
 
     explicit Schema(Fields fields, KeysType keys_type);
 
+    // if we use this constructor and share the name_to_index with another schema,
+    // we must make sure another shema is read only!!!
     explicit Schema(Schema* schema);
 
     explicit Schema(Schema* schema, const std::vector<ColumnId>& cids);
 
+    // if we use this constructor and share the name_to_index with another schema,
+    // we must make sure another shema is read only!!!
     Schema(const Schema& schema);
 
+    // if we use this constructor and share the name_to_index with another schema,
+    // we must make sure another shema is read only!!!
     Schema& operator=(const Schema& other);
 
     size_t num_fields() const { return _fields.size(); }

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -43,7 +43,7 @@ public:
         _num_keys = 0;
         _name_to_index.reset();
         _name_to_index_append_buffer.reset();
-        _read_append_only = false;
+        _share_name_to_index = false;
     }
 
     const FieldPtr& field(size_t idx) const;
@@ -78,10 +78,10 @@ private:
     // to allocate a new _name_to_index, so here we saves new append fileds in
     // _name_to_index_append_buffer.
     std::shared_ptr<std::unordered_map<std::string_view, size_t>> _name_to_index_append_buffer;
-    // If _read_append_only is true, it means that we only perform read or
-    // append to the schema, the append field's name will be written to
-    // _name_to_index_append_buffer.
-    bool _read_append_only;
+    // If _share_name_to_index is true, it means that we share the _name_to_index
+    // with another schema, and we only perform read or append to current schema,
+    // the append field's name will be written to _name_to_index_append_buffer.
+    mutable bool _share_name_to_index = false;
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
 };

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -136,22 +136,12 @@ starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id
 }
 
 starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const starrocks::TabletSchema& schema) {
-    starrocks::vectorized::Fields fields;
-    for (ColumnId cid = 0; cid < schema.num_columns(); ++cid) {
-        auto f = convert_field_to_format_v2(cid, schema.column(cid));
-        fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
-    }
-    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
+    return starrocks::vectorized::Schema(schema.schema());
 }
 
 starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const starrocks::TabletSchema& schema,
                                                                        const std::vector<ColumnId>& cids) {
-    starrocks::vectorized::Fields fields;
-    for (ColumnId cid : cids) {
-        auto f = convert_field_to_format_v2(cid, schema.column(cid));
-        fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
-    }
-    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
+    return starrocks::vectorized::Schema(schema.schema(), cids);
 }
 
 starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -145,12 +145,11 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
 }
 
 starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {
-    starrocks::vectorized::Fields fields;
+    std::vector<ColumnId> short_key_cids;
     for (ColumnId cid = 0; cid < schema.num_short_key_columns(); ++cid) {
-        auto f = convert_field_to_format_v2(cid, schema.column(cid));
-        fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
+        short_key_cids.push_back(cid);
     }
-    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
+    return starrocks::vectorized::Schema(schema.schema(), short_key_cids);
 }
 
 ColumnId ChunkHelper::max_column_id(const starrocks::vectorized::Schema& schema) {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -26,11 +26,13 @@
 #include <string_view>
 #include <vector>
 
+#include "column/chunk.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/olap_define.h"
 #include "storage/type_utils.h"
 #include "storage/types.h"
 #include "util/c_string.h"
+#include "util/once.h"
 
 namespace starrocks {
 
@@ -268,6 +270,8 @@ public:
 
     bool shared() const { return _schema_map != nullptr; }
 
+    starrocks::vectorized::Schema* schema() const;
+
 private:
     friend class SegmentReaderWriterTest;
     FRIEND_TEST(SegmentReaderWriterTest, estimate_segment_size);
@@ -275,6 +279,8 @@ private:
 
     friend bool operator==(const TabletSchema& a, const TabletSchema& b);
     friend bool operator!=(const TabletSchema& a, const TabletSchema& b);
+
+    Status _init_schema() const;
 
     SchemaId _id = invalid_id();
     TabletSchemaMap* _schema_map = nullptr;
@@ -293,6 +299,10 @@ private:
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
 
     bool _has_bf_fpp = false;
+
+    mutable std::unique_ptr<starrocks::vectorized::Schema> _schema;
+
+    mutable StarRocksCallOnce<Status> _schema_init;
 };
 
 bool operator==(const TabletSchema& a, const TabletSchema& b);

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -32,17 +32,19 @@ public:
 
     void TearDown() override { StoragePageCache::release_global_cache(); }
 
-    TabletSchema create_schema(const std::vector<TabletColumn>& columns, int num_short_key_columns = -1) {
-        TabletSchema res;
+    std::unique_ptr<TabletSchema> create_schema(const std::vector<TabletColumn>& columns,
+                                                int num_short_key_columns = -1) {
+        std::unique_ptr<TabletSchema> res;
+        res.reset(new TabletSchema());
         int num_key_columns = 0;
         for (auto& col : columns) {
             if (col.is_key()) {
                 num_key_columns++;
             }
-            res._cols.push_back(col);
+            res->_cols.push_back(col);
         }
-        res._num_key_columns = num_key_columns;
-        res._num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
+        res->_num_key_columns = num_key_columns;
+        res->_num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
         return res;
     }
 
@@ -70,7 +72,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     TabletColumn c1 = create_int_key(1);
     TabletColumn c2 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
 
-    TabletSchema tablet_schema = create_schema({c1, c2});
+    std::unique_ptr<TabletSchema> tablet_schema = create_schema({c1, c2});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -78,7 +80,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     std::string file_name = kSegmentDir + "/low_card_cols";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema.get(), opts);
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = 10000;
@@ -89,7 +91,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
         // col0
         std::vector<uint32_t> column_indexes = {0};
         ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -105,7 +107,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
         // col1
         std::vector<uint32_t> column_indexes{1};
         ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -119,7 +121,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -127,7 +129,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     seg_options.fs = _fs;
     seg_options.stats = &stats;
 
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
 
     vectorized::Schema vec_schema;
@@ -191,7 +193,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     TabletColumn c1 = create_int_key(1);
     TabletColumn c2 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
 
-    TabletSchema tablet_schema = create_schema({c1, c2});
+    std::unique_ptr<TabletSchema> tablet_schema = create_schema({c1, c2});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 1024;
@@ -199,7 +201,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     std::string file_name = kSegmentDir + "/no_dict";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema.get(), opts);
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = slice_num;
@@ -210,7 +212,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
         // col0
         std::vector<uint32_t> column_indexes = {0};
         ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -226,7 +228,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
         // col1
         std::vector<uint32_t> column_indexes{1};
         ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -240,7 +242,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -248,7 +250,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     seg_options.fs = _fs;
     seg_options.stats = &stats;
 
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
 
     ColumnIterator* scalar_iter = nullptr;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -50,17 +50,19 @@ protected:
         StoragePageCache::release_global_cache();
     }
 
-    TabletSchema create_schema(const std::vector<TabletColumn>& columns, int num_short_key_columns = -1) {
-        TabletSchema res;
+    std::unique_ptr<TabletSchema> create_schema(const std::vector<TabletColumn>& columns,
+                                                int num_short_key_columns = -1) {
+        std::unique_ptr<TabletSchema> res;
+        res.reset(new TabletSchema());
         int num_key_columns = 0;
         for (auto& col : columns) {
             if (col.is_key()) {
                 num_key_columns++;
             }
-            res._cols.push_back(col);
+            res->_cols.push_back(col);
         }
-        res._num_key_columns = num_key_columns;
-        res._num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
+        res->_num_key_columns = num_key_columns;
+        res->_num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
         return res;
     }
 
@@ -72,7 +74,8 @@ protected:
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {
-    TabletSchema partial_tablet_schema = create_schema({create_int_key(1), create_int_key(2), create_int_value(4)});
+    std::unique_ptr<TabletSchema> partial_tablet_schema =
+            create_schema({create_int_key(1), create_int_key(2), create_int_value(4)});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -80,12 +83,12 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     std::string file_name = kSegmentDir + "/partial_rowset";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &partial_tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, partial_tablet_schema.get(), opts);
     ASSERT_OK(writer.init());
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = 10000;
-    auto partial_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(partial_tablet_schema);
+    auto partial_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*partial_tablet_schema);
     auto partial_chunk = vectorized::ChunkHelper::new_chunk(partial_schema, chunk_size);
 
     for (auto i = 0; i < num_rows % chunk_size; ++i) {
@@ -108,17 +111,18 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_position(footer_position);
     partial_rowset_footer.set_size(file_size - footer_position);
 
-    auto partial_segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &partial_tablet_schema);
+    auto partial_segment =
+            *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, partial_tablet_schema.get());
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
-    TabletSchema tablet_schema = create_schema(
+    std::unique_ptr<TabletSchema> tablet_schema = create_schema(
             {create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4), create_int_value(5)});
     std::string dst_file_name = kSegmentDir + "/rewrite_rowset";
     std::vector<uint32_t> read_column_ids{2, 4};
     std::vector<std::unique_ptr<vectorized::Column>> write_columns(read_column_ids.size());
     for (auto i = 0; i < read_column_ids.size(); ++i) {
         const auto read_column_id = read_column_ids[i];
-        auto tablet_column = tablet_schema.column(read_column_id);
+        auto tablet_column = tablet_schema->column(read_column_id);
         auto column =
                 vectorized::ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         write_columns[i] = column->clone_empty();
@@ -127,17 +131,17 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
         }
     }
 
-    ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, tablet_schema, read_column_ids, write_columns,
+    ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, *tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, dst_file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, dst_file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
     seg_options.fs = _fs;
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
     auto seg_iterator = res.value();
@@ -172,7 +176,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     std::vector<std::unique_ptr<vectorized::Column>> new_write_columns(read_column_ids.size());
     for (auto i = 0; i < read_column_ids.size(); ++i) {
         const auto read_column_id = read_column_ids[i];
-        auto tablet_column = tablet_schema.column(read_column_id);
+        auto tablet_column = tablet_schema->column(read_column_id);
         auto column =
                 vectorized::ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         new_write_columns[i] = column->clone_empty();
@@ -180,9 +184,9 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
             new_write_columns[i]->append_datum(vectorized::Datum(static_cast<int32_t>(j + read_column_ids[i])));
         }
     }
-    ASSERT_OK(SegmentRewriter::rewrite(file_name, tablet_schema, read_column_ids, new_write_columns,
+    ASSERT_OK(SegmentRewriter::rewrite(file_name, *tablet_schema, read_column_ids, new_write_columns,
                                        partial_segment->id(), partial_rowset_footer));
-    auto rewrite_segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto rewrite_segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
 
     ASSERT_EQ(rewrite_segment->num_rows(), num_rows);
     res = rewrite_segment->new_iterator(schema, seg_options);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -72,17 +72,20 @@ protected:
 
     void TearDown() override { StoragePageCache::release_global_cache(); }
 
-    TabletSchema create_schema(const std::vector<TabletColumn>& columns, int num_short_key_columns = -1) {
-        TabletSchema res;
+    std::unique_ptr<TabletSchema> create_schema(const std::vector<TabletColumn>& columns,
+                                                int num_short_key_columns = -1) {
+        std::unique_ptr<TabletSchema> res;
+        res.reset(new TabletSchema());
+
         int num_key_columns = 0;
         for (auto& col : columns) {
             if (col.is_key()) {
                 num_key_columns++;
             }
-            res._cols.push_back(col);
+            res->_cols.push_back(col);
         }
-        res._num_key_columns = num_key_columns;
-        res._num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
+        res->_num_key_columns = num_key_columns;
+        res->_num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
         return res;
     }
 
@@ -174,24 +177,25 @@ TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
 }
 
 TEST_F(SegmentReaderWriterTest, TestBloomFilterIndexUniqueModel) {
-    TabletSchema schema = create_schema({create_int_key(1), create_int_key(2), create_int_key(3),
-                                         create_int_value(4, OLAP_FIELD_AGGREGATION_REPLACE, true, "", true)});
+    std::unique_ptr<TabletSchema> schema =
+            create_schema({create_int_key(1), create_int_key(2), create_int_key(3),
+                           create_int_value(4, OLAP_FIELD_AGGREGATION_REPLACE, true, "", true)});
 
     // for not base segment
     SegmentWriterOptions opts1;
     shared_ptr<Segment> seg1;
-    build_segment(opts1, schema, schema, 100, DefaultIntGenerator, &seg1);
+    build_segment(opts1, *schema, *schema, 100, DefaultIntGenerator, &seg1);
     ASSERT_TRUE(seg1->column(3)->has_bloom_filter_index());
 
     // for base segment
     SegmentWriterOptions opts2;
     shared_ptr<Segment> seg2;
-    build_segment(opts2, schema, schema, 100, DefaultIntGenerator, &seg2);
+    build_segment(opts2, *schema, *schema, 100, DefaultIntGenerator, &seg2);
     ASSERT_TRUE(seg2->column(3)->has_bloom_filter_index());
 }
 
 TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
-    TabletSchema tablet_schema =
+    std::unique_ptr<TabletSchema> tablet_schema =
             create_schema({create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
 
     SegmentWriterOptions opts;
@@ -200,12 +204,12 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     std::string file_name = kSegmentDir + "/horizontal_write_case";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema.get(), opts);
     ASSERT_OK(writer.init());
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = 10000;
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
     for (auto i = 0; i < num_rows % chunk_size; ++i) {
         chunk->reset();
@@ -224,7 +228,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     uint64_t footer_position;
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -255,7 +259,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
 }
 
 TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
-    TabletSchema tablet_schema =
+    std::unique_ptr<TabletSchema> tablet_schema =
             create_schema({create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
 
     SegmentWriterOptions opts;
@@ -264,7 +268,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
     std::string file_name = kSegmentDir + "/vertical_write_case";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema.get(), opts);
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = 10000;
@@ -275,7 +279,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         // col1 col2
         std::vector<uint32_t> column_indexes{0, 1};
         ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -293,7 +297,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         // col3
         std::vector<uint32_t> column_indexes{2};
         ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -310,7 +314,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         // col4
         std::vector<uint32_t> column_indexes{3};
         ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -325,14 +329,14 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
 
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
     seg_options.fs = _fs;
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
     auto seg_iterator = res.value();
@@ -373,7 +377,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     TabletColumn c3 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
     c3.set_length(65535);
 
-    TabletSchema tablet_schema = create_schema({c1, c2, c3});
+    std::unique_ptr<TabletSchema> tablet_schema = create_schema({c1, c2, c3});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -381,7 +385,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     std::string file_name = kSegmentDir + "/read_multiple_types_column";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
 
-    SegmentWriter writer(std::move(wfile), 0, &tablet_schema, opts);
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema.get(), opts);
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = 10000;
@@ -392,7 +396,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
         // col1 col2
         std::vector<uint32_t> column_indexes{0, 1};
         ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -410,7 +414,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
         // col3
         std::vector<uint32_t> column_indexes{2};
         ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -424,14 +428,14 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     }
 
     ASSERT_OK(writer.finalize_footer(&file_size));
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, &tablet_schema);
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
     seg_options.fs = _fs;
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
-    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
     auto seg_iterator = res.value();


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7920

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In previous implementation, creating a new vectorized schema has a high overhead,
we need to do everything from sratch, such as allocating all fileds from the heap,
prepare the _name_to_index, these stpes bring a lot of overhead to memory and CPU.

In fact, in most case, vectorized schemas are derived from the tablet schema and
tablet schema is read-only, so we can reuse the previously creating vectorized schema,
no need to build a new vectorized schema from scratch.

This pr optimizes vectorized schema, it will reuse the fields and _name_to_index
creating by previous vectorized schema. Besides that, it introduces a new member
`_name_to_index_append_buffer` for newly append fields if the schema is _read_append_only.