### PR TITLE
[BugFix][Variables]check null before use sessiioinVar in VariableMgr::dump()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -495,7 +495,7 @@ public class VariableMgr {
 
                 // For session variables, the flag is VariableMgr.SESSION | VariableMgr.INVISIBLE
                 // For global variables, the flag is VariableMgr.GLOBAL | VariableMgr.INVISIBLE
-                if ((ctx.getFlag() > VariableMgr.INVISIBLE) && !sessionVar.isEnableShowAllVariables()) {
+                if ((ctx.getFlag() > VariableMgr.INVISIBLE) && sessionVar != null && !sessionVar.isEnableShowAllVariables()) {
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -495,7 +495,7 @@ public class VariableMgr {
 
                 // For session variables, the flag is VariableMgr.SESSION | VariableMgr.INVISIBLE
                 // For global variables, the flag is VariableMgr.GLOBAL | VariableMgr.INVISIBLE
-                if ((ctx.getFlag() > VariableMgr.INVISIBLE) && sessionVar != null && !sessionVar.isEnableShowAllVariables()) {
+                if (sessionVar == null || ((ctx.getFlag() > VariableMgr.INVISIBLE) && !sessionVar.isEnableShowAllVariables())) {
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -240,7 +240,11 @@ public class VariableMgrTest {
         Assert.assertTrue(vars.toString().contains("cbo_use_correlated_join_estimate"));
 
         vars = VariableMgr.dump(SetType.DEFAULT, null, null);
-        Assert.assertTrue(vars.isEmpty());
+        List<List<String>> vars1 = VariableMgr.dump(SetType.GLOBAL, null, null);
+        Assert.assertTrue(vars.size() < vars1.size());
+
+        List<List<String>> vars2 = VariableMgr.dump(SetType.SESSION, null, null);
+        Assert.assertTrue(vars.size() == vars2.size());
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -238,6 +238,9 @@ public class VariableMgrTest {
         sv.setEnableShowAllVariables(true);
         vars = VariableMgr.dump(SetType.DEFAULT, sv, null);
         Assert.assertTrue(vars.toString().contains("cbo_use_correlated_join_estimate"));
+
+        vars = VariableMgr.dump(SetType.DEFAULT, null, null);
+        Assert.assertTrue(vars.isEmpty());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/8296

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`sessionVar` is used directly but maybe null, so check it first to avoid NPE.
