### PR TITLE
Fix wrong metrics and rename thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -179,9 +179,9 @@ CONF_mInt32(status_report_interval, "5");
 // Local directory to copy UDF libraries from HDFS into.
 CONF_String(local_library_dir, "${UDF_RUNTIME_DIR}");
 // Number of olap/external scanner thread pool size.
-CONF_mInt32(table_scanner_thread_pool_thread_num, "48");
+CONF_mInt32(doris_scanner_thread_pool_thread_num, "48");
 // Number of olap/external scanner thread pool size.
-CONF_Int32(table_scanner_thread_pool_queue_size, "102400");
+CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
 CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 // Number of etl thread pool size.
 CONF_Int32(etl_thread_pool_size, "8");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -178,10 +178,10 @@ CONF_Bool(serialize_batch, "false");
 CONF_mInt32(status_report_interval, "5");
 // Local directory to copy UDF libraries from HDFS into.
 CONF_String(local_library_dir, "${UDF_RUNTIME_DIR}");
-// Number of olap scanner thread pool size.
-CONF_mInt32(doris_scanner_thread_pool_thread_num, "48");
-// Number of olap scanner thread pool size.
-CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
+// Number of olap/external scanner thread pool size.
+CONF_mInt32(table_scanner_thread_pool_thread_num, "48");
+// Number of olap/external scanner thread pool size.
+CONF_Int32(table_scanner_thread_pool_queue_size, "102400");
 CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 // Number of etl thread pool size.
 CONF_Int32(etl_thread_pool_size, "8");

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -181,7 +181,6 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     _profile.bytes_read_counter = ADD_COUNTER(_runtime_profile, "BytesRead", TUnit::BYTES);
 
     _profile.scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
-    _profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
     _profile.scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
 
     _profile.reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
@@ -223,7 +222,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path));
 
-    COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
     HdfsScannerParams scanner_params;
     scanner_params.runtime_filter_collector = _runtime_filters;
     scanner_params.scan_ranges = {&scan_range};

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -53,9 +53,6 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* bytes_read_counter = nullptr;
     RuntimeProfile::Counter* scan_timer = nullptr;
-    RuntimeProfile::Counter* scanner_queue_counter = nullptr;
-    RuntimeProfile::Counter* scanner_queue_timer = nullptr;
-    RuntimeProfile::Counter* scan_ranges_counter = nullptr;
     RuntimeProfile::Counter* scan_files_counter = nullptr;
     RuntimeProfile::Counter* reader_init_timer = nullptr;
     RuntimeProfile::Counter* open_file_timer = nullptr;

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -48,9 +48,9 @@ void UpdateConfigAction::handle(HttpRequest* req) {
     LOG(INFO) << req->debug_string();
 
     std::call_once(_once_flag, [&]() {
-        _config_callback.emplace("table_scanner_thread_pool_thread_num", [&]() {
-            LOG(INFO) << "set table_scanner_thread_pool_thread_num:" << config::table_scanner_thread_pool_thread_num;
-            _exec_env->thread_pool()->set_num_thread(config::table_scanner_thread_pool_thread_num);
+        _config_callback.emplace("doris_scanner_thread_pool_thread_num", [&]() {
+            LOG(INFO) << "set doris_scanner_thread_pool_thread_num:" << config::doris_scanner_thread_pool_thread_num;
+            _exec_env->thread_pool()->set_num_thread(config::doris_scanner_thread_pool_thread_num);
         });
     });
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -48,9 +48,9 @@ void UpdateConfigAction::handle(HttpRequest* req) {
     LOG(INFO) << req->debug_string();
 
     std::call_once(_once_flag, [&]() {
-        _config_callback.emplace("doris_scanner_thread_pool_thread_num", [&]() {
-            LOG(INFO) << "set doris_scanner_thread_pool_thread_num:" << config::doris_scanner_thread_pool_thread_num;
-            _exec_env->thread_pool()->set_num_thread(config::doris_scanner_thread_pool_thread_num);
+        _config_callback.emplace("table_scanner_thread_pool_thread_num", [&]() {
+            LOG(INFO) << "set table_scanner_thread_pool_thread_num:" << config::table_scanner_thread_pool_thread_num;
+            _exec_env->thread_pool()->set_num_thread(config::table_scanner_thread_pool_thread_num);
         });
     });
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -162,9 +162,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     // query_context_mgr keeps slotted map with 64 slot to reduce contention
     _query_context_mgr = new pipeline::QueryContextManager(6);
     RETURN_IF_ERROR(_query_context_mgr->init());
-    _thread_pool = new PriorityThreadPool("olap_scan_io", // olap scan io
-                                          config::doris_scanner_thread_pool_thread_num,
-                                          config::doris_scanner_thread_pool_queue_size);
+    _thread_pool = new PriorityThreadPool("table_scan_io", // olap/external table scan thread pool
+                                          config::table_scanner_thread_pool_thread_num,
+                                          config::table_scanner_thread_pool_queue_size);
 
     int hdfs_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
     CHECK_GT(hdfs_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -163,8 +163,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _query_context_mgr = new pipeline::QueryContextManager(6);
     RETURN_IF_ERROR(_query_context_mgr->init());
     _thread_pool = new PriorityThreadPool("table_scan_io", // olap/external table scan thread pool
-                                          config::table_scanner_thread_pool_thread_num,
-                                          config::table_scanner_thread_pool_queue_size);
+                                          config::doris_scanner_thread_pool_thread_num,
+                                          config::doris_scanner_thread_pool_queue_size);
 
     int hdfs_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
     CHECK_GT(hdfs_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：

- the metric ScanRanges is double-counted with ConnectorScanNode::set_scan_ranges
- the name olap_scan_io of thread pool is misleading because it will be used in external table scan