### PR TITLE
[Enhancment] add child fragments of removed right fragment to left fragment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1884,6 +1884,7 @@ public class PlanFragmentBuilder {
                     joinNode.setChild(0, leftFragment.getPlanRoot());
                     joinNode.setChild(1, rightFragment.getPlanRoot());
                     leftFragment.setPlanRoot(joinNode);
+                    leftFragment.addChildren(rightFragment.getChildren());
                     context.getFragments().remove(rightFragment);
 
                     context.getFragments().remove(leftFragment);
@@ -1905,6 +1906,7 @@ public class PlanFragmentBuilder {
                         joinNode.setChild(0, leftFragment.getPlanRoot());
                         joinNode.setChild(1, rightFragment.getPlanRoot());
                         leftFragment.setPlanRoot(joinNode);
+                        leftFragment.addChildren(rightFragment.getChildren());
                         context.getFragments().remove(rightFragment);
 
                         context.getFragments().remove(leftFragment);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When merging the left and right fragment to a fragment for join, the child fragments of the removed right fragment isn't added to the left fragment for the bucket shuffle join and colocate join sometimes.


