### PR TITLE
[Enhancement] Make Parser parsing syntax errors compatible with mysql's error format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/ErrorHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/ErrorHandler.java
@@ -4,11 +4,14 @@ package com.starrocks.sql.parser;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
 
 class ErrorHandler extends BaseErrorListener {
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine,
                             String message, RecognitionException e) {
-        throw new ParsingException(message);
-    }
+        String errorMessage = String.format("You have an error in your SQL syntax; " +
+                "check the manual that corresponds to your MySQL server version for the right syntax to use " +
+                "near '%s' at line %d", ((Token) offendingSymbol).getText(), line);
+        throw new ParsingException(errorMessage);    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -18,9 +18,7 @@ public class AdminSetTest {
     @Test
     public void TestAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
-
-        analyzeFail("admin set frontend config;",
-                "mismatched input '<EOF>' expecting '('");
+        analyzeFail("admin set frontend config;", "You have an error in your SQL syntax");
     }
 
     @Test
@@ -38,6 +36,4 @@ public class AdminSetTest {
         analyzeFail("admin set replica status properties(\"unknown_config\" = \"10003\");",
                 "Unknown property: unknown_config");
     }
-
-
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
