### PR TITLE
[Refactor] remove hash predicates line from Join explain

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -438,8 +438,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         String distrModeStr =
                 (distrMode != DistributionMode.NONE) ? (" (" + distrMode.toString() + ")") : "";
         StringBuilder output = new StringBuilder().append(
-                detailPrefix + "join op: " + joinOp.toString() + distrModeStr + "\n").append(
-                detailPrefix + "hash predicates:\n");
+                detailPrefix + "join op: " + joinOp.toString() + distrModeStr + "\n");
 
         output.append(detailPrefix).append("colocate: ").append(isColocate)
                 .append(isColocate ? "" : ", reason: " + colocateReason).append("\n");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -689,7 +689,6 @@ public class AggregateTest extends PlanTestBase {
         explainString = getFragmentPlan(queryStr);
         Assert.assertTrue(explainString.contains("13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: k3 <=> 17: k3"));
     }
@@ -861,7 +860,6 @@ public class AggregateTest extends PlanTestBase {
                     "  |  \n" +
                     "  3:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 4: v4");
         }
@@ -879,7 +877,6 @@ public class AggregateTest extends PlanTestBase {
                     "  |  \n" +
                     "  3:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 4: v4");
         }
@@ -902,7 +899,6 @@ public class AggregateTest extends PlanTestBase {
                     "  |  \n" +
                     "  2:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (COLOCATE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: true\n" +
                     "  |  equal join conjunct: 1: v1 = 4: v4");
         }
@@ -920,7 +916,6 @@ public class AggregateTest extends PlanTestBase {
                     "  |  \n" +
                     "  3:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v4 = 4: v1");
         }
