### PR TITLE
[Feature] set global_runtime_filter_build_max_size to 0 to force use filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -155,11 +155,14 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         }
 
         if (distrMode.equals(DistributionMode.PARTITIONED) || distrMode.equals(DistributionMode.LOCAL_HASH_BUCKET)) {
-            // if it's partitioned join, and we can not get correct ndv
+            // If it's partitioned join, and we can not get correct ndv
             // then it's hard to estimate right bloom filter size, or it's too big.
             // so we'd better to skip this global runtime filter.
+            // If buildMaxSize == 0, the filter must be used
+            // Otherwise would decide based on cardinality
             long card = inner.getCardinality();
-            if (card <= 0 || card > sessionVariable.getGlobalRuntimeFilterBuildMaxSize()) {
+            long buildMaxSize = sessionVariable.getGlobalRuntimeFilterBuildMaxSize();
+            if (buildMaxSize > 0 && (card <= 0 || card > buildMaxSize)) {
                 return;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -94,11 +94,17 @@ public class RuntimeFilterDescription {
             return true;
         }
 
+        long probeMin = sessionVariable.getGlobalRuntimeFilterProbeMinSize();
         long card = node.getCardinality();
-        if (card < sessionVariable.getGlobalRuntimeFilterProbeMinSize()) {
+        // The special value 0 means force use this filter
+        if (probeMin == 0) {
+            return true;
+        }
+        if (card < probeMin) {
             return false;
         }
-        float sel = (1.0f - buildCardinality * 1.0f / card);
+        long buildCard = Math.max(0, buildCardinality);
+        float sel = (1.0f - buildCard * 1.0f / card);
         return !(sel < sessionVariable.getGlobalRuntimeFilterProbeMinSelectivity());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -519,6 +519,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_GLOBAL_RUNTIME_FILTER)
     private boolean enableGlobalRuntimeFilter = true;
 
+    // Parameters to determine the usage of runtime filter
+    // Either the build_max or probe_min equal to 0 would force use the filter,
+    // otherwise would decide based on the cardinality
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_BUILD_MAX_SIZE, flag = VariableMgr.INVISIBLE)
     private long globalRuntimeFilterBuildMaxSize = 64 * 1024 * 1024;
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_PROBE_MIN_SIZE, flag = VariableMgr.INVISIBLE)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Make `global_runtime_filter_build_max_size = 0` as a special value to force use the filter, regardless of estimated cardinality.

The use case is some wrong cardinality estimation would miss the opportunity of runtime filter.