### PR TITLE
[Enhancement] deliver fragments in batch

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -659,6 +659,9 @@ CONF_Int64(pipeline_hdfs_scan_thread_pool_thread_num, "48");
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
+// The number of threads for preparing fragment instances in pipeline engine, vCPUs by default.
+CONF_Int64(pipeline_prepare_thread_pool_thread_num, "0");
+CONF_Int64(pipeline_prepare_thread_pool_queue_size, "102400");
 // The buffer size of io task.
 CONF_Int64(pipeline_io_buffer_size, "64");
 // The buffer size of SinkBuffer.

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -68,7 +68,7 @@ public:
     // new sink is written to *sink, and is owned by the caller.
     static Status create_data_sink(RuntimeState* state, const TDataSink& thrift_sink,
                                    const std::vector<TExpr>& output_exprs, const TPlanFragmentExecParams& params,
-                                   const RowDescriptor& row_desc, std::unique_ptr<DataSink>* sink);
+                                   int32_t sender_id, const RowDescriptor& row_desc, std::unique_ptr<DataSink>* sink);
 
     // Returns the runtime profile for the sink.
     virtual RuntimeProfile* profile() = 0;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -40,6 +40,32 @@ using WorkGroupManager = workgroup::WorkGroupManager;
 using WorkGroup = workgroup::WorkGroup;
 using WorkGroupPtr = workgroup::WorkGroupPtr;
 
+/// UnifiedExecPlanFragmentParams.
+const std::vector<TScanRangeParams> UnifiedExecPlanFragmentParams::_no_scan_ranges;
+const std::map<int32_t, std::vector<TScanRangeParams>> UnifiedExecPlanFragmentParams::_no_scan_ranges_per_driver_seq;
+
+const std::vector<TScanRangeParams>& UnifiedExecPlanFragmentParams::scan_ranges_of_node(TPlanNodeId node_id) const {
+    return FindWithDefault(_unique_request.params.per_node_scan_ranges, node_id, _no_scan_ranges);
+}
+
+const std::map<int32_t, std::vector<TScanRangeParams>>&
+UnifiedExecPlanFragmentParams::per_driver_seq_scan_ranges_of_node(TPlanNodeId node_id) const {
+    if (!_unique_request.params.__isset.node_to_per_driver_seq_scan_ranges) {
+        return _no_scan_ranges_per_driver_seq;
+    }
+
+    return FindWithDefault(_unique_request.params.node_to_per_driver_seq_scan_ranges, node_id,
+                           _no_scan_ranges_per_driver_seq);
+}
+
+const TDataSink& UnifiedExecPlanFragmentParams::output_sink() const {
+    if (_unique_request.fragment.__isset.output_sink) {
+        return _unique_request.fragment.output_sink;
+    }
+    return _common_request.fragment.output_sink;
+}
+
+/// Profile methods.
 static void setup_profile_hierarchy(RuntimeState* runtime_state, const PipelinePtr& pipeline) {
     runtime_state->runtime_profile()->add_child(pipeline->runtime_profile(), true, nullptr);
 }
@@ -57,12 +83,13 @@ static void setup_profile_hierarchy(const PipelinePtr& pipeline, const DriverPtr
     }
 }
 
-Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
+/// FragmentExecutor.
+Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) {
     // prevent an identical fragment instance from multiple execution caused by FE's
     // duplicate invocations of rpc exec_plan_fragment.
-    const auto& params = request.params;
+    const auto& params = request.common().params;
     const auto& query_id = params.query_id;
-    const auto& fragment_instance_id = params.fragment_instance_id;
+    const auto& fragment_instance_id = request.fragment_instance_id();
 
     auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (existing_query_ctx) {
@@ -87,12 +114,11 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFr
     return Status::OK();
 }
 
-Status FragmentExecutor::_prepare_fragment_ctx(const TExecPlanFragmentParams& request) {
-    const auto& coord = request.coord;
-    const auto& params = request.params;
-    const auto& query_id = params.query_id;
-    const auto& fragment_instance_id = params.fragment_instance_id;
-    const auto& query_options = request.query_options;
+Status FragmentExecutor::_prepare_fragment_ctx(const UnifiedExecPlanFragmentParams& request) {
+    const auto& coord = request.common().coord;
+    const auto& query_id = request.common().params.query_id;
+    const auto& fragment_instance_id = request.fragment_instance_id();
+    const auto& query_options = request.common().query_options;
 
     _fragment_ctx = std::make_shared<FragmentContext>();
 
@@ -108,19 +134,18 @@ Status FragmentExecutor::_prepare_fragment_ctx(const TExecPlanFragmentParams& re
     }
 
     LOG(INFO) << "Prepare(): query_id=" << print_id(query_id)
-              << " fragment_instance_id=" << print_id(params.fragment_instance_id)
-              << " backend_num=" << request.backend_num;
+              << " fragment_instance_id=" << print_id(fragment_instance_id) << " backend_num=" << request.backend_num();
 
     return Status::OK();
 }
 
-Status FragmentExecutor::_prepare_workgroup(const TExecPlanFragmentParams& request) {
+Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams& request) {
     // wg is always non-nullable, when request.enable_resource_group is true.
     WorkGroupPtr wg = nullptr;
-    if (request.__isset.enable_resource_group && request.enable_resource_group) {
+    if (request.common().__isset.enable_resource_group && request.common().enable_resource_group) {
         _fragment_ctx->set_enable_resource_group();
-        if (request.__isset.workgroup && request.workgroup.id != WorkGroup::DEFAULT_WG_ID) {
-            wg = std::make_shared<WorkGroup>(request.workgroup);
+        if (request.common().__isset.workgroup && request.common().workgroup.id != WorkGroup::DEFAULT_WG_ID) {
+            wg = std::make_shared<WorkGroup>(request.common().workgroup);
             wg = WorkGroupManager::instance()->add_workgroup(wg);
         } else {
             wg = WorkGroupManager::instance()->get_default_workgroup();
@@ -134,13 +159,13 @@ Status FragmentExecutor::_prepare_workgroup(const TExecPlanFragmentParams& reque
     return Status::OK();
 }
 
-Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
-    const auto& params = request.params;
+Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) {
+    const auto& params = request.common().params;
     const auto& query_id = params.query_id;
-    const auto& fragment_instance_id = params.fragment_instance_id;
-    const auto& query_globals = request.query_globals;
-    const auto& query_options = request.query_options;
-    const auto& t_desc_tbl = request.desc_tbl;
+    const auto& fragment_instance_id = request.fragment_instance_id();
+    const auto& query_globals = request.common().query_globals;
+    const auto& query_options = request.common().query_options;
+    const auto& t_desc_tbl = request.common().desc_tbl;
     const int32_t degree_of_parallelism = _calc_dop(exec_env, request);
     auto& wg = _wg;
 
@@ -163,17 +188,16 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const TExecPl
 
     auto* runtime_state = _fragment_ctx->runtime_state();
     runtime_state->set_enable_pipeline_engine(true);
-    int func_version = request.__isset.func_version ? request.func_version : 2;
+    int func_version = request.common().__isset.func_version ? request.common().func_version : 2;
     runtime_state->set_func_version(func_version);
     runtime_state->init_mem_trackers(query_mem_tracker);
-    runtime_state->set_be_number(request.backend_num);
+    runtime_state->set_be_number(request.backend_num());
     runtime_state->set_query_ctx(_query_ctx);
 
     // RuntimeFilterWorker::open_query is idempotent
-    if (params.__isset.runtime_filter_params && params.runtime_filter_params.id_to_prober_params.size() != 0) {
+    if (params.__isset.runtime_filter_params && !params.runtime_filter_params.id_to_prober_params.empty()) {
         _query_ctx->set_is_runtime_filter_coordinator(true);
-        exec_env->runtime_filter_worker()->open_query(query_id, request.query_options, params.runtime_filter_params,
-                                                      true);
+        exec_env->runtime_filter_worker()->open_query(query_id, query_options, params.runtime_filter_params, true);
     }
     _fragment_ctx->prepare_pass_through_chunk_buffer();
 
@@ -199,13 +223,13 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const TExecPl
     return Status::OK();
 }
 
-int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const {
-    int32_t degree_of_parallelism = request.__isset.pipeline_dop ? request.pipeline_dop : 0;
+int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
+    int32_t degree_of_parallelism = request.pipeline_dop();
     return exec_env->calc_pipeline_dop(degree_of_parallelism);
 }
 
-int FragmentExecutor::_calc_delivery_expired_seconds(const TExecPlanFragmentParams& request) const {
-    const auto& query_options = request.query_options;
+int FragmentExecutor::_calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const {
+    const auto& query_options = request.common().query_options;
 
     int expired_seconds = QueryContext::DEFAULT_EXPIRE_SECONDS;
     if (query_options.__isset.query_delivery_timeout) {
@@ -221,8 +245,8 @@ int FragmentExecutor::_calc_delivery_expired_seconds(const TExecPlanFragmentPara
     return std::max<int>(1, expired_seconds);
 }
 
-int FragmentExecutor::_calc_query_expired_seconds(const TExecPlanFragmentParams& request) const {
-    const auto& query_options = request.query_options;
+int FragmentExecutor::_calc_query_expired_seconds(const UnifiedExecPlanFragmentParams& request) const {
+    const auto& query_options = request.common().query_options;
 
     if (query_options.__isset.query_timeout) {
         return std::max<int>(1, query_options.query_timeout);
@@ -231,13 +255,18 @@ int FragmentExecutor::_calc_query_expired_seconds(const TExecPlanFragmentParams&
     return QueryContext::DEFAULT_EXPIRE_SECONDS;
 }
 
-Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
+Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) {
     auto* runtime_state = _fragment_ctx->runtime_state();
     auto* obj_pool = runtime_state->obj_pool();
     const DescriptorTbl& desc_tbl = runtime_state->desc_tbl();
-    const auto& params = request.params;
-    const auto& fragment = request.fragment;
+    const auto& params = request.common().params;
+    const auto& fragment = request.common().fragment;
     const auto dop = _calc_dop(exec_env, request);
+    const auto& query_options = request.common().query_options;
+
+    bool enable_shared_scan = request.common().__isset.enable_shared_scan && request.common().enable_shared_scan;
+    bool enable_tablet_internal_parallel =
+            query_options.__isset.enable_tablet_internal_parallel && query_options.enable_tablet_internal_parallel;
 
     // Set up plan
     RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, desc_tbl, &_fragment_ctx->plan()));
@@ -252,33 +281,22 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
     plan->collect_nodes(TPlanNodeType::EXCHANGE_NODE, &exch_nodes);
     for (auto* exch_node : exch_nodes) {
         int num_senders = FindWithDefault(params.per_exch_num_senders, exch_node->id(), 0);
-        static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
+        down_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;
-    std::vector<TScanRangeParams> no_scan_ranges;
-    std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
     plan->collect_scan_nodes(&scan_nodes);
-
-    bool enable_shared_scan = false;
-    if (request.__isset.enable_shared_scan) {
-        enable_shared_scan = request.enable_shared_scan;
-    }
 
     MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
     for (auto& i : scan_nodes) {
         auto* scan_node = down_cast<ScanNode*>(i);
-        const std::vector<TScanRangeParams>& scan_ranges =
-                FindWithDefault(params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
-        auto& scan_ranges_per_driver_seq = params.__isset.node_to_per_driver_seq_scan_ranges
-                                                   ? FindWithDefault(params.node_to_per_driver_seq_scan_ranges,
-                                                                     scan_node->id(), no_scan_ranges_per_driver_seq)
-                                                   : no_scan_ranges_per_driver_seq;
+        const std::vector<TScanRangeParams>& scan_ranges = request.scan_ranges_of_node(scan_node->id());
+        const auto& scan_ranges_per_driver_seq = request.per_driver_seq_scan_ranges_of_node(scan_node->id());
 
-        ASSIGN_OR_RETURN(auto morsel_queue_factory,
-                         scan_node->convert_scan_range_to_morsel_queue_factory(scan_ranges, scan_ranges_per_driver_seq,
-                                                                               scan_node->id(), request, dop));
+        ASSIGN_OR_RETURN(auto morsel_queue_factory, scan_node->convert_scan_range_to_morsel_queue_factory(
+                                                            scan_ranges, scan_ranges_per_driver_seq, scan_node->id(),
+                                                            dop, enable_tablet_internal_parallel));
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
 
         if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
@@ -289,10 +307,11 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFr
     return Status::OK();
 }
 
-Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
-    const auto fragment_instance_id = request.params.fragment_instance_id;
+Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) {
+    const auto fragment_instance_id = request.fragment_instance_id();
     const auto degree_of_parallelism = _calc_dop(exec_env, request);
-    const auto& fragment = request.fragment;
+    const auto& fragment = request.common().fragment;
+    const auto& params = request.common().params;
     ExecNode* plan = _fragment_ctx->plan();
 
     Drivers drivers;
@@ -307,10 +326,11 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
 
     // Set up sink if required
     std::unique_ptr<DataSink> datasink;
-    if (fragment.__isset.output_sink) {
+    if (request.isset_output_sink()) {
+        const auto& tsink = request.output_sink();
         RowDescriptor row_desc;
-        RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, request.fragment.output_sink,
-                                                   request.fragment.output_exprs, request.params, row_desc, &datasink));
+        RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, tsink, fragment.output_exprs, params,
+                                                   request.sender_id(), row_desc, &datasink));
         RuntimeProfile* sink_profile = datasink->profile();
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
@@ -389,22 +409,26 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
     return Status::OK();
 }
 
-Status FragmentExecutor::_prepare_global_dict(const TExecPlanFragmentParams& request) {
+Status FragmentExecutor::_prepare_global_dict(const UnifiedExecPlanFragmentParams& request) {
+    const auto& fragment = request.common().fragment;
     // Set up global dict
     auto* runtime_state = _fragment_ctx->runtime_state();
-    if (request.fragment.__isset.query_global_dicts) {
-        RETURN_IF_ERROR(runtime_state->init_query_global_dict(request.fragment.query_global_dicts));
+    if (fragment.__isset.query_global_dicts) {
+        RETURN_IF_ERROR(runtime_state->init_query_global_dict(fragment.query_global_dicts));
     }
 
-    if (request.fragment.__isset.load_global_dicts) {
-        RETURN_IF_ERROR(runtime_state->init_load_global_dict(request.fragment.load_global_dicts));
+    if (fragment.__isset.load_global_dicts) {
+        RETURN_IF_ERROR(runtime_state->init_load_global_dict(fragment.load_global_dicts));
     }
     return Status::OK();
 }
 
-Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
-    DCHECK(request.__isset.desc_tbl);
-    DCHECK(request.__isset.fragment);
+Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request,
+                                 const TExecPlanFragmentParams& unique_request) {
+    DCHECK(common_request.__isset.desc_tbl);
+    DCHECK(common_request.__isset.fragment);
+
+    UnifiedExecPlanFragmentParams request(common_request, unique_request);
 
     bool prepare_success = false;
     DeferOp defer([this, &prepare_success]() {
@@ -422,7 +446,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     RETURN_IF_ERROR(_prepare_global_dict(request));
     RETURN_IF_ERROR(_prepare_pipeline_driver(exec_env, request));
 
-    _query_ctx->fragment_mgr()->register_ctx(request.params.fragment_instance_id, _fragment_ctx);
+    _query_ctx->fragment_mgr()->register_ctx(request.fragment_instance_id(), _fragment_ctx);
     prepare_success = true;
 
     return Status::OK();
@@ -470,7 +494,7 @@ void FragmentExecutor::_fail_cleanup() {
 }
 
 Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_state, PipelineBuilderContext* context,
-                                                          const TExecPlanFragmentParams& params,
+                                                          const UnifiedExecPlanFragmentParams& request,
                                                           std::unique_ptr<starrocks::DataSink>& datasink) {
     auto fragment_ctx = context->fragment_context();
     if (typeid(*datasink) == typeid(starrocks::ResultSink)) {
@@ -484,7 +508,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
     } else if (typeid(*datasink) == typeid(starrocks::DataStreamSender)) {
         starrocks::DataStreamSender* sender = down_cast<starrocks::DataStreamSender*>(datasink.get());
         auto dop = fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
-        auto& t_stream_sink = params.fragment.output_sink.stream_sink;
+        auto& t_stream_sink = request.output_sink().stream_sink;
         bool is_dest_merge = false;
         if (t_stream_sink.__isset.is_merge && t_stream_sink.is_merge) {
             is_dest_merge = true;
@@ -527,7 +551,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         // Further workflow explanation is in mcast_local_exchange.h file.
         starrocks::MultiCastDataStreamSink* mcast_sink = down_cast<starrocks::MultiCastDataStreamSink*>(datasink.get());
         const auto& sinks = mcast_sink->get_sinks();
-        auto& t_multi_case_stream_sink = params.fragment.output_sink.multi_cast_stream_sink;
+        auto& t_multi_case_stream_sink = request.output_sink().multi_cast_stream_sink;
 
         // === create exchange ===
         auto mcast_local_exchanger = std::make_shared<MultiCastLocalExchanger>(runtime_state, sinks.size());
@@ -574,8 +598,8 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             fragment_ctx->pipelines().emplace_back(pp);
         }
     } else if (typeid(*datasink) == typeid(starrocks::stream_load::OlapTableSink)) {
-        runtime_state->set_per_fragment_instance_idx(params.params.sender_id);
-        runtime_state->set_num_per_fragment_instances(params.params.num_senders);
+        runtime_state->set_per_fragment_instance_idx(request.sender_id());
+        runtime_state->set_num_per_fragment_instances(request.common().params.num_senders);
         OpFactoryPtr op =
                 std::make_shared<OlapTableSinkOperatorFactory>(context->next_operator_id(), datasink, fragment_ctx);
         fragment_ctx->pipelines().back()->add_op_factory(op);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -19,16 +19,70 @@ class FragmentContext;
 class PipelineBuilderContext;
 class QueryContext;
 
+// For the exec_batch_plan_fragments RPC request, common_request and unique_request are different.
+// - common_request contains the common fields of all the fragment instances.
+// - unique_request contains the unique fields for a specific fragment instance, including:
+//    - backend_num
+//    - pipeline_dop
+//    - params.fragment_instance_id
+//    - params.sender_id
+//    - params.per_node_scan_ranges
+//    - fragment.output_sink (only for MultiCastDataStreamSink and ExportSink)
+// For the exec_plan_fragments request, common_request and unique_request are identical.
+class UnifiedExecPlanFragmentParams {
+public:
+    UnifiedExecPlanFragmentParams(const TExecPlanFragmentParams& common_request,
+                                  const TExecPlanFragmentParams& unique_request)
+            : _common_request(common_request), _unique_request(unique_request) {
+        DCHECK(unique_request.__isset.backend_num);
+        DCHECK(unique_request.__isset.pipeline_dop);
+        DCHECK(unique_request.__isset.params);
+        DCHECK(unique_request.params.__isset.sender_id);
+    }
+
+    // Disable copy/move ctor and assignment.
+    UnifiedExecPlanFragmentParams(const UnifiedExecPlanFragmentParams&) = delete;
+    UnifiedExecPlanFragmentParams& operator=(const UnifiedExecPlanFragmentParams&) = delete;
+    UnifiedExecPlanFragmentParams(UnifiedExecPlanFragmentParams&&) = delete;
+    UnifiedExecPlanFragmentParams& operator=(UnifiedExecPlanFragmentParams&&) = delete;
+
+    // Access the common fields by this method.
+    const TExecPlanFragmentParams& common() const { return _common_request; }
+
+    // Access the unique fields by the following methods.
+    int32_t backend_num() const { return _unique_request.backend_num; }
+    int32_t pipeline_dop() const { return _unique_request.__isset.pipeline_dop ? _unique_request.pipeline_dop : 0; }
+    const TUniqueId& fragment_instance_id() const { return _unique_request.params.fragment_instance_id; }
+    int32_t sender_id() const { return _unique_request.params.sender_id; }
+
+    const std::vector<TScanRangeParams>& scan_ranges_of_node(TPlanNodeId node_id) const;
+    const std::map<int32_t, std::vector<TScanRangeParams>>& per_driver_seq_scan_ranges_of_node(
+            TPlanNodeId node_id) const;
+
+    bool isset_output_sink() const {
+        return _common_request.fragment.__isset.output_sink || _unique_request.fragment.__isset.output_sink;
+    }
+    const TDataSink& output_sink() const;
+
+private:
+    static const std::vector<TScanRangeParams> _no_scan_ranges;
+    static const std::map<int32_t, std::vector<TScanRangeParams>> _no_scan_ranges_per_driver_seq;
+
+    const TExecPlanFragmentParams& _common_request;
+    const TExecPlanFragmentParams& _unique_request;
+};
+
 class FragmentExecutor {
 public:
-    Status prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
+    Status prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request,
+                   const TExecPlanFragmentParams& unique_request);
     Status execute(ExecEnv* exec_env);
 
 private:
     void _fail_cleanup();
-    int32_t _calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const;
-    int _calc_delivery_expired_seconds(const TExecPlanFragmentParams& request) const;
-    int _calc_query_expired_seconds(const TExecPlanFragmentParams& request) const;
+    int32_t _calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
+    int _calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
+    int _calc_query_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
 
     // Several steps of prepare a fragment
     // 1. query context
@@ -37,16 +91,16 @@ private:
     // 4. runtime state
     // 5. exec plan
     // 6. pipeline driver
-    Status _prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
-    Status _prepare_fragment_ctx(const TExecPlanFragmentParams& request);
-    Status _prepare_workgroup(const TExecPlanFragmentParams& request);
-    Status _prepare_runtime_state(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
-    Status _prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
-    Status _prepare_global_dict(const TExecPlanFragmentParams& request);
-    Status _prepare_pipeline_driver(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
+    Status _prepare_query_ctx(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_fragment_ctx(const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_workgroup(const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_runtime_state(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_exec_plan(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_global_dict(const UnifiedExecPlanFragmentParams& request);
+    Status _prepare_pipeline_driver(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
 
     Status _decompose_data_sink_to_operator(RuntimeState* runtime_state, PipelineBuilderContext* context,
-                                            const TExecPlanFragmentParams& params,
+                                            const UnifiedExecPlanFragmentParams& request,
                                             std::unique_ptr<starrocks::DataSink>& datasink);
 
     QueryContext* _query_ctx = nullptr;

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -68,10 +68,10 @@ public:
     virtual StatusOr<pipeline::MorselQueueFactoryPtr> convert_scan_range_to_morsel_queue_factory(
             const std::vector<TScanRangeParams>& scan_ranges,
             const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
-            const TExecPlanFragmentParams& request, int pipeline_dop);
+            int pipeline_dop, bool enable_tablet_internal_parallel);
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
-            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request,
-            size_t num_total_scan_ranges);
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
+            bool enable_tablet_internal_parallel, size_t num_total_scan_ranges);
 
     // If this scan node accept empty scan ranges.
     virtual bool accept_empty_scan_ranges() const { return true; }

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -344,8 +344,8 @@ void OlapScanNode::enable_shared_scan(bool enable) {
 }
 
 StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_queue(
-        const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request,
-        size_t num_total_scan_ranges) {
+        const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
+        bool enable_tablet_internal_parallel, size_t num_total_scan_ranges) {
     pipeline::Morsels morsels;
     for (const auto& scan_range : scan_ranges) {
         morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, scan_range));
@@ -357,17 +357,14 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
     }
 
     // Disable by the session variable shouldn't use tablet internal parallel.
-    const auto& query_options = request.query_options;
-    bool enable =
-            query_options.__isset.enable_tablet_internal_parallel && query_options.enable_tablet_internal_parallel;
-    if (!enable) {
+    if (!enable_tablet_internal_parallel) {
         return std::make_unique<pipeline::FixedMorselQueue>(std::move(morsels));
     }
 
     int64_t scan_dop;
     int64_t splitted_scan_rows;
-    ASSIGN_OR_RETURN(auto could, _could_tablet_internal_parallel(scan_ranges, request, num_total_scan_ranges, &scan_dop,
-                                                                 &splitted_scan_rows));
+    ASSIGN_OR_RETURN(auto could, _could_tablet_internal_parallel(scan_ranges, pipeline_dop, num_total_scan_ranges,
+                                                                 &scan_dop, &splitted_scan_rows));
     if (!could) {
         return std::make_unique<pipeline::FixedMorselQueue>(std::move(morsels));
     }
@@ -382,13 +379,10 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
 }
 
 StatusOr<bool> OlapScanNode::_could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
-                                                             const TExecPlanFragmentParams& request,
-                                                             size_t num_total_scan_ranges, int64_t* scan_dop,
-                                                             int64_t* splitted_scan_rows) const {
+                                                             int32_t pipeline_dop, size_t num_total_scan_ranges,
+                                                             int64_t* scan_dop, int64_t* splitted_scan_rows) const {
     // The enough number of tablets shouldn't use tablet internal parallel.
-    int32_t dop = request.__isset.pipeline_dop ? request.pipeline_dop : 0;
-    dop = ExecEnv::GetInstance()->calc_pipeline_dop(dop);
-    if (num_total_scan_ranges >= dop) {
+    if (num_total_scan_ranges >= pipeline_dop) {
         return false;
     }
 
@@ -405,9 +399,9 @@ StatusOr<bool> OlapScanNode::_could_tablet_internal_parallel(const std::vector<T
                      std::min(*splitted_scan_rows, config::tablet_internal_parallel_max_splitted_scan_rows));
     // scan_dop is restricted in the range [1, dop].
     *scan_dop = num_table_rows / *splitted_scan_rows;
-    *scan_dop = std::max<int64_t>(1, std::min<int64_t>(*scan_dop, dop));
+    *scan_dop = std::max<int64_t>(1, std::min<int64_t>(*scan_dop, pipeline_dop));
 
-    bool could = *scan_dop >= dop || *scan_dop >= config::tablet_internal_parallel_min_scan_dop;
+    bool could = *scan_dop >= pipeline_dop || *scan_dop >= config::tablet_internal_parallel_min_scan_dop;
     return could;
 }
 

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -54,8 +54,8 @@ public:
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
-            const std::vector<TScanRangeParams>& scan_ranges, int node_id, const TExecPlanFragmentParams& request,
-            size_t num_total_scan_ranges) override;
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
+            bool enable_tablet_internal_parallel, size_t num_total_scan_ranges) override;
 
     void debug_string(int indentation_level, std::stringstream* out) const override {
         *out << "vectorized::OlapScanNode";
@@ -137,7 +137,7 @@ private:
     void _estimate_scan_and_output_row_bytes();
 
     StatusOr<bool> _could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
-                                                   const TExecPlanFragmentParams& request, size_t num_total_scan_ranges,
+                                                   int32_t pipeline_dop, size_t num_total_scan_ranges,
                                                    int64_t* scan_dop, int64_t* splitted_scan_rows) const;
     StatusOr<bool> _could_split_tablet_physically(const std::vector<TScanRangeParams>& scan_ranges) const;
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -190,6 +190,13 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _udf_call_pool = new PriorityThreadPool("udf", config::udf_thread_pool_size, config::udf_thread_pool_size);
     _fragment_mgr = new FragmentMgr(this);
 
+    int num_prepare_threads = config::pipeline_prepare_thread_pool_thread_num;
+    if (num_prepare_threads <= 0) {
+        num_prepare_threads = std::thread::hardware_concurrency();
+    }
+    _pipeline_prepare_pool =
+            new PriorityThreadPool("pip_prepare", num_prepare_threads, config::pipeline_prepare_thread_pool_queue_size);
+
     std::unique_ptr<ThreadPool> driver_executor_thread_pool;
     _max_executor_threads = std::thread::hardware_concurrency();
     if (config::pipeline_exec_thread_pool_thread_num > 0) {
@@ -450,6 +457,10 @@ void ExecEnv::_destroy() {
     if (_udf_call_pool) {
         delete _udf_call_pool;
         _udf_call_pool = nullptr;
+    }
+    if (_pipeline_prepare_pool) {
+        delete _pipeline_prepare_pool;
+        _pipeline_prepare_pool = nullptr;
     }
     if (_pipeline_scan_io_thread_pool) {
         delete _pipeline_scan_io_thread_pool;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -143,6 +143,7 @@ public:
     size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
     size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
+    PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverExecutor* driver_executor() { return _driver_executor; }
     starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
@@ -242,6 +243,7 @@ private:
     PriorityThreadPool* _pipeline_hdfs_scan_io_thread_pool = nullptr;
     std::atomic<size_t> _num_scan_operators{0};
     PriorityThreadPool* _udf_call_pool = nullptr;
+    PriorityThreadPool* _pipeline_prepare_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
     starrocks::pipeline::QueryContextManager* _query_context_mgr = nullptr;
     starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -146,7 +146,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     // set up sink, if required
     if (request.fragment.__isset.output_sink) {
         RETURN_IF_ERROR(DataSink::create_data_sink(_runtime_state, request.fragment.output_sink,
-                                                   request.fragment.output_exprs, params, row_desc(), &_sink));
+                                                   request.fragment.output_exprs, params, params.sender_id, row_desc(),
+                                                   &_sink));
         DCHECK(_sink != nullptr);
         RETURN_IF_ERROR(_sink->prepare(runtime_state()));
         _sink->set_query_statistics(_query_statistics);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -42,7 +42,7 @@
 namespace starrocks {
 
 using PromiseStatus = std::promise<Status>;
-using PromiseStatusPtr = std::unique_ptr<PromiseStatus>;
+using PromiseStatusSharedPtr = std::shared_ptr<PromiseStatus>;
 
 template <typename T>
 PInternalServiceImplBase<T>::PInternalServiceImplBase(ExecEnv* exec_env) : _exec_env(exec_env) {}
@@ -214,15 +214,15 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl) 
 template <typename T>
 Status PInternalServiceImplBase<T>::_exec_batch_plan_fragments(brpc::Controller* cntl) {
     auto ser_request = cntl->request_attachment().to_string();
-    TExecBatchPlanFragmentsParams t_batch_requests;
+    std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests = std::make_shared<TExecBatchPlanFragmentsParams>();
     {
         const uint8_t* buf = (const uint8_t*)ser_request.data();
         uint32_t len = ser_request.size();
-        RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, &t_batch_requests));
+        RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, t_batch_requests.get()));
     }
 
-    auto& common_request = t_batch_requests.common_param;
-    auto& unique_requests = t_batch_requests.unique_param_per_instance;
+    auto& common_request = t_batch_requests->common_param;
+    auto& unique_requests = t_batch_requests->unique_param_per_instance;
 
     if (unique_requests.empty()) {
         return Status::OK();
@@ -232,7 +232,7 @@ Status PInternalServiceImplBase<T>::_exec_batch_plan_fragments(brpc::Controller*
     // and prepare the other fragment instances concurrently using the cached desc_tbl.
     common_request.desc_tbl.__set_is_cached(true);
 
-    std::vector<PromiseStatusPtr> promise_statuses;
+    std::vector<PromiseStatusSharedPtr> promise_statuses;
     for (int i = 1; i < unique_requests.size(); ++i) {
         auto& unique_request = unique_requests[i];
         LOG(INFO) << "exec plan fragment, fragment_instance_id=" << print_id(unique_request.params.fragment_instance_id)
@@ -240,26 +240,25 @@ Status PInternalServiceImplBase<T>::_exec_batch_plan_fragments(brpc::Controller*
                   << ", is_pipeline=1"
                   << ", chunk_size=" << common_request.query_options.batch_size;
 
-        PromiseStatusPtr ms = std::make_unique<PromiseStatus>();
-        _exec_env->pipeline_prepare_pool()->offer([promise = ms.get(), this, &common_request, &unique_request] {
-            promise->set_value(_exec_plan_fragment_by_pipeline(common_request, unique_request));
+        PromiseStatusSharedPtr ms = std::make_shared<PromiseStatus>();
+        _exec_env->pipeline_prepare_pool()->offer([ms, t_batch_requests, i, this] {
+            ms->set_value(_exec_plan_fragment_by_pipeline(t_batch_requests->common_param,
+                                                          t_batch_requests->unique_param_per_instance[i]));
         });
         promise_statuses.emplace_back(std::move(ms));
     }
 
-    Status result_status = Status::OK();
     for (auto& promise : promise_statuses) {
-        Status status = promise->get_future().get();
-        if (result_status.ok() && !status.ok()) {
-            result_status = status;
-        }
+        // When a preparation fails, return error immediately. The other unfinished preparation is safe,
+        // since they can use the shared pointer of promise and t_batch_requests.
+        RETURN_IF_ERROR(promise->get_future().get());
     }
 
-    return result_status;
+    return Status::OK();
 }
 
 template <typename T>
-Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(TExecPlanFragmentParams& t_common_param,
+Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_param,
                                                                     const TExecPlanFragmentParams& t_unique_request) {
     auto fragment_executor = std::make_unique<starrocks::pipeline::FragmentExecutor>();
     auto status = fragment_executor->prepare(_exec_env, t_common_param, t_unique_request);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -31,6 +31,7 @@ class Controller;
 
 namespace starrocks {
 
+class TExecPlanFragmentParams;
 class ExecEnv;
 
 template <typename T>
@@ -52,6 +53,10 @@ public:
 
     void exec_plan_fragment(google::protobuf::RpcController* controller, const PExecPlanFragmentRequest* request,
                             PExecPlanFragmentResult* result, google::protobuf::Closure* done) override;
+
+    void exec_batch_plan_fragments(google::protobuf::RpcController* controller,
+                                   const PExecBatchPlanFragmentsRequest* request, PExecBatchPlanFragmentsResult* result,
+                                   google::protobuf::Closure* done) override;
 
     void cancel_plan_fragment(google::protobuf::RpcController* controller, const PCancelPlanFragmentRequest* request,
                               PCancelPlanFragmentResult* result, google::protobuf::Closure* done) override;
@@ -82,6 +87,10 @@ public:
 
 private:
     Status _exec_plan_fragment(brpc::Controller* cntl);
+    Status _exec_batch_plan_fragments(brpc::Controller* cntl);
+    Status _exec_plan_fragment_by_pipeline(TExecPlanFragmentParams& t_common_request,
+                                           const TExecPlanFragmentParams& t_unique_request);
+    Status _exec_plan_fragment_by_non_pipeline(const TExecPlanFragmentParams& t_request);
 
 protected:
     ExecEnv* _exec_env;

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -88,7 +88,7 @@ public:
 private:
     Status _exec_plan_fragment(brpc::Controller* cntl);
     Status _exec_batch_plan_fragments(brpc::Controller* cntl);
-    Status _exec_plan_fragment_by_pipeline(TExecPlanFragmentParams& t_common_request,
+    Status _exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_request,
                                            const TExecPlanFragmentParams& t_unique_request);
     Status _exec_plan_fragment_by_non_pipeline(const TExecPlanFragmentParams& t_request);
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -363,6 +363,23 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return result;
     }
 
+    /**
+     * Create thrift fragment with the unique fields, including
+     * - output_sink (only for MultiCastDataStreamSink and ExportSink).
+     * @return The thrift fragment with the unique fields.
+     */
+    public TPlanFragment toThriftForUniqueFields() {
+        TPlanFragment result = new TPlanFragment();
+        // Fill the required field.
+        result.setPartition(dataPartition.toThrift());
+
+        if (sink != null && (this instanceof MultiCastPlanFragment || sink instanceof ExportSink)) {
+            result.setOutput_sink(sink.toThrift());
+        }
+
+        return result;
+    }
+
     private List<TGlobalDict> dictToThrift(List<Pair<Integer, ColumnDict>> dicts) {
         List<TGlobalDict> result = Lists.newArrayList();
         for (Pair<Integer, ColumnDict> dictPair : dicts) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -67,6 +67,7 @@ import com.starrocks.planner.ResultSink;
 import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.UnionNode;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.proto.StatusPB;
@@ -83,6 +84,7 @@ import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.InternalServiceVersion;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TEsScanRange;
+import com.starrocks.thrift.TExecBatchPlanFragmentsParams;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -123,6 +125,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -133,6 +136,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class Coordinator {
@@ -518,6 +522,27 @@ public class Coordinator {
         for (TUniqueId instanceId : instanceIds) {
             profileDoneSignal.addMark(instanceId, -1L /* value is meaningless */);
         }
+
+        deliverExecFragments();
+    }
+
+    private void deliverExecFragments() throws Exception {
+        // Disable pipeline engine for `INSERT INTO`.
+        // TODO: remove this when load supports pipeline engine.
+        boolean enablePipelineEngine = connectContext != null &&
+                connectContext.getSessionVariable().isEnablePipelineEngine() &&
+                fragments.stream().allMatch(PlanFragment::canUsePipeline);
+        boolean enableDeliverBatchFragments = enablePipelineEngine
+                && connectContext.getSessionVariable().isEnableDeliverBatchFragments();
+
+        if (enableDeliverBatchFragments) {
+            deliverExecBatchFragmentsRequests();
+        } else {
+            deliverExecFragmentRequests(enablePipelineEngine);
+        }
+    }
+
+    private void deliverExecFragmentRequests(boolean enablePipelineEngine) throws Exception {
         long queryDeliveryTimeoutMs = Math.min(queryOptions.query_timeout, queryOptions.query_delivery_timeout) * 1000L;
         lock();
         try {
@@ -525,11 +550,6 @@ public class Coordinator {
             int backendId = 0;
             int profileFragmentId = 0;
 
-            // Disable pipeline engine for `INSERT INTO`.
-            // TODO: remove this when load supports pipeline engine.
-            boolean isEnablePipelineEngine = connectContext != null &&
-                    connectContext.getSessionVariable().isEnablePipelineEngine() &&
-                    fragments.stream().allMatch(PlanFragment::canUsePipeline);
             Set<Long> dbIds = connectContext != null ? connectContext.getCurrentSqlDbIds() : null;
 
             Set<TNetworkAddress> firstDeliveryAddresses = new HashSet<>();
@@ -549,9 +569,9 @@ public class Coordinator {
                 // Fragment instances to keep consistent order with Fragment instances in
                 // FragmentExecParams.instanceExecParams.
                 for (FInstanceExecParam fInstanceExecParam : params.instanceExecParams) {
-                    fInstanceExecParam.backendId = backendId++;
+                    fInstanceExecParam.backendNum = backendId++;
                 }
-                if (isEnablePipelineEngine) {
+                if (enablePipelineEngine) {
                     List<FInstanceExecParam> firstFInstanceParamList = new ArrayList<>();
                     List<FInstanceExecParam> remainingFInstanceParamList = new ArrayList<>();
 
@@ -587,7 +607,7 @@ public class Coordinator {
                     Map<TUniqueId, TNetworkAddress> instanceId2Host =
                             fInstanceExecParamList.stream().collect(Collectors.toMap(f -> f.instanceId, f -> f.host));
                     List<TExecPlanFragmentParams> tParams =
-                            params.toThrift(instanceId2Host.keySet(), descTable, dbIds, isEnablePipelineEngine);
+                            params.toThrift(instanceId2Host.keySet(), descTable, dbIds, enablePipelineEngine);
                     List<Pair<BackendExecState, Future<PExecPlanFragmentResult>>> futures = Lists.newArrayList();
 
                     boolean needCheckBackendState = false;
@@ -658,6 +678,210 @@ public class Coordinator {
                 }
                 profileFragmentId += 1;
             }
+            attachInstanceProfileToFragmentProfile();
+        } finally {
+            unlock();
+        }
+    }
+
+    /**
+     * Compute the topological order of the fragment tree.
+     *
+     * @return multiple fragment groups. Each group should be delivered sequentially,
+     * and fragments in a group can be delivered concurrently.
+     */
+    private List<List<PlanFragment>> computeTopologicalOrderFragments() {
+        Queue<PlanFragment> queue = Lists.newLinkedList();
+        Map<PlanFragment, Integer> inDegrees = Maps.newHashMap();
+
+        PlanFragment root = fragments.get(0);
+        inDegrees.put(root, 0);
+        queue.add(root);
+        // Compute in-degree of each fragment.
+        while (!queue.isEmpty()) {
+            PlanFragment fragment = queue.poll();
+            for (PlanFragment child : fragment.getChildren()) {
+                Integer v = inDegrees.get(child);
+                if (v != null) {
+                    inDegrees.put(child, v + 1);
+                } else {
+                    inDegrees.put(child, 1);
+                    queue.add(child);
+                }
+            }
+        }
+
+        if (fragments.size() != inDegrees.size()) {
+            for (PlanFragment fragment : fragments) {
+                if (!inDegrees.containsKey(fragment)) {
+                    LOG.warn("This fragment does not belong to the fragment tree: {}", fragment.getFragmentId());
+                }
+            }
+            throw new StarRocksPlannerException("Some fragments do not belong to the fragment tree",
+                    ErrorType.INTERNAL_ERROR);
+        }
+
+        // `queue` contains the fragments whose in-degree is zero.
+        queue.add(root);
+        List<List<PlanFragment>> results = Lists.newArrayList();
+        int numOutputFragments = 0;
+        while (!queue.isEmpty()) {
+            int size = queue.size();
+            numOutputFragments += size;
+            List<PlanFragment> curResults = new ArrayList<>(size);
+            // The next `size` fragments can be delivered concurrently, because zero in-degree indicates that
+            // they don't depend on each other and all the fragments depending on them have been delivered.
+            for (int i = 0; i < size; ++i) {
+                PlanFragment fragment = queue.poll();
+                curResults.add(fragment);
+
+                for (PlanFragment child : fragment.getChildren()) {
+                    int degree = inDegrees.compute(child, (k, v) -> v - 1);
+                    if (degree == 0) {
+                        queue.add(child);
+                    }
+                }
+            }
+            results.add(curResults);
+        }
+        Preconditions.checkState(fragments.size() == numOutputFragments);
+
+        return results;
+    }
+
+    /**
+     * Deliver multiple fragments concurrently according to the topological order,
+     * and all the instances of a fragment to the same destination host are delivered in the same request.
+     */
+    private void deliverExecBatchFragmentsRequests() throws Exception {
+        long queryDeliveryTimeoutMs = Math.min(queryOptions.query_timeout, queryOptions.query_delivery_timeout) * 1000L;
+        List<List<PlanFragment>> topologicalFragments = computeTopologicalOrderFragments();
+
+        lock();
+        try {
+            // execute all instances from up to bottom
+            int backendNum = 0;
+            int profileFragmentId = 0;
+
+            Set<Long> dbIds = connectContext != null ? connectContext.getCurrentSqlDbIds() : null;
+            // The cached desc table is only used for the non-first instance request to the same host.
+            // Since all the instances of a fragment will be sent in a request,
+            // there is no chance to use the cached desc table.
+            descTable.setIs_cached(false);
+
+            for (List<PlanFragment> concurrencyFragments : topologicalFragments) {
+                List<Pair<BackendExecState, Future<PExecBatchPlanFragmentsResult>>> futures = Lists.newArrayList();
+
+                for (PlanFragment fragment : concurrencyFragments) {
+                    FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
+                    Preconditions.checkState(!params.instanceExecParams.isEmpty());
+
+                    // Fragment instances' ordinals in FragmentExecParams.instanceExecParams determine
+                    // shuffle partitions' ordinals in DataStreamSink. backendIds of Fragment instances that
+                    // contains shuffle join determine the ordinals of GRF components in the GRF. For a
+                    // shuffle join, its shuffle partitions and corresponding one-map-one GRF components
+                    // should have the same ordinals. so here assign monotonic unique backendIds to
+                    // Fragment instances to keep consistent order with Fragment instances in
+                    // FragmentExecParams.instanceExecParams.
+                    for (FInstanceExecParam fInstanceExecParam : params.instanceExecParams) {
+                        fInstanceExecParam.backendNum = backendNum++;
+                    }
+
+                    Map<TNetworkAddress, List<FInstanceExecParam>> requestsPerHost = params.instanceExecParams.stream()
+                            .collect(Collectors.groupingBy(FInstanceExecParam::getHost, HashMap::new,
+                                    Collectors.mapping(Function.identity(), Collectors.toList())));
+                    for (Map.Entry<TNetworkAddress, List<FInstanceExecParam>> hostAndRequests : requestsPerHost.entrySet()) {
+                        TNetworkAddress host = hostAndRequests.getKey();
+                        List<FInstanceExecParam> requests = hostAndRequests.getValue();
+                        if (requests.isEmpty()) {
+                            continue;
+                        }
+
+                        Set<TUniqueId> instanceIds = requests.stream()
+                                .map(FInstanceExecParam::getInstanceId)
+                                .collect(Collectors.toSet());
+                        TExecBatchPlanFragmentsParams tRequest =
+                                params.toThriftInBatch(instanceIds, host, descTable, dbIds);
+                        TExecPlanFragmentParams tCommonParams = tRequest.getCommon_param();
+                        List<TExecPlanFragmentParams> tUniqueParamsList = tRequest.getUnique_param_per_instance();
+                        Preconditions.checkState(!tUniqueParamsList.isEmpty());
+
+                        // this is a load process, and it is the first fragment.
+                        // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
+                        // so that we can check these backends' state when joining this Coordinator
+                        boolean needCheckBackendState =
+                                queryOptions.getQuery_type() == TQueryType.LOAD && profileFragmentId == 0;
+
+                        // Create ExecState for each fragment instance.
+                        BackendExecState lastExecState = null;
+                        for (TExecPlanFragmentParams tUniquePrams : tUniqueParamsList) {
+                            // TODO: pool of pre-formatted BackendExecStates?
+                            BackendExecState execState = new BackendExecState(fragment.getFragmentId(), host,
+                                    profileFragmentId, tCommonParams, tUniquePrams, this.addressToBackendID);
+                            backendExecStates.put(tUniquePrams.backend_num, execState);
+                            if (needCheckBackendState) {
+                                needCheckBackendExecStates.add(execState);
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("add need check backend {} for fragment, {} job: {}",
+                                            execState.backend.getId(),
+                                            fragment.getFragmentId().asInt(), jobId);
+                                }
+                            }
+                            lastExecState = execState;
+                        }
+
+                        if (lastExecState != null) {
+                            // Just choose any instance ExecState to send the RPC request.
+                            futures.add(Pair.create(lastExecState, lastExecState.execRemoteBatchFragmentsAsync(tRequest)));
+                        }
+                    }
+
+                    profileFragmentId += 1;
+                }
+
+                for (Pair<BackendExecState, Future<PExecBatchPlanFragmentsResult>> pair : futures) {
+                    TStatusCode code;
+                    String errMsg = null;
+                    try {
+                        PExecBatchPlanFragmentsResult result =
+                                pair.second.get(queryDeliveryTimeoutMs, TimeUnit.MILLISECONDS);
+                        code = TStatusCode.findByValue(result.status.statusCode);
+                        if (result.status.errorMsgs != null && !result.status.errorMsgs.isEmpty()) {
+                            errMsg = result.status.errorMsgs.get(0);
+                        }
+                    } catch (ExecutionException e) {
+                        LOG.warn("catch a execute exception", e);
+                        code = TStatusCode.THRIFT_RPC_ERROR;
+                    } catch (InterruptedException e) {
+                        LOG.warn("catch a interrupt exception", e);
+                        code = TStatusCode.INTERNAL_ERROR;
+                    } catch (TimeoutException e) {
+                        LOG.warn("catch a timeout exception", e);
+                        code = TStatusCode.TIMEOUT;
+                    }
+
+                    if (code != TStatusCode.OK) {
+                        if (errMsg == null) {
+                            errMsg = "exec rpc error. backend id: " + pair.first.backend.getId();
+                        }
+                        queryStatus.setStatus(errMsg);
+                        LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
+                                errMsg, code, pair.first.fragmentId,
+                                pair.first.address.hostname, pair.first.address.port);
+                        cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
+                        switch (Objects.requireNonNull(code)) {
+                            case TIMEOUT:
+                                throw new UserException("query timeout. backend id: " + pair.first.backend.getId());
+                            case THRIFT_RPC_ERROR:
+                                SimpleScheduler.addToBlacklist(pair.first.backend.getId());
+                                throw new RpcException(pair.first.backend.getHost(), "rpc failed");
+                            default:
+                                throw new UserException(errMsg);
+                        }
+                    }
+                }
+            }
+
             attachInstanceProfileToFragmentProfile();
         } finally {
             unlock();
@@ -1179,7 +1403,8 @@ public class Coordinator {
         ComputeNode computeNode = GlobalStateMgr.getCurrentSystemInfo().getBackendWithBePort(
                 host.getHostname(), host.getPort());
         if (computeNode == null) {
-            computeNode = GlobalStateMgr.getCurrentSystemInfo().getComputeNodeWithBePort(host.getHostname(), host.getPort());
+            computeNode =
+                    GlobalStateMgr.getCurrentSystemInfo().getComputeNodeWithBePort(host.getHostname(), host.getPort());
             if (computeNode == null) {
                 throw new UserException("Backend not found. Check if any backend is down or not");
             }
@@ -1191,7 +1416,8 @@ public class Coordinator {
         ComputeNode computeNode = GlobalStateMgr.getCurrentSystemInfo().getBackendWithBePort(
                 host.getHostname(), host.getPort());
         if (computeNode == null) {
-            computeNode = GlobalStateMgr.getCurrentSystemInfo().getComputeNodeWithBePort(host.getHostname(), host.getPort());
+            computeNode =
+                    GlobalStateMgr.getCurrentSystemInfo().getComputeNodeWithBePort(host.getHostname(), host.getPort());
             if (computeNode == null) {
                 throw new UserException("Backend not found. Check if any backend is down or not");
             }
@@ -1999,7 +2225,7 @@ public class Coordinator {
 
         Map<Integer, Integer> bucketSeqToDriverSeq = Maps.newHashMap();
 
-        int backendId;
+        int backendNum;
 
         FragmentExecParams fragmentExecParams;
 
@@ -2040,6 +2266,14 @@ public class Coordinator {
         public Map<Integer, Map<Integer, List<TScanRangeParams>>> getNodeToPerDriverSeqScanRanges() {
             return nodeToPerDriverSeqScanRanges;
         }
+
+        public TNetworkAddress getHost() {
+            return host;
+        }
+
+        public TUniqueId getInstanceId() {
+            return instanceId;
+        }
     }
 
     // map from an impalad host address to the per-node assigned scan ranges;
@@ -2059,7 +2293,8 @@ public class Coordinator {
     // record backend execute state
     // TODO(zhaochun): add profile information and others
     public class BackendExecState {
-        TExecPlanFragmentParams rpcParams;
+        TExecPlanFragmentParams commonRpcParams;
+        TExecPlanFragmentParams uniqueRpcParams;
         PlanFragmentId fragmentId;
         boolean initiated;
         boolean done;
@@ -2071,10 +2306,18 @@ public class Coordinator {
         long lastMissingHeartbeatTime = -1;
 
         public BackendExecState(PlanFragmentId fragmentId, TNetworkAddress host, int profileFragmentId,
-                                TExecPlanFragmentParams rpcParams, Map<TNetworkAddress, Long> addressToBackendID) {
+                                TExecPlanFragmentParams rpcParams,
+                                Map<TNetworkAddress, Long> addressToBackendID) {
+            this(fragmentId, host, profileFragmentId, rpcParams, rpcParams, addressToBackendID);
+        }
+
+        public BackendExecState(PlanFragmentId fragmentId, TNetworkAddress host, int profileFragmentId,
+                                TExecPlanFragmentParams commonRpcParams, TExecPlanFragmentParams uniqueRpcParams,
+                                Map<TNetworkAddress, Long> addressToBackendID) {
             this.profileFragmentId = profileFragmentId;
             this.fragmentId = fragmentId;
-            this.rpcParams = rpcParams;
+            this.commonRpcParams = commonRpcParams;
+            this.uniqueRpcParams = uniqueRpcParams;
             this.initiated = false;
             this.done = false;
             this.address = host;
@@ -2084,7 +2327,8 @@ public class Coordinator {
                 backend = idToComputeNode.get(addressToBackendID.get(address));
             }
             String name =
-                    "Instance " + DebugUtil.printId(rpcParams.params.fragment_instance_id) + " (host=" + address + ")";
+                    "Instance " + DebugUtil.printId(uniqueRpcParams.params.fragment_instance_id) + " (host=" + address +
+                            ")";
             this.profile = new RuntimeProfile(name);
             this.hasCanceled = false;
             this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();
@@ -2134,7 +2378,7 @@ public class Coordinator {
 
                 try {
                     BackendServiceClient.getInstance().cancelPlanFragmentAsync(brpcAddress,
-                            queryId, fragmentInstanceId(), cancelReason, rpcParams.is_pipeline);
+                            queryId, fragmentInstanceId(), cancelReason, commonRpcParams.is_pipeline);
                 } catch (RpcException e) {
                     LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
                             brpcAddress.getPort());
@@ -2175,7 +2419,7 @@ public class Coordinator {
             }
             this.initiated = true;
             try {
-                return BackendServiceClient.getInstance().execPlanFragmentAsync(brpcAddress, rpcParams);
+                return BackendServiceClient.getInstance().execPlanFragmentAsync(brpcAddress, uniqueRpcParams);
             } catch (RpcException e) {
                 // DO NOT throw exception here, return a complete future with error code,
                 // so that the following logic will cancel the fragment.
@@ -2215,6 +2459,56 @@ public class Coordinator {
             }
         }
 
+        public Future<PExecBatchPlanFragmentsResult> execRemoteBatchFragmentsAsync(
+                TExecBatchPlanFragmentsParams tRequest) throws TException {
+            TNetworkAddress brpcAddress;
+            try {
+                brpcAddress = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
+            } catch (Exception e) {
+                throw new TException(e.getMessage());
+            }
+            this.initiated = true;
+            try {
+                return BackendServiceClient.getInstance().execBatchPlanFragmentsAsync(brpcAddress, tRequest);
+            } catch (RpcException e) {
+                // DO NOT throw exception here, return a complete future with error code,
+                // so that the following logic will cancel the fragment.
+                return new Future<PExecBatchPlanFragmentsResult>() {
+                    @Override
+                    public boolean cancel(boolean mayInterruptIfRunning) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isDone() {
+                        return true;
+                    }
+
+                    @Override
+                    public PExecBatchPlanFragmentsResult get() {
+                        PExecBatchPlanFragmentsResult result = new PExecBatchPlanFragmentsResult();
+                        StatusPB pStatus = new StatusPB();
+                        pStatus.errorMsgs = Lists.newArrayList();
+                        pStatus.errorMsgs.add(e.getMessage());
+                        // use THRIFT_RPC_ERROR so that this BE will be added to the blacklist later.
+                        pStatus.statusCode = TStatusCode.THRIFT_RPC_ERROR.getValue();
+                        result.status = pStatus;
+                        return result;
+                    }
+
+                    @Override
+                    public PExecBatchPlanFragmentsResult get(long timeout, TimeUnit unit) {
+                        return get();
+                    }
+                };
+            }
+        }
+
         public FragmentInstanceInfo buildFragmentInstanceInfo() {
             return new QueryStatisticsItem.FragmentInstanceInfo.Builder()
                     .instanceId(fragmentInstanceId()).fragmentId(String.valueOf(fragmentId)).address(this.address)
@@ -2222,8 +2516,34 @@ public class Coordinator {
         }
 
         private TUniqueId fragmentInstanceId() {
-            return this.rpcParams.params.getFragment_instance_id();
+            return this.uniqueRpcParams.params.getFragment_instance_id();
         }
+    }
+
+    private WorkGroup chooseWorkGroup(Set<Long> dbIds) {
+        WorkGroup workgroup = null;
+        if (connectContext != null && connectContext.getSessionVariable().isEnableResourceGroup()) {
+            SessionVariable sessionVariable = connectContext.getSessionVariable();
+
+            // First try to use the resource group specified by the variable
+            if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
+                String rgName = sessionVariable.getResourceGroup();
+                workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroupByName(rgName);
+            }
+
+            // Second if the specified resource group not exist try to use the default one
+            if (workgroup == null) {
+                workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroup(
+                        connectContext, WorkGroupClassifier.QueryType.SELECT, dbIds);
+            }
+
+            if (workgroup != null) {
+                connectContext.getAuditEventBuilder().setResourceGroup(workgroup.getName());
+                connectContext.setWorkGroup(workgroup);
+            }
+        }
+
+        return workgroup;
     }
 
     // execution parameters for a single fragment,
@@ -2260,41 +2580,186 @@ public class Coordinator {
             }
         }
 
+        /**
+         * Set the common fields of all the fragment instances to the destination common thrift params.
+         *
+         * @param commonParams           The destination common thrift params.
+         * @param destHost               The destination host to delivery these instances.
+         * @param descTable              The descriptor table, empty for the non-first instance
+         *                               when enable pipeline and disable multi fragments in one request.
+         * @param workgroup              The workgroup for this query, used when enable pipeline and enable resource group.
+         * @param isEnablePipelineEngine Whether enable pipeline engine.
+         */
+        private void toThriftForCommonParams(TExecPlanFragmentParams commonParams,
+                                             TNetworkAddress destHost, TDescriptorTable descTable,
+                                             WorkGroup workgroup,
+                                             boolean isEnablePipelineEngine) {
+            commonParams.setProtocol_version(InternalServiceVersion.V1);
+            commonParams.setFragment(fragment.toThrift());
+            commonParams.setDesc_tbl(descTable);
+            commonParams.setFunc_version(3);
+            commonParams.setCoord(coordAddress);
+
+            commonParams.setParams(new TPlanFragmentExecParams());
+            commonParams.params.setUse_vectorized(true);
+            commonParams.params.setQuery_id(queryId);
+            commonParams.params.setInstances_number(hostToNumbers.get(destHost));
+            commonParams.params.setDestinations(destinations);
+            commonParams.params.setNum_senders(instanceExecParams.size());
+            commonParams.params.setPer_exch_num_senders(perExchNumSenders);
+            if (runtimeFilterParams.isSetRuntime_filter_builder_number()) {
+                commonParams.params.setRuntime_filter_params(runtimeFilterParams);
+            }
+            commonParams.params.setSend_query_statistics_with_every_batch(
+                    fragment.isTransferQueryStatisticsWithEveryBatch());
+
+            commonParams.setQuery_globals(queryGlobals);
+            if (isEnablePipelineEngine) {
+                commonParams.setQuery_options(new TQueryOptions(queryOptions));
+            } else {
+                commonParams.setQuery_options(queryOptions);
+            }
+            // For broker load, the ConnectContext.get() is null
+            if (connectContext != null) {
+                SessionVariable sessionVariable = connectContext.getSessionVariable();
+
+                if (isEnablePipelineEngine) {
+                    commonParams.setIs_pipeline(true);
+                    commonParams.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
+                    commonParams.setEnable_shared_scan(
+                            sessionVariable.isEnableSharedScan() && fragment.isEnableSharedScan());
+                    commonParams.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
+
+                    boolean enableResourceGroup = sessionVariable.isEnableResourceGroup();
+                    commonParams.setEnable_resource_group(enableResourceGroup);
+                    if (enableResourceGroup) {
+                        // session variable workgroup_id is just for verification of resource isolation.
+                        long workgroupId = connectContext.getSessionVariable().getWorkGroupId();
+                        if (workgroupId > 0) {
+                            TWorkGroup wg = new TWorkGroup();
+                            wg.setName("");
+                            wg.setId(connectContext.getSessionVariable().getWorkGroupId());
+                            wg.setVersion(0);
+                            commonParams.setWorkgroup(wg);
+                        } else if (workgroup != null) {
+                            commonParams.setWorkgroup(workgroup.toThrift());
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Set the unique fields for a fragment instance to the destination unique thrift params, including:
+         * - backend_num
+         * - pipeline_dop (used when isEnablePipelineEngine is true)
+         * - params.fragment_instance_id
+         * - params.sender_id
+         * - params.per_node_scan_ranges
+         * - fragment.output_sink (only for MultiCastDataStreamSink and ExportSink)
+         *
+         * @param uniqueParams           The destination unique thrift params.
+         * @param fragmentIndex          The index of this instance in this.instanceExecParams.
+         * @param instanceExecParam      The instance param.
+         * @param isEnablePipelineEngine Whether enable pipeline engine.
+         */
+        private void toThriftForUniqueParams(TExecPlanFragmentParams uniqueParams, int fragmentIndex,
+                                             FInstanceExecParam instanceExecParam, boolean isEnablePipelineEngine)
+                throws Exception {
+            uniqueParams.setProtocol_version(InternalServiceVersion.V1);
+            uniqueParams.setBackend_num(instanceExecParam.backendNum);
+            if (isEnablePipelineEngine) {
+                if (instanceExecParam.isSetPipelineDop()) {
+                    uniqueParams.setPipeline_dop(instanceExecParam.pipelineDop);
+                } else {
+                    uniqueParams.setPipeline_dop(fragment.getPipelineDop());
+                }
+            }
+
+            // add instance number in file name prefix when export job
+            if (fragment.getSink() instanceof ExportSink) {
+                ExportSink exportSink = (ExportSink) fragment.getSink();
+                if (exportSink.getFileNamePrefix() != null) {
+                    exportSink.setFileNamePrefix(exportSink.getFileNamePrefix() + fragmentIndex + "_");
+                }
+            }
+
+            if (!uniqueParams.isSetFragment()) {
+                uniqueParams.setFragment(fragment.toThriftForUniqueFields());
+            }
+
+            /*
+             * For MultiCastDataFragment, output only send to local, and the instance is keep
+             * same with MultiCastDataFragment
+             * */
+            if (fragment instanceof MultiCastPlanFragment) {
+                List<List<TPlanFragmentDestination>> multiFragmentDestinations =
+                        uniqueParams.getFragment().getOutput_sink().getMulti_cast_stream_sink().getDestinations();
+                List<List<TPlanFragmentDestination>> newDestinations = Lists.newArrayList();
+                for (List<TPlanFragmentDestination> destinations : multiFragmentDestinations) {
+                    Preconditions.checkState(instanceExecParams.size() == destinations.size());
+                    TPlanFragmentDestination ndes = destinations.get(fragmentIndex);
+
+                    Preconditions.checkState(ndes.getServer().equals(toRpcHost(instanceExecParam.host)));
+                    newDestinations.add(Lists.newArrayList(ndes));
+                }
+
+                uniqueParams.getFragment().getOutput_sink().getMulti_cast_stream_sink()
+                        .setDestinations(newDestinations);
+            }
+
+            if (!uniqueParams.isSetParams()) {
+                uniqueParams.setParams(new TPlanFragmentExecParams());
+            }
+            uniqueParams.params.setQuery_id(queryId);
+            uniqueParams.params.setFragment_instance_id(instanceExecParam.instanceId);
+
+            Map<Integer, List<TScanRangeParams>> scanRanges = instanceExecParam.perNodeScanRanges;
+            if (scanRanges == null) {
+                scanRanges = Maps.newHashMap();
+            }
+            uniqueParams.params.setPer_node_scan_ranges(scanRanges);
+            uniqueParams.params.setNode_to_per_driver_seq_scan_ranges(instanceExecParam.nodeToPerDriverSeqScanRanges);
+
+            uniqueParams.params.setSender_id(fragmentIndex);
+        }
+
+        /**
+         * Fill required fields of thrift params with meaningless values.
+         *
+         * @param params The thrift params need to be filled required fields.
+         */
+        private void fillRequiredFieldsToThrift(TExecPlanFragmentParams params) {
+            TPlanFragmentExecParams fragmentExecParams = params.getParams();
+
+            if (!fragmentExecParams.isSetFragment_instance_id()) {
+                fragmentExecParams.setFragment_instance_id(new TUniqueId(0, 0));
+            }
+
+            if (!fragmentExecParams.isSetInstances_number()) {
+                fragmentExecParams.setInstances_number(0);
+            }
+
+            if (!fragmentExecParams.isSetSender_id()) {
+                fragmentExecParams.setSender_id(0);
+            }
+
+            if (!fragmentExecParams.isSetPer_node_scan_ranges()) {
+                fragmentExecParams.setPer_node_scan_ranges(Maps.newHashMap());
+            }
+
+            if (!fragmentExecParams.isSetPer_exch_num_senders()) {
+                fragmentExecParams.setPer_exch_num_senders(Maps.newHashMap());
+            }
+        }
+
         List<TExecPlanFragmentParams> toThrift(Set<TUniqueId> inFlightInstanceIds,
                                                TDescriptorTable descTable,
                                                Set<Long> dbIds,
                                                boolean isEnablePipelineEngine) throws Exception {
-            // add instance number in file name prefix when export job
-            DataSink sink = fragment.getSink();
-            ExportSink exportSink = null;
-            String fileNamePrefix = null;
-            if (sink instanceof ExportSink) {
-                exportSink = (ExportSink) sink;
-                fileNamePrefix = exportSink.getFileNamePrefix();
-            }
-
-            WorkGroup workgroup = null;
-            if (connectContext != null && connectContext.getSessionVariable().isEnableResourceGroup()) {
-                SessionVariable sessionVariable = connectContext.getSessionVariable();
-
-                // First try to use the resource group specified by the variable
-                if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
-                    String rgName = sessionVariable.getResourceGroup();
-                    workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroupByName(rgName);
-                }
-
-                // Second if the specified resource group not exist try to use the default one
-                if (workgroup == null) {
-                    workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroup(
-                            connectContext, WorkGroupClassifier.QueryType.SELECT, dbIds);
-                }
-
-                if (workgroup != null) {
-                    connectContext.getAuditEventBuilder().setResourceGroup(workgroup.getName());
-                    connectContext.setWorkGroup(workgroup);
-                }
-            }
+            WorkGroup workgroup = chooseWorkGroup(dbIds);
             setBucketSeqToInstanceForRuntimeFilters();
+
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();
             for (int i = 0; i < instanceExecParams.size(); ++i) {
                 final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);
@@ -2303,100 +2768,44 @@ public class Coordinator {
                 }
                 TExecPlanFragmentParams params = new TExecPlanFragmentParams();
 
-                if (exportSink != null && fileNamePrefix != null) {
-                    exportSink.setFileNamePrefix(fileNamePrefix + i + "_");
-                }
+                toThriftForCommonParams(params, instanceExecParam.getHost(), descTable, workgroup,
+                        isEnablePipelineEngine);
+                toThriftForUniqueParams(params, i, instanceExecParam, isEnablePipelineEngine);
 
-                params.setProtocol_version(InternalServiceVersion.V1);
-                params.setFragment(fragment.toThrift());
-
-                /*
-                 * For MultiCastDataFragment, output only send to local, and the instance is keep
-                 * same with MultiCastDataFragment
-                 * */
-                if (fragment instanceof MultiCastPlanFragment) {
-                    List<List<TPlanFragmentDestination>> multiFragmentDestinations =
-                            params.getFragment().getOutput_sink().getMulti_cast_stream_sink().getDestinations();
-                    List<List<TPlanFragmentDestination>> newDestinations = Lists.newArrayList();
-                    for (List<TPlanFragmentDestination> destinations : multiFragmentDestinations) {
-                        Preconditions.checkState(instanceExecParams.size() == destinations.size());
-                        TPlanFragmentDestination ndes = destinations.get(i);
-
-                        Preconditions.checkState(ndes.getServer().equals(toRpcHost(instanceExecParam.host)));
-                        newDestinations.add(Lists.newArrayList(ndes));
-                    }
-                    params.getFragment().getOutput_sink().getMulti_cast_stream_sink().setDestinations(newDestinations);
-                }
-
-                params.setDesc_tbl(descTable);
-                params.setParams(new TPlanFragmentExecParams());
-                params.setFunc_version(3);
-                params.params.setUse_vectorized(true);
-                params.params.setQuery_id(queryId);
-                params.params.setFragment_instance_id(instanceExecParam.instanceId);
-                Map<Integer, List<TScanRangeParams>> scanRanges = instanceExecParam.perNodeScanRanges;
-                if (scanRanges == null) {
-                    scanRanges = Maps.newHashMap();
-                }
-
-                params.params.setPer_node_scan_ranges(scanRanges);
-                params.params.setNode_to_per_driver_seq_scan_ranges(instanceExecParam.nodeToPerDriverSeqScanRanges);
-                params.params.setPer_exch_num_senders(perExchNumSenders);
-
-                params.params.setDestinations(destinations);
-                params.params.setSender_id(i);
-                params.params.setNum_senders(instanceExecParams.size());
-                if (runtimeFilterParams.isSetRuntime_filter_builder_number()) {
-                    params.params.setRuntime_filter_params(runtimeFilterParams);
-                }
-                params.setCoord(coordAddress);
-                params.setBackend_num(instanceExecParam.backendId);
-                params.setQuery_globals(queryGlobals);
-                if (isEnablePipelineEngine) {
-                    params.setQuery_options(new TQueryOptions(queryOptions));
-                } else {
-                    params.setQuery_options(queryOptions);
-                }
-                params.params.setSend_query_statistics_with_every_batch(
-                        fragment.isTransferQueryStatisticsWithEveryBatch());
-                params.params.setInstances_number(hostToNumbers.get(instanceExecParams.get(i).host));
-                // For broker load, the ConnectContext.get() is null
-                if (connectContext != null) {
-                    SessionVariable sessionVariable = connectContext.getSessionVariable();
-
-                    if (isEnablePipelineEngine) {
-                        params.setIs_pipeline(true);
-                        params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
-                        params.setEnable_shared_scan(sessionVariable.isEnableSharedScan() && fragment.isEnableSharedScan());
-
-                        if (instanceExecParam.isSetPipelineDop()) {
-                            params.setPipeline_dop(instanceExecParam.pipelineDop);
-                        } else {
-                            params.setPipeline_dop(fragment.getPipelineDop());
-                        }
-
-                        boolean enableResourceGroup = sessionVariable.isEnableResourceGroup();
-                        params.setEnable_resource_group(enableResourceGroup);
-                        if (enableResourceGroup) {
-                            // session variable workgroup_id is just for verification of resource isolation.
-                            long workgroupId = connectContext.getSessionVariable().getWorkGroupId();
-                            if (workgroupId > 0) {
-                                TWorkGroup wg = new TWorkGroup();
-                                wg.setName("");
-                                wg.setId(connectContext.getSessionVariable().getWorkGroupId());
-                                wg.setVersion(0);
-                                params.setWorkgroup(wg);
-                            } else if (workgroup != null) {
-                                params.setWorkgroup(workgroup.toThrift());
-                            }
-                        }
-                    }
-
-                    params.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
-                }
                 paramsList.add(params);
             }
             return paramsList;
+        }
+
+        TExecBatchPlanFragmentsParams toThriftInBatch(
+                Set<TUniqueId> inFlightInstanceIds, TNetworkAddress destHost, TDescriptorTable descTable,
+                Set<Long> dbIds) throws Exception {
+
+            WorkGroup workgroup = chooseWorkGroup(dbIds);
+            setBucketSeqToInstanceForRuntimeFilters();
+
+            TExecPlanFragmentParams commonParams = new TExecPlanFragmentParams();
+            toThriftForCommonParams(commonParams, destHost, descTable, workgroup, true);
+            fillRequiredFieldsToThrift(commonParams);
+
+            List<TExecPlanFragmentParams> uniqueParamsList = Lists.newArrayList();
+            for (int i = 0; i < instanceExecParams.size(); ++i) {
+                final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);
+                if (!inFlightInstanceIds.contains(instanceExecParam.instanceId)) {
+                    continue;
+                }
+
+                TExecPlanFragmentParams uniqueParams = new TExecPlanFragmentParams();
+                toThriftForUniqueParams(uniqueParams, i, instanceExecParam, true);
+                fillRequiredFieldsToThrift(uniqueParams);
+
+                uniqueParamsList.add(uniqueParams);
+            }
+
+            TExecBatchPlanFragmentsParams request = new TExecBatchPlanFragmentsParams();
+            request.setCommon_param(commonParams);
+            request.setUnique_param_per_instance(uniqueParamsList);
+            return request;
         }
 
         // Append range information

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -688,7 +688,8 @@ public class Coordinator {
     /**
      * Compute the topological order of the fragment tree.
      * It will divide fragments to several groups.
-     * - All the upstream fragments of the fragments in the i-th group must belong to any j-th group where j<i.
+     * - There is no data dependency among fragments in a group.
+     * - All the upstream fragments of the fragments in a group must belong to the previous groups.
      * - Each group should be delivered sequentially, and fragments in a group can be delivered concurrently.
      * <p>
      * For example, the following tree will produce four groups: [[1], [2, 3, 4], [5, 6], [7]]

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2520,32 +2520,6 @@ public class Coordinator {
         }
     }
 
-    private WorkGroup chooseWorkGroup(Set<Long> dbIds) {
-        WorkGroup workgroup = null;
-        if (connectContext != null && connectContext.getSessionVariable().isEnableResourceGroup()) {
-            SessionVariable sessionVariable = connectContext.getSessionVariable();
-
-            // First try to use the resource group specified by the variable
-            if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
-                String rgName = sessionVariable.getResourceGroup();
-                workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroupByName(rgName);
-            }
-
-            // Second if the specified resource group not exist try to use the default one
-            if (workgroup == null) {
-                workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroup(
-                        connectContext, WorkGroupClassifier.QueryType.SELECT, dbIds);
-            }
-
-            if (workgroup != null) {
-                connectContext.getAuditEventBuilder().setResourceGroup(workgroup.getName());
-                connectContext.setWorkGroup(workgroup);
-            }
-        }
-
-        return workgroup;
-    }
-
     // execution parameters for a single fragment,
     // per-fragment can have multiple FInstanceExecParam,
     // used to assemble TPlanFragmentExecParas
@@ -2578,6 +2552,32 @@ public class Coordinator {
                 }
                 rf.setBucketSeqToInstance(seqToInstance);
             }
+        }
+
+        private WorkGroup chooseWorkGroup(Set<Long> dbIds) {
+            WorkGroup workgroup = null;
+            if (connectContext != null && connectContext.getSessionVariable().isEnableResourceGroup()) {
+                SessionVariable sessionVariable = connectContext.getSessionVariable();
+
+                // First try to use the resource group specified by the variable
+                if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
+                    String rgName = sessionVariable.getResourceGroup();
+                    workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroupByName(rgName);
+                }
+
+                // Second if the specified resource group not exist try to use the default one
+                if (workgroup == null) {
+                    workgroup = GlobalStateMgr.getCurrentState().getWorkGroupMgr().chooseWorkGroup(
+                            connectContext, WorkGroupClassifier.QueryType.SELECT, dbIds);
+                }
+
+                if (workgroup != null) {
+                    connectContext.getAuditEventBuilder().setResourceGroup(workgroup.getName());
+                    connectContext.setWorkGroup(workgroup);
+                }
+            }
+
+            return workgroup;
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -750,7 +750,7 @@ public class Coordinator {
         while (!queue.isEmpty()) {
             int groupSize = queue.size();
             List<PlanFragment> group = new ArrayList<>(groupSize);
-            // The next `size` fragments can be delivered concurrently, because zero in-degree indicates that
+            // The next `groupSize` fragments can be delivered concurrently, because zero in-degree indicates that
             // they don't depend on each other and all the fragments depending on them have been delivered.
             for (int i = 0; i < groupSize; ++i) {
                 PlanFragment fragment = queue.poll();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -715,6 +715,7 @@ public class Coordinator {
         PlanFragment root = fragments.get(0);
 
         // Compute in-degree of each fragment by BFS.
+        // `queue` contains the fragments need to visit its in-edges.
         inDegrees.put(root, 0);
         queue.add(root);
         while (!queue.isEmpty()) {
@@ -741,6 +742,7 @@ public class Coordinator {
                     ErrorType.INTERNAL_ERROR);
         }
 
+        // Compute fragment groups by BFS.
         // `queue` contains the fragments whose in-degree is zero.
         queue.add(root);
         List<List<PlanFragment>> results = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -797,11 +797,11 @@ public class Coordinator {
                             continue;
                         }
 
-                        Set<TUniqueId> instanceIds = requests.stream()
+                        Set<TUniqueId> curInstanceIds = requests.stream()
                                 .map(FInstanceExecParam::getInstanceId)
                                 .collect(Collectors.toSet());
                         TExecBatchPlanFragmentsParams tRequest =
-                                params.toThriftInBatch(instanceIds, host, descTable, dbIds);
+                                params.toThriftInBatch(curInstanceIds, host, descTable, dbIds);
                         TExecPlanFragmentParams tCommonParams = tRequest.getCommon_param();
                         List<TExecPlanFragmentParams> tUniqueParamsList = tRequest.getUnique_param_per_instance();
                         Preconditions.checkState(!tUniqueParamsList.isEmpty());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -147,6 +147,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
+    public static final String ENABLE_DELIVER_BATCH_FRAGMENTS = "enable_deliver_batch_fragments";
+
     // Use resource group. It will influence the CPU schedule, I/O scheduler, and
     // memory limit etc. in BE.
     public static final String ENABLE_RESOURCE_GROUP = "enable_resource_group";
@@ -262,6 +264,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PREFER_COMPUTE_NODE)
     private boolean preferComputeNode = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_DELIVER_BATCH_FRAGMENTS)
+    private boolean enableDeliverBatchFragments = true;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_SCAN_WAIT_TIME, flag = VariableMgr.INVISIBLE)
     private long runtimeFilterScanWaitTime = 20L;
@@ -861,6 +866,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public float getGlobalRuntimeFilterProbeMinSelectivity() {
         return globalRuntimeFilterProbeMinSelectivity;
+    }
+
+    public boolean isEnableDeliverBatchFragments() {
+        return enableDeliverBatchFragments;
     }
 
     public boolean isEnablePipelineEngine() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -265,6 +265,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PREFER_COMPUTE_NODE)
     private boolean preferComputeNode = false;
 
+    /**
+     * If enable this variable (only take effect for pipeline), it will deliver fragment instances
+     * to BE in batch and concurrently.
+     * - Uses `exec_batch_plan_fragments` instead of `exec_plan_fragment` RPC API, which all the instances
+     *   of a fragment to the same destination host are delivered in the same request.
+     * - Send different fragments concurrently according to topological order of the fragment tree
+     */
     @VariableMgr.VarAttr(name = ENABLE_DELIVER_BATCH_FRAGMENTS)
     private boolean enableDeliverBatchFragments = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -21,8 +21,10 @@
 
 package com.starrocks.rpc;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
@@ -30,6 +32,7 @@ import com.starrocks.proto.PProxyRequest;
 import com.starrocks.proto.PProxyResult;
 import com.starrocks.proto.PTriggerProfileReportResult;
 import com.starrocks.proto.PUniqueId;
+import com.starrocks.thrift.TExecBatchPlanFragmentsParams;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TUniqueId;
@@ -42,6 +45,8 @@ import java.util.concurrent.Future;
 
 public class BackendServiceClient {
     private static final Logger LOG = LogManager.getLogger(BackendServiceClient.class);
+
+    private static final int RETRY_TIMES = 2;
 
     private BackendServiceClient() {
     }
@@ -78,6 +83,40 @@ public class BackendServiceClient {
                     address.getHostname(), address.getPort(), e);
             throw new RpcException(address.hostname, e.getMessage());
         }
+    }
+
+    public Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(
+            TNetworkAddress address, TExecBatchPlanFragmentsParams tRequest)
+            throws TException, RpcException {
+        final PExecBatchPlanFragmentsRequest pRequest = new PExecBatchPlanFragmentsRequest();
+        pRequest.setRequest(tRequest);
+
+        Future<PExecBatchPlanFragmentsResult> resultFuture = null;
+        for (int i = 1; i <= RETRY_TIMES && resultFuture == null; ++i) {
+            try {
+                final PBackendService service = BrpcProxy.getInstance().getBackendService(address);
+                resultFuture = service.execBatchPlanFragmentsAsync(pRequest);
+            } catch (NoSuchElementException e) {
+                // Retry `RETRY_TIMES`, when NoSuchElementException occurs.
+                if (i >= RETRY_TIMES) {
+                    LOG.warn("Execute batch plan fragments retry failed, address={}:{}",
+                            address.getHostname(), address.getPort(), e);
+                    throw new RpcException(address.hostname, e.getMessage());
+                }
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            } catch (Throwable e) {
+                LOG.warn("Execute batch plan fragments catch a exception, address={}:{}",
+                        address.getHostname(), address.getPort(), e);
+                throw new RpcException(address.hostname, e.getMessage());
+            }
+        }
+
+        Preconditions.checkState(resultFuture != null);
+        return resultFuture;
     }
 
     public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
@@ -24,6 +24,7 @@ package com.starrocks.rpc;
 import com.baidu.jprotobuf.pbrpc.ProtobufRPC;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PProxyRequest;
@@ -36,6 +37,9 @@ public interface PBackendService {
     @ProtobufRPC(serviceName = "PBackendService", methodName = "exec_plan_fragment",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
     Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request);
+    @ProtobufRPC(serviceName = "PBackendService", methodName = "exec_batch_plan_fragments",
+            attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
+    Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(PExecBatchPlanFragmentsRequest request);
 
     @ProtobufRPC(serviceName = "PBackendService", methodName = "cancel_plan_fragment",
             onceTalkTimeout = 5000)

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PExecBatchPlanFragmentsRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PExecBatchPlanFragmentsRequest.java
@@ -1,0 +1,9 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.rpc;
+
+import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
+
+@ProtobufClass
+public class PExecBatchPlanFragmentsRequest extends AttachmentRequest {
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -22,6 +22,7 @@ import com.starrocks.common.ClientPool;
 import com.starrocks.master.MasterImpl;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PProxyRequest;
@@ -31,6 +32,7 @@ import com.starrocks.proto.PTriggerProfileReportResult;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.PBackendService;
+import com.starrocks.rpc.PExecBatchPlanFragmentsRequest;
 import com.starrocks.rpc.PExecPlanFragmentRequest;
 import com.starrocks.rpc.PFetchDataRequest;
 import com.starrocks.rpc.PTriggerProfileReportRequest;
@@ -321,6 +323,18 @@ public class MockedBackend {
         public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
             return executor.submit(() -> {
                 PExecPlanFragmentResult result = new PExecPlanFragmentResult();
+                StatusPB pStatus = new StatusPB();
+                pStatus.statusCode = 0;
+                result.status = pStatus;
+                return result;
+            });
+        }
+
+        @Override
+        public Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(
+                PExecBatchPlanFragmentsRequest request) {
+            return executor.submit(() -> {
+                PExecBatchPlanFragmentsResult result = new PExecBatchPlanFragmentsResult();
                 StatusPB pStatus = new StatusPB();
                 pStatus.statusCode = 0;
                 result.status = pStatus;

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -33,6 +33,7 @@ option cc_generic_services = true;
 service PBackendService {
     rpc transmit_data(starrocks.PTransmitDataParams) returns (starrocks.PTransmitDataResult);
     rpc exec_plan_fragment(starrocks.PExecPlanFragmentRequest) returns (starrocks.PExecPlanFragmentResult);
+    rpc exec_batch_plan_fragments(starrocks.PExecBatchPlanFragmentsRequest) returns (starrocks.PExecBatchPlanFragmentsResult);
     rpc cancel_plan_fragment(starrocks.PCancelPlanFragmentRequest) returns (starrocks.PCancelPlanFragmentResult);
     rpc fetch_data(starrocks.PFetchDataRequest) returns (starrocks.PFetchDataResult);
     rpc tablet_writer_open(starrocks.PTabletWriterOpenRequest) returns (starrocks.PTabletWriterOpenResult);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -210,6 +210,13 @@ message PExecPlanFragmentResult {
     required StatusPB status = 1;
 };
 
+message PExecBatchPlanFragmentsRequest {
+};
+
+message PExecBatchPlanFragmentsResult {
+    optional StatusPB status = 1;
+};
+
 enum PPlanFragmentCancelReason {
     // 0 is reserved
     LIMIT_REACH = 1;
@@ -306,6 +313,7 @@ message PProxyResult {
 service PInternalService {
     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
     rpc exec_plan_fragment(PExecPlanFragmentRequest) returns (PExecPlanFragmentResult);
+    rpc exec_batch_plan_fragments(PExecBatchPlanFragmentsRequest) returns (PExecBatchPlanFragmentsResult);
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
     rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -315,11 +315,6 @@ struct TExecBatchPlanFragmentsParams {
   2: optional list<TExecPlanFragmentParams> unique_param_per_instance
 }
 
-struct TExecMultiPlanFragmentsResult {
-  // required in V1
-  1: optional Status.TStatus status
-}
-
 // CancelPlanFragment
 struct TCancelPlanFragmentParams {
   1: required InternalServiceVersion protocol_version

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -308,6 +308,18 @@ struct TExecPlanFragmentResult {
   1: optional Status.TStatus status
 }
 
+struct TExecBatchPlanFragmentsParams {
+  // required in V1
+  1: optional TExecPlanFragmentParams common_param
+  // required in V1
+  2: optional list<TExecPlanFragmentParams> unique_param_per_instance
+}
+
+struct TExecMultiPlanFragmentsResult {
+  // required in V1
+  1: optional Status.TStatus status
+}
+
 // CancelPlanFragment
 struct TCancelPlanFragmentParams {
   1: required InternalServiceVersion protocol_version


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

All the fragment instances delivered to the same BE will be composed to a request `TExecBatchPlanFragmentsParams`, which has two fields:
- `TExecPlanFragmentParams common_param`.  The common parameters for all the instances.
- `list<TExecPlanFragmentParams> unique_param_per_instance`. The unique parameters for each instance, which contains:
    - pipeline_dop
    - backend_num
    - params.fragment_instance_id
    - params.sender_id
    - params.per_node_scan_ranges
    - fragment.output_sink (only for BatchCastDataStreamSink and ExportSink)

Compute the topological order of the fragment tree to batchple group fragments.
- Each group should be delivered sequentially,
- and fragments in a group can be delivered concurrently.

When BE receives a `TExecBatchPlanFragmentsParams` request , 
1. it prepares the first fragment instance and sets desc_tbl to cache, 
2. prepare the other fragment instances concurrently using the cached desc_tbl in a new thread pool with `pipeline_prepare_thread_pool_thread_num` threads, default is vCPUs.

## Test

### Test1
Create 30 BE on 3 machines (each with 16 vCPUs and 64GB RAM).

Configuration
- Query: Q14 of tpcds_1g .
- parallel_fragment_exec_instance_num = 32.

Result
- 18000 fragment instances in total.
- The delivery time decreases from 36s to 6s.

### Test2
3 BE on 3 machines (each with 16 vCPUs and 64GB RAM).

Test on the SSB, TPC-H, TPC-DS with 100g scale, there isn't performance regression compared to before.

### Test3
3 BE on 3 machines (each with 16 vCPUs and 64GB RAM).
SSB with 100g scale.

Running the following 1000-cocurrentcy queries, the cancelling speed of enable and disable `deliver_batch_fragments` is similar

```bash
mysqlslap xxxx \
    --concurrency=1000 \
    --number-of-queries=1000 \
    --create-schema=ssb \
    --query=" select max(s_address) from lineorder_flat where split(s_city, ' ')[1] in ('CHINA', 'CANADA', 'INDIA');"
```



