### PR TITLE
[Bugfix] use correct mem_tracker for exchange/result sink

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -218,7 +218,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, std::function<vo
             return;
         }
 
-        TransmitChunkInfo request = buffer.front();
+        TransmitChunkInfo& request = buffer.front();
         bool need_wait = false;
         DeferOp pop_defer([&need_wait, &buffer]() {
             if (need_wait) {
@@ -273,7 +273,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, std::function<vo
         }
 
         auto* closure = new DisposableClosure<PTransmitChunkResult, ClosureContext>(
-                {instance_id, request.params->sequence(), GetCurrentTimeNanos()});
+                {instance_id, request.params->sequence(), GetCurrentTimeNanos()}, _mem_tracker);
 
         closure->addFailedHandler([this](const ClosureContext& ctx) noexcept {
             _is_finishing = true;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -109,7 +109,7 @@ private:
     int64_t _network_time();
 
     FragmentContext* _fragment_ctx;
-    const MemTracker* _mem_tracker;
+    MemTracker* const _mem_tracker;
     const int32_t _brpc_timeout_ms;
     const bool _is_dest_merge;
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -72,13 +72,23 @@ StatusOr<vectorized::ChunkPtr> ResultSinkOperator::pull_chunk(RuntimeState* stat
     return Status::InternalError("Shouldn't pull chunk from result sink operator");
 }
 
+Status ResultSinkOperator::set_cancelled(RuntimeState* state) {
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+
+    _fetch_data_result.clear();
+    return Status::OK();
+}
+
 bool ResultSinkOperator::need_input() const {
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+
     if (is_finished()) {
         return false;
     }
     if (_fetch_data_result.empty()) {
         return true;
     }
+
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
     auto status = mysql_writer->try_add_batch(_fetch_data_result);
     if (status.ok()) {
@@ -90,10 +100,20 @@ bool ResultSinkOperator::need_input() const {
 }
 
 Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    // The ResultWriter memory that sends the results is no longer recorded to the query memory.
+    // There are two reason:
+    // 1. the query result has come out, and then the memory limit is triggered, cancel, it is not necessary
+    // 2. if this memory is counted, The memory of the receiving thread needs to be recorded,
+    // and the life cycle of MemTracker needs to be considered
+    //
+    // All the places where acquire and release memory of _fetch_data_result must use process_mem_tracker.
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+
     if (!_last_error.ok()) {
         return _last_error;
     }
     DCHECK(_fetch_data_result.empty());
+
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
     auto status = mysql_writer->process_chunk_for_pipeline(chunk.get());
     if (status.ok()) {
@@ -120,4 +140,5 @@ void ResultSinkOperatorFactory::close(RuntimeState* state) {
     Expr::close(_output_expr_ctxs, state);
     OperatorFactory::close(state);
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -48,6 +48,8 @@ public:
         return Status::OK();
     }
 
+    Status set_cancelled(RuntimeState* state) override;
+
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are some places where acquiring and releasing memory use different memory tracker, which causes query_mem_tracker cannot be decremented as expected.
- ExchangeSinkOperator
    - Construct requests in driver thread (`pull_chunk`).
    - Release requests when deleting `Controller` in `DisposableClosure::Run()` in bthread.
- ResultSinkOperator
    - Construct request in driver thread (`push_chunk`).
    - Release request maybe in driver thread (`push_chunk` and `need_input`) or `fetch_data` RPC handler in bthread.

Therefore,
- ExchangeSinkOperator
    - Use instance mem tracker for releasing requests when deleting `Controller` in `DisposableClosure::Run()` in bthread.
- ResultSinkOperator
    - Use process mem tracker in `push_chunk` and `need_input`.



