### PR TITLE
[BugFix] try to parse it when casting string to json

### DIFF
--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -116,7 +116,12 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
         } else if constexpr (pt_is_boolean<FromType>) {
             value = JsonValue::from_bool(viewer.value(row));
         } else if constexpr (pt_is_binary<FromType>) {
-            value = JsonValue::from_string(viewer.value(row));
+            auto maybe = JsonValue::parse_json_or_string(viewer.value(row));
+            if (maybe.ok()) {
+                value = maybe.value();
+            } else {
+                overflow = true;
+            }
         } else {
             CHECK(false) << "not supported type " << FromType;
         }

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -2,6 +2,8 @@
 
 #include "util/json.h"
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 #include <vector>
 
@@ -16,6 +18,34 @@
 #include "velocypack/vpack.h"
 
 namespace starrocks {
+
+static bool is_json_start_char(char ch) {
+    return ch == '{' || ch == '[' || ch == '"' || std::isdigit(ch);
+}
+
+StatusOr<JsonValue> JsonValue::parse_json_or_string(const Slice& src) {
+    try {
+        if (src.empty()) {
+            return JsonValue(noneJsonSlice());
+        }
+        // Check the first character for its type
+        auto end = src.get_data() + src.get_size();
+        auto iter = std::find_if_not(src.get_data(), end, std::iswspace);
+        if (iter != end && is_json_start_char(*iter)) {
+            // Parse it as an object or array
+            auto b = vpack::Parser::fromJson(src.get_data(), src.get_size());
+            JsonValue res;
+            res.assign(*b);
+            return res;
+        } else {
+            // Consider it as a sub-type string
+            return from_string(src);
+        }
+    } catch (const vpack::Exception& e) {
+        return fromVPackException(e);
+    }
+    return Status::OK();
+}
 
 Status JsonValue::parse(const Slice& src, JsonValue* out) {
     try {

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -79,8 +79,9 @@ public:
 
     ////////////////// parsing  //////////////////////
     static Status parse(const Slice& src, JsonValue* out);
-
     static StatusOr<JsonValue> parse(const Slice& src);
+    // Try to parse it as JSON object, otherwise consider it as a string
+    static StatusOr<JsonValue> parse_json_or_string(const Slice& src);
 
     ////////////////// serialization  //////////////////////
     size_t serialize(uint8_t* dst) const;

--- a/be/test/exprs/vectorized/cast_expr_test.cpp
+++ b/be/test/exprs/vectorized/cast_expr_test.cpp
@@ -1522,11 +1522,17 @@ TEST_F(VectorizedCastExprTest, sqlToJson) {
 
     // string
     {
-        std::string str = "star";
-        EXPECT_EQ(R"("star")", evaluateCastToJson<TYPE_CHAR>(cast_expr, str));
-        EXPECT_EQ(R"("star")", evaluateCastToJson<TYPE_VARCHAR>(cast_expr, str));
+        EXPECT_EQ(R"("star")", evaluateCastToJson<TYPE_CHAR>(cast_expr, "star"));
+        EXPECT_EQ(R"(" star")", evaluateCastToJson<TYPE_VARCHAR>(cast_expr, " star"));
 
-        str = "上海";
+        EXPECT_EQ(R"(1)", evaluateCastToJson<TYPE_CHAR>(cast_expr, " 1"));
+        EXPECT_EQ(R"("1")", evaluateCastToJson<TYPE_CHAR>(cast_expr, "\"1\""));
+        EXPECT_EQ(R"({})", evaluateCastToJson<TYPE_CHAR>(cast_expr, "{}"));
+        EXPECT_EQ(R"({})", evaluateCastToJson<TYPE_CHAR>(cast_expr, "   {}"));
+        EXPECT_EQ(R"({"star": "rocks"})", evaluateCastToJson<TYPE_CHAR>(cast_expr, R"({"star": "rocks"})"));
+        EXPECT_EQ(R"([])", evaluateCastToJson<TYPE_CHAR>(cast_expr, "[]"));
+
+        std::string str = "上海";
         EXPECT_EQ(R"("上海")", evaluateCastToJson<TYPE_CHAR>(cast_expr, str));
         EXPECT_EQ(R"("上海")", evaluateCastToJson<TYPE_VARCHAR>(cast_expr, str));
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8127

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

**Before**
```sql
mysql> select cast('1'as json);
-------------------------------------------
"1"
```

**After**
```sql
mysql> select cast('1' as json);
-------------------------------------------
1
```

This change would make the implicit casting behavior more user-friendly, in most cases user do not need to manually call the `parse_json` function.

E.g. Before this PR, user should write `select json_query(parse_json('{"a": 1}), 'a')` to get a valid JSON, but not the `select json_query('{"a": 1}', 'a')`. Cause the second case insert an implicit `cast(varchar as json)` , which would tread the varchar as a `json subtype string`, but not parse it as a json object.
