### PR TITLE
[BugFix] bug in Array column's `byte_size`

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -45,7 +45,8 @@ uint8_t* ArrayColumn::mutable_raw_data() {
 
 size_t ArrayColumn::byte_size(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
-    return _elements->byte_size(_offsets->get_data()[from], _offsets->get_data()[from + size]) +
+    return _elements->byte_size(_offsets->get_data()[from],
+                                _offsets->get_data()[from + size] - _offsets->get_data()[from]) +
            _offsets->Column::byte_size(from, size);
 }
 

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -144,6 +144,10 @@ PARALLEL_TEST(ArrayColumnTest, test_byte_size) {
     // offset 0 with 4 bytes.
     ASSERT_EQ(16, column->byte_size(0, 1));
     ASSERT_EQ(16, column->byte_size(0));
+
+    // elements 1 with 12 bytes.
+    // offset 1 with 4 bytes.
+    ASSERT_EQ(16, column->byte_size(1, 1));
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8306

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

_elements->byte_size 's input variables are (from, from + size), it should be (from, size)