### PR TITLE
[Enhancement] limit buffer capacity instead of scan concurrency

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -146,6 +146,7 @@ set(EXEC_FILES
     pipeline/scan/olap_scan_context.cpp
     pipeline/scan/connector_scan_operator.cpp
     pipeline/scan/morsel.cpp
+    pipeline/scan/chunk_buffer_limiter.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_context.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -59,6 +59,8 @@ public:
     FragmentContext* fragment_context() { return _fragment_context; }
 
     MorselQueue* morsel_queue_of_source_operator(const SourceOperatorFactory* source_op);
+    size_t degree_of_parallelism_of_source_operator(int32_t source_node_id) const;
+    size_t degree_of_parallelism_of_source_operator(const SourceOperatorFactory* source_op) const;
 
 private:
     static constexpr int kLocalExchangeBufferChunks = 8;

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -2,6 +2,8 @@
 
 #include "exec/pipeline/scan/chunk_buffer_limiter.h"
 
+#include "glog/logging.h"
+
 namespace starrocks::pipeline {
 
 void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
@@ -29,6 +31,11 @@ ChunkBufferTokenPtr DynamicChunkBufferLimiter::pin(int num_chunks) {
         return nullptr;
     }
     return std::make_unique<DynamicChunkBufferLimiter::Token>(_pinned_chunks_counter, num_chunks);
+}
+
+void DynamicChunkBufferLimiter::_unpin(int num_chunks) {
+    int prev_value = _pinned_chunks_counter.fetch_sub(num_chunks);
+    DCHECK_GE(prev_value, 1);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -23,12 +23,12 @@ void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes,
 }
 
 ChunkBufferTokenPtr DynamicChunkBufferLimiter::pin(int num_chunks) {
-    size_t prev_acquired_chunks_counter = _acquired_chunks_counter.fetch_add(num_chunks);
-    if (prev_acquired_chunks_counter + num_chunks > _capacity) {
+    size_t prev_value = _pinned_chunks_counter.fetch_add(num_chunks);
+    if (prev_value + num_chunks > _capacity) {
         _unpin(num_chunks);
         return nullptr;
     }
-    return std::make_unique<DynamicChunkBufferLimiter::Token>(_acquired_chunks_counter, num_chunks);
+    return std::make_unique<DynamicChunkBufferLimiter::Token>(_pinned_chunks_counter, num_chunks);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
+
+namespace starrocks::pipeline {
+
+void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    _sum_row_bytes += added_sum_row_bytes;
+    _num_rows += added_num_rows;
+    size_t avg_row_bytes = 0;
+    if (_num_rows > 0) {
+        avg_row_bytes = _sum_row_bytes / _num_rows;
+    }
+    if (avg_row_bytes == 0) {
+        return;
+    }
+
+    size_t chunk_mem_usage = avg_row_bytes * _chunk_size;
+    size_t new_capacity = std::max<size_t>(_mem_limit / chunk_mem_usage, 1);
+    _capacity = std::min(new_capacity, _max_capacity);
+}
+
+ChunkBufferTokenPtr DynamicChunkBufferLimiter::pin(int num_chunks) {
+    size_t prev_acquired_chunks_counter = _acquired_chunks_counter.fetch_add(num_chunks);
+    if (prev_acquired_chunks_counter + num_chunks > _capacity) {
+        _unpin(num_chunks);
+        return nullptr;
+    }
+    return std::make_unique<DynamicChunkBufferLimiter::Token>(_acquired_chunks_counter, num_chunks);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -106,11 +106,9 @@ public:
     size_t default_capacity() const override { return _default_capacity; }
 
 private:
-    void _unpin(int num_chunks) {
-        int prev_value = _pinned_chunks_counter.fetch_sub(num_chunks);
-        DCHECK_GE(prev_value, 1);
-    }
+    void _unpin(int num_chunks);
 
+private:
     std::mutex _mutex;
     size_t _sum_row_bytes = 0;
     size_t _num_rows = 0;

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -1,0 +1,125 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+namespace starrocks::pipeline {
+
+class ChunkBufferToken;
+using ChunkBufferTokenPtr = std::unique_ptr<ChunkBufferToken>;
+class ChunkBufferLimiter;
+using ChunkBufferLimiterPtr = std::unique_ptr<ChunkBufferLimiter>;
+
+class ChunkBufferToken {
+public:
+    virtual ~ChunkBufferToken() = default;
+};
+
+// Limit the capacity of a chunk buffer.
+// - Before creating a new chunk, should use `pin()` to pin a position in the buffer and return a token.
+// - After a chunk is popped from buffer, should desctruct the token to unpin the position.
+// All the methods are thread-safe.
+class ChunkBufferLimiter {
+public:
+    virtual ~ChunkBufferLimiter() = default;
+
+    // Update the chunk memory usage statistics.
+    // `added_sum_row_bytes` is the bytes of the new reading rows.
+    // `added_num_rows` is the number of the new read rows.
+    virtual void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) = 0;
+
+    // Pin a position in the buffer and return a token.
+    // When desctructing the token, the position will be unpinned.
+    virtual ChunkBufferTokenPtr pin(int num_chunks) = 0;
+
+    // Returns true, when it cannot pin a position for now.
+    virtual bool is_full() const = 0;
+    // The number of already pinned positions.
+    virtual size_t size() const = 0;
+    // The max number of positions able to be pinned.
+    virtual size_t capacity() const = 0;
+    // The default capacity when there isn't chunk memory usage statistics.
+    virtual size_t default_capacity() const = 0;
+};
+
+// The capacity of this limiter is unlimited.
+class UnlimitedChunkBufferLimiter final : public ChunkBufferLimiter {
+public:
+    class Token final : public ChunkBufferToken {
+    public:
+        ~Token() override = default;
+    };
+
+public:
+    ~UnlimitedChunkBufferLimiter() override = default;
+
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override {}
+
+    ChunkBufferTokenPtr pin(int num_chunks) override { return std::make_unique<Token>(); }
+
+    bool is_full() const override { return false; }
+    size_t size() const override { return 0; }
+    size_t capacity() const override { return 0; }
+    size_t default_capacity() const override { return 0; }
+};
+
+// Use the dynamic chunk memory usage statistics to compute the capacity.
+class DynamicChunkBufferLimiter final : public ChunkBufferLimiter {
+public:
+    class Token final : public ChunkBufferToken {
+    public:
+        Token(std::atomic<size_t>& acquired_tokens_counter, int num_tokens)
+                : _acquired_tokens_counter(acquired_tokens_counter), _num_tokens(num_tokens) {}
+
+        ~Token() override { _acquired_tokens_counter.fetch_sub(_num_tokens); }
+
+        // Disable copy/move ctor and assignment.
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        Token(Token&&) = delete;
+        Token& operator=(Token&&) = delete;
+
+    private:
+        std::atomic<size_t>& _acquired_tokens_counter;
+        const int _num_tokens;
+    };
+
+public:
+    DynamicChunkBufferLimiter(size_t max_capacity, size_t default_capacity, int64_t mem_limit, int chunk_size)
+            : _capacity(default_capacity),
+              _max_capacity(max_capacity),
+              _default_capacity(default_capacity),
+              _mem_limit(mem_limit),
+              _chunk_size(chunk_size) {}
+    ~DynamicChunkBufferLimiter() override = default;
+
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override;
+
+    ChunkBufferTokenPtr pin(int num_chunks) override;
+
+    bool is_full() const override { return _acquired_chunks_counter >= _capacity; }
+    size_t size() const override { return _acquired_chunks_counter; }
+    size_t capacity() const override { return _capacity; }
+    size_t default_capacity() const override { return _default_capacity; }
+
+private:
+    void _unpin(int num_chunks) { _acquired_chunks_counter.fetch_sub(num_chunks); }
+
+    std::mutex _mutex;
+    size_t _sum_row_bytes = 0;
+    size_t _num_rows = 0;
+
+    size_t _capacity;
+    const size_t _max_capacity;
+    const size_t _default_capacity;
+
+    const int64_t _mem_limit;
+    const int _chunk_size;
+
+    std::atomic<size_t> _acquired_chunks_counter = 0;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -27,6 +27,8 @@ public:
 
     virtual Status prepare(RuntimeState* state) = 0;
 
+    // Mark that it needn't produce any chunk anymore.
+    virtual Status set_finished(RuntimeState* state) = 0;
     virtual void close(RuntimeState* state) = 0;
 
     // Return true if eos is not reached

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -13,9 +13,13 @@ class ScanNode;
 
 namespace pipeline {
 
+class ChunkBufferToken;
+using ChunkBufferTokenPtr = std::unique_ptr<ChunkBufferToken>;
+class ChunkBufferLimiter;
+
 class ConnectorScanOperatorFactory final : public ScanOperatorFactory {
 public:
-    ConnectorScanOperatorFactory(int32_t id, ScanNode* scan_node);
+    ConnectorScanOperatorFactory(int32_t id, ScanNode* scan_node, ChunkBufferLimiterPtr buffer_limiter);
 
     ~ConnectorScanOperatorFactory() override = default;
 
@@ -27,7 +31,7 @@ public:
 class ConnectorScanOperator final : public ScanOperator {
 public:
     ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                          std::atomic<int>& num_committed_scan_tasks);
+                          ChunkBufferLimiter* buffer_limiter);
 
     ~ConnectorScanOperator() override = default;
 
@@ -41,7 +45,7 @@ private:
 class ConnectorChunkSource final : public ChunkSource {
 public:
     ConnectorChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
-                         vectorized::ConnectorScanNode* scan_node);
+                         vectorized::ConnectorScanNode* scan_node, ChunkBufferLimiter* const buffer_limiter);
 
     ~ConnectorChunkSource() override;
 
@@ -63,6 +67,8 @@ public:
                                                            workgroup::WorkGroupPtr running_wg) override;
 
 private:
+    using ChunkWithToken = std::pair<vectorized::ChunkPtr, ChunkBufferTokenPtr>;
+
     Status _read_chunk(vectorized::ChunkPtr* chunk);
 
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
@@ -87,7 +93,9 @@ private:
     bool _closed = false;
     uint64_t _rows_read = 0;
     uint64_t _bytes_read = 0;
-    UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_buffer;
+
+    UnboundedBlockingQueue<ChunkWithToken> _chunk_buffer;
+    ChunkBufferLimiter* const _buffer_limiter;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -51,6 +51,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
+    Status set_finished(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
     bool has_next_chunk() const override;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -42,6 +42,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
+    Status set_finished(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
     bool has_next_chunk() const override;

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -72,13 +72,4 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
     return Status::OK();
 }
 
-void OlapScanContext::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    _sum_row_bytes += added_sum_row_bytes;
-    _num_rows += added_num_rows;
-    if (_num_rows > 0) {
-        _avg_row_bytes = _sum_row_bytes / _num_rows;
-    }
-}
-
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -38,9 +38,6 @@ public:
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
 
-    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows);
-    size_t avg_row_bytes() const { return _avg_row_bytes; }
-
 private:
     vectorized::OlapScanNode* _scan_node;
 
@@ -53,11 +50,6 @@ private:
     ObjectPool _obj_pool;
 
     std::atomic<bool> _is_prepare_finished{false};
-
-    std::mutex _mutex;
-    size_t _sum_row_bytes = 0;
-    size_t _num_rows = 0;
-    size_t _avg_row_bytes = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -3,6 +3,7 @@
 #include "exec/pipeline/scan/olap_scan_operator.h"
 
 #include "column/chunk.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/olap_chunk_source.h"
 #include "exec/pipeline/scan/olap_scan_context.h"
 #include "exec/vectorized/olap_scan_node.h"
@@ -18,8 +19,9 @@ namespace starrocks::pipeline {
 
 // ==================== OlapScanOperatorFactory ====================
 
-OlapScanOperatorFactory::OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextPtr ctx)
-        : ScanOperatorFactory(id, scan_node), _ctx(std::move(ctx)) {}
+OlapScanOperatorFactory::OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, ChunkBufferLimiterPtr buffer_limiter,
+                                                 OlapScanContextPtr ctx)
+        : ScanOperatorFactory(id, scan_node, std::move(buffer_limiter)), _ctx(std::move(ctx)) {}
 
 Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
     return Status::OK();
@@ -28,16 +30,14 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _num_committed_scan_tasks, _ctx);
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _buffer_limiter.get(), _ctx);
 }
 
 // ==================== OlapScanOperator ====================
 
 OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                                   std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx)
