### PR TITLE
[BugFix][Branch-2.3] Fix invalid ref to counter in `HdfsParquetScanner`

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -177,7 +177,6 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
 
     _profile.runtime_profile = _runtime_profile;
-    _profile.pool = _pool;
     _profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
     _profile.bytes_read_counter = ADD_COUNTER(_runtime_profile, "BytesRead", TUnit::BYTES);
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -46,11 +46,8 @@ struct HdfsScanStats {
     int64_t group_dict_decode_ns = 0;
 };
 
-class HdfsParquetProfile;
-
 struct HdfsScanProfile {
     RuntimeProfile* runtime_profile = nullptr;
-    ObjectPool* pool = nullptr;
 
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* bytes_read_counter = nullptr;
@@ -67,7 +64,6 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* io_counter = nullptr;
     RuntimeProfile::Counter* column_read_timer = nullptr;
     RuntimeProfile::Counter* column_convert_timer = nullptr;
-    HdfsParquetProfile* parquet_profile = nullptr;
 };
 
 struct HdfsScannerParams {

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -7,8 +7,9 @@
 
 namespace starrocks::vectorized {
 
-class HdfsParquetProfile {
-public:
+static const std::string kParquetProfileSectionPrefix = "Parquet";
+
+void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     // read & decode
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
@@ -23,12 +24,7 @@ public:
     RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
 
-    void init(RuntimeProfile* root);
-};
-
-static const std::string kParquetProfileSectionPrefix = "Parquet";
-
-void HdfsParquetProfile::init(RuntimeProfile* root) {
+    RuntimeProfile* root = profile->runtime_profile;
     ADD_TIMER(root, kParquetProfileSectionPrefix);
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
@@ -40,30 +36,19 @@ void HdfsParquetProfile::init(RuntimeProfile* root) {
     group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
+
+    COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
+    COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
+    COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);
+    COUNTER_UPDATE(footer_read_timer, _stats.footer_read_ns);
+    COUNTER_UPDATE(column_reader_init_timer, _stats.column_reader_init_ns);
+    COUNTER_UPDATE(group_chunk_read_timer, _stats.group_chunk_read_ns);
+    COUNTER_UPDATE(group_dict_filter_timer, _stats.group_dict_filter_ns);
+    COUNTER_UPDATE(group_dict_decode_timer, _stats.group_dict_decode_ns);
 }
 
 Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
-    HdfsScanProfile* profile = scanner_params.profile;
-    // initialized once.
-    if (profile != nullptr && profile->parquet_profile == nullptr) {
-        profile->parquet_profile = profile->pool->add(new HdfsParquetProfile());
-        profile->parquet_profile->init(profile->runtime_profile);
-    }
     return Status::OK();
-}
-
-void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
-    HdfsParquetProfile* parquet_profile = profile->parquet_profile;
-    if (parquet_profile != nullptr) {
-        COUNTER_UPDATE(parquet_profile->value_decode_timer, _stats.value_decode_ns);
-        COUNTER_UPDATE(parquet_profile->level_decode_timer, _stats.level_decode_ns);
-        COUNTER_UPDATE(parquet_profile->page_read_timer, _stats.page_read_ns);
-        COUNTER_UPDATE(parquet_profile->footer_read_timer, _stats.footer_read_ns);
-        COUNTER_UPDATE(parquet_profile->column_reader_init_timer, _stats.column_reader_init_ns);
-        COUNTER_UPDATE(parquet_profile->group_chunk_read_timer, _stats.group_chunk_read_ns);
-        COUNTER_UPDATE(parquet_profile->group_dict_filter_timer, _stats.group_dict_filter_ns);
-        COUNTER_UPDATE(parquet_profile->group_dict_decode_timer, _stats.group_dict_decode_ns);
-    }
 }
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


I just came across a buggy case, and I think it could be general cases, so I bring it out and hope it would be helpful to you.
In our object pool implementation, we release object in reversed order.
- If we allocate object in A, B, C
- then we release object in C, B, A
- And we have to make sure that, in dtor of B, we don't use C. 

----- 
But that case happens to me.   We have `HiveDataSource`, which has a object pool `pool` it allocates HdfsParquetScanner first. and in HdfsParquetScanner, it allocates HdfsParquetProfile

```
HiveDataSource (pool)
 -> pool.add(new HdfsParquetScanner()) -> scanner
   -> pool.add(new HdfsParquetProfile()) -> profile
~HdfsParquetScanner() {
  close()
 }
HdfsParquetScanner::close() {
  update_parquet_profile(profile)
}
```

In normal case, everything works fine. But when a user cancels a query(to me it's because of memory limit), it will call ~HiveDataSource, and pool will release objects in following order: 
- release profile
- release scanner (calling ~HdfsParquetScanner)

In ~HdfsParquetScanner, we try to update profile. However right now `profile` object has been released, 

----
So to summarize the problem is that:
- A has a object pool 
- A allocates two objects B, C.  And B holds C
- when ~A is called, C will be released first, and B will be released then.
- But in ~B we might use C. The bug happens.
