### PR TITLE
[BugFix] When the status of HeartBeat is not ok, it also need to be synced to follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -82,10 +82,10 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
             } else {
                 if (isAlive) {
                     isAlive = false;
-                    isChanged = true;
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            isChanged = true;
         }
 
         return isChanged;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -85,11 +85,11 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
-            // When master received hb info status not ok, the hb info also need to be synced to follower.
-            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // When the master receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
-            // if it is not synchronized to the follower, 
-            // this will cause the master and follower's metadata to be inconsistent
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
             isChanged = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -85,6 +85,11 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            // When master received hb info status not ok, the hb info also need to be synced to follower.
+            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if it is not synchronized to the follower, 
+            // this will cause the master and follower's metadata to be inconsistent
             isChanged = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -406,6 +406,11 @@ public class ComputeNode implements IComputable, Writable {
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
                 lastMissingHeartbeatTime = System.currentTimeMillis();
             }
+            // When master received hb info status not ok, the hb info also need to be synced to follower.
+            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if it is not synchronized to the follower, 
+            // this will cause the master and follower's metadata to be inconsistent
             isChanged = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -406,11 +406,11 @@ public class ComputeNode implements IComputable, Writable {
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
                 lastMissingHeartbeatTime = System.currentTimeMillis();
             }
-            // When master received hb info status not ok, the hb info also need to be synced to follower.
-            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // When the master receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
-            // if it is not synchronized to the follower, 
-            // this will cause the master and follower's metadata to be inconsistent
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
             isChanged = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -401,13 +401,12 @@ public class ComputeNode implements IComputable, Writable {
                 this.heartbeatRetryTimes++;
             } else {
                 if (isAlive.compareAndSet(true, false)) {
-                    isChanged = true;
                     LOG.info("{} is dead,", this.toString());
                 }
-
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
                 lastMissingHeartbeatTime = System.currentTimeMillis();
             }
+            isChanged = true;
         }
 
         return isChanged;

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -150,11 +150,11 @@ public class Frontend implements Writable {
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
-            // When master received hb info status not ok, the hb info also need to be synced to follower.
-            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // When the master receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
-            // if it is not synchronized to the follower, 
-            // this will cause the master and follower's metadata to be inconsistent
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
             isChanged = true;
         }
         return isChanged;

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -147,10 +147,10 @@ public class Frontend implements Writable {
             } else {
                 if (isAlive) {
                     isAlive = false;
-                    isChanged = true;
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            isChanged = true;
         }
         return isChanged;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -150,6 +150,11 @@ public class Frontend implements Writable {
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            // When master received hb info status not ok, the hb info also need to be synced to follower.
+            // Otherwise, the failed heartbeat information will not be synchronized to the follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if it is not synchronized to the follower, 
+            // this will cause the master and follower's metadata to be inconsistent
             isChanged = true;
         }
         return isChanged;

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -1,0 +1,21 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.system;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.starrocks.system.HeartbeatResponse.HbStatus;
+
+public class ComputeNodeTest {
+    
+    @Test
+    public void testHbStatusBadNeedSync() {
+
+        BackendHbResponse hbResponse = new BackendHbResponse();
+        hbResponse.status = HbStatus.BAD;
+
+        ComputeNode node = new ComputeNode();
+        boolean needSync = node.handleHbResponse(hbResponse);
+        Assert.assertTrue(needSync);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/system/FrontendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/FrontendTest.java
@@ -16,4 +16,13 @@ public class FrontendTest {
         Assert.assertEquals("modifiedHost", fe.getHost());
         Assert.assertTrue(fe.getEditLogPort() == 2110);
     }
+
+    @Test
+    public void testHbStatusBadNeedSync() {
+        FrontendHbResponse hbResponse = new FrontendHbResponse("BAD", "");
+        
+        Frontend fe = new Frontend(FrontendNodeType.FOLLOWER, "name", "testHost", 1110);
+        boolean needSync = fe.handleHbResponse(hbResponse, true);
+        Assert.assertTrue(needSync);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8259

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When master the received heartbeat status is not ok, the heartbeat info also need to be synced to follower. 
Otherwise, the failed heartbeat information will not be synchronized to the follower.
Since the failed heartbeat info also modifies fe's memory, `this.heartbeatRetryTimes++;` 
if it is not synchronized to the follower, this will cause the master and follower's metadata to be inconsistent