### PR TITLE
[Refactor] Changing the inappropriate name write_tmp to improve readability.

### DIFF
--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -58,8 +58,7 @@ public:
     TabletUid tablet_uid = {0, 0};
     PUniqueId load_id{};
     // temporary segment files create or not, set false as default
-    // only use for schema change vectorized by now
-    bool write_tmp = false;
+    bool schema_change_sorting = false;
 
     RowsetStatePB rowset_state = PREPARED;
     SegmentsOverlapPB segments_overlap = OVERLAP_UNKNOWN;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1513,7 +1513,7 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
         writer_context.segments_overlap = sc_params.rowsets_to_change[i]->rowset_meta()->segments_overlap();
 
         if (sc_params.sc_sorting) {
-            writer_context.write_tmp = true;
+            writer_context.schema_change_sorting = true;
         }
 
         std::unique_ptr<RowsetWriter> rowset_writer;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7790

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
<!-- (At least include the following, feel free to add if you have more content) -->

## Refactoring request

**Is your refactoring request related to a problem? Please describe.**
<!-- A clear and concise description of what the problem is. Ex. I'm having problems reading the code/add a feature because [...] -->

https://github.com/StarRocks/starrocks/blob/28cf7fac018c3bf9c176a1b800c08edc2e368420/be/src/storage/rowset/rowset_writer_context.h#L62

the variable so-called write_tmp semantic not as its name, and not well encapsulated.

it seems write_tmp original intention means write temporary segment files, but
- this variable do not real decide whether writing temparory files or not actually, but a flag of schema change sorting, and its just one of judging factors. this name will misleading reader.
- writing temporary segment files is a implementation detail of rowset writer, the schema change procedure should not know the underlying implementation as a user of rowset writer. this name will increase burden of reader.
- write_tmp is a wide and abstract description, it has a large gap towards "write temporary segment files".