@@ -948,7 +943,6 @@ public class AggregateTest extends PlanTestBase {
                 "  |  \n" +
                 "  5:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----4:EXCHANGE\n" +
@@ -1239,7 +1233,6 @@ public class AggregateTest extends PlanTestBase {
                 "    RANDOM");
         assertContains(plan, "  18:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n");
         assertContains(plan, "  3:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
@@ -1384,7 +1377,6 @@ public class AggregateTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, " 13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 15: t1a <=> 13: t1a");
 
@@ -1392,7 +1384,6 @@ public class AggregateTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 13: t1a <=> 16: t1a\n" +
                 "  |  equal join conjunct: 14: t1b <=> 17: t1b\n" +
@@ -1402,12 +1393,10 @@ public class AggregateTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 20: t1c <=> 15: t1c");
         assertContains(plan, "21:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 15: t1c <=> 17: t1c");
 
@@ -1419,7 +1408,6 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 11> : CAST(2: t1b AS INT) + 1");
         assertContains(plan, "22:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: t1c <=> 19: t1c\n" +
                 "  |  equal join conjunct: 17: expr <=> 20: expr");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1360,7 +1360,7 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testMultiDistinctAggregate() throws Exception {
         connectContext.getSessionVariable().setCboCteReuse(true);
-        String sql =  "select count(distinct t1b), count(distinct t1b, t1c) from test_all_type";
+        String sql = "select count(distinct t1b), count(distinct t1b, t1c) from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "MultiCastDataSinks\n" +
                 "  STREAM DATA SINK\n" +
@@ -1369,18 +1369,18 @@ public class AggregateTest extends PlanTestBase {
                 "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 09\n" +
                 "    RANDOM");
-        assertContains(plan, "18:CROSS JOIN\n" +
-                "  |  cross join:\n" +
-                "  |  predicates is NULL.");
+        assertContains(plan, "  18:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n");
 
-        sql =  "select count(distinct t1b) as cn_t1b, count(distinct t1b, t1c) cn_t1b_t1c from test_all_type group by t1a";
+        sql = "select count(distinct t1b) as cn_t1b, count(distinct t1b, t1c) cn_t1b_t1c from test_all_type group by t1a";
         plan = getFragmentPlan(sql);
         assertContains(plan, " 13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 15: t1a <=> 13: t1a");
 
-        sql =  "select count(distinct t1b) as cn_t1b, count(distinct t1b, t1c) cn_t1b_t1c from test_all_type group by t1a,t1b,t1c";
+        sql = "select count(distinct t1b) as cn_t1b, count(distinct t1b, t1c) cn_t1b_t1c from test_all_type group by t1a,t1b,t1c";
         plan = getFragmentPlan(sql);
         assertContains(plan, "13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
@@ -1508,8 +1508,9 @@ public class AggregateTest extends PlanTestBase {
         String sql = "select avg(distinct s_suppkey), count(distinct s_acctbal) " +
                 "from supplier having avg(distinct s_suppkey) > 3 ;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  16:CROSS JOIN\n" +
-                "  |  cross join:\n" +
-                "  |  predicates: CAST(12: sum AS DOUBLE) / CAST(14: count AS DOUBLE) > 3.0");
+        assertContains(plan, "  16:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  other predicates: CAST(12: sum AS DOUBLE) / CAST(14: count AS DOUBLE) > 3.0\n");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1495,15 +1495,6 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
-    public void testAvgCountDistinctWithMultiColumns() throws Exception {
-        // expectedException.expect(StarRocksPlannerException.class);
-        // expectedException.expectMessage(
-        // "The query contains multi count distinct or sum distinct, each can't have multi columns");
-        String sql = "select avg(distinct s_suppkey), count(distinct s_acctbal,s_nationkey) from supplier;";
-        getFragmentPlan(sql);
-    }
-
-    @Test
     public void testAvgCountDistinctWithHaving() throws Exception {
         String sql = "select avg(distinct s_suppkey), count(distinct s_acctbal) " +
                 "from supplier having avg(distinct s_suppkey) > 3 ;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1496,9 +1496,9 @@ public class AggregateTest extends PlanTestBase {
 
     @Test
     public void testAvgCountDistinctWithMultiColumns() throws Exception {
-        expectedException.expect(StarRocksPlannerException.class);
-        expectedException.expectMessage(
-                "The query contains multi count distinct or sum distinct, each can't have multi columns");
+        // expectedException.expect(StarRocksPlannerException.class);
+        // expectedException.expectMessage(
+        // "The query contains multi count distinct or sum distinct, each can't have multi columns");
         String sql = "select avg(distinct s_suppkey), count(distinct s_acctbal,s_nationkey) from supplier;";
         getFragmentPlan(sql);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -91,7 +91,6 @@ public class CTEPlanTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 7: v4 = 10: v1"));
         Assert.assertFalse(plan.contains("MultiCastDataSinks"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -484,7 +484,6 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  7:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----6:EXCHANGE\n");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -112,7 +112,6 @@ public class ExternalTableTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: order_no = 8: t1a\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -543,17 +543,14 @@ public class InsertPlanTest extends PlanTestBase {
         String plan = getInsertExecPlan(sql);
         Assert.assertTrue(plan.contains("  11:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (COLOCATE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: true\n" +
                 "  |  equal join conjunct: 1: distinct_id = 49: distinct_id"));
         Assert.assertTrue(plan.contains("  7:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (COLOCATE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: true\n" +
                 "  |  equal join conjunct: 1: distinct_id = 45: distinct_id"));
         Assert.assertTrue(plan.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (COLOCATE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: true\n" +
                 "  |  equal join conjunct: 1: distinct_id = 41: distinct_id"));
         FeConstants.runningUnitTest = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -98,7 +98,6 @@ public class JoinTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment, planFragment.contains("  3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----2:EXCHANGE\n"));
@@ -109,7 +108,6 @@ public class JoinTest extends PlanTestBase {
         Assert.assertTrue(planFragment,
                 planFragment.contains("  3:NESTLOOP JOIN\n" +
                         "  |  join op: CROSS JOIN\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  \n" +
                         "  |----2:EXCHANGE\n" +
@@ -382,7 +380,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  2:HASH JOIN\n"
                 + "  |  join op: INNER JOIN (COLOCATE)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: true\n"
                 + "  |  equal join conjunct: 1: v1 = 4: v1");
         FeConstants.runningUnitTest = false;
@@ -511,7 +508,6 @@ public class JoinTest extends PlanTestBase {
                 "  |  \n" +
                 "  4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v4 = 7: v10\n" +
                 "  |  equal join conjunct: 5: v5 = 7: v10\n" +
@@ -601,19 +597,16 @@ public class JoinTest extends PlanTestBase {
         String sql = "select * from t0 as x0 inner join t0 as x1 on x0.v1 = x1.v1;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (COLOCATE)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: true");
 
         sql = "select * from t0 as x0 inner join[shuffle] t0 as x1 on x0.v1 = x1.v1;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: ");
 
         sql = "select * from t0 as x0 inner join[colocate] t0 as x1 on x0.v1 = x1.v1;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (COLOCATE)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: true");
         FeConstants.runningUnitTest = false;
     }
@@ -624,19 +617,16 @@ public class JoinTest extends PlanTestBase {
         String sql = "select * from t0 as x0 inner join t1 as x1 on x0.v1 = x1.v4;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: ");
 
         sql = "select * from t0 as x0 inner join[shuffle] t1 as x1 on x0.v1 = x1.v4;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: ");
 
         sql = "select * from t0 as x0 inner join[bucket] t1 as x1 on x0.v1 = x1.v4;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: ");
         FeConstants.runningUnitTest = false;
     }
@@ -656,7 +646,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n");
     }
 
@@ -680,7 +669,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "12:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: v2 = 24: v1");
     }
