### PR TITLE
[Refactor] refactor and fix the scan counters

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -37,6 +37,8 @@ public:
     virtual int64_t num_rows_read() const = 0;
     // how many bytes read from external
     virtual int64_t num_bytes_read() const = 0;
+    // CPU time of this data source
+    virtual int64_t cpu_time_spent() const = 0;
 
     // following fields are set by framework
     // 1. runtime profile: any metrics you want to record

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -81,6 +81,9 @@ int64_t ESDataSource::num_rows_read() const {
 int64_t ESDataSource::num_bytes_read() const {
     return _bytes_read;
 }
+int64_t ESDataSource::cpu_time_spent() const {
+    return _cpu_time_ns;
+}
 
 Status ESDataSource::_build_conjuncts() {
     Status status = Status::OK();
@@ -217,6 +220,8 @@ Status ESDataSource::get_next(RuntimeState* state, vectorized::ChunkPtr* chunk) 
                 return Status::EndOfFile("");
             }
         }
+
+        SCOPED_RAW_TIMER(&_cpu_time_ns);
         {
             SCOPED_TIMER(_materialize_timer);
             RETURN_IF_ERROR(_es_scroll_parser->fill_chunk(state, chunk, &_line_eof));

--- a/be/src/connector/es_connector.h
+++ b/be/src/connector/es_connector.h
@@ -51,6 +51,7 @@ public:
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;
     int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
 
 private:
     const ESDataSourceProvider* _provider;
@@ -76,6 +77,7 @@ private:
     int64_t _rows_read_number = 0;
     int64_t _rows_return_number = 0;
     int64_t _bytes_read = 0;
+    int64_t _cpu_time_ns = 0;
 
     ESScanReader* _es_reader = nullptr;
     std::unique_ptr<vectorized::ScrollParser> _es_scroll_parser;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -295,6 +295,10 @@ int64_t HiveDataSource::num_bytes_read() const {
     if (_scanner == nullptr) return 0;
     return _scanner->num_bytes_read();
 }
+int64_t HiveDataSource::cpu_time_spent() const {
+    if (_scanner == nullptr) return 0;
+    return _scanner->cpu_time_spent();
+}
 
 } // namespace connector
 } // namespace starrocks

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -44,6 +44,7 @@ public:
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;
     int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
 
 private:
     const HiveDataSourceProvider* _provider;

