### PR TITLE
[Bugfix] Fix FE web front crash in M1 Macbook

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/action/IndexAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/IndexAction.java
@@ -113,8 +113,9 @@ public class IndexAction extends WebBaseAction {
         processorInfo.add(" " + processor.getPhysicalProcessorCount() + " physical CPU core(s)");
         processorInfo.add(" " + processor.getLogicalProcessorCount() + " logical CPU(s)");
 
-        processorInfo.add("Identifier: " + processor.getIdentifier());
-        processorInfo.add("ProcessorID: " + processor.getProcessorID());
+        CentralProcessor.ProcessorIdentifier processorIdentifier = processor.getProcessorIdentifier();
+        processorInfo.add("Identifier: " + processorIdentifier.getIdentifier());
+        processorInfo.add("ProcessorID: " + processorIdentifier.getProcessorID());
         processorInfo.add("Context Switches/Interrupts: " + processor.getContextSwitches()
                 + " / " + processor.getInterrupts() + "\n");
 
@@ -160,7 +161,8 @@ public class IndexAction extends WebBaseAction {
             procCpu.append(String.format(" %.1f%%", avg * 100));
         }
         processorInfo.add(procCpu.toString());
-        long freq = processor.getVendorFreq();
+
+        long freq = processorIdentifier.getVendorFreq();
         if (freq > 0) {
             processorInfo.add("Vendor Frequency: " + FormatUtil.formatHertz(freq));
         }
@@ -196,7 +198,7 @@ public class IndexAction extends WebBaseAction {
         List<String> processInfo = new ArrayList<>();
         processInfo.add("Processes: " + os.getProcessCount() + ", Threads: " + os.getThreadCount());
         // Sort by highest CPU
-        List<OSProcess> procs = Arrays.asList(os.getProcesses(5, OperatingSystem.ProcessSort.CPU));
+        List<OSProcess> procs = os.getProcesses(null, OperatingSystem.ProcessSorting.CPU_DESC, 5);
 
         processInfo.add("   PID  %CPU %MEM       VSZ       RSS Name");
         for (int i = 0; i < procs.size() && i < 5; i++) {
@@ -209,7 +211,7 @@ public class IndexAction extends WebBaseAction {
         return processInfo;
     }
 
-    private List<String> getDisks(HWDiskStore[] diskStores) {
+    private List<String> getDisks(List<HWDiskStore> diskStores) {
         List<String> diskInfo = new ArrayList<>();
         diskInfo.add("Disks:");
         for (HWDiskStore disk : diskStores) {
@@ -223,7 +225,7 @@ public class IndexAction extends WebBaseAction {
                             readwrite ? disk.getWrites() : "?",
                             readwrite ? FormatUtil.formatBytes(disk.getWriteBytes()) : "?",
                             readwrite ? disk.getTransferTime() : "?"));
-            HWPartition[] partitions = disk.getPartitions();
+            List<HWPartition> partitions = disk.getPartitions();
             for (HWPartition part : partitions) {
                 diskInfo.add(String.format(" |-- %s: %s (%s) Maj:Min=%d:%d, size: %s%s", part.getIdentification(),
                         part.getName(), part.getType(), part.getMajor(), part.getMinor(),
@@ -241,7 +243,7 @@ public class IndexAction extends WebBaseAction {
         fsInfo.add(String.format(" File Descriptors: %d/%d", fileSystem.getOpenFileDescriptors(),
                 fileSystem.getMaxFileDescriptors()));
 
-        OSFileStore[] fsArray = fileSystem.getFileStores();
+        List<OSFileStore> fsArray = fileSystem.getFileStores();
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
@@ -257,7 +259,7 @@ public class IndexAction extends WebBaseAction {
         return fsInfo;
     }
 
-    private List<String> getNetworkInterfaces(NetworkIF[] networkIFs) {
+    private List<String> getNetworkInterfaces(List<NetworkIF> networkIFs) {
         List<String> getNetwork = new ArrayList<>();
         getNetwork.add("Network interfaces:");
         for (NetworkIF net : networkIFs) {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -493,7 +493,7 @@ under the License.
             <dependency>
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>
-                <version>4.9.5</version>
+                <version>6.2.1</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.jboss.xnio/xnio-nio -->


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When using Apple Chip, accessing FE's front-end page will crash because the `oshi` version is too old.
Just need to upgrade the `oshi` version can solve this problem.
