### PR TITLE
[BugFix] Fix CompactionManagerTest.test_compaction_tasks uninit max task num

### DIFF
--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -107,6 +107,8 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
         tasks.emplace_back(std::move(task));
     }
 
+    StorageEngine::instance()->compaction_manager()->init_max_task_num();
+
     for (int i = 0; i < config::max_compaction_concurrency; i++) {
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());
         ASSERT_TRUE(ret);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```bash
./run-ut.sh --run --gtest_filter=CompactionManagerTest.test_compaction_tasks
```
```
******************************
    Running StarRocks BE Unittest    
******************************
******************************
    Running StarRocks BE Unittest    
******************************
Note: Google Test filter = CompactionManagerTest.test_compaction_tasks:-*S3*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CompactionManagerTest
[ RUN      ] CompactionManagerTest.test_compaction_tasks
../test/storage/compaction_manager_test.cpp:112: Failure
Value of: ret
  Actual: false
Expected: true
[  FAILED  ] CompactionManagerTest.test_compaction_tasks (0 ms)
[----------] 1 test from CompactionManagerTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CompactionManagerTest.test_compaction_tasks

 1 FAILED TEST
[qzc@starrocks-sandbox04 starrocks]$
```
