### PR TITLE
[BugFix] Raise exception if image download fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -811,7 +811,7 @@ public class GlobalStateMgr {
         auditEventProcessor.start();
 
         // 2. get cluster id and role (Observer or Follower)
-        nodeMgr.getClusterIdAndRole();
+        nodeMgr.getClusterIdAndRoleOnStartup();
 
         // 3. Load image first and replay edits
         initJournal();
@@ -1100,7 +1100,7 @@ public class GlobalStateMgr {
         DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(curFile)));
 
         long checksum = 0;
-        long remoteChecksum = 0;
+        long remoteChecksum = -1;  // in case of empty image file checksum match
         try {
             checksum = loadHeader(dis, checksum);
             checksum = nodeMgr.loadMasterInfo(dis, checksum);

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -179,7 +179,7 @@ public class NodeMgr {
         return brokerMgr;
     }
 
-    public void getClusterIdAndRole() throws IOException {
+    public void getClusterIdAndRoleOnStartup() throws IOException {
         File roleFile = new File(this.imageDir, Storage.ROLE_FILE);
         File versionFile = new File(this.imageDir, Storage.VERSION_FILE);
 
@@ -343,7 +343,7 @@ public class NodeMgr {
                     System.exit(-1);
                 }
             }
-            getNewImage(rightHelperNode);
+            getNewImageOnStartup(rightHelperNode);
         }
 
         if (Config.cluster_id != -1 && clusterId != Config.cluster_id) {
@@ -622,25 +622,28 @@ public class NodeMgr {
         return false;
     }
 
-    private void getNewImage(Pair<String, Integer> helperNode) throws IOException {
+    /**
+     * When a new node joins in the cluster for the first time, it will download image from the helper at the very beginning
+     * Exception are free to raise on initialized phase
+     */
+    private void getNewImageOnStartup(Pair<String, Integer> helperNode) throws IOException {
         long localImageVersion = 0;
         Storage storage = new Storage(this.imageDir);
         localImageVersion = storage.getImageJournalId();
 
-        try {
-            URL infoUrl = new URL("http://" + helperNode.first + ":" + Config.http_port + "/info");
-            StorageInfo info = getStorageInfo(infoUrl);
-            long version = info.getImageJournalId();
-            if (version > localImageVersion) {
-                String url = "http://" + helperNode.first + ":" + Config.http_port
-                        + "/image?version=" + version;
-                String filename = Storage.IMAGE + "." + version;
-                File dir = new File(this.imageDir);
-                MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000, MetaHelper.getOutputStream(filename, dir));
-                MetaHelper.complete(filename, dir);
-            }
-        } catch (Exception e) {
-            return;
+        URL infoUrl = new URL("http://" + helperNode.first + ":" + Config.http_port + "/info");
+        StorageInfo info = getStorageInfo(infoUrl);
+        long version = info.getImageJournalId();
+        if (version > localImageVersion) {
+            String url = "http://" + helperNode.first + ":" + Config.http_port
+                    + "/image?version=" + version;
+            LOG.info("start to download image.{} from {}", version, url);
+            String filename = Storage.IMAGE + "." + version;
+            File dir = new File(this.imageDir);
+            MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000, MetaHelper.getOutputStream(filename, dir));
+            MetaHelper.complete(filename, dir);
+        } else {
+            LOG.info("skip download image, current version {} >= version {} from {}", localImageVersion, version, helperNode);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7754

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix these 2 cases.
1. No exception will throw on loading an empty image file.
2. No exception will throw when failing to download an image from the helper. For example, if the image dir is readable to the FE process but the image file is not.

Can't find a way to add unittest, just manually test the above cases.