### PR TITLE
[cherry-pick][branch-2.3] FORCE_REDUNDANT should also check NEED_FURTHER_REPAIR (#7844)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -418,6 +418,14 @@ public class LocalTablet extends Tablet {
         return tabletRowCount;
     }
 
+    private Pair<TabletStatus, TabletSchedCtx.Priority> createRedundantSchedCtx(
+            TabletStatus status, Priority prio, Replica needFurtherRepairReplica) {
+        if (needFurtherRepairReplica != null) {
+            return Pair.create(TabletStatus.NEED_FURTHER_REPAIR, TabletSchedCtx.Priority.HIGH);
+        }
+        return Pair.create(status, prio);
+    }
+
     /**
      * A replica is healthy only if
      * 1. the backend is available
@@ -452,6 +460,10 @@ public class LocalTablet extends Tablet {
             }
             alive++;
 
+            if (replica.needFurtherRepair() && needFurtherRepairReplica == null) {
+                needFurtherRepairReplica = replica;
+            }
+
             if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
                 // this replica is alive but version incomplete
                 continue;
@@ -469,10 +481,6 @@ public class LocalTablet extends Tablet {
                 continue;
             }
             availableInCluster++;
-
-            if (replica.needFurtherRepair() && needFurtherRepairReplica == null) {
-                needFurtherRepairReplica = replica;
-            }
         }
 
         // 1. alive replicas are not enough
@@ -487,7 +495,8 @@ public class LocalTablet extends Tablet {
             // 2. replicas.size() >= aliveBackendsNum: the existing replicas occupies all available backends
             // 3. aliveBackendsNum >= replicationNum: make sure after deleting, there will be at least one backend for new replica.
             // 4. replicationNum > 1: if replication num is set to 1, do not delete any replica, for safety reason
-            return Pair.create(TabletStatus.FORCE_REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH);
+            return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+                    needFurtherRepairReplica);
         } else if (alive < (replicationNum / 2) + 1) {
             return Pair.create(TabletStatus.REPLICA_MISSING, TabletSchedCtx.Priority.HIGH);
         } else if (alive < replicationNum) {
@@ -500,11 +509,9 @@ public class LocalTablet extends Tablet {
         } else if (aliveAndVersionComplete < replicationNum) {
             return Pair.create(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.NORMAL);
         } else if (aliveAndVersionComplete > replicationNum) {
-            if (needFurtherRepairReplica != null) {
-                return Pair.create(TabletStatus.NEED_FURTHER_REPAIR, TabletSchedCtx.Priority.HIGH);
-            }
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
-            return Pair.create(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH);
+            return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+                    needFurtherRepairReplica);
         }
 
         // 3. replica is under relocating
@@ -517,9 +524,9 @@ public class LocalTablet extends Tablet {
             if (replicaBeIds.containsAll(availableBeIds)
                     && availableBeIds.size() >= replicationNum
                     && replicationNum > 1) { // No BE can be choose to create a new replica
-                return Pair.create(TabletStatus.FORCE_REDUNDANT,
+                return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT,
                         stable < (replicationNum / 2) + 1 ? TabletSchedCtx.Priority.NORMAL :
-                                TabletSchedCtx.Priority.LOW);
+                                TabletSchedCtx.Priority.LOW, needFurtherRepairReplica);
             }
             if (stable < (replicationNum / 2) + 1) {
                 return Pair.create(TabletStatus.REPLICA_RELOCATING, TabletSchedCtx.Priority.NORMAL);
@@ -532,11 +539,9 @@ public class LocalTablet extends Tablet {
         if (availableInCluster < replicationNum) {
             return Pair.create(TabletStatus.REPLICA_MISSING_IN_CLUSTER, TabletSchedCtx.Priority.LOW);
         } else if (replicas.size() > replicationNum) {
-            if (needFurtherRepairReplica != null) {
-                return Pair.create(TabletStatus.NEED_FURTHER_REPAIR, TabletSchedCtx.Priority.HIGH);
-            }
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
-            return Pair.create(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH);
+            return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+                    needFurtherRepairReplica);
         }
 
         // 5. healthy


### PR DESCRIPTION
FORCE_REDUNDANT should also check NEED_FURTHER_REPAIR before dropping a replica,
or else the newly cloned replica with stale version could be
dropped(because the loading process continue updating tablet).

(cherry picked from 80eba32ed4c3c331b82528098e6c9a3bd03b86f5)

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7844

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
