### PR TITLE
[Enhancement] Window function binary search optimization

### DIFF
--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -118,6 +118,7 @@ Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr
             *eos = true;
             return Status::OK();
         }
+        DCHECK(_analytor->has_output());
         SCOPED_TIMER(_analytor->compute_timer());
 
         bool is_new_partition = _analytor->is_new_partition();

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -28,6 +28,38 @@ struct FrameRange {
     int64_t end;
 };
 
+class SegmentStatistics {
+private:
+    // We will not perform loop search until processing enough segments
+    // segment canbe partition or peer group
+    static constexpr int64_t MIN_SEGMENT_NUM = 16;
+
+    // Overhead of binary search is O(N/S logN), where S denote the average size of segment
+    // Overhead of loop search is O(N)
+    // The default chunk_size is 4096, then logN turns out to be log(4096) = 12
+    // Considering the error of estimation, we set the threshold to 8
+    static constexpr int64_t AVERAGE_SIZE_THRESHOLD = 8;
+
+public:
+    void update(int64_t segment_size) {
+        _count++;
+        _cumulative_size += segment_size;
+        _average_size = _cumulative_size / _count;
+    }
+
+    void reset() {
+        _count = 0;
+        _cumulative_size = 0;
+        _average_size = 0;
+    }
+
+    bool is_high_cardinality() { return _count > MIN_SEGMENT_NUM && _average_size < AVERAGE_SIZE_THRESHOLD; }
+
+    int64_t _count = 0;
+    int64_t _cumulative_size = 0;
+    int64_t _average_size = 0;
+};
+
 class Analytor;
 using AnalytorPtr = std::shared_ptr<Analytor>;
 using Analytors = std::vector<AnalytorPtr>;
@@ -141,7 +173,8 @@ private:
     RuntimeProfile::Counter* _rows_returned_counter = nullptr;
     RuntimeProfile::Counter* _column_resize_timer = nullptr;
     RuntimeProfile::Counter* _compute_timer = nullptr;
-    RuntimeProfile::Counter* _binary_search_timer = nullptr;
+    RuntimeProfile::Counter* _partition_search_timer = nullptr;
+    RuntimeProfile::Counter* _peer_group_search_timer = nullptr;
 
     int64_t _num_rows_returned = 0;
     int64_t _limit; // -1: no limit
@@ -168,6 +201,8 @@ private:
     // If first = true, then second record the first position of the latest Chunk that is not equal to the PartitionKey.
     // If first = false, then second points to the last position + 1.
     std::pair<bool, int64_t> _found_partition_end = {false, 0};
+    SegmentStatistics _partition_statistics;
+    std::queue<int64_t> _candidate_partition_ends;
 
     // A peer group is all of the rows that are peers within the specified ordering.
     // Record the start pos of current peer group.
@@ -178,6 +213,8 @@ private:
     // If first = true, then second record the first position of the latest Chunk that is not equal to the peer group.
     // If first = false, then second points to the last position + 1.
     std::pair<bool, int64_t> _found_peer_group_end = {false, 0};
+    SegmentStatistics _peer_group_statistics;
+    std::queue<int64_t> _candidate_peer_group_ends;
 
     // Offset from the current row for ROWS windows with start or end bounds specified
     // with offsets. Is positive if the offset is FOLLOWING, negative if PRECEDING, and 0
@@ -225,6 +262,8 @@ private:
                                        int64_t frame_end);
 
     int64_t _find_first_not_equal(vectorized::Column* column, int64_t target, int64_t start, int64_t end);
+    void _find_candidate_partition_ends();
+    void _find_candidate_peer_group_ends();
 };
 
 // Helper class that properly invokes destructor when state goes out of scope.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7904
Fixes #8001. It is introduced by #7902, which is reverted now. The root cause is when removing unused buffer, `_candidate_partition_end` was not changed at the same time.

```diff
void Analytor::remove_unused_buffer_values(RuntimeState* state) {
    ...
    _removed_from_buffer_rows += remove_count;
    _partition_start -= remove_count;
    _partition_end -= remove_count;
    _found_partition_end.second -= remove_count;
    _current_row_position -= remove_count;
    _peer_group_start -= remove_count;
    _peer_group_end -= remove_count;
    _found_peer_group_end.second -= remove_count;
    int32_t candidate_partition_end_size = _candidate_partition_ends.size();
+  while (--candidate_partition_end_size >= 0) {
+      auto peek = _candidate_partition_ends.front();
+      _candidate_partition_ends.pop();
+      _candidate_partition_ends.push(peek - remove_count);
+  }
+  int32_t candidate_peer_group_end_size = _candidate_peer_group_ends.size();
+  while (--candidate_peer_group_end_size >= 0) {
+      auto peek = _candidate_peer_group_ends.front();
+      _candidate_peer_group_ends.pop();
+      _candidate_peer_group_ends.push(peek - remove_count);
+  }

    ...
}
```

## Enhancement

Repropose the previous work #7902, and perform the same procedure of pre-computation on peer group end
