### PR TITLE
[Enhancement] Read hdfs through fs_hdfs directly

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -71,6 +71,10 @@ inline bool is_staros_uri(std::string_view uri) {
     return starts_with(uri, "staros_");
 }
 
+bool FileSystem::is_hdfs(std::string_view uri) {
+    return is_hdfs_uri(uri);
+}
+
 StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::string_view uri) {
     if (is_posix_uri(uri)) {
         return new_fs_posix();

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -56,6 +56,10 @@ public:
 
     static StatusOr<std::shared_ptr<FileSystem>> CreateSharedFromString(std::string_view uri);
 
+    // TODO(xyz): temporary used by file_scanner, lator we will remove this interface
+    // after we support directly access S3 in file_scanner(to substitute broker access)
+    static bool is_hdfs(std::string_view uri);
+
     // Return a default environment suitable for the current operating
     // system.  Sophisticated users may wish to provide their own FileSystem
     // implementation instead of relying on this default environment.

--- a/be/src/fs/fs_hdfs.h
+++ b/be/src/fs/fs_hdfs.h
@@ -6,6 +6,6 @@
 
 namespace starrocks {
 
-std::unique_ptr<FileSystem> new_fs_hdfs();
+std::unique_ptr<FileSystem> new_fs_hdfs(int read_buffer_size = 0);
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -265,6 +265,21 @@ public class Config extends ConfigBase {
     public static boolean ignore_unknown_log_id = false;
 
     /**
+     *  whether read hdfs through broker
+     *  If read_hdfs_directly is not set, we will read hdfs thourgh broker
+     *  If read_hdfs_directly is set, we will read through lib hdfs directly
+     */
+    @ConfField(mutable = true)
+    public static boolean read_hdfs_directly = false;
+
+    /**
+     * only works when read_hdfs_directly is set true, 
+     * hdfs_read_buffer_size_kb for reading through lib hdfs directly
+     */
+    @ConfField(mutable = true)
+    public static int hdfs_read_buffer_size_kb = 8192;
+
+    /**
      * Non-master FE will stop offering service
      * if meta data delay gap exceeds *meta_delay_toleration_second*
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -270,13 +270,12 @@ public class Config extends ConfigBase {
      *  If read_hdfs_directly is set, we will read through lib hdfs directly
      */
     @ConfField(mutable = true)
-    public static boolean read_hdfs_directly = false;
+    public static boolean read_hdfs_directly = true;
 
     /**
      * only works when read_hdfs_directly is set true, 
      * hdfs_read_buffer_size_kb for reading through lib hdfs directly
      */
-    @ConfField(mutable = true)
     public static int hdfs_read_buffer_size_kb = 8192;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -940,6 +940,8 @@ public class SparkLoadJob extends BulkLoadJob {
                                           List<Column> columns, BrokerDesc brokerDesc) throws AnalysisException {
             // scan range params
             TBrokerScanRangeParams params = new TBrokerScanRangeParams();
+            params.setRead_hdfs_directly(Config.read_hdfs_directly);
+            params.setHdfs_read_buffer_size_kb(Config.hdfs_read_buffer_size_kb);
             params.setStrict_mode(false);
             params.setProperties(brokerDesc.getProperties());
             TupleDescriptor srcTupleDesc = descTable.createTupleDescriptor();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -227,6 +227,8 @@ public class FileScanNode extends LoadScanNode {
     private void initParams(ParamCreateContext context)
             throws UserException {
         TBrokerScanRangeParams params = new TBrokerScanRangeParams();
+        params.setRead_hdfs_directly(Config.read_hdfs_directly);
+        params.setHdfs_read_buffer_size_kb(Config.hdfs_read_buffer_size_kb);
         context.params = params;
 
         BrokerFileGroup fileGroup = context.fileGroup;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.load.Load;
 import com.starrocks.task.StreamLoadTask;
@@ -140,6 +141,8 @@ public class StreamLoadScanNode extends LoadScanNode {
         srcTupleDesc = analyzer.getDescTbl().createTupleDescriptor("StreamLoadScanNode");
 
         TBrokerScanRangeParams params = new TBrokerScanRangeParams();
+        params.setRead_hdfs_directly(Config.read_hdfs_directly);
+        params.setHdfs_read_buffer_size_kb(Config.hdfs_read_buffer_size_kb);
         params.setStrict_mode(streamLoadTask.isStrictMode());
 
         Load.initColumns(dstTable, streamLoadTask.getColumnExprDescs(), null /* no hadoop function */,

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -179,6 +179,11 @@ struct TBrokerScanRangeParams {
     11: optional string multi_column_separator;
     // If multi_row_delimiter is set, row_delimiter will ignore.
     12: optional string multi_row_delimiter;
+    // If read_hdfs_directly is not set, we will read hdfs thourgh broker
+    // If read_hdfs_directly is set, we will read through lib hdfs directly
+    13: optional bool read_hdfs_directly = false;
+    // hdfs_read_buffer_size_kb for reading through lib hdfs directly
+    14: optional i32 hdfs_read_buffer_size_kb = 0;
 }
 
 // Broker scan range


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8129 #8339

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
currently we use broker(fs-broker) to read data from hdfs, read through broker has many
performance losses, we can directly use fs-hdfs to read data from hdfs