### PR TITLE
Update sonar4fe.yml

### DIFF
--- a/.github/workflows/sonar4fe.yml
+++ b/.github/workflows/sonar4fe.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+#  pull_request:
+#    types: [opened, synchronize, reopened]
   
 jobs:
   build:


### PR DESCRIPTION
## What type of PR is this：
- [y] bug

## Which issues of this PR fixes ：
pull_request trigger does not invoke the correct workflow

## Problem Summary(Required) ：
pull_request trigger does not invoke the correct workflow

Workflows triggered via pull_request_target have write permission to the target repository. They also have access to target repository secrets. The same is true for workflows triggered on pull_request from a branch in the same repository, but not from external forks. The reasoning behind the latter is that it is safe to share the repository secrets if the user creating the PR has write permission to the target repository already.