### PR TITLE
[BugFix]: Fix compaction error using persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -530,7 +530,7 @@ public:
                 not_found->hashes.emplace_back(hash);
             } else {
                 values[i] = iter->second;
-                nfound += (iter->second != NullIndexValue);
+                nfound += (iter->second.get_value() != NullIndexValue);
             }
         }
         *num_found = nfound;
@@ -552,7 +552,7 @@ public:
             } else {
                 auto old_value = p.first->second;
                 old_values[i] = old_value;
-                nfound += (old_value != NullIndexValue);
+                nfound += (old_value.get_value() != NullIndexValue);
                 p.first->second = v;
             }
         }
@@ -575,7 +575,7 @@ public:
             } else {
                 // key exist
                 auto old_value = p.first->second;
-                nfound += (old_value != NullIndexValue);
+                nfound += (old_value.get_value() != NullIndexValue);
                 p.first->second = v;
             }
         }
@@ -621,7 +621,7 @@ public:
         for (size_t i = 0; i < n; i++) {
             const auto& key = fkeys[i];
             uint64_t hash = FixedKeyHash<KeySize>()(key);
-            auto p = _map.emplace_with_hash(hash, key, NullIndexValue);
+            auto p = _map.emplace_with_hash(hash, key, IndexValue(NullIndexValue));
             if (p.second) {
                 // key not exist previously
                 old_values[i] = NullIndexValue;
@@ -630,7 +630,7 @@ public:
             } else {
                 // key exist
                 old_values[i] = p.first->second;
-                nfound += (p.first->second != NullIndexValue);
+                nfound += (p.first->second.get_value() != NullIndexValue);
                 p.first->second = NullIndexValue;
             }
         }
@@ -678,7 +678,7 @@ public:
         }
         auto hasher = FixedKeyHash<KeySize>();
         for (const auto& e : _map) {
-            if (without_null && e.second == NullIndexValue) {
+            if (without_null && e.second.get_value() == NullIndexValue) {
                 continue;
             }
             const auto& k = e.first;
@@ -1077,7 +1077,7 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta) {
             size_t buf_offset = 0;
             for (size_t j = 0; j < batch_num; ++j) {
                 memcpy(keys + j * key_size, buff.data() + buf_offset, key_size);
-                IndexValue val = UNALIGNED_LOAD64(buff.data() + buf_offset + key_size);
+                uint64_t val = UNALIGNED_LOAD64(buff.data() + buf_offset + key_size);
                 values.emplace_back(val);
                 buf_offset += kv_size;
             }
@@ -1523,13 +1523,13 @@ Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue
     std::vector<IndexValue> found_values;
     found_values.reserve(n);
     RETURN_IF_ERROR(get(n, keys, found_values.data()));
-    uint32_t rowid_start = (uint32_t)(values[0] & 0xFFFFFFFF);
     std::vector<size_t> replace_idxes;
     for (size_t i = 0; i < n; ++i) {
-        if (found_values[i] != NullIndexValue && ((uint32_t)(found_values[i] >> 32)) == src_rssid[i]) {
+        if (values[i].get_value() != NullIndexValue &&
+            ((uint32_t)(found_values[i].get_value() >> 32)) == src_rssid[i]) {
             replace_idxes.emplace_back(i);
         } else {
-            failed->emplace_back(rowid_start + i);
+            failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
         }
     }
     RETURN_IF_ERROR(_l0->replace(keys, values, replace_idxes));
@@ -1541,7 +1541,7 @@ Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue
         fixed_buf.reserve(replace_idxes.size() * (_key_size + sizeof(IndexValue)));
         for (size_t i = 0; i < replace_idxes.size(); ++i) {
             fixed_buf.append(fkeys + replace_idxes[i] * _key_size, _key_size);
-            put_fixed64_le(&fixed_buf, values[replace_idxes[i]]);
+            put_fixed64_le(&fixed_buf, values[replace_idxes[i]].get_value());
         }
         RETURN_IF_ERROR(_index_file->append(fixed_buf));
         _page_size += fixed_buf.size();
@@ -1554,9 +1554,9 @@ Status PersistentIndex::_append_wal(size_t n, const void* keys, const IndexValue
     faststring fixed_buf;
     fixed_buf.reserve(n * (_key_size + sizeof(IndexValue)));
     for (size_t i = 0; i < n; i++) {
-        const auto v = (values != nullptr) ? values[i] : NullIndexValue;
+        const auto v = (values != nullptr) ? values[i] : IndexValue(NullIndexValue);
         fixed_buf.append(fkeys + i * _key_size, _key_size);
-        put_fixed64_le(&fixed_buf, v);
+        put_fixed64_le(&fixed_buf, v.get_value());
     }
     RETURN_IF_ERROR(_index_file->append(fixed_buf));
     _page_size += fixed_buf.size();
@@ -1694,7 +1694,7 @@ Status merge_shard_kvs_fixed_len(std::vector<KVRef>& l0_kvs, std::vector<KVRef>&
         }
     }
     for (auto& kv : l0_kvs) {
-        IndexValue v = UNALIGNED_LOAD64(kv.kv_pos + KeySize);
+        uint64_t v = UNALIGNED_LOAD64(kv.kv_pos + KeySize);
         if (v == NullIndexValue) {
             // delete
             kvs_set.erase(kv);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -28,8 +28,18 @@ enum PersistentIndexFileVersion {
     PERSISTENT_INDEX_VERSION_1,
 };
 
-using IndexValue = uint64_t;
-static constexpr IndexValue NullIndexValue = -1;
+static constexpr uint64_t NullIndexValue = -1;
+
+// Use `uint8_t[8]` to store the value of a `uint64_t` to reduce memory cost in phmap
+struct IndexValue {
+    uint8_t v[8];
+    IndexValue() = default;
+    explicit IndexValue(const uint64_t val) { UNALIGNED_STORE64(v, val); }
+
+    uint64_t get_value() const { return UNALIGNED_LOAD64(v); }
+    bool operator==(const IndexValue& rhs) const { return memcmp(v, rhs.v, 8) == 0; }
+    void operator=(uint64_t rhs) { return UNALIGNED_STORE64(v, rhs); }
+};
 
 class ImmutableIndexShard;
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1064,7 +1064,8 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowids, 0, pks.size(), &values);
-    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(), values.data(), true));
+    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(),
+                                              reinterpret_cast<IndexValue*>(values.data()), true));
     return Status::OK();
 }
 
