### PR TITLE
Make complex set var use old parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SetPassVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SetPassVar.java
@@ -53,6 +53,11 @@ public class SetPassVar extends SetVar {
     }
 
     @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        analyze();
+    }
+
+    @Override
     public void analyze() {
         boolean isSelf = false;
         ConnectContext ctx = ConnectContext.get();

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SetStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SetStmt.java
@@ -48,6 +48,7 @@ public class SetStmt extends StatementBase {
 
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
+        analyze();
     }
 
     public void analyze()  {
@@ -96,7 +97,10 @@ public class SetStmt extends StatementBase {
 
     @Override
     public boolean isSupportNewPlanner() {
-        return true;
+        return setVars.stream().noneMatch(var -> var instanceof SetNamesVar ||
+                var instanceof SetPassVar ||
+                var instanceof SetTransaction ||
+                var instanceof SetUserPropertyVar);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1734,7 +1734,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         if (ctx.varType() != null) {
             return new SetVar(getVariableType(ctx.varType()), variable, expr);
         }
-        return visitChildren(ctx);
+        return new SetVar(variable, expr);
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
https://github.com/StarRocks/starrocks/pull/7840 introduced a bug: will make the following stmts parsed error:

- SetNamesVar
- SetPassVar
- SetTransaction
- SetUserPropertyVar
