### PR TITLE
[BugFix] fix unstable UT testRollbackExceptionOnSetupCluster

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -325,6 +325,8 @@ public class BDBEnvironmentTest {
             Assert.assertEquals(DB_INDEX_OLD, followerEnvironment.getDatabaseNames().get(0));
         }
 
+        // set retry times = 1 to ensure no recovery
+        BDBEnvironment.RETRY_TIME = 1;
         // start master will get rollback exception
         BDBEnvironment maserEnvironment = new BDBEnvironment(
                 masterPath,


### PR DESCRIPTION
This UT is meant to simulate the case where a newer FE has way too many new logs than the remaining ones, yet after retries several times, there were small chances to recover.
Set retry times to 1 to prevent recovery after retry.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
