### PR TITLE
[cherry-pick] [BugFix] Remove the helpers from bdb ReplicationGroupAdmin when dropped fe (#6773)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2626,6 +2626,7 @@ public class Catalog {
 
                 BDBHA ha = (BDBHA) haProtocol;
                 ha.removeUnstableNode(host, getFollowerCnt());
+                ha.removeHelperSocket(host, port);
             }
             editLog.logRemoveFrontend(fe);
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -236,6 +236,17 @@ public class BDBHA implements HAProtocol {
         }
     }
 
+    public void removeHelperSocket(String ip, Integer port) {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        Set<InetSocketAddress> helperSockets = Sets.newHashSet(replicationGroupAdmin.getHelperSockets());
+        InetSocketAddress targetAddress = new InetSocketAddress(ip, port);
+        if (helperSockets.contains(targetAddress)) {
+            helperSockets.remove(targetAddress);
+            environment.setNewReplicationGroupAdmin(helperSockets);
+            LOG.info("remove helper socket {}:{} from replicationGroupAdmin", ip, port);
+        }
+    }
+
     public void removeNodeIfExist(String host, int port) {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5663

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove the helpers from bdb ReplicationGroupAdmin when dropped fe