### PR TITLE
[Enhance] allow simple limit sql exceed bigquery_scan_rows_limit

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -288,6 +288,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
     std::vector<ExecNode*> scan_nodes;
     plan->collect_scan_nodes(&scan_nodes);
 
+    int64_t sum_limit = 0;
+    int64_t underlying_scan_limit = 0;
     MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
     for (auto& i : scan_nodes) {
         auto* scan_node = down_cast<ScanNode*>(i);
@@ -301,6 +303,21 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
 
         if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
             olap_scan->enable_shared_scan(enable_shared_scan);
+        }
+        if (scan_node->limit() > 0) {
+            sum_limit += scan_node->limit();
+            int parallelism = dop * ScanOperator::MAX_IO_TASKS_PER_OP;
+            underlying_scan_limit += scan_node->limit() * parallelism;
+        }
+    }
+
+    if (_wg && _wg->big_query_scan_rows_limit() > 0) {
+        // For SQL like: select * from xxx limit 5, the underlying scan_limit should be 5 * parallelism
+        // Otherwise this SQL would exceed the bigquery_rows_limit due to underlying IO parallelization
+        if (sum_limit <= _wg->big_query_scan_rows_limit()) {
+            _query_ctx->set_scan_limit(underlying_scan_limit);
+        } else {
+            _query_ctx->set_scan_limit(_wg->big_query_scan_rows_limit());
         }
     }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -288,8 +288,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
     std::vector<ExecNode*> scan_nodes;
     plan->collect_scan_nodes(&scan_nodes);
 
-    int64_t sum_limit = 0;
-    int64_t underlying_scan_limit = 0;
+    int64_t sum_scan_limit = 0;
     MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
     for (auto& i : scan_nodes) {
         auto* scan_node = down_cast<ScanNode*>(i);
@@ -305,17 +304,17 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
             olap_scan->enable_shared_scan(enable_shared_scan);
         }
         if (scan_node->limit() > 0) {
-            sum_limit += scan_node->limit();
-            int parallelism = dop * ScanOperator::MAX_IO_TASKS_PER_OP;
-            underlying_scan_limit += scan_node->limit() * parallelism;
+            sum_scan_limit += scan_node->limit();
         }
     }
 
     if (_wg && _wg->big_query_scan_rows_limit() > 0) {
         // For SQL like: select * from xxx limit 5, the underlying scan_limit should be 5 * parallelism
         // Otherwise this SQL would exceed the bigquery_rows_limit due to underlying IO parallelization
-        if (sum_limit <= _wg->big_query_scan_rows_limit()) {
-            _query_ctx->set_scan_limit(underlying_scan_limit);
+        if (sum_scan_limit <= _wg->big_query_scan_rows_limit()) {
+            int parallelism = dop * ScanOperator::MAX_IO_TASKS_PER_OP;
+            int64_t parallel_scan_limit = sum_scan_limit * parallelism;
+            _query_ctx->set_scan_limit(parallel_scan_limit);
         } else {
             _query_ctx->set_scan_limit(_wg->big_query_scan_rows_limit());
         }

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -113,6 +113,9 @@ public:
     int64_t query_begin_time() const { return _query_begin_time; }
     void init_query_begin_time() { _query_begin_time = MonotonicNanos(); }
 
+    void set_scan_limit(int64_t scan_limit) { _scan_limit = scan_limit; }
+    int64_t get_scan_limit() const { return _scan_limit; }
+
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
 
@@ -140,6 +143,7 @@ private:
     std::atomic<int64_t> _cur_scan_rows_num = 0;
     std::atomic<int64_t> _cur_scan_bytes = 0;
 
+    int64_t _scan_limit = 0;
     int64_t _init_wg_cpu_cost = 0;
 };
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -15,6 +15,8 @@ namespace pipeline {
 
 class ScanOperator : public SourceOperator {
 public:
+    static constexpr int MAX_IO_TASKS_PER_OP = 4;
+
     ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
                  std::atomic<int>& num_committed_scan_tasks);
 
@@ -56,7 +58,6 @@ public:
     virtual size_t max_scan_concurrency() const { return 0; }
 
 protected:
-    static constexpr int MAX_IO_TASKS_PER_OP = 4;
     const size_t _buffer_size = config::pipeline_io_buffer_size;
 
     // Shared scan

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -354,7 +354,9 @@ Status WorkGroup::check_big_query(const QueryContext& query_context) {
     }
 
     // Check scan rows number
-    if (_big_query_scan_rows_limit && query_context.cur_scan_rows_num() > _big_query_scan_rows_limit) {
+    int64_t bigquery_scan_limit =
+            query_context.get_scan_limit() > 0 ? query_context.get_scan_limit() : _big_query_scan_rows_limit;
+    if (_big_query_scan_rows_limit && query_context.cur_scan_rows_num() > bigquery_scan_limit) {
         _bigquery_count++;
         return Status::Cancelled(fmt::format("exceed big query scan_rows limit: current is {} but limit is {}",
                                              query_context.cur_scan_rows_num(), _big_query_scan_rows_limit));

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -270,7 +270,6 @@ void PipeLineFileScanNodeTest::execute_pipeline() {
 
 void PipeLineFileScanNodeTest::generate_morse_queue(std::vector<starrocks::vectorized::ConnectorScanNode*> scan_nodes,
                                                     std::vector<TScanRangeParams> scan_ranges) {
-    TExecPlanFragmentParams request;
     std::vector<TScanRangeParams> no_scan_ranges;
     MorselQueueFactoryMap& morsel_queue_factories = _fragment_ctx->morsel_queue_factories();
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For resource group which limit `big_query_scan_rows_limit = 5`, the SQL `select * from xxx limit 4` may exceed the `scan_rows_limit`, since the physical IO Tasks are concurrent executed and scan more rows than limited.

As a solution, we modify the limitation strategy:
- Use `sum_scan_limit` as summary of all `ScanNode`'s limit
- Use `underlying_scan_limit` as physical scan limit, which multiply the parallelism 
- So the real limitation consider the parallelism, if `sum_scan_limit` is less equal than the resource group's `big_query_scan_rows_limit`
