### PR TITLE
[Bugfix] DOP of OlapScanPrepareOperator is 1 for DCHECK

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -334,7 +334,8 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const TExec
             auto source_id = pipeline->get_op_factories()[0]->plan_node_id();
             DCHECK(morsel_queue_factories.count(source_id));
             auto& morsel_queue_factory = morsel_queue_factories[source_id];
-            DCHECK_EQ(cur_pipeline_dop, morsel_queue_factory->size());
+            // DOP of OlapScanPrepareOperator is always 1.
+            DCHECK(cur_pipeline_dop == 1 || cur_pipeline_dop == morsel_queue_factory->size());
 
             for (size_t i = 0; i < cur_pipeline_dop; ++i) {
                 auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixed #8177.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`morsel_queue_factory->size()` is equal to the `DOP` of `ScanOperator`.

When checking `DOP` of scan node in `FragmentExecutor::_prepare_pipeline_driver`, it uses `node_id` to find the related `morsel_queue_factory` and expected `morsel_queue_factory->size()` equal to `DOP` of this `ScanOperator`.

However, the node id of `OlapScanPrepareOperator` is the same as `OlapScanOperator`, but the `DOP` is 1.

