### PR TITLE
[Bugfix] Fix wrong has_null properties when load parquet files

### DIFF
--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -233,7 +233,7 @@ Status ParquetScanner::convert_array_to_column(ConvertFunc conv_func, size_t num
         auto nullable_column = down_cast<NullableColumn*>(column.get());
         auto null_column = nullable_column->mutable_null_column();
         size_t null_count = fill_null_column(array, _batch_start_idx, num_elements, null_column, _chunk_start_idx);
-        nullable_column->set_has_null(null_count != 0);
+        nullable_column->set_has_null(nullable_column->has_null() || null_count != 0);
         null_data = &null_column->get_data().front() + _chunk_start_idx;
         data_column = nullable_column->data_column().get();
     } else {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
fix issue like this:
```
    @          0xb81692d  google::LogMessage::Fail()
    @          0xb818d9f  google::LogMessage::SendToLog()
    @          0xb81647e  google::LogMessage::Flush()
    @          0xb8193a9  google::LogMessageFatal::~LogMessageFatal()
    @          0x73ccd26  starrocks::vectorized::NullableColumn::check_or_die()
    @          0x738b86e  starrocks::vectorized::Chunk::check_or_die()
    @          0x7386e92  starrocks::vectorized::Chunk::append_column()
    @          0x887dbf3  starrocks::vectorized::ParquetScanner::finalize_src_chunk()
    @          0x8881414  starrocks::vectorized::ParquetScanner::get_next()
    @          0x7d95f7b  starrocks::vectorized::FileScanNode::_scanner_scan()
    @          0x7d970b6  starrocks::vectorized::FileScanNode::_scanner_worker()
    @          0x7d9feef  std::__invoke_impl<>()
    @          0x7d9fc7c  std::__invoke<>()
    @          0x7d9fb73  _ZNSt6thread8_InvokerISt5tupleIJMN9starrocks10vectorized12FileScanNodeEFviiEPS4_imEEE9_M_invokeIJLm0ELm1ELm2ELm3EEEEvSt12_Index_tupleIJXspT_EEE
    @          0x7d9faf4  std::thread::_Invoker<>::operator()()
    @          0x7d9fad8  std::thread::_State_impl<>::_M_run()
    @          0xd402390  execute_native_thread_routine
    @     0x7f554fe6eea5  start_thread
    @     0x7f554f4898dd  __clone
    @              (nil)  (unknown)
```
