### PR TITLE
[Bugfix] release request memory before instance_mem_tracker desctructed

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -60,7 +60,8 @@ public:
     // Channel will sent input request directly without batch it.
     // This function is only used when broadcast, because request can be reused
     // by all the channels.
-    Status send_chunk_request(PTransmitChunkParamsPtr chunk_request, const butil::IOBuf& attachment);
+    Status send_chunk_request(PTransmitChunkParamsPtr chunk_request, const butil::IOBuf& attachment,
+                              int64_t attachment_physical_bytes);
 
     // Used when doing shuffle.
     // This function will copy selective rows in chunks to batch.
@@ -224,8 +225,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         _chunk_request->set_eos(eos);
         _chunk_request->set_use_pass_through(_use_pass_through);
         butil::IOBuf attachment;
-        _parent->construct_brpc_attachment(_chunk_request, attachment);
-        TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment};
+        int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
+        TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment,
+                                  attachment_physical_bytes};
         _parent->_buffer->add_request(info);
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -236,14 +238,16 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
 }
 
 Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParamsPtr chunk_request,
-                                                         const butil::IOBuf& attachment) {
+                                                         const butil::IOBuf& attachment,
+                                                         int64_t attachment_physical_bytes) {
     chunk_request->set_node_id(_dest_node_id);
     chunk_request->set_sender_id(_parent->_sender_id);
     chunk_request->set_be_number(_parent->_be_number);
     chunk_request->set_eos(false);
     chunk_request->set_use_pass_through(_use_pass_through);
 
-    TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment};
+    TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment,
+                              attachment_physical_bytes};
     _parent->_buffer->add_request(info);
 
     return Status::OK();
@@ -456,11 +460,12 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > config::max_transmit_batched_bytes) {
                 butil::IOBuf attachment;
-                construct_brpc_attachment(_chunk_request, attachment);
+                int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
                 for (auto idx : _channel_indices) {
                     if (!_channels[idx]->use_pass_through()) {
                         PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
-                        RETURN_IF_ERROR(_channels[idx]->send_chunk_request(copy, attachment));
+                        RETURN_IF_ERROR(
+                                _channels[idx]->send_chunk_request(copy, attachment, attachment_physical_bytes));
                     }
                 }
                 _current_request_bytes = 0;
@@ -573,10 +578,10 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
     if (_chunk_request != nullptr) {
         butil::IOBuf attachment;
-        construct_brpc_attachment(_chunk_request, attachment);
+        int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
         for (const auto& [_, channel] : _instance_id2channel) {
             PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
-            channel->send_chunk_request(copy, attachment);
+            channel->send_chunk_request(copy, attachment, attachment_physical_bytes);
         }
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -659,17 +664,25 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
     return Status::OK();
 }
 
-void ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParamsPtr chunk_request, butil::IOBuf& attachment) {
+int64_t ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParamsPtr chunk_request,
+                                                        butil::IOBuf& attachment) {
+    int64_t attachment_physical_bytes = 0;
     for (int i = 0; i < chunk_request->chunks().size(); ++i) {
         auto chunk = chunk_request->mutable_chunks(i);
         chunk->set_data_size(chunk->data().size());
+
+        int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
         attachment.append(chunk->data());
+        attachment_physical_bytes += CurrentThread::current().get_consumed_bytes() - before_bytes;
+
         chunk->clear_data();
         // If the request is too big, free the memory in order to avoid OOM
         if (_is_large_chunk(chunk->data_size())) {
             chunk->mutable_data()->shrink_to_fit();
         }
     }
+
+    return attachment_physical_bytes;
 }
 
 ExchangeSinkOperatorFactory::ExchangeSinkOperatorFactory(

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -63,6 +63,7 @@ public:
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const vectorized::Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
+    // Return the physical bytes of attachment.
     int64_t construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
 
 private:

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -63,7 +63,7 @@ public:
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const vectorized::Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
-    void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
+    int64_t construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -37,6 +37,7 @@ struct TransmitChunkInfo {
     doris::PBackendService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;
     butil::IOBuf attachment;
+    int64_t attachment_physical_bytes;
 };
 
 struct ClosureContext {

--- a/be/src/util/disposable_closure.h
+++ b/be/src/util/disposable_closure.h
@@ -18,17 +18,21 @@ class MemTracker;
 template <typename T, typename C = void>
 class DisposableClosure : public google::protobuf::Closure {
 public:
-    DisposableClosure(const C& ctx, MemTracker* const mem_tracker) : _ctx(ctx), _mem_tracker(mem_tracker) {}
-    ~DisposableClosure() override = default;
+    using FailedFunc = std::function<void(const C&)>;
+    using SuccessFunc = std::function<void(const C&, const T&)>;
 
+    DisposableClosure(const C& ctx) : _ctx(ctx) {}
+    ~DisposableClosure() override = default;
     // Disallow copy and assignment.
     DisposableClosure(const DisposableClosure& other) = delete;
     DisposableClosure& operator=(const DisposableClosure& other) = delete;
 
-    void addFailedHandler(std::function<void(const C&)> fn) { _failed_handler = std::move(fn); }
-    void addSuccessHandler(std::function<void(const C&, const T&)> fn) { _success_handler = fn; }
+    void addFailedHandler(FailedFunc fn) { _failed_handler = std::move(fn); }
+    void addSuccessHandler(SuccessFunc fn) { _success_handler = fn; }
 
     void Run() noexcept override {
+        std::unique_ptr<DisposableClosure> self_guard(this);
+
         try {
             if (cntl.Failed()) {
                 LOG(WARNING) << "brpc failed, error=" << berror(cntl.ErrorCode())
@@ -37,12 +41,6 @@ public:
             } else {
                 _success_handler(_ctx, result);
             }
-            {
-                // The request memory is acquired by ExchangeSinkOperator,
-                // so use the instance_mem_tracker passed from ExchangeSinkOperator to release memory.
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
-                delete this;
-            }
         } catch (const std::exception& exp) {
             LOG(FATAL) << "[ExchangeSinkOperator] Callback error: " << exp.what();
         } catch (...) {
@@ -50,13 +48,13 @@ public:
         }
     }
 
+public:
     brpc::Controller cntl;
     T result;
 
 private:
     const C _ctx;
-    std::function<void(const C&)> _failed_handler;
-    std::function<void(const C&, const T&)> _success_handler;
-    MemTracker* const _mem_tracker = nullptr;
+    FailedFunc _failed_handler;
+    SuccessFunc _success_handler;
 };
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/703.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
There are some other problems about mem_tracker of ExchangeSinkOperator, because the RPC response callback sends a new RPC request again:
- Request except attachment:
    - Created by exec threads (`push_chunk`).
    - Released by exec threads or bthreads (`SinkBuffer::_try_to_send_rpc` can be invoked by `push_chunk` or  the response callback).
- Attachment:
    - Created by exec threads (`push_chunk`).
    - Released by bthreads (the response callback).
- Serialized protobuf request:
    - Created by exec threads or bthreads (`SinkBuffer::_try_to_send_rpc`).
    - Released by bthreads (the response callback).

Therefore, In `SinkBuffer::_try_to_send_rpc`:
- use instance_mem_tracker to release request.
- move the memory record from instance_mem_tracker to process_mem_tracker.
- use process_mem_tracker to create Serialized protobuf request.

<img width="995" alt="image" src="https://user-images.githubusercontent.com/13313784/178098667-44dd0a0a-bf83-4d3b-808d-357714a953ac.png">