@@ -1074,7 +1075,8 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
     values.reserve(pks.size());
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    _persistent_index->upsert(pks.size(), pks.continuous_data(), values.data(), old_values.data());
+    _persistent_index->upsert(pks.size(), pks.continuous_data(), reinterpret_cast<IndexValue*>(values.data()),
+                              reinterpret_cast<IndexValue*>(old_values.data()));
     for (uint32_t i = 0; i < old_values.size(); ++i) {
         uint64_t old = old_values[i];
         if ((old != NullIndexValue) && (old >> 32) == rssid) {
@@ -1088,7 +1090,8 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
 
 void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(), old_values.data());
+    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(),
+                                         reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1101,7 +1104,8 @@ void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, De
 }
 
 void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
-    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(), rowids->data());
+    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(),
+                                       reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
@@ -1112,7 +1116,8 @@ void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_star
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(), values.data(), src_rssid, deletes);
+    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
+                                               reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -171,7 +171,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(index.get(keys.size(), keys.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
-            ASSERT_EQ(NullIndexValue, get_values[i]);
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
         for (int i = N / 2; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
@@ -188,7 +188,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(new_index.get(keys.size(), keys.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
-            ASSERT_EQ(NullIndexValue, get_values[i]);
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
         for (int i = N / 2; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
@@ -395,7 +395,7 @@ void build_persistent_index_from_tablet(size_t N) {
         primary_results.resize(pks.size());
         persistent_results.resize(pks.size());
         primary_index.get(pks, &primary_results);
-        persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+        persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
         ASSERT_EQ(primary_results.size(), persistent_results.size());
         for (size_t j = 0; j < primary_results.size(); ++j) {
             ASSERT_EQ(primary_results[i], persistent_results[i]);
@@ -419,7 +419,7 @@ void build_persistent_index_from_tablet(size_t N) {
             primary_results.resize(pks.size());
             persistent_results.resize(pks.size());
             primary_index.get(pks, &primary_results);
-            persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+            persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
             ASSERT_EQ(primary_results.size(), persistent_results.size());
             for (size_t j = 0; j < primary_results.size(); ++j) {
                 ASSERT_EQ(primary_results[i], persistent_results[i]);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7244

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When PersistentIndex is turned on, we use phmap as l0 to save kv pairs.

However, the kv pair storage may be discontinuous because phmap is aligned, which causes the wrong data to be written during flush. So the subsequent compaction may fail.

We will use uint8_t[8] instead of uint64_t to avoid the alignment of phmap and save memory usage.

