### PR TITLE
[BugFix] Skip check partition when change kafka offset if not initialized

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -126,12 +126,13 @@ public class KafkaProgress extends RoutineLoadProgress {
     // modify the partition offset of this progress.
     // throw exception is the specified partition does not exist in progress.
     public void modifyOffset(List<Pair<Integer, Long>> kafkaPartitionOffsets) throws DdlException {
+        // kafka progress will not initialized & update if current role is follower
+        boolean notInitialized = partitionIdToOffset.isEmpty();
         for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
-            if (!partitionIdToOffset.containsKey(pair.first)) {
+            if (!notInitialized && !partitionIdToOffset.containsKey(pair.first)) {
                 throw new DdlException("The specified partition " + pair.first + " is not in the consumed partitions");
             }
         }
-
         for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
             partitionIdToOffset.put(pair.first, pair.second);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
@@ -12,6 +12,7 @@ import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +41,8 @@ public class KafkaProgressTest {
         };
 
         KafkaProgress progress = new KafkaProgress();
+        // modify offset while paused
+        progress.modifyOffset(Arrays.asList(new Pair<>(3, 20L)));
         progress.addPartitionOffset(new Pair<>(0, -1L));
         progress.addPartitionOffset(new Pair<>(1, -2L));
         progress.addPartitionOffset(new Pair<>(2, 10L));
@@ -47,5 +50,6 @@ public class KafkaProgressTest {
         Assert.assertEquals(100L, (long) progress.getOffsetByPartition(0));
         Assert.assertEquals(1L, (long) progress.getOffsetByPartition(1));
         Assert.assertEquals(10L, (long) progress.getOffsetByPartition(2));
+        Assert.assertEquals(20L, (long) progress.getOffsetByPartition(3));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7775

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
