### PR TITLE
[Action] Update admit.yml

### DIFF
--- a/.github/workflows/admit.yml
+++ b/.github/workflows/admit.yml
@@ -26,3 +26,6 @@ jobs:
           parameter: '{ "GITHUB_PR_NUMBER": "${{ env.GITHUB_PR_NUMBER }}", "GITHUB_PR_TARGET_BRANCH": "${{ env.GITHUB_PR_TARGET_BRANCH}}" }'
           wait: "true"
           timeout: "3600"
+        env:
+          GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
+          GITHUB_PR_TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
environment variable for GITHUB_PR_NUMBER and GITHUB_PR_TARGET_BRANCH is empty before

## What type of PR is this：
- [y] bug

## Which issues of this PR fixes ：
environment variables for pr related is empty before

## Problem Summary(Required) ：
set environment for pr related
