### PR TITLE
[BugFix] Fix parquet scanner converter not set has_null

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -164,6 +164,10 @@ void NullableColumn::fill_null_with_default() {
     _data_column->fill_default(_null_column->get_data());
 }
 
+void NullableColumn::update_has_null() {
+    _has_null = SIMD::count_nonzero(_null_column->get_data());
+}
+
 Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t replace_num = src.size();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -56,11 +56,7 @@ public:
 
     void fill_default(const Filter& filter) override {}
 
-    void update_has_null() {
-        const NullColumn::Container& v = _null_column->get_data();
-        const auto* p = v.data();
-        _has_null = (p != nullptr) && (nullptr != memchr(p, 1, v.size() * sizeof(v[0])));
-    }
+    void update_has_null();
 
     bool is_nullable() const override { return true; }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
