### PR TITLE
[BugFix] Fix unstable ut when encountering the conflicting node types

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -37,7 +37,9 @@ public class BDBEnvironmentTest {
     @Before
     public void setup() throws Exception {
         BDBEnvironment.RETRY_TIME = 3;
-        BDBEnvironment.SLEEP_INTERVAL_SEC = 0;
+        // give master time to update membership
+        // otherwise may get error Conflicting node types: uses: SECONDARY Replica is configured as type: ELECTABLE
+        BDBEnvironment.SLEEP_INTERVAL_SEC = 1;
     }
 
     @After


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix unstable ut.

```
Conflicting node types for: follower1(-1) Feeder thinks it uses: SECONDARY Replica is configured as type: ELECTABLE 
```