### PR TITLE
Write rowset type field into meta explicitly for compatibility.

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -81,6 +81,7 @@ Status BetaRowsetWriter::init() {
     _rowset_meta->set_partition_id(_context.partition_id);
     _rowset_meta->set_tablet_id(_context.tablet_id);
     _rowset_meta->set_tablet_schema_hash(_context.tablet_schema_hash);
+    _rowset_meta->set_rowset_type(BETA_ROWSET);
     _rowset_meta->set_rowset_state(_context.rowset_state);
     _rowset_meta->set_segments_overlap(_context.segments_overlap);
     if (_context.rowset_state == PREPARED || _context.rowset_state == COMMITTED) {

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -107,6 +107,10 @@ public:
         _rowset_meta_pb.set_tablet_schema_hash(tablet_schema_hash);
     }
 
+    RowsetTypePB rowset_type() const { return _rowset_meta_pb.rowset_type(); }
+
+    void set_rowset_type(RowsetTypePB rowset_type) { _rowset_meta_pb.set_rowset_type(rowset_type); }
+
     RowsetStatePB rowset_state() const { return _rowset_meta_pb.rowset_state(); }
 
     void set_rowset_state(RowsetStatePB rowset_state) { _rowset_meta_pb.set_rowset_state(rowset_state); }

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -321,6 +321,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
 
     tablet_meta_pb->set_in_restore_mode(in_restore_mode());
 
+    tablet_meta_pb->set_preferred_rowset_type(BETA_ROWSET);
+
     // to avoid modify tablet meta to the greatest extend
     if (_updates != nullptr) {
         _updates->to_updates_pb(tablet_meta_pb->mutable_updates());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
tablet_manager.cpp:674] Unsupported rowset type 0 tablet_id=26071 tablet_uid=0000000000000000-0000000000000000 schema_hash=790659129 rowset_id=02000000000034c71a4c37d2dd4091ae2eaf3ee35eb36586
```
main backward to older version, will encounter to unsupport rowset type because miss writing the field into meta explicitly for compatibility.