### PR TITLE
[Enhancement] Inner join derive on columns is not null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -201,7 +201,7 @@ public class Optimizer {
 
         // Add full cte required columns, and save orig required columns
         // If cte was inline, the columns don't effect normal prune
-        ColumnRefSet requiredColumns = (ColumnRefSet) rootTaskContext.getRequiredColumns().clone();
+        ColumnRefSet requiredColumns = rootTaskContext.getRequiredColumns().clone();
         rootTaskContext.getRequiredColumns().union(cteContext.getAllRequiredColumns());
 
         // Note: PUSH_DOWN_PREDICATE tasks should be executed before MERGE_LIMIT tasks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -551,4 +551,11 @@ public class Utils {
         }
         return Optional.empty();
     }
+
+    public static ScalarOperator transTrue2Null(ScalarOperator predicates) {
+        if (ConstantOperator.TRUE.equals(predicates)) {
+            return null;
+        }
+        return predicates;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -227,7 +227,7 @@ public class Utils {
         return false;
     }
 
-    public static ScalarOperator compoundOr(List<ScalarOperator> nodes) {
+    public static ScalarOperator compoundOr(Collection<ScalarOperator> nodes) {
         return createCompound(CompoundPredicateOperator.CompoundType.OR, nodes);
     }
 
@@ -235,7 +235,7 @@ public class Utils {
         return createCompound(CompoundPredicateOperator.CompoundType.OR, Arrays.asList(nodes));
     }
 
-    public static ScalarOperator compoundAnd(List<ScalarOperator> nodes) {
+    public static ScalarOperator compoundAnd(Collection<ScalarOperator> nodes) {
         return createCompound(CompoundPredicateOperator.CompoundType.AND, nodes);
     }
 
@@ -270,7 +270,7 @@ public class Utils {
     //  /\   /\
     // a  b c  d
     public static ScalarOperator createCompound(CompoundPredicateOperator.CompoundType type,
-                                                List<ScalarOperator> nodes) {
+                                                Collection<ScalarOperator> nodes) {
         LinkedList<ScalarOperator> link =
                 nodes.stream().filter(Objects::nonNull).collect(Collectors.toCollection(Lists::newLinkedList));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
@@ -23,15 +23,15 @@ public class LogicalJoinOperator extends LogicalOperator {
     private final String joinHint;
     // For mark the node has been push  down join on clause, avoid dead-loop
     private boolean hasPushDownJoinOnClause = false;
+    private boolean hasDeriveIsNotNullPredicate = false;
 
     public LogicalJoinOperator(JoinOperator joinType, ScalarOperator onPredicate) {
         this(joinType, onPredicate, "", Operator.DEFAULT_LIMIT, null, false);
     }
 
-    public LogicalJoinOperator(JoinOperator joinType, ScalarOperator onPredicate, String joinHint,
-                               long limit,
-                               ScalarOperator predicate,
-                               boolean hasPushDownJoinOnClause) {
+    private LogicalJoinOperator(JoinOperator joinType, ScalarOperator onPredicate, String joinHint,
+                                long limit, ScalarOperator predicate,
+                                boolean hasPushDownJoinOnClause) {
         super(OperatorType.LOGICAL_JOIN, limit, predicate, null);
         this.joinType = joinType;
         this.onPredicate = onPredicate;
@@ -39,6 +39,7 @@ public class LogicalJoinOperator extends LogicalOperator {
         this.joinHint = joinHint;
 
         this.hasPushDownJoinOnClause = hasPushDownJoinOnClause;
+        this.hasDeriveIsNotNullPredicate = false;
     }
 
     private LogicalJoinOperator(Builder builder) {
@@ -48,6 +49,7 @@ public class LogicalJoinOperator extends LogicalOperator {
         this.joinHint = builder.joinHint;
 
         this.hasPushDownJoinOnClause = builder.hasPushDownJoinOnClause;
+        this.hasDeriveIsNotNullPredicate = builder.hasDeriveIsNotNullPredicate;
     }
 
     // Constructor for UT, don't use this ctor except ut
@@ -58,12 +60,20 @@ public class LogicalJoinOperator extends LogicalOperator {
         this.joinHint = "";
     }
 
-    public boolean isHasPushDownJoinOnClause() {
+    public boolean hasPushDownJoinOnClause() {
         return hasPushDownJoinOnClause;
     }
 
     public void setHasPushDownJoinOnClause(boolean hasPushDownJoinOnClause) {
         this.hasPushDownJoinOnClause = hasPushDownJoinOnClause;
+    }
+
+    public boolean hasDeriveIsNotNullPredicate() {
+        return hasDeriveIsNotNullPredicate;
+    }
+
+    public void setHasDeriveIsNotNullPredicate(boolean hasDeriveIsNotNullPredicate) {
+        this.hasDeriveIsNotNullPredicate = hasDeriveIsNotNullPredicate;
     }
 
     public JoinOperator getJoinType() {
@@ -159,6 +169,7 @@ public class LogicalJoinOperator extends LogicalOperator {
         private ScalarOperator onPredicate;
         private String joinHint = "";
         private boolean hasPushDownJoinOnClause = false;
+        private boolean hasDeriveIsNotNullPredicate = false;
 
         @Override
         public LogicalJoinOperator build() {
@@ -172,6 +183,7 @@ public class LogicalJoinOperator extends LogicalOperator {
             this.onPredicate = joinOperator.onPredicate;
             this.joinHint = joinOperator.joinHint;
             this.hasPushDownJoinOnClause = joinOperator.hasPushDownJoinOnClause;
+            this.hasDeriveIsNotNullPredicate = joinOperator.hasDeriveIsNotNullPredicate;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -58,6 +58,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     private static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
     private static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
 
+    public static final ConstantOperator TRUE = ConstantOperator.createBoolean(true);
+
     // Don't need fixWidth
     private static final DateTimeFormatter DATE_TIME_FORMATTER_MS =
             DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarEquivalenceExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarEquivalenceExtractor.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.Utils;
-import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
@@ -86,7 +85,7 @@ public class ScalarEquivalenceExtractor {
             }
 
             // Derive columnRef = columnRef, like {a = b, b = c} => {a = c}
-            if (isColumnRefOperator(operator)) {
+            if (operator.isColumnRef()) {
                 ColumnRefOperator ref = (ColumnRefOperator) operator;
                 tempResult.addAll(columnRefEquivalenceMap.getOrDefault(ref, Collections.emptySet()));
                 continue;
@@ -137,7 +136,7 @@ public class ScalarEquivalenceExtractor {
 
         for (ScalarOperator operator : search) {
             // can't resolve function(columnRef)
-            if (!isColumnRefOperator(operator)) {
+            if (!operator.isColumnRef()) {
                 continue;
             }
 
@@ -147,7 +146,7 @@ public class ScalarEquivalenceExtractor {
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteMap);
 
         for (ScalarOperator operator : search) {
-            if (!isColumnRefOperator(operator)) {
+            if (!operator.isColumnRef()) {
                 continue;
             }
 
@@ -194,13 +193,13 @@ public class ScalarEquivalenceExtractor {
                 columnValuesMap.get(child1).add(predicate);
 
                 // handle column-constant relation, should check left is column, use for optimizer derive function
-                if (!isColumnRefOperator(predicate.getChild(0))) {
+                if (!predicate.getChild(0).isColumnRef()) {
                     return null;
                 }
 
                 child1 = (ColumnRefOperator) predicate.getChild(0);
                 if (BinaryPredicateOperator.BinaryType.EQ.equals(predicate.getBinaryType()) &&
-                        isConstantOperator(predicate.getChild(1))) {
+                        predicate.getChild(1).isConstantRef()) {
                     if (!columnRefEquivalenceMap.containsKey(child1)) {
                         columnRefEquivalenceMap.put(child1, Sets.newLinkedHashSet());
                     }
@@ -217,14 +216,14 @@ public class ScalarEquivalenceExtractor {
 
             // add (right column)-(left column) relation in columnRef-columnRef mapping
             ScalarOperator child2 = predicate.getChild(1);
-            if (isColumnRefOperator(child2)) {
+            if (child2.isColumnRef()) {
                 ColumnRefOperator ref2 = (ColumnRefOperator) child2;
                 Set<ScalarOperator> child2Set = columnRefEquivalenceMap.getOrDefault(ref2, Sets.newLinkedHashSet());
                 child2Set.add(predicate.getChild(0));
                 columnRefEquivalenceMap.put(ref2, child2Set);
             }
 
-            if (!isColumnRefOperator(predicate.getChild(0))) {
+            if (!predicate.getChild(0).isColumnRef()) {
                 return null;
             }
 
@@ -277,11 +276,4 @@ public class ScalarEquivalenceExtractor {
         }
     }
 
-    private boolean isColumnRefOperator(ScalarOperator operator) {
-        return OperatorType.VARIABLE.equals(operator.getOpType());
-    }
-
-    private boolean isConstantOperator(ScalarOperator operator) {
-        return OperatorType.CONSTANT.equals(operator.getOpType());
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -14,7 +14,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
-import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedSameColumnRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
 import java.util.List;
 
@@ -48,7 +48,7 @@ public class ScalarOperatorRewriter {
             new ReduceCastRule(),
             new NormalizePredicateRule(),
             new FoldConstantsRule(),
-            new SimplifiedSameColumnRule(),
+            new SimplifiedScanColumnRule(),
             new SimplifiedPredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedScanColumnRule.java
@@ -4,10 +4,11 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 
-public class SimplifiedSameColumnRule extends BottomUpScalarOperatorRewriteRule {
+public class SimplifiedScanColumnRule extends BottomUpScalarOperatorRewriteRule {
     //Simplify the comparison result of the same column
     //eg a >= a with not nullable transform to true constant;
     @Override
@@ -33,6 +34,17 @@ public class SimplifiedSameColumnRule extends BottomUpScalarOperatorRewriteRule 
                 }
             }
         }
+        return predicate;
+    }
+
+    @Override
+    public ScalarOperator visitIsNullPredicate(IsNullPredicateOperator predicate,
+                                               ScalarOperatorRewriteContext context) {
+        ScalarOperator child = predicate.getChild(0);
+        if (child.isColumnRef() && !child.isNullable()) {
+            return ConstantOperator.createBoolean(predicate.isNotNull());
+        }
+
         return predicate;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -25,7 +25,7 @@ public class PushDownJoinOnClauseRule extends PushDownJoinPredicateBase {
     public boolean check(final OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
 
-        if (joinOperator.isHasPushDownJoinOnClause()) {
+        if (joinOperator.hasPushDownJoinOnClause()) {
             return false;
         }
         return joinOperator.getOnPredicate() != null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -33,6 +33,7 @@ public class PushDownJoinOnClauseRule extends PushDownJoinPredicateBase {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        List<OptExpression> children = Lists.newArrayList(input.getInputs());
         LogicalJoinOperator join = (LogicalJoinOperator) input.getOp();
 
         ScalarOperator on = join.getOnPredicate();
@@ -42,7 +43,8 @@ public class PushDownJoinOnClauseRule extends PushDownJoinPredicateBase {
 
         OptExpression root = pushDownOnPredicate(input, on);
         ((LogicalJoinOperator) root.getOp()).setHasPushDownJoinOnClause(true);
-        if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate())) {
+        if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate()) &&
+                children.equals(root.getInputs())) {
             return Collections.emptyList();
         }
         return Lists.newArrayList(root);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -16,12 +16,12 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarEquivalenceExtractor;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -31,16 +31,18 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         super(type, pattern);
     }
 
-    public static OptExpression pushDownPredicate(OptExpression root, ScalarOperator leftPushDown,
-                                                  ScalarOperator rightPushDown) {
-        if (leftPushDown != null) {
-            OptExpression newLeft = new OptExpression(new LogicalFilterOperator(leftPushDown));
+    public static OptExpression pushDownPredicate(OptExpression root, List<ScalarOperator> leftPushDown,
+                                                  List<ScalarOperator> rightPushDown) {
+        if (leftPushDown != null && !leftPushDown.isEmpty()) {
+            Set<ScalarOperator> set = Sets.newLinkedHashSet(leftPushDown);
+            OptExpression newLeft = new OptExpression(new LogicalFilterOperator(Utils.compoundAnd(set)));
             newLeft.getInputs().add(root.getInputs().get(0));
             root.getInputs().set(0, newLeft);
         }
 
-        if (rightPushDown != null) {
-            OptExpression newRight = new OptExpression(new LogicalFilterOperator(rightPushDown));
+        if (rightPushDown != null && !rightPushDown.isEmpty()) {
+            Set<ScalarOperator> set = Sets.newLinkedHashSet(rightPushDown);
+            OptExpression newRight = new OptExpression(new LogicalFilterOperator(Utils.compoundAnd(set)));
             newRight.getInputs().add(root.getInputs().get(1));
             root.getInputs().set(1, newRight);
         }
@@ -102,7 +104,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         conjunctList.removeAll(leftPushDown);
         conjunctList.removeAll(rightPushDown);
 
-        ScalarOperator joinPredicate = Utils.compoundAnd(new ArrayList<>(eqConjuncts));
+        ScalarOperator joinPredicate = Utils.compoundAnd(Lists.newArrayList(eqConjuncts));
         ScalarOperator postJoinPredicate = Utils.compoundAnd(conjunctList);
 
         OptExpression root;
@@ -132,7 +134,9 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
             }
             root = OptExpression.create(newJoin, input.getInputs());
         }
-        return pushDownPredicate(root, Utils.compoundAnd(leftPushDown), Utils.compoundAnd(rightPushDown));
+
+        deriveIsNotNullPredicate(eqConjuncts, root, leftPushDown, rightPushDown);
+        return pushDownPredicate(root, leftPushDown, rightPushDown);
     }
 
     public static ScalarOperator equivalenceDerive(ScalarOperator predicate, boolean returnInputPredicate) {
@@ -169,18 +173,44 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         }
 
         if (!returnInputPredicate) {
-            allPredicate.removeAll(inputPredicates);
+            inputPredicates.forEach(allPredicate::remove);
         }
         return Utils.compoundAnd(Lists.newArrayList(allPredicate));
     }
 
     public static ScalarOperator rangePredicateDerive(ScalarOperator predicate) {
         ScalarRangePredicateExtractor scalarRangePredicateExtractor = new ScalarRangePredicateExtractor();
-
-        return scalarRangePredicateExtractor.rewriteAll(
-                Utils.compoundAnd(
-                        Utils.extractConjuncts(predicate).stream().map(scalarRangePredicateExtractor::rewriteAll)
-                                .collect(Collectors.toList())));
+        return scalarRangePredicateExtractor.rewriteAll(Utils.compoundAnd(
+                Utils.extractConjuncts(predicate).stream().map(scalarRangePredicateExtractor::rewriteAll)
+                        .collect(Collectors.toList())));
     }
 
+    private static void deriveIsNotNullPredicate(List<BinaryPredicateOperator> onEQPredicates, OptExpression join,
+                                                 List<ScalarOperator> leftPushDown,
+                                                 List<ScalarOperator> rightPushDown) {
+        List<ScalarOperator> leftEQ = Lists.newArrayList();
+        List<ScalarOperator> rightEQ = Lists.newArrayList();
+
+        for (BinaryPredicateOperator bpo : onEQPredicates) {
+            if (!bpo.getBinaryType().isEqual()) {
+                continue;
+            }
+
+            if (join.getChildOutputColumns(0).containsAll(bpo.getChild(0).getUsedColumns())) {
+                leftEQ.add(bpo.getChild(0));
+                rightEQ.add(bpo.getChild(1));
+            } else if (join.getChildOutputColumns(0).containsAll(bpo.getChild(0).getUsedColumns())) {
+                leftEQ.add(bpo.getChild(1));
+                rightEQ.add(bpo.getChild(0));
+            }
+        }
+
+        JoinOperator joinType = ((LogicalJoinOperator) join.getOp()).getJoinType();
+        if ((joinType.isInnerJoin() || joinType.isRightSemiJoin()) && leftPushDown.isEmpty()) {
+            leftEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone())).forEach(leftPushDown::add);
+        }
+        if ((joinType.isInnerJoin() || joinType.isLeftSemiJoin()) && rightPushDown.isEmpty()) {
+            rightEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone())).forEach(rightPushDown::add);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -201,7 +201,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
             if (join.getChildOutputColumns(0).containsAll(bpo.getChild(0).getUsedColumns())) {
                 leftEQ.add(bpo.getChild(0));
                 rightEQ.add(bpo.getChild(1));
-            } else if (join.getChildOutputColumns(0).containsAll(bpo.getChild(0).getUsedColumns())) {
+            } else if (join.getChildOutputColumns(0).containsAll(bpo.getChild(1).getUsedColumns())) {
                 leftEQ.add(bpo.getChild(1));
                 rightEQ.add(bpo.getChild(0));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -52,6 +52,7 @@ public class PushDownPredicateScanRule extends TransformationRule {
         Preconditions.checkState(predicates != null);
         predicates = scalarOperatorRewriter.rewrite(predicates,
                 ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
+        predicates = Utils.transTrue2Null(predicates);
 
         if (logicalScanOperator instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) logicalScanOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -127,13 +127,13 @@ public class CTEPlanTest extends PlanTestBase {
 
         String sql = "with xx as (select * from t0) select * from xx as x0 join xx as x1 on x0.v1 = x1.v1;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("MultiCastDataSinks\n" +
+        assertContains(plan, "  MultiCastDataSinks\n" +
                 "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 01\n" +
                 "    RANDOM\n" +
                 "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    RANDOM"));
+                "    EXCHANGE ID: 04\n" +
+                "    RANDOM");
 
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
     }
@@ -274,13 +274,13 @@ public class CTEPlanTest extends PlanTestBase {
 
         String plan = getFragmentPlan(sql);
         defaultCTEReuse();
-        Assert.assertTrue(plan.contains("  5:SELECT\n" +
+        assertContains(plan, "  6:SELECT\n" +
                 "  |  predicates: 4: v1 = 2\n" +
                 "  |  \n" +
-                "  4:Project\n" +
+                "  5:Project\n" +
                 "  |  <slot 4> : 1: v1\n" +
                 "  |  <slot 5> : 2: v2\n" +
-                "  |  <slot 6> : 3: v3"));
+                "  |  <slot 6> : 3: v3");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -63,7 +63,6 @@ public class DecimalTypeTest extends PlanTestBase {
         String snippet = "  1:OlapScanNode\n" +
                 "     TABLE: tab1\n" +
                 "     PREAGGREGATION: OFF. Reason: Has can not pre-aggregation Join\n" +
-                "     PREDICATES: TRUE\n" +
                 "     partitions=0/1\n" +
                 "     rollup: tab1\n" +
                 "     tabletRatio=0/0\n" +
@@ -71,7 +70,7 @@ public class DecimalTypeTest extends PlanTestBase {
                 "     cardinality=1\n" +
                 "     avgRowSize=3.0\n" +
                 "     numNodes=0";
-        Assert.assertTrue(explain.contains(snippet));
+        assertContains(explain, snippet);
     }
 
     @Test
@@ -91,10 +90,10 @@ public class DecimalTypeTest extends PlanTestBase {
     public void testDecimalConstRewrite() throws Exception {
         String sql = "select * from t0 WHERE CAST( - 8 AS DECIMAL ) * + 52 + 87 < - 86";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  0:OlapScanNode\n" +
+        assertContains(plan, "  0:OlapScanNode\n" +
                 "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: TRUE"));
+                "     partitions=0/1");
     }
 
     @Test
@@ -154,11 +153,12 @@ public class DecimalTypeTest extends PlanTestBase {
                 + "     PREAGGREGATION: ON\n"
                 + "     PREDICATES: 2: v11 > 1"));
 
-        Assert.assertTrue(plan.contains("  2:OlapScanNode\n"
-                + "     TABLE: test_all_type\n"
-                + "     PREAGGREGATION: ON\n"
-                + "     partitions=0/1\n"
-                + "     rollup: test_all_type\n"));
+        assertContains(plan, "  2:OlapScanNode\n" +
+                "     TABLE: test_all_type\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: CAST(13: id_decimal AS DECIMAL128(21,2)) IS NOT NULL\n" +
+                "     partitions=0/1\n" +
+                "     rollup: test_all_type");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -212,8 +212,9 @@ public class ExternalTableTest extends PlanTestBase {
 
         queryStr = "select * from jointest t1, mysql_table t2, mysql_table t3 where t1.k1 = t3.k1";
         explainString = getFragmentPlan(queryStr);
+        System.out.println(explainString);
         Assert.assertFalse(explainString.contains("INNER JOIN (BUCKET_SHUFFLE))"));
-        Assert.assertTrue(explainString.contains("1:SCAN MYSQL"));
+        Assert.assertTrue(explainString.contains("4:SCAN MYSQL"));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -1947,13 +1947,13 @@ public class JoinTest extends PlanTestBase {
                 "WHERE ((t0.v2) BETWEEN (CAST(subt3.v11 AS STRING)) AND (t0.v2)) = (t1.v4);";
         String plan = getFragmentPlan(sql);
         // check no exception
-        assertContains(plan, "  11:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  10:AGGREGATE (update finalize)\n" +
                 "  |  group by: 1: v4\n" +
                 "  |  \n" +
-                "  10:Project\n" +
+                "  9:Project\n" +
                 "  |  <slot 1> : 1: v4\n" +
                 "  |  \n" +
-                "  9:HASH JOIN\n" +
+                "  8:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 1: v4 = 10: cast");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -42,7 +42,7 @@ public class JoinTest extends PlanTestBase {
     public void testInnerJoinWithPredicate() throws Exception {
         String sql = "SELECT * from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 = 1;";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 = 1"));
+        assertContains(planFragment, "PREDICATES: 1: v1 = 1");
     }
 
     @Test
@@ -101,7 +101,6 @@ public class JoinTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----2:EXCHANGE\n"));
-
 
         sql = "select * from t0 join test_all_type on NOT 69 IS NOT NULL where true";
         planFragment = getFragmentPlan(sql);
@@ -667,7 +666,7 @@ public class JoinTest extends PlanTestBase {
                 "             AND (v3 IN (SELECT v1 FROM t0)));";
         // check no exception
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "12:HASH JOIN\n" +
+        assertContains(plan, "13:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: v2 = 24: v1");
@@ -1223,10 +1222,10 @@ public class JoinTest extends PlanTestBase {
 
         sql = "select * from test.join1 inner join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
-        Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
+        assertContains(explainString, "  0:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: round(2, 0) > 3");
 
         sql = "select * from test.join1 where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
@@ -1269,9 +1268,9 @@ public class JoinTest extends PlanTestBase {
                 "and (join2.id > 1 or join2.id < 10);";
         String explainString = getFragmentPlan(sql);
 
-        Assert.assertTrue(explainString.contains("join op: LEFT OUTER JOIN (BROADCAST)"));
-        Assert.assertTrue(explainString.contains("PREDICATES: (5: id > 1) OR (5: id < 10)"));
-        Assert.assertTrue(explainString.contains("equal join conjunct: 2: id = 5: id"));
+        assertContains(explainString, "join op: LEFT OUTER JOIN (BROADCAST)");
+        assertContains(explainString, "PREDICATES: (5: id > 1) OR (5: id < 10)");
+        assertContains(explainString, "equal join conjunct: 2: id = 5: id");
     }
 
     @Test
@@ -1536,19 +1535,19 @@ public class JoinTest extends PlanTestBase {
         sql = "select * from join1 left join join2 as b on join1.id = b.id\n" +
                 "left join join2 as c on join1.id = c.id \n" +
                 "where b.dt > 1 and c.dt > 1;";
-        starRocksAssert.query(sql).explainContains("6:HASH JOIN\n" +
-                        "  |  join op: INNER JOIN (BROADCAST)\n" +
+        assertContains(starRocksAssert.query(sql).explainQuery(), "  7:HASH JOIN\n" +
+                        "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 8: id",
-                "  3:HASH JOIN\n" +
-                        "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  4:HASH JOIN\n" +
+                        "  |  join op: INNER JOIN (PARTITIONED)\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 5: id",
-                "  4:OlapScanNode\n" +
+                "  5:OlapScanNode\n" +
                         "     TABLE: join2\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     PREDICATES: 7: dt > 1",
-                "  1:OlapScanNode\n" +
+                "  2:OlapScanNode\n" +
                         "     TABLE: join2\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     PREDICATES: 4: dt > 1");
@@ -1709,10 +1708,10 @@ public class JoinTest extends PlanTestBase {
                 "left join join2 on join1.id = join2.id\n" +
                 "where join2.id > 1;";
         explainString = getFragmentPlan(sql);
-        Assert.assertTrue(explainString.contains("  1:OlapScanNode\n" +
+        assertContains(explainString, "  1:OlapScanNode\n" +
                 "     TABLE: join2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 5: id > 1"));
+                "     PREDICATES: 5: id > 1");
 
         // test left join: right table join predicate, only push down right table
         sql = "select *\n from join1\n" +
@@ -2424,7 +2423,7 @@ public class JoinTest extends PlanTestBase {
             String sql =
                     "select * from ( select * from t0 left join[bucket] t1 on t0.v1 = t1.v4 ) s1 join[bucket] t2 on s1.v4 = t2.v7";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  |  join op: INNER JOIN (PARTITIONED)\n" +
+            assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 7: v7");
         }
@@ -2560,7 +2559,6 @@ public class JoinTest extends PlanTestBase {
                 "  |  other predicates: [1: v1, BIGINT, true] < [4: v7, BIGINT, true]\n" +
                 "  |  cardinality: 1\n");
 
-
         sql = "select * from t0 join t2 on t0.v1 + t2.v7 < 2";
         plan = getVerboseExplain(sql);
         assertNotContains(plan, "build runtime filters");
@@ -2585,6 +2583,29 @@ public class JoinTest extends PlanTestBase {
                 "     probe runtime filters:\n" +
                 "     - filter_id = 1, probe_expr = (1: v4)");
          */
+    }
+
+    @Test
+    public void testIsNotNullOnPredicate() throws Exception {
+        String sql = "select * from " +
+                "t0 left outer join t1 on t0.v3 = t1.v6 " +
+                "              join t2 on t1.v5 = t2.v8";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 5: v5 IS NOT NULL");
+        assertContains(plan, "PREDICATES: 8: v8 IS NOT NULL");
+        assertContains(plan, "PREDICATES: 3: v3 IS NOT NULL");
+    }
+
+    @Test
+    public void testIsNotNullWherePredicate() throws Exception {
+        String sql = "select * from " +
+                "t0 left outer join t1 on t0.v3 = t1.v6 " +
+                "              ,t2 " +
+                "where t1.v5 = t2.v8";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 5: v5 IS NOT NULL");
+        assertContains(plan, "PREDICATES: 8: v8 IS NOT NULL");
+        assertContains(plan, "PREDICATES: 3: v3 IS NOT NULL");
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -666,7 +666,7 @@ public class JoinTest extends PlanTestBase {
                 "             AND (v3 IN (SELECT v1 FROM t0)));";
         // check no exception
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "13:HASH JOIN\n" +
+        assertContains(plan, "11:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: v2 = 24: v1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -229,9 +229,8 @@ public class LimitTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join [broadcast] " +
                 "(select v1, v2 from t0 limit 1) b on a.v1 = b.v1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("    EXCHANGE ID: 03\n" +
-                "    UNPARTITIONED"));
-
+        assertContains(plan, "    EXCHANGE ID: 04\n" +
+                "    UNPARTITIONED");
     }
 
     @Test
@@ -250,9 +249,15 @@ public class LimitTest extends PlanTestBase {
                 "(select v1, v2 from t0 limit 1) b on a.v1 = b.v1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, ("join op: INNER JOIN (PARTITIONED)"));
-        assertContains(plan, ("  |----5:EXCHANGE\n" +
-                "  |       limit: 1"));
-        assertContains(plan, ("  2:EXCHANGE\n" +
+        assertContains(plan, ("  6:SELECT\n" +
+                "  |  predicates: 4: v1 IS NOT NULL\n" +
+                "  |  \n" +
+                "  5:EXCHANGE\n" +
+                "     limit: 1"));
+        assertContains(plan, ("  2:SELECT\n" +
+                "  |  predicates: 1: v1 IS NOT NULL\n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
                 "     limit: 10"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -896,8 +896,8 @@ public class LowCardinalityTest extends PlanTestBase {
         String sql = "select t0.S_ADDRESS from (select S_ADDRESS, S_NATIONKEY from supplier_nullable limit 10) t0" +
                 " inner join supplier on t0.S_NATIONKEY = supplier.S_NATIONKEY;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  6:Decode\n" +
-                "  |  <dict id 17> : <string id 3>"));
+        assertContains(plan, "  2:Decode\n" +
+                "  |  <dict id 17> : <string id 3>\n");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -164,7 +164,7 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
 
         // Top join tree
-        Assert.assertTrue(planFragment.contains("  21:HASH JOIN\n" +
+        assertContains(planFragment, "  21:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v10 = 11: v4\n" +
@@ -172,15 +172,7 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |----20:EXCHANGE\n" +
                 "  |    \n" +
                 "  0:OlapScanNode\n" +
-                "     TABLE: t3\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: t3\n" +
-                "     tabletRatio=3/3\n" +
-                "     tabletList=10033,10035,10037\n" +
-                "     cardinality=1000000000\n" +
-                "     avgRowSize=1.0\n" +
-                "     numNodes=0\n"));
+                "     TABLE: t3\n");
 
         // Left sub join tree (b)
         Assert.assertTrue(planFragment.contains("  19:HASH JOIN\n" +
@@ -357,7 +349,7 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
 
         // Top join tree
-        Assert.assertTrue(planFragment.contains("  25:HASH JOIN\n" +
+        assertContains(planFragment, "  25:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v10 = 11: v4\n" +
@@ -365,15 +357,7 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |----24:EXCHANGE\n" +
                 "  |    \n" +
                 "  0:OlapScanNode\n" +
-                "     TABLE: t3\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: t3\n" +
-                "     tabletRatio=3/3\n" +
-                "     tabletList=10033,10035,10037\n" +
-                "     cardinality=1000000000\n" +
-                "     avgRowSize=1.0\n" +
-                "     numNodes=0\n"));
+                "     TABLE: t3\n");
 
         // Left sub join tree (b)
         Assert.assertTrue(planFragment, planFragment.contains("  23:HASH JOIN\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -191,28 +191,17 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |----18:EXCHANGE\n" +
                 "  |    \n" +
                 "  1:OlapScanNode\n" +
-                "     TABLE: t1\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: t1\n" +
-                "     tabletRatio=3/3\n" +
-                "     tabletList=10015,10017,10019\n" +
-                "     cardinality=10\n" +
-                "     avgRowSize=2.0\n" +
-                "     numNodes=0\n"));
+                "     TABLE: t1\n"));
 
         // Right sub join tree (a)
-        Assert.assertTrue(planFragment, planFragment.contains("  16:NESTLOOP JOIN\n" +
+        assertContains(planFragment, "  16:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----15:EXCHANGE\n" +
                 "  |    \n" +
-                "  13:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(10: count)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  12:EXCHANGE\n"));
+                "  2:OlapScanNode\n" +
+                "     TABLE: t0");
     }
 
     @Test
@@ -415,7 +404,7 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     numNodes=0\n"));
 
         // Right sub join tree (a)
-        Assert.assertTrue(planFragment, planFragment.contains("  STREAM DATA SINK\n" +
+        assertContains(planFragment, "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 18\n" +
                 "    UNPARTITIONED\n" +
                 "\n" +
@@ -428,11 +417,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |  \n" +
                 "  |----15:EXCHANGE\n" +
                 "  |    \n" +
-                "  13:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(10: count)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  12:EXCHANGE\n"));
+                "  2:OlapScanNode\n" +
+                "     TABLE: t0\n");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -759,30 +759,31 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         // === check union plan ====
         {
             String unionPlan = plans.get(0);
-            Assert.assertTrue(unionPlan.contains("  0:UNION\n" +
+            assertContains(unionPlan, "  0:UNION\n" +
                     "  |  child exprs:\n" +
                     "  |      [4, BIGINT, true] | [2, BIGINT, true] | [3, BIGINT, true]\n" +
                     "  |      [8, BIGINT, true] | [6, BIGINT, true] | [7, BIGINT, true]\n" +
-                    "  |  pass-through-operands: all\n" +
-                    "  |  cardinality: 800000"));
-            Assert.assertTrue(unionPlan.contains("  4:OlapScanNode\n" +
+                    "  |  pass-through-operands: all\n");
+            assertContains(unionPlan, "  4:OlapScanNode\n" +
                     "     table: t1, rollup: t1\n" +
                     "     preAggregation: on\n" +
+                    "     Predicates: 5: v4 + 2 IS NOT NULL\n" +
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=10015,10017,10019\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 400000\n" +
+                    "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
-                    "     - filter_id = 0, probe_expr = (5: v4 + 2)"));
-            Assert.assertTrue(unionPlan.contains("  1:OlapScanNode\n" +
+                    "     - filter_id = 0, probe_expr = (5: v4 + 2)");
+            assertContains(unionPlan, "  1:OlapScanNode\n" +
                     "     table: t0, rollup: t0\n" +
                     "     preAggregation: on\n" +
+                    "     Predicates: 1: v1 + 1 IS NOT NULL\n" +
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=10006,10008,10010\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 400000\n" +
+                    "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
-                    "     - filter_id = 0, probe_expr = (1: v1 + 1)"));
+                    "     - filter_id = 0, probe_expr = (1: v1 + 1)");
         }
         // === check except plan ===
         {
@@ -790,25 +791,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             Assert.assertTrue(exceptPlan.contains("  0:EXCEPT\n" +
                     "  |  child exprs:\n" +
                     "  |      [4, BIGINT, true] | [2, BIGINT, true] | [3, BIGINT, true]\n" +
-                    "  |      [8, BIGINT, true] | [6, BIGINT, true] | [7, BIGINT, true]\n" +
-                    "  |  cardinality: 800000"));
-            Assert.assertTrue(exceptPlan.contains("  4:OlapScanNode\n" +
-                    "     table: t1, rollup: t1\n" +
-                    "     preAggregation: on\n" +
-                    "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
-                    "     tabletList=10015,10017,10019\n" +
-                    "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 400000\n" +
-                    "     probe runtime filters:\n" +
+                    "  |      [8, BIGINT, true] | [6, BIGINT, true] | [7, BIGINT, true]\n"));
+            Assert.assertTrue(exceptPlan.contains("     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (5: v4 + 2)"));
-            Assert.assertTrue(exceptPlan.contains("  1:OlapScanNode\n" +
-                    "     table: t0, rollup: t0\n" +
-                    "     preAggregation: on\n" +
-                    "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
-                    "     tabletList=10006,10008,10010\n" +
-                    "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 800000\n" +
-                    "     probe runtime filters:\n" +
+            Assert.assertTrue(exceptPlan.contains("     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (1: v1 + 1)"));
         }
         // === check intersect plan ====
@@ -817,25 +803,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             Assert.assertTrue(intersectPlan.contains("  0:INTERSECT\n" +
                     "  |  child exprs:\n" +
                     "  |      [4, BIGINT, true] | [2, BIGINT, true] | [3, BIGINT, true]\n" +
-                    "  |      [8, BIGINT, true] | [6, BIGINT, true] | [7, BIGINT, true]\n" +
-                    "  |  cardinality: 400000"));
-            Assert.assertTrue(intersectPlan.contains("  4:OlapScanNode\n" +
-                    "     table: t1, rollup: t1\n" +
-                    "     preAggregation: on\n" +
-                    "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
-                    "     tabletList=10015,10017,10019\n" +
-                    "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 400000\n" +
-                    "     probe runtime filters:\n" +
+                    "  |      [8, BIGINT, true] | [6, BIGINT, true] | [7, BIGINT, true]\n"));
+            Assert.assertTrue(intersectPlan.contains("     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (5: v4 + 2)"));
-            Assert.assertTrue(intersectPlan.contains("  1:OlapScanNode\n" +
-                    "     table: t0, rollup: t0\n" +
-                    "     preAggregation: on\n" +
-                    "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
-                    "     tabletList=10006,10008,10010\n" +
-                    "     actualRows=0, avgRowSize=4.0\n" +
-                    "     cardinality: 400000\n" +
-                    "     probe runtime filters:\n" +
+            Assert.assertTrue(intersectPlan.contains("     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (1: v1 + 1)"));
         }
     }
@@ -1040,11 +1011,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 01\n" +
-                "    HASH_PARTITIONED: 3: v3");
+                "    HASH_PARTITIONED: 2: v2");
 
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 6: v6");
+                "    HASH_PARTITIONED: 5: v5");
 
         sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6 " +
                 "               join[broadcast] t2 on t0.v2 = t2.v8";
@@ -1052,11 +1023,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 01\n" +
-                "    HASH_PARTITIONED: 3: v3");
+                "    HASH_PARTITIONED: 2: v2");
 
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 6: v6");
+                "    HASH_PARTITIONED: 5: v5");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -906,13 +906,13 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     probe runtime filters:\n" +
                 "     - filter_id = 0, probe_expr = (1: v4)"));
 
-        Assert.assertTrue(plan.contains("  10:HASH JOIN\n" +
+        assertContains(plan, "  11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [10: v4, BIGINT, true] = [7: v7, BIGINT, true]\n" +
                 "  |  build runtime filters:\n" +
                 "  |  - filter_id = 0, build_expr = (7: v7), remote = false\n" +
                 "  |  output columns: 10\n" +
-                "  |  cardinality: 400000"));
+                "  |  cardinality: 360000");
 
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setEnablePipelineEngine(false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -1052,8 +1052,10 @@ public class PlanTestBase {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
     }
 
-    public static void assertContains(String text, String pattern) {
-        Assert.assertTrue(text, text.contains(pattern));
+    public static void assertContains(String text, String... pattern) {
+        for (String s : pattern) {
+            Assert.assertTrue(text, text.contains(s));
+        }
     }
 
     public static void assertNotContains(String text, String pattern) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -177,7 +177,7 @@ public class ReplayFromDumpTest {
         Assert.assertEquals(replaySessionVariable.getParallelExecInstanceNum(), 4);
         System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("  |----24:EXCHANGE\n" +
-                "  |       cardinality: 73049\n" +
+                "  |       cardinality: 65744\n" +
                 "  |    \n" +
                 "  18:UNION\n" +
                 "  |  child exprs:\n" +
@@ -205,7 +205,7 @@ public class ReplayFromDumpTest {
         // Check the size of the left and right tables
         Assert.assertTrue(replayPair.second.contains(" |  \n" +
                 "  |----30:EXCHANGE\n" +
-                "  |       cardinality: 6326\n" +
+                "  |       cardinality: 6304\n" +
                 "  |    \n" +
                 "  14:OlapScanNode\n" +
                 "     table: customer, rollup: customer"));
@@ -367,7 +367,7 @@ public class ReplayFromDumpTest {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/decode_limit_with_project"), null,
                         TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second.contains("  12:Decode\n" +
+        Assert.assertTrue(replayPair.second.contains("  14:Decode\n" +
                 "  |  <dict id 42> : <string id 18>"));
         FeConstants.USE_MOCK_DICT_MANAGER = false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -69,20 +69,19 @@ public class ScanTest extends PlanTestBase {
     public void testPreAggregation() throws Exception {
         String sql = "select k1 from t0 inner join baseall on v1 = cast(k8 as int) group by k1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("1:Project\n" +
+        assertContains(plan, "1:Project\n" +
                 "  |  <slot 4> : 4: k1\n" +
                 "  |  <slot 15> : CAST(CAST(13: k8 AS INT) AS BIGINT)\n" +
                 "  |  \n" +
                 "  0:OlapScanNode\n" +
                 "     TABLE: baseall\n" +
-                "     PREAGGREGATION: OFF. Reason: Predicates include the value column\n" +
-                "     partitions=0/1"));
+                "     PREAGGREGATION: OFF. Reason: Predicates include the value column\n");
 
         sql = "select 0 from baseall inner join t0 on v1 = k1 group by (v2 + k2),k1";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("0:OlapScanNode\n" +
+        assertContains(plan, "0:OlapScanNode\n" +
                 "     TABLE: baseall\n" +
-                "     PREAGGREGATION: OFF. Reason: Group columns isn't bound table baseall"));
+                "     PREAGGREGATION: OFF. Reason: Group columns isn't bound table baseall");
     }
 
     @Test
@@ -92,7 +91,8 @@ public class ScanTest extends PlanTestBase {
         assertContains(plan, "  RESULT SINK\n" +
                 "\n" +
                 "  0:SCAN SCHEMA\n" +
-                "     limit: 1\n");;
+                "     limit: 1\n");
+        ;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -51,7 +51,10 @@ public class SelectConstTest extends PlanTestBase {
                 "  |  <slot 6> : 2\n" +
                 "  |  <slot 7> : CAST(1 AS BIGINT)\n" +
                 "  |  \n" +
-                "  1:UNION\n" +
+                "  1:SELECT\n" +
+                "  |  predicates: TRUE\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
     }
@@ -93,7 +96,7 @@ public class SelectConstTest extends PlanTestBase {
         assertPlanContains("select * from t0 where not exists (select 9)", "  1:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
-        assertPlanContains("select * from t0 where v3 = (select 6)", "  4:Project\n" +
+        assertPlanContains("select * from t0 where v3 = (select 6)", "  5:Project\n" +
                 "  |  <slot 7> : CAST(5: expr AS BIGINT)", "equal join conjunct: 3: v3 = 7: cast");
         assertPlanContains("select case when (select max(v4) from t1) > 1 then 2 else 3 end", "  5:Project\n" +
                 "  |  <slot 7> : if(5: max > 1, 2, 3)\n" +

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -18,7 +18,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
                 EXCHANGE BROADCAST
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE BROADCAST
-                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-2]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
@@ -29,7 +29,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
                 EXCHANGE BROADCAST
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE SHUFFLE[18]
-                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-3]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
@@ -41,7 +41,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
                 INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                     EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-4]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
@@ -52,7 +52,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
             EXCHANGE SHUFFLE[37]
                 INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
                     EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE SHUFFLE[11]
                         SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
@@ -63,7 +63,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
             INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                 SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE SHUFFLE[18]
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
             EXCHANGE BROADCAST
                 SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -73,7 +73,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
         INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
             INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
                 EXCHANGE SHUFFLE[18]
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                 EXCHANGE SHUFFLE[11]
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
             EXCHANGE BROADCAST
@@ -86,7 +86,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
             SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
             EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE BROADCAST
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -98,7 +98,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
             EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                     EXCHANGE SHUFFLE[37]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE SHUFFLE[36]
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -108,7 +108,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
         INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
             EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE BROADCAST
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE SHUFFLE[11]
@@ -121,7 +121,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
             EXCHANGE SHUFFLE[18]
                 INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                     EXCHANGE SHUFFLE[37]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE SHUFFLE[36]
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE SHUFFLE[11]
@@ -137,7 +137,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                     EXCHANGE BROADCAST
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                 EXCHANGE BROADCAST
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-12]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
@@ -149,7 +149,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                     EXCHANGE BROADCAST
                         SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                 EXCHANGE SHUFFLE[18]
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-13]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
@@ -162,7 +162,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                     INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                         SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                         EXCHANGE SHUFFLE[18]
-                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-14]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
@@ -174,7 +174,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                 EXCHANGE SHUFFLE[37]
                     INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
                         EXCHANGE SHUFFLE[18]
-                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
 [end]
@@ -186,7 +186,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                 INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                     EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -197,7 +197,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
             INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                 INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
                     EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                     EXCHANGE SHUFFLE[11]
                         SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE BROADCAST
@@ -211,7 +211,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                 SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -224,7 +224,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                 EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                         EXCHANGE SHUFFLE[37]
-                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                         EXCHANGE SHUFFLE[36]
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
@@ -235,7 +235,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
             INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
                 EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                 EXCHANGE SHUFFLE[11]
@@ -249,7 +249,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
                 EXCHANGE SHUFFLE[18]
                     INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
                         EXCHANGE SHUFFLE[37]
-                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[null])
+                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                         EXCHANGE SHUFFLE[36]
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
                 EXCHANGE SHUFFLE[11]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q15.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q15.sql
@@ -47,7 +47,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -65,7 +65,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -82,7 +82,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -100,7 +100,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -117,7 +117,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -136,7 +136,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -154,7 +154,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -173,7 +173,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                             EXCHANGE SHUFFLE[30]
@@ -191,7 +191,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -210,7 +210,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -228,7 +228,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -247,7 +247,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -265,7 +265,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -285,7 +285,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -304,7 +304,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -324,7 +324,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
             EXCHANGE BROADCAST
-                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                     EXCHANGE GATHER
                         AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                             AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -343,7 +343,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -361,7 +361,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -378,7 +378,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -397,7 +397,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -415,7 +415,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -434,7 +434,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -452,7 +452,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -472,7 +472,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -491,7 +491,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -509,7 +509,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -526,7 +526,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -545,7 +545,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
                                     EXCHANGE SHUFFLE[30]
@@ -563,7 +563,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -582,7 +582,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(45: expr)}] group by [[30: L_SUPPKEY]] having [null]
@@ -600,7 +600,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[11]
                             SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]
@@ -620,7 +620,7 @@ TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
                             AGGREGATE ([LOCAL] aggregate [{27: sum=sum(26: expr)}] group by [[11: L_SUPPKEY]] having [null]
                                 SCAN (columns[19: L_SHIPDATE, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-07-01 AND 19: L_SHIPDATE < 1995-10-01])
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                             EXCHANGE GATHER
                                 AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                                     AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/constant-query.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/constant-query.sql
@@ -87,7 +87,7 @@ SCAN (columns[1: v1] predicate[null])
 [sql]
 select v1 from t0 where (null * null) is null
 [result]
-SCAN (columns[1: v1] predicate[true])
+SCAN (columns[1: v1] predicate[null])
 [end]
 
 [sql]
@@ -142,7 +142,7 @@ SCAN (columns[4: t1d, 9: id_date] predicate[9: id_date = 2020-01-01])
 [sql]
 select v1 from t0 where ((NULL) - (NULL)) <=> ((NULL) % (NULL))
 [result]
-SCAN (columns[1: v1] predicate[true])
+SCAN (columns[1: v1] predicate[null])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
@@ -190,7 +190,7 @@ select t1f from test_all_type left semi join (select v1,v2 from t0 order by v1) 
 [result]
 RIGHT SEMI JOIN (join-predicate [14: cast = 6: t1f] post-join-predicate [null])
     EXCHANGE SHUFFLE[14]
-        SCAN (columns[12: v2] predicate[null])
+        SCAN (columns[12: v2] predicate[cast(12: v2 as double) IS NOT NULL])
     EXCHANGE SHUFFLE[6]
         SCAN (columns[6: t1f] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
@@ -3,7 +3,7 @@ select * from (select sum(v1) as v, sum(v2) from t0) a left semi join (select v1
 [result]
 RIGHT SEMI JOIN (join-predicate [7: v2 = 4: sum] post-join-predicate [null])
     EXCHANGE SHUFFLE[7]
-        SCAN (columns[7: v2] predicate[null])
+        SCAN (columns[7: v2] predicate[7: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum), 5: sum=sum(5: sum)}] group by [[]] having [null]
             EXCHANGE GATHER
@@ -16,7 +16,7 @@ select t1.* from t0 right semi join t1 on t0.v2 = t1.v5;
 [result]
 RIGHT SEMI JOIN (join-predicate [2: v2 = 5: v5] post-join-predicate [null])
     EXCHANGE SHUFFLE[2]
-        SCAN (columns[2: v2] predicate[null])
+        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[5]
         SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
 [fragment]
@@ -80,11 +80,12 @@ HASH_PARTITIONED: 2: v2
 0:OlapScanNode
 TABLE: t0
 PREAGGREGATION: ON
+PREDICATES: 2: v2 IS NOT NULL
 partitions=1/1
 rollup: t0
 tabletRatio=3/3
 tabletList=10006,10008,10010
-cardinality=10000
+cardinality=9000
 avgRowSize=1.0
 numNodes=0
 [end]
@@ -93,18 +94,18 @@ numNodes=0
 select t0.*,v1,t1.* from t0 join t1 on t0.v1=t1.v4;
 [result]
 INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select t0.*,v1,t1.* from t0 join t1 on t0.v1=t1.v4;
 [result]
 INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -121,7 +122,7 @@ select * from (select sum(v1) as v, sum(v2) from t0) a left semi join (select v1
 [result]
 RIGHT SEMI JOIN (join-predicate [8: v3 = 4: sum] post-join-predicate [null])
     EXCHANGE SHUFFLE[8]
-        SCAN (columns[8: v3] predicate[null])
+        SCAN (columns[8: v3] predicate[8: v3 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum), 5: sum=sum(5: sum)}] group by [[]] having [null]
             EXCHANGE GATHER
@@ -136,7 +137,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
     LEFT SEMI JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE SHUFFLE[4]
-            SCAN (columns[4: v4] predicate[null])
+            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
     EXCHANGE BROADCAST
         SCAN (columns[7: v7] predicate[null])
 [end]
@@ -146,7 +147,7 @@ SELECT t2.v7 FROM  t0 right SEMI JOIN t1 on t0.v1=t1.v4, t2
 [result]
 CROSS JOIN (join-predicate [null] post-join-predicate [null])
     RIGHT SEMI JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-        SCAN (columns[1: v1] predicate[null])
+        SCAN (columns[1: v1] predicate[1: v1 IS NOT NULL])
         EXCHANGE SHUFFLE[4]
             SCAN (columns[4: v4] predicate[null])
     EXCHANGE BROADCAST
@@ -158,7 +159,7 @@ SELECT t1.* FROM  t0 right SEMI JOIN t1 on t0.v1=t1.v4, t2
 [result]
 CROSS JOIN (join-predicate [null] post-join-predicate [null])
     RIGHT SEMI JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-        SCAN (columns[1: v1] predicate[null])
+        SCAN (columns[1: v1] predicate[1: v1 IS NOT NULL])
         EXCHANGE SHUFFLE[4]
             SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
     EXCHANGE BROADCAST
@@ -170,18 +171,18 @@ select v1 from t0 inner join [shuffle] t1 on t0.v2 = t1.v4
 [result]
 INNER JOIN (join-predicate [2: v2 = 4: v4] post-join-predicate [null])
     EXCHANGE SHUFFLE[2]
-        SCAN (columns[1: v1, 2: v2] predicate[null])
+        SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 inner join [BROADCAST] t1 on t0.v3 = t1.v4
 [result]
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
-    SCAN (columns[1: v1, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 3: v3] predicate[3: v3 IS NOT NULL])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -217,7 +218,7 @@ select v1,v2,v3 from t0 left semi join t1 on v1=v5 and 1>2
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v5 = 1: v1] post-join-predicate [null])
     EXCHANGE SHUFFLE[5]
-        SCAN (columns[5: v5] predicate[null])
+        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
     EXCHANGE SHUFFLE[1]
         VALUES
 [end]
@@ -280,12 +281,12 @@ AGGREGATE ([GLOBAL] aggregate [{13: count=count(13: count)}] group by [[]] havin
         AGGREGATE ([LOCAL] aggregate [{13: count=count()}] group by [[]] having [null]
             CROSS JOIN (join-predicate [null] post-join-predicate [null])
                 INNER JOIN (join-predicate [4: v1 = 1: v7] post-join-predicate [null])
-                    SCAN (columns[4: v1] predicate[null])
+                    SCAN (columns[4: v1] predicate[4: v1 IS NOT NULL])
                     EXCHANGE SHUFFLE[1]
-                        SCAN (columns[1: v7] predicate[null])
+                        SCAN (columns[1: v7] predicate[1: v7 IS NOT NULL])
                 EXCHANGE BROADCAST
                     INNER JOIN (join-predicate [7: v10 = 10: v4 AND 8: v11 = 10: v4 AND 9: v12 = 11: v5] post-join-predicate [null])
-                        SCAN (columns[7: v10, 8: v11, 9: v12] predicate[null])
+                        SCAN (columns[7: v10, 8: v11, 9: v12] predicate[7: v10 IS NOT NULL AND 8: v11 IS NOT NULL AND 9: v12 IS NOT NULL])
                         EXCHANGE SHUFFLE[10]
-                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                            SCAN (columns[10: v4, 11: v5] predicate[10: v4 IS NOT NULL AND 11: v5 IS NOT NULL])
 [end]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
@@ -72,14 +72,14 @@ select v1 from t0 inner join t1 on v3 = v4 where v2 = 2 or (v2 = 3 and v3 = 3) o
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 2 OR 2: v2 = 3 AND 3: v3 = 3 OR 2: v2 = 4 AND 3: v3 = 4 AND 2: v2 IN (2, 3, 4)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 inner join t1 on v3 = v4 where (v2 = 2 or v2 = 3);
 [result]
 INNER JOIN (join-predicate [4: v4 = 3: v3] post-join-predicate [null])
-    SCAN (columns[4: v4] predicate[null])
+    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[3]
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IN (2, 3)])
 [end]
@@ -88,7 +88,7 @@ INNER JOIN (join-predicate [4: v4 = 3: v3] post-join-predicate [null])
 select v1 from t0 inner join t1 on v3 = v4 where (v2 = 2 or v2 = 3) and (v3 = 3 or v4 = 4);
 [result]
 INNER JOIN (join-predicate [4: v4 = 3: v3 AND 3: v3 = 3 OR 4: v4 = 4] post-join-predicate [null])
-    SCAN (columns[4: v4] predicate[null])
+    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[3]
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IN (2, 3)])
 [end]
@@ -99,7 +99,7 @@ select v1 from t0 inner join t1 on v3 = v4 where  v2 = 2 or (v2 = 3 and v3 = 3) 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 2 OR 2: v2 = 3 AND 3: v3 = 3 OR 2: v2 = 4 AND 3: v3 = 4 AND 3: v3 = 5 AND 2: v2 IN (2, 3, 4)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -108,7 +108,7 @@ select v1 from t0 inner join t1 on v3 = v4 where  v2 = 2 or (v2 = 3 and v3 = 3) 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 2 OR 2: v2 = 3 AND 3: v3 = 3 OR 2: v2 = 4 AND 3: v3 = 4 OR 2: v2 = 5 AND 2: v2 IN (2, 3, 4, 5)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -117,7 +117,7 @@ select v1 from t0 inner join t1 on v3 = v4 where  v2 in (1,2) or (v2 = 3 and v3 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IN (1, 2) OR 2: v2 = 3 AND 3: v3 = 3 OR 2: v2 IN (4, 5) AND 3: v3 = 4 AND 2: v2 = 6 AND 2: v2 IN (1, 2, 3)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -126,7 +126,7 @@ select v1 from t0 inner join t1 on v3 = v4 where  v2 = 2 or (v2 = 3 and v3 = 3) 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 2 OR 2: v2 = 3 AND 3: v3 = 3 OR 2: v2 = 4 AND 3: v3 = 4 OR 2: v2 IN (6, 7, 8) AND 3: v3 = 6 AND 2: v2 IN (2, 3, 4, 6, 7, 8)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -135,14 +135,14 @@ select v1 from t0 inner join t1 on v3 = v4 where  v2 = 2 or (v2 = 3 and v3 = 3) 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 2 OR 2: v2 = 3 AND 3: v3 = 3 OR 3: v3 = 4 OR 2: v2 IN (6, 7, 8) AND 3: v3 = 6])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 inner join t1 on v3 = v4 where (v1 = 1 AND v2 = 2) OR (v1 = 3 AND v2 = 4 AND v1 != 5)
 [result]
 INNER JOIN (join-predicate [4: v4 = 3: v3] post-join-predicate [null])
-    SCAN (columns[4: v4] predicate[null])
+    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[3]
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 = 1 AND 2: v2 = 2 OR 1: v1 = 3 AND 2: v2 = 4 AND 1: v1 != 5 AND 1: v1 IN (1, 3) AND 2: v2 IN (2, 4)])
 [end]
@@ -153,14 +153,14 @@ select v1 from t0 inner join t1 on v3 = v4 where (v1 = 1 AND v2 = 2) OR (v2 = 4 
 INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 = 1 AND 2: v2 = 2 OR 2: v2 = 4 AND 1: v1 = 3: v3 AND 2: v2 IN (2, 4)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[null])
+        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 inner join t1 on v3 = v4 where (v1 = 1 AND v2 = 2) OR (v2 = 4 AND v1 not in (1,2))
 [result]
 INNER JOIN (join-predicate [4: v4 = 3: v3] post-join-predicate [null])
-    SCAN (columns[4: v4] predicate[null])
+    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[3]
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 = 1 AND 2: v2 = 2 OR 2: v2 = 4 AND 1: v1 NOT IN (1, 2) AND 2: v2 IN (2, 4)])
 [end]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
@@ -2,9 +2,9 @@
 select v1, v2, ta, td from t0 inner join tall on t0.v1 = tall.td
 [result]
 INNER JOIN (join-predicate [1: v1 = 7: td] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
     EXCHANGE SHUFFLE[7]
-        SCAN (columns[4: ta, 7: td] predicate[null])
+        SCAN (columns[4: ta, 7: td] predicate[7: td IS NOT NULL])
 [end]
 
 [sql]
@@ -20,9 +20,9 @@ CROSS JOIN (join-predicate [null] post-join-predicate [1: v1 > 4: v4])
 select v1 from t0 inner join t1 on v1>v4 and v2 = v5
 [result]
 INNER JOIN (join-predicate [2: v2 = 5: v5 AND 1: v1 > 4: v4] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4, 5: v5] predicate[null])
+        SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
 [end]
 
 [sql]
@@ -83,9 +83,9 @@ select v1 from t0 inner join t1 where t0.v1 = t1.v4 or t0.v2 = t1.v5
 select v1,v5 from t0,t1 where t0.v1 = t1.v4 and t0.v2 > t1.v5
 [result]
     INNER JOIN (join-predicate [1: v1 = 4: v4 AND 2: v2 > 5: v5] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        SCAN (columns[4: v4, 5: v5] predicate[null])
+        SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -119,7 +119,7 @@ RIGHT OUTER JOIN (join-predicate [4: v4 = 1: v1] post-join-predicate [null])
 select v1 from t0 left join t1 on v1 = v4 where v2 = v5 and v3 = 3
 [result]
 INNER JOIN (join-predicate [4: v4 = 1: v1 AND 5: v5 = 2: v2] post-join-predicate [null])
-    SCAN (columns[4: v4, 5: v5] predicate[null])
+    SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL AND 5: v5 IS NOT NULL])
     EXCHANGE SHUFFLE[1]
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 = 3])
 [end]
@@ -201,40 +201,40 @@ INNER JOIN (join-predicate [5: v5 = 1: v1] post-join-predicate [null])
 select v1 from t0 left outer join t1 on t0.v1 = t1.v5 where t0.v2 = t1.v6
 [result]
     INNER JOIN (join-predicate [1: v1 = 5: v5 AND 2: v2 = 6: v6] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL AND 2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[5]
-        SCAN (columns[5: v5, 6: v6] predicate[null])
+        SCAN (columns[5: v5, 6: v6] predicate[5: v5 IS NOT NULL AND 6: v6 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 right outer join t1 on t0.v1 = t1.v5 where t0.v2 = t1.v6
 [result]
     INNER JOIN (join-predicate [1: v1 = 5: v5 AND 2: v2 = 6: v6] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL AND 2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[5]
-        SCAN (columns[5: v5, 6: v6] predicate[null])
+        SCAN (columns[5: v5, 6: v6] predicate[5: v5 IS NOT NULL AND 6: v6 IS NOT NULL])
 [end]
 
 [sql]
 select * from t0 left outer join (select v4,max(v5) as m from t1 group by v4) t on v1 = v4 where v2 = case (t.m is null) when true then NULL when false then m end
 [result]
 INNER JOIN (join-predicate [1: v1 = 4: v4 AND 2: v2 = 8: case] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL AND 2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        AGGREGATE ([GLOBAL] aggregate [{7: max=max(7: max)}] group by [[4: v4]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{7: max=max(7: max)}] group by [[4: v4]] having [CASE 7: max IS NULL WHEN true THEN null WHEN false THEN 7: max END IS NOT NULL]
             AGGREGATE ([LOCAL] aggregate [{7: max=max(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+                SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
 select * from t0 left outer join (select v4,max(v5) as m from t1 group by v4) t on v1 = v4 where v2 = case (t.m is null) when true then m when false then NULL end
 [result]
 INNER JOIN (join-predicate [1: v1 = 4: v4 AND 2: v2 = 8: case] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL AND 2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        AGGREGATE ([GLOBAL] aggregate [{7: max=max(7: max)}] group by [[4: v4]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{7: max=max(7: max)}] group by [[4: v4]] having [CASE 7: max IS NULL WHEN true THEN 7: max WHEN false THEN null END IS NOT NULL]
             AGGREGATE ([LOCAL] aggregate [{7: max=max(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+                SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]
@@ -252,11 +252,11 @@ LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [2: v2 = CAS
 select * from t0 left outer join (select v4,count(v5) as m from t1 group by v4) t on v1 = v4 where v2 = case (t.m is null) when true then m when false then 0 end
 [result]
 INNER JOIN (join-predicate [1: v1 = 4: v4 AND 2: v2 = 8: case] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL AND 2: v2 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
-        AGGREGATE ([GLOBAL] aggregate [{7: count=count(7: count)}] group by [[4: v4]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{7: count=count(7: count)}] group by [[4: v4]] having [CASE 7: count IS NULL WHEN true THEN 7: count WHEN false THEN 0 END IS NOT NULL]
             AGGREGATE ([LOCAL] aggregate [{7: count=count(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+                SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
@@ -156,26 +156,26 @@ SCAN (columns[1: v1, 2: v2, 3: v3] predicate[abs(1: v1) = abs(1: v1)])
 [sql]
 select * from t0_not_null where v1=v1
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[true])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 [end]
 
 [sql]
 select * from t0_not_null where v1>=v1
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[true])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 [end]
 
 [sql]
 select * from t0_not_null where v1<=v1
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[true])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 
 [end]
 
 [sql]
 select * from t0_not_null where v1<=>v1
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[true])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 [end]
 
 [sql]
@@ -199,5 +199,5 @@ VALUES
 [sql]
 select * from t0 where v1<=>v1
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[true])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -14,7 +14,7 @@ select t0.v1 from t0 where exists (select t3.v11 from t3 where t0.v3 = t3.v12)
 LEFT SEMI JOIN (join-predicate [3: v3 = 6: v12] post-join-predicate [null])
     SCAN (columns[1: v1, 3: v3] predicate[null])
     EXCHANGE BROADCAST
-        SCAN (columns[6: v12] predicate[null])
+        SCAN (columns[6: v12] predicate[6: v12 IS NOT NULL])
 [end]
 
 [sql]
@@ -44,7 +44,7 @@ select t0.v1 from t0 where exists (select t3.v11 from t3 where t0.v3 = t3.v12) a
 LEFT SEMI JOIN (join-predicate [3: v3 = 6: v12] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 3])
     EXCHANGE BROADCAST
-        SCAN (columns[6: v12] predicate[null])
+        SCAN (columns[6: v12] predicate[6: v12 IS NOT NULL])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -101,7 +101,7 @@ select v2, min(v1) from t0 group by v2 having exists (select v4 from t1 where v5
 [result]
 RIGHT SEMI JOIN (join-predicate [6: v5 = 2: v2] post-join-predicate [null])
     EXCHANGE SHUFFLE[6]
-        SCAN (columns[6: v5] predicate[null])
+        SCAN (columns[6: v5] predicate[6: v5 IS NOT NULL])
     AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
         EXCHANGE SHUFFLE[2]
             AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[2: v2]] having [null]
@@ -113,7 +113,7 @@ select v2, min(v1) from t0 group by v2 having exists (select v4 from t1 where v5
 [result]
 RIGHT SEMI JOIN (join-predicate [6: v5 = 2: v2 AND 2: v2 < 7: v6] post-join-predicate [null])
     EXCHANGE SHUFFLE[6]
-        SCAN (columns[6: v5, 7: v6] predicate[null])
+        SCAN (columns[6: v5, 7: v6] predicate[6: v5 IS NOT NULL])
     AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
         EXCHANGE SHUFFLE[2]
             AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[2: v2]] having [null]
@@ -203,7 +203,7 @@ LEFT SEMI JOIN (join-predicate [1: v1 = 5: v5] post-join-predicate [null])
         AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v5, 6: v6]] having [null]
             EXCHANGE SHUFFLE[5, 6]
                 AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v5, 6: v6]] having [null]
-                    SCAN (columns[5: v5, 6: v6] predicate[null])
+                    SCAN (columns[5: v5, 6: v6] predicate[5: v5 IS NOT NULL])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
@@ -149,7 +149,7 @@ LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11] post-join-predicate [null])
 select v2, min(v1) from t0 group by v2 having min(v1) in (select v4 from t1 where v5 = v2);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL])
+    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL AND 6: v5 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]
@@ -161,7 +161,7 @@ RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2] post-join-pre
 select v2, min(v1) from t0 group by v2 having min(v1) in (select v4 from t1 where v5 = v2 and v2 < v6);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2 AND 2: v2 < 7: v6] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 IS NOT NULL])
+    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 IS NOT NULL AND 6: v5 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]
@@ -173,7 +173,7 @@ RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2 AND 2: v2 < 7:
 select v2, min(v1) from t0 group by v2 having v2 in (select v4 from t1 where v5 = v2);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 2: v2 AND 6: v5 = 2: v2] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL])
+    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL AND 6: v5 IS NOT NULL])
     EXCHANGE SHUFFLE[2]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]

--- a/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
@@ -4,7 +4,7 @@ select t0.v1 from t0 where t0.v2 in (select t3.v11 from t3)
 LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[null])
     EXCHANGE BROADCAST
-        SCAN (columns[5: v11] predicate[null])
+        SCAN (columns[5: v11] predicate[5: v11 IS NOT NULL])
 [end]
 
 [sql]
@@ -34,7 +34,7 @@ select t0.v1 from t0 where t0.v2 in (select t3.v11 from t3 where t0.v3 = t3.v12)
 LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11 AND 3: v3 = 6: v12] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
     EXCHANGE BROADCAST
-        SCAN (columns[5: v11, 6: v12] predicate[null])
+        SCAN (columns[5: v11, 6: v12] predicate[5: v11 IS NOT NULL AND 6: v12 IS NOT NULL])
 [end]
 
 [sql]
@@ -43,7 +43,7 @@ select t0.v1 from t0 where t0.v2 in (select t3.v11 from t3 where t0.v3 > t3.v12)
 LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11 AND 3: v3 > 6: v12] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
     EXCHANGE BROADCAST
-        SCAN (columns[5: v11, 6: v12] predicate[null])
+        SCAN (columns[5: v11, 6: v12] predicate[5: v11 IS NOT NULL])
 [end]
 
 [sql]
@@ -88,7 +88,7 @@ select t0.v1 from t0 where t0.v2 in (select t3.v11 from t3 where t0.v3 > t3.v12)
 LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11 AND 3: v3 > 6: v12] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 3])
     EXCHANGE BROADCAST
-        SCAN (columns[5: v11, 6: v12] predicate[5: v11 = 3])
+        SCAN (columns[5: v11, 6: v12] predicate[5: v11 IS NOT NULL AND 5: v11 = 3])
 [end]
 
 [sql]
@@ -142,14 +142,14 @@ select t0.v1 from t0 where t0.v2 in (select t3.v11 from t3 where t3.v10 > 2) and
 LEFT SEMI JOIN (join-predicate [2: v2 = 5: v11] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[2: v2 = 3])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v10, 5: v11] predicate[5: v11 = 3 AND 4: v10 > 2])
+        SCAN (columns[4: v10, 5: v11] predicate[5: v11 IS NOT NULL AND 5: v11 = 3 AND 4: v10 > 2])
 [end]
 
 [sql]
 select v2, min(v1) from t0 group by v2 having min(v1) in (select v4 from t1 where v5 = v2);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5] predicate[null])
+    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]
@@ -161,7 +161,7 @@ RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2] post-join-pre
 select v2, min(v1) from t0 group by v2 having min(v1) in (select v4 from t1 where v5 = v2 and v2 < v6);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2 AND 2: v2 < 7: v6] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[null])
+    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]
@@ -173,7 +173,7 @@ RIGHT SEMI JOIN (join-predicate [5: v4 = 4: min AND 6: v5 = 2: v2 AND 2: v2 < 7:
 select v2, min(v1) from t0 group by v2 having v2 in (select v4 from t1 where v5 = v2);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 2: v2 AND 6: v5 = 2: v2] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5] predicate[null])
