### PR TITLE
[BugFix] Fix invalid broker load exec_mem_limit error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ExportStmt.java
@@ -303,12 +303,11 @@ public class ExportStmt extends StatementBase {
         this.columnSeparator = Delimiter.convertDelimiter(this.columnSeparator);
         this.rowDelimiter = PropertyAnalyzer.analyzeRowDelimiter(properties, ExportStmt.DEFAULT_LINE_DELIMITER);
         this.rowDelimiter = Delimiter.convertDelimiter(this.rowDelimiter);
-        // exec_mem_limit
         if (properties.containsKey(LoadStmt.LOAD_MEM_LIMIT)) {
             try {
                 Long.parseLong(properties.get(LoadStmt.LOAD_MEM_LIMIT));
             } catch (NumberFormatException e) {
-                throw new AnalysisException("Invalid exec_mem_limit value: " + e.getMessage());
+                throw new AnalysisException("Invalid load_mem_limit value: " + e.getMessage());
             }
         } else {
             // use session variables


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For compatibility reasons, we continue to use `load_mem_limit` for export, so update the error message.