### PR TITLE
[Enhancement] limit buffer capacity instead of scan concurrency

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -149,6 +149,7 @@ set(EXEC_FILES
     pipeline/scan/olap_scan_context.cpp
     pipeline/scan/connector_scan_operator.cpp
     pipeline/scan/morsel.cpp
+    pipeline/scan/chunk_buffer_limiter.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_context.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -6,6 +6,7 @@
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "gen_cpp/InternalService_types.h"
+#include "gutil/macros.h"
 
 namespace starrocks {
 class DataSink;
@@ -40,11 +41,7 @@ public:
         DCHECK(unique_request.params.__isset.sender_id);
     }
 
-    // Disable copy/move ctor and assignment.
-    UnifiedExecPlanFragmentParams(const UnifiedExecPlanFragmentParams&) = delete;
-    UnifiedExecPlanFragmentParams& operator=(const UnifiedExecPlanFragmentParams&) = delete;
-    UnifiedExecPlanFragmentParams(UnifiedExecPlanFragmentParams&&) = delete;
-    UnifiedExecPlanFragmentParams& operator=(UnifiedExecPlanFragmentParams&&) = delete;
+    DISALLOW_COPY_AND_MOVE(UnifiedExecPlanFragmentParams);
 
     // Access the common fields by this method.
     const TExecPlanFragmentParams& common() const { return _common_request; }

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -7,8 +7,8 @@
 
 namespace starrocks::pipeline {
 
-BalancedChunkBuffer::BalancedChunkBuffer(BalanceStrategy strategy, int output_operators)
-        : _output_operators(output_operators), _strategy(strategy) {
+BalancedChunkBuffer::BalancedChunkBuffer(BalanceStrategy strategy, int output_operators, ChunkBufferLimiterPtr limiter)
+        : _output_operators(output_operators), _strategy(strategy), _limiter(std::move(limiter)) {
     DCHECK_GT(output_operators, 0);
     for (int i = 0; i < output_operators; i++) {
         _sub_buffers.emplace_back(std::make_unique<QueueT>());
@@ -51,22 +51,33 @@ void BalancedChunkBuffer::close() {
 }
 
 bool BalancedChunkBuffer::try_get(int buffer_index, vectorized::ChunkPtr* output_chunk) {
-    return _get_sub_buffer(buffer_index)->try_get(output_chunk);
+    // Will release the token after exiting this scope.
+    ChunkWithToken chunk_with_token = std::make_pair(nullptr, nullptr);
+    bool ok = _get_sub_buffer(buffer_index)->try_get(&chunk_with_token);
+    if (ok) {
+        *output_chunk = std::move(chunk_with_token.first);
+    }
+    return ok;
 }
 
-bool BalancedChunkBuffer::put(int buffer_index, vectorized::ChunkPtr chunk) {
+bool BalancedChunkBuffer::put(int buffer_index, vectorized::ChunkPtr chunk, ChunkBufferTokenPtr chunk_token) {
     if (_strategy == BalanceStrategy::kDirect) {
-        return _get_sub_buffer(buffer_index)->put(chunk);
+        return _get_sub_buffer(buffer_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
     } else if (_strategy == BalanceStrategy::kRoundRobin) {
         // TODO: try to balance data according to number of rows
         // But the hard part is, that may needs to maintain a min-heap to account the rows of each
         // output operator, which would introduce some extra overhead
         int target_index = _output_index.fetch_add(1);
         target_index %= _output_operators;
-        return _get_sub_buffer(target_index)->put(chunk);
+        return _get_sub_buffer(target_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
     } else {
         CHECK(false) << "unreachable";
     }
+}
+
+void BalancedChunkBuffer::set_finished(int buffer_index) {
+    _get_sub_buffer(buffer_index)->shutdown();
+    _get_sub_buffer(buffer_index)->clear();
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "column/chunk.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "util/blocking_queue.hpp"
 
 namespace starrocks::pipeline {
@@ -18,18 +19,23 @@ enum BalanceStrategy {
 // A chunk-buffer which try to balance output for each operator
 class BalancedChunkBuffer {
 public:
-    BalancedChunkBuffer(BalanceStrategy strategy, int output_operators);
+    BalancedChunkBuffer(BalanceStrategy strategy, int output_operators, ChunkBufferLimiterPtr limiter);
     ~BalancedChunkBuffer();
 
     bool all_empty() const;
     size_t size(int buffer_index) const;
     bool empty(int buffer_index) const;
     bool try_get(int buffer_index, vectorized::ChunkPtr* output_chunk);
-    bool put(int buffer_index, vectorized::ChunkPtr chunk);
+    bool put(int buffer_index, vectorized::ChunkPtr chunk, ChunkBufferTokenPtr chunk_token);
     void close();
+    // Mark that it needn't produce any chunk anymore.
+    void set_finished(int buffer_index);
+
+    ChunkBufferLimiter* limiter() { return _limiter.get(); }
 
 private:
-    using QueueT = UnboundedBlockingQueue<vectorized::ChunkPtr>;
+    using ChunkWithToken = std::pair<vectorized::ChunkPtr, ChunkBufferTokenPtr>;
+    using QueueT = UnboundedBlockingQueue<ChunkWithToken>;
     using SubBuffer = std::unique_ptr<QueueT>;
 
     const SubBuffer& _get_sub_buffer(int index) const;
@@ -39,6 +45,8 @@ private:
     const BalanceStrategy _strategy;
     std::vector<SubBuffer> _sub_buffers;
     std::atomic_int64_t _output_index = 0;
+
+    ChunkBufferLimiterPtr _limiter;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -1,0 +1,41 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
+
+#include "glog/logging.h"
+
+namespace starrocks::pipeline {
+
+void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    _sum_row_bytes += added_sum_row_bytes;
+    _num_rows += added_num_rows;
+    size_t avg_row_bytes = 0;
+    if (_num_rows > 0) {
+        avg_row_bytes = _sum_row_bytes / _num_rows;
+    }
+    if (avg_row_bytes == 0) {
+        return;
+    }
+
+    size_t chunk_mem_usage = avg_row_bytes * _chunk_size;
+    size_t new_capacity = std::max<size_t>(_mem_limit / chunk_mem_usage, 1);
+    _capacity = std::min(new_capacity, _max_capacity);
+}
+
+ChunkBufferTokenPtr DynamicChunkBufferLimiter::pin(int num_chunks) {
+    size_t prev_value = _pinned_chunks_counter.fetch_add(num_chunks);
+    if (prev_value + num_chunks > _capacity) {
+        _unpin(num_chunks);
+        return nullptr;
+    }
+    return std::make_unique<DynamicChunkBufferLimiter::Token>(_pinned_chunks_counter, num_chunks);
+}
+
+void DynamicChunkBufferLimiter::_unpin(int num_chunks) {
+    int prev_value = _pinned_chunks_counter.fetch_sub(num_chunks);
+    DCHECK_GE(prev_value, 1);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -50,31 +50,10 @@ class UnlimitedChunkBufferLimiter final : public ChunkBufferLimiter {
 public:
     class Token final : public ChunkBufferToken {
     public:
-        ~Token() override = default;
-    };
+        Token(std::atomic<int>& pinned_tokens_counter, int num_tokens)
+                : _pinned_tokens_counter(pinned_tokens_counter), _num_tokens(num_tokens) {}
 
-public:
-    ~UnlimitedChunkBufferLimiter() override = default;
-
-    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override {}
-
-    ChunkBufferTokenPtr pin(int num_chunks) override { return std::make_unique<Token>(); }
-
-    bool is_full() const override { return false; }
-    size_t size() const override { return 0; }
-    size_t capacity() const override { return 0; }
-    size_t default_capacity() const override { return 0; }
-};
-
-// Use the dynamic chunk memory usage statistics to compute the capacity.
-class DynamicChunkBufferLimiter final : public ChunkBufferLimiter {
-public:
-    class Token final : public ChunkBufferToken {
-    public:
-        Token(std::atomic<int>& acquired_tokens_counter, int num_tokens)
-                : _acquired_tokens_counter(acquired_tokens_counter), _num_tokens(num_tokens) {}
-
-        ~Token() override { _acquired_tokens_counter.fetch_sub(_num_tokens); }
+        ~Token() override { _pinned_tokens_counter.fetch_sub(_num_tokens); }
 
         // Disable copy/move ctor and assignment.
         Token(const Token&) = delete;
@@ -83,7 +62,47 @@ public:
         Token& operator=(Token&&) = delete;
 
     private:
-        std::atomic<int>& _acquired_tokens_counter;
+        std::atomic<int>& _pinned_tokens_counter;
+        const int _num_tokens;
+    };
+
+public:
+    ~UnlimitedChunkBufferLimiter() override = default;
+
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override {}
+
+    ChunkBufferTokenPtr pin(int num_chunks) override {
+        _pinned_chunks_counter.fetch_add(num_chunks);
+        return std::make_unique<UnlimitedChunkBufferLimiter::Token>(_pinned_chunks_counter, num_chunks);
+    }
+
+    bool is_full() const override { return false; }
+    size_t size() const override { return _pinned_chunks_counter; }
+    size_t capacity() const override { return std::numeric_limits<int64_t>::max(); }
+    size_t default_capacity() const override { return std::numeric_limits<int64_t>::max(); }
+
+private:
+    std::atomic<int> _pinned_chunks_counter = 0;
+};
+
+// Use the dynamic chunk memory usage statistics to compute the capacity.
+class DynamicChunkBufferLimiter final : public ChunkBufferLimiter {
+public:
+    class Token final : public ChunkBufferToken {
+    public:
+        Token(std::atomic<int>& pinned_tokens_counter, int num_tokens)
+                : _pinned_tokens_counter(pinned_tokens_counter), _num_tokens(num_tokens) {}
+
+        ~Token() override { _pinned_tokens_counter.fetch_sub(_num_tokens); }
+
+        // Disable copy/move ctor and assignment.
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        Token(Token&&) = delete;
+        Token& operator=(Token&&) = delete;
+
+    private:
+        std::atomic<int>& _pinned_tokens_counter;
         const int _num_tokens;
     };
 

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -1,0 +1,126 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+namespace starrocks::pipeline {
+
+class ChunkBufferToken;
+using ChunkBufferTokenPtr = std::unique_ptr<ChunkBufferToken>;
+class ChunkBufferLimiter;
+using ChunkBufferLimiterPtr = std::unique_ptr<ChunkBufferLimiter>;
+
+class ChunkBufferToken {
+public:
+    virtual ~ChunkBufferToken() = default;
+};
+
+// Limit the capacity of a chunk buffer.
+// - Before creating a new chunk, should use `pin()` to pin a position in the buffer and return a token.
+// - After a chunk is popped from buffer, should desctruct the token to unpin the position.
+// All the methods are thread-safe.
+class ChunkBufferLimiter {
+public:
+    virtual ~ChunkBufferLimiter() = default;
+
+    // Update the chunk memory usage statistics.
+    // `added_sum_row_bytes` is the bytes of the new reading rows.
+    // `added_num_rows` is the number of the new read rows.
+    virtual void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) = 0;
+
+    // Pin a position in the buffer and return a token.
+    // When desctructing the token, the position will be unpinned.
+    virtual ChunkBufferTokenPtr pin(int num_chunks) = 0;
+
+    // Returns true, when it cannot pin a position for now.
+    virtual bool is_full() const = 0;
+    // The number of already pinned positions.
+    virtual size_t size() const = 0;
+    // The max number of positions able to be pinned.
+    virtual size_t capacity() const = 0;
+    // The default capacity when there isn't chunk memory usage statistics.
+    virtual size_t default_capacity() const = 0;
+};
+
+// The capacity of this limiter is unlimited.
+class UnlimitedChunkBufferLimiter final : public ChunkBufferLimiter {
+public:
+    class Token final : public ChunkBufferToken {
+    public:
+        ~Token() override = default;
+    };
+
+public:
+    ~UnlimitedChunkBufferLimiter() override = default;
+
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override {}
+
+    ChunkBufferTokenPtr pin(int num_chunks) override { return std::make_unique<Token>(); }
+
+    bool is_full() const override { return false; }
+    size_t size() const override { return 0; }
+    size_t capacity() const override { return 0; }
+    size_t default_capacity() const override { return 0; }
+};
+
+// Use the dynamic chunk memory usage statistics to compute the capacity.
+class DynamicChunkBufferLimiter final : public ChunkBufferLimiter {
+public:
+    class Token final : public ChunkBufferToken {
+    public:
+        Token(std::atomic<int>& acquired_tokens_counter, int num_tokens)
+                : _acquired_tokens_counter(acquired_tokens_counter), _num_tokens(num_tokens) {}
+
+        ~Token() override { _acquired_tokens_counter.fetch_sub(_num_tokens); }
+
+        // Disable copy/move ctor and assignment.
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        Token(Token&&) = delete;
+        Token& operator=(Token&&) = delete;
+
+    private:
+        std::atomic<int>& _acquired_tokens_counter;
+        const int _num_tokens;
+    };
+
+public:
+    DynamicChunkBufferLimiter(size_t max_capacity, size_t default_capacity, int64_t mem_limit, int chunk_size)
+            : _capacity(default_capacity),
+              _max_capacity(max_capacity),
+              _default_capacity(default_capacity),
+              _mem_limit(mem_limit),
+              _chunk_size(chunk_size) {}
+    ~DynamicChunkBufferLimiter() override = default;
+
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override;
+
+    ChunkBufferTokenPtr pin(int num_chunks) override;
+
+    bool is_full() const override { return _pinned_chunks_counter >= _capacity; }
+    size_t size() const override { return _pinned_chunks_counter; }
+    size_t capacity() const override { return _capacity; }
+    size_t default_capacity() const override { return _default_capacity; }
+
+private:
+    void _unpin(int num_chunks);
+
+private:
+    std::mutex _mutex;
+    size_t _sum_row_bytes = 0;
+    size_t _num_rows = 0;
+
+    size_t _capacity;
+    const size_t _max_capacity;
+    const size_t _default_capacity;
+
+    const int64_t _mem_limit;
+    const int _chunk_size;
+
+    std::atomic<int> _pinned_chunks_counter = 0;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -6,6 +6,8 @@
 #include <memory>
 #include <mutex>
 
+#include "gutil/macros.h"
+
 namespace starrocks::pipeline {
 
 class ChunkBufferToken;
@@ -55,11 +57,7 @@ public:
 
         ~Token() override { _pinned_tokens_counter.fetch_sub(_num_tokens); }
 
-        // Disable copy/move ctor and assignment.
-        Token(const Token&) = delete;
-        Token& operator=(const Token&) = delete;
-        Token(Token&&) = delete;
-        Token& operator=(Token&&) = delete;
+        DISALLOW_COPY_AND_MOVE(Token);
 
     private:
         std::atomic<int>& _pinned_tokens_counter;
@@ -95,11 +93,7 @@ public:
 
         ~Token() override { _pinned_tokens_counter.fetch_sub(_num_tokens); }
 
-        // Disable copy/move ctor and assignment.
-        Token(const Token&) = delete;
-        Token& operator=(const Token&) = delete;
-        Token(Token&&) = delete;
-        Token& operator=(Token&&) = delete;
+        DISALLOW_COPY_AND_MOVE(Token);
 
     private:
         std::atomic<int>& _pinned_tokens_counter;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -21,7 +21,7 @@ public:
             ActiveInputKey, typename phmap::Hash<ActiveInputKey>, typename phmap::EqualTo<ActiveInputKey>,
             typename std::allocator<ActiveInputKey>, NUM_LOCK_SHARD_LOG, std::mutex, true>;
 
-    ConnectorScanOperatorFactory(int32_t id, ScanNode* scan_node, size_t dop);
+    ConnectorScanOperatorFactory(int32_t id, ScanNode* scan_node, size_t dop, ChunkBufferLimiterPtr buffer_limiter);
 
     ~ConnectorScanOperatorFactory() override = default;
 
@@ -39,8 +39,7 @@ private:
 
 class ConnectorScanOperator final : public ScanOperator {
 public:
-    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                          std::atomic<int>& num_committed_scan_tasks);
+    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
 
     ~ConnectorScanOperator() override = default;
 
@@ -54,8 +53,13 @@ public:
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
     bool has_buffer_output() const override;
-    bool has_available_buffer() const override;
     ChunkPtr get_chunk_from_buffer() override;
+    size_t buffer_size() const override;
+    size_t buffer_capacity() const override;
+    size_t default_buffer_capacity() const override;
+    ChunkBufferTokenPtr pin_chunk(int num_chunks);
+    bool is_buffer_full() const override;
+    void set_buffer_finished() override;
 };
 
 class ConnectorChunkSource final : public ChunkSource {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -355,11 +355,11 @@ void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
     _scan_bytes = stats.bytes_read;
     _cpu_time_spent_ns = stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;
 
-    // Update local countesr
+    // Update local counters.
     _local_sum_row_bytes += chunk->memory_usage();
     _local_num_rows += chunk->num_rows();
     if (_local_sum_chunks++ % UPDATE_AVG_ROW_BYTES_FREQUENCY == 0) {
-        _scan_ctx->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows);
+        _chunk_buffer.limiter()->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows);
         _local_sum_row_bytes = 0;
         _local_num_rows = 0;
     }

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -97,13 +97,4 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
     return Status::OK();
 }
 
-void OlapScanContext::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    _sum_row_bytes += added_sum_row_bytes;
-    _num_rows += added_num_rows;
-    if (_num_rows > 0) {
-        _avg_row_bytes = _sum_row_bytes / _num_rows;
-    }
-}
-
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -28,16 +28,14 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _num_committed_scan_tasks, _ctx);
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _ctx);
 }
 
 // ==================== OlapScanOperator ====================
 
 OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                                   std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx)
-        : ScanOperator(factory, id, driver_sequence, scan_node, num_committed_scan_tasks),
-          _ctx(std::move(ctx)),
-          _default_max_scan_concurrency(scan_node->max_scan_concurrency()) {
+                                   OlapScanContextPtr ctx)
+        : ScanOperator(factory, id, driver_sequence, scan_node), _ctx(std::move(ctx)) {
     _ctx->ref();
 }
 
@@ -74,18 +72,12 @@ bool OlapScanOperator::is_finished() const {
 }
 
 Status OlapScanOperator::do_prepare(RuntimeState*) {
-    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "DefaultMaxScanConcurrency", TUnit::UNIT);
-    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_default_max_scan_concurrency));
     bool shared_scan = _ctx->is_shared_scan();
     _unique_metrics->add_info_string("SharedScan", shared_scan ? "True" : "False");
-
     return Status::OK();
 }
 
-void OlapScanOperator::do_close(RuntimeState* state) {
-    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "AvgMaxScanConcurrency", TUnit::UNIT);
-    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_avg_max_scan_concurrency()));
-}
+void OlapScanOperator::do_close(RuntimeState* state) {}
 
 ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);
@@ -117,42 +109,28 @@ ChunkPtr OlapScanOperator::get_chunk_from_buffer() {
     return nullptr;
 }
 
-bool OlapScanOperator::has_available_buffer() const {
-    // TODO: consider the global buffer
-    return _ctx->get_chunk_buffer().size(_driver_sequence) <= _buffer_size;
+size_t OlapScanOperator::buffer_size() const {
+    return _ctx->get_chunk_buffer().limiter()->size();
 }
 
-size_t OlapScanOperator::max_scan_concurrency() const {
-    int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
-
-    size_t avg_row_bytes = _ctx->avg_row_bytes();
-    if (avg_row_bytes == 0) {
-        return _default_max_scan_concurrency;
-    }
-
-    // Assume that the memory tried in the storage layer is the same as the output chunk.
-    size_t row_mem_usage = avg_row_bytes * 2;
-    size_t chunk_mem_usage = row_mem_usage * runtime_state()->chunk_size();
-    DCHECK_GT(chunk_mem_usage, 0);
-
-    // limit scan memory usage not greater than 1/4 query limit.
-    size_t concurrency = std::max<size_t>(query_limit * config::scan_use_query_mem_ratio / chunk_mem_usage, 1);
-
-    if (_prev_max_scan_concurrency != concurrency) {
-        _sum_max_scan_concurrency += concurrency;
-        ++_num_max_scan_concurrency;
-        _prev_max_scan_concurrency = concurrency;
-    }
-
-    return concurrency;
+size_t OlapScanOperator::buffer_capacity() const {
+    return _ctx->get_chunk_buffer().limiter()->capacity();
 }
 
-size_t OlapScanOperator::_avg_max_scan_concurrency() const {
-    if (_num_max_scan_concurrency > 0) {
-        return _sum_max_scan_concurrency / _num_max_scan_concurrency;
-    }
+size_t OlapScanOperator::default_buffer_capacity() const {
+    return _ctx->get_chunk_buffer().limiter()->default_capacity();
+}
 
-    return 0;
+ChunkBufferTokenPtr OlapScanOperator::pin_chunk(int num_chunks) {
+    return _ctx->get_chunk_buffer().limiter()->pin(num_chunks);
+}
+
+bool OlapScanOperator::is_buffer_full() const {
+    return _ctx->get_chunk_buffer().limiter()->is_full();
+}
+
+void OlapScanOperator::set_buffer_finished() {
+    _ctx->get_chunk_buffer().set_finished(_driver_sequence);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -33,7 +33,7 @@ private:
 class OlapScanOperator final : public ScanOperator {
 public:
     OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                     std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx);
+                     OlapScanContextPtr ctx);
 
     ~OlapScanOperator() override;
 
@@ -44,27 +44,21 @@ public:
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
-    size_t max_scan_concurrency() const override;
-
 protected:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
     bool has_buffer_output() const override;
-    bool has_available_buffer() const override;
     ChunkPtr get_chunk_from_buffer() override;
-
-private:
-    size_t _avg_max_scan_concurrency() const;
+    size_t buffer_size() const override;
+    size_t buffer_capacity() const override;
+    size_t default_buffer_capacity() const override;
+    ChunkBufferTokenPtr pin_chunk(int num_chunks);
+    bool is_buffer_full() const override;
+    void set_buffer_finished() override;
 
 private:
     OlapScanContextPtr _ctx;
-
-    const size_t _default_max_scan_concurrency;
-    // These three fields are used to calculate the average of different `max_scan_concurrency`s for profile.
-    mutable size_t _prev_max_scan_concurrency = 0;
-    mutable size_t _sum_max_scan_concurrency = 0;
-    mutable size_t _num_max_scan_concurrency = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -16,12 +16,10 @@ namespace starrocks::pipeline {
 
 // ========== ScanOperator ==========
 
-ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                           std::atomic<int>& num_committed_scan_tasks)
+ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node)
         : SourceOperator(factory, id, scan_node->name(), scan_node->id(), driver_sequence),
           _scan_node(scan_node),
           _chunk_source_profiles(MAX_IO_TASKS_PER_OP),
-          _num_committed_scan_tasks(num_committed_scan_tasks),
           _is_io_task_running(MAX_IO_TASKS_PER_OP),
           _chunk_sources(MAX_IO_TASKS_PER_OP) {
     for (auto i = 0; i < MAX_IO_TASKS_PER_OP; i++) {
@@ -44,6 +42,7 @@ Status ScanOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     _unique_metrics->add_info_string("MorselQueueType", _morsel_queue->name());
+    _peak_buffer_size_counter = _unique_metrics->AddHighWaterMarkCounter("PeakChunkBufferSize", TUnit::UNIT);
 
     if (_workgroup == nullptr) {
         DCHECK(_io_threads != nullptr);
@@ -65,6 +64,8 @@ void ScanOperator::close(RuntimeState* state) {
     if (_workgroup == nullptr) {
         state->exec_env()->decrement_num_scan_operators(1);
     }
+
+    set_buffer_finished();
     // For the running io task, we close its chunk sources in ~ScanOperator not in ScanOperator::close.
     for (size_t i = 0; i < _chunk_sources.size(); i++) {
         if (!_is_io_task_running[i]) {
@@ -72,7 +73,13 @@ void ScanOperator::close(RuntimeState* state) {
         }
     }
 
+    auto* default_buffer_capacity_counter = ADD_COUNTER(_unique_metrics, "DefaultChunkBufferCapacity", TUnit::UNIT);
+    COUNTER_SET(default_buffer_capacity_counter, static_cast<int64_t>(default_buffer_capacity()));
+    auto* buffer_capacity_counter = ADD_COUNTER(_unique_metrics, "ChunkBufferCapacity", TUnit::UNIT);
+    COUNTER_SET(buffer_capacity_counter, static_cast<int64_t>(buffer_capacity()));
+
     _merge_chunk_source_profiles();
+
     do_close(state);
     Operator::close(state);
 }
@@ -89,8 +96,7 @@ bool ScanOperator::has_output() const {
         return true;
     }
 
-    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP ||
-        _exceed_max_scan_concurrency(_num_committed_scan_tasks.load())) {
+    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP || is_buffer_full()) {
         return false;
     }
 
@@ -154,6 +160,9 @@ Status ScanOperator::set_finishing(RuntimeState* state) {
 
 StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     RETURN_IF_ERROR(_get_scan_status());
+
+    _peak_buffer_size_counter->set(buffer_size());
+
     RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
     if (_workgroup != nullptr) {
         _workgroup->incr_period_ask_chunk_num(1);
@@ -226,7 +235,6 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
     _last_growth_cpu_time_ns += cpu_time_ns;
     _last_scan_rows_num += scan_rows;
     _last_scan_bytes += scan_bytes;
-    _decrease_committed_scan_tasks();
     _num_running_io_tasks--;
 
     DCHECK(_chunk_sources[chunk_source_index] != nullptr);
@@ -238,16 +246,12 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
-    // Check if the buffer has available capacity to avoid occupy too much momory
-    if (!has_available_buffer()) {
+    ChunkBufferTokenPtr buffer_token;
+    if (buffer_token = pin_chunk(1); buffer_token == nullptr) {
         return Status::OK();
     }
 
-    // Check if exceed the concurrency limitation
-    if (!_try_to_increase_committed_scan_tasks()) {
-        return Status::OK();
-    }
-
+    _chunk_sources[chunk_source_index]->pin_chunk_token(std::move(buffer_token));
     _num_running_io_tasks++;
     _is_io_task_running[chunk_source_index] = true;
 
@@ -321,6 +325,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     if (offer_task_success) {
         _io_task_retry_cnt = 0;
     } else {
+        _chunk_sources[chunk_source_index]->unpin_chunk_token();
         _num_running_io_tasks--;
         _is_io_task_running[chunk_source_index] = false;
         // TODO(hcf) set a proper retry times
@@ -374,21 +379,6 @@ void ScanOperator::_merge_chunk_source_profiles() {
 
     _unique_metrics->copy_all_info_strings_from(merged_profile);
     _unique_metrics->copy_all_counters_from(merged_profile);
-}
-
-bool ScanOperator::_try_to_increase_committed_scan_tasks() {
-    int old_num = _num_committed_scan_tasks.fetch_add(1);
-    if (_exceed_max_scan_concurrency(old_num)) {
-        _decrease_committed_scan_tasks();
-        return false;
-    }
-    return true;
-}
-
-bool ScanOperator::_exceed_max_scan_concurrency(int num_committed_scan_tasks) const {
-    size_t max = max_scan_concurrency();
-    // max_scan_concurrency takes effect, only when it is positive.
-    return max > 0 && num_committed_scan_tasks >= max;
 }
 
 // ========== ScanOperatorFactory ==========

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -13,14 +13,18 @@ class ScanNode;
 
 namespace pipeline {
 
+class ChunkBufferToken;
+using ChunkBufferTokenPtr = std::unique_ptr<ChunkBufferToken>;
+
 class ScanOperator : public SourceOperator {
 public:
     static constexpr int MAX_IO_TASKS_PER_OP = 4;
 
-    ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                 std::atomic<int>& num_committed_scan_tasks);
+    ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
 
     ~ScanOperator() override;
+
+    static size_t max_buffer_capacity() { return config::pipeline_io_buffer_size; }
 
     Status prepare(RuntimeState* state) override;
 
@@ -54,19 +58,22 @@ public:
     int64_t get_last_scan_rows_num() { return _last_scan_rows_num.exchange(0); }
     int64_t get_last_scan_bytes() { return _last_scan_bytes.exchange(0); }
 
-    // It takes effect, only when it is positive.
-    virtual size_t max_scan_concurrency() const { return 0; }
-
 protected:
     const size_t _buffer_size = config::pipeline_io_buffer_size;
 
-    // Shared scan
+    // TODO: remove this to the base ScanContext.
+    /// Shared scan
     virtual void attach_chunk_source(int32_t source_index) = 0;
     virtual void detach_chunk_source(int32_t source_index) {}
     virtual bool has_shared_chunk_source() const = 0;
     virtual bool has_buffer_output() const = 0;
-    virtual bool has_available_buffer() const = 0;
     virtual ChunkPtr get_chunk_from_buffer() = 0;
+    virtual size_t buffer_size() const = 0;
+    virtual size_t buffer_capacity() const = 0;
+    virtual size_t default_buffer_capacity() const = 0;
+    virtual ChunkBufferTokenPtr pin_chunk(int num_chunks) = 0;
+    virtual bool is_buffer_full() const = 0;
+    virtual void set_buffer_finished() = 0;
 
 private:
     // This method is only invoked when current morsel is reached eof
@@ -91,10 +98,6 @@ private:
         return _scan_status;
     }
 
-    bool _try_to_increase_committed_scan_tasks();
-    void _decrease_committed_scan_tasks() { _num_committed_scan_tasks.fetch_sub(1); }
-    bool _exceed_max_scan_concurrency(int num_committed_scan_tasks) const;
-
 protected:
     ScanNode* _scan_node = nullptr;
     // ScanOperator may do parallel scan, so each _chunk_sources[i] needs to hold
@@ -105,9 +108,6 @@ protected:
     std::vector<std::shared_ptr<RuntimeProfile>> _chunk_source_profiles;
 
     bool _is_finished = false;
-
-    // Shared by all the ScanOperators created by the same ScanOperatorFactory.
-    std::atomic<int>& _num_committed_scan_tasks;
 
 private:
     int32_t _io_task_retry_cnt = 0;
@@ -127,6 +127,8 @@ private:
     workgroup::WorkGroupPtr _workgroup = nullptr;
     std::atomic_int64_t _last_scan_rows_num = 0;
     std::atomic_int64_t _last_scan_bytes = 0;
+
+    RuntimeProfile::HighWaterMarkCounter* _peak_buffer_size_counter = nullptr;
 };
 
 class ScanOperatorFactory : public SourceOperatorFactory {
@@ -153,8 +155,6 @@ public:
 protected:
     ScanNode* const _scan_node;
     bool _need_local_shuffle = true;
-
-    std::atomic<int> _num_committed_scan_tasks{0};
 };
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -99,9 +99,6 @@ public:
 
     const std::string& name() const { return _name; }
 
-    // Used by pipeline, 0 means there is no limitation.
-    virtual int max_scan_concurrency() const { return 0; }
-
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "common/config.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/connector_scan_operator.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
@@ -131,7 +132,8 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
 pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     size_t dop = context->dop_of_source_operator(id());
-    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop);
+    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(
+            context->next_operator_id(), this, dop, std::make_unique<pipeline::UnlimitedChunkBufferLimiter>());
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -11,6 +11,7 @@
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/noop_sink_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/olap_scan_operator.h"
 #include "exec/pipeline/scan/olap_scan_prepare_operator.h"
 #include "exec/vectorized/olap_scan_prepare.h"
@@ -639,7 +640,7 @@ StatusOr<TabletSharedPtr> OlapScanNode::get_tablet(const TInternalScanRange* sca
     return tablet;
 }
 
-int OlapScanNode::max_scan_concurrency() const {
+int OlapScanNode::estimated_max_concurrent_chunks() const {
     int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
 
     // We temporarily assume that the memory tried in the storage layer
@@ -715,7 +716,7 @@ void OlapScanNode::_estimate_scan_and_output_row_bytes() {
 }
 
 size_t OlapScanNode::_scanner_concurrency() const {
-    int concurrency = max_scan_concurrency();
+    int concurrency = estimated_max_concurrent_chunks();
     // limit concurrency not greater than scanner numbers
     concurrency = std::min<int>(concurrency, _num_scanners);
     concurrency = std::min<int>(concurrency, kMaxConcurrency);
@@ -758,7 +759,15 @@ void OlapScanNode::_close_pending_scanners() {
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     // Set the dop according to requested parallelism and number of morsels
     size_t dop = context->dop_of_source_operator(id());
-    auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this, dop, _enable_shared_scan);
+
+    size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
+    size_t default_buffer_capacity = std::min<size_t>(max_buffer_capacity, estimated_max_concurrent_chunks());
+    int64_t mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * config::scan_use_query_mem_ratio;
+    pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
+            max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());
+
+    auto scan_ctx =
+            std::make_shared<pipeline::OlapScanContext>(this, dop, _enable_shared_scan, std::move(buffer_limiter));
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     // scan_prepare_op.

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -76,7 +76,7 @@ public:
 
     static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
 
-    int max_scan_concurrency() const override;
+    int estimated_max_concurrent_chunks() const;
 
 private:
     friend class TabletScanner;

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -230,7 +230,11 @@ public:
     bool try_get(T* out) {
         std::unique_lock<Lock> l(_lock);
         if (!_items.empty()) {
-            *out = _items.front();
+            if constexpr (std::is_move_assignable<T>::value) {
+                *out = std::move(_items.front());
+            } else {
+                *out = _items.front();
+            }
             _items.pop_front();
             return true;
         }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -59,7 +59,8 @@ const std::string RuntimeProfile::ROOT_COUNTER = ""; // NOLINT
 RuntimeProfile::PeriodicCounterUpdateState RuntimeProfile::_s_periodic_counter_update_state;
 
 const std::unordered_set<std::string> RuntimeProfile::NON_MERGE_COUNTER_NAMES = {
-        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum", "PushdownPredicates", "MemoryLimit"};
+        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum",         "PushdownPredicates",
+        "MemoryLimit",         "ChunkBufferCapacity",   "DefaultChunkBufferCapacity", "PeakChunkBufferSize"};
 
 RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
         : _parent(nullptr),


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Use the dynamic statistics of chunk memory usage to limit the capacity of a chunk buffer instead of scan concurrency.

Before triggering a new I/O task, pin a chunk token to pin a position in the buffer.
Before creating a new chunk in the I/O task, pin a chunk token, except the first new chunk (because it already pined a token in the step 1).
After a chunk is popped from buffer, unpin the token.

Related to the #8427 in branch-2.3.
