### PR TITLE
[cherry-pick] [branch-2.1] [Enhancement] Update tablet_updates.cpp (#6681)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -978,8 +978,8 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, boo
                 return Status::InternalError(msg);
             } else {
                 input_rowsets[i] = itr->second;
-                input_rowsets_size = input_rowsets[i]->data_disk_size();
-                input_row_num = input_rowsets[i]->num_rows();
+                input_rowsets_size += input_rowsets[i]->data_disk_size();
+                input_row_num += input_rowsets[i]->num_rows();
             }
         }
     }


### PR DESCRIPTION
the do_compaction compute get_segment_max_rows just use the last Rowset not all Rowsets's accumulated average data
Use all rowsets's accumulated average data to compute get_segment_max_rows.
