### PR TITLE
[Enhancement] Do not need check rssid equivalence when compaction.

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1535,8 +1535,9 @@ Status PersistentIndex::erase(size_t n, const void* keys, IndexValue* old_values
     return Status::OK();
 }
 
-Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue* values,
-                                    const std::vector<uint32_t>& src_rssid, std::vector<uint32_t>* failed) {
+[[maybe_unused]] Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue* values,
+                                                     const std::vector<uint32_t>& src_rssid,
+                                                     std::vector<uint32_t>* failed) {
     std::vector<IndexValue> found_values;
     found_values.reserve(n);
     RETURN_IF_ERROR(get(n, keys, found_values.data()));
@@ -1544,6 +1545,37 @@ Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue
     for (size_t i = 0; i < n; ++i) {
         if (values[i].get_value() != NullIndexValue &&
             ((uint32_t)(found_values[i].get_value() >> 32)) == src_rssid[i]) {
+            replace_idxes.emplace_back(i);
+        } else {
+            failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
+        }
+    }
+    RETURN_IF_ERROR(_l0->replace(keys, values, replace_idxes));
+    _dump_snapshot |= _can_dump_directly();
+    if (!_dump_snapshot) {
+        // write wal
+        const uint8_t* fkeys = reinterpret_cast<const uint8_t*>(keys);
+        faststring fixed_buf;
+        fixed_buf.reserve(replace_idxes.size() * (_key_size + sizeof(IndexValue)));
+        for (size_t i = 0; i < replace_idxes.size(); ++i) {
+            fixed_buf.append(fkeys + replace_idxes[i] * _key_size, _key_size);
+            put_fixed64_le(&fixed_buf, values[replace_idxes[i]].get_value());
+        }
+        RETURN_IF_ERROR(_index_file->append(fixed_buf));
+        _page_size += fixed_buf.size();
+    }
+    return Status::OK();
+}
+
+Status PersistentIndex::try_replace(size_t n, const void* keys, const IndexValue* values, const uint32_t max_src_rssid,
+                                    std::vector<uint32_t>* failed) {
+    std::vector<IndexValue> found_values;
+    found_values.reserve(n);
+    RETURN_IF_ERROR(get(n, keys, found_values.data()));
+    std::vector<size_t> replace_idxes;
+    for (size_t i = 0; i < n; ++i) {
+        if (values[i].get_value() != NullIndexValue &&
+            ((uint32_t)(found_values[i].get_value() >> 32)) <= max_src_rssid) {
             replace_idxes.emplace_back(i);
         } else {
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -298,13 +298,23 @@ public:
     // |old_values|: return old values if key exist, or set to NullValue if not
     Status erase(size_t n, const void* keys, IndexValue* old_values);
 
+    // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // batch replace
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
     // |values|: value array
     // |src_rssid|: rssid array
     // |failed|: return not match rowid
-    Status try_replace(size_t n, const void* keys, const IndexValue* values, const std::vector<uint32_t>& src_rssid,
+    [[maybe_unused]] Status try_replace(size_t n, const void* keys, const IndexValue* values,
+                                        const std::vector<uint32_t>& src_rssid, std::vector<uint32_t>* failed);
+
+    // batch replace
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |values|: value array
+    // |max_src_rssid|: maximum of rssid array
+    // |failed|: return not match rowid
+    Status try_replace(size_t n, const void* keys, const IndexValue* values, const uint32_t max_src_rssid,
                        std::vector<uint32_t>* failed);
 
     size_t mutable_index_size();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -39,9 +39,14 @@ public:
     // batch upsert a range [idx_begin, idx_end) of keys
     virtual void upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, uint32_t idx_begin,
                         uint32_t idx_end, DeletesMap* deletes) = 0;
+    // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // batch try_replace a range [idx_begin, idx_end) of keys
+    [[maybe_unused]] virtual void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                              const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                                              vector<uint32_t>* failed) = 0;
+
     virtual void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                             const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                             const uint32_t max_src_rssid, uint32_t idx_begin, uint32_t idx_end,
                              vector<uint32_t>* failed) = 0;
     // batch erase a range [idx_begin, idx_end) of keys
     virtual void erase(const vectorized::Column& pks, uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) = 0;
@@ -149,9 +154,9 @@ public:
         }
     }
 
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                     const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
-                     vector<uint32_t>* failed) override {
+    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                      const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                                      vector<uint32_t>* failed) override {
         auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
@@ -163,6 +168,22 @@ public:
                 p->second = RowIdPack4(base + i);
             } else {
                 // not match, mark failed
+                failed->push_back(rowid_start + i);
+            }
+        }
+    }
+
+    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
+                     uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
+        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        for (uint32_t i = idx_begin; i < idx_end; i++) {
+            uint32_t prefetch_i = i + PREFETCHN;
+            if (LIKELY(prefetch_i < idx_end)) _map.prefetch(keys[prefetch_i]);
+            auto p = _map.find(keys[i]);
+            if (p != _map.end() && (uint32_t)(p->second.value >> 32) <= max_src_rssid) {
+                p->second = RowIdPack4(base + i);
+            } else {
                 failed->push_back(rowid_start + i);
             }
         }