-        : ScanOperator(factory, id, driver_sequence, scan_node, num_committed_scan_tasks),
-          _ctx(std::move(ctx)),
-          _default_max_scan_concurrency(scan_node->max_scan_concurrency()) {
+                                   ChunkBufferLimiter* buffer_limiter, OlapScanContextPtr ctx)
+        : ScanOperator(factory, id, driver_sequence, scan_node, buffer_limiter), _ctx(std::move(ctx)) {
     _ctx->ref();
 }
 
@@ -74,54 +74,15 @@ bool OlapScanOperator::is_finished() const {
 }
 
 Status OlapScanOperator::do_prepare(RuntimeState*) {
-    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "DefaultMaxScanConcurrency", TUnit::UNIT);
-    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_default_max_scan_concurrency));
-
     return Status::OK();
 }
 
-void OlapScanOperator::do_close(RuntimeState* state) {
-    auto* max_scan_concurrency_counter = ADD_COUNTER(_unique_metrics, "AvgMaxScanConcurrency", TUnit::UNIT);
-    COUNTER_SET(max_scan_concurrency_counter, static_cast<int64_t>(_avg_max_scan_concurrency()));
-}
+void OlapScanOperator::do_close(RuntimeState* state) {}
 
 ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);
     return std::make_shared<OlapChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel),
