### PR TITLE
[BugFix] Fix the check the state of opening sink

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -55,6 +55,12 @@ Status OlapTableSinkOperator::set_cancelled(RuntimeState* state) {
 }
 
 Status OlapTableSinkOperator::set_finishing(RuntimeState* state) {
+    if (!_is_open_done) {
+        // we will be here since _sink->is_open_done() return true
+        RETURN_IF_ERROR(_sink->open_wait());
+        _is_open_done = true;
+    }
+
     _is_finished = true;
 
     return _sink->try_close(state);

--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -56,7 +56,7 @@ Status OlapTableSinkOperator::set_cancelled(RuntimeState* state) {
 
 Status OlapTableSinkOperator::set_finishing(RuntimeState* state) {
     if (!_is_open_done) {
-        // we will be here since _sink->is_open_done() return true
+        // _is_open_done indicates the reponse of open() is returned or not
         RETURN_IF_ERROR(_sink->open_wait());
         _is_open_done = true;
     }
@@ -78,7 +78,7 @@ bool OlapTableSinkOperator::need_input() const {
 
 Status OlapTableSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     if (!_is_open_done) {
-        // we will be here since _sink->is_open_done() return true
+        // _is_open_done indicates the reponse of open() is returned or not
         RETURN_IF_ERROR(_sink->open_wait());
         _is_open_done = true;
     }


### PR DESCRIPTION
To improve the performance, the sink will call try_open() in prepare() of OlapTableSinkOperator.
And then call open_wait() in the push_chunk() to wait for the sink opened.
If the chunk is empty, the pull_chunk() has been not called.
So we should call open_wait() in set_finishing() to wait for the sink opened.
Otherwise, the close() and open() will be overlapped and cause an error.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