+    SCAN (columns[5: v4, 6: v5] predicate[5: v4 IS NOT NULL])
     EXCHANGE SHUFFLE[2]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[2: v2]] having [null]
             EXCHANGE SHUFFLE[2]
@@ -185,7 +185,7 @@ RIGHT SEMI JOIN (join-predicate [5: v4 = 2: v2 AND 6: v5 = 2: v2] post-join-pred
 select v3, min(v1) from t0 group by v3 having v3 in (select v4 from t1 where v5 = v6);
 [result]
 RIGHT SEMI JOIN (join-predicate [5: v4 = 3: v3] post-join-predicate [null])
-    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 7: v6])
+    SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 IS NOT NULL AND 6: v5 = 7: v6])
     EXCHANGE SHUFFLE[3]
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
             EXCHANGE SHUFFLE[3]
@@ -202,7 +202,7 @@ LEFT SEMI JOIN (join-predicate [3: v3 = 8: max] post-join-predicate [null])
             AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[3: v3]] having [null]
                 SCAN (columns[1: v1, 3: v3] predicate[null])
     EXCHANGE SHUFFLE[8]
-        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[7: v6]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[7: v6]] having [8: max IS NOT NULL]
             EXCHANGE SHUFFLE[7]
                 AGGREGATE ([LOCAL] aggregate [{8: max=max(5: v4)}] group by [[7: v6]] having [null]
                     SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 5])