--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -96,6 +96,10 @@ int64_t JDBCDataSource::num_rows_read() const {
 int64_t JDBCDataSource::num_bytes_read() const {
     return _bytes_read;
 }
+int64_t JDBCDataSource::cpu_time_spent() const {
+    // TODO: calculte the real cputime
+    return 0;
+}
 
 Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     const TJDBCScanNode& jdbc_scan_node = _provider->_jdbc_scan_node;

--- a/be/src/connector/jdbc_connector.h
+++ b/be/src/connector/jdbc_connector.h
@@ -50,6 +50,7 @@ public:
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;
     int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
 
 private:
     Status _create_scanner(RuntimeState* state);

--- a/be/src/connector/mysql_connector.cpp
+++ b/be/src/connector/mysql_connector.cpp
@@ -247,11 +247,17 @@ int64_t MySQLDataSource::num_bytes_read() const {
     return _bytes_read;
 }
 
+int64_t MySQLDataSource::cpu_time_spent() const {
+    return _cpu_time_spent_ns;
+}
+
 void MySQLDataSource::close(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 }
 
 Status MySQLDataSource::fill_chunk(vectorized::ChunkPtr* chunk, char** data, size_t* length) {
+    SCOPED_RAW_TIMER(&_cpu_time_spent_ns);
+
     int materialized_col_idx = -1;
     for (size_t col_idx = 0; col_idx < _slot_num; ++col_idx) {
         SlotDescriptor* slot_desc = _tuple_desc->slots()[col_idx];

--- a/be/src/connector/mysql_connector.h
+++ b/be/src/connector/mysql_connector.h
@@ -49,6 +49,7 @@ public:
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;
     int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
 
 private:
     const MySQLDataSourceProvider* _provider;
@@ -77,6 +78,7 @@ private:
 
     int64_t _rows_read = 0;
     int64_t _bytes_read = 0;
+    int64_t _cpu_time_spent_ns = 0;
 
     Status fill_chunk(vectorized::ChunkPtr* chunk, char** data, size_t* length);
 

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -45,28 +45,21 @@ public:
                                                                    size_t* num_read_chunks, int worker_id,
                                                                    workgroup::WorkGroupPtr running_wg) = 0;
 
-    // Some statistic of chunk source
-    virtual int64_t last_spent_cpu_time_ns() { return 0; }
-
-    virtual int64_t last_scan_rows_num() {
-        int64_t res = _last_scan_rows_num;
-        _last_scan_rows_num = 0;
-        return res;
-    }
-
-    virtual int64_t last_scan_bytes() {
-        int64_t res = _last_scan_bytes;
-        _last_scan_bytes = 0;
-        return res;
-    }
+    // Counters of scan
+    int64_t get_cpu_time_spent() { return _cpu_time_spent_ns; }
+    int64_t get_scan_rows() const { return _scan_rows_num; }
+    int64_t get_scan_bytes() const { return _scan_bytes; }
 
 protected:
     const int32_t _scan_operator_seq;
     RuntimeProfile* _runtime_profile;
     // The morsel will own by pipeline driver
     MorselPtr _morsel;
-    int64_t _last_scan_rows_num = 0;
-    int64_t _last_scan_bytes = 0;
+
+    // NOTE: These counters need to be maintained by ChunkSource implementations, and update in realtime
+    int64_t _cpu_time_spent_ns = 0;
+    int64_t _scan_rows_num = 0;
+    int64_t _scan_bytes = 0;
 };
 
 using ChunkSourcePtr = std::shared_ptr<ChunkSource>;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -232,18 +232,13 @@ Status ConnectorChunkSource::_read_chunk(vectorized::ChunkPtr* chunk) {
         return Status::EndOfFile("limit reach");
     }
 
-    int64_t before_rows_read = _data_source->raw_rows_read();
     do {
         RETURN_IF_ERROR(_data_source->get_next(state, chunk));
     } while ((*chunk)->num_rows() == 0);
 
-    int64_t raw_rows_read = _data_source->raw_rows_read() - before_rows_read;
-    DCHECK_GE(raw_rows_read, 0);
     _rows_read += (*chunk)->num_rows();
-    _last_scan_rows_num += raw_rows_read;
-
-    _last_scan_bytes += _data_source->num_bytes_read() - _bytes_read;
-    _bytes_read = _data_source->num_bytes_read();
+    _scan_rows_num = _data_source->raw_rows_read();
+    _scan_bytes = _data_source->num_bytes_read();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -302,17 +302,6 @@ StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     return chunk;
 }
 
-void OlapChunkSource::_update_avg_row_bytes(vectorized::Chunk* chunk, size_t chunk_index, size_t batch_size) {
-    _local_sum_row_bytes += chunk->memory_usage();
-    _local_num_rows += chunk->num_rows();
-
-    if (chunk_index % UPDATE_AVG_ROW_BYTES_FREQUENCY == 0 || chunk_index == batch_size - 1) {
-        _scan_ctx->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows);
-        _local_sum_row_bytes = 0;
-        _local_num_rows = 0;
-    }
-}
-
 Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, RuntimeState* state) {
     if (!_status.ok()) {
         return _status;
@@ -326,13 +315,11 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, Run
         if (!_status.ok()) {
             // end of file is normal case, need process chunk
             if (_status.is_end_of_file()) {
-                _update_avg_row_bytes(chunk.get(), i, batch_size);
                 _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
             }
             break;
         }
 
-        _update_avg_row_bytes(chunk.get(), i, batch_size);
         _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
     }
 
@@ -359,14 +346,12 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t b
                 // end of file is normal case, need process chunk
                 if (_status.is_end_of_file()) {
                     ++(*num_read_chunks);
-                    _update_avg_row_bytes(chunk.get(), i, batch_size);
                     _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
                 }
                 break;
             }
 
             ++(*num_read_chunks);
-            _update_avg_row_bytes(chunk.get(), i, batch_size);
             _chunk_buffer.put(_scan_operator_seq, std::move(chunk));
         }
 
@@ -449,26 +434,22 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
     return Status::OK();
 }
 
