### PR TITLE
[BugFix] Fix race condition of TMasterInfo

### DIFF
--- a/be/src/agent/CMakeLists.txt
+++ b/be/src/agent/CMakeLists.txt
@@ -24,11 +24,12 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/agent")
 
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/agent")
-  
+
 add_library(Agent STATIC
-    agent_server.cpp
-    heartbeat_server.cpp
-    task_worker_pool.cpp
-    utils.cpp
-    publish_version.cpp
-)
+        agent_server.cpp
+        heartbeat_server.cpp
+        task_worker_pool.cpp
+        utils.cpp
+        publish_version.cpp
+        master_info.cpp
+        )

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -33,14 +33,13 @@ class ExecEnv;
 class MasterServerClient;
 class TaskWorkerPool;
 class TFinishTaskRequest;
-class TMasterInfo;
 class TMasterResult;
 class TReportRequest;
 
 // Each method corresponds to one RPC from FE Master, see BackendService.
 class AgentServer {
 public:
-    explicit AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info);
+    explicit AgentServer(ExecEnv* exec_env);
     ~AgentServer();
 
     // Receive agent task from FE master
@@ -58,16 +57,12 @@ public:
 
     AgentStatus report_task(const TReportRequest& request, TMasterResult* result);
 
-    const TMasterInfo& master_info() const { return _master_info; }
-
     AgentServer(const AgentServer&) = delete;
     const AgentServer& operator=(const AgentServer&) = delete;
 
 private:
     // Not Owned
     ExecEnv* _exec_env;
-    // Reference to the ExecEnv::_master_info
-    const TMasterInfo& _master_info;
     std::unique_ptr<MasterServerClient> _master_client;
 
     std::unique_ptr<TaskWorkerPool> _create_tablet_workers;

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -21,11 +21,13 @@
 
 #include "agent/heartbeat_server.h"
 
+#include <fmt/format.h>
 #include <thrift/TProcessor.h>
 
 #include <ctime>
 #include <fstream>
 
+#include "agent/master_info.h"
 #include "common/status.h"
 #include "gen_cpp/HeartbeatService.h"
 #include "runtime/heartbeat_flags.h"