@@ -455,7 +455,8 @@ select * from t0 where v3 in (select * from (values(2),(3)) t);
 LEFT SEMI JOIN (join-predicate [3: v3 = 6: cast] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
     EXCHANGE BROADCAST
-        VALUES (2),(3)
+        PREDICATE cast(4: column_0 as bigint(20)) IS NOT NULL
+            VALUES (2),(3)
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -2,11 +2,12 @@
 select t0.v1 from t0 where t0.v2 = (select t3.v11 from t3)
 [result]
 INNER JOIN (join-predicate [2: v2 = 5: v11] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE BROADCAST
-        ASSERT LE 1
-            EXCHANGE GATHER
-                SCAN (columns[5: v11] predicate[null])
+        PREDICATE 5: v11 IS NOT NULL
+            ASSERT LE 1
+                EXCHANGE GATHER
+                    SCAN (columns[5: v11] predicate[null])
 [fragment]
 PLAN FRAGMENT 0
 OUTPUT EXPRS:1: v1
@@ -14,33 +15,33 @@ PARTITION: UNPARTITIONED
 
 RESULT SINK
 
-7:EXCHANGE
+8:EXCHANGE
 
 PLAN FRAGMENT 1
 OUTPUT EXPRS:
 PARTITION: RANDOM
 
 STREAM DATA SINK
-EXCHANGE ID: 07
+EXCHANGE ID: 08
 UNPARTITIONED
 
-6:Project
+7:Project
 |  <slot 1> : 1: v1
 |
-5:HASH JOIN
+6:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  colocate: false, reason:
 |  equal join conjunct: 2: v2 = 5: v11
 |
-|----4:EXCHANGE
+|----5:EXCHANGE
 |
 0:OlapScanNode
 TABLE: t0
 PREAGGREGATION: ON
+PREDICATES: 2: v2 IS NOT NULL
 partitions=1/1
 rollup: t0
 tabletRatio=3/3
-tabletList=10006,10008,10010
 cardinality=1
 avgRowSize=2.0
 numNodes=0
@@ -50,9 +51,12 @@ OUTPUT EXPRS:
 PARTITION: UNPARTITIONED
 
 STREAM DATA SINK
-EXCHANGE ID: 04
+EXCHANGE ID: 05
 UNPARTITIONED
 
+4:SELECT
+|  predicates: 5: v11 IS NOT NULL
+|
 3:ASSERT NUMBER OF ROWS
 |  assert number of rows: LE 1
 |
@@ -72,7 +76,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: t3
 tabletRatio=3/3
-tabletList=10033,10035,10037
 cardinality=1
 avgRowSize=1.0
 numNodes=0
@@ -93,12 +96,12 @@ CROSS JOIN (join-predicate [null] post-join-predicate [2: v2 < 5: v11])
 select t0.v1 from t0 where t0.v2 < (select SUM(t3.v11) from t3 where t0.v3 = t3.v12)
 [result]
 INNER JOIN (join-predicate [3: v3 = 6: v12 AND 2: v2 < 7: sum] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[6: v12]] having [null]
             EXCHANGE SHUFFLE[6]
                 AGGREGATE ([LOCAL] aggregate [{7: sum=sum(5: v11)}] group by [[6: v12]] having [null]
-                    SCAN (columns[5: v11, 6: v12] predicate[null])
+                    SCAN (columns[5: v11, 6: v12] predicate[6: v12 IS NOT NULL])
 [fragment]
 PLAN FRAGMENT 0
 OUTPUT EXPRS:1: v1
@@ -130,6 +133,7 @@ UNPARTITIONED
 0:OlapScanNode
 TABLE: t0
 PREAGGREGATION: ON
+PREDICATES: 3: v3 IS NOT NULL
 partitions=1/1
 rollup: t0
 tabletRatio=3/3
@@ -167,6 +171,7 @@ HASH_PARTITIONED: 6: v12
 1:OlapScanNode
 TABLE: t3
 PREAGGREGATION: ON
+PREDICATES: 6: v12 IS NOT NULL
 partitions=1/1
 rollup: t3
 tabletRatio=3/3
@@ -179,35 +184,35 @@ numNodes=0
 select t0.v1 from t0 where t0.v2 < (select SUM(t3.v11) from t3 where t0.v3 = t3.v12 and t0.v1 = t3.v10)
 [result]
 INNER JOIN (join-predicate [3: v3 = 6: v12 AND 1: v1 = 4: v10 AND 2: v2 < 7: sum] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL AND 1: v1 IS NOT NULL])
     EXCHANGE SHUFFLE[4]
         AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[4: v10, 6: v12]] having [null]
             AGGREGATE ([LOCAL] aggregate [{7: sum=sum(5: v11)}] group by [[4: v10, 6: v12]] having [null]
-                SCAN (columns[4: v10, 5: v11, 6: v12] predicate[null])
+                SCAN (columns[4: v10, 5: v11, 6: v12] predicate[6: v12 IS NOT NULL AND 4: v10 IS NOT NULL])
 [end]
 
 [sql]
 select t0.v1 from t0 where t0.v2 < (select SUM(t3.v11) from t3 where t0.v3 = t3.v12 and abs(t0.v1) = abs(t3.v10))
 [result]
 INNER JOIN (join-predicate [3: v3 = 6: v12 AND 10: abs = 9: abs AND 2: v2 < 7: sum] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL AND abs(1: v1) IS NOT NULL])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[6: v12, 9: abs]] having [null]
             EXCHANGE SHUFFLE[6, 9]
                 AGGREGATE ([LOCAL] aggregate [{7: sum=sum(5: v11)}] group by [[6: v12, 9: abs]] having [null]
-                    SCAN (columns[4: v10, 5: v11, 6: v12] predicate[null])
+                    SCAN (columns[4: v10, 5: v11, 6: v12] predicate[6: v12 IS NOT NULL AND abs(4: v10) IS NOT NULL])
 [end]
 
 [sql]
 select t0.v1 from t0 where t0.v2 < (select SUM(abs(t3.v11)) from t3 where t0.v3 = t3.v12 and abs(t0.v1) = abs(t3.v10))
 [result]
 INNER JOIN (join-predicate [3: v3 = 6: v12 AND 11: abs = 10: abs AND cast(2: v2 as largeint(40)) < 8: sum] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL AND abs(1: v1) IS NOT NULL])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{8: sum=sum(8: sum)}] group by [[6: v12, 10: abs]] having [null]
             EXCHANGE SHUFFLE[6, 10]
                 AGGREGATE ([LOCAL] aggregate [{8: sum=sum(7: abs)}] group by [[6: v12, 10: abs]] having [null]
-                    SCAN (columns[4: v10, 5: v11, 6: v12] predicate[null])
+                    SCAN (columns[4: v10, 5: v11, 6: v12] predicate[6: v12 IS NOT NULL AND abs(4: v10) IS NOT NULL])
 [fragment]
 PLAN FRAGMENT 0
 OUTPUT EXPRS:1: v1
@@ -246,6 +251,7 @@ UNPARTITIONED
 0:OlapScanNode
 TABLE: t0
 PREAGGREGATION: ON
+PREDICATES: 3: v3 IS NOT NULL, abs(1: v1) IS NOT NULL
 partitions=1/1
 rollup: t0
 tabletRatio=3/3
@@ -288,6 +294,7 @@ HASH_PARTITIONED: 6: v12, 10: abs
 2:OlapScanNode
 TABLE: t3
 PREAGGREGATION: ON
+PREDICATES: 6: v12 IS NOT NULL, abs(4: v10) IS NOT NULL
 partitions=1/1
 rollup: t3
 tabletRatio=3/3
@@ -332,10 +339,11 @@ CROSS JOIN (join-predicate [null] post-join-predicate [1: v1 <= 11: v4])
 select * from t0 where v3 = (select * from (values(2)) t);
 [result]
 INNER JOIN (join-predicate [3: v3 = 6: cast] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
     EXCHANGE BROADCAST
-        ASSERT LE 1
-            VALUES (2)
+        PREDICATE cast(4: column_0 as bigint(20)) IS NOT NULL
+            ASSERT LE 1
+                VALUES (2)
 [end]
 
 [sql]
@@ -377,12 +385,12 @@ LEFT OUTER JOIN (join-predicate [3: v3 = 5: v5] post-join-predicate [2: v2 > ifn
 select v1 from t0 where v2 > (select max(v4) from t1 where v3 = v5)
 [result]
 INNER JOIN (join-predicate [3: v3 = 5: v5 AND 2: v2 > 7: max] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IS NOT NULL])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{7: max=max(7: max)}] group by [[5: v5]] having [null]
             EXCHANGE SHUFFLE[5]
                 AGGREGATE ([LOCAL] aggregate [{7: max=max(4: v4)}] group by [[5: v5]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
+                    SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
 [end]
 
 [sql]
@@ -448,9 +456,9 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
 select t0.v1 from t0 where t0.v2 = (select SUM(v4) from t1) / 2;
 [result]
 INNER JOIN (join-predicate [9: cast = 10: divide] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[cast(2: v2 as double) IS NOT NULL])
     EXCHANGE BROADCAST
-        AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[]] having [divide(cast(7: sum as double), 2.0) IS NOT NULL]
             EXCHANGE GATHER
                 AGGREGATE ([LOCAL] aggregate [{7: sum=sum(4: v4)}] group by [[]] having [null]
                     SCAN (columns[4: v4] predicate[null])
@@ -463,42 +471,45 @@ INNER JOIN (join-predicate [7: expr = 8: v7] post-join-predicate [null])
     CROSS JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
         EXCHANGE BROADCAST
+            PREDICATE 4: v4 IS NOT NULL
+                ASSERT LE 1
+                    EXCHANGE GATHER
+                        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE BROADCAST
+        PREDICATE 8: v7 IS NOT NULL
             ASSERT LE 1
                 EXCHANGE GATHER
-                    SCAN (columns[4: v4] predicate[null])
-    EXCHANGE BROADCAST
-        ASSERT LE 1
-            EXCHANGE GATHER
-                SCAN (columns[8: v7] predicate[null])
+                    SCAN (columns[8: v7] predicate[null])
 [end]
 
 [sql]
 select * from t0 where (select SUM(v4) from t1 where t0.v1 = t1.v4) = (select SUM(v7) from t2 where t0.v2 = t2.v8)
 [result]
 INNER JOIN (join-predicate [2: v2 = 10: v8 AND 8: expr = 12: sum] post-join-predicate [null])
-    LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IS NOT NULL])
         EXCHANGE SHUFFLE[4]
-            AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[4: v4]] having [null]
+            AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(7: sum)}] group by [[4: v4]] having [7: sum IS NOT NULL]
                 AGGREGATE ([LOCAL] aggregate [{7: sum=sum(4: v4)}] group by [[4: v4]] having [null]
                     SCAN (columns[4: v4] predicate[null])
     EXCHANGE BROADCAST
-        AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(12: sum)}] group by [[10: v8]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(12: sum)}] group by [[10: v8]] having [12: sum IS NOT NULL]
             EXCHANGE SHUFFLE[10]
                 AGGREGATE ([LOCAL] aggregate [{12: sum=sum(9: v7)}] group by [[10: v8]] having [null]
-                    SCAN (columns[9: v7, 10: v8] predicate[null])
+                    SCAN (columns[9: v7, 10: v8] predicate[10: v8 IS NOT NULL])
 [end]
 
 [sql]
 select v1 from t0 where v2 = (with cte as (select v4,v5 from t1 order by 2 limit 10) select v4 from cte order by 1 limit 1)
 [result]
 INNER JOIN (join-predicate [2: v2 = 7: v4] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2] predicate[null])