-int64_t OlapChunkSource::last_spent_cpu_time_ns() {
-    int64_t time_ns = _last_spent_cpu_time_ns;
-    _last_spent_cpu_time_ns += _reader->stats().decompress_ns;
-    _last_spent_cpu_time_ns += _reader->stats().vec_cond_ns;
-    _last_spent_cpu_time_ns += _reader->stats().del_filter_ns;
-    return _last_spent_cpu_time_ns - time_ns;
-}
-
 void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
-    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
-    _compressed_bytes_read += _reader->stats().compressed_bytes_read;
-    _reader->mutable_stats()->compressed_bytes_read = 0;
-
-    COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
-    _raw_rows_read += _reader->stats().raw_rows_read;
-    _last_scan_rows_num += _reader->stats().raw_rows_read;
-    _last_scan_bytes += _reader->stats().bytes_read;
-
-    _reader->mutable_stats()->raw_rows_read = 0;
+    auto& stats = _reader->stats();
     _num_rows_read += chunk->num_rows();
+    _compressed_bytes_read = stats.compressed_bytes_read;
+    _scan_rows_num = stats.raw_rows_read;
+    _scan_bytes = stats.bytes_read;
+    _cpu_time_spent_ns = stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;
+
+    // Update local countesr
+    _local_sum_row_bytes += chunk->memory_usage();
+    _local_num_rows += chunk->num_rows();
+    if (_local_sum_chunks++ % UPDATE_AVG_ROW_BYTES_FREQUENCY == 0) {
+        _scan_ctx->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows);
+        _local_sum_row_bytes = 0;
+        _local_num_rows = 0;
+    }
 }
 
 void OlapChunkSource::_update_counter() {
@@ -477,7 +458,6 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_io_timer, _reader->stats().io_ns);
     COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
-    _compressed_bytes_read += _reader->stats().compressed_bytes_read;
     COUNTER_UPDATE(_decompress_timer, _reader->stats().decompress_ns);
     COUNTER_UPDATE(_read_uncompressed_counter, _reader->stats().uncompressed_bytes_read);
     COUNTER_UPDATE(_bytes_read_counter, _reader->stats().bytes_read);
@@ -487,14 +467,10 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_block_fetch_timer, _reader->stats().block_fetch_ns);
     COUNTER_UPDATE(_block_seek_timer, _reader->stats().block_seek_ns);
 
-    COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
-    _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
-    _last_scan_rows_num += _reader->mutable_stats()->raw_rows_read;
-    _last_scan_bytes += _reader->mutable_stats()->bytes_read;
-
     COUNTER_UPDATE(_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
-
     COUNTER_UPDATE(_seg_init_timer, _reader->stats().segment_init_ns);
+
+    COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
 
     int64_t cond_evaluate_ns = 0;
     cond_evaluate_ns += _reader->stats().vec_cond_evaluate_ns;
@@ -525,8 +501,8 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_SET(_pushdown_predicates_counter, (int64_t)_params.predicates.size());
 
-    StarRocksMetrics::instance()->query_scan_bytes.increment(_compressed_bytes_read);
-    StarRocksMetrics::instance()->query_scan_rows.increment(_raw_rows_read);
+    StarRocksMetrics::instance()->query_scan_bytes.increment(_scan_bytes);
+    StarRocksMetrics::instance()->query_scan_rows.increment(_scan_rows_num);
 
     if (_reader->stats().decode_dict_ns > 0) {
         RuntimeProfile::Counter* c = ADD_TIMER(_runtime_profile, "DictDecode");

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -437,7 +437,6 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
 void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
     auto& stats = _reader->stats();
     _num_rows_read += chunk->num_rows();
-    _compressed_bytes_read = stats.compressed_bytes_read;
     _scan_rows_num = stats.raw_rows_read;
     _scan_bytes = stats.bytes_read;
     _cpu_time_spent_ns = stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -116,7 +116,6 @@ private:
 
     // The following are profile meatures
     int64_t _num_rows_read = 0;
-    int64_t _compressed_bytes_read = 0;
 
     // Local counters for row-size estimation, will be reset after a batch
     size_t _local_sum_row_bytes = 0;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -57,7 +57,6 @@ public:
                                                            size_t* num_read_chunks, int worker_id,
                                                            workgroup::WorkGroupPtr running_wg) override;
 
-
 private:
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -57,7 +57,6 @@ public:
                                                            size_t* num_read_chunks, int worker_id,
                                                            workgroup::WorkGroupPtr running_wg) override;
 
