### PR TITLE
[Bugfix] Fix ranking topn assert error

### DIFF
--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -79,7 +79,7 @@ private:
                                DataSegments& segments);
 
     Status _merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, const size_t rows_to_keep,
-                              size_t sorted_size, size_t permutation_size, Permutation& new_permutation);
+                              size_t sorted_size, Permutation& new_permutation);
 
     static void _set_permutation_before(Permutation&, size_t size, std::vector<std::vector<uint8_t>>& filter_array);
 

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -493,6 +493,10 @@ Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<C
 }
 
 void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm) {
+    if (chunks.empty() || perm.empty()) {
+        return;
+    }
+
     std::vector<const Chunk*> src;
     src.reserve(chunks.size());
     for (auto& chunk : chunks) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8066

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If `_topn_type == TTopNType::RANK` and `rows_to_keep==0`, the `new_permutation.second` may also be empty, and in this case, some assertions(`DCHECK`) inside `_merge_sort_common` will fail, including
* `ExprContext::evaluate` require chunk is not empty
* `append_by_permutation` require perm is not empty

```cpp
    if (rows_to_keep > 0 || _topn_type == TTopNType::RANK) {
        ...
        RETURN_IF_ERROR(_merge_sort_common(big_chunk, segments, rows_to_keep, sorted_size, second_size,
                                           new_permutation.second));
    }
```