### PR TITLE
[Cherry-pick][BugFix][Branch-2.3]: Fix compaction error using persistent index (#8002)

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -28,8 +28,18 @@ enum PersistentIndexFileVersion {
     PERSISTENT_INDEX_VERSION_1,
 };
 
-using IndexValue = uint64_t;
-static constexpr IndexValue NullIndexValue = -1;
+static constexpr uint64_t NullIndexValue = -1;
+
+// Use `uint8_t[8]` to store the value of a `uint64_t` to reduce memory cost in phmap
+struct IndexValue {
+    uint8_t v[8];
+    IndexValue() = default;
+    explicit IndexValue(const uint64_t val) { UNALIGNED_STORE64(v, val); }
+
+    uint64_t get_value() const { return UNALIGNED_LOAD64(v); }
+    bool operator==(const IndexValue& rhs) const { return memcmp(v, rhs.v, 8) == 0; }
+    void operator=(uint64_t rhs) { return UNALIGNED_STORE64(v, rhs); }
+};
 
 class ImmutableIndexShard;
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1057,7 +1057,8 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowids, 0, pks.size(), &values);
-    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(), values.data(), true));
+    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(),
+                                              reinterpret_cast<IndexValue*>(values.data()), true));
     return Status::OK();
 }
 
@@ -1067,7 +1068,8 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
     values.reserve(pks.size());
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    _persistent_index->upsert(pks.size(), pks.continuous_data(), values.data(), old_values.data());
+    _persistent_index->upsert(pks.size(), pks.continuous_data(), reinterpret_cast<IndexValue*>(values.data()),
+                              reinterpret_cast<IndexValue*>(old_values.data()));
     for (uint32_t i = 0; i < old_values.size(); ++i) {
         uint64_t old = old_values[i];
         if ((old != NullIndexValue) && (old >> 32) == rssid) {
@@ -1081,7 +1083,8 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
 
 void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(), old_values.data());
+    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(),
+                                         reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1094,7 +1097,8 @@ void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, De
 }
 
 void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
-    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(), rowids->data());
+    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(),
+                                       reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
@@ -1105,7 +1109,8 @@ void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_star
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(), values.data(), src_rssid, deletes);
+    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
+                                               reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -170,7 +170,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(index.get(keys.size(), keys.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
-            ASSERT_EQ(NullIndexValue, get_values[i]);
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
         for (int i = N / 2; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
@@ -187,7 +187,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(new_index.get(keys.size(), keys.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
-            ASSERT_EQ(NullIndexValue, get_values[i]);
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
         for (int i = N / 2; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
@@ -395,7 +395,7 @@ void build_persistent_index_from_tablet(size_t N) {
         primary_results.resize(pks.size());
         persistent_results.resize(pks.size());
         primary_index.get(pks, &primary_results);
-        persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+        persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
         ASSERT_EQ(primary_results.size(), persistent_results.size());
         for (size_t j = 0; j < primary_results.size(); ++j) {
             ASSERT_EQ(primary_results[i], persistent_results[i]);
@@ -419,7 +419,7 @@ void build_persistent_index_from_tablet(size_t N) {
             primary_results.resize(pks.size());
             persistent_results.resize(pks.size());
             primary_index.get(pks, &primary_results);
-            persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+            persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
             ASSERT_EQ(primary_results.size(), persistent_results.size());
             for (size_t j = 0; j < primary_results.size(); ++j) {
                 ASSERT_EQ(primary_results[i], persistent_results[i]);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7244 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When PersistentIndex is turned on, we use phmap as l0 to save kv pairs.
However, the kv pair storage may be discontinuous because phmap is aligned, which causes the wrong data to be written during flush. So the subsequent compaction may fail.
We will use uint8_t[8] instead of uint64_t to avoid the alignment of phmap and save memory usage.
