### PR TITLE
[Cherry-pick][Enhancement][Branch-2.3]Optimize `find_buckets_to_move` to make sure find a move solution (#7685)

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -184,83 +184,69 @@ struct MoveDest {
     bool operator<(const MoveDest& rhs) const { return npack < rhs.npack; }
 };
 
-static Status find_buckets_to_move(uint32_t pageid, size_t min_pack_to_move, const uint8_t* bucket_packs_in_page,
-                                   std::vector<BucketToMove>* buckets_to_move) {
-    std::vector<int> bucketid_ordered_by_packs(bucket_per_page);
-    for (int i = 0; i < bucket_per_page; i++) {
-        bucketid_ordered_by_packs[i] = i;
-    }
-    std::sort(bucketid_ordered_by_packs.begin(), bucketid_ordered_by_packs.end(),
-              [&](const int& l, const int& r) -> bool { return bucket_packs_in_page[l] < bucket_packs_in_page[r]; });
-    // try find solution of moving 1 bucket
-    for (int oi = 0; oi < bucket_per_page; oi++) {
-        int i = bucketid_ordered_by_packs[oi];
-        auto bucket_packs = bucket_packs_in_page[i];
-        if (bucket_packs >= min_pack_to_move) {
-            buckets_to_move->emplace_back(bucket_packs, pageid, i);
-            return Status::OK();
+static std::vector<int8_t> get_move_buckets(size_t target, const uint8_t* bucket_packs_in_page) {
+    vector<int8_t> idxes;
+    idxes.reserve(bucket_per_page);
+    int32_t total_buckets = 0;
+    for (int8_t i = 0; i < bucket_per_page; i++) {
+        if (bucket_packs_in_page[i] > 0) {
+            idxes.push_back(i);
         }
+        total_buckets += bucket_packs_in_page[i];
     }
-    // try find solution of moving 2 bucket
-    std::array<int, 3> move2_min = {INT_MAX, -1, -1};
-    for (int oi = 0; oi < bucket_per_page; oi++) {
-        int i = bucketid_ordered_by_packs[oi];
-        if (bucket_packs_in_page[i] == 0) {
-            continue;
+    std::sort(idxes.begin(), idxes.end(),
+              [&](int8_t lhs, int8_t rhs) { return bucket_packs_in_page[lhs] < bucket_packs_in_page[rhs]; });
+    // store idx if this sum value uses bucket_packs_in_page[idx], or -1
+    std::vector<int8_t> dp(total_buckets + 1, -1);
+    dp[0] = bucket_per_page;           // assign an id that will never be used but >= 0
+    int32_t valid_sum = total_buckets; // total_buckets is already a valid solution
+    auto get_list_from_dp = [&] {
+        vector<int8_t> ret;
+        ret.reserve(16);
+        while (valid_sum > 0) {
+            ret.emplace_back(dp[valid_sum]);
+            valid_sum -= bucket_packs_in_page[dp[valid_sum]];
         }
-        for (int oj = oi + 1; oj < bucket_per_page; oj++) {
-            int j = bucketid_ordered_by_packs[oj];
-            auto bucket_packs = bucket_packs_in_page[i] + bucket_packs_in_page[j];
-            if (bucket_packs == min_pack_to_move) {
-                buckets_to_move->emplace_back(bucket_packs_in_page[i], pageid, i);
-                buckets_to_move->emplace_back(bucket_packs_in_page[j], pageid, j);
-                return Status::OK();
-            } else if (bucket_packs > min_pack_to_move && bucket_packs < move2_min[0]) {
-                move2_min = {bucket_packs, i, j};
-                break;
+        return ret;
+    };
+    int32_t max_sum = 0; // current max sum
+    for (int8_t idx = 0; idx < idxes.size(); idx++) {
+        int8_t i = idxes[idx];
+        for (int32_t v = 0; v <= max_sum; v++) {
+            if (dp[v] < 0 || dp[v] == i) {
+                continue;
             }
-        }
-    }
-    if (move2_min[2] >= 0) {
-        for (int i = 1; i < 3; i++) {
-            auto bucketid = move2_min[i];
-            buckets_to_move->emplace_back(bucket_packs_in_page[bucketid], pageid, bucketid);
-        }
-        return Status::OK();
-    }
-    // try find solution of moving 3 bucket
-    std::array<int, 4> move3_min = {INT_MAX, -1, -1, -1};
-    for (int oi = 0; oi < bucket_per_page; oi++) {
-        int i = bucketid_ordered_by_packs[oi];
-        if (bucket_packs_in_page[i] == 0) {
-            continue;
-        }
-        for (int oj = oi + 1; oj < bucket_per_page; oj++) {
-            int j = bucketid_ordered_by_packs[oj];
-            for (int ok = oj + 1; ok < bucket_per_page; ok++) {
-                int k = bucketid_ordered_by_packs[ok];
-                auto bucket_packs = bucket_packs_in_page[i] + bucket_packs_in_page[j] + bucket_packs_in_page[k];
-                if (bucket_packs == min_pack_to_move) {
-                    buckets_to_move->emplace_back(bucket_packs_in_page[i], pageid, i);
-                    buckets_to_move->emplace_back(bucket_packs_in_page[j], pageid, j);
-                    buckets_to_move->emplace_back(bucket_packs_in_page[k], pageid, k);
-                    return Status::OK();
-                } else if (bucket_packs > min_pack_to_move && bucket_packs < move3_min[0]) {
-                    move3_min = {bucket_packs, i, j, k};
-                    break;
+            int32_t nv = v + bucket_packs_in_page[i];
+            if (dp[nv] >= 0) {
+                continue;
+            }
+            dp[nv] = i;
+            if (nv > max_sum) {
+                max_sum = nv;
+            }
+            if (nv >= target) {
+                valid_sum = std::min(valid_sum, nv);
+                if (valid_sum == target) {
+                    return get_list_from_dp();
                 }
             }
         }
     }
-    if (move3_min[2] >= 0) {
-        for (int i = 1; i < 4; i++) {
-            auto bucketid = move3_min[i];
-            buckets_to_move->emplace_back(bucket_packs_in_page[bucketid], pageid, bucketid);
-        }
-        return Status::OK();
+    return get_list_from_dp();
+}
+
+static Status find_buckets_to_move(uint32_t pageid, size_t min_pack_to_move, const uint8_t* bucket_packs_in_page,
+                                   std::vector<BucketToMove>* buckets_to_move) {
+    auto ret = get_move_buckets(min_pack_to_move, bucket_packs_in_page);
+
+    size_t move_packs = 0;
+    for (int32_t i = 0; i < ret.size(); ++i) {
+        buckets_to_move->emplace_back(bucket_packs_in_page[ret[i]], pageid, ret[i]);
+        move_packs += bucket_packs_in_page[ret[i]];
     }
-    // TODO: current algorithm is sub-optimal, find buckets to move using DP
-    return Status::InternalError("find_buckets_to_move");
+    DCHECK(move_packs >= min_pack_to_move);
+
+    return Status::OK();
 }
 
 struct BucketMovement {
@@ -409,6 +395,7 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_
             copy_kv_to_page(kv_size, bucket_info.size, bucket_kv_ptrs_tags[bid].first.data(),
                             bucket_kv_ptrs_tags[bid].second.data(), page.pack(cur_packid));
             cur_packid += bucket_packs[bid];
+            //LOG(INFO) << "cur_packid is " << cur_packid;
             DCHECK(cur_packid <= page_size / pack_size);
         }
         for (auto& move : moves) {
@@ -1819,6 +1806,10 @@ Status PersistentIndex::_merge_compaction() {
         }
     }
     return writer.finish();
+}
+
+std::vector<int8_t> PersistentIndex::test_get_move_buckets(size_t target, const uint8_t* bucket_packs_in_page) {
+    return get_move_buckets(target, bucket_packs_in_page);
 }
 
 } // namespace starrocks

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -301,6 +301,8 @@ public:
 
     size_t mutable_index_capacity();
 
+    std::vector<int8_t> test_get_move_buckets(size_t target, const uint8_t* bucket_packs_in_page);
+
 private:
     std::string _get_l0_index_file_name(std::string& dir, const EditVersion& version);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7577 #4775

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, find_buckets_to_move uses a brute force search algorithm to search buckets to move, only searching 1/2/3 of bucket movements which may find a solution.
