### PR TITLE
[BugFix] Fix broker exception the fd is not owned by client null

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
@@ -58,6 +58,7 @@ public class ClientContextManager {
             clientContexts.putIfAbsent(clientId, new ClientResourceContext(clientId));
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
+        clientContext.updateClientLastPingTime();
         clientContext.putOutputStream(fd, fsDataOutputStream, brokerFileSystem);
         fdToClientMap.putIfAbsent(fd, clientId);
     }
@@ -68,6 +69,7 @@ public class ClientContextManager {
             clientContexts.putIfAbsent(clientId, new ClientResourceContext(clientId));
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
+        clientContext.updateClientLastPingTime();
         clientContext.putInputStream(fd, fsDataInputStream, brokerFileSystem);
         fdToClientMap.putIfAbsent(fd, clientId);
     }
@@ -79,6 +81,7 @@ public class ClientContextManager {
                     "the fd is not owned by client {}", clientId);
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
+        clientContext.updateClientLastPingTime();
         FSDataInputStream fsDataInputStream = clientContext.getInputStream(fd);
         return fsDataInputStream;
     }
@@ -90,6 +93,7 @@ public class ClientContextManager {
                     "the fd is not owned by client {}", clientId);
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
+        clientContext.updateClientLastPingTime();
         FSDataOutputStream fsDataOutputStream = clientContext.getOutputStream(fd);
         return fsDataOutputStream;
     }
@@ -228,6 +232,10 @@ public class ClientContextManager {
                 return brokerOutputStream.getOutputStream();
             }
             return null;
+        }
+
+        public void updateClientLastPingTime() {
+            this.lastPingTimestamp = System.currentTimeMillis();
         }
         
         public void updateLastPingTime() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7774

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Broker has control plane heartbeat service, It may be timeout when the pressure is high. Then it will be removed from clientContexts and make data plane throw `fd is not owned by client null` exception.
So that we update the heartbeat timestamp both control plane & data plane to avoid this problem.