### PR TITLE
[BugFix] compaction_candidate has already been moved

### DIFF
--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -71,7 +71,7 @@ bool CompactionScheduler::_can_schedule_next() {
 void CompactionScheduler::_wait_to_run() {
     std::unique_lock<std::mutex> lk(_mutex);
     // check _can_schedule_next every five second to avoid deadlock and support modifying config online
-    while (!_cv.wait_for(lk, 5000ms, [this] { return _can_schedule_next(); })) {
+    while (!_cv.wait_for(lk, 5000ms, [] { return _can_schedule_next(); })) {
     }
 }
 
@@ -87,7 +87,7 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
     });
     // to compatible with old compaction framework
     // TODO: can be optimized to use just one lock
-    int64_t last_failure_ms = 0;
+    int64_t last_failure_ms;
     DataDir* data_dir = tablet->data_dir();
     if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
         std::unique_lock lk(tablet->get_cumulative_lock(), std::try_to_lock);
@@ -200,13 +200,15 @@ bool CompactionScheduler::_can_do_compaction(const CompactionCandidate& candidat
     }
 }
 
-std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_task() {
+std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_task() const {
     VLOG(2) << "try to get next qualified tablet for round:" << _round
             << ", current candidates size:" << StorageEngine::instance()->compaction_manager()->candidates_size();
     // tmp_tablets save the tmp picked candidates tablets
     std::vector<CompactionCandidate> tmp_candidates;
     CompactionCandidate compaction_candidate;
     bool found = false;
+    int64_t tablet_id;
+    CompactionType compaction_type;
     std::shared_ptr<CompactionTask> compaction_task;
     while (true) {
         if (!_can_schedule_next()) {
@@ -220,8 +222,9 @@ std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_ta
             LOG(INFO) << "do not get a qualified candidate";
             break;
         }
-        VLOG(2) << "try tablet:" << compaction_candidate.tablet->tablet_id()
-                << ", compaction type:" << to_string(compaction_candidate.type);
+        tablet_id = compaction_candidate.tablet->tablet_id();
+        compaction_type = compaction_candidate.type;
+        VLOG(2) << "try tablet:" << tablet_id << ", compaction type:" << to_string(compaction_type);
         bool need_reschedule = true;
         found = _can_do_compaction(compaction_candidate, &need_reschedule, &compaction_task);
         if (need_reschedule) {
@@ -236,8 +239,7 @@ std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_ta
     VLOG(2) << "tmp tablets size:" << tmp_candidates.size();
     StorageEngine::instance()->compaction_manager()->insert_candidates(std::move(tmp_candidates));
     if (found) {
-        VLOG(2) << "get a qualified tablet:" << compaction_candidate.tablet->tablet_id()
-                << ", compaction type:" << to_string(compaction_candidate.type)
+        VLOG(2) << "get a qualified tablet:" << tablet_id << ", compaction type:" << to_string(compaction_type)
                 << ", compaction task:" << compaction_task->get_task_info();
         return compaction_task;
     } else {

--- a/be/src/storage/compaction_scheduler.h
+++ b/be/src/storage/compaction_scheduler.h
@@ -32,24 +32,24 @@ private:
     // wait until current running tasks are below max_concurrent_num
     void _wait_to_run();
 
-    bool _can_schedule_next();
+    static bool _can_schedule_next();
 
-    std::shared_ptr<CompactionTask> _try_get_next_compaction_task();
+    std::shared_ptr<CompactionTask> _try_get_next_compaction_task() const;
 
-    bool _can_do_compaction(const CompactionCandidate& candidate, bool* need_reschedule,
+    static bool _can_do_compaction(const CompactionCandidate& candidate, bool* need_reschedule,
                             std::shared_ptr<CompactionTask>* compaction_task);
 
     // if check fails, should not reschedule the tablet
-    bool _check_precondition(const CompactionCandidate& candidate);
+    static bool _check_precondition(const CompactionCandidate& candidate);
 
-    bool _can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task);
+    static bool _can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task);
 
 private:
     std::unique_ptr<ThreadPool> _compaction_pool;
 
     std::mutex _mutex;
     std::condition_variable _cv;
-    uint64_t _round;
+    uint64_t _round = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/compaction_scheduler.h
+++ b/be/src/storage/compaction_scheduler.h
@@ -37,7 +37,7 @@ private:
     std::shared_ptr<CompactionTask> _try_get_next_compaction_task() const;
 
     static bool _can_do_compaction(const CompactionCandidate& candidate, bool* need_reschedule,
-                            std::shared_ptr<CompactionTask>* compaction_task);
+                                   std::shared_ptr<CompactionTask>* compaction_task);
 
     // if check fails, should not reschedule the tablet
     static bool _check_precondition(const CompactionCandidate& candidate);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`compaction_candidate` has already been moved.

```
        VLOG(2) << "get a qualified tablet:" << compaction_candidate.tablet->tablet_id()
                << ", compaction type:" << to_string(compaction_candidate.type)
                << ", compaction task:" << compaction_task->get_task_info();
```
