### PR TITLE
[BUG] Fix invalid replay argument for create and fresh materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2952,7 +2952,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 // create task
                 Task task = TaskBuilder.buildMvTask(materializedView, dbName);
                 TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-                taskManager.createTask(task, true);
+                taskManager.createTask(task, false);
                 // run task
                 taskManager.executeTask(task.getName());
             }
@@ -3017,7 +3017,7 @@ public class LocalMetastore implements ConnectorMetadata {
         final String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
         if (!taskManager.containTask(mvTaskName)) {
             Task task = TaskBuilder.buildMvTask(materializedView, dbName);
-            taskManager.createTask(task, true);
+            taskManager.createTask(task, false);
         }
         // run task
         taskManager.executeTask(mvTaskName);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8008 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix invalid replay argument for create and fresh materialized view. If isReplay is true, it is used when replay image log. When create mv and refresh mv, it should be false.