### PR TITLE
[Enhancement] orc format to support coalesce reads

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -711,7 +711,10 @@ CONF_Bool(object_storage_endpoint_use_https, "false");
 
 CONF_Bool(enable_orc_late_materialization, "true");
 // orc reader, if RowGroup/Stripe/File size is less than this value, read all data.
-CONF_Int32(orc_file_cache_max_size, "2097152");
+CONF_Int32(orc_file_cache_max_size, "8388608");
+CONF_Int32(orc_natural_read_size, "8388608");
+CONF_mBool(orc_coalesce_read_enable, "true");
+
 // parquet reader, each column will reserve X bytes for read
 // but with coalesce read enabled, this value is not used.
 CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -8,6 +8,7 @@
 #include "fs/fs.h"
 #include "gen_cpp/orc_proto.pb.h"
 #include "storage/chunk_helper.h"
+#include "util/buffered_stream.h"
 #include "util/runtime_profile.h"
 #include "util/timezone_utils.h"
 
@@ -16,14 +17,14 @@ class ORCHdfsFileStream : public orc::InputStream {
 public:
     // |file| must outlive ORCHdfsFileStream
     ORCHdfsFileStream(RandomAccessFile* file, uint64_t length)
-            : _file(std::move(file)), _length(length), _cache_buffer(0), _cache_offset(0) {}
+            : _file(std::move(file)), _length(length), _cache_buffer(0), _cache_offset(0), _buffer_stream(_file) {}
 
     ~ORCHdfsFileStream() override = default;
 
     uint64_t getLength() const override { return _length; }
 
     // refers to paper `Delta Lake: High-Performance ACID Table Storage over Cloud Object Stores`
-    uint64_t getNaturalReadSize() const override { return 1 * 1024 * 1024; }
+    uint64_t getNaturalReadSize() const override { return config::orc_natural_read_size; }
 
     // It's for read size after doing seek.
     // When doing read after seek, we make assumption that we are doing random read because of seeking row group.
@@ -39,7 +40,7 @@ public:
     // And this value can not be too small because if we can not read a row group in a single shot,
     // we will fallback to read in normal size, and we pay cost of a extra read.
 
-    uint64_t getNaturalReadSizeAfterSeek() const override { return 256 * 1024; }
+    uint64_t getNaturalReadSizeAfterSeek() const override { return config::orc_natural_read_size / 4; }
 
     void prepareCache(orc::InputStream::PrepareCacheScope scope, uint64_t offset, uint64_t length) override {
         const size_t cache_max_size = config::orc_file_cache_max_size;
@@ -54,7 +55,7 @@ public:
 
         _cache_buffer.resize(length);
         _cache_offset = offset;
-        doRead(_cache_buffer.data(), length, offset);
+        doRead(_cache_buffer.data(), length, offset, true);
     }
 
     bool canUseCacheBuffer(uint64_t offset, uint64_t length) {
@@ -70,16 +71,25 @@ public:
             size_t idx = offset - _cache_offset;
             memcpy(buf, _cache_buffer.data() + idx, length);
         } else {
-            doRead(buf, length, offset);
+            doRead(buf, length, offset, false);
         }
     }
 