+    SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE BROADCAST
-        ASSERT LE 1
-            EXCHANGE GATHER
-                TOP-N (order by [[7: v4 ASC NULLS FIRST]])
-                    TOP-N (order by [[8: v5 ASC NULLS FIRST]])
+        PREDICATE 7: v4 IS NOT NULL
+            ASSERT LE 1
+                EXCHANGE GATHER
+                    TOP-N (order by [[7: v4 ASC NULLS FIRST]])
                         TOP-N (order by [[8: v5 ASC NULLS FIRST]])
-                            SCAN (columns[7: v4, 8: v5] predicate[null])
+                            TOP-N (order by [[8: v5 ASC NULLS FIRST]])
+                                SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q15.sql
@@ -40,7 +40,7 @@ order by
 TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
     TOP-N (order by [[1: S_SUPPKEY ASC NULLS FIRST]])
         INNER JOIN (join-predicate [47: max = 27: sum] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [null]
+            AGGREGATE ([GLOBAL] aggregate [{47: max=max(47: max)}] group by [[]] having [47: max IS NOT NULL]
                 EXCHANGE GATHER
                     AGGREGATE ([LOCAL] aggregate [{47: max=max(46: sum)}] group by [[]] having [null]
                         AGGREGATE ([GLOBAL] aggregate [{46: sum=sum(46: sum)}] group by [[30: L_SUPPKEY]] having [null]

--- a/fe/fe-core/src/test/resources/sql/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q2.sql
@@ -60,7 +60,7 @@ TOP-N (order by [[16: S_ACCTBAL DESC NULLS LAST, 26: N_NAME ASC NULLS FIRST, 12:
                                         INNER JOIN (join-predicate [1: P_PARTKEY = 34: PS_PARTKEY] post-join-predicate [null])
                                             SCAN (columns[1: P_PARTKEY, 3: P_MFGR, 5: P_TYPE, 6: P_SIZE] predicate[6: P_SIZE = 12 AND 5: P_TYPE LIKE %COPPER])
                                             EXCHANGE SHUFFLE[34]
-                                                AGGREGATE ([GLOBAL] aggregate [{57: min=min(57: min)}] group by [[34: PS_PARTKEY]] having [null]
+                                                AGGREGATE ([GLOBAL] aggregate [{57: min=min(57: min)}] group by [[34: PS_PARTKEY]] having [57: min IS NOT NULL]
                                                     AGGREGATE ([LOCAL] aggregate [{57: min=min(37: PS_SUPPLYCOST)}] group by [[34: PS_PARTKEY]] having [null]
                                                         INNER JOIN (join-predicate [35: PS_SUPPKEY = 40: S_SUPPKEY] post-join-predicate [null])
                                                             SCAN (columns[34: PS_PARTKEY, 35: PS_SUPPKEY, 37: PS_SUPPLYCOST] predicate[null])

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q15.sql
@@ -168,6 +168,7 @@ OutPut Exchange Id: 15
 
 14:AGGREGATE (merge finalize)
 |  aggregate: max[([47: max, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  having: 47: max IS NOT NULL
 |  cardinality: 1
 |  column statistics:
 |  * max-->[810.9, 120725.0156485172, 0.0, 8.0, 1.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q2.sql
@@ -274,6 +274,7 @@ OutPut Exchange Id: 31
 25:AGGREGATE (update finalize)
 |  aggregate: min[([37: PS_SUPPLYCOST, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  group by: [34: PS_PARTKEY, INT, false]
+|  having: 57: min IS NOT NULL
 |  cardinality: 16000000
 |  column statistics:
 |  * PS_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 1.6E7] ESTIMATE


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

like SQL:
```
select * 
from t0 left outer join t1 on t0.v3 = t1.v6
                   inner  join t2 on t1.v5 = t2.v8
```

it's equals as
```
select * 
from t0 inner join t1 on t0.v3 = t1.v6
             inner join t2 on t1.v5 = t2.v8
```

because t2 inner join t1 will required t1.v5 is not null, like to
```
select * 
from (
    select * 
    from t0 left outer join t1 on t0.v3 = t1.v6
    where t1.v5 is not null) inner join t2 on t1.v5 = t2.v8
```