### PR TITLE
[StarRocks On ES] Support ES 8.x 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -79,8 +79,8 @@ public class EsTable extends Table {
     // index name can be specific index, wildcard matched or alias.
     private String indexName;
 
-    // which type used for `indexName`, default to `_doc`
-    private String mappingType = "_doc";
+    // which type used for `indexName`
+    private String mappingType = null;
     private String transport = "http";
     // only save the partition definition, save the partition key,
     // partition list is got from es cluster dynamically and is saved in esTableState
@@ -226,6 +226,8 @@ public class EsTable extends Table {
         if (!Strings.isNullOrEmpty(properties.get(TYPE))
                 && !Strings.isNullOrEmpty(properties.get(TYPE).trim())) {
             mappingType = properties.get(TYPE).trim();
+        } else {
+            mappingType = null;
         }
         if (!Strings.isNullOrEmpty(properties.get(TRANSPORT))
                 && !Strings.isNullOrEmpty(properties.get(TRANSPORT).trim())) {
@@ -270,7 +272,9 @@ public class EsTable extends Table {
         tableContext.put("userName", userName);
         tableContext.put("passwd", passwd);
         tableContext.put("indexName", indexName);
-        tableContext.put("mappingType", mappingType);
+        if (mappingType != null) {
+            tableContext.put("mappingType", mappingType);
+        }
         tableContext.put("transport", transport);
         if (majorVersion != null) {
             tableContext.put("majorVersion", majorVersion.toString());
@@ -316,7 +320,9 @@ public class EsTable extends Table {
                 // index name
                 adler32.update(indexName.getBytes(charsetName));
                 // mappingType
-                adler32.update(mappingType.getBytes(charsetName));
+                if (mappingType != null) {
+                    adler32.update(mappingType.getBytes(charsetName));
+                }
                 // transport
                 adler32.update(transport.getBytes(charsetName));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsRestClient.java
@@ -134,11 +134,8 @@ public class EsRestClient {
      * @return
      * @throws Exception
      */
-    public String getMapping(String indexName, boolean includeTypeName) throws StarRocksESException {
+    public String getMapping(String indexName) throws StarRocksESException {
         String path = indexName + "/_mapping";
-        if (includeTypeName) {
-            path += "?include_type_name=true";
-        }
         String indexMapping = execute(path);
         if (indexMapping == null) {
             throw new StarRocksESException("index[" + indexName + "] not found");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -262,7 +262,9 @@ public class EsScanNode extends ScanNode {
                 TEsScanRange esScanRange = new TEsScanRange();
                 esScanRange.setEs_hosts(shardAllocations);
                 esScanRange.setIndex(shardRouting.get(0).getIndexName());
-                esScanRange.setType(table.getMappingType());
+                if (table.getMappingType() != null) {
+                    esScanRange.setType(table.getMappingType());
+                }
                 esScanRange.setShard_id(shardRouting.get(0).getShardId());
                 // Scan range
                 TScanRange scanRange = new TScanRange();

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2102,7 +2102,9 @@ public class GlobalStateMgr {
             sb.append("\"user\" = \"").append(esTable.getUserName()).append("\",\n");
             sb.append("\"password\" = \"").append(hidePassword ? "" : esTable.getPasswd()).append("\",\n");
             sb.append("\"index\" = \"").append(esTable.getIndexName()).append("\",\n");
-            sb.append("\"type\" = \"").append(esTable.getMappingType()).append("\",\n");
+            if (esTable.getMappingType() != null) {
+                sb.append("\"type\" = \"").append(esTable.getMappingType()).append("\",\n");
+            }
             sb.append("\"transport\" = \"").append(esTable.getTransport()).append("\",\n");
             sb.append("\"enable_docvalue_scan\" = \"").append(esTable.isDocValueScanEnable()).append("\",\n");
             sb.append("\"max_docvalue_fields\" = \"").append(esTable.maxDocValueFields()).append("\",\n");

--- a/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/MappingPhaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/elasticsearch/MappingPhaseTest.java
@@ -90,7 +90,7 @@ public class MappingPhaseTest extends EsTestCase {
         String jsonMapping = loadJsonFromFile("data/es/test_index_mapping.json");
         new Expectations(client) {
             {
-                client.getMapping(anyString, anyBoolean);
+                client.getMapping(anyString);
                 minTimes = 0;
                 result = jsonMapping;
             }


### PR DESCRIPTION
1. Elasticsearch 7.x, type was removed from ES mapping, default type is `_doc` 
    [7.0 reference](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/removal-of-types.html)
2. From Elasticsearch 8.x
    a. Specifying types in requests is no longer supported,
    b. The include_type_name parameter is removed
    [7.17 reference](        https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html
)


If the version of Elasticsearch is 8.x, do not specify the type when creating the table， such as

```
CREATE EXTERNAL TABLE `es8x` (
  `k1` varchar(20) NULL COMMENT "",
  `k2` varchar(20) NULL COMMENT ""
) ENGINE=ELASTICSEARCH 
COMMENT "ELASTICSEARCH"
PROPERTIES (
"hosts" = "http://127.0.0.1:9200",
"index" = "test_index"
);

```

If the version of ES is greater than or equal to 7.x, it is recommended to no longer specify type


**Known compatibility issues Please Note**：

**If the table ( only for 8.x ES) was created before upgrading the version that contains this PR, you need to delete the created table and recreate it after the upgrade**





## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/7823

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
