### PR TITLE
[Enhancement] Retry building ImmutableIndexShard if move_bucket failed

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -332,8 +332,7 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_
 
 StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::try_create(size_t kv_size,
                                                                                const std::vector<KVRef>& kv_refs,
-                                                                               size_t npage_hint) {
-    size_t npage = npage_hint;
+                                                                               size_t npage) {
     size_t bucket_size_limit = std::min(bucket_size_max, (page_size - page_header_size) / (kv_size + 1));
     size_t nbucket = npage * bucket_per_page;
     std::vector<uint8_t> bucket_sizes(nbucket);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -31,6 +31,7 @@ constexpr size_t page_size = 4096;
 constexpr size_t page_header_size = 64;
 constexpr size_t bucket_per_page = 16;
 constexpr size_t shard_max = 1 << 16;
+constexpr uint64_t page_max = 1ULL << 32;
 constexpr size_t pack_size = 16;
 constexpr size_t page_pack_limit = (page_size - page_header_size) / pack_size;
 constexpr size_t bucket_size_max = 256;
@@ -149,6 +150,9 @@ struct ImmutableIndexShard {
     }
 
     Status write(WritableFile& wb) const;
+
+    static StatusOr<std::unique_ptr<ImmutableIndexShard>> try_create(size_t kv_size, const std::vector<KVRef>& kv_refs,
+                                                                     size_t npage_hint);
 
     static StatusOr<std::unique_ptr<ImmutableIndexShard>> create(size_t kv_size, const std::vector<KVRef>& kv_refs,
                                                                  size_t npage_hint);
@@ -315,6 +319,20 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_
     if (kv_refs.size() == 0) {
         return std::make_unique<ImmutableIndexShard>(0);
     }
+    for (size_t npage = npage_hint; npage < page_max; npage++) {
+        auto rs_create = ImmutableIndexShard::try_create(kv_size, kv_refs, npage);
+        // increase npage and retry
+        if (!rs_create.ok()) {
+            continue;
+        }
+        return std::move(rs_create.value());
+    }
+    return Status::InternalError("failed to create immutable index shard");
+}
+
+StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::try_create(size_t kv_size,
+                                                                               const std::vector<KVRef>& kv_refs,
+                                                                               size_t npage_hint) {
     size_t npage = npage_hint;
     size_t bucket_size_limit = std::min(bucket_size_max, (page_size - page_header_size) / (kv_size + 1));
     size_t nbucket = npage * bucket_per_page;
@@ -332,7 +350,6 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_
         auto bid = page * bucket_per_page + bucket;
         auto& sz = bucket_sizes[bid];
         if (sz == bucket_size_limit) {
-            // TODO: increase npage and retry
             return Status::InternalError("bucket size limit exceeded");
         }
         sz++;
@@ -396,7 +413,6 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_
             copy_kv_to_page(kv_size, bucket_info.size, bucket_kv_ptrs_tags[bid].first.data(),
                             bucket_kv_ptrs_tags[bid].second.data(), page.pack(cur_packid));
             cur_packid += bucket_packs[bid];
-            //LOG(INFO) << "cur_packid is " << cur_packid;
             DCHECK(cur_packid <= page_size / pack_size);
         }
         for (auto& move : moves) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4774

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, move_bucket may fail even though we find a move solution, and building ImmutableIndex will fail if a shard is very imbalanced. We need to prevent building index failure, when move_bucket failed, we can increase the number of pages and retry, until it works.
