### PR TITLE
[BugFix] heap-use-after-free in ExternalScanContextMgr

### DIFF
--- a/be/src/runtime/external_scan_context_mgr.h
+++ b/be/src/runtime/external_scan_context_mgr.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <ctime>
 #include <map>
 #include <memory>
@@ -51,7 +52,7 @@ class ExternalScanContextMgr {
 public:
     ExternalScanContextMgr(ExecEnv* exec_env);
 
-    ~ExternalScanContextMgr() {}
+    ~ExternalScanContextMgr();
 
     Status create_scan_context(std::shared_ptr<ScanContext>* p_context);
 
@@ -64,7 +65,10 @@ private:
     std::map<std::string, std::shared_ptr<ScanContext>> _active_contexts;
     void gc_expired_context();
     std::unique_ptr<std::thread> _keep_alive_reaper;
+
     std::mutex _lock;
+    std::condition_variable _cv;
+    bool _closing = false;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8279

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This fixes the `heap-use-after-free` in ExternalScanContextMgr. The previous implement detaches the `_keep_alive_reaper` of `ExternalScanContextMgr`, which leads thread leak. The detached thread may access the freed memory.  The new implement would wait until the thread exit in `ExternalScanContextMgr` destructor.