### PR TITLE
[Bugfix] Fix PlanFragmentWithCostTest failed

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1077,18 +1077,18 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         System.out.println(plan);
 
         assertContains(plan, "  Input Partition: RANDOM\n" +
-                "  OutPut Partition: HASH_PARTITIONED: 3: v3\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 2: v2\n" +
                 "  OutPut Exchange Id: 01");
 
         assertContains(plan, "Input Partition: RANDOM\n" +
-                "  OutPut Partition: HASH_PARTITIONED: 6: v6\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 5: v5\n" +
                 "  OutPut Exchange Id: 03");
 
         assertContains(plan, "  |  build runtime filters:\n" +
-                "  |  - filter_id = 1, build_expr = (6: v6), remote = true\n");
+                "  |  - filter_id = 0, build_expr = (5: v5), remote = true\n");
 
         assertContains(plan, "probe runtime filters:\n" +
-                "     - filter_id = 1, probe_expr = (3: v3)");
+                "     - filter_id = 0, probe_expr = (2: v2)");
     }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
ut failed, some descriptions:
```
Error Message
PLAN FRAGMENT 0(F05)
  Output Exprs:1: v1 | 2: v2 | 3: v3 | 4: v4 | 5: v5 | 6: v6
  Input Partition: UNPARTITIONED
  RESULT SINK

  5:EXCHANGE
     cardinality: 90000

PLAN FRAGMENT 1(F04)

  Input Partition: HASH_PARTITIONED: 2: v2
  OutPut Partition: UNPARTITIONED
  OutPut Exchange Id: 05

  4:HASH JOIN
  |  join op: INNER JOIN (PARTITIONED)
  |  equal join conjunct: [2: v2, BIGINT, true] = [5: v5, BIGINT, true]
  |  equal join conjunct: [3: v3, BIGINT, true] = [6: v6, BIGINT, true]
  |  build runtime filters:
  |  - filter_id = 0, build_expr = (5: v5), remote = true
  |  cardinality: 90000
  |  
  |----3:EXCHANGE
  |       cardinality: 100000
  |    
  1:EXCHANGE
     cardinality: 4000000

PLAN FRAGMENT 2(F02)

  Input Partition: RANDOM
  OutPut Partition: HASH_PARTITIONED: 5: v5
  OutPut Exchange Id: 03

  2:OlapScanNode
     table: t1, rollup: t1
     preAggregation: on
     Predicates: 5: v5 IS NOT NULL, 6: v6 IS NOT NULL
     partitionsRatio=1/1, tabletsRatio=3/3
     tabletList=10015,10017,10019
     actualRows=0, avgRowSize=12.0
     cardinality: 100000

PLAN FRAGMENT 3(F00)

  Input Partition: RANDOM
  OutPut Partition: HASH_PARTITIONED: 2: v2
  OutPut Exchange Id: 01

  0:OlapScanNode
     table: t0, rollup: t0
     preAggregation: on
     Predicates: 2: v2 IS NOT NULL, 3: v3 IS NOT NULL
     partitionsRatio=1/1, tabletsRatio=3/3
     tabletList=10006,10008,10010
     actualRows=0, avgRowSize=12.0
     cardinality: 4000000
     probe runtime filters:
     - filter_id = 0, probe_expr = (2: v2)
Stacktrace
java.lang.AssertionError: 
PLAN FRAGMENT 0(F05)
  Output Exprs:1: v1 | 2: v2 | 3: v3 | 4: v4 | 5: v5 | 6: v6
  Input Partition: UNPARTITIONED
  RESULT SINK

  5:EXCHANGE
     cardinality: 90000

PLAN FRAGMENT 1(F04)

  Input Partition: HASH_PARTITIONED: 2: v2
  OutPut Partition: UNPARTITIONED
  OutPut Exchange Id: 05

  4:HASH JOIN
  |  join op: INNER JOIN (PARTITIONED)
  |  equal join conjunct: [2: v2, BIGINT, true] = [5: v5, BIGINT, true]
  |  equal join conjunct: [3: v3, BIGINT, true] = [6: v6, BIGINT, true]
  |  build runtime filters:
  |  - filter_id = 0, build_expr = (5: v5), remote = true
  |  cardinality: 90000
  |  
  |----3:EXCHANGE
  |       cardinality: 100000
  |    
  1:EXCHANGE
     cardinality: 4000000

PLAN FRAGMENT 2(F02)

  Input Partition: RANDOM
  OutPut Partition: HASH_PARTITIONED: 5: v5
  OutPut Exchange Id: 03

  2:OlapScanNode
     table: t1, rollup: t1
     preAggregation: on
     Predicates: 5: v5 IS NOT NULL, 6: v6 IS NOT NULL
     partitionsRatio=1/1, tabletsRatio=3/3
     tabletList=10015,10017,10019
     actualRows=0, avgRowSize=12.0
     cardinality: 100000

PLAN FRAGMENT 3(F00)

  Input Partition: RANDOM
  OutPut Partition: HASH_PARTITIONED: 2: v2
  OutPut Exchange Id: 01

  0:OlapScanNode
     table: t0, rollup: t0
     preAggregation: on
     Predicates: 2: v2 IS NOT NULL, 3: v3 IS NOT NULL
     partitionsRatio=1/1, tabletsRatio=3/3
     tabletList=10006,10008,10010
     actualRows=0, avgRowSize=12.0
     cardinality: 4000000
     probe runtime filters:
     - filter_id = 0, probe_expr = (2: v2)

	at com.starrocks.sql.plan.PlanTestBase.assertContains(PlanTestBase.java:1057)
	at com.starrocks.sql.plan.PlanFragmentWithCostTest.testMultiJoinColumnPruneShuffleColumnsAndGRF(PlanFragmentWithCostTest.java:1079)
```
