### PR TITLE
Remove config entry star_mgr_addr.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,7 +755,6 @@ CONF_Int32(max_batch_publish_latency_ms, "100");
 CONF_String(jaeger_endpoint, "");
 
 #ifdef USE_STAROS
-CONF_String(starmgr_addr, "");
 CONF_Int32(starlet_port, "9070");
 #endif
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -81,7 +81,6 @@ void init_staros_worker() {
     g_worker = std::make_shared<StarOSWorker>();
     g_starlet = new staros::starlet::Starlet(g_worker);
     g_starlet->init(starlet_config);
-    g_starlet->set_star_mgr_addr(config::starmgr_addr);
     g_starlet->start();
 }
 


### PR DESCRIPTION
StarMgr will send heartbeat to BE worker which contains leader starmgr address,
so there is no need add config starmgr addr any more

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