-    int64_t last_spent_cpu_time_ns() override;
 
 private:
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
@@ -80,8 +79,6 @@ private:
     void _update_counter();
     void _update_realtime_counter(vectorized::Chunk* chunk);
     void _decide_chunk_size();
-
-    void _update_avg_row_bytes(vectorized::Chunk* chunk, size_t chunk_index, size_t batch_size);
 
 private:
     vectorized::TabletReaderParams _params{};
@@ -120,12 +117,12 @@ private:
 
     // The following are profile meatures
     int64_t _num_rows_read = 0;
-    int64_t _raw_rows_read = 0;
     int64_t _compressed_bytes_read = 0;
-    int64_t _last_spent_cpu_time_ns = 0;
 
+    // Local counters for row-size estimation, will be reset after a batch
     size_t _local_sum_row_bytes = 0;
     size_t _local_num_rows = 0;
+    size_t _local_sum_chunks = 0;
 
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -210,10 +210,11 @@ inline bool is_uninitialized(const std::weak_ptr<QueryContext>& ptr) {
     return !ptr.owner_before(wp{}) && !wp{}.owner_before(ptr);
 }
 
-void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_source_index) {
-    _last_growth_cpu_time_ns += _chunk_sources[chunk_source_index]->last_spent_cpu_time_ns();
-    _last_scan_rows_num += _chunk_sources[chunk_source_index]->last_scan_rows_num();
-    _last_scan_bytes += _chunk_sources[chunk_source_index]->last_scan_bytes();
+void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns,
+                                             int64_t scan_rows, int64_t scan_bytes) {
+    _last_growth_cpu_time_ns += cpu_time_ns;
+    _last_scan_rows_num += scan_rows;
+    _last_scan_bytes += scan_bytes;
     _decrease_committed_scan_tasks();
     _num_running_io_tasks--;
 
@@ -246,25 +247,33 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
         _query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
     }
     if (_workgroup != nullptr) {
-        workgroup::ScanTask task = workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state,
-                                                                    chunk_source_index](int worker_id) {
-            if (auto sp = wp.lock()) {
-                {
-                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-                    size_t num_read_chunks = 0;
-                    Status status = _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking_for_workgroup(
-                            _buffer_size, state, &num_read_chunks, worker_id, _workgroup);
-                    if (!status.ok() && !status.is_end_of_file()) {
-                        _set_scan_status(status);
+        workgroup::ScanTask task =
+                workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index](int worker_id) {
+                    if (auto sp = wp.lock()) {
+                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+
+                        auto& chunk_source = _chunk_sources[chunk_source_index];
+                        size_t num_read_chunks = 0;
+                        int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
+                        int64_t prev_scan_rows = chunk_source->get_scan_rows();
+                        int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
+
+                        // Read chunk
+                        Status status = chunk_source->buffer_next_batch_chunks_blocking_for_workgroup(
+                                _buffer_size, state, &num_read_chunks, worker_id, _workgroup);
+                        if (!status.ok() && !status.is_end_of_file()) {
+                            _set_scan_status(status);
+                        }
+
+                        int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
+                        _workgroup->increment_real_runtime_ns(delta_cpu_time);
+                        _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
+
+                        _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
+                                                  chunk_source->get_scan_rows() - prev_scan_rows,
+                                                  chunk_source->get_scan_bytes() - prev_scan_bytes);
                     }
-                    _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
-                    _workgroup->increment_real_runtime_ns(_chunk_sources[chunk_source_index]->last_spent_cpu_time_ns());
-                }
-
-                _finish_chunk_source_task(state, chunk_source_index);
-            }
-        });
-
+                });
         if (dynamic_cast<ConnectorScanOperator*>(this) != nullptr) {
             offer_task_success = ExecEnv::GetInstance()->hdfs_scan_executor()->submit(std::move(task));
         } else {
@@ -274,16 +283,23 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
         PriorityThreadPool::Task task;
         task.work_function = [wp = _query_ctx, this, state, chunk_source_index]() {
             if (auto sp = wp.lock()) {
-                {
-                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-                    Status status =
-                            _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, state);
-                    if (!status.ok() && !status.is_end_of_file()) {
-                        _set_scan_status(status);
-                    }
-                }
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
 
-                _finish_chunk_source_task(state, chunk_source_index);
+                auto& chunk_source = _chunk_sources[chunk_source_index];
+                int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
+                int64_t prev_scan_rows = chunk_source->get_scan_rows();
+                int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
+
+                Status status =
+                        _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, state);
+                if (!status.ok() && !status.is_end_of_file()) {
+                    _set_scan_status(status);
+                }
+                int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
+
+                _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
+                                          chunk_source->get_scan_rows() - prev_scan_rows,
+                                          chunk_source->get_scan_bytes() - prev_scan_bytes);
             }
         };
         // TODO(by satanson): set a proper priority

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -49,22 +49,11 @@ public:
     virtual void do_close(RuntimeState* state) = 0;
     virtual ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) = 0;
 
