### PR TITLE
[BugFix] Fix datediff compute expression stats encounter DateTimeException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -436,12 +436,6 @@ public class ExpressionStatisticCalculator {
                     minValue = left.getMinValue() - right.getMaxValue();
                     maxValue = left.getMaxValue() - right.getMinValue();
                     break;
-                case FunctionSet.DATEDIFF:
-                    minValue = Utils.getDatetimeFromLong((long) left.getMinValue()).toLocalDate().toEpochDay() -
-                            Utils.getDatetimeFromLong((long) right.getMaxValue()).toLocalDate().toEpochDay();
-                    maxValue = Utils.getDatetimeFromLong((long) left.getMaxValue()).toLocalDate().toEpochDay() -
-                            Utils.getDatetimeFromLong((long) right.getMinValue()).toLocalDate().toEpochDay();
-                    break;
                 case FunctionSet.YEARS_DIFF:
                     interval = 3600 * 24 * 365;
                     minValue = (left.getMinValue() - right.getMaxValue()) / interval;
@@ -458,6 +452,7 @@ public class ExpressionStatisticCalculator {
                     maxValue = (left.getMaxValue() - right.getMinValue()) / interval;
                     break;
                 case FunctionSet.DAYS_DIFF:
+                case FunctionSet.DATEDIFF:
                     interval = 3600 * 24;
                     minValue = (left.getMinValue() - right.getMaxValue()) / interval;
                     maxValue = (left.getMaxValue() - right.getMinValue()) / interval;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -408,11 +408,6 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(-300, columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
-        // test datediff function
-        callOperator = new CallOperator(FunctionSet.DATEDIFF, Type.BIGINT, Lists.newArrayList(left, right));
-        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
-        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
-        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
         // test years_diff function
         callOperator = new CallOperator(FunctionSet.YEARS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
@@ -430,6 +425,11 @@ public class ExpressionStatisticsCalculatorTest {
         Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
         // test days_diff function
         callOperator = new CallOperator(FunctionSet.DAYS_DIFF, Type.BIGINT, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.01);
+        Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.01);
+        // test datediff function
+        callOperator = new CallOperator(FunctionSet.DATEDIFF, Type.BIGINT, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(0, columnStatistic.getMinValue(), 0.01);
         Assert.assertEquals(0, columnStatistic.getMaxValue(), 0.01);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1058,4 +1058,13 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "    EXCHANGE ID: 03\n" +
                 "    HASH_PARTITIONED: 6: v6");
     }
+
+    @Test
+    public void testDateDiffWithStringConstant() throws Exception {
+        String sql = "select count(t.a) from (select datediff(\"1981-09-06t03:40:33\", L_SHIPDATE) as a from lineitem) as t;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, " 1:Project\n" +
+                "  |  <slot 18> : datediff(CAST('1981-09-06t03:40:33' AS DATETIME), CAST(11: L_SHIPDATE AS DATETIME))\n" +
+                "  |  ");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksBenchmark/issues/163

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Utils.getDatetimeFromLong can not deal with -inf/inf, wiil throw DateTimeException