### PR TITLE
fixup bug introduced by PR-7751 (#7832)

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -364,7 +364,6 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
                                                      RuntimeBloomFilterEvalContext& eval_context) {
     eval_context.selectivity.clear();
     size_t chunk_size = chunk->num_rows();
-    auto& selection = eval_context.running_context.selection;
     auto& merged_selection = eval_context.running_context.merged_selection;
     auto& use_merged_selection = eval_context.running_context.use_merged_selection;
     use_merged_selection = true;
@@ -374,6 +373,9 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
         if (filter == nullptr) {
             continue;
         }
+        auto& selection = eval_context.running_context.use_merged_selection
+                                  ? eval_context.running_context.merged_selection
+                                  : eval_context.running_context.selection;
         auto ctx = rf_desc->probe_expr_ctx();
         ColumnPtr column = EVALUATE_NULL_IF_ERROR(ctx, ctx->root(), chunk);
         // for colocate grf


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Bug introduced by https://github.com/StarRocks/starrocks/pull/7751
https://github.com/StarRocks/StarRocksTest/issues/608
https://github.com/StarRocks/StarRocksTest/issues/609
https://github.com/StarRocks/StarRocksTest/issues/613
https://github.com/StarRocks/StarRocksTest/issues/614
https://github.com/StarRocks/StarRocksTest/issues/615

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In  RuntimeFilterProbeCollector::update_selectivity function, when compute the selectivity of the first rf, then RunningContext::merge_selection is used to store the hit row ordinals; RunningContext::selection is used to store the hit row ordinals for the rest rf(s). selection instead of merge_selection is used to filter chunk mistakenly when apply the first rf to chunk. so a Chunk::filter applying to the misuse selection whose size large than the chunk will corrupt the chunk. 

Failed daily cases as follows pass:
```
nosetests-3.4 -s --with-xunit --xunit-file=./result/test_hudi_extbl_standard_sqlset_py_TestHudiEXTblStandardSqlset_test_standard_query_hdfs_tpch_parquet_gzip_1G.xml --verbose case/system_case/test_ddl/test_external_table/test_hudi_external_table/test_hudi_extbl_standard_sqlset.py:TestHudiEXTblStandardSqlset.test_standard_query_hdfs_tpch_parquet_gzip_1G --nologcapture

nosetests-3.4 -s --with-xunit --xunit-file=./result/test_colocate_GRF_py_TestColocateGRF_test_Colocate_GRF.xml --verbose case/system_case/test_ddl/test_colocate_join/test_colocate_GRF.py:TestColocateGRF.test_Colocate_GRF --nologcapture


```