@@ -738,7 +726,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: 1: v1 != 4: v4, 2: v2 != 5: v5\n");
     }
@@ -749,7 +736,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  other join predicates: 2: v2 != 5: v5");
@@ -773,7 +759,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, " 8:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 1: v1 = 7: v7");
@@ -789,13 +774,11 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "12:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 7: v7 = 10: v10\n" +
                 "  |  equal join conjunct: 8: v8 = 11: v11");
         assertContains(plan, "8:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 1: v1 = 7: v7");
@@ -811,7 +794,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, " 8:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 1: v1 = 7: v7");
@@ -827,7 +809,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "12:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 10: v10\n" +
                 "  |  equal join conjunct: 2: v2 = 11: v11");
@@ -849,7 +830,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "8:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 3: v3 = 6: v6\n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
@@ -868,7 +848,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "12:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 1: v1 = 7: v7");
@@ -893,13 +872,11 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "14:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 4: v4 = 8: v8");
         assertContains(plan, " 11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 7: v7 = 10: v10\n" +
                 "  |  equal join conjunct: 8: v8 = 11: v11");
@@ -918,13 +895,11 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "14:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                 "  |  equal join conjunct: 4: v4 = 10: v10");
         assertContains(plan, "11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 7: v7 = 10: v10\n" +
                 "  |  equal join conjunct: 8: v8 = 11: v11");
@@ -945,7 +920,6 @@ public class JoinTest extends PlanTestBase {
                 "AND CASE WHEN NULL THEN t0.v1 ELSE '' END = CASE WHEN true THEN 'fGrak3iTt' WHEN false THEN t3.v10 ELSE 'asf' END";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  join op: RIGHT SEMI JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v1");
     }
@@ -958,7 +932,6 @@ public class JoinTest extends PlanTestBase {
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
         assertContains(plan, "11:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: 1: v1 + 10: v10 = 2\n");
     }
@@ -982,7 +955,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "3:HASH JOIN\n" +
                 "  |  join op: FULL OUTER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  \n" +
