### PR TITLE
[Enhancement] Slide window support removable cumulative algo

### DIFF
--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ios>
 #include <memory>
 
 #include "column/chunk.h"
@@ -43,30 +44,24 @@ Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
         if (window.__isset.window_start) {
             TAnalyticWindowBoundary b = window.window_start;
             if (b.__isset.rows_offset_value) {
-                _rows_start_offset = b.rows_offset_value;
-                if (b.type == TAnalyticWindowBoundaryType::PRECEDING) {
-                    _rows_start_offset *= -1;
-                }
+                DCHECK_EQ(b.type, TAnalyticWindowBoundaryType::PRECEDING);
+                _preceding = b.rows_offset_value;
             } else {
                 DCHECK_EQ(b.type, TAnalyticWindowBoundaryType::CURRENT_ROW);
-                _rows_start_offset = 0;
+                _preceding = 0;
             }
         }
 
         if (window.__isset.window_end) {
             TAnalyticWindowBoundary b = window.window_end;
             if (b.__isset.rows_offset_value) {
-                _rows_end_offset = b.rows_offset_value;
-                if (b.type == TAnalyticWindowBoundaryType::PRECEDING) {
-                    _rows_end_offset *= -1;
-                }
+                DCHECK_EQ(b.type, TAnalyticWindowBoundaryType::FOLLOWING);
+                _following = b.rows_offset_value;
             } else {
                 DCHECK_EQ(b.type, TAnalyticWindowBoundaryType::CURRENT_ROW);
-                _rows_end_offset = 0;
+                _following = 0;
             }
         }
-
-        _is_range_with_start = window.__isset.window_start;
     }
 }
 
@@ -120,8 +115,13 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
             if (!state->enable_pipeline_engine()) {
                 return Status::NotSupported("The NTILE window function is only supported by the pipeline engine.");
             }
-
             _need_partition_materializing = true;
+        }
+
+        if (fn.name.function_name == "sum" || fn.name.function_name == "avg" || fn.name.function_name == "count") {
+            if (state->enable_pipeline_engine()) {
+                _support_cumulative_algo = true;
+            }
         }
 
         bool is_input_nullable = false;
@@ -359,10 +359,10 @@ void Analytor::offer_chunk_to_buffer(const vectorized::ChunkPtr& chunk) {
 }
 
 FrameRange Analytor::get_sliding_frame_range() {
-    if (_is_range_with_start) {
-        return {_current_row_position + _rows_start_offset, _current_row_position + _rows_end_offset + 1};
+    if (_preceding >= 0) {
+        return {_current_row_position - _preceding, _current_row_position + _following + 1};
     } else {
-        return {_partition_start, _current_row_position + _rows_end_offset + 1};
+        return {_partition_start, _current_row_position + _following + 1};
     }
 }
 
@@ -670,6 +670,18 @@ void Analytor::remove_unused_buffer_values(RuntimeState* state) {
     DCHECK_GE(_current_row_position, 0);
 }
 
+std::string Analytor::debug_string() const {
+    std::stringstream ss;
+    ss << std::boolalpha;
+
+    ss << "current_row_position=" << _current_row_position << ", partition=(" << _partition_start << ", "
+       << _partition_end << ", " << _found_partition_end.second << "/" << _found_partition_end.first
+       << "), peer_group=(" << _peer_group_start << ", " << _peer_group_end << ")"
+       << ", frame=(" << _preceding << ", " << _following << ")";
+
+    return ss.str();
+}
+
 void Analytor::_update_window_batch_lead_lag(int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                              int64_t frame_end) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
@@ -691,6 +703,17 @@ void Analytor::_update_window_batch_normal(int64_t peer_group_start, int64_t pee
         _agg_functions[i]->update_batch_single_state(
                 _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], &agg_column,
                 peer_group_start, peer_group_end, frame_start, frame_end);
+    }
+}
+
+void Analytor::update_window_batch_removable_cumulatively() {
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        const vectorized::Column* agg_column = _agg_intput_columns[i][0].get();
+        _agg_functions[i]->update_state_removable_cumulatively(
+                _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], &agg_column,
+                _current_row_position, _partition_start, _partition_end,
+                _preceding >= 0 ? _preceding : (_current_row_position - _partition_start),
+                _following >= 0 ? _following : (_partition_end - 1 - _current_row_position));
     }
 }
 

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -220,13 +220,14 @@ private:
     SegmentStatistics _peer_group_statistics;
     std::queue<int64_t> _candidate_peer_group_ends;
 
-    // -1 means unbounded preceding
-    // 0 means current row
-    int64_t _preceding = -1;
+    // Offset from the current row for ROWS windows with start or end bounds specified
+    // with offsets. Is positive if the offset is FOLLOWING, negative if PRECEDING, and 0
+    // if type is CURRENT ROW or UNBOUNDED PRECEDING/FOLLOWING.
+    int64_t _rows_start_offset = 0;
+    int64_t _rows_end_offset = 0;
 
-    // -1 means unbounded following
-    // 0 means current row
-    int64_t _following = -1;
+    bool _is_unbounded_preceding = false;
+    bool _is_unbounded_following = false;
 
     // The offset of the n-th window function in a row of window functions.
     std::vector<size_t> _agg_states_offsets;

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -128,6 +128,7 @@ public:
     Status add_chunk(const vectorized::ChunkPtr& chunk);
 
     void update_window_batch(int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start, int64_t frame_end);
+    void update_window_batch_removable_cumulatively();
     void reset_window_state();
     void get_window_function_result(size_t frame_start, size_t frame_end);
 
@@ -144,6 +145,10 @@ public:
     void remove_unused_buffer_values(RuntimeState* state);
 
     bool need_partition_materializing() const { return _need_partition_materializing; }
+
+    bool support_cumulative_algo() const { return _support_cumulative_algo; }
+
+    std::string debug_string() const;
 
 #ifdef NDEBUG
     static constexpr int32_t BUFFER_CHUNK_NUMBER = 1000;
@@ -179,7 +184,6 @@ private:
     int64_t _num_rows_returned = 0;
     int64_t _limit; // -1: no limit
     bool _has_lead_lag_function = false;
-    bool _is_range_with_start = false;
 
     vectorized::Columns _result_window_columns;
     std::vector<vectorized::ChunkPtr> _input_chunks;
@@ -216,11 +220,13 @@ private:
     SegmentStatistics _peer_group_statistics;
     std::queue<int64_t> _candidate_peer_group_ends;
 
-    // Offset from the current row for ROWS windows with start or end bounds specified
-    // with offsets. Is positive if the offset is FOLLOWING, negative if PRECEDING, and 0
-    // if type is CURRENT ROW or UNBOUNDED PRECEDING/FOLLOWING.
-    int64_t _rows_start_offset = 0;
-    int64_t _rows_end_offset = 0;
+    // -1 means unbounded preceding
+    // 0 means current row
+    int64_t _preceding = -1;
+
+    // -1 means unbounded following
+    // 0 means current row
+    int64_t _following = -1;
 
     // The offset of the n-th window function in a row of window functions.
     std::vector<size_t> _agg_states_offsets;
@@ -251,6 +257,8 @@ private:
     // Some window functions, eg. NTILE, need the boundary of partition to calculate its value.
     // For these functions, we must wait util the partition finished.
     bool _need_partition_materializing = false;
+
+    bool _support_cumulative_algo = false;
 
 private:
     void _append_column(size_t chunk_size, vectorized::Column* dst_column, vectorized::ColumnPtr& src_column);

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -111,6 +111,17 @@ public:
     virtual void update_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state, int64_t peer_group_start,
                                           int64_t peer_group_end) const {}
 
+    // For window functions with slide frame
+    // For example, given a slide frame, i.e. "sum() over (m preceding and n following)",
+    // if we had already evaluated the state of (i-1)-th frame, then we can get the i-th frame through reusing
+    // the sum of (i-1)-th frame, i.e. "sum(i) = sum(i-1) - v[i-1-m] +  v[i+n]"
+    // Ignore subtraction if preceding is negative
+    // Ignore addition if following is negative
+    virtual void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state,
+                                                     const Column** columns, int64_t current_row_position,
+                                                     int64_t partition_start, int64_t partition_end, int64_t preceding,
+                                                     int64_t following) const {}
+
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"
     // and do a single call to "merge_batch" for devirtualization and inlining.

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -114,13 +114,14 @@ public:
     // For window functions with slide frame
     // For example, given a slide frame, i.e. "sum() over (m preceding and n following)",
     // if we had already evaluated the state of (i-1)-th frame, then we can get the i-th frame through reusing
-    // the sum of (i-1)-th frame, i.e. "sum(i) = sum(i-1) - v[i-1-m] +  v[i+n]"
-    // Ignore subtraction if preceding is negative
-    // Ignore addition if following is negative
+    // the sum of (i-1)-th frame, i.e. "sum(i) = sum(i-1) - v[i-1+rows_start_offset] +  v[i+rows_end_offset]"
+    // Ignore subtraction if ignore_subtraction is true
+    // Ignore addition if ignore_addition is true
     virtual void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state,
                                                      const Column** columns, int64_t current_row_position,