-    void doRead(void* buf, uint64_t length, uint64_t offset) {
+    void doRead(void* buf, uint64_t length, uint64_t offset, bool direct) {
         if (buf == nullptr) {
             throw orc::ParseError("Buffer is null");
         }
-
-        Status status = _file->read_at_fully(offset, buf, length);
+        Status status;
+        if (direct || !_buffer_stream_enabled) {
+            status = _file->read_at_fully(offset, buf, length);
+        } else {
+            const uint8_t* ptr = nullptr;
+            size_t nbytes = length;
+            status = _buffer_stream.get_bytes(&ptr, offset, &nbytes);
+            if (status.ok()) {
+                ::memcpy(buf, ptr, length);
+            }
+        }
         if (!status.ok()) {
             auto msg = strings::Substitute("Failed to read $0: $1", _file->filename(), status.to_string());
             throw orc::ParseError(msg);
@@ -88,11 +98,33 @@ public:
 
     const std::string& getName() const override { return _file->filename(); }
 
+    void emptyIORanges() override {
+        _buffer_stream_enabled = false;
+        _buffer_stream.release();
+    }
+
+    void setIORanges(std::vector<orc::InputStream::IORange>& io_ranges) override {
+        if (!config::orc_coalesce_read_enable) return;
+        _buffer_stream_enabled = true;
+        std::vector<SharedBufferedInputStream::IORange> bs_io_ranges;
+        for (const auto& r : io_ranges) {
+            bs_io_ranges.emplace_back(SharedBufferedInputStream::IORange{.offset = static_cast<int64_t>(r.offset),
+                                                                         .size = static_cast<int64_t>(r.size)});
+        }
+        Status st = _buffer_stream.set_io_ranges(bs_io_ranges);
+        if (!st.ok()) {
+            auto msg = strings::Substitute("Failed to setIORanges $0: $1", _file->filename(), st.to_string());
+            throw orc::ParseError(msg);
+        }
+    }
+
 private:
     RandomAccessFile* _file;
     uint64_t _length;
     std::vector<char> _cache_buffer;
     uint64_t _cache_offset;
+    SharedBufferedInputStream _buffer_stream;
+    bool _buffer_stream_enabled = false;
 };
 
 class OrcRowReaderFilter : public orc::RowReaderFilter {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -98,13 +98,14 @@ public:
 
     const std::string& getName() const override { return _file->filename(); }
 
-    void emptyIORanges() override {
+    bool isIORangesEnabled() const override { return config::orc_coalesce_read_enable; }
+
+    void clearIORanges() override {
         _buffer_stream_enabled = false;
         _buffer_stream.release();
     }
 
     void setIORanges(std::vector<orc::InputStream::IORange>& io_ranges) override {
-        if (!config::orc_coalesce_read_enable) return;
         _buffer_stream_enabled = true;
         std::vector<SharedBufferedInputStream::IORange> bs_io_ranges;
         for (const auto& r : io_ranges) {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -86,6 +86,7 @@ public:
             const uint8_t* ptr = nullptr;
             size_t nbytes = length;
             status = _buffer_stream.get_bytes(&ptr, offset, &nbytes);
+            DCHECK_EQ(nbytes, length);
             if (status.ok()) {
                 ::memcpy(buf, ptr, length);
             }

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -39,10 +39,13 @@ namespace orc {
    */
 class InputStream {
 public:
+    struct IORange {
+        uint64_t offset;
+        uint64_t size;
+    };
     enum class PrepareCacheScope {
         READ_FULL_FILE,
         READ_FULL_STRIPE,
-        READ_ROW_GROUP_INDEX,
     };
 
     virtual ~InputStream();
@@ -79,6 +82,9 @@ public:
     virtual const std::string& getName() const = 0;
 
     virtual void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length);
+
+    virtual void emptyIORanges();
+    virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges);
 };
 
 /**

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -83,7 +83,8 @@ public:
 
     virtual void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length);
 
-    virtual void emptyIORanges();
+    virtual bool isIORangesEnabled() const;
+    virtual void clearIORanges();
     virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges);
 };
 

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -191,6 +191,8 @@ private:
      */
     bool hasBadBloomFilters();
 
+    void buildIORanges(std::vector<InputStream::IORange>* io_ranges);
+
 public:
     /**
     * Constructor that lets the user specify additional options.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is quite similar to PR https://github.com/StarRocks/starrocks/pull/7478

With this feature, there is no need to do `prepareCache` for `RowGroupIndex` any more, so I remove it.

Beside coalesce reading feature, I also ship with some modifications:
- add `filename` field when logging error message
- put `OrcNaturalReadSize` as a configuration variable(and increase to 8MB).

I'll post performance benchmark report later.

---

Take SSB/Q4.1 for example 

```
-- Q4.1
select d_year, c_nation, sum(lo_revenue) - sum(lo_supplycost) as profit
from lineorder
join dates on lo_orderdate = d_datekey
join customer on lo_custkey = c_custkey
join supplier on lo_suppkey = s_suppkey
join part on lo_partkey = p_partkey
where c_region = 'AMERICA' and s_region = 'AMERICA' and (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2')
group by d_year, c_nation
order by d_year, c_nation;
```

Running on my local env with 100G on OSS

- disable_coalesce_reads: IO=5900, Bytes=7168MB
- enable_coalesce_reads: IO=1800, Bytes=7229.44MB

```
mbp :: ~/Downloads » scan-node-io-stat --file disable.html --node 0 
hosts: ( 172.26.92.205 ) => 1 hosts
IO bytes = 7168MB
IO counter = 5900
IO time = 32635ms
IO scan ranges = 300
IO scan files = 0
Rows = return 9979019, read 600037902
avg read size = 1244KB
avg read lat = 5.5313559322033896ms

mbp :: ~/Downloads » scan-node-io-stat --file enable.html --node 0
hosts: ( 172.26.92.205 ) => 1 hosts
IO bytes = 7229.44MB
IO counter = 1800
IO time = 31142ms
IO scan ranges = 300
IO scan files = 0
Rows = return 9994849, read 600037902
avg read size = 4112.7480888888886KB
avg read lat = 17.301111111111112ms
```

---

Benchmark on SSB-100G, 3 BE nodes, 1 FE nodes. Coalesce-Reads does not hurt performance.

ORC in zlib



Query | SR(P=8) | Coalesce Reads | Ratio
-- | -- | -- | --
Q01 | 2060 | 2011 | 0.98
Q02 | 2081 | 1965 | 0.94
Q03 | 1949 | 1834 | 0.94
Q04 | 3271 | 2986 | 0.91
Q05 | 3134 | 2941 | 0.94
Q06 | 3094 | 2992 | 0.97
Q07 | 3579 | 3438 | 0.96
Q08 | 2967 | 2718 | 0.92
Q09 | 2900 | 2654 | 0.92
Q10 | 2853 | 2691 | 0.94
Q11 | 5042 | 4837 | 0.96
Q12 | 4876 | 4556 | 0.93
Q13 | 4744 | 4448 | 0.94
SUM | 42550 | 40071 | 0.94



