### PR TITLE
[Bugfix] Fix task type always manual

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskSchedule.java
@@ -3,6 +3,7 @@
 package com.starrocks.scheduler.persist;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.sql.optimizer.Utils;
 
 import java.util.concurrent.TimeUnit;
 
@@ -46,5 +47,10 @@ public class TaskSchedule {
 
     public void setTimeUnit(TimeUnit timeUnit) {
         this.timeUnit = timeUnit;
+    }
+
+    public String toString() {
+        return " (START " + Utils.getDatetimeFromLong(startTime)
+                + " EVERY(" + period + " " + timeUnit + "))";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -71,10 +71,13 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.StreamLoadTask;
@@ -451,7 +454,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             TTaskInfo info = new TTaskInfo();
             info.setTask_name(task.getName());
             info.setCreate_time(task.getCreateTime() / 1000);
-            info.setSchedule(task.getType().name());
+            String scheduleStr = task.getType().name();
+            if (task.getType() == Constants.TaskType.PERIODICAL) {
+                TaskSchedule schedule = task.getSchedule();
+                scheduleStr += " (START "
+                        + Utils.getDatetimeFromLong(schedule.getStartTime())
+                        + " EVERY("
+                        + schedule.getPeriod() + " " + schedule.getTimeUnit()
+                        + "))";
+            }
+            info.setSchedule(scheduleStr);
             info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
             info.setDefinition(task.getDefinition());
             info.setExpire_time(task.getExpireTime() / 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -451,8 +451,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             TTaskInfo info = new TTaskInfo();
             info.setTask_name(task.getName());
             info.setCreate_time(task.getCreateTime() / 1000);
-            // Now there are only MANUAL types of Tasks
-            info.setSchedule("MANUAL");
+            info.setSchedule(task.getType().name());
             info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
             info.setDefinition(task.getDefinition());
             info.setExpire_time(task.getExpireTime() / 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -75,9 +75,7 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
-import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.StreamLoadTask;
@@ -456,12 +454,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             info.setCreate_time(task.getCreateTime() / 1000);
             String scheduleStr = task.getType().name();
             if (task.getType() == Constants.TaskType.PERIODICAL) {
-                TaskSchedule schedule = task.getSchedule();
-                scheduleStr += " (START "
-                        + Utils.getDatetimeFromLong(schedule.getStartTime())
-                        + " EVERY("
-                        + schedule.getPeriod() + " " + schedule.getTimeUnit()
-                        + "))";
+                scheduleStr += task.getSchedule();
             }
             info.setSchedule(scheduleStr);
             info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTaskTest.java
@@ -1,0 +1,98 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.analysis;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.persist.TaskSchedule;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.sql.ast.SubmitTaskStmt;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.thrift.TGetTaskInfoResult;
+import com.starrocks.thrift.TGetTasksParams;
+import com.starrocks.thrift.TTaskInfo;
+import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ShowTaskTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.enable_experimental_mv = true;
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+    }
+
+    @Test
+    public void testShowTasks() throws Exception {
+        FrontendServiceImpl frontendService = new FrontendServiceImpl(null);
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(UUIDUtil.genUUID()));
+
+        String submitSQL = "submit task as create table temp as select count(*) as cnt from tbl1";
+        SubmitTaskStmt submitTaskStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(submitSQL, connectContext);
+        Task manualTask = TaskBuilder.buildTask(submitTaskStmt, connectContext);
+        taskManager.createTask(manualTask, true);
+
+        Task periodTask = new Task();
+        periodTask.setName("test_periodical");
+        periodTask.setCreateTime(System.currentTimeMillis());
+        periodTask.setDbName("test");
+        periodTask.setDefinition("select 1");
+        periodTask.setExpireTime(0L);
+        long startTime = Utils.getLongFromDateTime(LocalDateTime.of(2020, 04, 21, 0, 0, 0));
+        TaskSchedule taskSchedule = new TaskSchedule(startTime, 5, TimeUnit.SECONDS);
+        periodTask.setSchedule(taskSchedule);
+        periodTask.setType(Constants.TaskType.PERIODICAL);
+        taskManager.createTask(periodTask, true);
+
+        UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
+        TGetTasksParams tGetTasksParams = new TGetTasksParams();
+        tGetTasksParams.setCurrent_user_ident(new TUserIdentity(currentUserIdentity.toThrift()));
+        TGetTaskInfoResult taskResult = frontendService.getTasks(tGetTasksParams);
+        List<TTaskInfo> tasks = taskResult.getTasks();
+        Assert.assertEquals(tasks.size() , 2);
+        for (TTaskInfo task : tasks) {
+            if(task.getTask_name().equals("test_periodical")) {
+                Assert.assertEquals(task.getSchedule(),"PERIODICAL (START 2020-04-21T00:00 EVERY(5 SECONDS))");
+            } else {
+                Assert.assertEquals(task.getSchedule(),"MANUAL");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
IF add PERIODICAL Task,  command `select * from information_schema.tasks` return type is incorrect
```
+-----------+---------------------+----------+----------+----------------------------------------------------------------------------------+-------------+
| TASK_NAME | CREATE_TIME         | SCHEDULE | DATABASE | DEFINITION                                                                       | EXPIRE_TIME |
+-----------+---------------------+----------+----------+----------------------------------------------------------------------------------+-------------+
| mv-27018  | 2022-06-30 11:09:30 | MANUAL   | test     | SELECT `test`.`tbl1`.`k1` AS `k1`, `test`.`tbl1`.`k2` AS `k2` FROM `test`.`tbl1` | NULL        |
+-----------+---------------------+----------+----------+----------------------------------------------------------------------------------+-------------+
1 row in set (29.65 sec)
```