-                                                     int64_t partition_start, int64_t partition_end, int64_t preceding,
-                                                     int64_t following) const {}
+                                                     int64_t partition_start, int64_t partition_end,
+                                                     int64_t rows_start_offset, int64_t rows_end_offset,
+                                                     bool ignore_subtraction, bool ignore_addition) const {}
 
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -222,5 +222,7 @@ class AggregateFunctionBatchHelper : public AggregateFunctionStateHelper<State> 
 
 using AggregateFunctionPtr = std::shared_ptr<AggregateFunction>;
 
+struct AggregateFunctionEmptyState {};
+
 } // namespace vectorized
 } // namespace starrocks

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -70,8 +70,9 @@ AggregateFunctionPtr AggregateFactory::MakeIntersectCountAggregateFunction() {
     return std::make_shared<IntersectCountAggregateFunction<PT>>();
 }
 
+template <bool IsWindowFunc>
 AggregateFunctionPtr AggregateFactory::MakeCountAggregateFunction() {
-    return std::make_shared<CountAggregateFunction>();
+    return std::make_shared<CountAggregateFunction<IsWindowFunc>>();
 }
 
 template <PrimitiveType PT>
@@ -94,8 +95,9 @@ AggregateFunctionPtr AggregateFactory::MakeGroupConcatAggregateFunction() {
     return std::make_shared<GroupConcatAggregateFunction<PT>>();
 }
 
+template <bool IsWindowFunc>
 AggregateFunctionPtr AggregateFactory::MakeCountNullableAggregateFunction() {
-    return std::make_shared<CountNullableAggregateFunction>();
+    return std::make_shared<CountNullableAggregateFunction<IsWindowFunc>>();
 }
 
 template <PrimitiveType PT>
@@ -114,15 +116,16 @@ AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
             AnyValueAggregateFunction<PT, AnyValueAggregateData<PT>, AnyValueElement<PT, AnyValueAggregateData<PT>>>>();
 }
 
-template <typename NestedState, bool IgnoreNull>
+template <typename NestedState, bool IsWindowFunc, bool IgnoreNull>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(AggregateFunctionPtr nested_function) {
-    using AggregateDataType = NullableAggregateFunctionState<NestedState>;
-    return std::make_shared<NullableAggregateFunctionUnary<AggregateDataType, IgnoreNull>>(nested_function);
+    using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
+    return std::make_shared<NullableAggregateFunctionUnary<AggregateDataType, IsWindowFunc, IgnoreNull>>(
+            nested_function);
 }
 
 template <typename NestedState>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function) {
-    using AggregateDataType = NullableAggregateFunctionState<NestedState>;
+    using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
     return std::make_shared<NullableAggregateFunctionVariadic<AggregateDataType>>(nested_function);
 }
 
@@ -241,13 +244,17 @@ AggregateFunctionPtr AggregateFactory::MakeHistogramAggregationFunction() {
 // ----------------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------
 
-typedef std::tuple<std::string, int, int, bool> Quadruple;
+// 1. name
+// 2. arg primitive type
+// 3. return primitive type
+// 4. is_window_function
+// 5. is_nullable
+typedef std::tuple<std::string, int, int, bool, bool> AggregateFuncKey;
 
 struct AggregateFuncMapHash {
-    size_t operator()(const Quadruple& quadruple) const {
+    size_t operator()(const AggregateFuncKey& key) const {
         std::hash<std::string> hasher;
-        return hasher(std::get<0>(quadruple)) ^ std::get<1>(quadruple) ^ std::get<2>(quadruple) ^
-               std::get<3>(quadruple);
+        return hasher(std::get<0>(key)) ^ std::get<1>(key) ^ std::get<2>(key) ^ std::get<3>(key) ^ std::get<4>(key);
     }
 };
 
@@ -256,44 +263,57 @@ class AggregateFuncResolver {
 
 public:
     const AggregateFunction* get_aggregate_info(const std::string& name, const PrimitiveType arg_type,
-                                                const PrimitiveType return_type, const bool is_null) const {
-        auto pair = _infos_mapping.find(std::make_tuple(name, arg_type, return_type, is_null));
+                                                const PrimitiveType return_type, const bool is_window_function,
+                                                const bool is_null) const {
+        auto pair = _infos_mapping.find(std::make_tuple(name, arg_type, return_type, is_window_function, is_null));
         if (pair == _infos_mapping.end()) {
             return nullptr;
         }
         return pair->second.get();
     }
 
-    template <PrimitiveType arg_type, PrimitiveType return_type>
+    template <PrimitiveType arg_type, PrimitiveType return_type, bool AddWindowVersion = false>
     void add_aggregate_mapping(std::string&& name) {
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
-                               create_function<arg_type, return_type, false>(name));
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
-                               create_function<arg_type, return_type, true>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, false),
+                               create_function<arg_type, return_type, false, false>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, true),
+                               create_function<arg_type, return_type, false, true>(name));
+        if constexpr (AddWindowVersion) {
+            _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true, false),
+                                   create_function<arg_type, return_type, true, false>(name));
+            _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true, true),
+                                   create_function<arg_type, return_type, true, true>(name));
+        }
     }
 
     template <PrimitiveType arg_type, PrimitiveType return_type>
     void add_object_mapping(std::string&& name) {
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, false),
                                create_object_function<arg_type, return_type, false>(name));
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, true),
                                create_object_function<arg_type, return_type, true>(name));
     }
 
     template <PrimitiveType arg_type, PrimitiveType return_type>
     void add_array_mapping(std::string&& name) {
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, false),
                                create_array_function<arg_type, return_type, false>(name));
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, true),
                                create_array_function<arg_type, return_type, true>(name));
     }
 
-    template <PrimitiveType arg_type, PrimitiveType return_type>
+    template <PrimitiveType arg_type, PrimitiveType return_type, bool AddWindowVersion = false>
     void add_decimal_mapping(std::string&& name) {
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
-                               create_decimal_function<arg_type, return_type, false>(name));
-        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
-                               create_decimal_function<arg_type, return_type, true>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, false),
+                               create_decimal_function<arg_type, return_type, false, false>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false, true),
+                               create_decimal_function<arg_type, return_type, false, true>(name));
+        if constexpr (AddWindowVersion) {
+            _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true, false),
+                                   create_decimal_function<arg_type, return_type, true, false>(name));
+            _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true, true),
+                                   create_decimal_function<arg_type, return_type, true, true>(name));
+        }
     }
 
     template <PrimitiveType arg_type, PrimitiveType return_type, bool is_null>
@@ -354,9 +374,9 @@ public:
         return nullptr;
     }
 