@@ -342,9 +363,9 @@ public:
             }
         }
     }
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                     const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
-                     vector<uint32_t>* failed) override {
+    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                      const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                                      vector<uint32_t>* failed) override {
         const Slice* keys = reinterpret_cast<const Slice*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         uint32_t n = idx_end - idx_begin;
@@ -377,6 +398,50 @@ public:
             for (uint32_t i = idx_begin; i < idx_end; i++) {
                 auto p = _map.find(FixSlice<S>(keys[i]));
                 if (p != _map.end() && (uint32_t)(p->second.value >> 32) == src_rssid[i]) {
+                    // matched, can replace
+                    p->second.value = base + i;
+                } else {
+                    // not match, mark failed
+                    failed->push_back(rowid_start + i);
+                }
+            }
+        }
+    }
+
+    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
+                     uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
+        const Slice* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        uint32_t n = idx_end - idx_begin;
+        if (n >= PREFETCHN * 2) {
+            FixSlice<S> prefetch_keys[PREFETCHN];
+            size_t prefetch_hashes[PREFETCHN];
+            for (uint32_t i = 0; i < PREFETCHN; i++) {
+                prefetch_keys[i].assign(keys[idx_begin + i]);
+                prefetch_hashes[i] = FixSliceHash<S>()(prefetch_keys[i]);
+                _map.prefetch_hash(prefetch_hashes[i]);
+            }
+            for (uint32_t i = idx_begin; i < idx_end; i++) {
+                uint32_t pslot = (i - idx_begin) % PREFETCHN;
+                auto p = _map.find(prefetch_keys[pslot], prefetch_hashes[pslot]);
+                if (p != _map.end() && (uint32_t)(p->second.value >> 32) <= max_src_rssid) {
+                    // matched, can replace
+                    p->second.value = base + i;
+                } else {
+                    // not match, mark failed
+                    failed->push_back(rowid_start + i);
+                }
+                uint32_t prefetch_i = i + PREFETCHN;
+                if (LIKELY(prefetch_i < idx_end)) {
+                    prefetch_keys[pslot].assign(keys[prefetch_i]);
+                    prefetch_hashes[pslot] = FixSliceHash<S>()(prefetch_keys[pslot]);
+                    _map.prefetch_hash(prefetch_hashes[pslot]);
+                }
+            }
+        } else {
+            for (uint32_t i = idx_begin; i < idx_end; i++) {
+                auto p = _map.find(FixSlice<S>(keys[i]));
+                if (p != _map.end() && (uint32_t)(p->second.value >> 32) <= max_src_rssid) {
                     // matched, can replace
                     p->second.value = base + i;
                 } else {
@@ -533,14 +598,30 @@ public:
         }
     }
 
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                     const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
-                     vector<uint32_t>* failed) override {
+    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                      const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                                      vector<uint32_t>* failed) override {
         auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             auto p = _map.find(keys[i].to_string());
             if (p != _map.end() && (uint32_t)(p->second >> 32) == src_rssid[i]) {
+                // matched, can replace
+                p->second = base + i;
+            } else {
+                // not match, mark failed
+                failed->push_back(rowid_start + i);
+            }
+        }
+    }
+
+    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
+                     uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
+        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        for (uint32_t i = idx_begin; i < idx_end; i++) {
+            auto p = _map.find(keys[i].to_string());
+            if (p != _map.end() && (uint32_t)(p->second >> 32) <= max_src_rssid) {
                 // matched, can replace
                 p->second = base + i;
             } else {
@@ -710,9 +791,9 @@ public:
         }
     }
 
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                     const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
-                     vector<uint32_t>* failed) override {
+    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                      const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
+                                      vector<uint32_t>* failed) override {
         if (idx_begin < idx_end) {
             auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
@@ -724,6 +805,22 @@ public:
             }
             get_index_by_length(keys[idx_begin].size)
                     ->try_replace(rssid, rowid_start, pks, src_rssid, idx_begin, idx_end, failed);
+        }
+    }
+
+    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
+                     uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
+        if (idx_begin < idx_end) {
+            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
+                if (keys[i].size != keys[idx_begin].size) {
+                    get_index_by_length(keys[idx_begin].size)
+                            ->try_replace(rssid, rowid_start, pks, max_src_rssid, idx_begin, i, failed);
+                    idx_begin = i;
+                }
+            }
+            get_index_by_length(keys[idx_begin].size)
+                    ->try_replace(rssid, rowid_start, pks, max_src_rssid, idx_begin, idx_end, failed);
         }
     }
 