-                                             olap_scan_node, _ctx.get());
-}
-
-size_t OlapScanOperator::max_scan_concurrency() const {
-    int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
-
-    size_t avg_row_bytes = _ctx->avg_row_bytes();
-    if (avg_row_bytes == 0) {
-        return _default_max_scan_concurrency;
-    }
-
-    // Assume that the memory tried in the storage layer is the same as the output chunk.
-    size_t row_mem_usage = avg_row_bytes * 2;
-    size_t chunk_mem_usage = row_mem_usage * runtime_state()->chunk_size();
-    DCHECK_GT(chunk_mem_usage, 0);
-
-    // limit scan memory usage not greater than 1/4 query limit.
-    size_t concurrency = std::max<size_t>(query_limit * config::scan_use_query_mem_ratio / chunk_mem_usage, 1);
-
-    if (_prev_max_scan_concurrency != concurrency) {
-        _sum_max_scan_concurrency += concurrency;
-        ++_num_max_scan_concurrency;
-        _prev_max_scan_concurrency = concurrency;
-    }
-
-    return concurrency;
-}
-
-size_t OlapScanOperator::_avg_max_scan_concurrency() const {
-    if (_num_max_scan_concurrency > 0) {
-        return _sum_max_scan_concurrency / _num_max_scan_concurrency;
-    }
-
-    return 0;
+                                             olap_scan_node, _ctx.get(), _buffer_limiter);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -18,7 +18,8 @@ using OlapScanContextPtr = std::shared_ptr<OlapScanContext>;
 
 class OlapScanOperatorFactory final : public ScanOperatorFactory {
 public:
-    OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextPtr ctx);
+    OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, ChunkBufferLimiterPtr buffer_limiter,
+                            OlapScanContextPtr ctx);
 
     ~OlapScanOperatorFactory() override = default;
 
