### PR TITLE
[Enhancement] choose src replica with bigger version first when cloning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -546,6 +546,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             throw new SchedException(Status.UNRECOVERABLE, "unable to find source replica");
         }
 
+        // Sort the candidates by version in desc order, so that replica with higher version
+        // can be used as clone source first.
+        candidates.sort((c1, c2) -> (int) (c2.getVersion() - c1.getVersion()));
+
         // choose a replica which slot is available from candidates.
         for (Replica srcReplica : candidates) {
             PathSlot slot = backendsWorkingSlots.get(srcReplica.getBackendId());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8345 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

this pr https://github.com/StarRocks/starrocks/pull/6271 has change the clone logic when caculating missing versions with src BE.

This refactor changes the whole clone process for the primary tablet, dest replica BE does not use FE's snapshot_version anymore, instead, it calculates all the missing version ranges, and sends them to src replica BE as a new make_snapshot parameter.

So when scheduling, we also need to choose a src replica with biggest version.
