### PR TITLE
Fix the wrong ScanTime metric

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -126,7 +126,6 @@ Status HdfsScanner::_build_scanner_context() {
 
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     RETURN_IF_CANCELLED(_runtime_state);
-    SCOPED_RAW_TIMER(&_stats.scan_ns);
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
         if (!_conjunct_ctxs.empty()) {
@@ -221,9 +220,7 @@ void HdfsScanner::update_counter() {
 
     update_hdfs_counter(profile);
 
-    COUNTER_UPDATE(profile->scan_timer, _stats.scan_ns);
     COUNTER_UPDATE(profile->reader_init_timer, _stats.reader_init_ns);
-
     COUNTER_UPDATE(profile->rows_read_counter, _stats.raw_rows_read);
     COUNTER_UPDATE(profile->bytes_read_counter, _stats.bytes_read);
     COUNTER_UPDATE(profile->expr_filter_timer, _stats.expr_filter_ns);

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -21,7 +21,6 @@ namespace starrocks::vectorized {
 class RuntimeFilterProbeCollector;
 
 struct HdfsScanStats {
-    int64_t scan_ns = 0;
     int64_t raw_rows_read = 0;
     int64_t num_rows_read = 0;
     int64_t expr_filter_ns = 0;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
the metric ScanTime is double-counted with [HiveDataSource::get_next](https://github.com/StarRocks/starrocks/blob/main/be/src/connector/hive_connector.cpp#L277)