-    virtual int64_t get_last_scan_rows_num() {
-        int64_t scan_rows_num = _last_scan_rows_num;
-        _last_scan_rows_num = 0;
-        return scan_rows_num;
-    }
+    int64_t get_last_scan_rows_num() { return _last_scan_rows_num.exchange(0); }
+    int64_t get_last_scan_bytes() { return _last_scan_bytes.exchange(0); }
 
-    virtual int64_t get_last_scan_bytes() {
-        int64_t res = _last_scan_bytes;
-        _last_scan_bytes = 0;
-        return res;
-    }
-
-    virtual size_t max_scan_concurrency() const {
-        // It takes effect, only when it is positive.
-        return 0;
-    }
+    // It takes effect, only when it is positive.
+    virtual size_t max_scan_concurrency() const { return 0; }
 
 protected:
     static constexpr int MAX_IO_TASKS_PER_OP = 4;
@@ -84,7 +73,8 @@ private:
     Status _pickup_morsel(RuntimeState* state, int chunk_source_index);
     Status _trigger_next_scan(RuntimeState* state, int chunk_source_index);
     Status _try_to_trigger_next_scan(RuntimeState* state);
-    void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index);
+    void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns, int64_t scan_rows,
+                                   int64_t scan_bytes);
     void _merge_chunk_source_profiles();
 
     inline void _set_scan_status(const Status& status) {

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -44,6 +44,12 @@ struct HdfsScanStats {
     int64_t group_chunk_read_ns = 0;
     int64_t group_dict_filter_ns = 0;
     int64_t group_dict_decode_ns = 0;
+
+    int64_t get_cpu_time_ns() const {
+        // TODO: make it more accurate
+        return expr_filter_ns + column_convert_ns + level_decode_ns + value_decode_ns + group_dict_filter_ns +
+               group_dict_decode_ns;
+    }
 };
 
 class HdfsParquetProfile;
@@ -191,6 +197,7 @@ public:
     int64_t num_bytes_read() const { return _stats.bytes_read; }
     int64_t raw_rows_read() const { return _stats.raw_rows_read; }
     int64_t num_rows_read() const { return _stats.num_rows_read; }
+    int64_t cpu_time_spent() const { return _stats.get_cpu_time_ns(); }
     void set_keep_priority(bool v) { _keep_priority = v; }
     bool keep_priority() const { return _keep_priority; }
     void update_counter();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Counters of `ScanOperator` are used for audit-log and workgroup scheduling, whose correctness is criticial.

But current implementation is buggy and chaotic, we need to refactor it:
1. Fix the `scan_bytes` counter correctness, which try to accumulate an accumulated value
2. Fix the `cpu_time_spent` counter correctness, which try to to accumulate an accumulated value
3. Introduce `cpu_time_spent` for `ConnectorScanOperator` and various `DataSource`
4. Refactor the counters and `ChunkSource`,  to make it maintain an accumulated value
5. Refactor the `OlapChunkSource::update_realtime_counters`, remove useless counter update
6. Refactor the `OlapChunkSource::update_avg_row_size`, embed it to the `update_realtime_counters`
