### PR TITLE
Revert "hive external unsupport binary type (backport #8025)"

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -150,6 +150,7 @@ public class HiveMetaStoreTableUtils {
                 return primitiveType == PrimitiveType.DATE;
             case "STRING":
             case "VARCHAR":
+            case "BINARY":
                 return primitiveType == PrimitiveType.VARCHAR;
             case "CHAR":
                 return primitiveType == PrimitiveType.CHAR ||
@@ -202,6 +203,7 @@ public class HiveMetaStoreTableUtils {
                 primitiveType = PrimitiveType.DATE;
                 break;
             case "STRING":
+            case "BINARY":
                 return ScalarType.createDefaultString();
             case "VARCHAR":
                 return ScalarType.createVarcharType(Utils.getVarcharLength(hiveType));


### PR DESCRIPTION
Reverts StarRocks/starrocks#8026

This pr will cause #8073. we will filter the column of binary type when processing columns info from hive metastore. And it will be fixed on branch main. 
we are worried that fix #8073 may cause other problems, so revert first. 
cc @DorianZheng @tiannan-sr 