### PR TITLE
Remove meaningless DCHECK for create_varchar_type

### DIFF
--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -69,8 +69,6 @@ struct TypeDescriptor {
     explicit TypeDescriptor(PrimitiveType type) : type(type), len(-1), precision(-1), scale(-1) {}
 
     static TypeDescriptor create_char_type(int len) {
-        DCHECK_GE(len, 1);
-        DCHECK_LE(len, MAX_CHAR_LENGTH);
         TypeDescriptor ret;
         ret.type = TYPE_CHAR;
         ret.len = len;
@@ -78,8 +76,6 @@ struct TypeDescriptor {
     }
 
     static TypeDescriptor create_varchar_type(int len) {
-        DCHECK_GE(len, 1);
-        DCHECK_LE(len, MAX_VARCHAR_LENGTH);
         TypeDescriptor ret;
         ret.type = TYPE_VARCHAR;
         ret.len = len;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

for https://github.com/StarRocks/starrocks/issues/8106

```
k0=k0,k1=k1,k2=k2,k3=k3,k4=k4,k5=k5,k6=k6,k7=k7,k8=k8,k9=k9
```
in the case, the k0, k1,...k9 columns are all path columns.

The reason is for path columns, the varchar column len is -1, so the BE check failed.
```
                        if (pathColumns.contains(columnName) || exprArgsColumns.contains(columnName)) {
                            // columns from path or columns in expr args should be parsed as varchar type
                            slotDesc.setType(Type.VARCHAR);
                            slotDesc.setColumn(new Column(columnName, Type.VARCHAR));
                            varcharColumns.add(columnName);
```

The create_varchar_type method is only used by `json_scanner.cpp` and `file_scanner.cpp`, and they both don't care the varchar length, so we could remove the meaningless DCHECK safely.
