### PR TITLE
[BugFix] Fix unstable attribute of is_pipeline_level_shuffle

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -284,7 +284,6 @@ ExchangeSinkOperator::ExchangeSinkOperator(OperatorFactory* factory, int32_t id,
           _buffer(buffer),
           _part_type(part_type),
           _destinations(destinations),
-          _is_pipeline_level_shuffle(is_pipeline_level_shuffle),
           _num_shuffles_per_channel(num_shuffles_per_channel > 0 ? num_shuffles_per_channel : 1),
           _sender_id(sender_id),
           _dest_node_id(dest_node_id),
@@ -332,6 +331,8 @@ ExchangeSinkOperator::ExchangeSinkOperator(OperatorFactory* factory, int32_t id,
         }
     }
     _num_shuffles = _channels.size() * _num_shuffles_per_channel;
+
+    _is_pipeline_level_shuffle = is_pipeline_level_shuffle && (_num_shuffles > 1);
 }
 
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -83,7 +83,7 @@ private:
     const std::vector<TPlanFragmentDestination> _destinations;
     // If the pipeline of dest be is ExchangeSourceOperator -> AggregateBlockingSinkOperator(with group by)
     // then we shuffle for different parallelism at sender side(ExchangeSinkOperator) if _is_pipeline_level_shuffle is true
-    const bool _is_pipeline_level_shuffle;
+    bool _is_pipeline_level_shuffle;
     // Degree of pipeline level shuffle
     // - If _is_pipeline_level_shuffle is false, it is set to 1.
     // - If _is_pipeline_level_shuffle is true,

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -460,8 +460,11 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
     ChunkQueue chunks;
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
+    bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+    // If _is_pipeline_level_shuffle is already set to true, then it will never go back to false
+    DCHECK(!prev_is_pipeline_level_shuffle || _is_pipeline_level_shuffle);
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;
@@ -588,8 +591,11 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
     ChunkQueue local_chunk_queue;
+    bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+    // If _is_pipeline_level_shuffle is already set to true, then it will never go back to false
+    DCHECK(!prev_is_pipeline_level_shuffle || _is_pipeline_level_shuffle);
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

if `_num_shuffles == 1`, then sink operator works in `UNPARTITION` mode
* if local pass through is enabled, then `ExchangeSinkOperator::Channel::send_one_chunk` will be invoked, and the `ExchangeSinkOperator::Channel::_chunk_request` will set `is_pipeline_level_shuffle` to true
    ```cpp
        for (auto idx : _channel_indices) {
            if (_channels[idx]->use_pass_through()) {
                RETURN_IF_ERROR(_channels[idx]->send_one_chunk(send_chunk, DEFAULT_DRIVER_SEQUENCE, false));
            } else {
                has_not_pass_through = true;
            }
        }
    ```
* when sink operator finishing execution, `ExchangeSinkOperator::set_finishing`, the `ExchangeSinkOperator::_chunk_request` will not set `is_pipeline_level_shuffle` to true (the default is false)
    ```cpp
    Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
        _is_finished = true;

        if (_chunk_request != nullptr) {
            butil::IOBuf attachment;
            construct_brpc_attachment(_chunk_request, attachment);
            for (const auto& [_, channel] : _instance_id2channel) {
                PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
                channel->send_chunk_request(copy, attachment);
            }
            _current_request_bytes = 0;
            _chunk_request.reset();
        }

        for (auto& [_, channel] : _instance_id2channel) {
            channel->close(state, _fragment_ctx);
        }

        _buffer->set_finishing();
        return Status::OK();
    }
    ```

Since the pipeline level shuffle will be applied only when `_num_shuffles > 1`, so we can init `_is_pipeline_level_shuffle` both considering the ctor's param `is_pipeline_level_shuffle` and `_num_shuffles`