### PR TITLE
[Enhance] limit size of ChunkSource::chunk_buffer

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -214,6 +214,9 @@ inline bool is_uninitialized(const std::weak_ptr<QueryContext>& ptr) {
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
+    if (_chunk_sources[chunk_source_index]->get_buffer_size() >= _buffer_size) {
+        return Status::OK();
+    }
     if (!_try_to_increase_committed_scan_tasks()) {
         return Status::OK();
     }


### PR DESCRIPTION
## What type of PR is this：
- [] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When the consumer of `ScanOperator` too slow, the `chunk_buffer` would occupy a lot of memory.

So we need to add a limitation for this buffer:
1. Each `chunk_buffer` is limited to `64`
2. Each `ScanOperator` has 4 `chunk_buffer`
