### PR TITLE
[BugFix] raise exception and retry on read fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1680,7 +1680,7 @@ public class GlobalStateMgr {
         listener.setMetaContext(metaContext);
     }
 
-    public synchronized boolean replayJournal(long toJournalId) {
+    public synchronized boolean replayJournal(long toJournalId) throws JournalException {
         long newToJournalId = toJournalId;
         if (newToJournalId == -1) {
             newToJournalId = getMaxJournalId();
@@ -1704,8 +1704,8 @@ public class GlobalStateMgr {
             JournalEntity entity = null;
             try {
                 entity = cursor.next();
-            } catch (InterruptedException | JournalException | JournalInconsistentException e) {
-                LOG.warn("got exception when get next, will exit, ", e);
+            } catch (InterruptedException | JournalInconsistentException e) {
+                LOG.warn("got interrupt exception or inconsistent exception when get next, will exit, ", e);
                 // TODO exit gracefully
                 Util.stdoutWithTime(e.getMessage());
                 System.exit(-1);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7991 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This bug was introduced by https://github.com/StarRocks/starrocks/pull/7455, which adds a retry policy in the inner loop when read fails, but forgets to raise to the outer loop after all attempts fail. 