### PR TITLE
[Refactor] Simplify partition and peer group boundary search procedure

### DIFF
--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -175,9 +175,9 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState*
                 // The condition `partition_start <= current_row_position < partition_end` is satisfied
                 // so `partition_end` must point at the genuine partition boundary, and found_partition_end must equals
                 // to partition_end if current partition haven't finished processing
-                DCHECK_EQ(_analytor->partition_end(), _analytor->found_partition_end());
+                DCHECK_EQ(_analytor->partition_end(), _analytor->found_partition_end().second);
                 // So the found_partition_end also points at genuine partition boundary, then we pass true to the following function
-                _analytor->find_and_check_peer_group_end(true);
+                _analytor->find_peer_group_end();
                 DCHECK_GE(_analytor->peer_group_end(), _analytor->peer_group_start());
                 _analytor->update_window_batch(_analytor->peer_group_start(), _analytor->peer_group_end(),
                                                _analytor->peer_group_start(), _analytor->peer_group_end());
@@ -261,10 +261,10 @@ Status AnalyticNode::_get_next_for_rows_between_unbounded_preceding_and_current_
     _analytor->create_agg_result_columns(chunk_size);
 
     do {
-        bool end = _analytor->find_and_check_partition_end();
+        _analytor->find_partition_end();
 
-        while (_analytor->current_row_position() < _analytor->found_partition_end()) {
-            _analytor->update_window_batch(_analytor->partition_start(), _analytor->found_partition_end(),
+        while (_analytor->current_row_position() < _analytor->found_partition_end().second) {
+            _analytor->update_window_batch(_analytor->partition_start(), _analytor->found_partition_end().second,
                                            _analytor->current_row_position(), _analytor->current_row_position() + 1);
 
             _analytor->update_window_result_position(1);
@@ -276,7 +276,7 @@ Status AnalyticNode::_get_next_for_rows_between_unbounded_preceding_and_current_
             _analytor->update_current_row_position(1);
         }
 
-        if (end) {
+        if (_analytor->found_partition_end().first) {
             _analytor->reset_state_for_next_partition();
         }
     } while (!_analytor->is_current_chunk_finished_eval());
@@ -285,11 +285,11 @@ Status AnalyticNode::_get_next_for_rows_between_unbounded_preceding_and_current_
 }
 
 Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state) {
-    _analytor->find_and_check_partition_end();
-    while (!_analytor->is_partition_boundary_reached()) {
+    _analytor->find_partition_end();
+    while (!_analytor->found_partition_end().first) {
         RETURN_IF_ERROR(state->check_mem_limit("analytic node fetch next partition data"));
         RETURN_IF_ERROR(_fetch_next_chunk(state));
-        _analytor->find_and_check_partition_end();
+        _analytor->find_partition_end();
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -74,10 +74,10 @@ public:
     void update_current_row_position(int64_t increment) { _current_row_position += increment; }
     int64_t partition_start() const { return _partition_start; }
     int64_t partition_end() const { return _partition_end; }
-    int64_t found_partition_end() const { return _found_partition_end; }
+    const std::pair<bool, int64_t>& found_partition_end() const { return _found_partition_end; }
     int64_t peer_group_start() const { return _peer_group_start; }
     int64_t peer_group_end() const { return _peer_group_end; }
-    int64_t found_peer_group_end() const { return _found_peer_group_end; }
+    const std::pair<bool, int64_t>& found_peer_group_end() const { return _found_peer_group_end; }
 
     const std::vector<starrocks_udf::FunctionContext*>& agg_fn_ctxs() { return _agg_fn_ctxs; }
     const std::vector<std::vector<ExprContext*>>& agg_expr_ctxs() { return _agg_expr_ctxs; }
@@ -99,17 +99,13 @@ public:
     void reset_window_state();
     void get_window_function_result(size_t frame_start, size_t frame_end);
 
-    bool is_partition_boundary_reached();
     Status output_result_chunk(vectorized::ChunkPtr* chunk);
     void create_agg_result_columns(int64_t chunk_size);
 
     bool is_new_partition();
     int64_t get_total_position(int64_t local_position);
-    bool find_and_check_partition_end();
+    void find_partition_end();
     void find_peer_group_end();
-    // is_found_partition_end_genuine_boundary = true means _found_partition_end point at
-    // the genuine partition boundary
-    bool find_and_check_peer_group_end(bool is_found_partition_end_genuine_boundary = false);
     void reset_state_for_cur_partition();
     void reset_state_for_next_partition();
 
@@ -169,9 +165,9 @@ private:
     // Record the end pos of current partition.
     // If the end position has not been found during the iteration, _partition_end = _partition_start.
     int64_t _partition_end = 0;
-    // Used to record the first position of the latest Chunk that is not equal to the PartitionKey.
-    // If not found, it points to the last position + 1.
-    int64_t _found_partition_end = 0;
+    // If first = true, then second record the first position of the latest Chunk that is not equal to the PartitionKey.
+    // If first = false, then second points to the last position + 1.
+    std::pair<bool, int64_t> _found_partition_end = {false, 0};
 
     // A peer group is all of the rows that are peers within the specified ordering.
     // Record the start pos of current peer group.
@@ -179,9 +175,9 @@ private:
     // Record the end pos of current peer group.
     // If the end position has not been found during the iteration, _peer_group_end = _peer_group_start.
     int64_t _peer_group_end = 0;
-    // Used to record the first position of the latest Chunk that is not equal to the peer group.
-    // If not found, it points to the last position + 1.
-    int64_t _found_peer_group_end = 0;
+    // If first = true, then second record the first position of the latest Chunk that is not equal to the peer group.
+    // If first = false, then second points to the last position + 1.
+    std::pair<bool, int64_t> _found_peer_group_end = {false, 0};
 
     // Offset from the current row for ROWS windows with start or end bounds specified
     // with offsets. Is positive if the offset is FOLLOWING, negative if PRECEDING, and 0

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -27,9 +27,9 @@ TEST_F(AnalytorTest, find_peer_group_end) {
 
     analytor.update_input_rows(20);
     analytor._order_columns.emplace_back(c1);
-    analytor._found_partition_end = 20;
+    analytor._found_partition_end = {true, 20};
 
-    analytor.find_and_check_peer_group_end(true);
+    analytor.find_peer_group_end();
     ASSERT_EQ(analytor.peer_group_end(), 10);
 }
 
@@ -41,7 +41,7 @@ TEST_F(AnalytorTest, reset_state_for_cur_partition) {
 
     analytor._partition_start = 3;
     analytor._partition_end = 10;
-    analytor._found_partition_end = 20;
+    analytor._found_partition_end = {true, 20};
     analytor.reset_state_for_cur_partition();
     ASSERT_EQ(analytor.partition_start(), 10);
     ASSERT_EQ(analytor.partition_end(), 20);
@@ -56,7 +56,7 @@ TEST_F(AnalytorTest, reset_state_for_next_partition) {
 
     analytor._partition_start = 10;
     analytor._partition_end = 10;
-    analytor._found_partition_end = 20;
+    analytor._found_partition_end = {true, 20};
     analytor.reset_state_for_next_partition();
     ASSERT_EQ(analytor.partition_start(), 20);
     ASSERT_EQ(analytor.partition_end(), 20);
@@ -64,7 +64,7 @@ TEST_F(AnalytorTest, reset_state_for_next_partition) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(AnalytorTest, find_and_check_partition_end) {
+TEST_F(AnalytorTest, find_partition_end) {
     TPlanNode plan_node;
     RowDescriptor row_desc;
     Analytor analytor1(plan_node, row_desc, nullptr);
@@ -86,42 +86,42 @@ TEST_F(AnalytorTest, find_and_check_partition_end) {
     analytor1._partition_columns.emplace_back(c1);
     analytor1._partition_columns.emplace_back(c2);
 
-    analytor1._current_row_position = analytor1.found_partition_end();
-    bool end = analytor1.find_and_check_partition_end();
-    ASSERT_TRUE(end);
-    ASSERT_EQ(analytor1.found_partition_end(), 5);
+    analytor1._current_row_position = analytor1.found_partition_end().second;
+    analytor1.find_partition_end();
+    ASSERT_TRUE(analytor1.found_partition_end().first);
+    ASSERT_EQ(analytor1.found_partition_end().second, 5);
 
     analytor1.reset_state_for_cur_partition();
 
-    analytor1._current_row_position = analytor1.found_partition_end();
-    end = analytor1.find_and_check_partition_end();
-    ASSERT_TRUE(end);
-    ASSERT_EQ(analytor1.found_partition_end(), 10);
+    analytor1._current_row_position = analytor1.found_partition_end().second;
+    analytor1.find_partition_end();
+    ASSERT_TRUE(analytor1.found_partition_end().first);
+    ASSERT_EQ(analytor1.found_partition_end().second, 10);
 
     analytor1.reset_state_for_cur_partition();
 
-    analytor1._current_row_position = analytor1.found_partition_end();
-    end = analytor1.find_and_check_partition_end();
-    ASSERT_FALSE(end);
-    ASSERT_EQ(analytor1.found_partition_end(), 20);
+    analytor1._current_row_position = analytor1.found_partition_end().second;
+    analytor1.find_partition_end();
+    ASSERT_FALSE(analytor1.found_partition_end().first);
+    ASSERT_EQ(analytor1.found_partition_end().second, 20);
 
     // partition columns is empty
     Analytor analytor2(plan_node, row_desc, nullptr);
     analytor2.update_input_rows(20);
 
-    analytor2._current_row_position = analytor2.found_partition_end();
-    end = analytor2.find_and_check_partition_end();
-    ASSERT_FALSE(end);
-    ASSERT_EQ(analytor2.found_partition_end(), 20);
+    analytor2._current_row_position = analytor2.found_partition_end().second;
+    analytor2.find_partition_end();
+    ASSERT_FALSE(analytor2.found_partition_end().first);
+    ASSERT_EQ(analytor2.found_partition_end().second, 20);
 
     // input rows = 0
     Analytor analytor3(plan_node, row_desc, nullptr);
     analytor3.update_input_rows(0);
 
-    analytor2._current_row_position = analytor2.found_partition_end();
-    end = analytor3.find_and_check_partition_end();
-    ASSERT_FALSE(end);
-    ASSERT_EQ(analytor3.found_partition_end(), 0);
+    analytor2._current_row_position = analytor2.found_partition_end().second;
+    analytor3.find_partition_end();
+    ASSERT_FALSE(analytor3.found_partition_end().first);
+    ASSERT_EQ(analytor3.found_partition_end().second, 0);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Enhancement

`Analytor::find_partition_end` will try to find the partition end
* If it returns true, then `_found_partition_end` will  point at the genuine partition end
* If it returns false, then `_found_partition_end` will point at the boundary of the input chunks

And the result has not been kept,  so we need another function `is_partition_boundary_reached` to determine whether reaching partition boundary. And the last condition `_found_partition_end != _partition_columns[0]->size()` is necessary but not sufficient condition. 

```cpp
bool Analytor::is_partition_boundary_reached() {
    if (_input_eos) {
        return true;
    }

    // There is no partition, or it hasn't fetched any chunk.
    if (_partition_ctxs.empty() || _found_partition_end == 0) {
        return false;
    }

    // If found_partition_end == _partition_columns[0]->size(),
    // the next chunk maybe also belongs to the current partition.
    return _found_partition_end != _partition_columns[0]->size();
}
```


So I try to save the result of the function by using `std::pair<bool, int64_t>`, the first value determining whether second value point at the genuine partition end. And the function `is_partition_boundary_reached` can be removed


```diff
- int64_t _found_partition_end  = 0;
+ std::pair<bool, int64_t> _found_partition_end = {false, 0};
```

So as `Analytor::find_peer_group_end`, no more detail descriptions here.

```diff
- int64_t _found_peer_group_end  = 0;
+ std::pair<bool, int64_t> _found_peer_group_end = {false, 0};
```