@@ -1069,7 +1041,6 @@ public class JoinTest extends PlanTestBase {
         String explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id"));
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
@@ -1359,7 +1330,6 @@ public class JoinTest extends PlanTestBase {
                 "where join2.id > 1;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1376,7 +1346,6 @@ public class JoinTest extends PlanTestBase {
                 "where join2.id > 1 or join2.id < 10 ;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  1:OlapScanNode\n" +
@@ -1390,7 +1359,6 @@ public class JoinTest extends PlanTestBase {
         //        getFragmentPlan(sql);
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id\n" +
                 "  |  other predicates: (5: id > 1) OR (5: id IS NULL)");
@@ -1400,7 +1368,6 @@ public class JoinTest extends PlanTestBase {
                 "where b.id > 1;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1417,7 +1384,6 @@ public class JoinTest extends PlanTestBase {
                 "where b.id > 1;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1434,7 +1400,6 @@ public class JoinTest extends PlanTestBase {
                 "where join2.id is null;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id\n" +
                 "  |  other predicates: 5: id IS NULL");
@@ -1444,7 +1409,6 @@ public class JoinTest extends PlanTestBase {
                 "group by join2.id having join2.id > 1;";
         starRocksAssert.query(sql).explainContains("  4:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1465,7 +1429,6 @@ public class JoinTest extends PlanTestBase {
                         "  |  having: 7: count > 1",
                 "  3:HASH JOIN\n" +
                         "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id");
 
@@ -1474,7 +1437,6 @@ public class JoinTest extends PlanTestBase {
                 "where join1.id > 1;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1490,7 +1452,6 @@ public class JoinTest extends PlanTestBase {
         sql = "select * from join1 full outer join join2 on join1.id = join2.id\n" +
                 "where join1.id > 1;";
         starRocksAssert.query(sql).explainContains("  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1506,7 +1467,6 @@ public class JoinTest extends PlanTestBase {
                 "where join1.id > 1;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id\n" +
                         "  |  other join predicates: 1: dt != 2",
@@ -1524,7 +1484,6 @@ public class JoinTest extends PlanTestBase {
                 "where join2.id > 1;";
         starRocksAssert.query(sql).explainContains("  4:HASH JOIN\n" +
                         "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  2:OlapScanNode\n" +
@@ -1541,7 +1500,6 @@ public class JoinTest extends PlanTestBase {
                 "where join2.id > 1 and join1.id > 10;";
         starRocksAssert.query(sql).explainContains("  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  0:OlapScanNode\n" +
@@ -1560,12 +1518,10 @@ public class JoinTest extends PlanTestBase {
 
         starRocksAssert.query(sql).explainContains("7:HASH JOIN\n" +
                         "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 8: id",
                 "4:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 5: id = 2: id",
                 "0:OlapScanNode\n" +
@@ -1582,12 +1538,10 @@ public class JoinTest extends PlanTestBase {
                 "where b.dt > 1 and c.dt > 1;";
         starRocksAssert.query(sql).explainContains("6:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 8: id",
                 "  3:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
-                        "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
                 "  4:OlapScanNode\n" +
@@ -1634,7 +1588,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "4:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: id = 2: id");
         assertContains(plan, "  2:EMPTYSET\n");
@@ -1650,12 +1603,10 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  9:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 9: k3 = 4: dt");
         assertContains(plan, "  6:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: id = 2: id\n" +
                 "  |  other join predicates: 4: dt = 1");
@@ -1669,12 +1620,10 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  9:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 9: k3 = 4: dt");
         assertContains(plan, "  6:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: id = 2: id");
     }
@@ -1687,7 +1636,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  6:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 8: expr = 11: expr");
         assertContains(plan, "  4:Project\n" +
@@ -1742,7 +1690,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id\n" +
                 "  |  other join predicates: 2: id > 1"));
@@ -1860,7 +1807,6 @@ public class JoinTest extends PlanTestBase {
                 "     PREDICATES: 5: id > 1"));
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id"));
 
@@ -1871,7 +1817,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id"));
         Assert.assertTrue(explainString.contains("  1:OlapScanNode\n" +
@@ -1886,7 +1831,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id\n" +
                 "  |  other join predicates: 2: id > 1"));
@@ -1898,7 +1842,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id"));
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
@@ -1914,7 +1857,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  4:HASH JOIN\n" +
                 "  |  join op: RIGHT ANTI JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: id = 2: id"));
         Assert.assertTrue(explainString.contains("  2:OlapScanNode\n" +
@@ -1930,7 +1872,6 @@ public class JoinTest extends PlanTestBase {
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: id = 5: id"));
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
@@ -2015,7 +1956,6 @@ public class JoinTest extends PlanTestBase {
                 "  |  \n" +
                 "  9:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v4 = 10: cast");
     }
@@ -2140,7 +2080,6 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, " 5:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: t1a = 21: cast\n" +
                 "  |  equal join conjunct: 22: cast = 11: t1a");
@@ -2232,7 +2171,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 ) s1 join[shuffle] t2 on s1.v5 = t2.v8";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
                     "  |  \n" +
@@ -2240,7 +2178,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  4:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 5: v5");
         }
@@ -2250,7 +2187,6 @@ public class JoinTest extends PlanTestBase {
                             "join[shuffle] t2 on s1.v2 = t2.v8 and s1.v6 = t2.v9";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 8: v8\n" +
                     "  |  equal join conjunct: 6: v6 = 9: v9\n" +
@@ -2259,7 +2195,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  4:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 5: v5\n" +
                     "  |  equal join conjunct: 3: v3 = 6: v6");
@@ -2270,7 +2205,6 @@ public class JoinTest extends PlanTestBase {
                             "join[shuffle] t2 on s1.v5 = t2.v8 and s1.v3 = t2.v9";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
                     "  |  equal join conjunct: 3: v3 = 9: v9\n" +
@@ -2279,7 +2213,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  4:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 5: v5\n" +
                     "  |  equal join conjunct: 3: v3 = 6: v6");
@@ -2290,7 +2223,6 @@ public class JoinTest extends PlanTestBase {
                             "join[shuffle] t2 on s1.v5 = t2.v8 and s1.v6 = t2.v9";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
                     "  |  equal join conjunct: 6: v6 = 9: v9\n" +
@@ -2299,7 +2231,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  4:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 5: v5\n" +
                     "  |  equal join conjunct: 3: v3 = 6: v6");
@@ -2312,7 +2243,6 @@ public class JoinTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 6: v6 = 9: v9\n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
@@ -2321,7 +2251,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  4:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 5: v5\n" +
                     "  |  equal join conjunct: 3: v3 = 6: v6\n" +
@@ -2350,7 +2279,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select * from t0 join[bucket] t1 on t0.v1 = t1.v4 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2360,7 +2288,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select * from t0 join[bucket] t1 on t1.v4 = t0.v1 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2370,7 +2297,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select t1.v4 from t0 join[bucket] t1 on t0.v1 = t1.v4 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2383,7 +2309,6 @@ public class JoinTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  9:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 10: v10");
         }
@@ -2395,7 +2320,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t3 on t2.v7 = t3.v10";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 7: v7 = 10: v10");
         }
@@ -2408,7 +2332,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t4 on t3.v10 = t4.v13";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 10: v10 = 13: v13");
         }
@@ -2424,7 +2347,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t2 on s1.v1 = t2.v7 and s1.v5 = t2.v8";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 7: v7\n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8");
@@ -2435,7 +2357,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t2 on s1.v4 = t2.v7 and s1.v2 = t2.v8";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7\n" +
                     "  |  equal join conjunct: 2: v2 = 8: v8");
