### PR TITLE
rectify wildcard decimal types of multi_distinct_sum converted from sum(distinct) and avg(distinct)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -24,6 +24,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.HdfsURI;
 import com.starrocks.common.io.Text;
@@ -37,6 +38,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 import static com.starrocks.common.io.IOUtils.writeOptionString;
 
 /**
@@ -741,5 +743,53 @@ public class Function implements Writable {
             return true;
         }
         return obj != null && obj.getClass() == this.getClass() && isIdentical((Function) obj);
+    }
+
+    // This function is used to convert the sum(distinct) function to the multi_distinct_sum function in
+    // optimizing phase and PlanFragment building phase.
+    // Decimal types of multi_distinct_sum must be rectified because the function signature registered in
+    // FunctionSet contains wildcard decimal types which is invalid in BE, so it is forbidden to be used
+    // without decimal type rectification.
+    public static Function convertSumToMultiDistinctSum(Function sumFn, Type argType) {
+        AggregateFunction fn = (AggregateFunction) Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
+                new Type[]{argType},
+                IS_NONSTRICT_SUPERTYPE_OF);
+        Preconditions.checkArgument(fn != null);
+        ScalarType decimal128Type = ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(sumFn.getArgs()), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
+
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
+    }
+
+    // When converting avg(distinct) into sum(distinct)/count(distinct), invoke this function to
+    // rectify the sum function(is_distinct flag is on) that contains wildcard decimal types.
+    public static Function rectifySumDistinct(Function sumFn, Type argType) {
+        if (!argType.isDecimalV3()) {
+            return sumFn;
+        }
+        ScalarType decimalType = (ScalarType) argType;
+        AggregateFunction fn = (AggregateFunction) sumFn;
+        ScalarType decimal128Type = ScalarType.createDecimalV3Type(
+                PrimitiveType.DECIMAL128, 38, decimalType.getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(decimalType), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedSet;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.Expr;
@@ -17,6 +18,8 @@ import com.starrocks.catalog.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 
 public class DecimalV3FunctionAnalyzer {
     public static final Set<String> DECIMAL_UNARY_FUNCTION_SET =
@@ -206,6 +209,54 @@ public class DecimalV3FunctionAnalyzer {
         AggregateFunction newFn = new AggregateFunction(fn.getFunctionName(), Arrays.asList(argType), returnType,
                 fn.getIntermediateType(), fn.hasVarArgs());
 
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
+    }
+
+    // This function is used to convert the sum(distinct) function to the multi_distinct_sum function in
+    // optimizing phase and PlanFragment building phase.
+    // Decimal types of multi_distinct_sum must be rectified because the function signature registered in
+    // FunctionSet contains wildcard decimal types which is invalid in BE, so it is forbidden to be used
+    // without decimal type rectification.
+    public static Function convertSumToMultiDistinctSum(Function sumFn, Type argType) {
+        AggregateFunction fn = (AggregateFunction) Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
+                new Type[]{argType},
+                IS_NONSTRICT_SUPERTYPE_OF);
+        Preconditions.checkArgument(fn != null);
+        ScalarType decimal128Type = ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(sumFn.getArgs()), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
+
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
+    }
+
+    // When converting avg(distinct) into sum(distinct)/count(distinct), invoke this function to
+    // rectify the sum function(is_distinct flag is on) that contains wildcard decimal types.
+    public static Function rectifySumDistinct(Function sumFn, Type argType) {
+        if (!argType.isDecimalV3()) {
+            return sumFn;
+        }
+        ScalarType decimalType = (ScalarType) argType;
+        AggregateFunction fn = (AggregateFunction) sumFn;
+        ScalarType decimal128Type = ScalarType.createDecimalV3Type(
+                PrimitiveType.DECIMAL128, 38, decimalType.getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(decimalType), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
         newFn.setFunctionId(fn.getFunctionId());
         newFn.setChecksum(fn.getChecksum());
         newFn.setBinaryType(fn.getBinaryType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -10,6 +10,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -271,7 +272,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                             cteProduce, factory));
                 }
 
-                CallOperator distinctAvgCallOperator = new CallOperator("divide", avgCallOperator.getType(),
+                CallOperator distinctAvgCallOperator = new CallOperator(FunctionSet.DIVIDE, avgCallOperator.getType(),
                         Lists.newArrayList(sumColumnRef, countColumnRef));
                 if (avgCallOperator.getType().isDecimalV3()) {
                     // There is not need to apply ImplicitCastRule to divide operator of decimal types.
@@ -294,8 +295,8 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                 avgCallOperator.getFunction().getArgs(), avgCallOperator.getType(), false);
         Function fn = GlobalStateMgr.getCurrentState().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
 
-        if (fn.getFunctionName().getFunction().equalsIgnoreCase(FunctionSet.SUM)) {
-            fn = Function.rectifySumDistinct(fn, avgCallOperator.getChild(0).getType());
+        if (fn.getFunctionName().getFunction().equals(FunctionSet.SUM)) {
+            fn = DecimalV3FunctionAnalyzer.rectifySumDistinct(fn, avgCallOperator.getChild(0).getType());
         }
         return new CallOperator(functionName, fn.getReturnType(), avgCallOperator.getChildren(), fn,
                 avgCallOperator.isDistinct());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -8,6 +8,7 @@ import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -27,6 +28,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
@@ -269,10 +271,18 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                             cteProduce, factory));
                 }
 
-                CallOperator distinctAvgCallOperator = (CallOperator) scalarRewriter.rewrite(
-                        new CallOperator("divide", avgCallOperator.getType(),
-                                Lists.newArrayList(sumColumnRef, countColumnRef)),
-                        Lists.newArrayList(new ImplicitCastRule()));
+                CallOperator distinctAvgCallOperator = new CallOperator("divide", avgCallOperator.getType(),
+                        Lists.newArrayList(sumColumnRef, countColumnRef));
+                if (avgCallOperator.getType().isDecimalV3()) {
+                    // There is not need to apply ImplicitCastRule to divide operator of decimal types.
+                    // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
+                    ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+                    distinctAvgCallOperator.getChildren().set(
+                            1, new CastOperator(decimal128p38s0, distinctAvgCallOperator.getChild(1), true));
+                } else {
+                    distinctAvgCallOperator = (CallOperator) scalarRewriter.rewrite(distinctAvgCallOperator,
+                            Lists.newArrayList(new ImplicitCastRule()));
+                }
                 projectionMap.put(aggregation.getKey(), distinctAvgCallOperator);
             }
         }
@@ -284,6 +294,9 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                 avgCallOperator.getFunction().getArgs(), avgCallOperator.getType(), false);
         Function fn = GlobalStateMgr.getCurrentState().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
 
+        if (fn.getFunctionName().getFunction().equalsIgnoreCase(FunctionSet.SUM)) {
+            fn = Function.rectifySumDistinct(fn, avgCallOperator.getChild(0).getType());
+        }
         return new CallOperator(functionName, fn.getReturnType(), avgCallOperator.getChildren(), fn,
                 avgCallOperator.isDistinct());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -8,6 +8,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.AggType;
@@ -117,7 +118,7 @@ public class RewriteMultiDistinctRule extends TransformationRule {
                 sumColRef = sumColRef == null ?
                         context.getColumnRefFactory().create(sum, sum.getType(), sum.isNullable()) : sumColRef;
                 newAggMapWithAvg.put(sumColRef, sum);
-                CallOperator multiAvg = new CallOperator("divide", oldFunctionCall.getType(),
+                CallOperator multiAvg = new CallOperator(FunctionSet.DIVIDE, oldFunctionCall.getType(),
                         Lists.newArrayList(sumColRef, countColRef));
                 if (multiAvg.getType().isDecimalV3()) {
                     // There is not need to apply ImplicitCastRule to divide operator of decimal types.
@@ -170,7 +171,7 @@ public class RewriteMultiDistinctRule extends TransformationRule {
     }
 
     private CallOperator buildMultiSumDistinct(CallOperator oldFunctionCall) {
-        Function multiDistinctSum = Function.convertSumToMultiDistinctSum(
+        Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
                 oldFunctionCall.getFunction(), oldFunctionCall.getChild(0).getType());
         return (CallOperator) scalarRewriter.rewrite(
                 new CallOperator(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -12,6 +12,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -274,8 +275,8 @@ public class SplitAggregateRule extends TransformationRule {
             return new CallOperator(FunctionSet.MULTI_DISTINCT_COUNT, fnCall.getType(), fnCall.getChildren(),
                     Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT, new Type[] {fnCall.getChild(0).getType()},
                             IS_NONSTRICT_SUPERTYPE_OF), false);
-        } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
-            Function multiDistinctSumFn = Function.convertSumToMultiDistinctSum(
+        } else if (functionName.equals(FunctionSet.SUM)) {
+            Function multiDistinctSumFn = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
                     fnCall.getFunction(), fnCall.getChild(0).getType());
             return new CallOperator(
                     FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(), multiDistinctSumFn, false);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -275,9 +275,10 @@ public class SplitAggregateRule extends TransformationRule {
                     Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT, new Type[] {fnCall.getChild(0).getType()},
                             IS_NONSTRICT_SUPERTYPE_OF), false);
         } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
-            return new CallOperator(FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(),
-                    Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM, new Type[] {fnCall.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF), false);
+            Function multiDistinctSumFn = Function.convertSumToMultiDistinctSum(
+                    fnCall.getFunction(), fnCall.getChild(0).getType());
+            return new CallOperator(
+                    FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(), multiDistinctSumFn, false);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -68,6 +68,7 @@ import com.starrocks.planner.UnionNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.JoinHelper;
@@ -1344,7 +1345,7 @@ public class PlanFragmentBuilder {
                     replaceExpr.getParams().setIsDistinct(false);
                 } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_SUM, functionCallExpr.getParams());
-                    Function multiDistinctSum = Function.convertSumToMultiDistinctSum(
+                    Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
                             functionCallExpr.getFn(), functionCallExpr.getChild(0).getType());
                     replaceExpr.setFn(multiDistinctSum);
                     replaceExpr.getParams().setIsDistinct(false);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
@@ -1343,9 +1344,9 @@ public class PlanFragmentBuilder {
                     replaceExpr.getParams().setIsDistinct(false);
                 } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_SUM, functionCallExpr.getParams());
-                    replaceExpr.setFn(Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
-                            new Type[] {functionCallExpr.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF));
+                    Function multiDistinctSum = Function.convertSumToMultiDistinctSum(
+                            functionCallExpr.getFn(), functionCallExpr.getChild(0).getType());
+                    replaceExpr.setFn(multiDistinctSum);
                     replaceExpr.getParams().setIsDistinct(false);
                 }
                 Preconditions.checkState(replaceExpr != null);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes # https://github.com/StarRocks/starrocks/issues/8378


BE crash when handle wildcard decimal types.

```
*** Aborted at 1656926537 (unix time) try "date -d @1656926537" if you are using GNU date ***
PC: @          0x172d362 starrocks::vectorized::DecimalV3Column<>::put_mysql_row_buffer()
*** SIGFPE (@0x172d362) received by PID 114509 (TID 0x7fe2255a0700) from PID 24302434; stack trace: ***
    @          0x33c5422 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fe256d3f5e0 (unknown)
    @          0x172d362 starrocks::vectorized::DecimalV3Column<>::put_mysql_row_buffer()
    @          0x2d8f73c starrocks::MysqlResultWriter::process_chunk()
    @          0x2d906cb starrocks::MysqlResultWriter::append_chunk()
    @          0x2d6fcf5 starrocks::ResultSink::send_chunk()
    @          0x1bc5dc0 starrocks::PlanFragmentExecutor::_open_internal_vectorized()
    @          0x1bc67a7 starrocks::PlanFragmentExecutor::open()
    @          0x1b69002 starrocks::FragmentExecState::execute()
    @          0x1b6d055 starrocks::FragmentMgr::exec_actual()
    @          0x1b6d6b0 _ZNSt17_Function_handlerIFvvEZN9starrocks11FragmentMgr18exec_plan_fragmentERKNS1_23TExecPlanFragmentParamsERKSt8functionIFvPNS1_20PlanFragmentExecutorEEESC_EUlvE_E9_M_invokeERKSt9_Any_data
    @          0x1c94979 starrocks::ThreadPool::dispatch_thread()
    @          0x1ca2f75 starrocks::Thread::supervise_thread()
    @     0x7fe256d37e25 start_thread
    @     0x7fe25614134d __clone
    @                0x0 (unknown)
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In optimize-phase, sum(distinct c) is converted into multi_distinct_sum(c), and avg(distinct c) is converted into multi_distinct_sum(c) / multi_distinct_count(c), the resloved function signature of decimal types carries wildcard decimal, which is illegal in BE, so we must rectify wildcard decimal types by replace it with real decimal types as we do in analyze-phase.