### PR TITLE
[Lake] Support lake table query plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -52,6 +52,12 @@ import java.util.Map;
 public class Table extends MetaObject implements Writable {
     private static final Logger LOG = LogManager.getLogger(Table.class);
 
+    // 1. Native table:
+    //   1.1 Local: OLAP, MATERIALIZED_VIEW
+    //   1.2 Lake: LAKE
+    // 2. System table: SCHEMA
+    // 3. View: INLINE_VIEW, VIEW
+    // 4. External table: MYSQL, OLAP_EXTERNAL, BROKER, ELASTICSEARCH, HIVE, ICEBERG, HUDI, ODBC, JDBC
     public enum TableType {
         MYSQL,
         OLAP,
@@ -165,18 +171,24 @@ public class Table extends MetaObject implements Writable {
     public boolean isOlapTable() {
         return type == TableType.OLAP;
     }
+
     public boolean isMaterializedView() {
         return type == TableType.MATERIALIZED_VIEW;
-    }
-
-    public boolean isNativeTable() {
-        return isOlapTable() || isMaterializedView();
     }
 
     public boolean isLakeTable() {
         return type == TableType.LAKE;
     }
 
+    public boolean isLocalTable() {
+        return isOlapTable() || isMaterializedView();
+    }
+
+    public boolean isNativeTable() {
+        return isLocalTable() || isLakeTable();
+    }
+
+    // for create table
     public boolean isOlapOrLakeTable() {
         return isOlapTable() || isLakeTable();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -57,8 +57,8 @@ public class AnalyzeStmtAnalyzer {
             if (StatisticUtils.statisticDatabaseBlackListCheck(statement.getTableName().getDb())) {
                 throw new SemanticException("Forbidden collect database: %s", statement.getTableName().getDb());
             }
-            if (analyzeTable.getType() != Table.TableType.OLAP) {
-                throw new SemanticException("Table '%s' is not a OLAP table", analyzeTable.getName());
+            if (!analyzeTable.isNativeTable()) {
+                throw new SemanticException("Table '%s' is not a OLAP/LAKE table", analyzeTable.getName());
             }
 
             // Analyze columns mentioned in the statement.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -671,7 +671,7 @@ public class QueryAnalyzer {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, tbName);
             }
 
-            if (table.getType() == Table.TableType.OLAP &&
+            if (table.isNativeTable() &&
                     (((OlapTable) table).getState() == OlapTable.OlapTableState.RESTORE
                             || ((OlapTable) table).getState() == OlapTable.OlapTableState.RESTORE_WITH_LOAD)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -451,7 +451,7 @@ public class Utils {
         int schemaHash = table.getSchemaHashByIndexId(selectedIndexId);
         for (Long partitionId : selectedPartitionId) {
             Partition partition = table.getPartition(partitionId);
-            if (partition.isUseStarOS()) {
+            if (table.isLakeTable()) {
                 // TODO(wyb): necessary to support?
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -510,7 +510,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private long getTableRowCount(Table table, Operator node) {
-        if (Table.TableType.OLAP == table.getType()) {
+        if (table.isNativeTable()) {
             OlapTable olapTable = (OlapTable) table;
             List<Partition> selectedPartitions;
             if (node.isLogical()) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -106,7 +106,7 @@ public class AnalyzeManager implements Writable {
                 continue;
             }
 
-            if (table.getType() != Table.TableType.OLAP) {
+            if (!table.isNativeTable()) {
                 expireList.add(job);
                 continue;
             }
@@ -263,7 +263,7 @@ public class AnalyzeManager implements Writable {
         }
 
         public void checkAndExpireCachedStatistics(Table table, AnalyzeJob job) {
-            if (null == table || !Table.TableType.OLAP.equals(table.getType())) {
+            if (null == table || !table.isNativeTable()) {
                 return;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -240,7 +240,7 @@ public class StatisticAutoCollector extends MasterDaemon {
 
     private void createTableJobs(Map<Long, TableCollectJob> tableJobs, AnalyzeJob job,
                                  Database db, Table table) {
-        if (null == table || !Table.TableType.OLAP.equals(table.getType())) {
+        if (null == table || !table.isNativeTable()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionLogApplierFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionLogApplierFactory.java
@@ -11,7 +11,7 @@ public class TransactionLogApplierFactory {
         if (table.isLakeTable()) {
             return new LakeTableTxnLogApplier((LakeTable) table);
         }
-        if (table.isNativeTable()) {
+        if (table.isLocalTable()) {
             return new OlapTableTxnLogApplier((OlapTable) table);
         }
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListenerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListenerFactory.java
@@ -11,7 +11,7 @@ public class TransactionStateListenerFactory {
         if (table.isLakeTable()) {
             return new LakeTableTxnStateListener(dbTxnMgr, (LakeTable) table);
         }
-        if (table.isNativeTable()) {
+        if (table.isLocalTable()) {
             return new OlapTableTxnStateListener(dbTxnMgr, (OlapTable) table);
         }
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -1916,8 +1916,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo1;
                 minTimes = 0;
 
-                olapTable1.getType();
-                result = Table.TableType.OLAP;
+                olapTable1.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
 
@@ -1938,8 +1938,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo2;
                 minTimes = 0;
 
-                olapTable2.getType();
-                result = Table.TableType.OLAP;
+                olapTable2.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
         };
@@ -2029,8 +2029,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo1;
                 minTimes = 0;
 
-                olapTable1.getType();
-                result = Table.TableType.OLAP;
+                olapTable1.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
 
@@ -2051,8 +2051,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo2;
                 minTimes = 0;
 
-                olapTable2.getType();
-                result = Table.TableType.OLAP;
+                olapTable2.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
         };
@@ -2118,8 +2118,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo1;
                 minTimes = 0;
 
-                olapTable1.getType();
-                result = Table.TableType.OLAP;
+                olapTable1.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
 
@@ -2140,8 +2140,8 @@ public class OptimizerTaskTest {
                 result = hashDistributionInfo2;
                 minTimes = 0;
 
-                olapTable2.getType();
-                result = Table.TableType.OLAP;
+                olapTable2.isNativeTable();
+                result = true;
                 minTimes = 0;
             }
         };

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -62,6 +62,7 @@ enum TPlanNodeType {
   TABLE_FUNCTION_NODE,
   DECODE_NODE,
   JDBC_SCAN_NODE,
+  LAKE_SCAN_NODE
 }
 
 // phases of an execution node
@@ -328,6 +329,20 @@ struct TJDBCScanNode {
   5: optional i64 limit
 }
 
+struct TLakeScanNode {
+  1: required Types.TTupleId tuple_id
+  2: required list<string> key_column_name
+  3: required list<Types.TPrimitiveType> key_column_type
+  4: required bool is_preaggregation
+  5: optional string sort_column
+  // For profile attributes' printing: `Rollup` `Predicates`
+  6: optional string rollup_name
+  7: optional string sql_predicates
+  8: optional bool enable_column_expr_predicate
+  9: optional map<i32, i32> dict_string_id_to_int_ids
+  // which columns only be used to filter data in the stage of scan data
+  10: optional list<string> unused_output_column_name
+}
 
 struct TEqJoinCondition {
   // left-hand side of "<a> = <b>"
@@ -891,6 +906,8 @@ struct TPlanNode {
   61: optional TConnectorScanNode connector_scan_node;
 
   62: optional TCrossJoinNode cross_join_node;
+
+  63: optional TLakeScanNode lake_scan_node
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Use the same query plan as olap table.
1. Add new TLakeScanNode, and BE will scan lake tablet by connector framework if is lake table.
2. Other plan adaptation: analyzer, statistics calculator.
3. Refactor table type method.