@@ -33,7 +34,7 @@ private:
 class OlapScanOperator final : public ScanOperator {
 public:
     OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                     std::atomic<int>& num_committed_scan_tasks, OlapScanContextPtr ctx);
+                     ChunkBufferLimiter* buffer_limiter, OlapScanContextPtr ctx);
 
     ~OlapScanOperator() override;
 
@@ -44,19 +45,8 @@ public:
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
-    size_t max_scan_concurrency() const override;
-
-private:
-    size_t _avg_max_scan_concurrency() const;
-
 private:
     OlapScanContextPtr _ctx;
-
-    const size_t _default_max_scan_concurrency;
-    // These three fields are used to calculate the average of different `max_scan_concurrency`s for profile.
-    mutable size_t _prev_max_scan_concurrency = 0;
-    mutable size_t _sum_max_scan_concurrency = 0;
-    mutable size_t _num_max_scan_concurrency = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -48,7 +48,7 @@ Status ScanOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     _unique_metrics->add_info_string("MorselQueueType", _morsel_queue->name());
-    _peak_buffer_size_counter = _unique_metrics->AddHighWaterMarkCounter("PeakBufferSize", TUnit::UNIT);
+    _peak_buffer_size_counter = _unique_metrics->AddHighWaterMarkCounter("PeakChunkBufferSize", TUnit::UNIT);
 
     if (_workgroup == nullptr) {
         DCHECK(_io_threads != nullptr);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -5,6 +5,7 @@
 #include "column/chunk.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/connector_scan_operator.h"
 #include "exec/vectorized/olap_scan_node.h"
 #include "exec/workgroup/scan_executor.h"
@@ -17,11 +18,11 @@ namespace starrocks::pipeline {
 // ========== ScanOperator ==========
 
 ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                           std::atomic<int>& num_committed_scan_tasks)
+                           ChunkBufferLimiter* buffer_limiter)
         : SourceOperator(factory, id, scan_node->name(), scan_node->id(), driver_sequence),
           _scan_node(scan_node),
           _chunk_source_profiles(MAX_IO_TASKS_PER_OP),
