### PR TITLE
[BugFix] Fix error update of PersistentIndexMeta

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1386,6 +1386,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         data->set_offset(0);
         data->set_size(0);
         l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_1);
+        // if _flushed is true, we will create a new empty _l0 file, set _offset to 0
         _offset = 0;
         _page_size = 0;
         // clear _l0 and reload _l1
@@ -1413,7 +1414,8 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         data->set_offset(0);
         data->set_size(snapshot_size);
         l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_1);
-        _offset += snapshot_size;
+        // if _dump_snapshot is true, we will dump a snapshot to new _l0 file, set _offset to snapshot_size
+        _offset = snapshot_size;
         _page_size = 0;
     } else {
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8144

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If PersistentIndex choose dump snapshot, we will dump snapshot into a new `_l0` file, so we should set file offset as `snapshot_size` but not add `snapshot_size`
