### PR TITLE
[Enhance] turn on pass_through by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2392,9 +2392,7 @@ public class Coordinator {
                         }
                     }
 
-                    if (sessionVariable.isEnableExchangePassThrough()) {
-                        params.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
-                    }
+                    params.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
                 }
                 paramsList.add(params);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -222,7 +222,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
-    public static final String ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE = "enable_exchange_pass_through_expire";
 
     public static final String SINGLE_NODE_EXEC_PLAN = "single_node_exec_plan";
 
@@ -524,14 +523,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_COLUMN_EXPR_PREDICATE)
     private boolean enableColumnExprPredicate = false;
 
-    // Currently, if enable_exchange_pass_through is turned on. The performance has no improve on benchmark test,
-    // and it will cause memory statistics problem of fragment instance,
-    // It also which will introduce the problem of cross-thread memory allocate and release,
-    // So i temporarily disable the enable_exchange_pass_through.
-    // I will turn on int after all the above problems are solved.
-    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH_EXPIRE, alias = ENABLE_EXCHANGE_PASS_THROUGH,
-            show = ENABLE_EXCHANGE_PASS_THROUGH)
-    private boolean enableExchangePassThrough = false;
+    @VariableMgr.VarAttr(name = ENABLE_EXCHANGE_PASS_THROUGH, flag = VariableMgr.INVISIBLE)
+    private boolean enableExchangePassThrough = true;
 
     @VariableMgr.VarAttr(name = ALLOW_DEFAULT_PARTITION, flag = VariableMgr.INVISIBLE)
     private boolean allowDefaultPartition = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7270

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Turn on the `exchange_pass_through`, since it could reduce the network cost in network-intensive scenarios.

## Experimental result

For tpch-100 and tpcds-100: 
- Most cases has not difference
- For `tpcds_query21` has a little regression
- For network-intensive query, the pass-through show some superiority

| Query | Before | After |
| --- |  --- | --- |
| tpcds.query21 | 102 |  301 | 
| tpcds.query54 | 6882 | 2065 |
| tpch.q18 | 7495 | 3502 | 






<br class="Apple-interchange-newline">