### PR TITLE
[BugFix] only compute no empty partition when adjust partition statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -91,7 +91,7 @@ public class PredicateStatisticsCalculator {
 
             ScalarOperator firstChild = getChildForCastOperator(predicate.getChild(0));
             List<ScalarOperator> otherChildrenList =
-                    predicate.getChildren().stream().skip(1).map(this::getChildForCastOperator)
+                    predicate.getChildren().stream().skip(1).map(this::getChildForCastOperator).distinct()
                             .collect(Collectors.toList());
             // 1. compute the inPredicate children column statistics
             ColumnStatistic inColumnStatistic = getExpressionStatistic(firstChild);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -458,8 +458,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
      */
     private ColumnStatistic adjustPartitionStatistic(Collection<Long> selectedPartitionId, OlapTable olapTable) {
         int selectedPartitionsSize = selectedPartitionId.size();
-        int allPartitionsSize = olapTable.getPartitions().size();
-        if (selectedPartitionsSize != allPartitionsSize) {
+        int allNoEmptyPartitionsSize = (int) olapTable.getPartitions().stream().filter(Partition::hasData).count();
+        if (selectedPartitionsSize != allNoEmptyPartitionsSize) {
             if (olapTable.getPartitionColumnNames().size() != 1) {
                 return null;
             }
@@ -500,7 +500,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 }
                 double distinctValues =
                         partitionColumnStatistic.getDistinctValuesCount() * 1.0 * selectedPartitionsSize /
-                                allPartitionsSize;
+                                allNoEmptyPartitionsSize;
                 return buildFrom(partitionColumnStatistic).
                         setMinValue(min).setMaxValue(max).setDistinctValuesCount(max(distinctValues, 1)).build();
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
At present, we only have table-level statistics. When partition prune occurs, the statistics of the Partition column need to be adjusted to avoid subsequent estimation errors. but when there are alot of empty partitions, we should only compute no empty partitions for right ndv estimate