### PR TITLE
[BugFix] Avoid repeatedly adding tablet to pending queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -263,6 +263,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         this.lastAdjustPrioTime = 0;
     }
 
+    public Priority getDynamicPriority() {
+        return dynamicPriority;
+    }
+
     public void increaseFailedSchedCounter() {
         ++failedSchedCounter;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -410,8 +410,10 @@ public class TabletScheduler extends MasterDaemon {
     private void schedulePendingTablets() {
         long start = System.currentTimeMillis();
         List<TabletSchedCtx> currentBatch = getNextTabletCtxBatch();
-        debugLogPendingTabletsStats();
-        LOG.debug("get {} tablets to schedule", currentBatch.size());
+        if (LOG.isDebugEnabled()) {
+            debugLogPendingTabletsStats();
+            LOG.debug("get {} tablets to schedule", currentBatch.size());
+        }
 
         AgentBatchTask batchTask = new AgentBatchTask();
         for (TabletSchedCtx tabletCtx : currentBatch) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -427,7 +427,7 @@ public class TabletScheduler extends MasterDaemon {
                 tabletCtx.setErrMsg(e.getMessage());
 
                 if (e.getStatus() == Status.SCHEDULE_FAILED) {
-                    LOG.info("scheduling for tablet[{}] failed, type: {}, reason: {}",
+                    LOG.debug("scheduling for tablet[{}] failed, type: {}, reason: {}",
                             tabletCtx.getTabletId(), tabletCtx.getType().name(), e.getMessage());
                     if (tabletCtx.getType() == Type.BALANCE) {
                         // if balance is disabled, remove this tablet

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -243,7 +243,7 @@ public class TabletScheduler extends MasterDaemon {
         // can be messed up.
         // `force` here should only mean that we can exceed the size limit of
         // `pendingTablets` and `runningTablets` if there is too many tablets to schedule.
-        if(containsTablet(tablet.getTabletId())) {
+        if (containsTablet(tablet.getTabletId())) {
             return AddResult.ALREADY_IN;
         }
 
@@ -1220,7 +1220,10 @@ public class TabletScheduler extends MasterDaemon {
 
     private synchronized void addBackToPendingTablets(TabletSchedCtx tabletCtx) {
         // Since we know it's add back, corresponding tablet id is still recorded in `allTabletIds`,
-        // so we explicitly remove the id from `allTabletIds`, otherwise `addTablet()` may fail
+        // so we explicitly remove the id from `allTabletIds`, otherwise `addTablet()` may fail.
+        // And when adding back, we don't want it to be failed because of exceeding limit of
+        // `Config.max_scheduling_tablets` since it's already got scheduled before, we just adjusted
+        // its priority and want it to be scheduled again, so we set force to be true here.
         allTabletIds.remove(tabletCtx.getTabletId());
         addTablet(tabletCtx, true /* force */);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7871

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
        // Under no circumstance should we repeatedly add a tablet to pending queue
        // to schedule, because this will break the scheduling logic. Besides, with current design,
        // we have to maintain the constraint that `allTabletIds = runningTablets + pendingTablets`.
        // `allTabletIds` and `runningTablets` are defined as unique container, if we schedule a
        // tablet with different `TabletSchedCtx` at the same time, the reference in `runningTablets`
        // can be messed up.
        // `force` here should only mean that we can exceed the size limit of
        // `pendingTablets` and `runningTablets` if there is too many tablets to schedule.

we check `pendingList` before add a new tablet to it.
