### PR TITLE
[BugFix] Use byte array to serialize lake object storage info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
@@ -22,7 +22,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -34,9 +33,9 @@ public class LakeTable extends OlapTable implements GsonPreProcessable {
     // Currently, storage group is table level, which stores all the tablets data and metadata of this table.
     // Format: service storage uri (from StarOS) + table id
     //
-    // "shardStorageInfoStr" is used for serialization of "shardStorageInfo".
-    @SerializedName(value = "shardStorageInfoStr")
-    private String shardStorageInfoStr;
+    // "shardStorageInfoBytes" is used for serialization of "shardStorageInfo".
+    @SerializedName(value = "shardStorageInfoBytes")
+    private byte[] shardStorageInfoBytes;
     private ShardStorageInfo shardStorageInfo;
 
     public LakeTable(long id, String tableName, List<Column> baseSchema, KeysType keysType, PartitionInfo partitionInfo,
@@ -83,14 +82,13 @@ public class LakeTable extends OlapTable implements GsonPreProcessable {
 
     @Override
     public void gsonPreProcess() throws IOException {
-        shardStorageInfoStr = new String(shardStorageInfo.toByteArray(), StandardCharsets.UTF_8);
+        shardStorageInfoBytes = shardStorageInfo.toByteArray();
     }
 
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-
-        shardStorageInfo = ShardStorageInfo.parseFrom(shardStorageInfoStr.getBytes(StandardCharsets.UTF_8));
+        shardStorageInfo = ShardStorageInfo.parseFrom(shardStorageInfoBytes);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/lake/LakeTableTest.java
@@ -53,6 +53,7 @@ public class LakeTableTest {
         long tablet1Id = 10L;
         long tablet2Id = 11L;
         String serviceStorageUri = "s3://bucket/service/";
+        String endpoint = "region.host.com";
 
         // Schema
         List<Column> columns = Lists.newArrayList();
@@ -82,7 +83,8 @@ public class LakeTableTest {
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
         table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
-        ObjectStorageInfo objectStorageInfo = ObjectStorageInfo.newBuilder().setObjectUri(serviceStorageUri).build();
+        ObjectStorageInfo objectStorageInfo =
+                ObjectStorageInfo.newBuilder().setObjectUri(serviceStorageUri).setEndpoint(endpoint).build();
         ShardStorageInfo shardStorageInfo =
                 ShardStorageInfo.newBuilder().setObjectStorageInfo(objectStorageInfo).build();
         table.setShardStorageInfo(shardStorageInfo);
@@ -104,6 +106,8 @@ public class LakeTableTest {
         Assert.assertTrue(newTable.isLakeTable());
         LakeTable newLakeTable = (LakeTable) newTable;
         Assert.assertEquals(String.format("%s%d/", serviceStorageUri, tableId), newLakeTable.getStorageGroup());
+        ObjectStorageInfo newObjectStorageInfo = newLakeTable.getShardStorageInfo().getObjectStorageInfo();
+        Assert.assertEquals(endpoint, newObjectStorageInfo.getEndpoint());
 
         Partition p1 = newLakeTable.getPartition(partitionId);
         MaterializedIndex newIndex = p1.getBaseIndex();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8258

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

String(byte[]) always replaces malformed-input and unmappable-character sequences
with this charsets default replacement string.
This will cause inconsistence with the origin protobuf, and deserialize failed when FE restart.
So use byte array directly to serialize lake object storage info.