### PR TITLE
[Cherry-pick][BugFix][Branch-2.3]: Change `enable_persistent_index` of primary table may cause be crash in ASAN mode (#7762)

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1053,7 +1053,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     // because the primary index is available in cache
                     // But it will be remove from index cache after apply is finished
                     auto manager = StorageEngine::instance()->update_manager();
-                    manager->index_cache().remove_by_key(tablet->tablet_id());
+                    manager->index_cache().try_remove_by_key(tablet->tablet_id());
                     break;
                 }
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7762

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This is caused by concurrency between apply and modify enable_persistent_index. The reference of primary index may not equal 1, so it will cause crash when call function remove in ASAN mode.
