### PR TITLE
[Feature] set global_runtime_filter_build_max_size to 0 to force use filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -170,7 +170,8 @@ public class HashJoinNode extends PlanNode {
             // then it's hard to estimate right bloom filter size, or it's too big.
             // so we'd better to skip this global runtime filter.
             long card = inner.getCardinality();
-            if (card <= 0 || card > sessionVariable.getGlobalRuntimeFilterBuildMaxSize()) {
+            long buildMax = sessionVariable.getGlobalRuntimeFilterBuildMaxSize();
+            if (buildMax > 0 && card <= 0 || card > buildMax) {
                 return;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -97,10 +97,14 @@ public class RuntimeFilterDescription {
         }
 
         long card = node.getCardinality();
-        if (card < sessionVariable.getGlobalRuntimeFilterProbeMinSize()) {
+        long probeMin = sessionVariable.getGlobalRuntimeFilterProbeMinSize();
+        if (probeMin == 0) {
+            return true;
+        }
+        if (card < probeMin) {
             return false;
         }
-        float sel = (1.0f - buildCardinality * 1.0f / card);
+        float sel = (1.0f - Math.max(0, buildCardinality) * 1.0f / card);
         return !(sel < sessionVariable.getGlobalRuntimeFilterProbeMinSelectivity());
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Use `global_runtime_filter_build_max_size = 0` to force use the runtime filter.