### PR TITLE
[Enhancement] compute semi join statistics instead of use inner join statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -798,8 +798,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 computeNullFractionForOuterJoin(leftRowCount, innerRowCount, rightStatistics, joinStatsBuilder);
                 break;
             case LEFT_SEMI_JOIN:
+                joinStatsBuilder = Statistics.buildFrom(StatisticsEstimateUtils.adjustStatisticsByRowCount(
+                        innerJoinStats, Math.min(leftRowCount, innerRowCount)));
+                break;
             case RIGHT_SEMI_JOIN:
-                joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
+                joinStatsBuilder = Statistics.buildFrom(StatisticsEstimateUtils.adjustStatisticsByRowCount(
+                        innerJoinStats, Math.min(rightRowCount, innerRowCount)));
                 break;
             case LEFT_ANTI_JOIN:
             case NULL_AWARE_LEFT_ANTI_JOIN:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -32,4 +32,23 @@ public class StatisticsEstimateUtils {
                 .setDistinctValuesCount(newRange.getDistinctValues());
         return builder.build();
     }
+
+    public static Statistics adjustStatisticsByRowCount(Statistics statistics, double rowCount) {
+        // Do not compute predicate statistics if column statistics is unknown or table row count may inaccurate
+        if (statistics.getColumnStatistics().values().stream().anyMatch(ColumnStatistic::isUnknown) ||
+                statistics.isTableRowCountMayInaccurate()) {
+            return statistics;
+        }
+        Statistics.Builder builder = Statistics.buildFrom(statistics);
+        builder.setOutputRowCount(rowCount);
+        // use row count to adjust column statistics distinct values
+        double distinctValues = Math.max(1, rowCount);
+        statistics.getColumnStatistics().forEach((column, columnStatistic) -> {
+            if (columnStatistic.getDistinctValuesCount() > distinctValues) {
+                builder.addColumnStatistic(column,
+                        ColumnStatistic.buildFrom(columnStatistic).setDistinctValuesCount(distinctValues).build());
+            }
+        });
+        return builder.build();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -320,7 +320,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    numwait desc,\n" +
                 "    s_name limit 100;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(227, planCount);
+        Assert.assertEquals(86, planCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
@@ -43,7 +43,7 @@ Input Partition: UNPARTITIONED
 RESULT SINK
 
 25:MERGING-EXCHANGE
-cardinality: 1561188
+cardinality: 40000
 column statistics:
 * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
@@ -59,7 +59,7 @@ OutPut Exchange Id: 25
 24:SORT
 |  order by: [2, VARCHAR, false] ASC
 |  offset: 0
-|  cardinality: 1561188
+|  cardinality: 40000
 |  column statistics:
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
@@ -70,7 +70,7 @@ OutPut Exchange Id: 25
 |  output columns:
 |  2 <-> [2: S_NAME, VARCHAR, false]
 |  3 <-> [3: S_ADDRESS, VARCHAR, false]
-|  cardinality: 1561188
+|  cardinality: 40000
 |  column statistics:
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * S_ADDRESS-->[-Infinity, Infinity, 0.0, 40.0, 10000.0] ESTIMATE
@@ -81,7 +81,7 @@ OutPut Exchange Id: 25
 |  build runtime filters:
 |  - filter_id = 4, build_expr = (1: S_SUPPKEY), remote = true
 |  output columns: 2, 3
-|  cardinality: 1561188
+|  cardinality: 40000
 |  column statistics:
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
@@ -84,21 +84,24 @@ HASH_PARTITIONED: 2: S_NAME
 |  <slot 2> : 2: S_NAME
 |
 22:HASH JOIN
-|  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
 |  colocate: false, reason:
-|  equal join conjunct: 41: L_ORDERKEY = 9: L_ORDERKEY
-|  other join predicates: 43: L_SUPPKEY != 11: L_SUPPKEY
+|  equal join conjunct: 26: O_ORDERKEY = 9: L_ORDERKEY
 |
 |----21:EXCHANGE
 |
+1:Project
+|  <slot 26> : 26: O_ORDERKEY
+|
 0:OlapScanNode
-TABLE: lineitem
+TABLE: orders
 PREAGGREGATION: ON
+PREDICATES: 28: O_ORDERSTATUS = 'F'
 partitions=1/1
-rollup: lineitem
-tabletRatio=20/20
-cardinality=600000000
-avgRowSize=12.0
+rollup: orders
+tabletRatio=10/10
+cardinality=50000000
+avgRowSize=9.0
 numNodes=0
 
 PLAN FRAGMENT 3
@@ -112,27 +115,23 @@ BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
 20:Project
 |  <slot 2> : 2: S_NAME
 |  <slot 9> : 9: L_ORDERKEY
-|  <slot 11> : 11: L_SUPPKEY
 |
 19:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
 |  colocate: false, reason:
-|  equal join conjunct: 26: O_ORDERKEY = 9: L_ORDERKEY
+|  equal join conjunct: 41: L_ORDERKEY = 9: L_ORDERKEY
+|  other join predicates: 43: L_SUPPKEY != 11: L_SUPPKEY
 |
 |----18:EXCHANGE
 |
-2:Project
-|  <slot 26> : 26: O_ORDERKEY
-|
-1:OlapScanNode
-TABLE: orders
+2:OlapScanNode
+TABLE: lineitem
 PREAGGREGATION: ON
-PREDICATES: 28: O_ORDERSTATUS = 'F'
 partitions=1/1
-rollup: orders
-tabletRatio=10/10
-cardinality=50000000
-avgRowSize=9.0
+rollup: lineitem
+tabletRatio=20/20
+cardinality=600000000
+avgRowSize=12.0
 numNodes=0
 
 PLAN FRAGMENT 4


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
StarRocks use inner join stats as semi join stats before,  inner join cardinalty estimation may larger than semi join table row count, which will result in error estimation