### PR TITLE
[BugFix] Fix no push_chunk() before set_finishing() in OlapTableSinkOperator

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.h
+++ b/be/src/exec/pipeline/olap_table_sink_operator.h
@@ -50,7 +50,7 @@ private:
     FragmentContext* const _fragment_ctx;
 
     bool _is_finished = false;
-    bool _is_open_done = false;
+    mutable bool _is_open_done = false;
 };
 
 class OlapTableSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -415,6 +415,9 @@ private:
 
     // the timeout of load channels opened by this tablet sink. in second
     int64_t _load_channel_timeout_s = 0;
+
+    bool _open_done = false;
+    bool _close_done = false;
 };
 
 } // namespace stream_load


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
#8239 will block pipeline engine in set_finishing(), we need check is_open_done() before open_wait()