### PR TITLE
[BugFix][Branch-2.2] Fix invalid ref to counter in `HdfsParquetScanner`

### DIFF
--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -703,7 +703,6 @@ void HdfsScanNode::_update_status(const Status& status) {
 
 void HdfsScanNode::_init_counter() {
     _profile.runtime_profile = _runtime_profile.get();
-    _profile.pool = _pool;
 
     // inherited from scan node.
     _profile.rows_read_counter = _rows_read_counter;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -45,11 +45,8 @@ struct HdfsScanStats {
     int64_t group_dict_decode_ns = 0;
 };
 
-class HdfsParquetProfile;
-
 struct HdfsScanProfile {
     RuntimeProfile* runtime_profile = nullptr;
-    ObjectPool* pool = nullptr;
 
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* bytes_read_counter = nullptr;
@@ -65,7 +62,6 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* io_counter = nullptr;
     RuntimeProfile::Counter* column_read_timer = nullptr;
     RuntimeProfile::Counter* column_convert_timer = nullptr;
-    HdfsParquetProfile* parquet_profile = nullptr;
 };
 
 struct HdfsScannerParams {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


I just came across a buggy case, and I think it could be general cases, so I bring it out and hope it would be helpful to you.
In our object pool implementation, we release object in reversed order.
- If we allocate object in A, B, C
- then we release object in C, B, A
- And we have to make sure that, in dtor of B, we don't use C. 

----- 
But that case happens to me.   We have `HiveDataSource`, which has a object pool `pool` it allocates HdfsParquetScanner first. and in HdfsParquetScanner, it allocates HdfsParquetProfile

```
HiveDataSource (pool)
 -> pool.add(new HdfsParquetScanner()) -> scanner
   -> pool.add(new HdfsParquetProfile()) -> profile
~HdfsParquetScanner() {
  close()
 }
HdfsParquetScanner::close() {
  update_parquet_profile(profile)
}
```

In normal case, everything works fine. But when a user cancels a query(to me it's because of memory limit), it will call ~HiveDataSource, and pool will release objects in following order: 
- release profile
- release scanner (calling ~HdfsParquetScanner)

In ~HdfsParquetScanner, we try to update profile. However right now `profile` object has been released, 

----
So to summarize the problem is that:
- A has a object pool 
- A allocates two objects B, C.  And B holds C
- when ~A is called, C will be released first, and B will be released then.
- But in ~B we might use C. The bug happens.
