### PR TITLE
[BugFix] Fix return non-existent codes in global dictionary optimization

### DIFF
--- a/be/src/storage/rowset/column_decoder.cpp
+++ b/be/src/storage/rowset/column_decoder.cpp
@@ -32,6 +32,9 @@ Status ColumnDecoder::encode_to_global_id(vectorized::Column* datas, vectorized:
                 }
             }
         }
+        // set null info to the the lowcardinality column
+        lowcard_nullcolumn->set_has_null(nullable_column->has_null());
+        lowcard_nullcolumn->null_column()->swap_column(*nullable_column->null_column());
     } else {
         auto* binary_column = down_cast<vectorized::BinaryColumn*>(datas);
         auto* lowcard_column = down_cast<vectorized::LowCardDictColumn*>(codes);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -103,7 +103,7 @@ public class CacheDictManager implements IDictManager {
         }
         int dictSize = tGlobalDict.getIdsSize();
         ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
-        if (dictSize > 256) {
+        if (dictSize > LOW_CARDINALITY_THRESHOLD) {
             noDictStringColumns.add(columnIdentifier);
             return Optional.empty();
         } else {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #8030 

## Problem Summary(Required) ：
After these change, when BE returns to a dictionary of size 256, FE will not use this dictionary.
