### PR TITLE
[BugFix] Report tablet ids when publish is failed 

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -781,7 +781,7 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
                     break;
                 } else if (st.is_service_unavailable()) {
                     // Status::ServiceUnavailable is returned when all of the threads of the pool are busy.
-                    LOG(WARNING) << "publish version threadpool is busy, retry later. [txn_id: "
+                    LOG(WARNING) << "publish version threadpool is busy, retry later. txn_id: "
                                  << publish_version_req.transaction_id << ", tablet_id: " << tablet_rs.first.tablet_id;
                     // In general, publish version is fast. A small sleep is needed here.
                     SleepFor(MonoDelta::FromMilliseconds(50 * retry_time));

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -779,13 +779,14 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
 
                 if (st.ok()) {
                     break;
-                } else if (st.is_service_unavailable()) {
-                    // Status::ServiceUnavailable is returned when all of the threads of the pool are busy.
-                    LOG(WARNING) << "publish version threadpool is busy, retry later. txn_id: "
-                                 << publish_version_req.transaction_id << ", tablet_id: " << tablet_rs.first.tablet_id;
-                    // In general, publish version is fast. A small sleep is needed here.
-                    SleepFor(MonoDelta::FromMilliseconds(50 * retry_time));
                 }
+
+                // Status::ServiceUnavailable is returned when all of the threads of the pool are busy.
+                LOG(WARNING) << "publish version thread pool is not ready, retry later. txn_id: "
+                             << publish_version_req.transaction_id << ", tablet_id: " << tablet_rs.first.tablet_id
+                             << ", err: " << st;
+                // In general, publish version is fast. A small sleep is needed here.
+                SleepFor(MonoDelta::FromMilliseconds(50 * retry_time));
 
                 if (++retry_time < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
                     LOG(WARNING) << "Retry of publish version on partition is beyond limit. partition: " << partition_id

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -831,7 +831,7 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
                     // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
                     // But it seems that there's no limit for the number of tablets of a partition.
                     // Since a large queue size brings a little overhead, a big one is chosen here.
-                    .set_max_queue_size(2048)
+                    .set_max_queue_size(8192)
                     .build(&threadpool);
     assert(st.ok());
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -743,7 +743,7 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
         tablet_infos.reserve(tablet_related_rs.size());
 
         // vector for tablet publishing version status, which collects the execution results of the corresponding tablet.
-        std::vector<Status> statuses(tablet_related_rs.size(), Status::OK());
+        std::vector<Status> statuses(tablet_related_rs.size(), Status::Unknown("publish task not being executed"));
 
         size_t idx = 0;
         // each tablet
@@ -752,11 +752,11 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
 
             uint32_t retry_time = 0;
 
-            auto st = &statuses[idx];
-            while (retry_time++ < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
+            auto status = &statuses[idx];
+            while (true) {
                 // submit publishing tablet version task to the threadpool.
-                *st = threadpool->submit_func([&worker_pool_this, &tablet_rs, st, &version, &transaction_id,
-                                               &partition_id]() {
+                auto st = threadpool->submit_func([&worker_pool_this, &tablet_rs, status, &version, &transaction_id,
+                                                   &partition_id]() {
                     const TabletInfo& tablet_info = tablet_rs.first;
                     const RowsetSharedPtr& rowset = tablet_rs.second;
                     // if rowset is null, it means this be received write task, but failed during write
@@ -765,29 +765,35 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
                     if (rowset == nullptr) {
                         LOG(WARNING) << "Not found rowset of tablet: " << tablet_info.tablet_id << ", txn_id "
                                      << transaction_id;
-                        *st = Status::NotFound(fmt::format("Not found rowset of tablet: {}, txn_id: {}",
-                                                           tablet_info.tablet_id, transaction_id));
+                        *status = Status::NotFound(fmt::format("Not found rowset of tablet: {}, txn_id: {}",
+                                                               tablet_info.tablet_id, transaction_id));
                         return;
                     }
                     EnginePublishVersionTask engine_task(transaction_id, partition_id, version, tablet_info, rowset);
 
-                    *st = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
-                    if (!st->ok())
+                    *status = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
+                    if (status->ok())
                         LOG(WARNING) << "failed to publish version for tablet, tablet_id " << tablet_info.tablet_id
-                                     << ", txn_id " << transaction_id << ", err: " << st;
+                                     << ", txn_id " << transaction_id << ", err: " << *status;
                 });
 
-                if (st->is_service_unavailable()) {
+                if (st.ok()) {
+                    break;
+                } else if (st.is_service_unavailable()) {
                     // Status::ServiceUnavailable is returned when all of the threads of the pool are busy.
                     LOG(WARNING) << "publish version threadpool is busy, retry later. [txn_id: "
                                  << publish_version_req.transaction_id << ", tablet_id: " << tablet_rs.first.tablet_id;
                     // In general, publish version is fast. A small sleep is needed here.
                     SleepFor(MonoDelta::FromMilliseconds(50 * retry_time));
-                    continue;
                 }
-                break;
-            }
 
+                if (++retry_time < PUBLISH_VERSION_SUBMIT_MAX_RETRY) {
+                    LOG(WARNING) << "Retry of publish version on partition is beyond limit. partition: " << partition_id
+                                 << ", txn_id: " << transaction_id << ", version: " << version
+                                 << ", retry_time: " << retry_time;
+                    break;
+                }
+            }
             ++idx;
         }
         // wait until that all jobs in threadpool are done.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6500

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR fix the problem that no error tablet id is reported when the publish task submitting is failed.