### PR TITLE
[Enhancement] Add ut for compaction with empty rowset

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -241,6 +241,8 @@ public:
 
     uint64_t total_mem_footprint() const override { return _scalar_column_writer->total_mem_footprint(); }
 
+    Status check_string_lengths(const vectorized::Column& column);
+
 private:
     std::unique_ptr<ScalarColumnWriter> _scalar_column_writer;
     bool _is_speculated = false;
@@ -896,6 +898,7 @@ StringColumnWriter::StringColumnWriter(const ColumnWriterOptions& opts, std::uni
         : ColumnWriter(std::move(field), opts.meta->is_nullable()), _scalar_column_writer(std::move(column_writer)) {}
 
 Status StringColumnWriter::append(const vectorized::Column& column) {
+    DCHECK(check_string_lengths(column).ok());
     if (_is_speculated) {
         return _scalar_column_writer->append(column);
     }
@@ -974,6 +977,17 @@ Status StringColumnWriter::finish() {
     }
 
     return _scalar_column_writer->finish();
+}
+
+Status StringColumnWriter::check_string_lengths(const vectorized::Column& column) {
+    size_t limit = get_field()->length();
+    const Slice* slices = (const Slice*)column.raw_data();
+    for (size_t i = 0; i < column.size(); i++) {
+        if (slices[i].get_size() > limit) {
+            return Status::InvalidArgument(fmt::format("string length({}) > limit({})", slices[i].get_size(), limit));
+        }
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -69,6 +69,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
 
     TabletColumn c1 = create_int_key(1);
     TabletColumn c2 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
+    c2.set_length(128);
 
     TabletSchema tablet_schema = create_schema({c1, c2});
 

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -191,6 +191,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
 
     TabletColumn c1 = create_int_key(1);
     TabletColumn c2 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
+    c2.set_length(overflow_sz + 10);
 
     TabletSchema tablet_schema = create_schema({c1, c2});
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -69,13 +69,21 @@ public:
         auto chunk = vectorized::ChunkHelper::new_chunk(schema, keys.size());
         auto& cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(vectorized::Datum(key));
-            cols[1]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
-            if (cols[2]->is_binary()) {
-                string v = fmt::to_string(key % 1000 + 2);
-                cols[2]->append_datum(vectorized::Datum(Slice(v)));
+            if (schema.num_key_fields() == 1) {
+                cols[0]->append_datum(vectorized::Datum(key));
             } else {
-                cols[2]->append_datum(vectorized::Datum((int32_t)(key % 1000 + 2)));
+                cols[0]->append_datum(vectorized::Datum(key));
+                string v = fmt::to_string(key * 234234342345);
+                cols[1]->append_datum(vectorized::Datum(Slice(v)));
+                cols[2]->append_datum(vectorized::Datum((int32_t)key));
+            }
+            int vcol_start = schema.num_key_fields();
+            cols[vcol_start]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
+            if (cols[vcol_start + 1]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[vcol_start + 1]->append_datum(vectorized::Datum(Slice(v)));
+            } else {
+                cols[vcol_start + 1]->append_datum(vectorized::Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (one_delete == nullptr && !keys.empty()) {
@@ -110,14 +118,16 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = vectorized::ChunkHelper::convert_schema_to_format_v2(*partial_schema.get());
 
-        auto chunk = vectorized::ChunkHelper::new_chunk(schema, keys.size());
-        EXPECT_TRUE(2 == chunk->num_columns());
-        auto& cols = chunk->columns();
-        for (size_t i = 0; i < keys.size(); i++) {
-            cols[0]->append_datum(vectorized::Datum(keys[i]));
-            cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 3)));
+        if (keys.size() > 0) {
+            auto chunk = vectorized::ChunkHelper::new_chunk(schema, keys.size());
+            EXPECT_TRUE(2 == chunk->num_columns());
+            auto& cols = chunk->columns();
+            for (size_t i = 0; i < keys.size(); i++) {
+                cols[0]->append_datum(vectorized::Datum(keys[i]));
+                cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 3)));
+            }
+            CHECK_OK(writer->flush_chunk(*chunk));
         }
-        CHECK_OK(writer->flush_chunk(*chunk));
         RowsetSharedPtr partial_rowset = *writer->build();
 
         return partial_rowset;
@@ -153,21 +163,40 @@ public:
         return *writer->build();
     }
 
-    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash, bool multi_column_pk = false) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 
-        TColumn k1;
-        k1.column_name = "pk";
-        k1.__set_is_key(true);
-        k1.column_type.type = TPrimitiveType::BIGINT;
-        request.tablet_schema.columns.push_back(k1);
+        if (multi_column_pk) {
+            TColumn pk1;
+            pk1.column_name = "pk1_bigint";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2_varchar";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::VARCHAR;
+            pk2.column_type.len = 128;
+            request.tablet_schema.columns.push_back(pk2);
+            TColumn pk3;
+            pk3.column_name = "pk3_int";
+            pk3.__set_is_key(true);
+            pk3.column_type.type = TPrimitiveType::INT;
+            request.tablet_schema.columns.push_back(pk3);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
 
         TColumn k2;
         k2.column_name = "v1";
@@ -250,6 +279,7 @@ public:
         k3.column_name = "v2";
         k3.__set_is_key(false);
         k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.len = 128;
         request.tablet_schema.columns.push_back(k3);
 
         auto st = StorageEngine::instance()->create_tablet(request);
@@ -376,6 +406,7 @@ public:
     void test_compaction_score_enough_normal(bool enable_persistent_index);
     void test_horizontal_compaction(bool enable_persistent_index);
     void test_vertical_compaction(bool enable_persistent_index);
+    void test_compaction_with_empty_rowset(bool enable_persistent_index, bool vertical, bool multi_column_pk);
     void test_link_from(bool enable_persistent_index);
     void test_convert_from(bool enable_persistent_index);
     void test_convert_from_with_pending(bool enable_persistent_index);
@@ -1075,7 +1106,9 @@ TEST_F(TabletUpdatesTest, compaction_score_enough_normal_persistent_index) {
 
 // NOLINTNEXTLINE
 void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index) {
+    auto orig = config::vertical_compaction_max_columns_per_group;
     config::vertical_compaction_max_columns_per_group = 5;
+    DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
 
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
@@ -1113,7 +1146,9 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_persistent_index) {
 }
 
 void TabletUpdatesTest::test_vertical_compaction(bool enable_persistent_index) {
+    auto orig = config::vertical_compaction_max_columns_per_group;
     config::vertical_compaction_max_columns_per_group = 1;
+    DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
 
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
@@ -1148,6 +1183,50 @@ TEST_F(TabletUpdatesTest, vertical_compaction) {
 
 TEST_F(TabletUpdatesTest, vertical_compaction_with_persistent_index) {
     test_vertical_compaction(true);
+}
+
+void TabletUpdatesTest::test_compaction_with_empty_rowset(bool enable_persistent_index, bool vertical,
+                                                          bool multi_column_pk) {
+    auto orig = config::vertical_compaction_max_columns_per_group;
+    config::vertical_compaction_max_columns_per_group = vertical ? 1 : 20;
+    DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
+    int N = 10000;
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand(), multi_column_pk);
+    _tablet->set_enable_persistent_index(enable_persistent_index);
+    std::vector<int64_t> keys2;
+    for (int i = 0; i < N; i++) {
+        keys2.push_back(i * 3);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys2)).ok());
+    std::vector<int64_t> keys3;
+    for (int i = 0; i < N; i++) {
+        keys3.push_back(i * 3 + 2);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys3)).ok());
+
+    std::vector<int64_t> keys4;
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys4)).ok());
+
+    std::vector<int64_t> keys5;
+    for (int i = 0; i < N; i++) {
+        keys5.push_back(i * 3 + 2);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(5, create_rowset(_tablet, keys5)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+TEST_F(TabletUpdatesTest, compaction_with_empty_rowset) {
+    test_compaction_with_empty_rowset(false, true, false);
+    test_compaction_with_empty_rowset(false, true, true);
+    test_compaction_with_empty_rowset(false, false, false);
+    test_compaction_with_empty_rowset(false, false, true);
+    test_compaction_with_empty_rowset(true, true, false);
+    test_compaction_with_empty_rowset(true, true, true);
+    test_compaction_with_empty_rowset(true, false, false);
+    test_compaction_with_empty_rowset(true, false, true);
 }
 
 void TabletUpdatesTest::test_link_from(bool enable_persistent_index) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Relates to: #7244

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
It's suspected that compaction may have some bug relates to empty rowsets, so this PR adds some UT for this scenario. Although no bug is found.

This PR also adds check to check input strings' lengths and easily identify bugs. And as a result, a bug in TestGlobalDictNotSuperSet and TestGlobalDictNoLocalDict was found. 