-    template <PrimitiveType arg_type, PrimitiveType return_type, bool is_null>
+    template <PrimitiveType ArgPT, PrimitiveType ResultPT, bool IsNull>
     AggregateFunctionPtr create_array_function(std::string& name) {
-        if constexpr (is_null) {
+        if constexpr (IsNull) {
             if (name == "dict_merge") {
                 auto dict_merge = AggregateFactory::MakeDictMergeAggregateFunction();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<DictMergeState>(dict_merge);
@@ -364,9 +384,9 @@ public:
                 auto retentoin = AggregateFactory::MakeRetentionAggregateFunction();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState>(retentoin);
             } else if (name == "window_funnel") {
-                if constexpr (arg_type == TYPE_DATETIME || arg_type == TYPE_DATE) {
-                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
-                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<arg_type>>(
+                if constexpr (ArgPT == TYPE_DATETIME || ArgPT == TYPE_DATE) {
+                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
+                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<ArgPT>>(
                             windowfunnel);
                 }
             }
@@ -376,8 +396,8 @@ public:
             } else if (name == "retention") {
                 return AggregateFactory::MakeRetentionAggregateFunction();
             } else if (name == "window_funnel") {
-                if constexpr (arg_type == TYPE_DATETIME || arg_type == TYPE_DATE) {
-                    return AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
+                if constexpr (ArgPT == TYPE_DATETIME || ArgPT == TYPE_DATE) {
+                    return AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
                 }
             }
         }
@@ -385,17 +405,19 @@ public:
         return nullptr;
     }
 
-    template <PrimitiveType ArgPT, PrimitiveType ResultPT, bool is_null>
+    template <PrimitiveType ArgPT, PrimitiveType ResultPT, bool IsWindowFunc, bool IsNull>
     std::enable_if_t<isArithmeticPT<ArgPT>, AggregateFunctionPtr> create_decimal_function(std::string& name) {
         static_assert(pt_is_decimal128<ResultPT>);
-        if constexpr (is_null) {
+        if constexpr (IsNull) {
             using ResultType = RunTimeCppType<ResultPT>;
             if (name == "decimal_avg") {
                 auto avg = AggregateFactory::MakeDecimalAvgAggregateFunction<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(avg);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
+                                                                            IsWindowFunc>(avg);
             } else if (name == "decimal_sum") {
                 auto sum = AggregateFactory::MakeDecimalSumAggregateFunction<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(sum);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
+                                                                            IsWindowFunc>(sum);
             } else if (name == "decimal_multi_distinct_sum") {
                 auto distinct_sum = AggregateFactory::MakeDecimalSumDistinctAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgPT, ResultPT>>(
@@ -414,16 +436,17 @@ public:
     }
 
     // TODO(kks): simplify create_function method
-    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool is_null>
+    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool IsWindowFunc, bool IsNull>
     std::enable_if_t<isArithmeticPT<ArgPT>, AggregateFunctionPtr> create_function(std::string& name) {
         using ArgType = RunTimeCppType<ArgPT>;
-        if constexpr (is_null) {
+        if constexpr (IsNull) {
             if (name == "count") {
-                return AggregateFactory::MakeCountNullableAggregateFunction();
+                return AggregateFactory::MakeCountNullableAggregateFunction<IsWindowFunc>();
             } else if (name == "sum") {
                 AggregateFunctionPtr sum = AggregateFactory::MakeSumAggregateFunction<ArgPT>();
                 using ResultType = RunTimeCppType<SumResultPT<ArgPT>>;
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<SumAggregateState<ResultType>>(sum);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<SumAggregateState<ResultType>,
+                                                                            IsWindowFunc>(sum);
             } else if (name == "variance" || name == "variance_pop" || name == "var_pop") {
                 auto variance = AggregateFactory::MakeVarianceAggregateFunction<ArgPT, false>();
                 using ResultType = RunTimeCppType<DevFromAveResultPT<ArgPT>>;
@@ -456,7 +479,8 @@ public:
             } else if (name == "avg") {
                 auto avg = AggregateFactory::MakeAvgAggregateFunction<ArgPT>();
                 using ResultType = RunTimeCppType<ImmediateAvgResultPT<ArgPT>>;
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(avg);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
+                                                                            IsWindowFunc>(avg);
             } else if (name == "multi_distinct_count") {
                 auto distinct = AggregateFactory::MakeCountDistinctAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<
@@ -490,7 +514,7 @@ public:
             }
         } else {
             if (name == "count") {
-                return AggregateFactory::MakeCountAggregateFunction();
+                return AggregateFactory::MakeCountAggregateFunction<IsWindowFunc>();
             } else if (name == "sum") {
                 return AggregateFactory::MakeSumAggregateFunction<ArgPT>();
             } else if (name == "variance" || name == "variance_pop" || name == "var_pop") {
@@ -548,10 +572,10 @@ public:
         return nullptr;
     }
 
-    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool is_null>
+    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool IsWindowFunc, bool IsNull>
     std::enable_if_t<pt_is_json<ArgPT>, AggregateFunctionPtr> create_function(std::string& name) {
         // TODO: support more functions for JSON type
-        if constexpr (is_null) {
+        if constexpr (IsNull) {
             if (name == "any_value") {
                 auto any_value = AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<AnyValueAggregateData<ArgPT>>(any_value);
@@ -565,15 +589,16 @@ public:
         return nullptr;
     }
 
-    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool is_null>
+    template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool IsWindowFunc, bool IsNull>
     std::enable_if_t<!isArithmeticPT<ArgPT> && !pt_is_json<ArgPT>, AggregateFunctionPtr> create_function(
             std::string& name) {
         using ArgType = RunTimeCppType<ArgPT>;
-        if constexpr (is_null) {
+        if constexpr (IsNull) {
             if (name == "avg") {
                 auto avg = AggregateFactory::MakeAvgAggregateFunction<ArgPT>();
                 using ResultType = RunTimeCppType<ImmediateAvgResultPT<ArgPT>>;
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(avg);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
+                                                                            IsWindowFunc>(avg);
             } else if (name == "max") {
                 auto max = AggregateFactory::MakeMaxAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<MaxAggregateData<ArgPT>>(max);
@@ -638,46 +663,46 @@ public:
     }
 
 private:
-    std::unordered_map<Quadruple, AggregateFunctionPtr, AggregateFuncMapHash> _infos_mapping;
+    std::unordered_map<AggregateFuncKey, AggregateFunctionPtr, AggregateFuncMapHash> _infos_mapping;
     AggregateFuncResolver(const AggregateFuncResolver&) = delete;
     const AggregateFuncResolver& operator=(const AggregateFuncResolver&) = delete;
 };
 
-#define ADD_ALL_TYPE(FUNCTIONNAME)                                       \
-    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BOOLEAN>(FUNCTIONNAME);     \
-    add_aggregate_mapping<TYPE_TINYINT, TYPE_TINYINT>(FUNCTIONNAME);     \
-    add_aggregate_mapping<TYPE_SMALLINT, TYPE_SMALLINT>(FUNCTIONNAME);   \
-    add_aggregate_mapping<TYPE_INT, TYPE_INT>(FUNCTIONNAME);             \
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>(FUNCTIONNAME);       \
-    add_aggregate_mapping<TYPE_LARGEINT, TYPE_LARGEINT>(FUNCTIONNAME);   \
-    add_aggregate_mapping<TYPE_FLOAT, TYPE_FLOAT>(FUNCTIONNAME);         \
-    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE>(FUNCTIONNAME);       \
-    add_aggregate_mapping<TYPE_VARCHAR, TYPE_VARCHAR>(FUNCTIONNAME);     \
-    add_aggregate_mapping<TYPE_CHAR, TYPE_CHAR>(FUNCTIONNAME);           \
-    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2>(FUNCTIONNAME); \
-    add_aggregate_mapping<TYPE_DATETIME, TYPE_DATETIME>(FUNCTIONNAME);   \
-    add_aggregate_mapping<TYPE_DATE, TYPE_DATE>(FUNCTIONNAME);           \
-    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL32>(FUNCTIONNAME); \
-    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL64>(FUNCTIONNAME); \
-    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>(FUNCTIONNAME);
+#define ADD_ALL_TYPE(FUNCTIONNAME, ADD_WINDOW_VERSION)                                       \
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BOOLEAN, ADD_WINDOW_VERSION>(FUNCTIONNAME);     \
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_TINYINT, ADD_WINDOW_VERSION>(FUNCTIONNAME);     \
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_SMALLINT, ADD_WINDOW_VERSION>(FUNCTIONNAME);   \
+    add_aggregate_mapping<TYPE_INT, TYPE_INT, ADD_WINDOW_VERSION>(FUNCTIONNAME);             \
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, ADD_WINDOW_VERSION>(FUNCTIONNAME);       \
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_LARGEINT, ADD_WINDOW_VERSION>(FUNCTIONNAME);   \
+    add_aggregate_mapping<TYPE_FLOAT, TYPE_FLOAT, ADD_WINDOW_VERSION>(FUNCTIONNAME);         \
+    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE, ADD_WINDOW_VERSION>(FUNCTIONNAME);       \
+    add_aggregate_mapping<TYPE_VARCHAR, TYPE_VARCHAR, ADD_WINDOW_VERSION>(FUNCTIONNAME);     \
+    add_aggregate_mapping<TYPE_CHAR, TYPE_CHAR, ADD_WINDOW_VERSION>(FUNCTIONNAME);           \
+    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2, ADD_WINDOW_VERSION>(FUNCTIONNAME); \
+    add_aggregate_mapping<TYPE_DATETIME, TYPE_DATETIME, ADD_WINDOW_VERSION>(FUNCTIONNAME);   \
+    add_aggregate_mapping<TYPE_DATE, TYPE_DATE, ADD_WINDOW_VERSION>(FUNCTIONNAME);           \
+    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL32, ADD_WINDOW_VERSION>(FUNCTIONNAME); \
+    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL64, ADD_WINDOW_VERSION>(FUNCTIONNAME); \
+    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, ADD_WINDOW_VERSION>(FUNCTIONNAME);
 
 AggregateFuncResolver::AggregateFuncResolver() {
     // The function should be placed by alphabetical order
 
-    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_TINYINT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_SMALLINT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_INT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_LARGEINT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_FLOAT, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE>("avg");
-    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2>("avg");
-    add_aggregate_mapping<TYPE_DATETIME, TYPE_DATETIME>("avg");
-    add_aggregate_mapping<TYPE_DATE, TYPE_DATE>("avg");
-    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("avg");
-    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("avg");
-    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("avg");
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_INT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_FLOAT, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE, true>("avg");
+    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2, true>("avg");
+    add_aggregate_mapping<TYPE_DATETIME, TYPE_DATETIME, true>("avg");
+    add_aggregate_mapping<TYPE_DATE, TYPE_DATE, true>("avg");
+    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128, true>("avg");
+    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128, true>("avg");
+    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, true>("avg");
 
     add_aggregate_mapping<TYPE_BOOLEAN, TYPE_ARRAY>("array_agg");
     add_aggregate_mapping<TYPE_TINYINT, TYPE_ARRAY>("array_agg");
@@ -699,11 +724,11 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_aggregate_mapping<TYPE_INT, TYPE_BIGINT>("bitmap_union_int");
     add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("bitmap_union_int");
 
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("count");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("count");
 
-    ADD_ALL_TYPE("max");
-    ADD_ALL_TYPE("min");
-    ADD_ALL_TYPE("any_value");
+    ADD_ALL_TYPE("max", true);
+    ADD_ALL_TYPE("min", true);
+    ADD_ALL_TYPE("any_value", true);
     add_aggregate_mapping<TYPE_JSON, TYPE_JSON>("any_value");
 
     add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BIGINT>("multi_distinct_count");
@@ -766,18 +791,18 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL64>("multi_distinct_sum2");
     add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("multi_distinct_sum2");
 
-    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BIGINT>("sum");
-    add_aggregate_mapping<TYPE_TINYINT, TYPE_BIGINT>("sum");
-    add_aggregate_mapping<TYPE_SMALLINT, TYPE_BIGINT>("sum");
-    add_aggregate_mapping<TYPE_INT, TYPE_BIGINT>("sum");
-    add_aggregate_mapping<TYPE_LARGEINT, TYPE_LARGEINT>("sum");
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("sum");
-    add_aggregate_mapping<TYPE_FLOAT, TYPE_DOUBLE>("sum");
-    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE>("sum");
-    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2>("sum");
-    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL64>("sum");
-    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL64>("sum");
-    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("sum");
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BIGINT, true>("sum");
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_BIGINT, true>("sum");
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_BIGINT, true>("sum");
+    add_aggregate_mapping<TYPE_INT, TYPE_BIGINT, true>("sum");
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_LARGEINT, true>("sum");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("sum");
+    add_aggregate_mapping<TYPE_FLOAT, TYPE_DOUBLE, true>("sum");
+    add_aggregate_mapping<TYPE_DOUBLE, TYPE_DOUBLE, true>("sum");
+    add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2, true>("sum");
+    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL64, true>("sum");
+    add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL64, true>("sum");
+    add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, true>("sum");
 
     add_aggregate_mapping<TYPE_BOOLEAN, TYPE_DOUBLE>("variance");
     add_aggregate_mapping<TYPE_TINYINT, TYPE_DOUBLE>("variance");
@@ -878,10 +903,10 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_aggregate_mapping<TYPE_DECIMALV2, TYPE_DECIMALV2>("stddev_samp");
     add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("stddev_samp");
 
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("dense_rank");
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("rank");
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("row_number");
-    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT>("ntile");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("dense_rank");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("rank");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("row_number");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, true>("ntile");
 
     add_aggregate_mapping<TYPE_CHAR, TYPE_VARCHAR>("group_concat");
     add_aggregate_mapping<TYPE_VARCHAR, TYPE_VARCHAR>("group_concat");
@@ -900,10 +925,10 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_aggregate_mapping<TYPE_DECIMAL64, TYPE_VARCHAR>("histogram");
     add_aggregate_mapping<TYPE_DECIMAL128, TYPE_VARCHAR>("histogram");
 
-    ADD_ALL_TYPE("first_value");
-    ADD_ALL_TYPE("last_value");
-    ADD_ALL_TYPE("lead");
-    ADD_ALL_TYPE("lag");
+    ADD_ALL_TYPE("first_value", true);
+    ADD_ALL_TYPE("last_value", true);
+    ADD_ALL_TYPE("lead", true);
+    ADD_ALL_TYPE("lag", true);
 
     add_object_mapping<TYPE_HLL, TYPE_HLL>("hll_union");
     add_object_mapping<TYPE_HLL, TYPE_HLL>("hll_raw_agg");
@@ -976,12 +1001,12 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_array_mapping<TYPE_ARRAY, TYPE_ARRAY>("retention");
 
     // sum, avg, distinct_sum use decimal128 as intermediate or result type to avoid overflow
-    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_avg");
-    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_avg");
-    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_avg");
-    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_sum");
-    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_sum");
-    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128, true>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128, true>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, true>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128, true>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128, true>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, true>("decimal_sum");
     add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
     add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
     add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
@@ -995,9 +1020,9 @@ AggregateFuncResolver::AggregateFuncResolver() {
 
 AggregateFuncResolver::~AggregateFuncResolver() = default;
 
-const AggregateFunction* get_aggregate_function(const std::string& name, PrimitiveType arg_type,
-                                                PrimitiveType return_type, bool is_null,
-                                                TFunctionBinaryType::type binary_type, int func_version) {
+static const AggregateFunction* get_function(const std::string& name, PrimitiveType arg_type, PrimitiveType return_type,
+                                             bool is_window_function, bool is_null,
+                                             TFunctionBinaryType::type binary_type, int func_version) {
     std::string func_name = name;
     if (func_version > 1) {
         if (name == "multi_distinct_sum") {
@@ -1021,17 +1046,24 @@ const AggregateFunction* get_aggregate_function(const std::string& name, Primiti
     }
 
     if (binary_type == TFunctionBinaryType::BUILTIN) {
-        return AggregateFuncResolver::instance()->get_aggregate_info(func_name, arg_type, return_type, is_null);
+        return AggregateFuncResolver::instance()->get_aggregate_info(func_name, arg_type, return_type,
+                                                                     is_window_function, is_null);
     } else if (binary_type == TFunctionBinaryType::SRJAR) {
         return getJavaUDAFFunction(is_null);
     }
     return nullptr;
 }
 
+const AggregateFunction* get_aggregate_function(const std::string& name, PrimitiveType arg_type,
+                                                PrimitiveType return_type, bool is_null,
+                                                TFunctionBinaryType::type binary_type, int func_version) {
+    return get_function(name, arg_type, return_type, false, is_null, binary_type, func_version);
+}
+
 const AggregateFunction* get_window_function(const std::string& name, PrimitiveType arg_type, PrimitiveType return_type,
                                              bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
     if (binary_type == TFunctionBinaryType::BUILTIN) {
-        return get_aggregate_function(name, arg_type, return_type, is_null, binary_type, func_version);
+        return get_function(name, arg_type, return_type, true, is_null, binary_type, func_version);
     } else if (binary_type == TFunctionBinaryType::SRJAR) {
         return getJavaWindowFunction();
     }

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -32,6 +32,7 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeIntersectCountAggregateFunction();
 
+    template <bool IsWindowFunc>
     static AggregateFunctionPtr MakeCountAggregateFunction();
 
     template <PrimitiveType PT>
@@ -42,6 +43,7 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeGroupConcatAggregateFunction();
 
+    template <bool IsWindowFunc>
     static AggregateFunctionPtr MakeCountNullableAggregateFunction();
 
     template <PrimitiveType PT>
@@ -53,7 +55,7 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
-    template <typename NestedState, bool IgnoreNull = true>
+    template <typename NestedState, bool IsWindowFunc = false, bool IgnoreNull = true>
     static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(AggregateFunctionPtr nested_function);
 
     template <typename NestedState>

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -170,6 +170,8 @@ public:
                 result = src_column->get_data()[i];
             } else if constexpr (pt_is_decimal<PT>) {
                 result = src_column->get_data()[i];
+            } else {
+                DCHECK(false) << "Invalid PrimitiveTypes for avg function";
             }
             memcpy(bytes.data() + old_size, &result, sizeof(ImmediateType));
             memcpy(bytes.data() + old_size + sizeof(ImmediateType), &count, sizeof(int64_t));
@@ -201,6 +203,8 @@ public:
             ResultType sum = ResultType(this->data(state).sum);
             ResultType count = ResultType(this->data(state).count);
             result = decimal_div_integer<ResultType>(sum, count, ctx->get_arg_type(0)->scale);
+        } else {
+            DCHECK(false) << "Invalid PrimitiveTypes for avg function";
         }
         column->append(result);
     }
@@ -225,6 +229,8 @@ public:
             ResultType sum = ResultType(this->data(state).sum);
             ResultType count = ResultType(this->data(state).count);
             result = decimal_div_integer<ResultType>(sum, count, ctx->get_arg_type(0)->scale);
+        } else {
+            DCHECK(false) << "Invalid PrimitiveTypes for avg function";
         }
         for (size_t i = start; i < end; ++i) {
             column->get_data()[i] = result;

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -72,6 +72,8 @@ public:
                 this->data(state).sum += column->get_data()[row_num];
             } else if constexpr (pt_is_decimal<PT>) {
                 this->data(state).sum += column->get_data()[row_num];
+            } else {
+                DCHECK(false) << "Invalid PrimitiveTypes for avg function";
             }
             this->data(state).count++;
         } else {
@@ -85,6 +87,8 @@ public:
                 this->data(state).sum -= column->get_data()[row_num];
             } else if constexpr (pt_is_decimal<PT>) {
                 this->data(state).sum -= column->get_data()[row_num];
+            } else {
+                DCHECK(false) << "Invalid PrimitiveTypes for avg function";
             }
             this->data(state).count--;
         }

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -57,24 +57,42 @@ public:
     using ResultType = RunTimeCppType<ResultPT>;
     using ResultColumnType = RunTimeColumnType<ResultPT>;
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
-                size_t row_num) const override {
+    template <bool is_inc>
+    void do_update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state, size_t row_num) const {
         DCHECK(!columns[0]->is_nullable());
         [[maybe_unused]] const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);
-        if constexpr (pt_is_datetime<PT>) {
-            this->data(state).sum += column->get_data()[row_num].to_unix_second();
-        } else if constexpr (pt_is_date<PT>) {
-            this->data(state).sum += column->get_data()[row_num].julian();
-        } else if constexpr (pt_is_decimalv2<PT>) {
-            this->data(state).sum += column->get_data()[row_num];
-        } else if constexpr (pt_is_arithmetic<PT>) {
-            this->data(state).sum += column->get_data()[row_num];
-        } else if constexpr (pt_is_decimal<PT>) {
-            this->data(state).sum += column->get_data()[row_num];
+        if constexpr (is_inc) {
+            if constexpr (pt_is_datetime<PT>) {
+                this->data(state).sum += column->get_data()[row_num].to_unix_second();
+            } else if constexpr (pt_is_date<PT>) {
+                this->data(state).sum += column->get_data()[row_num].julian();
+            } else if constexpr (pt_is_decimalv2<PT>) {
+                this->data(state).sum += column->get_data()[row_num];
+            } else if constexpr (pt_is_arithmetic<PT>) {
+                this->data(state).sum += column->get_data()[row_num];
+            } else if constexpr (pt_is_decimal<PT>) {
+                this->data(state).sum += column->get_data()[row_num];
+            }
+            this->data(state).count++;
         } else {
-            // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
+            if constexpr (pt_is_datetime<PT>) {
+                this->data(state).sum -= column->get_data()[row_num].to_unix_second();
+            } else if constexpr (pt_is_date<PT>) {
+                this->data(state).sum -= column->get_data()[row_num].julian();
+            } else if constexpr (pt_is_decimalv2<PT>) {
+                this->data(state).sum -= column->get_data()[row_num];
+            } else if constexpr (pt_is_arithmetic<PT>) {
+                this->data(state).sum -= column->get_data()[row_num];
+            } else if constexpr (pt_is_decimal<PT>) {
+                this->data(state).sum -= column->get_data()[row_num];
+            }
+            this->data(state).count--;
         }
-        this->data(state).count++;
+    }
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        do_update<true>(ctx, columns, state, row_num);
     }
 
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
@@ -82,6 +100,18 @@ public:
                                    int64_t frame_end) const override {
         for (size_t i = frame_start; i < frame_end; ++i) {
             update(ctx, columns, state, i);
+        }
+    }
+
+    void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                             int64_t current_row_position, int64_t partition_start,
+                                             int64_t partition_end, int64_t preceding,
+                                             int64_t following) const override {
+        if (preceding >= 0 && current_row_position - 1 - preceding >= partition_start) {
+            do_update<false>(ctx, columns, state, current_row_position - 1 - preceding);
+        }
+        if (following >= 0 && current_row_position + following < partition_end) {
+            do_update<true>(ctx, columns, state, current_row_position + following);
         }
     }
 
@@ -132,8 +162,6 @@ public:
                 result = src_column->get_data()[i];
             } else if constexpr (pt_is_decimal<PT>) {
                 result = src_column->get_data()[i];
-            } else {
-                // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
             }
             memcpy(bytes.data() + old_size, &result, sizeof(ImmediateType));
             memcpy(bytes.data() + old_size + sizeof(ImmediateType), &count, sizeof(int64_t));
@@ -165,8 +193,6 @@ public:
             ResultType sum = ResultType(this->data(state).sum);
             ResultType count = ResultType(this->data(state).count);
             result = decimal_div_integer<ResultType>(sum, count, ctx->get_arg_type(0)->scale);
-        } else {
-            // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
         }
         column->append(result);
     }
@@ -191,8 +217,6 @@ public:
             ResultType sum = ResultType(this->data(state).sum);
             ResultType count = ResultType(this->data(state).count);
             result = decimal_div_integer<ResultType>(sum, count, ctx->get_arg_type(0)->scale);
-        } else {
-            // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
         }
         for (size_t i = start; i < end; ++i) {
             column->get_data()[i] = result;

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -8,20 +8,27 @@
 
 namespace starrocks::vectorized {
 
-struct AggregateFunctionCountData {
-    int64_t count = 0;
-
+struct AggregateCountWindowFunctionState {
     // The following field are only used in "update_state_removable_cumulatively"
     bool is_frame_init = false;
 };
 
+template <bool IsWindowFunc>
+struct AggregateCountFunctionState
+        : public std::conditional_t<IsWindowFunc, AggregateCountWindowFunctionState, AggregateFunctionEmptyState> {
+    int64_t count = 0;
+};
+
 // count not null column
-class CountAggregateFunction final
-        : public AggregateFunctionBatchHelper<AggregateFunctionCountData, CountAggregateFunction> {
+template <bool IsWindowFunc>
+class CountAggregateFunction final : public AggregateFunctionBatchHelper<AggregateCountFunctionState<IsWindowFunc>,
+                                                                         CountAggregateFunction<IsWindowFunc>> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
         this->data(state).count = 0;
-        this->data(state).is_frame_init = false;
+        if constexpr (IsWindowFunc) {
+            this->data(state).is_frame_init = false;
+        }
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
@@ -50,20 +57,22 @@ public:
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
                                              bool ignore_subtraction, bool ignore_addition) const override {
-        DCHECK(!ignore_subtraction);
-        DCHECK(!ignore_addition);
-        // We don't actually update in removable cumulative way, since the ordinary way is effecient enough
-        const auto frame_start =
-                std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
-        const auto frame_end =
-                std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
-        this->data(state).count = (frame_end - frame_start);
+        if constexpr (IsWindowFunc) {
+            DCHECK(!ignore_subtraction);
+            DCHECK(!ignore_addition);
+            // We don't actually update in removable cumulative way, since the ordinary way is effecient enough
+            const auto frame_start =
+                    std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
+            const auto frame_end =
+                    std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
+            this->data(state).count = (frame_end - frame_start);
+        }
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_numeric());
         const auto* input_column = down_cast<const Int64Column*>(column);
-        data(state).count += input_column->get_data()[row_num];
+        this->data(state).count += input_column->get_data()[row_num];
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
@@ -85,7 +94,7 @@ public:
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
         for (size_t i = 0; i < chunk_size; i++) {
-            result_data.emplace_back(data(agg_states[i] + state_offset).count);
+            result_data.emplace_back(this->data(agg_states[i] + state_offset).count);
         }
     }
 
@@ -104,12 +113,16 @@ public:
 };
 
 // count null_able column
+template <bool IsWindowFunc>
 class CountNullableAggregateFunction final
-        : public AggregateFunctionBatchHelper<AggregateFunctionCountData, CountNullableAggregateFunction> {
+        : public AggregateFunctionBatchHelper<AggregateCountFunctionState<IsWindowFunc>,
+                                              CountNullableAggregateFunction<IsWindowFunc>> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).count = 0;
-        this->data(state).is_frame_init = false;
+        if constexpr (IsWindowFunc) {
+            this->data(state).is_frame_init = false;
+        }
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
@@ -162,57 +175,60 @@ public:
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
                                              bool ignore_subtraction, bool ignore_addition) const override {
-        DCHECK(!ignore_subtraction);
-        DCHECK(!ignore_addition);
-        const auto frame_start =
-                std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
-        const auto frame_end =
-                std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
-        const auto frame_size = frame_end - frame_start;
-        // For cases like: rows between 2 preceding and 1 preceding
-        // If frame_start ge frame_end, means the frame is empty,
-        // we could directly return.
-        if (frame_size <= 0) {
-            this->data(state).count = 0;
-            return;
-        }
-        if (columns[0]->is_nullable()) {
-            const auto* nullable_column = down_cast<const NullableColumn*>(columns[0]);
-            if (nullable_column->has_null()) {
-                const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
-                if (this->data(state).is_frame_init) {
-                    // Since frame has been evaluated, we only need to update the boundary
-                    const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
-                    const int64_t current_frame_last_position = current_row_position + rows_end_offset;
-                    if (previous_frame_first_position >= partition_start &&
-                        previous_frame_first_position < partition_end &&
-                        null_data[previous_frame_first_position] == 0) {
-                        this->data(state).count--;
-                    }
-                    if (current_frame_last_position >= partition_start && current_frame_last_position < partition_end &&
-                        null_data[current_frame_last_position] == 0) {
-                        this->data(state).count++;
-                    }
-                } else {
-                    // Build the frame for the first time
-                    for (size_t i = frame_start; i < frame_end; ++i) {
-                        this->data(state).count += !null_data[i];
-                    }
-                    this->data(state).is_frame_init = true;
-                }
+        if constexpr (IsWindowFunc) {
+            DCHECK(!ignore_subtraction);
+            DCHECK(!ignore_addition);
+            const auto frame_start =
+                    std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
+            const auto frame_end =
+                    std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
+            const auto frame_size = frame_end - frame_start;
+            // For cases like: rows between 2 preceding and 1 preceding
+            // If frame_start ge frame_end, means the frame is empty,
+            // we could directly return.
+            if (frame_size <= 0) {
+                this->data(state).count = 0;
                 return;
             }
-        }
+            if (columns[0]->is_nullable()) {
+                const auto* nullable_column = down_cast<const NullableColumn*>(columns[0]);
+                if (nullable_column->has_null()) {
+                    const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+                    if (this->data(state).is_frame_init) {
+                        // Since frame has been evaluated, we only need to update the boundary
+                        const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
+                        const int64_t current_frame_last_position = current_row_position + rows_end_offset;
+                        if (previous_frame_first_position >= partition_start &&
+                            previous_frame_first_position < partition_end &&
+                            null_data[previous_frame_first_position] == 0) {
+                            this->data(state).count--;
+                        }
+                        if (current_frame_last_position >= partition_start &&
+                            current_frame_last_position < partition_end &&
+                            null_data[current_frame_last_position] == 0) {
+                            this->data(state).count++;
+                        }
+                    } else {
+                        // Build the frame for the first time
+                        for (size_t i = frame_start; i < frame_end; ++i) {
+                            this->data(state).count += !null_data[i];
+                        }
+                        this->data(state).is_frame_init = true;
+                    }
+                    return;
+                }
+            }
 
-        // Has no null value
-        // We don't actually update in removable cumulative way, since the ordinary way is effecient enough
-        this->data(state).count = frame_size;
+            // Has no null value
+            // We don't actually update in removable cumulative way, since the ordinary way is effecient enough
+            this->data(state).count = frame_size;
+        }
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_numeric());
         const auto* input_column = down_cast<const Int64Column*>(column);
-        data(state).count += input_column->get_data()[row_num];
+        this->data(state).count += input_column->get_data()[row_num];
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
@@ -234,7 +250,7 @@ public:
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
         for (size_t i = 0; i < chunk_size; i++) {
-            result_data.emplace_back(data(agg_states[i] + state_offset).count);
+            result_data.emplace_back(this->data(agg_states[i] + state_offset).count);
         }
     }
 

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -26,8 +26,15 @@ constexpr bool IsWindowFunctionSliceState<MaxAggregateData<TYPE_VARCHAR>> = true
 template <>
 constexpr bool IsWindowFunctionSliceState<MinAggregateData<TYPE_VARCHAR>> = true;
 
-template <typename T>
-struct NullableAggregateFunctionState {
+struct NullableAggregateWindowFunctionState {
+    // The following two fields are only used in "update_state_removable_cumulatively"
+    bool is_frame_init = false;
+    int64_t null_count = 0;
+};
+
+template <typename T, bool IsWindowFunc>
+struct NullableAggregateFunctionState
+        : public std::conditional_t<IsWindowFunc, NullableAggregateWindowFunctionState, AggregateFunctionEmptyState> {
     using NestedState = T;
 
     NullableAggregateFunctionState() : _nested_state() {}
@@ -38,10 +45,6 @@ struct NullableAggregateFunctionState {
 
     bool is_null = true;
 
-    // The following two fields are only used in "update_state_removable_cumulatively"
-    bool is_frame_init = false;
-    int64_t null_count = 0;
-
     T _nested_state;
 };
 
@@ -49,7 +52,7 @@ struct NullableAggregateFunctionState {
 // If an aggregate function has at least one nullable argument, we should use this class.
 // If all row all are NULL, we will return NULL.
 // The State must be NullableAggregateFunctionState
-template <typename State, bool IgnoreNull = true>
+template <typename State, bool IsWindowFunc, bool IgnoreNull = true>
 class NullableAggregateFunctionBase : public AggregateFunctionStateHelper<State> {
 public:
     explicit NullableAggregateFunctionBase(AggregateFunctionPtr nested_function_)
@@ -59,8 +62,10 @@ public:
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).is_null = true;
-        this->data(state).is_frame_init = false;
-        this->data(state).null_count = 0;
+        if constexpr (IsWindowFunc) {
+            this->data(state).is_frame_init = false;
+            this->data(state).null_count = 0;
+        }
         nested_function->reset(ctx, args, this->data(state).mutable_nest_state());
     }
 
@@ -219,11 +224,11 @@ protected:
     AggregateFunctionPtr nested_function;
 };
 
-template <typename State, bool IgnoreNull = true>
-class NullableAggregateFunctionUnary final : public NullableAggregateFunctionBase<State, IgnoreNull> {
+template <typename State, bool IsWindowFunc = false, bool IgnoreNull = true>
+class NullableAggregateFunctionUnary final : public NullableAggregateFunctionBase<State, IsWindowFunc, IgnoreNull> {
 public:
     explicit NullableAggregateFunctionUnary(const AggregateFunctionPtr& nested_function)
-            : NullableAggregateFunctionBase<State, IgnoreNull>(nested_function) {}
+            : NullableAggregateFunctionBase<State, IsWindowFunc, IgnoreNull>(nested_function) {}
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {}
@@ -512,93 +517,95 @@ public:
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
                                              bool ignore_subtraction, bool ignore_addition) const override {
-        DCHECK(!ignore_subtraction);
-        DCHECK(!ignore_addition);
-        this->data(state).is_null = true;
-        const auto frame_start =
-                std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
-        const auto frame_end =
-                std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
-        const auto frame_size = frame_end - frame_start;
-        // For cases like: rows between 2 preceding and 1 preceding
-        // If frame_start ge frame_end, means the frame is empty,
-        // we could directly return.
-        if (frame_size <= 0) {
-            return;
-        }
-        if (columns[0]->is_nullable()) {
-            const auto* column = down_cast<const NullableColumn*>(columns[0]);
-            const Column* data_column = &column->data_column_ref();
-
-            // The fast pass
-            if (!column->has_null()) {
-                this->data(state).is_null = false;
-                if (this->data(state).is_frame_init) {
-                    // Since frame has been evaluated, we only need to update the boundary
-                    this->nested_function->update_state_removable_cumulatively(
-                            ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
-                            partition_start, partition_end, rows_start_offset, rows_end_offset, ignore_subtraction,
-                            ignore_addition);
-                } else {
-                    // Build the frame for the first time
-                    this->nested_function->update_batch_single_state(ctx, this->data(state).mutable_nest_state(),
-                                                                     &data_column, -1, -1, frame_start, frame_end);
-                    this->data(state).is_frame_init = true;
-                }
+        if constexpr (IsWindowFunc) {
+            DCHECK(!ignore_subtraction);
+            DCHECK(!ignore_addition);
+            this->data(state).is_null = true;
+            const auto frame_start =
+                    std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
+            const auto frame_end =
+                    std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
+            const auto frame_size = frame_end - frame_start;
+            // For cases like: rows between 2 preceding and 1 preceding
+            // If frame_start ge frame_end, means the frame is empty,
+            // we could directly return.
+            if (frame_size <= 0) {
                 return;
             }
+            if (columns[0]->is_nullable()) {
+                const auto* column = down_cast<const NullableColumn*>(columns[0]);
+                const Column* data_column = &column->data_column_ref();
 
-            const uint8_t* f_data = column->null_column()->raw_data();
-            if (this->data(state).is_frame_init) {
-                // Since frame has been evaluated, we only need to update the boundary
-                const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
-                const int64_t current_frame_last_position = current_row_position + rows_end_offset;
-                bool is_previous_frame_start_null = false;
-                if (previous_frame_first_position >= partition_start && previous_frame_first_position < partition_end &&
-                    f_data[previous_frame_first_position] == 1) {
-                    is_previous_frame_start_null = true;
-                    this->data(state).null_count--;
-                }
-                bool is_current_frame_end_null = false;
-                if (current_frame_last_position >= partition_start && current_frame_last_position < partition_end &&
-                    f_data[current_frame_last_position] == 1) {
-                    is_current_frame_end_null = true;
-                    this->data(state).null_count++;
-                }
-                this->nested_function->update_state_removable_cumulatively(
-                        ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
-                        partition_start, partition_end, rows_start_offset, rows_end_offset,
-                        is_previous_frame_start_null, is_current_frame_end_null);
-                if (frame_size != this->data(state).null_count) {
+                // The fast pass
+                if (!column->has_null()) {
                     this->data(state).is_null = false;
-                }
-            } else {
-                // Build the frame for the first time
-                for (size_t i = frame_start; i < frame_end; ++i) {
-                    if (f_data[i] == 0) {
-                        this->data(state).is_null = false;
-                        this->nested_function->update_batch_single_state(ctx, this->data(state).mutable_nest_state(),
-                                                                         &data_column, -1, -1, i, i + 1);
+                    if (this->data(state).is_frame_init) {
+                        // Since frame has been evaluated, we only need to update the boundary
+                        this->nested_function->update_state_removable_cumulatively(
+                                ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
+                                partition_start, partition_end, rows_start_offset, rows_end_offset, ignore_subtraction,
+                                ignore_addition);
                     } else {
+                        // Build the frame for the first time
+                        this->nested_function->update_batch_single_state(ctx, this->data(state).mutable_nest_state(),
+                                                                         &data_column, -1, -1, frame_start, frame_end);
+                        this->data(state).is_frame_init = true;
+                    }
+                    return;
+                }
+
+                const uint8_t* f_data = column->null_column()->raw_data();
+                if (this->data(state).is_frame_init) {
+                    // Since frame has been evaluated, we only need to update the boundary
+                    const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
+                    const int64_t current_frame_last_position = current_row_position + rows_end_offset;
+                    bool is_previous_frame_start_null = false;
+                    if (previous_frame_first_position >= partition_start &&
+                        previous_frame_first_position < partition_end && f_data[previous_frame_first_position] == 1) {
+                        is_previous_frame_start_null = true;
+                        this->data(state).null_count--;
+                    }
+                    bool is_current_frame_end_null = false;
+                    if (current_frame_last_position >= partition_start && current_frame_last_position < partition_end &&
+                        f_data[current_frame_last_position] == 1) {
+                        is_current_frame_end_null = true;
                         this->data(state).null_count++;
                     }
+                    this->nested_function->update_state_removable_cumulatively(
+                            ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
+                            partition_start, partition_end, rows_start_offset, rows_end_offset,
+                            is_previous_frame_start_null, is_current_frame_end_null);
+                    if (frame_size != this->data(state).null_count) {
+                        this->data(state).is_null = false;
+                    }
+                } else {
+                    // Build the frame for the first time
+                    for (size_t i = frame_start; i < frame_end; ++i) {
+                        if (f_data[i] == 0) {
+                            this->data(state).is_null = false;
+                            this->nested_function->update_batch_single_state(
+                                    ctx, this->data(state).mutable_nest_state(), &data_column, -1, -1, i, i + 1);
+                        } else {
+                            this->data(state).null_count++;
+                        }
+                    }
+                    this->data(state).is_frame_init = true;
                 }
-                this->data(state).is_frame_init = true;
+            } else {
+                this->data(state).is_null = false;
+                this->nested_function->update_state_removable_cumulatively(
+                        ctx, this->data(state).mutable_nest_state(), columns, current_row_position, partition_start,
+                        partition_end, rows_start_offset, rows_end_offset, ignore_subtraction, ignore_addition);
             }
-        } else {
-            this->data(state).is_null = false;
-            this->nested_function->update_state_removable_cumulatively(
-                    ctx, this->data(state).mutable_nest_state(), columns, current_row_position, partition_start,
-                    partition_end, rows_start_offset, rows_end_offset, ignore_subtraction, ignore_addition);
         }
     }
 };
 
 template <typename State>
-class NullableAggregateFunctionVariadic final : public NullableAggregateFunctionBase<State, true> {
+class NullableAggregateFunctionVariadic final : public NullableAggregateFunctionBase<State, false> {
 public:
     NullableAggregateFunctionVariadic(const AggregateFunctionPtr& nested_function)
-            : NullableAggregateFunctionBase<State>(nested_function) {}
+            : NullableAggregateFunctionBase<State, false>(nested_function) {}
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -469,7 +469,6 @@ public:
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         // For cases like: rows between 2 preceding and 1 preceding
-        // Please refer to AnalyticNode::_update_window_batch_normal
         // If frame_start ge frame_end, means the frame is empty,
         // we could directly return.
         if (frame_start >= frame_end) {
@@ -511,17 +510,25 @@ public:
 
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
-                                             int64_t partition_end, int64_t preceding,
-                                             int64_t following) const override {
-        DCHECK_GE(preceding, 0);
-        DCHECK_GE(following, 0);
+                                             int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
+                                             bool ignore_subtraction, bool ignore_addition) const override {
+        DCHECK(!ignore_subtraction);
+        DCHECK(!ignore_addition);
         this->data(state).is_null = true;
+        const auto frame_start =
+                std::min(std::max(current_row_position + rows_start_offset, partition_start), partition_end);
+        const auto frame_end =
+                std::max(std::min(current_row_position + rows_end_offset + 1, partition_end), partition_start);
+        const auto frame_size = frame_end - frame_start;
+        // For cases like: rows between 2 preceding and 1 preceding
+        // If frame_start ge frame_end, means the frame is empty,
+        // we could directly return.
+        if (frame_size <= 0) {
+            return;
+        }
         if (columns[0]->is_nullable()) {
             const auto* column = down_cast<const NullableColumn*>(columns[0]);
             const Column* data_column = &column->data_column_ref();
-            const auto frame_start = std::max(current_row_position - preceding, partition_start);
-            const auto frame_end = std::min(current_row_position + following + 1, partition_end);
-            const auto frame_size = frame_end - frame_start;
 
             // The fast pass
             if (!column->has_null()) {
@@ -530,7 +537,8 @@ public:
                     // Since frame has been evaluated, we only need to update the boundary
                     this->nested_function->update_state_removable_cumulatively(
                             ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
-                            partition_start, partition_end, preceding, following);
+                            partition_start, partition_end, rows_start_offset, rows_end_offset, ignore_subtraction,
+                            ignore_addition);
                 } else {
                     // Build the frame for the first time
                     this->nested_function->update_batch_single_state(ctx, this->data(state).mutable_nest_state(),
@@ -543,21 +551,24 @@ public:
             const uint8_t* f_data = column->null_column()->raw_data();
             if (this->data(state).is_frame_init) {
                 // Since frame has been evaluated, we only need to update the boundary
-                bool is_previous_preceding_null = false;
-                if (current_row_position - 1 - preceding >= partition_start &&
-                    f_data[current_row_position - 1 - preceding] == 1) {
-                    is_previous_preceding_null = true;
+                const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
+                const int64_t current_frame_last_position = current_row_position + rows_end_offset;
+                bool is_previous_frame_start_null = false;
+                if (previous_frame_first_position >= partition_start && previous_frame_first_position < partition_end &&
+                    f_data[previous_frame_first_position] == 1) {
+                    is_previous_frame_start_null = true;
                     this->data(state).null_count--;
                 }
-                bool is_current_following_null = false;
-                if (current_row_position + following < partition_end && f_data[current_row_position + following] == 1) {
-                    is_current_following_null = true;
+                bool is_current_frame_end_null = false;
+                if (current_frame_last_position >= partition_start && current_frame_last_position < partition_end &&
+                    f_data[current_frame_last_position] == 1) {
+                    is_current_frame_end_null = true;
                     this->data(state).null_count++;
                 }
                 this->nested_function->update_state_removable_cumulatively(
                         ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
-                        partition_start, partition_end, is_previous_preceding_null ? -1 : preceding,
-                        is_current_following_null ? -1 : following);
+                        partition_start, partition_end, rows_start_offset, rows_end_offset,
+                        is_previous_frame_start_null, is_current_frame_end_null);
                 if (frame_size != this->data(state).null_count) {
                     this->data(state).is_null = false;
                 }
@@ -576,9 +587,9 @@ public:
             }
         } else {
             this->data(state).is_null = false;
-            this->nested_function->update_state_removable_cumulatively(ctx, this->data(state).mutable_nest_state(),
-                                                                       columns, current_row_position, partition_start,
-                                                                       partition_end, preceding, following);
+            this->nested_function->update_state_removable_cumulatively(
+                    ctx, this->data(state).mutable_nest_state(), columns, current_row_position, partition_start,
+                    partition_end, rows_start_offset, rows_end_offset, ignore_subtraction, ignore_addition);
         }
     }
 };

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -254,6 +254,11 @@ DecimalV2Value& DecimalV2Value::operator+=(const DecimalV2Value& other) {
     return *this;
 }
 
+DecimalV2Value& DecimalV2Value::operator-=(const DecimalV2Value& other) {
+    *this = *this - other;
+    return *this;
+}
+
 int DecimalV2Value::parse_from_str(const char* decimal_str, int32_t length) {
     int32_t error = E_DEC_OK;
     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;

--- a/be/src/runtime/decimalv2_value.h
+++ b/be/src/runtime/decimalv2_value.h
@@ -129,6 +129,7 @@ public:
     operator double() const { return static_cast<double>(_value) / ONE_BILLION; }
 
     DecimalV2Value& operator+=(const DecimalV2Value& other);
+    DecimalV2Value& operator-=(const DecimalV2Value& other);
 
     // To be Compatible with OLAP
     // ATTN: NO-OVERFLOW should be guaranteed.

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -920,7 +920,7 @@ TEST_F(AggregateTest, test_dict_merge) {
 }
 
 TEST_F(AggregateTest, test_sum_nullable) {
-    using NullableSumInt64 = NullableAggregateFunctionState<SumAggregateState<int64_t>>;
+    using NullableSumInt64 = NullableAggregateFunctionState<SumAggregateState<int64_t>, false>;
     const AggregateFunction* sum_null = get_aggregate_function("sum", TYPE_INT, TYPE_BIGINT, true);
     auto state = ManagedAggrState::create(ctx, sum_null);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8359

## Enhancement

For some kind of window frame, like `rows between [m] preceding and [n] following`, and some kind of window functions, like `sum/avg/count`, we can get performance improvement by using **removable cumulative algorithm**.

It is obvious that `sum/avg` can benefit from the removable cumulative algorithm, but what about `count`? 

* For `not NullableColumn`, the current algorithm for `count` is fast enough
* For `NullableColumn`, a loop is introduced to count the not-null values, so the loop can be further optimized out by removable cumulative algorithm

So, here is the change list of this pr:

1. add an method `update_state_removable_cumulatively`(with a default empty implementation) to the interface.
2. `NullableAggregateFunctionUnary` implement the method `update_state_removable_cumulatively` to support both `NullableColumn` or `not NullableColumn`.
3. `CountAggregateFunction` and `CountNullableAggregateFunction` implement the method `update_state_removable_cumulatively` for null or not null situations.
4. `SumAggregateFunction` and `AvgAggregateFunction` implement the method `update_state_removable_cumulatively`.
5.  Since we need to add extra fieds at the AggregateState to support the removable cumulative algorithm, and in other way, for aggregate situations, we do not need the extra fields because it will cost more memory and slow down the computation. So I add a template parameter `IsWindowFunc` to distinguish the aggregate version and window version

## Test

**Cluster Info**
* 1fe/3be
* 64core/128G

**Data Set**

* Total rows: 130k
* v1: not null
* v2: has a null value every other 100 values

```sql
CREATE DATABASE IF NOT EXISTS `analytic`;
DROP TABLE IF EXISTS `analytic`.`tmp`;
CREATE TABLE IF NOT EXISTS `analytic`.`tmp` (
  `v1` int(11) NULL
) ENGINE=OLAP
DUPLICATE KEY(`v1`)
DISTRIBUTED BY HASH(`v1`) BUCKETS 10
PROPERTIES (
 "replication_num" = "1"
);

INSERT INTO `analytic`.`tmp` (v1) values (NULL);

INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;
INSERT INTO `analytic`.`tmp` SELECT * FROM `analytic`.`tmp`;

CREATE DATABASE IF NOT EXISTS `analytic`;
DROP TABLE IF EXISTS `analytic`.`t0`;
CREATE TABLE IF NOT EXISTS `analytic`.`t0` (
  `v1` int(11) NOT NULL,
  `v2` int(11) NULL
) ENGINE=OLAP
PRIMARY KEY(`v1`)
DISTRIBUTED BY HASH(`v1`) BUCKETS 10
PROPERTIES (
 "replication_num" = "1"
);

INSERT INTO `analytic`.`t0`
SELECT
    row_number() OVER() AS v0,
    row_number() OVER() AS v1 
FROM `analytic`.`tmp`;

UPDATE `analytic`.`t0` 
SET v2 = NULL
WHERE v2 % 100 = 0;
```

**In order to focus on the analytic's execution efficiency, all the test pattern will not have partition clause, and the window function's evaluation will be performed in one machine with one parallelism**

```sql
-- Pattern 1, not null column
select sum(wv) from (
select <FN>(v1) over(order by v1 rows between unbounded preceding and 1 following) as wv from t0
) a;

-- Pattern 2, null column
select sum(wv) from (
select <FN>(v2) over(order by v1 rows between unbounded preceding and 1 following) as wv from t0
) a;

-- Pattern 3, not null column
select sum(wv) from (
select <FN>(v1) over(order by v1 rows between <M> preceding and <N> following) as wv from t0
) a;

-- Pattern 4, null column
select sum(wv) from (
select <FN>(v2) over(order by v1 rows between <M> preceding and <N> following) as wv from t0
) a;
```

<table>
  <tr>
    <th>Query Pattern</th>
    <th>Window Function</th>
    <th>Preceding Distance</th>
    <th>Following Distance</th>
    <th>Before</th>
    <th>After</th>
    <th>Improvement Ratio</th>
  </tr>  
  <tr> 
    <td rowspan=3>P1</td>
    <td>sum</td>
    <td>\</td>
    <td>1</td>
    <td>1.337s</td>
    <td>0.053s</td>
    <td>25</td>
  </tr>
  <tr> 
    <td>avg</td>
    <td>\</td>
    <td>1</td>
    <td>12.928s</td>
    <td>0.050s</td>
    <td>258</td>
  </tr>
  <tr> 
    <td>count</td>
    <td>\</td>
    <td>1</td>
    <td>0.066s</td>
    <td>0.053s</td>
    <td>1.24</td>
  </tr>
  <tr> 
    <td rowspan=3>P2</td>
    <td>sum</td>
    <td>\</td>
    <td>1</td>
    <td>36.096s</td>
    <td>0.058s</td>
    <td>622</td>
  </tr>
  <tr> 
    <td>avg</td>
    <td>\</td>
    <td>1</td>
    <td>39.655s</td>
    <td>0.057s</td>
    <td>695</td>
  </tr>
  <tr> 
    <td>count</td>
    <td>\</td>
    <td>1</td>
    <td>2.196s</td>
    <td>0.056s</td>
    <td>39</td>
  </tr>
  <tr> 
    <td rowspan=12>P3</td>
    <td rowspan=4>sum</td>
    <td>1</td>
    <td>1</td>
    <td>0.068s</td>
    <td>0.049s</td>
    <td>1.39</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.070s</td>
    <td>0.050s</td>
    <td>1.40</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.072s</td>
    <td>0.049s</td>
    <td>1.47</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>0.103s</td>
    <td>0.050s</td>
    <td>2.06</td>
  </tr>
  <tr> 
    <td rowspan=4>avg</td>
    <td>1</td>
    <td>1</td>
    <td>0.069s</td>
    <td>0.049s</td>
    <td>1.41</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.069s</td>
    <td>0.049s</td>
    <td>1.41</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.072s</td>
    <td>0.049s</td>
    <td>1.47</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>0.105s</td>
    <td>0.050s</td>
    <td>2.10</td>
  </tr>
  <tr> 
    <td rowspan=4>count</td>
    <td>1</td>
    <td>1</td>
    <td>0.066s</td>
    <td>0.047s</td>
    <td>1.40</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.066s</td>
    <td>0.048s</td>
    <td>1.40</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.066s</td>
    <td>0.047s</td>
    <td>1.40</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>0.066s</td>
    <td>0.046s</td>
    <td>1.40</td>
  </tr>
  <tr> 
    <td rowspan=12>P4</td>
    <td rowspan=4>sum</td>
    <td>1</td>
    <td>1</td>
    <td>0.071s</td>
    <td>0.052s</td>
    <td>1.37</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.090s</td>
    <td>0.053s</td>
    <td>1.70</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.215s</td>
    <td>0.053s</td>
    <td>4.06</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>1.231s</td>
    <td>0.051s</td>
    <td>24</td>
  </tr>
  <tr> 
    <td rowspan=4>avg</td>
    <td>1</td>
    <td>1</td>
    <td>0.071s</td>
    <td>0.053s</td>
    <td>1.34</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.092s</td>
    <td>0.053s</td>
    <td>1.76</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.224s</td>
    <td>0.054s</td>
    <td>4.15</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>1.296s</td>
    <td>0.055s</td>
    <td>24</td>
  </tr>
  <tr> 
    <td rowspan=4>count</td>
    <td>1</td>
    <td>1</td>
    <td>0.069s</td>
    <td>0.055s</td>
    <td>1.25</td>
  </tr>
  <tr>
    <td>16</td>
    <td>16</td>
    <td>0.072s</td>
    <td>0.053s</td>
    <td>1.36</td>
  </tr>
  <tr>
    <td>128</td>
    <td>128</td>
    <td>0.079s</td>
    <td>0.054s</td>
    <td>1.46</td>
  </tr>
  <tr>
    <td>1024</td>
    <td>1024</td>
    <td>0.133s</td>
    <td>0.053s</td>
    <td>2.51</td>
  </tr>
</table>
