### PR TITLE
[BugFix] Fix the wrong parameter of log in Substitute

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1157,7 +1157,7 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
         if (std::find(ors.begin(), ors.end(), rowset_id) == ors.end()) {
             // This may happen after a full clone.
             _compaction_state.reset();
-            auto msg = Substitute("compaction input rowset($0) not found $2", rowset_id, _debug_string(false, false));
+            auto msg = Substitute("compaction input rowset($0) not found $1", rowset_id, _debug_string(false, false));
             LOG(WARNING) << msg;
             return Status::Cancelled(msg);
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
start time: Mon Jun 27 03:17:24 CST 2022
*** Check failure stack trace: ***
    @          0xb3d0aed  google::LogMessage::Fail()
    @          0xb3d2f5f  google::LogMessage::SendToLog()
    @          0xb3d063e  google::LogMessage::Flush()
    @          0xb3d0862  google::LogMessage::~LogMessage()
    @          0x4dac9c8  strings::internal::SubstitutedSize()
    @          0x4dad38d  strings::SubstituteAndAppend()
    @          0x4c8a414  strings::Substitute()
    @          0x4f7a8fe  starrocks::TabletUpdates::_commit_compaction()
    @          0x4f78e3a  starrocks::TabletUpdates::_do_compaction()
    @          0x4f89c47  starrocks::TabletUpdates::compaction()
    @          0x4de7d46  starrocks::StorageEngine::_perform_update_compaction()
    @          0x545ac8c  starrocks::StorageEngine::_update_compaction_thread_callback()
    @          0x5456c96  _ZZN9starrocks13StorageEngine16start_bg_threadsEvENKUlvE7_clEv
    @          0x5464a25  _ZSt13__invoke_implIvZN9starrocks13StorageEngine16start_bg_threadsEvEUlvE7_JEET_St14__invoke_otherOT0_DpOT1_
    @          0x546460e  _ZSt8__invokeIZN9starrocks13StorageEngine16start_bg_threadsEvEUlvE7_JEENSt15__invoke_resultIT_JDpT0_EE4typeEOS4_DpOS5_
    @          0x5464336  _ZNSt6thread8_InvokerISt5tupleIJZN9starrocks13StorageEngine16start_bg_threadsEvEUlvE7_EEE9_M_invokeIJLm0EEEEvSt12_Index_tupleIJXspT_EEE
    @          0x546418a  _ZNSt6thread8_InvokerISt5tupleIJZN9starrocks13StorageEngine16start_bg_threadsEvEUlvE7_EEEclEv
    @          0x5463ffa  _ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJZN9starrocks13StorageEngine16start_bg_threadsEvEUlvE7_EEEEE6_M_runEv
    @          0xcfbe230  execute_native_thread_routine
    @     0x7f2ac77a2ea5  start_thread
    @     0x7f2ac6dbd8dd  __clone
    @              (nil)  (unknown)
```