-          _num_committed_scan_tasks(num_committed_scan_tasks),
+          _buffer_limiter(buffer_limiter),
           _is_io_task_running(MAX_IO_TASKS_PER_OP),
           _chunk_sources(MAX_IO_TASKS_PER_OP) {
     for (auto i = 0; i < MAX_IO_TASKS_PER_OP; i++) {
@@ -47,6 +48,7 @@ Status ScanOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     _unique_metrics->add_info_string("MorselQueueType", _morsel_queue->name());
+    _peak_buffer_size_counter = _unique_metrics->AddHighWaterMarkCounter("PeakBufferSize", TUnit::UNIT);
 
     if (_workgroup == nullptr) {
         DCHECK(_io_threads != nullptr);
@@ -76,7 +78,13 @@ void ScanOperator::close(RuntimeState* state) {
         }
     }
 
+    auto* default_buffer_capacity_counter = ADD_COUNTER(_unique_metrics, "DefaultChunkBufferCapacity", TUnit::UNIT);
+    COUNTER_SET(default_buffer_capacity_counter, static_cast<int64_t>(_buffer_limiter->default_capacity()));
+    auto* buffer_capacity_counter = ADD_COUNTER(_unique_metrics, "ChunkBufferCapacity", TUnit::UNIT);
+    COUNTER_SET(buffer_capacity_counter, static_cast<int64_t>(_buffer_limiter->capacity()));
+
     _merge_chunk_source_profiles();
+
     do_close(state);
     Operator::close(state);
 }
@@ -96,8 +104,7 @@ bool ScanOperator::has_output() const {
         }
     }
 
