### PR TITLE
[Feature] Support prepare transaction stream load interface

### DIFF
--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -15,6 +15,7 @@ namespace starrocks {
 class ExecEnv;
 class Status;
 class StreamLoadContext;
+class TStreamLoadPutRequest;
 
 class TransactionManagerAction : public HttpHandler {
 public:
@@ -46,6 +47,7 @@ private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _exec_plan_fragment(HttpRequest* http_req, StreamLoadContext* ctx);
     void _send_error_reply(HttpRequest* req, Status st);
+    Status _parse_request(HttpRequest* http_req, StreamLoadContext* ctx, TStreamLoadPutRequest& request);
 
     ExecEnv* _exec_env;
 };

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -57,7 +57,7 @@ std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Sta
             writer.Int64(txn_id);
             writer.Key("BeginTxnTimeMs");
             writer.Int64(begin_txn_cost_nanos / 1000000);
-        } else if (boost::iequals(txn_op, TXN_COMMIT)) {
+        } else if (boost::iequals(txn_op, TXN_COMMIT) || boost::iequals(txn_op, TXN_PREPARE)) {
             // txn id
             writer.Key("TxnId");
             writer.Int64(txn_id);
@@ -71,10 +71,10 @@ std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Sta
             writer.Key("NumberUnselectedRows");
             writer.Int64(number_unselected_rows);
             writer.Key("LoadBytes");
-            writer.Int64(receive_bytes);
+            writer.Int64(total_receive_bytes);
             writer.Key("LoadTimeMs");
             writer.Int64(load_cost_nanos / 1000000);
-            writer.Key("StreamLoadPutTimeMs");
+            writer.Key("StreamLoadPlanTimeMs");
             writer.Int64(stream_load_put_cost_nanos / 1000000);
             writer.Key("ReceivedDataTimeMs");
             writer.Int64(total_received_data_cost_nanos / 1000000);
@@ -90,7 +90,7 @@ std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Sta
             // number_load_rows
             writer.Key("LoadBytes");
             writer.Int64(receive_bytes);
-            writer.Key("StreamLoadPutTimeMs");
+            writer.Key("StreamLoadPlanTimeMs");
             writer.Int64(stream_load_put_cost_nanos / 1000000);
             writer.Key("ReceivedDataTimeMs");
             writer.Int64(received_data_cost_nanos / 1000000);
@@ -158,7 +158,7 @@ std::string StreamLoadContext::to_json() const {
     writer.Int64(load_cost_nanos / 1000000);
     writer.Key("BeginTxnTimeMs");
     writer.Int64(begin_txn_cost_nanos / 1000000);
-    writer.Key("StreamLoadPutTimeMs");
+    writer.Key("StreamLoadPlanTimeMs");
     writer.Int64(stream_load_put_cost_nanos / 1000000);
     writer.Key("ReadDataTimeMs");
     writer.Int64(total_received_data_cost_nanos / 1000000);

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -80,6 +80,7 @@ class MessageBodySink;
 
 const std::string TXN_BEGIN = "begin";
 const std::string TXN_COMMIT = "commit";
+const std::string TXN_PREPARE = "prepare";
 const std::string TXN_ROLLBACK = "rollback";
 const std::string TXN_LOAD = "load";
 const std::string TXN_LIST = "list";
@@ -150,6 +151,7 @@ public:
     // only used to check if we receive whole body
     size_t body_bytes = 0;
     size_t receive_bytes = 0;
+    size_t total_receive_bytes = 0;
 
     // when use_streaming is true, we use stream_pipe to send source data,
     // otherwise we save source data to file first, then process it.
@@ -202,6 +204,8 @@ public:
     // max buffer size for JSON format is 4GB.
     static constexpr int64_t kJSONMaxBufferSize = 4294967296;
     ByteBufferPtr buffer = nullptr;
+
+    TStreamLoadPutRequest request;
 
 public:
     ExecEnv* exec_env() { return _exec_env; }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -219,6 +219,48 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
     return Status::OK();
 }
 
+Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
+    StarRocksMetrics::instance()->txn_commit_request_total.increment(1);
+
+    TLoadTxnCommitRequest request;
+    set_request_auth(&request, ctx->auth);
+    request.db = ctx->db;
+    request.tbl = ctx->table;
+    request.txnId = ctx->txn_id;
+    request.sync = true;
+    request.commitInfos = std::move(ctx->commit_infos);
+    request.__isset.commitInfos = true;
+    request.__set_thrift_rpc_timeout_ms(config::txn_commit_rpc_timeout_ms);
+
+    // set attachment if has
+    TTxnCommitAttachment attachment;
+    if (collect_load_stat(ctx, &attachment)) {
+        request.txnCommitAttachment = attachment;
+        request.__isset.txnCommitAttachment = true;
+    }
+
+    TNetworkAddress master_addr = get_master_address();
+    TLoadTxnCommitResult result;
+#ifndef BE_TEST
+    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&request, &result](FrontendServiceConnection& client) { client->loadTxnPrepare(result, request); },
+            config::txn_commit_rpc_timeout_ms));
+#else
+    result = k_stream_load_commit_result;
+#endif
+    // Return if this transaction is prepare successful; otherwise, we need try
+    // to rollback this transaction.
+    Status status(result.status);
+    if (!status.ok()) {
+        LOG(WARNING) << "prepare transaction failed, errmsg=" << status.get_error_msg() << ctx->brief();
+        return status;
+    }
+    // commit success, set need_rollback to false
+    ctx->need_rollback = false;
+    return Status::OK();
+}
+
 Status StreamLoadExecutor::rollback_txn(StreamLoadContext* ctx) {
     StarRocksMetrics::instance()->txn_rollback_request_total.increment(1);
 

--- a/be/src/runtime/stream_load/stream_load_executor.h
+++ b/be/src/runtime/stream_load/stream_load_executor.h
@@ -36,6 +36,8 @@ public:
 
     Status commit_txn(StreamLoadContext* ctx);
 
+    Status prepare_txn(StreamLoadContext* ctx);
+
     Status rollback_txn(StreamLoadContext* ctx);
 
     Status execute_plan_fragment(StreamLoadContext* ctx);

--- a/be/src/runtime/stream_load/transaction_mgr.h
+++ b/be/src/runtime/stream_load/transaction_mgr.h
@@ -92,7 +92,7 @@ public:
     Status list_transactions(const HttpRequest* req, std::string* resp);
 
     Status _begin_transaction(const HttpRequest* http_req, StreamLoadContext* ctx);
-    Status _commit_transaction(StreamLoadContext* ctx);
+    Status _commit_transaction(StreamLoadContext* ctx, bool prepare);
     Status _rollback_transaction(StreamLoadContext* ctx);
 
     std::string _build_reply(const std::string& txn_op, StreamLoadContext* ctx);

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -75,6 +75,9 @@ Status HttpServiceBE::start() {
     // BeginTrasaction:     POST /api/transaction/begin
     // CommitTransaction:   POST /api/transaction/commit
     // RollbackTransaction: POST /api/transaction/rollback
+    // PrepreTransaction:   POST /api/transaction/prepare
+    //
+    // ListTransactions:    POST /api/transaction/list
     TransactionManagerAction* transaction_manager_action = new TransactionManagerAction(_env);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/transaction/{txn_op}", transaction_manager_action);
     _http_handlers.emplace_back(transaction_manager_action);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -648,6 +648,12 @@ public class Config extends ConfigBase {
     public static int max_stream_load_timeout_second = 259200; // 3days
 
     /**
+     * Default prepared transaction timeout
+     */
+    @ConfField(mutable = true)
+    public static int prepared_transaction_default_timeout_second = 86400; // 1day
+
+    /**
      * Max load timeout applicable to all type of load except for stream load
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -114,6 +114,10 @@ public class HttpServer {
         registerActions();
     }
 
+    public ActionController getController() {
+        return controller;
+    }
+
     private void registerActions() throws IllegalArgException {
         // add rest action
         LoadAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionResult.java
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.http.rest;
+
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.Map;
+
+public class TransactionResult extends RestBaseResult {
+    private Map<String, Object> resultMap = Maps.newHashMap();
+
+    public TransactionResult() {
+        status = ActionStatus.OK;
+        msg = "";
+    }
+
+    public void addResultEntry(String key, Object value) {
+        resultMap.put(key, value);
+    }
+
+    public String toJson() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        addResultEntry("Status", status);
+        addResultEntry("Message", msg);
+        return gson.toJson(resultMap);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -982,8 +982,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (Strings.isNullOrEmpty(cluster)) {
             cluster = SystemInfoService.DEFAULT_CLUSTER;
         }
+
         if (request.isSetAuth_code()) {
-            // TODO(cmy): find a way to check
+            // TODO: find a way to check
         } else {
             checkPasswordAndPrivs(cluster, request.getUser(), request.getPasswd(), request.getDb(),
                     request.getTbl(), request.getUser_ip(), PrivPredicate.LOAD);
@@ -1052,6 +1053,70 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     @Override
+    public TLoadTxnCommitResult loadTxnPrepare(TLoadTxnCommitRequest request) throws TException {
+        String clientAddr = getClientAddrAsString();
+        LOG.info("receive txn prepare request. db: {}, tbl: {}, txn_id: {}, backend: {}",
+                request.getDb(), request.getTbl(), request.getTxnId(), clientAddr);
+        LOG.debug("txn prepare request: {}", request);
+
+        TLoadTxnCommitResult result = new TLoadTxnCommitResult();
+        // if current node is not master, reject the request
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master"));
+            result.setStatus(status);
+            return result;
+        }
+
+        TStatus status = new TStatus(TStatusCode.OK);
+        result.setStatus(status);
+        try {
+            loadTxnPrepareImpl(request);
+        } catch (UserException e) {
+            LOG.warn("failed to prepare txn_id: {}: {}", request.getTxnId(), e.getMessage());
+            status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
+            status.addToError_msgs(e.getMessage());
+        } catch (Throwable e) {
+            LOG.warn("catch unknown result.", e);
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs(Strings.nullToEmpty(e.getMessage()));
+            return result;
+        }
+        return result;
+    }
+
+    private void loadTxnPrepareImpl(TLoadTxnCommitRequest request) throws UserException {
+        String cluster = request.getCluster();
+        if (Strings.isNullOrEmpty(cluster)) {
+            cluster = SystemInfoService.DEFAULT_CLUSTER;
+        }
+
+        if (request.isSetAuth_code()) {
+            // TODO: find a way to check
+        } else {
+            checkPasswordAndPrivs(cluster, request.getUser(), request.getPasswd(), request.getDb(),
+                    request.getTbl(), request.getUser_ip(), PrivPredicate.LOAD);
+        }
+
+        // get database
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        String fullDbName = ClusterNamespace.getFullName(request.getDb());
+        Database db = globalStateMgr.getDb(fullDbName);
+        if (db == null) {
+            String dbName = fullDbName;
+            if (Strings.isNullOrEmpty(request.getCluster())) {
+                dbName = request.getDb();
+            }
+            throw new UserException("unknown database, database=" + dbName);
+        }
+        TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);
+        GlobalStateMgr.getCurrentGlobalTransactionMgr().prepareTransaction(
+                db.getId(), request.getTxnId(),
+                TabletCommitInfo.fromThrift(request.getCommitInfos()),
+                attachment);
+    }
+
+    @Override
     public TLoadTxnRollbackResult loadTxnRollback(TLoadTxnRollbackRequest request) throws TException {
         String clientAddr = getClientAddrAsString();
         LOG.info("receive txn rollback request. db: {}, tbl: {}, txn_id: {}, reason: {}, backend: {}",
@@ -1096,7 +1161,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         if (request.isSetAuth_code()) {
-            // TODO(cmy): find a way to check
+            // TODO: find a way to check
         } else {
             checkPasswordAndPrivs(cluster, request.getUser(), request.getPasswd(), request.getDb(),
                     request.getTbl(), request.getUser_ip(), PrivPredicate.LOAD);

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -248,6 +248,10 @@ public class ComputeNode implements IComputable, Writable {
         return this.isAlive.get();
     }
 
+    public void setIsAlive(boolean isAlive) {
+        this.isAlive.set(isAlive);
+    }
+
     public boolean isDecommissioned() {
         return this.isDecommissioned.get();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -170,6 +170,17 @@ public class SystemInfoService {
     }
 
     // for test
+    public void dropBackend(Backend backend) {
+        Map<Long, Backend> copiedBackends = Maps.newHashMap(idToBackendRef);
+        copiedBackends.remove(backend.getId());
+        idToBackendRef = ImmutableMap.copyOf(copiedBackends);
+
+        Map<Long, AtomicLong> copiedReportVerions = Maps.newHashMap(idToReportVersionRef);
+        copiedReportVerions.remove(backend.getId());
+        idToReportVersionRef = ImmutableMap.copyOf(copiedReportVerions);
+    }
+
+    // for test
     public void addBackend(Backend backend) {
         Map<Long, Backend> copiedBackends = Maps.newHashMap(idToBackendRef);
         copiedBackends.put(backend.getId(), backend);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -74,8 +74,10 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -470,6 +472,201 @@ public class DatabaseTransactionMgr {
         LOG.info("transaction:[{}] successfully committed", transactionState);
     }
 
+    /**
+     * pre commit transaction process as follows:
+     * 1. validate whether `Load` is cancelled
+     * 2. validate whether `Table` is deleted
+     * 3. validate replicas consistency
+     * 4. persistent transactionState
+     */
+    public void prepareTransaction(long transactionId, List<TabletCommitInfo> tabletCommitInfos,
+                                  TxnCommitAttachment txnCommitAttachment)
+            throws UserException {
+        // 1. check status
+        // the caller method already own db lock, we do not obtain db lock here
+        Database db = globalStateMgr.getDb(dbId);
+        if (null == db) {
+            throw new MetaNotFoundException("could not find db [" + dbId + "]");
+        }
+
+        TransactionState transactionState;
+        readLock();
+        try {
+            transactionState = unprotectedGetTransactionState(transactionId);
+        } finally {
+            readUnlock();
+        }
+        if (transactionState == null) {
+            throw new TransactionCommitFailedException("transaction not found");
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
+            throw new TransactionCommitFailedException(transactionState.getReason());
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
+            LOG.debug("transaction is already visible: {}", transactionId);
+            return;
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
+            LOG.debug("transaction is already committed: {}", transactionId);
+            return;
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.PREPARED) {
+            LOG.debug("transaction is already prepared: {}", transactionId);
+            return;
+        }
+        // For compatible reason, the default behavior of empty load is still returning "all partitions have no load data" and abort transaction.
+        if (Config.empty_load_as_error && (tabletCommitInfos == null || tabletCommitInfos.isEmpty())) {
+            throw new TransactionCommitFailedException(TransactionCommitFailedException.NO_DATA_TO_LOAD_MSG);
+        }
+
+        // update transaction state extra if exists
+        if (txnCommitAttachment != null) {
+            transactionState.setTxnCommitAttachment(txnCommitAttachment);
+        }
+
+        Span txnSpan = transactionState.getTxnSpan();
+        txnSpan.setAttribute("db", db.getFullName());
+        StringBuilder tableListString = new StringBuilder();
+        txnSpan.addEvent("pre_commit_start");
+
+        if (transactionState.getTableIdList().isEmpty()) {
+            // Defensive programming, there have been instances where the upper layer caller forgot to set tableIdList.
+            Set<Long> tableSet = Sets.newHashSet();
+            List<Long> tabletIds = tabletCommitInfos.stream().map(TabletCommitInfo::getTabletId).collect(Collectors.toList());
+            List<TabletMeta> tabletMetaList = globalStateMgr.getTabletInvertedIndex().getTabletMetaList(tabletIds);
+            for (TabletMeta meta : tabletMetaList) {
+                if (meta != TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                    tableSet.add(meta.getTableId());
+                }
+            }
+            transactionState.setTableIdList(Lists.newArrayList(tableSet));
+        }
+
+        List<TransactionStateListener> stateListeners = Lists.newArrayList();
+        for (Long tableId : transactionState.getTableIdList()) {
+            Table table = db.getTable(tableId);
+            if (table == null) {
+                // this can happen when tableId == -1 (tablet being dropping)
+                // or table really not exist.
+                continue;
+            }
+            TransactionStateListener listener = stateListenerFactory.create(this, table);
+            if (listener == null) {
+                throw new TransactionCommitFailedException(table.getName() + " does not support write");
+            }
+            listener.preCommit(transactionState, tabletCommitInfos);
+            if (tableListString.length() != 0) {
+                tableListString.append(',');
+            }
+            tableListString.append(table.getName());
+            stateListeners.add(listener);
+        }
+
+        txnSpan.setAttribute("tables", tableListString.toString());
+
+        Span unprotectedCommitSpan = TraceManager.startSpan("unprotectedPreparedTransaction", txnSpan);
+
+        writeLock();
+        try {
+            unprotectedPrepareTransaction(transactionState, stateListeners);
+        } finally {
+            writeUnlock();
+            int numPartitions = 0;
+            for (Map.Entry<Long, TableCommitInfo> entry : transactionState.getIdToTableCommitInfos().entrySet()) {
+                numPartitions += entry.getValue().getIdToPartitionCommitInfo().size();
+            }
+            txnSpan.setAttribute("num_partition", numPartitions);
+            unprotectedCommitSpan.end();
+        }
+
+        LOG.info("transaction:[{}] successfully prepare", transactionState);
+    }
+
+    public void commitPreparedTransaction(long transactionId)
+            throws UserException {
+        // 1. check status
+        // the caller method already own db lock, we do not obtain db lock here
+        Database db = globalStateMgr.getDb(dbId);
+        if (null == db) {
+            throw new MetaNotFoundException("could not find db [" + dbId + "]");
+        }
+
+        TransactionState transactionState;
+        readLock();
+        try {
+            transactionState = unprotectedGetTransactionState(transactionId);
+        } finally {
+            readUnlock();
+        }
+        if (transactionState == null) {
+            throw new TransactionCommitFailedException("transaction not found");
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
+            throw new TransactionCommitFailedException(transactionState.getReason());
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
+            LOG.debug("transaction is already visible: {}", transactionId);
+            return;
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
+            LOG.debug("transaction is already committed: {}", transactionId);
+            return;
+        }
+
+        Span txnSpan = transactionState.getTxnSpan();
+        txnSpan.setAttribute("db", db.getFullName());
+        StringBuilder tableListString = new StringBuilder();
+        txnSpan.addEvent("commit_start");
+
+        List<TransactionStateListener> stateListeners = Lists.newArrayList();
+        for (Long tableId : transactionState.getTableIdList()) {
+            Table table = db.getTable(tableId);
+            if (table == null) {
+                // this can happen when tableId == -1 (tablet being dropping)
+                // or table really not exist.
+                continue;
+            }
+            if (tableListString.length() != 0) {
+                tableListString.append(',');
+            }
+            tableListString.append(table.getName());
+        }
+
+        txnSpan.setAttribute("tables", tableListString.toString());
+
+        // before state transform
+        TxnStateChangeCallback callback = transactionState.beforeStateTransform(TransactionStatus.COMMITTED);
+        // transaction state transform
+        boolean txnOperated = false;
+
+        Span unprotectedCommitSpan = TraceManager.startSpan("unprotectedCommitPreparedTransaction", txnSpan);
+
+        writeLock();
+        try {
+            unprotectedCommitPreparedTransaction(transactionState, db);
+            txnOperated = true;
+        } finally {
+            writeUnlock();
+            int numPartitions = 0;
+            for (Map.Entry<Long, TableCommitInfo> entry : transactionState.getIdToTableCommitInfos().entrySet()) {
+                numPartitions += entry.getValue().getIdToPartitionCommitInfo().size();
+            }
+            txnSpan.setAttribute("num_partition", numPartitions);
+            unprotectedCommitSpan.end();
+            // after state transform
+            transactionState.afterStateTransform(TransactionStatus.COMMITTED, txnOperated, callback, null);
+        }
+
+        // 6. update nextVersion because of the failure of persistent transaction resulting in error version
+        Span updateCatalogAfterCommittedSpan = TraceManager.startSpan("updateCatalogAfterCommitted", txnSpan);
+        try {
+            updateCatalogAfterCommitted(transactionState, db);
+        } finally {
+            updateCatalogAfterCommittedSpan.end();
+        }
+        LOG.info("transaction:[{}] successfully committed", transactionState);
+    }
+
     public boolean waitTransactionVisible(Database db, long transactionId, long timeoutMillis)
             throws TransactionCommitFailedException {
         TransactionState transactionState = null;
@@ -528,6 +725,25 @@ public class DatabaseTransactionMgr {
             // find the latest txn (which id is largest)
             long maxTxnId = existingTxnIds.stream().max(Comparator.comparingLong(Long::valueOf)).get();
             return unprotectedGetTransactionState(maxTxnId).getTransactionStatus();
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public Long getLabelTxnID(String label) {
+        readLock();
+        try {
+            Set<Long> existingTxnIds = unprotectedGetTxnIdsByLabel(label);
+            if (existingTxnIds == null || existingTxnIds.isEmpty()) {
+                return (long) -1;
+            }
+            // find the latest txn (which id is largest)
+            Optional<Long> v = existingTxnIds.stream().max(Comparator.comparingLong(Long::valueOf));
+            if (v.isPresent()) {
+                return v.get();
+            } else {
+                return (long) -1;
+            }
         } finally {
             readUnlock();
         }
@@ -853,6 +1069,87 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    protected void unprotectedPrepareTransaction(TransactionState transactionState,
+            List<TransactionStateListener> stateListeners) {
+        // transaction state is modified during check if the transaction could committed
+        if (transactionState.getTransactionStatus() != TransactionStatus.PREPARE) {
+            return;
+        }
+        long commitTs = System.currentTimeMillis();
+        transactionState.setCommitTime(commitTs);
+        // update transaction state version
+        transactionState.setTransactionStatus(TransactionStatus.PREPARED);
+
+        for (TransactionStateListener listener : stateListeners) {
+            listener.preWriteCommitLog(transactionState);
+        }
+
+        // persist transactionState
+        unprotectUpsertTransactionState(transactionState, false);
+
+        for (TransactionStateListener listener : stateListeners) {
+            listener.postWriteCommitLog(transactionState);
+        }
+    }
+
+    protected void unprotectedCommitPreparedTransaction(TransactionState transactionState, Database db) {
+        // transaction state is modified during check if the transaction could committed
+        if (transactionState.getTransactionStatus() != TransactionStatus.PREPARED) {
+            return;
+        }
+        // since we send publish order by commit timestamp
+        // so that we need handle timetamp fallback
+        // & same timestamp cause by granularity
+        // The probability of timestamp fallback after FE failover is small
+        // and it is not considered at present
+        long commitTs = System.currentTimeMillis();
+        if (commitTs <= lastCommitTs) {
+            commitTs = lastCommitTs + ++commitTsInc;
+        } else {
+            commitTsInc = 0;
+        }
+        lastCommitTs = commitTs;
+        transactionState.setCommitTime(commitTs);
+        // update transaction state version
+        transactionState.setTransactionStatus(TransactionStatus.COMMITTED);
+
+        Iterator<TableCommitInfo> tableCommitInfoIterator = transactionState.getIdToTableCommitInfos().values().iterator();
+        while (tableCommitInfoIterator.hasNext()) {
+            TableCommitInfo tableCommitInfo = tableCommitInfoIterator.next();
+            long tableId = tableCommitInfo.getTableId();
+            OlapTable table = (OlapTable) db.getTable(tableId);
+            // table maybe dropped between commit and publish, ignore this error
+            if (table == null) {
+                transactionState.removeTable(tableId);
+                LOG.warn("table {} is dropped, skip version check and remove it from transaction state {}",
+                        tableId,
+                        transactionState);
+                continue;
+            }
+            Iterator<PartitionCommitInfo> partitionCommitInfoIterator = tableCommitInfo.getIdToPartitionCommitInfo()
+                    .values().iterator();
+            while (partitionCommitInfoIterator.hasNext()) {
+                PartitionCommitInfo partitionCommitInfo = partitionCommitInfoIterator.next();
+                long partitionId = partitionCommitInfo.getPartitionId();
+                Partition partition = table.getPartition(partitionId);
+                // partition maybe dropped between commit and publish version, ignore this error
+                if (partition == null) {
+                    partitionCommitInfoIterator.remove();
+                    LOG.warn("partition {} is dropped, skip and remove it from transaction state {}",
+                            partitionId,
+                            transactionState);
+                    continue;
+                }
+                partitionCommitInfo.setVersion(partition.getNextVersion());
+                partitionCommitInfo.setVersionTime(commitTs);
+            }
+        }
+
+        // persist transactionState
+        unprotectUpsertTransactionState(transactionState, false);
+
+    }
+
     // for add/update/delete TransactionState
     protected void unprotectUpsertTransactionState(TransactionState transactionState, boolean isReplay) {
         // if this is a replay operation, we should not log it
@@ -929,6 +1226,12 @@ public class DatabaseTransactionMgr {
 
     public void abortTransaction(long transactionId, String reason, TxnCommitAttachment txnCommitAttachment)
             throws UserException {
+        abortTransaction(transactionId, true, reason, txnCommitAttachment);
+    }
+
+    public void abortTransaction(long transactionId, boolean abortPrepared, String reason,
+            TxnCommitAttachment txnCommitAttachment)
+            throws UserException {
         if (transactionId < 0) {
             LOG.info("transaction id is {}, less than 0, maybe this is an old type load job, ignore abort operation",
                     transactionId);
@@ -955,10 +1258,14 @@ public class DatabaseTransactionMgr {
         boolean txnOperated = false;
         writeLock();
         try {
-            txnOperated = unprotectAbortTransaction(transactionId, reason);
+            txnOperated = unprotectAbortTransaction(transactionId, abortPrepared, reason);
         } finally {
             writeUnlock();
             transactionState.afterStateTransform(TransactionStatus.ABORTED, txnOperated, callback, reason);
+        }
+
+        if (txnOperated) {
+            LOG.info("transaction:[{}] successfully rollback", transactionState);
         }
 
         // send clear txn task to BE to clear the transactions on BE.
@@ -971,13 +1278,16 @@ public class DatabaseTransactionMgr {
         }
     }
 
-    private boolean unprotectAbortTransaction(long transactionId, String reason)
+    private boolean unprotectAbortTransaction(long transactionId, boolean abortPrepared, String reason)
             throws UserException {
         TransactionState transactionState = unprotectedGetTransactionState(transactionId);
         if (transactionState == null) {
             throw new TransactionNotFoundException("transaction not found", transactionId);
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
+            return false;
+        }
+        if (transactionState.getTransactionStatus() == TransactionStatus.PREPARED && !abortPrepared) {
             return false;
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED
@@ -990,7 +1300,9 @@ public class DatabaseTransactionMgr {
         transactionState.setTransactionStatus(TransactionStatus.ABORTED);
         unprotectUpsertTransactionState(transactionState, false);
         for (PublishVersionTask task : transactionState.getPublishVersionTasks().values()) {
-            AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
+            if (task != null) {
+                AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
+            }
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -112,6 +112,10 @@ public class PartitionCommitInfo implements Writable {
         return version;
     }
 
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
     public long getVersionTime() {
         return versionTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
@@ -22,7 +22,8 @@ public enum TransactionStatus {
     PREPARE(1),
     COMMITTED(2),
     VISIBLE(3),
-    ABORTED(4);
+    ABORTED(4),
+    PREPARED(5);
 
     private final int flag;
 
@@ -46,6 +47,8 @@ public enum TransactionStatus {
                 return VISIBLE;
             case 4:
                 return ABORTED;
+            case 5:
+                return PREPARED;
             default:
                 return UNKNOWN;
         }
@@ -68,6 +71,8 @@ public enum TransactionStatus {
                 return "VISIBLE";
             case ABORTED:
                 return "ABORTED";
+            case PREPARED:
+                return "PREPARED";
             default:
                 return "UNKNOWN";
         }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -53,6 +53,9 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionStatus;
+
 import junit.framework.AssertionFailedError;
 import mockit.Expectations;
 import mockit.Mock;
@@ -436,6 +439,22 @@ abstract public class StarRocksHttpTestCase {
             TabletInvertedIndex getCurrentInvertedIndex() {
                 return tabletInvertedIndex;
             }
+
+            @Mock
+            GlobalTransactionMgr getCurrentGlobalTransactionMgr() {
+                new MockUp<GlobalTransactionMgr>() {
+                    @Mock
+                    TransactionStatus getLabelState(long dbId, String label) {
+                        if (label == "a") {
+                            return TransactionStatus.PREPARED;
+                        } else {
+                            return TransactionStatus.PREPARE;
+                        }
+                    }
+                };
+
+                return new GlobalTransactionMgr(null);
+            } 
         };
         assignBackends();
         doSetUp();

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -1,0 +1,295 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.http;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.DdlException;
+import com.starrocks.connector.ConnectorMetadata;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.BufferedSink;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.starrocks.http.rest.ActionStatus;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.http.rest.TransactionLoadAction;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+
+import mockit.MockUp;
+import mockit.Mock;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.List;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public class TransactionLoadActionTest extends StarRocksHttpTestCase {
+
+    private static HttpServer beServer;
+
+    @Override
+    @Before
+    public void setUp() {
+        Backend backend4 = new Backend(1234, "localhost", 8040);
+        backend4.setBePort(9300);
+        backend4.setAlive(true);
+        backend4.setHttpPort(9737);
+        backend4.setDisks(new ImmutableMap.Builder<String, DiskInfo>().put("1", new DiskInfo("")).build());
+        GlobalStateMgr.getCurrentSystemInfo().addBackend(backend4);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            boolean isLeader() {
+                return true;
+            }
+        };
+    }
+    
+    @After
+    public void tearDown() {
+        GlobalStateMgr.getCurrentSystemInfo().dropBackend(new Backend(1234, CLUSTER_NAME, HTTP_PORT));
+    }
+
+    @BeforeClass
+    public static void initBeServer() throws IllegalArgException, InterruptedException {
+        beServer = new HttpServer(9737);
+        BaseAction ac = new BaseAction(beServer.getController()) {
+
+            @Override
+            public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+                TransactionResult resp = new TransactionResult();
+                response.appendContent(resp.toJson());
+                writeResponse(request, response, HttpResponseStatus.OK);
+            }
+        };
+        beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/begin", ac);
+        beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/prepare", ac);
+        beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/commit", ac);
+        beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/rollback", ac);
+        beServer.start();
+        // must ensure the http server started before any unit test
+        while (!beServer.isStarted()) {
+            Thread.sleep(500);
+        }
+    }
+
+    @Test
+    public void beginTransactionTimes() throws IOException {
+        String PATH_URI = "http://localhost:" + HTTP_PORT + "/api/transaction/begin";
+
+        for (int i = 0; i < 4096; i ++) {
+            Request request = new Request.Builder()
+                    .get()
+                    .addHeader("Authorization", rootAuth)
+                    .addHeader("db", "testDb")
+                    .addHeader("label", String.valueOf(i))
+                    .url(PATH_URI)
+                    .method("POST", new RequestBody() {
+
+                        @Override
+                        public MediaType contentType() {
+                            return null;
+                        }
+
+                        @Override
+                        public void writeTo(BufferedSink arg0) throws IOException {
+                        }
+
+                    })
+                    .build();
+            Response response = networkClient.newCall(request).execute();
+            Assert.assertEquals(true, response.body().string().contains("OK"));
+
+            Assert.assertTrue(TransactionLoadAction.getAction().txnBackendMapSize() <= 2048);
+        }
+    }
+
+    @Test
+    public void beginTransaction() throws IOException {
+        String PATH_URI = "http://localhost:" + HTTP_PORT + "/api/transaction/begin";
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        Response response = networkClient.newCall(request).execute();
+
+        Assert.assertEquals(true, response.body().string().contains("OK"));
+    }
+
+    @Test
+    public void commitTransaction() throws IOException {
+        String PATH_URI = "http://localhost:" + HTTP_PORT + "/api/transaction/commit";
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        Response response = networkClient.newCall(request).execute();
+
+        Assert.assertEquals(false, response.body().string().contains("OK"));
+
+        request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .addHeader("db", "abc")
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        response = networkClient.newCall(request).execute();
+
+        Assert.assertEquals(false, response.body().string().contains("OK"));
+
+    }
+
+    @Test
+    public void rollbackTransaction() throws IOException {
+        String PATH_URI = "http://localhost:" + HTTP_PORT + "/api/transaction/rollback";
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        Response response = networkClient.newCall(request).execute();
+
+        Assert.assertEquals(false, response.body().string().contains("OK"));
+
+        request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .addHeader("db", "abc")
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        response = networkClient.newCall(request).execute();
+
+        Assert.assertEquals(false, response.body().string().contains("OK"));
+
+        request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .addHeader("db", "testDb")
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        response = networkClient.newCall(request).execute();
+        String res = response.body().string();
+
+        Assert.assertEquals(false, res.contains("OK"));
+    }
+
+    @Test
+    public void prepareTransaction() throws IOException {
+        String PATH_URI = "http://localhost:" + HTTP_PORT + "/api/transaction/prepare";
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(PATH_URI)
+                .method("POST", new RequestBody() {
+
+                    @Override
+                    public MediaType contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink arg0) throws IOException {
+                    }
+                    
+                })
+                .build();
+
+        Response response = networkClient.newCall(request).execute();
+        String res = response.body().string();
+        System.out.println(res);
+
+        Assert.assertEquals(true, res.contains("OK"));
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -988,6 +988,7 @@ service FrontendService {
     TLoadTxnBeginResult loadTxnBegin(1: TLoadTxnBeginRequest request)
     TLoadTxnCommitResult loadTxnCommit(1: TLoadTxnCommitRequest request)
     TLoadTxnRollbackResult loadTxnRollback(1: TLoadTxnRollbackRequest request)
+    TLoadTxnCommitResult loadTxnPrepare(1: TLoadTxnCommitRequest request)
 
     TStreamLoadPutResult streamLoadPut(1: TStreamLoadPutRequest request)
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8510 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
StarRocks implements the `/api/transaction/prepare` interface to put the current transaction to `PREPARED` state which temporarily persists changes. After preparing a transaction, the user can continue to commit or rollback the transaction.

The transaction preparation interface helps users achieve a more robust cross-system two-phase commit. After the transaction preparation is successful, even if StarRocks crashes, the user can continue to perform the commit or rollback this transaction after the system is recovered.