@@ -2446,7 +2367,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t2 on s1.v4 = t2.v7 and s1.v5 = t2.v8";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7\n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8");
@@ -2463,7 +2383,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] colocate_t2 on s1.v4 = colocate_t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2475,7 +2394,6 @@ public class JoinTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 10: v10");
         }
@@ -2486,7 +2404,6 @@ public class JoinTest extends PlanTestBase {
                             "join [colocate] colocate_t3 on s1.v7 = colocate_t3.v10";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v7 = 7: v10\n" +
                     "  |  \n" +
@@ -2494,7 +2411,6 @@ public class JoinTest extends PlanTestBase {
                     "  |    \n" +
                     "  3:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 4: v7");
         }
@@ -2509,7 +2425,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select * from t0 left join[bucket] t1 on t0.v1 = t1.v4 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2518,7 +2433,6 @@ public class JoinTest extends PlanTestBase {
                     "select * from ( select * from t0 right join[bucket] t1 on t0.v1 = t1.v4 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2534,7 +2448,6 @@ public class JoinTest extends PlanTestBase {
                             "join[bucket] t2 on s1.v5 = t2.v8";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                    "  |  hash predicates:\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
                     "  |  \n" +
@@ -2628,7 +2541,6 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  7:HASH JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 7: v4\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -73,7 +73,6 @@ public class LimitTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v4 = 2: v2\n" +
                 "  |  limit: 2"));