-    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP ||
-        _exceed_max_scan_concurrency(_num_committed_scan_tasks.load())) {
+    if (_num_running_io_tasks >= MAX_IO_TASKS_PER_OP || _buffer_limiter->is_full()) {
         return false;
     }
 
@@ -156,6 +163,9 @@ Status ScanOperator::set_finishing(RuntimeState* state) {
 
 StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     RETURN_IF_ERROR(_get_scan_status());
+
+    _peak_buffer_size_counter->set(_buffer_limiter->size());
+
     RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
     if (_workgroup != nullptr) {
         _workgroup->incr_period_ask_chunk_num(1);
@@ -218,19 +228,17 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
     _last_growth_cpu_time_ns += cpu_time_ns;
     _last_scan_rows_num += scan_rows;
     _last_scan_bytes += scan_bytes;
-    _decrease_committed_scan_tasks();
     _num_running_io_tasks--;
     _is_io_task_running[chunk_source_index] = false;
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
-    if (_chunk_sources[chunk_source_index]->get_buffer_size() >= _buffer_size) {
-        return Status::OK();
-    }
-    if (!_try_to_increase_committed_scan_tasks()) {
+    ChunkBufferTokenPtr buffer_token;
+    if (buffer_token = _buffer_limiter->pin(1); buffer_token == nullptr) {
         return Status::OK();
     }
 
+    _chunk_sources[chunk_source_index]->pin_chunk_token(std::move(buffer_token));
     _num_running_io_tasks++;
     _is_io_task_running[chunk_source_index] = true;
 
@@ -304,6 +312,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     if (offer_task_success) {
         _io_task_retry_cnt = 0;
     } else {
+        _chunk_sources[chunk_source_index]->unpin_chunk_token();
         _num_running_io_tasks--;
         _is_io_task_running[chunk_source_index] = false;
         // TODO(hcf) set a proper retry times
@@ -352,25 +361,12 @@ void ScanOperator::_merge_chunk_source_profiles() {
     _unique_metrics->copy_all_counters_from(merged_profile);
 }
 
-bool ScanOperator::_try_to_increase_committed_scan_tasks() {
-    int old_num = _num_committed_scan_tasks.fetch_add(1);
-    if (_exceed_max_scan_concurrency(old_num)) {
-        _decrease_committed_scan_tasks();
-        return false;
-    }
-    return true;
-}
-
-bool ScanOperator::_exceed_max_scan_concurrency(int num_committed_scan_tasks) const {
-    size_t max = max_scan_concurrency();
-    // max_scan_concurrency takes effect, only when it is positive.
-    return max > 0 && num_committed_scan_tasks >= max;
-}
-
 // ========== ScanOperatorFactory ==========
 
-ScanOperatorFactory::ScanOperatorFactory(int32_t id, ScanNode* scan_node)
-        : SourceOperatorFactory(id, scan_node->name(), scan_node->id()), _scan_node(scan_node) {}
+ScanOperatorFactory::ScanOperatorFactory(int32_t id, ScanNode* scan_node, ChunkBufferLimiterPtr buffer_limiter)
+        : SourceOperatorFactory(id, scan_node->name(), scan_node->id()),
+          _scan_node(scan_node),
+          _buffer_limiter(std::move(buffer_limiter)) {}
 
 Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
@@ -395,13 +391,8 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
                                                       ScanNode* scan_node, pipeline::PipelineBuilderContext* context) {
     OpFactories ops;
 
-    const auto* morsel_queue = context->morsel_queue_of_source_operator(scan_operator.get());
-
-    // ScanOperator's degree_of_parallelism is not more than the number of morsels
-    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
-    const auto degree_of_parallelism =
-            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
+    size_t scan_dop = context->degree_of_parallelism_of_source_operator(scan_operator.get());
+    scan_operator->set_degree_of_parallelism(scan_dop);
 
     ops.emplace_back(std::move(scan_operator));
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -72,9 +72,12 @@ void ScanOperator::close(RuntimeState* state) {
     }
     // For the running io task, we close its chunk sources in ~ScanOperator not in ScanOperator::close.
     for (size_t i = 0; i < _chunk_sources.size(); i++) {
-        if (_chunk_sources[i] != nullptr && !_is_io_task_running[i]) {
-            _chunk_sources[i]->close(state);
-            _chunk_sources[i] = nullptr;
+        if (_chunk_sources[i] != nullptr) {
+            _chunk_sources[i]->set_finished(state);
+            if (!_is_io_task_running[i]) {
+                _chunk_sources[i]->close(state);
+                _chunk_sources[i] = nullptr;
+            }
         }
     }
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -13,12 +13,17 @@ class ScanNode;
 
 namespace pipeline {
 
+class ChunkBufferLimiter;
+using ChunkBufferLimiterPtr = std::unique_ptr<ChunkBufferLimiter>;
+
 class ScanOperator : public SourceOperator {
 public:
     ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                 std::atomic<int>& num_committed_scan_tasks);
+                 ChunkBufferLimiter* buffer_limiter);
 
     ~ScanOperator() override;
+
+    static size_t max_buffer_capacity() { return config::pipeline_io_buffer_size; }
 
     Status prepare(RuntimeState* state) override;
 
@@ -52,9 +57,6 @@ public:
     int64_t get_last_scan_rows_num() { return _last_scan_rows_num.exchange(0); }
     int64_t get_last_scan_bytes() { return _last_scan_bytes.exchange(0); }
 
-    // It takes effect, only when it is positive.
-    virtual size_t max_scan_concurrency() const { return 0; }
-
 private:
     // This method is only invoked when current morsel is reached eof
     // and all cached chunk of this morsel has benn read out
@@ -77,10 +79,6 @@ private:
         return _scan_status;
     }
 
-    bool _try_to_increase_committed_scan_tasks();
-    void _decrease_committed_scan_tasks() { _num_committed_scan_tasks.fetch_sub(1); }
-    bool _exceed_max_scan_concurrency(int num_committed_scan_tasks) const;
-
 protected:
     ScanNode* _scan_node = nullptr;
     // ScanOperator may do parallel scan, so each _chunk_sources[i] needs to hold
@@ -91,9 +89,8 @@ protected:
     std::vector<std::shared_ptr<RuntimeProfile>> _chunk_source_profiles;
 
     bool _is_finished = false;
-
-    // Shared by all the ScanOperators created by the same ScanOperatorFactory.
-    std::atomic<int>& _num_committed_scan_tasks;
+    // Shared among scan operators decomposed from a scan node, and owned by ScanOperatorFactory.
+    ChunkBufferLimiter* _buffer_limiter;
 
 private:
     static constexpr int MAX_IO_TASKS_PER_OP = 4;
@@ -113,11 +110,13 @@ private:
     workgroup::WorkGroupPtr _workgroup = nullptr;
     std::atomic_int64_t _last_scan_rows_num = 0;
     std::atomic_int64_t _last_scan_bytes = 0;
+
+    RuntimeProfile::HighWaterMarkCounter* _peak_buffer_size_counter = nullptr;
 };
 
 class ScanOperatorFactory : public SourceOperatorFactory {
 public:
-    ScanOperatorFactory(int32_t id, ScanNode* scan_node);
+    ScanOperatorFactory(int32_t id, ScanNode* scan_node, ChunkBufferLimiterPtr buffer_limiter);
 
     ~ScanOperatorFactory() override = default;
 
@@ -135,8 +134,7 @@ public:
 
 protected:
     ScanNode* const _scan_node;
-
-    std::atomic<int> _num_committed_scan_tasks{0};
+    ChunkBufferLimiterPtr _buffer_limiter;
 };
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -92,9 +92,6 @@ public:
 
     const std::string& name() const { return _name; }
 
-    // Used by pipeline, 0 means there is no limitation.
-    virtual int max_scan_concurrency() const { return 0; }
-
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "common/config.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/connector_scan_operator.h"
 #include "runtime/current_thread.h"
 #include "util/priority_thread_pool.hpp"
@@ -128,7 +129,9 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 }
 
 pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this);
+    // TODO: apply ChunkBufferLimiter to ConnectorScanOperator.
+    auto scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(
+            context->next_operator_id(), this, std::make_unique<pipeline::UnlimitedChunkBufferLimiter>());
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -11,6 +11,7 @@
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/noop_sink_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/scan/chunk_buffer_limiter.h"
 #include "exec/pipeline/scan/olap_scan_operator.h"
 #include "exec/pipeline/scan/olap_scan_prepare_operator.h"
 #include "exec/vectorized/olap_scan_prepare.h"
@@ -638,7 +639,7 @@ StatusOr<TabletSharedPtr> OlapScanNode::get_tablet(const TInternalScanRange* sca
     return tablet;
 }
 
-int OlapScanNode::max_scan_concurrency() const {
+int OlapScanNode::estimated_max_concurrent_chunks() const {
     int64_t query_limit = runtime_state()->query_mem_tracker_ptr()->limit();
 
     // We temporarily assume that the memory tried in the storage layer
@@ -714,7 +715,7 @@ void OlapScanNode::_estimate_scan_and_output_row_bytes() {
 }
 
 size_t OlapScanNode::_scanner_concurrency() const {
-    int concurrency = max_scan_concurrency();
+    int concurrency = estimated_max_concurrent_chunks();
     // limit concurrency not greater than scanner numbers
     concurrency = std::min<int>(concurrency, _num_scanners);
     concurrency = std::min<int>(concurrency, kMaxConcurrency);
@@ -757,6 +758,7 @@ void OlapScanNode::_close_pending_scanners() {
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     auto scan_ctx = std::make_shared<pipeline::OlapScanContext>(this);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
+    size_t scan_dop = context->degree_of_parallelism_of_source_operator(id());
 
     // scan_prepare_op.
     auto scan_prepare_op =
@@ -771,8 +773,13 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
     context->add_pipeline(scan_prepare_pipeline);
 
     // scan_op.
-    auto scan_op =
-            std::make_shared<pipeline::OlapScanOperatorFactory>(context->next_operator_id(), this, std::move(scan_ctx));
+    size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * scan_dop;
+    size_t default_buffer_capacity = std::min<size_t>(max_buffer_capacity, estimated_max_concurrent_chunks());
+    int64_t mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * config::scan_use_query_mem_ratio;
+    pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
+            max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());
+    auto scan_op = std::make_shared<pipeline::OlapScanOperatorFactory>(context->next_operator_id(), this,
+                                                                       std::move(buffer_limiter), std::move(scan_ctx));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);
 
     return pipeline::decompose_scan_node_to_pipeline(scan_op, this, context);

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -72,7 +72,7 @@ public:
 
     static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
 
-    int max_scan_concurrency() const override;
+    int estimated_max_concurrent_chunks() const;
 
 private:
     friend class TabletScanner;

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -230,7 +230,11 @@ public:
     bool try_get(T* out) {
         std::unique_lock<Lock> l(_lock);
         if (!_items.empty()) {
-            *out = _items.front();
+            if constexpr (std::is_move_assignable<T>::value) {
+                *out = std::move(_items.front());
+            } else {
+                *out = _items.front();
+            }
             _items.pop_front();
             return true;
         }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -60,7 +60,7 @@ RuntimeProfile::PeriodicCounterUpdateState RuntimeProfile::_s_periodic_counter_u
 
 const std::unordered_set<std::string> RuntimeProfile::NON_MERGE_COUNTER_NAMES = {
         "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum",         "PushdownPredicates",
-        "MemoryLimit",         "ChunkBufferCapacity",   "DefaultChunkBufferCapacity", "PeakBufferSize"};
+        "MemoryLimit",         "ChunkBufferCapacity",   "DefaultChunkBufferCapacity", "PeakChunkBufferSize"};
 
 RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
         : _parent(nullptr),

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -59,7 +59,8 @@ const std::string RuntimeProfile::ROOT_COUNTER = ""; // NOLINT
 RuntimeProfile::PeriodicCounterUpdateState RuntimeProfile::_s_periodic_counter_update_state;
 
 const std::unordered_set<std::string> RuntimeProfile::NON_MERGE_COUNTER_NAMES = {
-        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum", "PushdownPredicates", "MemoryLimit"};
+        "DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum",         "PushdownPredicates",
+        "MemoryLimit",         "ChunkBufferCapacity",   "DefaultChunkBufferCapacity", "PeakBufferSize"};
 
 RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
         : _parent(nullptr),


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Use the dynamic statistics of chunk memory usage to limit the capacity of a chunk buffer instead of scan concurrency.
1. Before triggering a new I/O task, pin a chunk token to pin a position in the buffer.
2. Before creating a new chunk in the I/O task, pin a chunk token, except the first new chunk (because it already pined a token in the step 1).
3. After a chunk is popped from buffer, unpin the token.

