### PR TITLE
[Enhancement] move `scan_operator->prepare` operation into IO thread

### DIFF
--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -30,7 +30,7 @@
 namespace starrocks {
 
 MysqlScanner::MysqlScanner(const MysqlScannerParam& param)
-        : _my_param(param), _my_conn(nullptr), _my_result(nullptr), _is_open(false), _field_num(0) {}
+        : _my_param(param), _my_conn(nullptr), _my_result(nullptr), _opened(false), _field_num(0) {}
 
 MysqlScanner::~MysqlScanner() {
     if (_my_result) {
@@ -50,7 +50,7 @@ MysqlScanner::~MysqlScanner() {
 }
 
 Status MysqlScanner::open() {
-    if (_is_open) {
+    if (_opened) {
         LOG(INFO) << "this scanner already opened";
         return Status::OK();
     }
@@ -77,13 +77,13 @@ Status MysqlScanner::open() {
         return Status::InternalError("mysql set character set failed.");
     }
 
-    _is_open = true;
+    _opened = true;
 
     return Status::OK();
 }
 
 Status MysqlScanner::query(const std::string& query) {
-    if (!_is_open) {
+    if (!_opened) {
         return Status::InternalError("Query before open.");
     }
 
@@ -118,7 +118,7 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
                            const std::vector<std::string>& filters,
                            const std::unordered_map<std::string, std::vector<std::string>>& filters_in,
                            std::unordered_map<std::string, bool>& filters_null_in_set, int64_t limit) {
-    if (!_is_open) {
+    if (!_opened) {
         return Status::InternalError("Query before open.");
     }
 
@@ -191,7 +191,7 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
 }
 
 Status MysqlScanner::get_next_row(char*** buf, unsigned long** lengths, bool* eos) {
-    if (!_is_open) {
+    if (!_opened) {
         return Status::InternalError("GetNextRow before open.");
     }
 

--- a/be/src/exec/mysql_scanner.h
+++ b/be/src/exec/mysql_scanner.h
@@ -72,7 +72,7 @@ private:
     __StarRocksMysql* _my_conn;
     __StarRocksMysqlRes* _my_result;
     std::string _sql_str;
-    bool _is_open;
+    bool _opened;
     int _field_num;
 };
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -133,9 +133,7 @@ ConnectorChunkSource::~ConnectorChunkSource() {
 }
 
 Status ConnectorChunkSource::prepare(RuntimeState* state) {
-    // semantics of `prepare` in ChunkSource is identical to `open`
     _runtime_state = state;
-    RETURN_IF_ERROR(_data_source->open(state));
     return Status::OK();
 }
 
@@ -232,6 +230,11 @@ Status ConnectorChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(siz
 
 Status ConnectorChunkSource::_read_chunk(vectorized::ChunkPtr* chunk) {
     RuntimeState* state = _runtime_state;
+    if (!_opened) {
+        RETURN_IF_ERROR(_data_source->open(state));
+        _opened = true;
+    }
+
     if (state->is_cancelled()) {
         return Status::Cancelled("canceled state");
     }

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -106,6 +106,7 @@ private:
     // =========================
     RuntimeState* _runtime_state = nullptr;
     Status _status = Status::OK();
+    bool _opened = false;
     bool _closed = false;
     uint64_t _rows_read = 0;
     uint64_t _bytes_read = 0;

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -59,9 +59,9 @@ public:
         return Status::OK();
     }
     Status open(RuntimeState* state) {
-        if (_is_open) return Status::OK();
+        if (_opened) return Status::OK();
         RETURN_IF_ERROR(_data_source->open(state));
-        _is_open = true;
+        _opened = true;
         return Status::OK();
     }
     void close(RuntimeState* state) { _data_source->close(state); }
@@ -74,7 +74,7 @@ public:
     int64_t num_rows_read() const { return _data_source->num_rows_read(); }
     void set_keep_priority(bool v) { _keep_priority = v; }
     bool keep_priority() const { return _keep_priority; }
-    bool is_open() { return _is_open; }
+    bool is_open() { return _opened; }
 
     RuntimeState* runtime_state() { return _runtime_state; }
 
@@ -102,7 +102,7 @@ public:
 private:
     connector::DataSourcePtr _data_source = nullptr;
     RuntimeState* _runtime_state = nullptr;
-    bool _is_open = false;
+    bool _opened = false;
     bool _keep_priority = false;
     std::atomic_bool _pending_token = false;
     MonotonicStopWatch _pending_queue_sw;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -202,7 +202,7 @@ public:
 
     int32_t open_limit() { return _scanner_params.open_limit->load(std::memory_order_relaxed); }
 
-    bool is_open() { return _is_open; }
+    bool is_open() { return _opened; }
 
     bool acquire_pending_token(std::atomic_bool* token) {
         // acquire resource
@@ -231,8 +231,8 @@ public:
     uint64_t exit_pending_queue();
 
 private:
-    bool _is_open = false;
-    std::atomic<bool> _is_closed = false;
+    bool _opened = false;
+    std::atomic<bool> _closed = false;
     bool _keep_priority = false;
     Status _build_scanner_context();
     MonotonicStopWatch _pending_queue_sw;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The bad performance case happens in customer env:
- 1 BE node
- 4 cores
- query parquet file

And the main reason, there are a lot of IO-heavy operation in prepare stage when reading parquet file. And prepare stage runs in execution threads which will block CPU operations.

---

To reproduce customer's env, you have to make some changes

modify BE.conf
```
pipeline_prepare_thread_pool_thread_num = 4
pipeline_exec_thread_pool_thread_num = 4
```

modify start command
```
 nohup taskset -c 100-103 ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
```

And we use following query on tpch-100g to test performance

```
-- l_suppkey is not prefix key, so there are a lot orc read.
-- Q01. for tpch-100g, there are 574 rows.
select l_orderkey, l_partkey, l_suppkey, l_linenumber from lineitem where l_suppkey = 768951;
```

The test command line is
```
(py3env) sandbox-cloud :: ~/work/sql-bench ‹master› » python run-bench.py --times 5 --concurrency 1 --sql-file queryset/tpch_late_mat.sql --db tpch_100g_parquet_zlib --mysql --endpoint 127.0.0.1 --port 41003 --user root  --mem-limit 30 --include Q01 --pipeline 16 --threads 1 
===== settings =====
concurrency = 1
exec_mem_limit = 32212254720
parallel_fragment_exec_instance_num = 1
enable_cbo = true
enable_pipeline_engine = true
pipeline_dop = 16
```

---
before this PR
- it took 41008ms to run
- average CPU usage is 130%

after this PR
- it took 5371ms to run
- average CPU usage is 360%(almost fully utilized)

