### PR TITLE
[BugFix] Chunked json for txn stream load

### DIFF
--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -433,8 +433,8 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
                 // buffer capacity is not enough, so we try to expand the buffer.
                 auto data_sz = ctx->buffer->pos + len;
                 if (data_sz >= ctx->kJSONMaxBufferSize) {
-                    auto err_msg = fmt::format("payload size [{}] of single write beyond the JSON payload limit [{}]", data_sz,
-                                               ctx->kJSONMaxBufferSize);
+                    auto err_msg = fmt::format("payload size [{}] of single write beyond the JSON payload limit [{}]",
+                                               data_sz, ctx->kJSONMaxBufferSize);
                     LOG(WARNING) << err_msg;
                     ctx->status = Status::MemoryLimitExceeded(err_msg);
                     return;

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -410,23 +410,45 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
     auto evbuf = evhttp_request_get_input_buffer(ev_req);
 
     int64_t start_read_data_time = MonotonicNanos();
-    while (evbuffer_get_length(evbuf) > 0) {
-        ByteBufferPtr bb = ByteBuffer::allocate(4096);
+
+    size_t len = 0;
+    while ((len = evbuffer_get_length(evbuf)) > 0) {
+        if (ctx->buffer == nullptr) {
+            // Initialize buffer.
+            ctx->buffer = ByteBuffer::allocate(
+                    ctx->format == TFileFormatType::FORMAT_JSON ? std::max(len, ctx->kDefaultBufferSize) : len);
+
+        } else if (ctx->buffer->remaining() < len) {
+            if (ctx->format == TFileFormatType::FORMAT_JSON) {
+                // For json format, we need build a complete json before we push the buffer to the pipe.
+                // buffer capacity is not enough, so we try to expand the buffer.
+                ByteBufferPtr buf = ByteBuffer::allocate(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len));
+                buf->put_bytes(ctx->buffer->ptr, ctx->buffer->pos);
+                std::swap(buf, ctx->buffer);
+
+            } else {
+                // For non-json format, we could push buffer to the body_sink in streaming mode.
+                // buffer capacity is not enough, so we push the buffer to the pipe and allocate new one.
+                ctx->buffer->flip();
+                auto st = ctx->body_sink->append(std::move(ctx->buffer));
+                if (!st.ok()) {
+                    LOG(WARNING) << "append body content failed. errmsg=" << st << " context=" << ctx->brief();
+                    ctx->status = st;
+                    return;
+                }
+
+                ctx->buffer = ByteBuffer::allocate(std::max(len, ctx->kDefaultBufferSize));
+            }
+        }
+
         int remove_bytes;
         {
             // The memory is applied for in http server thread,
             // so the release of this memory must be recorded in ProcessMemTracker
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            remove_bytes = evbuffer_remove(evbuf, bb->ptr, bb->capacity);
+            remove_bytes = evbuffer_remove(evbuf, ctx->buffer->ptr + ctx->buffer->pos, ctx->buffer->remaining());
         }
-        bb->pos = remove_bytes;
-        bb->flip();
-        auto st = ctx->body_sink->append(std::move(bb));
-        if (!st.ok()) {
-            LOG(WARNING) << "append body content failed. errmsg=" << st.get_error_msg() << ctx->brief();
-            ctx->status = st;
-            return;
-        }
+        ctx->buffer->pos += remove_bytes;
         ctx->receive_bytes += remove_bytes;
     }
     ctx->received_data_cost_nanos = ctx->last_active_ts - start_read_data_time;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -199,6 +199,8 @@ public:
 
     // buffer for reading data from ev_buffer
     static constexpr size_t kDefaultBufferSize = 64 * 1024;
+    // max buffer size for JSON format is 4GB.
+    static constexpr size_t kJSONMaxBufferSize = 4 * 1024 * 1024 * 1024;
     ByteBufferPtr buffer = nullptr;
 
 public:

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -200,7 +200,7 @@ public:
     // buffer for reading data from ev_buffer
     static constexpr size_t kDefaultBufferSize = 64 * 1024;
     // max buffer size for JSON format is 4GB.
-    static constexpr int64_t kJSONMaxBufferSize = 4 * 1024 * 1024 * 1024;
+    static constexpr int64_t kJSONMaxBufferSize = 4294967296;
     ByteBufferPtr buffer = nullptr;
 
 public:

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -200,7 +200,7 @@ public:
     // buffer for reading data from ev_buffer
     static constexpr size_t kDefaultBufferSize = 64 * 1024;
     // max buffer size for JSON format is 4GB.
-    static constexpr size_t kJSONMaxBufferSize = 4 * 1024 * 1024 * 1024;
+    static constexpr int64_t kJSONMaxBufferSize = 4 * 1024 * 1024 * 1024;
     ByteBufferPtr buffer = nullptr;
 
 public:

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -289,6 +289,11 @@ Status TransactionMgr::_commit_transaction(StreamLoadContext* ctx) {
 
     if (ctx->body_sink != nullptr) {
         // 1. finish stream pipe & wait it done
+        if (ctx->buffer != nullptr && ctx->buffer->pos > 0) {
+            ctx->buffer->flip();
+            ctx->body_sink->append(std::move(ctx->buffer));
+            ctx->buffer = nullptr;
+        }
         RETURN_IF_ERROR(ctx->body_sink->finish());
         RETURN_IF_ERROR(ctx->future.get());
     } else {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5515

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds the support of chunked json for transaction stream load.
The total size of transaction would not be limited, but the data size of the single write in the transaction would be limited to 4GB.