@@ -1111,13 +1208,27 @@ void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col,
     }
 }
 
-void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                             const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
+[[maybe_unused]] void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
+                                                              const vectorized::Column& pks,
+                                                              const vector<uint32_t>& src_rssid,
+                                                              vector<uint32_t>* deletes) {
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
     Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
+    if (!st.ok()) {
+        LOG(WARNING) << "try replace persistent index failed";
+    }
+}
+
+void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                             const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+    std::vector<uint64_t> values;
+    values.reserve(pks.size());
+    _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
+    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
+                                               reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
@@ -1148,13 +1259,23 @@ void PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized
     }
 }
 
-void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                               const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
+[[maybe_unused]] void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                                const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
     if (_persistent_index != nullptr) {
         _replace_persistent_index(rssid, rowid_start, pks, src_rssid, deletes);
     } else {
         _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, src_rssid, 0, pks.size(), deletes);
+    }
+}
+
+void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                               const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+    DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    if (_persistent_index != nullptr) {
+        _replace_persistent_index(rssid, rowid_start, pks, max_src_rssid, deletes);
+    } else {
+        _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, max_src_rssid, 0, pks.size(), deletes);
     }
 }
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -56,17 +56,32 @@ public:
     // [not thread-safe]
     void upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, DeletesMap* deletes);
 
+    // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
     // input rowsets' rowid doesn't exist, this indicates that the row of output rowset is
     // deleted during compaction, so append it's rowid into |deletes|
     // |rssid| output segment's rssid
-    // |key_col| each output segment row's *encoded* primary key
+    // |rowid_start| row id left open interval
+    // |pks| each output segment row's *encoded* primary key
     // |src_rssid| each output segment row's source segment rssid
     // |failed| rowids of output segment's rows that failed to replace
     //
     // [not thread-safe]
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                     const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
+    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                      const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
+
+    // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
+    // input rowsets' rowid greater than the max src rssid, this indicates that the row of output rowset is
+    // deleted during compaction, so append it's rowid into |deletes|
+    // |rssid| output segment's rssid
+    // |rowid_start| row id left open interval
+    // |pks| each output segment row's *encoded* primary key
+    // |max_src_rssid| each output segment row's source segment rssid
+    // |failed| rowids of output segment's rows that failed to replace
+    //
+    // [not thread-safe]
+    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
+                     vector<uint32_t>* failed);
 
     // |key_col| contains the *encoded* primary keys to be deleted from this index.
     // The position of deleted keys will be appended into |new_deletes|.
@@ -120,8 +135,11 @@ private:
 
     void _get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const;
 
+    // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
+    [[maybe_unused]] void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                                    const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
     void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                   const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
+                                   const uint32_t max_src_rssid, vector<uint32_t>* deletes);
 
     std::mutex _lock;
     std::atomic<bool> _loaded{false};

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1296,7 +1296,8 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         uint32_t rssid = rowset_id + i;
         tmp_deletes.clear();
         // replace will not grow hashtable, so don't need to check memory limit
-        index.try_replace(rssid, 0, *sstate.pkeys, info->inputs.back(), &tmp_deletes);
+        index.try_replace(rssid, 0, *sstate.pkeys, *std::max_element(info->inputs.begin(), info->inputs.end()),
+                          &tmp_deletes);
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
             dv->init(version.major(), nullptr, 0);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1296,7 +1296,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         uint32_t rssid = rowset_id + i;
         tmp_deletes.clear();
         // replace will not grow hashtable, so don't need to check memory limit
-        index.try_replace(rssid, 0, *sstate.pkeys, sstate.src_rssids, &tmp_deletes);
+        index.try_replace(rssid, 0, *sstate.pkeys, info->inputs.back(), &tmp_deletes);
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
             dv->init(version.major(), nullptr, 0);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8411

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Just check whether the new rssid is larger than max rssid when doing compaction.