@@ -43,12 +45,13 @@ using apache::thrift::transport::TProcessor;
 
 namespace starrocks {
 
-HeartbeatServer::HeartbeatServer(TMasterInfo* master_info) : _master_info(master_info), _epoch(0) {
-    _olap_engine = StorageEngine::instance();
-}
+HeartbeatServer::HeartbeatServer() : _olap_engine(StorageEngine::instance()) {}
 
-void HeartbeatServer::init_cluster_id() {
-    _master_info->cluster_id = _olap_engine->effective_cluster_id();
+void HeartbeatServer::init_cluster_id_or_die() {
+    auto info = get_master_info();
+    info.cluster_id = _olap_engine->effective_cluster_id();
+    bool r = update_master_info(info);
+    CHECK(r) << "Fail to update master info";
 }
 
 void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMasterInfo& master_info) {
@@ -59,11 +62,37 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
                           << ", counter:" << google::COUNTER;
 
     // do heartbeat
-    Status st = _heartbeat(master_info);
-    st.to_thrift(&heartbeat_result.status);
+    StatusOr<CmpResult> res = compare_master_info(master_info);
+    res.status().to_thrift(&heartbeat_result.status);
+    if (!res.ok()) {
+        MasterInfoPtr ptr;
+        if (get_master_info(&ptr)) {
+            LOG(WARNING) << "Fail to handle heartbeat: " << res.status() << " cached master info: " << *ptr
+                         << " received master info: " << master_info;
+        } else {
+            LOG(WARNING) << "Fail to handle heartbeat: " << res.status();
+        }
+    } else if (*res == kNeedUpdate) {
+        LOG(INFO) << "Updating master info: " << master_info;
+        bool r = update_master_info(master_info);
+        LOG_IF(WARNING, !r) << "Fail to update master info, maybe the master info has been updated by another thread "
+                               "with a larger epoch";
+    } else if (*res == kNeedUpdateAndReport) {
+        LOG(INFO) << "Updating master info: " << master_info;
+        bool r = update_master_info(master_info);
+        LOG_IF(WARNING, !r) << "Fail to update master info, maybe the master info has been updated by another thread "
+                               "with a larger epoch";
+        if (r) {
+            LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
+            _olap_engine->trigger_report();
+        }
+    } else {
+        DCHECK_EQ(kUnchanged, *res);
+        // nothing to do
+    }
 
-    static int32_t num_hardware_cores = std::thread::hardware_concurrency();
-    if (st.ok()) {
+    static auto num_hardware_cores = (int32_t)std::thread::hardware_concurrency();
+    if (res.ok()) {
         heartbeat_result.backend_info.__set_be_port(config::be_port);
         heartbeat_result.backend_info.__set_http_port(config::webserver_port);
         heartbeat_result.backend_info.__set_be_rpc_port(-1);
@@ -76,42 +105,53 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
     }
 }
 
-Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
-    std::lock_guard<std::mutex> lk(_hb_mtx);
+StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const TMasterInfo& master_info) {
+    static const char* LOCALHOST = "127.0.0.1";
+
+    MasterInfoPtr curr_master_info;
+    if (!get_master_info(&curr_master_info)) {
+        return Status::InternalError("Fail to get local master info");
+    }
+
+    if (master_info.epoch < curr_master_info->epoch) {
+        return Status::InternalError("Out-dated epoch");
+    }
+
+    if (master_info.__isset.token && curr_master_info->__isset.token && master_info.token != curr_master_info->token) {
+        return Status::InternalError("Unmatched token");
+    }
+
+    if (curr_master_info->cluster_id != -1 && curr_master_info->cluster_id != master_info.cluster_id) {
+        return Status::InternalError("Unmatched cluster id");
+    }
+
+    if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
+        return Status::InternalError("FE heartbeat with localhost ip but BE is not deployed on the same machine");
+    }
 
     if (master_info.__isset.backend_ip) {
         if (master_info.backend_ip != BackendOptions::get_localhost()) {
             LOG(INFO) << master_info.backend_ip << " not equal to to backend localhost "
                       << BackendOptions::get_localhost();
             if (is_valid_ip(master_info.backend_ip)) {
-                LOG(WARNING) << "backend ip saved in master does not equal to backend local ip"
-                             << master_info.backend_ip << " vs. " << BackendOptions::get_localhost();
-                std::stringstream ss;
-                ss << "actual backend local ip: " << BackendOptions::get_localhost();
-                return Status::InternalError(ss.str());
+                return Status::InternalError("Invalid backend ip");
             }
 
             std::string ip = hostname_to_ip(master_info.backend_ip);
             if (ip.empty()) {
-                std::stringstream ss;
-                ss << "can not get ip from fqdn: " << master_info.backend_ip;
-                LOG(WARNING) << ss.str();
-                return Status::InternalError(ss.str());
+                return Status::InternalError("can not get ip from fqdn");
             }
 
             std::vector<InetAddress> hosts;
-            Status status = get_hosts_v4(&hosts);
-            if (!status.ok() || hosts.empty()) {
-                std::stringstream ss;
-                ss << "the status was not ok when get_hosts_v4, error is " << status.get_error_msg();
-                LOG(WARNING) << ss.str();
-                return Status::InternalError(ss.str());
+            RETURN_IF_ERROR(get_hosts_v4(&hosts));
+            if (hosts.empty()) {
+                return Status::InternalError("get_hosts_v4 is empty");
             }
 
             bool set_new_localhost = false;
 
-            for (std::vector<InetAddress>::iterator addr_it = hosts.begin(); addr_it != hosts.end(); ++addr_it) {
-                if (addr_it->is_address_v4() && addr_it->get_host_address_v4() == ip) {
+            for (auto& host : hosts) {
+                if (host.is_address_v4() && host.get_host_address_v4() == ip) {
                     BackendOptions::set_localhost(master_info.backend_ip);
                     set_new_localhost = true;
                     break;
@@ -119,11 +159,7 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
             }
 
             if (!set_new_localhost) {
-                std::stringstream ss;
-                ss << "the host recorded in master is " << master_info.backend_ip
-                   << ", but we cannot found the local ip that mapped to that host." << BackendOptions::get_localhost();
-                LOG(WARNING) << ss.str();
-                return Status::InternalError(ss.str());
+                return Status::InternalError("Unmatched backend ip");
             }
 
             LOG(INFO) << "update localhost done, the new localhost is " << BackendOptions::get_localhost();
@@ -131,71 +167,10 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
     }
 
     // Check cluster id
-    if (_master_info->cluster_id == -1) {
-        LOG(INFO) << "get first heartbeat. update cluster id";
+    if (curr_master_info->cluster_id == -1) {
+        LOG(INFO) << "Received first heartbeat. updating cluster id";
         // write and update cluster id
-        auto st = _olap_engine->set_cluster_id(master_info.cluster_id);
-        if (!st.ok()) {
-            LOG(WARNING) << "fail to set cluster id. status=" << st.get_error_msg();
-            return Status::InternalError("fail to set cluster id.");
-        } else {
-            std::string LOCALHOST = "127.0.0.1";
-            if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
-                std::stringstream ss;
-                ss << "FE heartbeat with localhost ip but BE is not deployed on the same machine "
-                   << master_info.backend_ip;
-                return Status::InternalError(ss.str());
-            } else {
-                _master_info->cluster_id = master_info.cluster_id;
-                LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
-                          << ". port: " << master_info.network_address.port
-                          << ". cluster id: " << master_info.cluster_id;
-            }
-        }
-    } else {
-        if (_master_info->cluster_id != master_info.cluster_id) {
-            LOG(WARNING) << "ignore invalid cluster id: " << master_info.cluster_id;
-            return Status::InternalError("invalid cluster id. ignore.");
-        }
-    }
-
-    bool need_report = false;
-    if (_master_info->network_address.hostname != master_info.network_address.hostname ||
-        _master_info->network_address.port != master_info.network_address.port) {
-        if (master_info.epoch > _epoch) {
-            _master_info->network_address.hostname = master_info.network_address.hostname;
-            _master_info->network_address.port = master_info.network_address.port;
-            _epoch = master_info.epoch;
-            need_report = true;
-            LOG(INFO) << "master change. new master host: " << _master_info->network_address.hostname
-                      << ". port: " << _master_info->network_address.port << ". epoch: " << _epoch;
-        } else {
-            LOG(WARNING) << "epoch is not greater than local. ignore heartbeat. host: "
-                         << _master_info->network_address.hostname << " port: " << _master_info->network_address.port
-                         << " local epoch: " << _epoch << " received epoch: " << master_info.epoch;
-            return Status::InternalError("epoch is not greater than local. ignore heartbeat.");
-        }
-    } else {
-        // when Master FE restarted, host and port remains the same, but epoch will be increased.
-        if (master_info.epoch > _epoch) {
-            _epoch = master_info.epoch;
-            need_report = true;
-            LOG(INFO) << "master restarted. epoch: " << _epoch;
-        }
-    }
-
-    if (master_info.__isset.token) {
-        if (!_master_info->__isset.token) {
-            _master_info->__set_token(master_info.token);
-            LOG(INFO) << "get token.  token: " << _master_info->token;
-        } else if (_master_info->token != master_info.token) {
-            LOG(WARNING) << "invalid token. local_token:" << _master_info->token << ". token:" << master_info.token;
-            return Status::InternalError("invalid token.");
-        }
-    }
-
-    if (master_info.__isset.http_port) {
-        _master_info->__set_http_port(master_info.http_port);
+        RETURN_IF_ERROR(_olap_engine->set_cluster_id(master_info.cluster_id));
     }
 
     if (master_info.__isset.heartbeat_flags) {
@@ -203,32 +178,23 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         heartbeat_flags->update(master_info.heartbeat_flags);
     }
 
-    if (master_info.__isset.backend_id) {
-        _master_info->__set_backend_id(master_info.backend_id);
+    if (curr_master_info->network_address != master_info.network_address) {
+        return kNeedUpdateAndReport;
     }
-
-    if (need_report) {
-        LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
-        _olap_engine->trigger_report();
+    if (*curr_master_info != master_info) {
+        return kNeedUpdate;
     }
-
-    return Status::OK();
+    return kUnchanged;
 }
 
-AgentStatus create_heartbeat_server(ExecEnv* exec_env, uint32_t server_port, ThriftServer** thrift_server,
-                                    uint32_t worker_thread_num, TMasterInfo* local_master_info) {
-    HeartbeatServer* heartbeat_server = new (nothrow) HeartbeatServer(local_master_info);
-    if (heartbeat_server == nullptr) {
-        return STARROCKS_ERROR;
-    }
-
-    heartbeat_server->init_cluster_id();
+StatusOr<std::unique_ptr<ThriftServer>> create_heartbeat_server(ExecEnv* exec_env, uint32_t server_port,
+                                                                uint32_t worker_thread_num) {
+    auto* heartbeat_server = new HeartbeatServer();
+    heartbeat_server->init_cluster_id_or_die();
 
     std::shared_ptr<HeartbeatServer> handler(heartbeat_server);
     std::shared_ptr<TProcessor> server_processor(new HeartbeatServiceProcessor(handler));
-    string server_name("heartbeat");
-    *thrift_server =
-            new ThriftServer(server_name, server_processor, server_port, exec_env->metrics(), worker_thread_num);
-    return STARROCKS_SUCCESS;
+    return std::make_unique<ThriftServer>("heartbeat", server_processor, server_port, exec_env->metrics(),
+                                          worker_thread_num);
 }
 } // namespace starrocks

--- a/be/src/agent/heartbeat_server.h
+++ b/be/src/agent/heartbeat_server.h
@@ -21,11 +21,14 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 
 #include "agent/status.h"
+#include "common/statusor.h"
 #include "gen_cpp/HeartbeatService.h"
 #include "gen_cpp/Status_types.h"
+#include "gutil/macros.h"
 #include "runtime/exec_env.h"
 #include "storage/olap_define.h"
 #include "thrift/transport/TTransportUtils.h"
@@ -38,10 +41,10 @@ class ThriftServer;
 
 class HeartbeatServer : public HeartbeatServiceIf {
 public:
-    explicit HeartbeatServer(TMasterInfo* master_info);
+    HeartbeatServer();
     ~HeartbeatServer() override = default;
 
-    virtual void init_cluster_id();
+    virtual void init_cluster_id_or_die();
 
     // Master send heartbeat to this server
     //
@@ -52,21 +55,20 @@ public:
     // * heartbeat_result: The result of heartbeat set
     void heartbeat(THeartbeatResult& heartbeat_result, const TMasterInfo& master_info) override;
 
+    DISALLOW_COPY_AND_MOVE(HeartbeatServer);
+
 private:
-    Status _heartbeat(const TMasterInfo& master_info);
+    enum CmpResult {
+        kUnchanged,
+        kNeedUpdate,
+        kNeedUpdateAndReport,
+    };
+
+    StatusOr<CmpResult> compare_master_info(const TMasterInfo& master_info);
 
     StorageEngine* _olap_engine;
-
-    // mutex to protect master_info and _epoch
-    std::mutex _hb_mtx;
-    // Not owned. Point to the ExecEnv::_master_info
-    TMasterInfo* _master_info;
-    int64_t _epoch;
-
-    HeartbeatServer(const HeartbeatServer&) = delete;
-    const HeartbeatServer& operator=(const HeartbeatServer&) = delete;
 }; // class HeartBeatServer
 
-AgentStatus create_heartbeat_server(ExecEnv* exec_env, uint32_t heartbeat_server_port, ThriftServer** heart_beat_server,
-                                    uint32_t worker_thread_num, TMasterInfo* local_master_info);
+StatusOr<std::unique_ptr<ThriftServer>> create_heartbeat_server(ExecEnv* exec_env, uint32_t heartbeat_server_port,
+                                                                uint32_t worker_thread_num);
 } // namespace starrocks

--- a/be/src/agent/master_info.cpp
+++ b/be/src/agent/master_info.cpp
@@ -1,0 +1,63 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "agent/master_info.h"
+
+namespace starrocks {
+
+static butil::DoublyBufferedData<TMasterInfo>* get_or_create_data() {
+    static butil::DoublyBufferedData<TMasterInfo> obj;
+    return &obj;
+}
+
+static bool update(TMasterInfo& bg, const TMasterInfo& new_value) {
+    if (new_value.epoch >= bg.epoch) {
+        bg = new_value;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool get_master_info(butil::DoublyBufferedData<TMasterInfo>::ScopedPtr* ptr) {
+    auto* data = get_or_create_data();
+    return data->Read(ptr) == 0;
+}
+
+TMasterInfo get_master_info() {
+    MasterInfoPtr ptr;
+    if (get_master_info(&ptr)) {
+        return *ptr;
+    }
+    return {};
+}
+
+bool update_master_info(const TMasterInfo& master_info) {
+    auto* data = get_or_create_data();
+    return data->Modify(update, master_info);
+}
+
+std::string get_master_token() {
+    MasterInfoPtr ptr;
+    if (get_master_info(&ptr)) {
+        return ptr->token;
+    }
+    return "";
+}
+
+TNetworkAddress get_master_address() {
+    MasterInfoPtr ptr;
+    if (get_master_info(&ptr)) {
+        return ptr->network_address;
+    }
+    return {};
+}
+
+std::optional<int64_t> get_backend_id() {
+    MasterInfoPtr ptr;
+    if (get_master_info(&ptr) && ptr->__isset.backend_id) {
+        return ptr->backend_id;
+    }
+    return {};
+}
+
+} // namespace starrocks

--- a/be/src/agent/master_info.h
+++ b/be/src/agent/master_info.h
@@ -1,0 +1,47 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <butil/containers/doubly_buffered_data.h>
+
+#include <optional>
+
+#include "gen_cpp/HeartbeatService_types.h"
+
+namespace starrocks {
+
+using MasterInfoPtr = butil::DoublyBufferedData<TMasterInfo>::ScopedPtr;
+
+// Put `TMasterInfo` instance into |ptr|. The instance will not be changed until |ptr| is destructed.
+//
+// Returns true on success, false otherwise.
+[[nodiscard]] bool get_master_info(MasterInfoPtr* ptr);
+
+// Returns a copy of the `TMasterInfo` instance.
+//
+// NOTE: `get_master_info()` relies on `get_master_info(MasterInfoPtr*)` and if
+// `get_master_info(MasterInfoPtr*)` failed a default constructed `TMasterInfo`
+// will be returned.
+[[nodiscard]] TMasterInfo get_master_info();
+
+// Returns true on success, false otherwise.
+//
+// NOTE: Do NOT call `update_master_info` while still holding a `MasterInfoPtr`
+// filled by `get_master_info(MasterInfoPtr*)`, otherwise deadlock will happen.
+[[nodiscard]] bool update_master_info(const TMasterInfo& master_info);
+
+// Returns the token of TMasterInfo instance.
+//
+// NOTE: Relies on `get_master_info()` and if `get_master_info()` failed an empty string
+// will be returned.
+[[nodiscard]] std::string get_master_token();
+
+// Returns the value of network_address field of TMasterInfo instance.
+//
+// NOTE: Relies on `get_master_info()` and if `get_master_info()` failed a default constructed
+// TNetworkAddress will be returned.
+[[nodiscard]] TNetworkAddress get_master_address();
+
+[[nodiscard]] std::optional<int64_t> get_backend_id();
+
+} // namespace starrocks

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -133,8 +133,6 @@ private:
     AgentStatus _move_dir(TTabletId tablet_id, TSchemaHash schema_hash, const std::string& src, int64_t job_id,
                           bool overwrite, std::vector<std::string>* error_msgs);
 
-    const TMasterInfo& master_info();
-
     AgentServer* _agent_server;
     TBackend _backend;
     ExecEnv* _env;

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -31,7 +31,7 @@ namespace starrocks {
 
 class MasterServerClient {
 public:
-    MasterServerClient(const TMasterInfo& master_info, FrontendServiceClientCache* client_cache);
+    explicit MasterServerClient(FrontendServiceClientCache* client_cache);
     virtual ~MasterServerClient() = default;
 
     // Reprot finished task to the master server
@@ -56,8 +56,6 @@ public:
     const MasterServerClient& operator=(const MasterServerClient&) = delete;
 
 private:
-    // Not ownder. Reference to the ExecEnv::_master_info
-    const TMasterInfo& _master_info;
     FrontendServiceClientCache* _client_cache;
 };
 

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -4,6 +4,7 @@
 #include <thrift/Thrift.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
+#include "agent/master_info.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
@@ -97,8 +98,9 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Frag
         params.__isset.error_log = (params.error_log.size() > 0);
     }
 
-    if (exec_env->master_info()->__isset.backend_id) {
-        params.__set_backend_id(exec_env->master_info()->backend_id);
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        params.__set_backend_id(backend_id.value());
     }
     return params;
 }

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -32,6 +32,7 @@
 #include <rapidjson/prettywriter.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
+#include "agent/master_info.h"
 #include "common/logging.h"
 #include "common/utils.h"
 #include "gen_cpp/FrontendService.h"
@@ -491,7 +492,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     }
     request.__set_thrift_rpc_timeout_ms(config::thrift_rpc_timeout_ms);
     // plan this load
-    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    TNetworkAddress master_addr = get_master_address();
 #ifndef BE_TEST
     if (!http_req->header(HTTP_MAX_FILTER_RATIO).empty()) {
         ctx->max_filter_ratio = strtod(http_req->header(HTTP_MAX_FILTER_RATIO).c_str(), nullptr);

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -14,6 +14,7 @@
 #include <rapidjson/prettywriter.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
+#include "agent/master_info.h"
 #include "common/logging.h"
 #include "common/utils.h"
 #include "gen_cpp/FrontendService.h"
@@ -361,7 +362,7 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
     }
     request.__set_thrift_rpc_timeout_ms(config::thrift_rpc_timeout_ms);
     // plan this load
-    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    auto master_addr = get_master_address();
 #ifndef BE_TEST
     if (!http_req->header(HTTP_MAX_FILTER_RATIO).empty()) {
         ctx->max_filter_ratio = strtod(http_req->header(HTTP_MAX_FILTER_RATIO).c_str(), nullptr);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -23,6 +23,7 @@
 
 #include <thread>
 
+#include "agent/master_info.h"
 #include "column/column_pool.h"
 #include "common/config.h"
 #include "common/logging.h"
@@ -216,7 +217,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _wg_driver_executor->initialize(_max_executor_threads);
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
-    _master_info = new TMasterInfo();
     _load_path_mgr = new LoadPathMgr(this);
     _broker_mgr = new BrokerMgr(this);
     _bfd_parser = BfdParser::create();
@@ -277,8 +277,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     return Status::OK();
 }
 
-const std::string& ExecEnv::token() const {
-    return _master_info->token;
+std::string ExecEnv::token() const {
+    return get_master_token();
 }
 
 void ExecEnv::add_rf_event(const RfTracePoint& pt) {
@@ -418,10 +418,6 @@ void ExecEnv::_destroy() {
     if (_load_path_mgr) {
         delete _load_path_mgr;
         _load_path_mgr = nullptr;
-    }
-    if (_master_info) {
-        delete _master_info;
-        _master_info = nullptr;
     }
     if (_driver_executor) {
         delete _driver_executor;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -52,7 +52,6 @@ class ThreadPool;
 class PriorityThreadPool;
 class ResultBufferMgr;
 class ResultQueueMgr;
-class TMasterInfo;
 class LoadChannelMgr;
 class ThreadResourceMgr;
 class WebPageHandler;
@@ -107,7 +106,7 @@ public:
     // declarations for classes in scoped_ptrs.
     ~ExecEnv() = default;
 
-    const std::string& token() const;
+    std::string token() const;
     ExternalScanContextMgr* external_scan_context_mgr() { return _external_scan_context_mgr; }
     MetricRegistry* metrics() const { return _metrics; }
     DataStreamMgr* stream_mgr() { return _stream_mgr; }
@@ -147,7 +146,6 @@ public:
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverExecutor* driver_executor() { return _driver_executor; }
     starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
-    TMasterInfo* master_info() { return _master_info; }
     LoadPathMgr* load_path_mgr() { return _load_path_mgr; }
     BfdParser* bfd_parser() const { return _bfd_parser; }
     BrokerMgr* broker_mgr() const { return _broker_mgr; }
@@ -249,7 +247,6 @@ private:
     pipeline::DriverLimiter* _driver_limiter;
     int64_t _max_executor_threads; // Max thread number of executor
 
-    TMasterInfo* _master_info = nullptr;
     LoadPathMgr* _load_path_mgr = nullptr;
 
     starrocks::workgroup::ScanExecutor* _scan_executor = nullptr;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <sstream>
 
+#include "agent/master_info.h"
 #include "common/object_pool.h"
 #include "gen_cpp/DataSinks_types.h"
 #include "gen_cpp/FrontendService.h"
@@ -282,8 +283,9 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
         params.__isset.error_log = (params.error_log.size() > 0);
     }
 
-    if (_exec_env->master_info()->__isset.backend_id) {
-        params.__set_backend_id(_exec_env->master_info()->backend_id);
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        params.__set_backend_id(backend_id.value());
     }
 
     TReportExecStatusResult res;

--- a/be/src/runtime/small_file_mgr.cpp
+++ b/be/src/runtime/small_file_mgr.cpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <utility>
 
+#include "agent/master_info.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
@@ -158,9 +159,9 @@ Status SmallFileMgr::_download_file(int64_t file_id, const std::string& md5, std
     HttpClient client;
 
     std::stringstream url_ss;
-    TMasterInfo* master_info = _exec_env->master_info();
-    url_ss << master_info->network_address.hostname << ":" << master_info->http_port << "/api/get_small_file?"
-           << "file_id=" << file_id << "&token=" << master_info->token;
+    TMasterInfo master_info = get_master_info();
+    url_ss << master_info.network_address.hostname << ":" << master_info.http_port << "/api/get_small_file?"
+           << "file_id=" << file_id << "&token=" << master_info.token;
 
     std::string url = url_ss.str();
 

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <filesystem>
 
+#include "agent/master_info.h"
 #include "common/logging.h"
 #include "fs/fs.h"
 #include "fs/fs_broker.h"
@@ -723,7 +724,7 @@ Status SnapshotLoader::_report_every(int report_threshold, int* counter, int32_t
     LOG(INFO) << "report to frontend. job id: " << _job_id << ", task id: " << _task_id
               << ", finished num: " << finished_num << ", total num:" << total_num;
 
-    TNetworkAddress master_addr = _env->master_info()->network_address;
+    TNetworkAddress master_addr = get_master_address();
 
     TSnapshotLoaderReportRequest request;
     request.job_id = _job_id;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -21,6 +21,7 @@
 
 #include "runtime/stream_load/stream_load_executor.h"
 
+#include "agent/master_info.h"
 #include "common/status.h"
 #include "common/utils.h"
 #include "gen_cpp/FrontendService.h"
@@ -142,7 +143,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     }
     request.__set_request_id(ctx->id.to_thrift());
 
-    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    TNetworkAddress master_addr = get_master_address();
     TLoadTxnBeginResult result;
 #ifndef BE_TEST
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
@@ -185,7 +186,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
         request.__isset.txnCommitAttachment = true;
     }
 
-    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    TNetworkAddress master_addr = get_master_address();
     TLoadTxnCommitResult result;
 #ifndef BE_TEST
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
@@ -213,7 +214,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
 Status StreamLoadExecutor::rollback_txn(StreamLoadContext* ctx) {
     StarRocksMetrics::instance()->txn_rollback_request_total.increment(1);
 
-    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    TNetworkAddress master_addr = get_master_address();
     TLoadTxnRollbackRequest request;
     set_request_auth(&request, ctx->auth);
     request.db = ctx->db;

--- a/be/src/service/service_be/backend_service.cpp
+++ b/be/src/service/service_be/backend_service.cpp
@@ -49,7 +49,7 @@ using apache::thrift::TProcessor;
 using apache::thrift::concurrency::ThreadFactory;
 
 BackendService::BackendService(ExecEnv* exec_env)
-        : BackendServiceBase(exec_env), _agent_server(new AgentServer(exec_env, *exec_env->master_info())) {}
+        : BackendServiceBase(exec_env), _agent_server(new AgentServer(exec_env)) {}
 
 Status BackendService::create_service(ExecEnv* exec_env, int port, ThriftServer** server) {
     std::shared_ptr<BackendService> handler(new BackendService(exec_env));

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <set>
 
+#include "agent/master_info.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "gen_cpp/BackendService.h"
@@ -59,15 +60,14 @@ const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
 const uint32_t LIST_REMOTE_FILE_TIMEOUT = 15;
 const uint32_t GET_LENGTH_TIMEOUT = 10;
 
-EngineCloneTask::EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& clone_req, const TMasterInfo& master_info,
-                                 int64_t signature, std::vector<string>* error_msgs,
-                                 std::vector<TTabletInfo>* tablet_infos, AgentStatus* res_status)
+EngineCloneTask::EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& clone_req, int64_t signature,
+                                 std::vector<string>* error_msgs, std::vector<TTabletInfo>* tablet_infos,
+                                 AgentStatus* res_status)
         : _clone_req(clone_req),
           _error_msgs(error_msgs),
           _tablet_infos(tablet_infos),
           _res_status(res_status),
-          _signature(signature),
-          _master_info(master_info) {
+          _signature(signature) {
     _mem_tracker = std::make_unique<MemTracker>(-1, "clone task", mem_tracker);
 }
 
@@ -299,7 +299,7 @@ Status EngineCloneTask::_clone_copy(DataDir& data_dir, const string& local_data_
                                     const std::vector<Version>* missed_versions,
                                     const std::vector<int64_t>* missing_version_ranges) {
     std::string local_path = local_data_path + "/";
-    const auto& token = _master_info.token;
+    std::string token = get_master_token();
 
     int timeout_s = 0;
     if (_clone_req.__isset.timeout_s) {

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -34,9 +34,8 @@ namespace starrocks {
 // add "Engine" as task prefix to prevent duplicate name with agent task
 class EngineCloneTask : public EngineTask {
 public:
-    EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& _clone_req, const TMasterInfo& _master_info,
-                    int64_t _signature, vector<string>* error_msgs, vector<TTabletInfo>* tablet_infos,
-                    AgentStatus* _res_status);
+    EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& _clone_req, int64_t _signature,
+                    vector<string>* error_msgs, vector<TTabletInfo>* tablet_infos, AgentStatus* _res_status);
 
     ~EngineCloneTask() override = default;
 
@@ -79,7 +78,6 @@ private:
     vector<TTabletInfo>* _tablet_infos;
     AgentStatus* _res_status;
     int64_t _signature;
-    const TMasterInfo& _master_info;
 }; // EngineTask
 
 } // namespace starrocks

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -76,7 +76,6 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._thread_mgr = new ThreadResourceMgr();
-        _env._master_info = new TMasterInfo();
         _env._load_stream_mgr = new LoadStreamMgr();
         _env._brpc_stub_cache = new BrpcStubCache();
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
@@ -88,8 +87,6 @@ public:
         _env._brpc_stub_cache = nullptr;
         delete _env._load_stream_mgr;
         _env._load_stream_mgr = nullptr;
-        delete _env._master_info;
-        _env._master_info = nullptr;
         delete _env._thread_mgr;
         _env._thread_mgr = nullptr;
         delete _env._stream_load_executor;

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -45,7 +45,6 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._thread_mgr = new ThreadResourceMgr();
-        _env._master_info = new TMasterInfo();
         _env._load_stream_mgr = new LoadStreamMgr();
         _env._brpc_stub_cache = new BrpcStubCache();
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
@@ -63,8 +62,6 @@ public:
         _env._brpc_stub_cache = nullptr;
         delete _env._load_stream_mgr;
         _env._load_stream_mgr = nullptr;
-        delete _env._master_info;
-        _env._master_info = nullptr;
         delete _env._thread_mgr;
         _env._thread_mgr = nullptr;
         delete _env._stream_load_executor;

--- a/be/test/runtime/routine_load_task_executor_test.cpp
+++ b/be/test/runtime/routine_load_task_executor_test.cpp
@@ -52,7 +52,6 @@ public:
         k_stream_load_rollback_result = TLoadTxnRollbackResult();
         k_stream_load_put_result = TStreamLoadPutResult();
 
-        _env._master_info = new TMasterInfo();
         _env._load_stream_mgr = new LoadStreamMgr();
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
 
@@ -61,8 +60,6 @@ public:
     }
 
     void TearDown() override {
-        delete _env._master_info;
-        _env._master_info = nullptr;
         delete _env._load_stream_mgr;
         _env._load_stream_mgr = nullptr;
         delete _env._stream_load_executor;

--- a/be/test/runtime/small_file_mgr_test.cpp
+++ b/be/test/runtime/small_file_mgr_test.cpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "agent/master_info.h"
 #include "common/logging.h"
 #include "gen_cpp/HeartbeatService_types.h"
 #include "http/ev_http_server.h"
@@ -109,8 +110,8 @@ TEST_F(SmallFileMgrTest, test_get_file) {
     TMasterInfo info;
     info.__set_network_address(addr);
     info.__set_http_port(real_port);
+    ASSERT_TRUE(update_master_info(info));
     ExecEnv* env = ExecEnv::GetInstance();
-    env->_master_info = &info;
     SmallFileMgr mgr(env, g_download_path);
     Status st = mgr.init();
     ASSERT_TRUE(st.ok());


### PR DESCRIPTION
The `TMasterInfo` instance of ExecEnv may be accessed by many `TaskWorkerPool` threads
and modified by `HeartbeatServer` from other threads.

Since `TMasterInfo` is read mostly and update rarely,  this implementation save `TMasterInfo` 
into a `butil::DoublyBufferedData` structure to achieve better read performance.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

