### PR TITLE
[Cherry-pick 2.2][BugFix] Raise exception if image download fails #8111

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -876,7 +876,7 @@ public class Catalog {
         auditEventProcessor.start();
 
         // 2. get cluster id and role (Observer or Follower)
-        getClusterIdAndRole();
+        getClusterIdAndRoleOnStartup();
 
         // 3. Load image first and replay edits
         this.editLog = new EditLog(nodeName);
@@ -915,7 +915,7 @@ public class Catalog {
         return isReady.get();
     }
 
-    private void getClusterIdAndRole() throws IOException {
+    private void getClusterIdAndRoleOnStartup() throws IOException {
         File roleFile = new File(this.imageDir, Storage.ROLE_FILE);
         File versionFile = new File(this.imageDir, Storage.VERSION_FILE);
 
@@ -1088,7 +1088,7 @@ public class Catalog {
                     System.exit(-1);
                 }
             }
-            getNewImage(rightHelperNode);
+            getNewImageOnStartup(rightHelperNode);
         }
 
         if (Config.cluster_id != -1 && clusterId != Config.cluster_id) {
@@ -1464,25 +1464,26 @@ public class Catalog {
         return false;
     }
 
-    private void getNewImage(Pair<String, Integer> helperNode) throws IOException {
+
+    /**
+      * When a new node joins in the cluster for the first time, it will download image from the helper at the very beginning
+      * Exception are free to raise on initialized phase
+      */
+    private void getNewImageOnStartup(Pair<String, Integer> helperNode) throws IOException {
         long localImageVersion = 0;
         Storage storage = new Storage(this.imageDir);
         localImageVersion = storage.getImageJournalId();
 
-        try {
-            URL infoUrl = new URL("http://" + helperNode.first + ":" + Config.http_port + "/info");
-            StorageInfo info = getStorageInfo(infoUrl);
-            long version = info.getImageJournalId();
-            if (version > localImageVersion) {
-                String url = "http://" + helperNode.first + ":" + Config.http_port
-                        + "/image?version=" + version;
-                String filename = Storage.IMAGE + "." + version;
-                File dir = new File(this.imageDir);
-                MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000, MetaHelper.getOutputStream(filename, dir));
-                MetaHelper.complete(filename, dir);
-            }
-        } catch (Exception e) {
-            return;
+        URL infoUrl = new URL("http://" + helperNode.first + ":" + Config.http_port + "/info");
+        StorageInfo info = getStorageInfo(infoUrl);
+        long version = info.getImageJournalId();
+        if (version > localImageVersion) {
+            String url = "http://" + helperNode.first + ":" + Config.http_port
+                    + "/image?version=" + version;
+            String filename = Storage.IMAGE + "." + version;
+            File dir = new File(this.imageDir);
+            MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000, MetaHelper.getOutputStream(filename, dir));
+            MetaHelper.complete(filename, dir);
         }
     }
 
@@ -1540,7 +1541,7 @@ public class Catalog {
         DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(curFile)));
 
         long checksum = 0;
-        long remoteChecksum = 0;
+        long remoteChecksum = -1;
         try {
             checksum = loadHeader(dis, checksum);
             checksum = loadMasterInfo(dis, checksum);


### PR DESCRIPTION
Fix these 2 cases.

1. No exception will throw on loading an empty image file.
2. No exception will throw when failing to download an image from the helper. For example, if the image dir is readable to the FE process but the image file is not.

Can't find a way to add unittest, just manually test the above cases.

Fixes #7754.

Note: This is not exactly a cherry-pick from 8d5e750.