### PR TITLE
[BugFix] Fix the problem of identical analytic expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -190,7 +190,6 @@ public class AnalyticExpr extends Expr {
                 && ((AggregateFunction) fn).isAnalyticFn();
     }
 
-
     public static boolean isOffsetFn(Function fn) {
         if (!isAnalyticFn(fn)) {
             return false;
@@ -214,7 +213,6 @@ public class AnalyticExpr extends Expr {
 
         return fn.functionName().equalsIgnoreCase(ROWNUMBER);
     }
-
 
     /**
      * check the value out of range in lag/lead() function

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
@@ -22,7 +22,6 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
-import com.starrocks.catalog.Function;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.thrift.TAnalyticWindow;
 import com.starrocks.thrift.TAnalyticWindowBoundary;
@@ -30,6 +29,7 @@ import com.starrocks.thrift.TAnalyticWindowBoundaryType;
 import com.starrocks.thrift.TAnalyticWindowType;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * Windowing clause of an analytic expr
@@ -218,6 +218,11 @@ public class AnalyticWindow implements ParseNode {
             return type == o.type && exprEqual;
         }
 
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, expr, offsetValue);
+        }
+
         public Boundary converse() {
             Boundary result = new Boundary(type.converse(),
                     (expr != null) ? expr.clone() : null);
@@ -374,6 +379,11 @@ public class AnalyticWindow implements ParseNode {
         return type_ == o.type_
                 && leftBoundary_.equals(o.leftBoundary_)
                 && rightBoundaryEqual;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type_, leftBoundary_, rightBoundary_, toSqlString_);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
@@ -383,7 +383,7 @@ public class AnalyticWindow implements ParseNode {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type_, leftBoundary_, rightBoundary_, toSqlString_);
+        return Objects.hash(type_, leftBoundary_, rightBoundary_);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -89,7 +89,7 @@ public final class SqlToScalarOperatorTranslator {
                                                                  ColumnRefFactory columnRefFactory) {
         ColumnRefOperator columnRef;
         ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expression, expressionMapping);
-        if (expressionMapping.hasExpression(expression) || scalarOperator.isColumnRef()) {
+        if (scalarOperator.isColumnRef()) {
             columnRef = (ColumnRefOperator) scalarOperator;
         } else if (scalarOperator.isVariable() && projections.containsValue(scalarOperator)) {
             columnRef = projections.entrySet().stream().filter(e -> scalarOperator.equals(e.getValue())).findAny().map(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -246,10 +246,8 @@ public class WindowTransformer {
                         SqlToScalarOperatorTranslator.translate(analyticExpr, subOpt.getExpressionMapping());
                 ColumnRefOperator columnRefOperator =
                         columnRefFactory.create(agg.toString(), agg.getType(), agg.isNullable());
-                if (agg instanceof CallOperator) {
-                    analyticCall.put(columnRefOperator, (CallOperator) agg);
-                    subOpt.getExpressionMapping().put(analyticExpr, columnRefOperator);
-                }
+                analyticCall.put(columnRefOperator, (CallOperator) agg);
+                subOpt.getExpressionMapping().put(analyticExpr, columnRefOperator);
             }
 
             List<ScalarOperator> partitions = new ArrayList<>();
@@ -465,7 +463,9 @@ public class WindowTransformer {
         }
 
         public void addFunction(AnalyticExpr analyticExpr) {
-            windowFunctions.add(analyticExpr);
+            if (!windowFunctions.contains(analyticExpr)) {
+                windowFunctions.add(analyticExpr);
+            }
         }
 
         public List<AnalyticExpr> getWindowFunctions() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -463,9 +463,7 @@ public class WindowTransformer {
         }
 
         public void addFunction(AnalyticExpr analyticExpr) {
-            if (!windowFunctions.contains(analyticExpr)) {
-                windowFunctions.add(analyticExpr);
-            }
+            windowFunctions.add(analyticExpr);
         }
 
         public List<AnalyticExpr> getWindowFunctions() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -246,8 +246,10 @@ public class WindowTransformer {
                         SqlToScalarOperatorTranslator.translate(analyticExpr, subOpt.getExpressionMapping());
                 ColumnRefOperator columnRefOperator =
                         columnRefFactory.create(agg.toString(), agg.getType(), agg.isNullable());
-                analyticCall.put(columnRefOperator, (CallOperator) agg);
-                subOpt.getExpressionMapping().put(analyticExpr, columnRefOperator);
+                if (agg instanceof CallOperator) {
+                    analyticCall.put(columnRefOperator, (CallOperator) agg);
+                    subOpt.getExpressionMapping().put(analyticExpr, columnRefOperator);
+                }
             }
 
             List<ScalarOperator> partitions = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -10,21 +10,10 @@ import org.junit.Test;
 public class WindowTest extends PlanTestBase {
 
     @Test
-    public void testIdenticalWindowFunctions() throws Exception {
-        String sql = "select sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_1," +
-                " sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_2 from t0;";
-        String plan = getFragmentPlan(sql);
-        System.out.println(plan);
-        assertContains(plan, "  4:Project\n" +
-                "  |  <slot 4> : 4: sum(1: v1)\n" +
-                "  |  <slot 5> : 5: sum(1: v1)");
-    }
-
-    @Test
     public void testLagWindowFunction() throws Exception {
         String sql = "select lag(id_datetime, 1, '2020-01-01') over(partition by t1c) from test_all_type;";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("signature:lag(DATETIME, BIGINT, DATETIME)"));
+        assertContains(plan, "signature:lag(DATETIME, BIGINT, DATETIME)");
 
         sql = "select lag(id_decimal, 1, 10000) over(partition by t1c) from test_all_type;";
         plan = getThriftPlan(sql);
@@ -37,7 +26,7 @@ public class WindowTest extends PlanTestBase {
 
         sql = "select lag(null, 1,1) OVER () from t0";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("functions: [, lag(NULL, 1, 1), ]"));
+        assertContains(plan, "functions: [, lag(NULL, 1, 1), ]");
 
         sql = "select lag(id_datetime, 1, '2020-01-01xxx') over(partition by t1c) from test_all_type;";
         expectedEx.expect(SemanticException.class);
@@ -50,7 +39,7 @@ public class WindowTest extends PlanTestBase {
         String sql = "select sum(t1c) from (select t1c, lag(id_datetime, 1, '2020-01-01') over( partition by t1c)" +
                 "from test_all_type) a ;";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("ANALYTIC"));
+        assertNotContains(plan, "ANALYTIC");
     }
 
     @Test
@@ -65,29 +54,38 @@ public class WindowTest extends PlanTestBase {
     public void testSameWindowFunctionReuse() throws Exception {
         String sql = "select sum(v1) over() as c1, sum(v1) over() as c2 from t0";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  3:Project\n" +
+        assertContains(plan, "  3:Project\n" +
                 "  |  <slot 4> : 4: sum(1: v1)\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
-                "  |  functions: [, sum(1: v1), ]"));
+                "  |  functions: [, sum(1: v1), ]");
+
+        sql = "select sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_1," +
+                " sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_2 from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  4:Project\n" +
+                "  |  <slot 4> : 4: sum(1: v1)\n" +
+                "  |  \n" +
+                "  3:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]");
 
         sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v1) over() as c2 from t0) t";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  3:Project\n" +
-                "  |  <slot 6> : 4: sum(1: v1) + 1\n" +
-                "  |  <slot 7> : 4: sum(1: v1) + 2\n" +
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 5> : 4: sum(1: v1) + 1\n" +
+                "  |  <slot 6> : 4: sum(1: v1) + 2\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
-                "  |  functions: [, sum(1: v1), ]"));
+                "  |  functions: [, sum(1: v1), ]");
 
         sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v3) over() as c2 from t0) t";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  3:Project\n" +
+        assertContains(plan, "  3:Project\n" +
                 "  |  <slot 6> : 4: sum(1: v1) + 1\n" +
                 "  |  <slot 7> : 5: sum(3: v3) + 2\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
-                "  |  functions: [, sum(1: v1), ], [, sum(3: v3), ]"));
+                "  |  functions: [, sum(1: v1), ], [, sum(3: v3), ]");
     }
 
     @Test
@@ -113,12 +111,12 @@ public class WindowTest extends PlanTestBase {
     public void testWindowWithAgg() throws Exception {
         String sql = "SELECT v1, sum(v2),  sum(v2) over (ORDER BY v1) AS `rank` FROM t0 group BY v1, v2";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"));
+        assertContains(plan, "window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql =
                 "SELECT v1, sum(v2),  sum(v2) over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS `rank`  FROM t0 group BY v1, v2";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"));
+        assertContains(plan, "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
     }
 
     @Test
@@ -126,31 +124,31 @@ public class WindowTest extends PlanTestBase {
         String sql = "SELECT v1, sum(v2) as x1, row_number() over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS `rank` " +
                 "FROM t0 group BY v1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  2:Project\n" +
+        assertContains(plan, "  2:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 4> : 4: sum\n" +
-                "  |  <slot 8> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)"));
+                "  |  <slot 8> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)");
     }
 
     @Test
     public void testWindowPartitionAndSortSameColumn() throws Exception {
         String sql = "SELECT k3, avg(k3) OVER (partition by k3 order by k3) AS sum FROM baseall;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  3:ANALYTIC\n" +
+        assertContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, avg(3: k3), ]\n" +
                 "  |  partition by: 3: k3\n" +
-                "  |  order by: 3: k3 ASC"));
-        Assert.assertTrue(plan.contains("  2:SORT\n" +
-                "  |  order by: <slot 3> 3: k3 ASC"));
+                "  |  order by: 3: k3 ASC");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: <slot 3> 3: k3 ASC");
     }
 
     @Test
     public void testWindowDuplicatePartition() throws Exception {
         String sql = "select max(v3) over (partition by v2,v2,v2 order by v2,v2) from t0;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  2:SORT\n"
+        assertContains(plan, "  2:SORT\n"
                 + "  |  order by: <slot 2> 2: v2 ASC\n"
-                + "  |  offset: 0"));
+                + "  |  offset: 0");
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -8,6 +8,17 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class WindowTest extends PlanTestBase {
+
+    @Test
+    public void testIdenticalWindowFunctions() throws Exception {
+        String sql = "select sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_1," +
+                " sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_2 from t0;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  4:Project\n" +
+                "  |  <slot 4> : 4: sum(1: v1)\n" +
+                "  |  <slot 5> : 5: sum(1: v1)");
+    }
+
     @Test
     public void testLagWindowFunction() throws Exception {
         String sql = "select lag(id_datetime, 1, '2020-01-01') over(partition by t1c) from test_all_type;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -14,6 +14,7 @@ public class WindowTest extends PlanTestBase {
         String sql = "select sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_1," +
                 " sum(v1) over(order by v2 rows between 1 preceding and 1 following) as sum_v1_2 from t0;";
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         assertContains(plan, "  4:Project\n" +
                 "  |  <slot 4> : 4: sum(1: v1)\n" +
                 "  |  <slot 5> : 5: sum(1: v1)");
@@ -73,8 +74,8 @@ public class WindowTest extends PlanTestBase {
         sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v1) over() as c2 from t0) t";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:Project\n" +
-                "  |  <slot 5> : 4: sum(1: v1) + 1\n" +
-                "  |  <slot 6> : 4: sum(1: v1) + 2\n" +
+                "  |  <slot 6> : 4: sum(1: v1) + 1\n" +
+                "  |  <slot 7> : 4: sum(1: v1) + 2\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
                 "  |  functions: [, sum(1: v1), ]"));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7015

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The root cause is the `AnalyticWindow` missing `hashCode` function, leading to `ExpressionMapping::hasExpression` failed to match the identical peers