@@ -297,7 +296,6 @@ public class LimitTest extends PlanTestBase {
         sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 limit 10";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: INNER JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 1: v1 = 4: v4\n"
                 + "  |  limit: 10\n"
@@ -310,7 +308,6 @@ public class LimitTest extends PlanTestBase {
         sql = "select * from t0 left anti join t1 on t0.v1 = t1.v4 limit 10";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: LEFT ANTI JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 1: v1 = 4: v4\n"
                 + "  |  limit: 10\n"
@@ -323,7 +320,6 @@ public class LimitTest extends PlanTestBase {
         sql = "select * from t0 right semi join t1 on t0.v1 = t1.v4 limit 10";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: LEFT SEMI JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 4: v4 = 1: v1\n"
                 + "  |  limit: 10\n"
@@ -339,7 +335,6 @@ public class LimitTest extends PlanTestBase {
         String sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 limit 10";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  limit: 10\n" +
@@ -367,7 +362,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  4:HASH JOIN\n"
                 + "  |  join op: FULL OUTER JOIN (PARTITIONED)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 1: v1 = 4: v4\n"
                 + "  |  limit: 10\n"
@@ -382,7 +376,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  limit: 10\n" +
                 "  |  \n" +
@@ -434,7 +427,6 @@ public class LimitTest extends PlanTestBase {
         String sql = "select v1 from t0 right outer join t1 on t0.v1 = t1.v4 limit 100";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  limit: 100"));
@@ -452,7 +444,6 @@ public class LimitTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains(" 5:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  \n" +
@@ -465,7 +456,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  limit: 1\n" +
@@ -489,7 +479,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "5:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  limit: 100\n" +
@@ -514,7 +503,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("5:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v4 = 1: v1\n" +
                 "  |  limit: 7\n" +
@@ -542,7 +530,6 @@ public class LimitTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("  3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: 2: v2 != 5: v5\n" +
                 "  |  limit: 10\n" +
@@ -555,7 +542,6 @@ public class LimitTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: 2: v2 != 5: v5\n" +
                 "  |  limit: 10\n" +
@@ -585,7 +571,6 @@ public class LimitTest extends PlanTestBase {
         String sql = "select * from t0 left join[shuffle] t1 on t0.v2 = t1.v5 where t1.v6 is null limit 2";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: v2 = 5: v5\n" +
                 "  |  other predicates: 6: v6 IS NULL\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -39,7 +39,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment, planFragment.contains("4:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE"));
@@ -70,7 +69,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     TABLE: t2"));
         Assert.assertTrue(planFragment.contains("  9:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n" +
                 "  |  \n" +
@@ -137,7 +135,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  25:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: v10 = 13: v4\n" +
                 "  |  \n" +
@@ -147,7 +144,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     TABLE: t3"));
         Assert.assertTrue(planFragment.contains("  11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n" +
                 "  |  \n" +
@@ -170,7 +166,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Top join tree
         Assert.assertTrue(planFragment.contains("  21:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v10 = 11: v4\n" +
                 "  |  \n" +
@@ -190,7 +185,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Left sub join tree (b)
         Assert.assertTrue(planFragment.contains("  19:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 12: v5 = 10: count\n" +
                 "  |  \n" +
@@ -210,7 +204,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Right sub join tree (a)
         Assert.assertTrue(planFragment, planFragment.contains("  16:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----15:EXCHANGE\n" +
@@ -233,12 +226,10 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "on t1.v5 = a.v8 ";
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 10: v4 = 13: v10\n"));
 
         Assert.assertTrue(planFragment.contains("  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n"));
     }
@@ -250,7 +241,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment, planFragment.contains("4:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE"));
@@ -282,7 +272,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     TABLE: t2"));
         Assert.assertTrue(planFragment.contains("  9:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n" +
                 "  |  \n" +
@@ -350,7 +339,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  25:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: v10 = 13: v4\n" +
                 "  |  \n" +
@@ -360,7 +348,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     TABLE: t3"));
         Assert.assertTrue(planFragment.contains("  11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n" +
                 "  |  \n" +
@@ -383,7 +370,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Top join tree
         Assert.assertTrue(planFragment.contains("  25:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v10 = 11: v4\n" +
                 "  |  \n" +
@@ -403,7 +389,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Left sub join tree (b)
         Assert.assertTrue(planFragment, planFragment.contains("  23:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 10: count = 12: v5\n" +
                 "  |  \n" +
@@ -414,7 +399,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |  \n" +
                 "  19:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----18:EXCHANGE\n" +
@@ -440,7 +424,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |  \n" +
                 "  16:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----15:EXCHANGE\n" +
@@ -463,12 +446,10 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "on t1.v5 = a.v8 ";
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 13: v10 = 10: v4\n"));
 
         Assert.assertTrue(planFragment.contains("  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v10 = 1: v4\n"));
     }
@@ -482,7 +463,6 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |  \n" +
                 "  7:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n"));
 
         sql = "select * from (select v1, 2 as v, 3 from t0 inner join t1 on v2 = v4) t,t2;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -26,7 +26,6 @@ public class NestLoopJoinTest extends PlanTestBase {
         System.err.println(planFragment);
         Assert.assertTrue(planFragment, planFragment.contains(" 3:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 3: v3 = 6: v3\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -340,7 +340,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  4:HASH JOIN\n"
                 + "  |  join op: INNER JOIN (PARTITIONED)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 2: v2 = 7: t1d\n"
                 + "  |  \n"
@@ -366,7 +365,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  3:HASH JOIN\n"
                 + "  |  join op: INNER JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 2: v2 = 7: t1d\n"
                 + "  |  \n"
@@ -385,7 +383,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  3:HASH JOIN\n"
                 + "  |  join op: INNER JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 7: t1d = 1: v1\n"
                 + "  |  \n"
@@ -497,12 +494,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  11:HASH JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN (REPLICATED)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: PS_PARTKEY = 20: P_PARTKEY"));
         Assert.assertTrue(plan.contains("  14:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 32: L_PARTKEY = 14: PS_PARTKEY\n" +
                 "  |  equal join conjunct: 33: L_SUPPKEY = 15: PS_SUPPKEY\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -300,7 +300,6 @@ public class ReplayFromDumpTest {
                 getPlanFragment(getDumpInfoFromFile("query_dump/cross_reorder"), null, TExplainLevel.NORMAL);
         Assert.assertTrue(replayPair.second, replayPair.second.contains("14:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: (2: v2 = CAST(8: v2 AS VARCHAR(1048576))) OR (3: v3 = 8: v2)\n"));
     }
@@ -395,7 +394,6 @@ public class ReplayFromDumpTest {
                 "  |  \n" +
                 "  17:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----16:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -100,7 +100,6 @@ public class SelectConstTest extends PlanTestBase {
                 "  |  \n" +
                 "  4:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE\n" +
@@ -115,7 +114,6 @@ public class SelectConstTest extends PlanTestBase {
                 "  |  \n" +
                 "  4:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -63,7 +63,6 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  \n" +
                 "  14:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----13:EXCHANGE\n" +
@@ -71,7 +70,6 @@ public class SubqueryTest extends PlanTestBase {
                 "  1:AGGREGATE (update finalize)");
         assertContains(plan, "  11:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----10:EXCHANGE\n" +
@@ -131,13 +129,11 @@ public class SubqueryTest extends PlanTestBase {
 
         Assert.assertTrue(explainString.contains("  5:HASH JOIN\n" +
                 "  |  join op: RIGHT ANTI JOIN (COLOCATE)\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: true\n" +
                 "  |  equal join conjunct: 9: id = 2: id\n" +
                 "  |  other join predicates: 1: dt = 2"));
         Assert.assertTrue(explainString.contains("  |    3:HASH JOIN\n" +
                 "  |    |  join op: LEFT ANTI JOIN (COLOCATE)\n" +
-                "  |    |  hash predicates:\n" +
                 "  |    |  colocate: true\n" +
                 "  |    |  equal join conjunct: 2: id = 5: id\n" +
                 "  |    |  other join predicates: 1: dt = 1"));
@@ -262,7 +258,6 @@ public class SubqueryTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  30:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: v1 = 1: v1\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
@@ -43,7 +43,6 @@ UNPARTITIONED
 |
 4:HASH JOIN
 |  join op: RIGHT SEMI JOIN (PARTITIONED)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: v2 = 5: v5
 |

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -29,7 +29,6 @@ UNPARTITIONED
 |
 5:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: v2 = 5: v11
 |
@@ -122,7 +121,6 @@ UNPARTITIONED
 |
 6:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 3: v3 = 6: v12
 |  other join predicates: 2: v2 < 7: sum
@@ -232,7 +230,6 @@ UNPARTITIONED
 |
 8:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 3: v3 = 6: v12
 |  equal join conjunct: 11: abs = 10: abs

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q10.sql
@@ -69,7 +69,6 @@ UNPARTITIONED
 |
 13:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 4: C_NATIONKEY = 37: N_NATIONKEY
 |
@@ -88,7 +87,6 @@ UNPARTITIONED
 |
 9:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 1: C_CUSTKEY = 11: O_CUSTKEY
 |
@@ -139,7 +137,6 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 11: O_CUSTKEY
 |
 6:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q11.sql
@@ -53,7 +53,6 @@ UNPARTITIONED
 |
 26:NESTLOOP JOIN
 |  join op: CROSS JOIN
-|  hash predicates:
 |  colocate: false, reason:
 |  other predicates: 21: sum > 43: expr
 |
@@ -69,7 +68,6 @@ UNPARTITIONED
 |
 8:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: PS_SUPPKEY = 7: S_SUPPKEY
 |
@@ -120,7 +118,6 @@ UNPARTITIONED
 |
 19:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 23: PS_SUPPKEY = 28: S_SUPPKEY
 |
@@ -150,7 +147,6 @@ UNPARTITIONED
 |
 16:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 31: S_NATIONKEY = 36: N_NATIONKEY
 |
@@ -203,7 +199,6 @@ UNPARTITIONED
 |
 5:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 10: S_NATIONKEY = 15: N_NATIONKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q12.sql
@@ -74,7 +74,6 @@ HASH_PARTITIONED: 25: L_SHIPMODE
 |
 4:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 1: O_ORDERKEY = 11: L_ORDERKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q13.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q13.sql
@@ -82,7 +82,6 @@ HASH_PARTITIONED: 1: C_CUSTKEY
 |
 5:HASH JOIN
 |  join op: RIGHT OUTER JOIN (PARTITIONED)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
@@ -49,7 +49,6 @@ UNPARTITIONED
 |
 4:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 18: P_PARTKEY = 2: L_PARTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q16.sql
@@ -79,7 +79,6 @@ HASH_PARTITIONED: 10: P_BRAND, 11: P_TYPE, 12: P_SIZE
 |
 8:HASH JOIN
 |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: PS_SUPPKEY = 17: S_SUPPKEY
 |
@@ -93,7 +92,6 @@ HASH_PARTITIONED: 10: P_BRAND, 11: P_TYPE, 12: P_SIZE
 |
 3:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 1: PS_PARTKEY = 7: P_PARTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q17.sql
@@ -49,7 +49,6 @@ UNPARTITIONED
 |
 11:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: L_PARTKEY = 18: P_PARTKEY
 |  other join predicates: 5: L_QUANTITY < 0.2 * 45: avg
@@ -81,7 +80,6 @@ UNPARTITIONED
 |
 8:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE(S))
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 29: L_PARTKEY = 18: P_PARTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q18.sql
@@ -68,7 +68,6 @@ UNPARTITIONED
 |
 13:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
 |
@@ -83,7 +82,6 @@ UNPARTITIONED
 |
 9:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
 |
@@ -133,7 +131,6 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
 |
 6:HASH JOIN
 |  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 10: O_ORDERKEY = 37: L_ORDERKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q19.sql
@@ -64,7 +64,6 @@ UNPARTITIONED
 |
 5:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 2: L_PARTKEY = 18: P_PARTKEY
 |  other join predicates: (((((21: P_BRAND = 'Brand#45') AND (24: P_CONTAINER IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))) AND ((5: L_QUANTITY >= 5.0) AND (5: L_QUANTITY <= 15.0))) AND (23: P_SIZE <= 5)) OR ((((21: P_BRAND = 'Brand#11') AND (24: P_CONTAINER IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'))) AND ((5: L_QUANTITY >= 15.0) AND (5: L_QUANTITY <= 25.0))) AND (23: P_SIZE <= 10))) OR ((((21: P_BRAND = 'Brand#21') AND (24: P_CONTAINER IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))) AND ((5: L_QUANTITY >= 25.0) AND (5: L_QUANTITY <= 35.0))) AND (23: P_SIZE <= 15))

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
@@ -80,7 +80,6 @@ HASH_PARTITIONED: 2: S_NAME
 |
 22:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 26: O_ORDERKEY = 9: L_ORDERKEY
 |
@@ -115,7 +114,6 @@ UNPARTITIONED
 |
 19:HASH JOIN
 |  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 41: L_ORDERKEY = 9: L_ORDERKEY
 |  other join predicates: 43: L_SUPPKEY != 11: L_SUPPKEY
@@ -148,7 +146,6 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
 |
 16:HASH JOIN
 |  join op: RIGHT ANTI JOIN (COLOCATE)
-|  hash predicates:
 |  colocate: true
 |  equal join conjunct: 59: L_ORDERKEY = 9: L_ORDERKEY
 |  other join predicates: 61: L_SUPPKEY != 11: L_SUPPKEY
@@ -160,7 +157,6 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
 |    |
 |    14:HASH JOIN
 |    |  join op: INNER JOIN (BROADCAST)
-|    |  hash predicates:
 |    |  colocate: false, reason:
 |    |  equal join conjunct: 11: L_SUPPKEY = 1: S_SUPPKEY
 |    |
@@ -212,7 +208,6 @@ UNPARTITIONED
 |
 11:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 4: S_NATIONKEY = 36: N_NATIONKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q22.sql
@@ -67,7 +67,6 @@ UNPARTITIONED
 |
 12:NESTLOOP JOIN
 |  join op: CROSS JOIN
-|  hash predicates:
 |  colocate: false, reason:
 |  other predicates: 6: C_ACCTBAL > 19: avg
 |
@@ -93,7 +92,6 @@ UNPARTITIONED
 |
 9:HASH JOIN
 |  join op: RIGHT ANTI JOIN (PARTITIONED)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 22: O_CUSTKEY = 1: C_CUSTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q4.sql
@@ -65,7 +65,6 @@ HASH_PARTITIONED: 6: O_ORDERPRIORITY
 |
 5:HASH JOIN
 |  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 11: L_ORDERKEY = 1: O_ORDERKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q8.sql
@@ -90,7 +90,6 @@ HASH_PARTITIONED: 69: year
 |
 29:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 14: S_NATIONKEY = 60: N_NATIONKEY
 |
@@ -104,7 +103,6 @@ HASH_PARTITIONED: 69: year
 |
 25:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 21: L_SUPPKEY = 11: S_SUPPKEY
 |
@@ -118,7 +116,6 @@ HASH_PARTITIONED: 69: year
 |
 21:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 37: O_CUSTKEY = 46: C_CUSTKEY
 |
@@ -133,7 +130,6 @@ HASH_PARTITIONED: 69: year
 |
 8:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 36: O_ORDERKEY = 19: L_ORDERKEY
 |
@@ -202,7 +198,6 @@ UNPARTITIONED
 |
 18:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 49: C_NATIONKEY = 55: N_NATIONKEY
 |
@@ -232,7 +227,6 @@ UNPARTITIONED
 |
 15:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 57: N_REGIONKEY = 65: R_REGIONKEY
 |
@@ -288,7 +282,6 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 19: L_ORDERKEY
 |
 5:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_PARTKEY = 1: P_PARTKEY
 |

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q9.sql
@@ -78,7 +78,6 @@ HASH_PARTITIONED: 53: N_NAME, 57: year
 |
 21:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 21: L_SUPPKEY = 11: S_SUPPKEY
 |
@@ -94,7 +93,6 @@ HASH_PARTITIONED: 53: N_NAME, 57: year
 |
 13:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 21: L_SUPPKEY = 37: PS_SUPPKEY
 |  equal join conjunct: 20: L_PARTKEY = 36: PS_PARTKEY
@@ -117,7 +115,6 @@ UNPARTITIONED
 |
 18:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 14: S_NATIONKEY = 52: N_NATIONKEY
 |
@@ -190,7 +187,6 @@ HASH_PARTITIONED: 21: L_SUPPKEY, 20: L_PARTKEY
 |
 8:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 19: L_ORDERKEY = 42: O_ORDERKEY
 |
@@ -206,7 +202,6 @@ HASH_PARTITIONED: 21: L_SUPPKEY, 20: L_PARTKEY
 |
 4:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_PARTKEY = 1: P_PARTKEY
 |


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Remove the useless `hash predicates` from Join's explain, which becomes:

```sql
HASH JOIN
  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)
  |  equal join conjunct: [1: PS_PARTKEY, INT, false] = [7: P_PARTKEY, INT, true]
  |  other predicates: 7: P_PARTKEY IS NULL
  |  output columns: 1, 2
  |  cardinality: 8000000
```


