### PR TITLE
[Enhancement] Keep trailing zero if specified

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -123,7 +123,6 @@ public class DecimalLiteral extends LiteralExpr {
         if (!Config.enable_decimal_v3) {
             type = ScalarType.DECIMALV2;
         } else {
-            this.value = value.stripTrailingZeros();
             int precision = getRealPrecision(this.value);
             int scale = getRealScale(this.value);
             int integerPartWidth = precision - scale;
@@ -148,7 +147,6 @@ public class DecimalLiteral extends LiteralExpr {
         ScalarType scalarType = (ScalarType) type;
         this.value = new BigDecimal(value.toPlainString());
         if (type.isDecimalV3()) {
-            this.value = value.stripTrailingZeros();
             int precision = scalarType.getScalarPrecision();
             int scale = scalarType.getScalarScale();
             int realPrecision = getRealPrecision(this.value);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -189,11 +189,20 @@ public class ScalarType extends Type implements Cloneable {
         return scalarType;
     }
 
-    // 0's type is decimal32(0,0)
-    public static ScalarType createDecimalV3TypeForZero() {
-        ScalarType scalarType = new ScalarType(PrimitiveType.DECIMAL32);
-        scalarType.precision = 0;
-        scalarType.scale = 0;
+    public static ScalarType createDecimalV3TypeForZero(int scale) {
+        final ScalarType scalarType;
+        if (scale <= PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL32)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL32);
+        } else if (scale <= PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL64)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL64);
+        } else if (scale <= PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL128)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL128);
+        } else {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL128);
+            scale = PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL128);
+        }
+        scalarType.precision = scale;
+        scalarType.scale = scale;
         return scalarType;
     }
 
@@ -221,7 +230,7 @@ public class ScalarType extends Type implements Cloneable {
 
     public static ScalarType createDecimalV3NarrowestType(int precision, int scale) {
         if (precision == 0 && scale == 0) {
-            return createDecimalV3TypeForZero();
+            return createDecimalV3TypeForZero(0);
         }
         final int decimal32MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL32);
         final int decimal64MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL64);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -234,7 +234,7 @@ public class ScalarType extends Type implements Cloneable {
             return createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
         } else {
             Preconditions.checkState(false,
-                    "Illegal decimal precision(1 to 38): pecision=" + precision);
+                    "Illegal decimal precision(1 to 38): precision=" + precision);
             return ScalarType.INVALID;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -85,7 +85,7 @@ public abstract class Type implements Cloneable {
 
     // DECIMAL64_INT and DECIMAL128_INT for integer casting to decimal
     public static final ScalarType DECIMAL_ZERO =
-            ScalarType.createDecimalV3TypeForZero();
+            ScalarType.createDecimalV3TypeForZero(0);
     public static final ScalarType DECIMAL32_INT =
             ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 0);
     public static final ScalarType DECIMAL64_INT =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -176,7 +176,7 @@ public enum ScalarOperatorEvaluator {
             try {
                 return (ConstantOperator) method.invoke(null, invokeArgs.toArray());
             } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
-                throw new AnalysisException(e.getLocalizedMessage());
+                throw new AnalysisException(e.getLocalizedMessage(), e);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -646,7 +646,6 @@ public class ScalarOperatorFunctions {
         if (!Config.enable_decimal_v3) {
             type = ScalarType.DECIMALV2;
         } else {
-            result = result.stripTrailingZeros();
             int precision = DecimalLiteral.getRealPrecision(result);
             int scale = DecimalLiteral.getRealScale(result);
             type = ScalarType.createDecimalV3NarrowestType(precision, scale);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -194,7 +194,7 @@ public class DecimalLiteralTest {
 
         type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4);
         decimalLiteral = new DecimalLiteral("12345678.90", type);
-        Assert.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 1));
+        Assert.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
         decimalLiteral = (DecimalLiteral) decimalLiteral.uncheckedCastTo(type);
         Assert.assertEquals(decimalLiteral.getType(), type);
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -226,7 +226,8 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
 
         sql = "select sum(dec_20_19) from test_decimal_type6";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("sum[(cast([7: dec_20_19, DECIMAL128(20,19), true] as DECIMAL128(38,18))); args: DECIMAL128; result: DECIMAL128(38,18); args nullable: true; result nullable: true]"));
+        Assert.assertTrue(plan.contains(
+                "sum[(cast([7: dec_20_19, DECIMAL128(20,19), true] as DECIMAL128(38,18))); args: DECIMAL128; result: DECIMAL128(38,18); args nullable: true; result nullable: true]"));
     }
 
     @Test
@@ -384,11 +385,13 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         sql = "select count(`dec_10_2` + dec_12_10) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         // decimal64(10, 2) + decimal64(12, 10) = decimal128(21, 10);
-        Assert.assertTrue(plan.contains("cast([4: dec_10_2, DECIMAL64(10,2), false] as DECIMAL128(19,2)) + cast([5: dec_12_10, DECIMAL64(12,10), false] as DECIMAL128(19,10))"));
+        Assert.assertTrue(plan.contains(
+                "cast([4: dec_10_2, DECIMAL64(10,2), false] as DECIMAL128(19,2)) + cast([5: dec_12_10, DECIMAL64(12,10), false] as DECIMAL128(19,10))"));
         // decimal64(18, 0) + decimal64(18, 18) = decimal(37, 18)
         sql = "select count(dec_18_0 + dec_18_18) from `test_decimal_type6`";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
+        Assert.assertTrue(plan.contains(
+                "cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
         // const decimal64(18, 0) + decimal64(18, 18) = decimal128(37, 18) literal
         sql = "select cast(1000000000000000000 as decimal(18, 0)) + cast(0.000000000000000001 as decimal(18, 18))";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
@@ -411,7 +414,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalMulZero() throws Exception {
         String sql = "select col_decimal32p9s2 * 0.0 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> [2: col_decimal32p9s2, DECIMAL32(9,2), false] * 0";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(9,2)) * 0.0";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -419,7 +422,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalDivZero() throws Exception {
         String sql = "select col_decimal32p9s2 / 0.0 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2)) / 0";
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2)) / 0.0";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -435,7 +438,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testZeroDivDecimal() throws Exception {
         String sql = "select 0.0 / col_decimal32p9s2 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> 0 / cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2))";
+        String snippet = "6 <-> 0.0 / cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2))";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -443,7 +446,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testZeroModDecimal() throws Exception {
         String sql = "select 0.0 % col_decimal32p9s2 from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> 0 % cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2))";
+        String snippet = "6 <-> 0.0 % cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2))";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -451,22 +454,25 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalNullableProperties() throws Exception {
         String sql;
         String plan;
-        
+
         // test decimal count(no-nullable decimal)
         sql = "select count(`dec_18_0`) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("aggregate: count[([2: dec_18_0, DECIMAL64(18,0), false]); args: DECIMAL64; result: BIGINT; args nullable: false; result nullable: true]"));
+        Assert.assertTrue(plan.contains(
+                "aggregate: count[([2: dec_18_0, DECIMAL64(18,0), false]); args: DECIMAL64; result: BIGINT; args nullable: false; result nullable: true]"));
 
         // test decimal add return a nullable column
         sql = "select count(`dec_18_0` + `dec_18_18`) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
+        Assert.assertTrue(plan.contains(
+                "cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(37,0)) + cast([3: dec_18_18, DECIMAL64(18,18), false] as DECIMAL128(37,18))"));
 
         // test decimal input function input no-nullable, output is nullable
         sql = "select round(`dec_18_0`) from `test_decimal_type6`";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         System.out.println("plan = " + plan);
-        Assert.assertTrue(plan.contains("round[(cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(18,0))); args: DECIMAL128; result: DECIMAL128(38,0); args nullable: true; result nullable: true]"));
+        Assert.assertTrue(plan.contains(
+                "round[(cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(18,0))); args: DECIMAL128; result: DECIMAL128(38,0); args nullable: true; result nullable: true]"));
     }
 
     @Test
@@ -476,12 +482,13 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         sql = "select 123456789000000000000000000000000000.00 * 123456789.123456789 * 123456789.123456789;";
         final long sqlMode = ctx.getSessionVariable().getSqlMode();
         final long code = SqlModeHelper.encode("MODE_DOUBLE_LITERAL");
-        ctx.getSessionVariable().setSqlMode(code|sqlMode);
+        ctx.getSessionVariable().setSqlMode(code | sqlMode);
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         Assert.assertTrue(plan.contains("  |  2 <-> 1.8816763755525075E51"));
         ctx.getSessionVariable().setSqlMode(sqlMode);
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("  |  2 <-> 123456789000000000000000000000000000 * 123456789.123456789 * 123456789.123456789"));
+        Assert.assertTrue(plan.contains(
+                "  |  2 <-> 123456789000000000000000000000000000.00 * 123456789.123456789 * 123456789.123456789"));
     }
 
     @Test
@@ -495,7 +502,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         Assert.assertTrue(plan.contains("truncate[(0.6798916342905857, 10); args: DOUBLE,INT; result: DOUBLE; " +
                 "args nullable: false; result nullable: true]"));
-
 
         sql = "select TRUNCATE(0.6798916342905857, to_base64('abc'));";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -886,7 +886,7 @@ public class AnalyzeDecimalV3Test {
                     ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
             Assert.assertEquals(items.get(2).getType(), ScalarType.DOUBLE);
             Assert.assertEquals(items.get(3).getType(), ScalarType.createDecimalV3NarrowestType(3, 2));
-            Assert.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3NarrowestType(1, 1));
+            Assert.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3TypeForZero(1));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -886,7 +886,7 @@ public class AnalyzeDecimalV3Test {
                     ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
             Assert.assertEquals(items.get(2).getType(), ScalarType.DOUBLE);
             Assert.assertEquals(items.get(3).getType(), ScalarType.createDecimalV3NarrowestType(3, 2));
-            Assert.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3TypeForZero());
+            Assert.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3NarrowestType(1, 1));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -528,7 +528,11 @@ public class ExpressionTest extends PlanTestBase {
     public void testCastDecimalZero() throws Exception {
         String sql = "select (CASE WHEN CAST(t0.v1 AS BOOLEAN ) THEN 0.00 END) BETWEEN (0.07) AND (0.04) from t0;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  |  <slot 7> : CAST(6: if AS DECIMAL32(2,2))\n"));
+        Assert.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 4> : (6: if >= 0.07) AND (6: if <= 0.04)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 5> : CAST(1: v1 AS BOOLEAN)\n" +
+                "  |  <slot 6> : if(5: cast, 0.00, NULL)"));
     }
 
     @Test
@@ -1005,14 +1009,14 @@ public class ExpressionTest extends PlanTestBase {
     @Test
     public void testTimestampadd() throws Exception {
         String sql = "select timestampadd(YEAR,1,'2022-04-02 13:21:03')";
-        String plan =  getFragmentPlan(sql);
+        String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("<slot 2> : '2023-04-02 13:21:03'"));
     }
 
     @Test
     public void testDaysSub() throws Exception {
         String sql = "select days_sub('2010-11-30 23:59:59', 0)";
-        String plan =  getFragmentPlan(sql);
+        String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("<slot 2> : '2010-11-30 23:59:59'"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -1183,56 +1183,56 @@ public class JoinTest extends PlanTestBase {
         Assert.assertTrue(explainString.contains("  2:OlapScanNode\n" +
                 "     TABLE: join2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 right semi join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
                 "     TABLE: join2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 right anti join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
                 "     TABLE: join2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 left join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  2:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 left semi join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 left anti join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
 
         sql = "select * from test.join1 inner join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         assertContains(explainString, "  0:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3");
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0");
 
         sql = "select * from test.join1 where round(2.0, 0) > 3.0";
         explainString = getFragmentPlan(sql);
         Assert.assertTrue(explainString.contains("  0:OlapScanNode\n" +
                 "     TABLE: join1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: round(2, 0) > 3"));
+                "     PREDICATES: CAST(round(2.0, 0) AS DOUBLE) > 3.0"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -41,16 +41,16 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testInnerJoinWithPredicate() throws Exception {
         String sql = "SELECT * from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 = 1;";
-        String planFragment = getFragmentPlan(sql);
-        assertContains(planFragment, "PREDICATES: 1: v1 = 1");
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 1: v1 = 1");
     }
 
     @Test
     public void testInnerJoinWithConstPredicate() throws Exception {
         String sql = "SELECT * from t0 join test_all_type on NOT NULL >= NULL";
 
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("  0:EMPTYSET\n"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  0:EMPTYSET\n");
     }
 
     @Test
@@ -62,23 +62,23 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testCorssJoinWithPredicate() throws Exception {
         String sql = "SELECT * from t0 join test_all_type where t0.v1 = 2;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 = 2"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 1: v1 = 2");
     }
 
     @Test
     public void testLeftOuterJoinWithPredicate() throws Exception {
         String sql = "SELECT * from t0 left join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 > 1;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 > 1"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 1: v1 > 1");
     }
 
     @Test
     public void testCrossJoinToInnerJoin() throws Exception {
         String sql = "SELECT t0.v1 from t0, test_all_type where t0.v1 = test_all_type.t1d";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("join op: INNER JOIN"));
-        Assert.assertTrue(planFragment.contains("equal join conjunct: 1: v1 = 7: t1d"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "join op: INNER JOIN");
+        assertContains(plan, "equal join conjunct: 1: v1 = 7: t1d");
     }
 
     @Test
@@ -87,25 +87,25 @@ public class JoinTest extends PlanTestBase {
         getFragmentPlan(sql);
 
         sql = " select a.v2 from t0 a join t0 b on a.v3 = b.v3;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("4:Project\n"
-                + "  |  <slot 2> : 2: v2"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "4:Project\n"
+                + "  |  <slot 2> : 2: v2");
     }
 
     @Test
     public void testCrossJoin() throws Exception {
         String sql = "SELECT * from t0 join test_all_type;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment, planFragment.contains("  3:NESTLOOP JOIN\n" +
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan, plan.contains("  3:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
                 "  |----2:EXCHANGE\n"));
 
         sql = "select * from t0 join test_all_type on NOT 69 IS NOT NULL where true";
-        planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment,
-                planFragment.contains("  3:NESTLOOP JOIN\n" +
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan,
+                plan.contains("  3:NESTLOOP JOIN\n" +
                         "  |  join op: CROSS JOIN\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  \n" +
@@ -117,28 +117,28 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testFullOuterJoin() throws Exception {
         String sql = "select * from t0 full outer join t1 on t0.v1 = t1.v4 where abs(1) > 2;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("     TABLE: t1\n"
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "     TABLE: t1\n"
                 + "     PREAGGREGATION: ON\n"
-                + "     PREDICATES: abs(1) > 2"));
-        Assert.assertTrue(planFragment.contains("     TABLE: t0\n"
+                + "     PREDICATES: abs(1) > 2");
+        assertContains(plan, "     TABLE: t0\n"
                 + "     PREAGGREGATION: ON\n"
-                + "     PREDICATES: abs(1) > 2"));
+                + "     PREDICATES: abs(1) > 2");
     }
 
     @Test
     public void testFullOuterJoinPredicatePushDown() throws Exception {
         String sql = "select * from t0 full outer join t1 on t0.v1 = t1.v4 " +
                 " where (NOT (t0.v2 IS NOT NULL))";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("other predicates: 2: v2 IS NULL"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "other predicates: 2: v2 IS NULL");
     }
 
     @Test
     public void testRightSemiJoinWithFilter() throws Exception {
         String sql = "select t1.v4 from t0 right semi join t1 on t0.v1 = t1.v4 and t0.v1 > 1 ";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: 1: v1 > 1"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 1: v1 > 1");
     }
 
     @Test
@@ -635,7 +635,7 @@ public class JoinTest extends PlanTestBase {
         String sql =
                 "select a.id_datetime from test_all_type as a join test_all_type as b where a.id_date in (b.id_date)";
         String plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("CAST(9: id_date AS DATETIME)"));
+        assertNotContains(plan, "CAST(9: id_date AS DATETIME)");
         assertContains(plan, "equal join conjunct: 9: id_date = 19: id_date");
     }
 
@@ -702,7 +702,7 @@ public class JoinTest extends PlanTestBase {
 
         sql = "select * from t0,t1 where v1 = v4";
         plan = getVerboseExplain(sql);
-        Assert.assertFalse(plan.contains("output columns"));
+        assertNotContains(plan, "output columns");
     }
 
     @Test
@@ -1080,16 +1080,16 @@ public class JoinTest extends PlanTestBase {
         String sql = "select * from join1 join join2 on join1.id = join2.id;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "join op: INNER JOIN (REPLICATED)");
-        Assert.assertFalse(plan.contains("EXCHANGE"));
+        assertNotContains(plan, "EXCHANGE");
 
         sql = "select * from join2 right join join1 on join1.id = join2.id;";
         plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("join op: INNER JOIN (REPLICATED)"));
+        assertNotContains(plan, "join op: INNER JOIN (REPLICATED)");
 
         sql = "select * from join1 as a join (select sum(id),id from join2 group by id) as b on a.id = b.id;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "join op: INNER JOIN (REPLICATED)");
-        Assert.assertFalse(plan.contains("EXCHANGE"));
+        assertNotContains(plan, "EXCHANGE");
 
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         sql = "select * from join1 as a join (select sum(id),dt from join2 group by dt) as b on a.id = b.dt;";
@@ -1100,11 +1100,11 @@ public class JoinTest extends PlanTestBase {
 
         sql = "select a.* from join1 as a join join1 as b ;";
         plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("EXCHANGE"));
+        assertNotContains(plan, "EXCHANGE");
 
         sql = "select a.* from join1 as a join (select sum(id) from join1 group by dt) as b ;";
         plan = getFragmentPlan(sql);
-        Assert.assertFalse(plan.contains("EXCHANGE"));
+        assertNotContains(plan, "EXCHANGE");
 
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         sql = "select a.* from join1 as a join (select sum(id) from join1 group by dt) as b ;";
@@ -1171,8 +1171,8 @@ public class JoinTest extends PlanTestBase {
     public void testColocateCoverReplicate() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql = "select * from join1 join join1 as xx on join1.id = xx.id;";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("  |  join op: INNER JOIN (COLOCATE)\n"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  join op: INNER JOIN (COLOCATE)\n");
         FeConstants.runningUnitTest = false;
     }
 
@@ -2006,10 +2006,10 @@ public class JoinTest extends PlanTestBase {
     public void testWherePredicatesToOnPredicate() throws Exception {
         String sql =
                 "SELECT t0.v1 from t0 join test_all_type on t0.v2 = test_all_type.t1d where t0.v1 = test_all_type.t1d";
-        String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("join op: INNER JOIN"));
-        Assert.assertTrue(planFragment.contains("  |  equal join conjunct: 2: v2 = 7: t1d\n"
-                + "  |  equal join conjunct: 1: v1 = 7: t1d"));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "join op: INNER JOIN");
+        assertContains(plan, "  |  equal join conjunct: 2: v2 = 7: t1d\n"
+                + "  |  equal join conjunct: 1: v1 = 7: t1d");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
@@ -617,6 +617,6 @@ public class TPCDSPlanTest extends TPCDSPlanTestBase {
 
         String plan = getFragmentPlan(sql);
         assertContains(plan,
-                "PREDICATES: 14: ss_sales_price >= 50, 14: ss_sales_price <= 200, 23: ss_net_profit >= 50, 23: ss_net_profit <= 300");
+                "PREDICATES: 14: ss_sales_price >= 50.00, 14: ss_sales_price <= 200.00, 23: ss_net_profit >= 50, 23: ss_net_profit <= 300");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8480

## Enhancement

Keep all the trailing zeros. And after this pr, the Q1, Q2 and Q3 memtioned at the issue, produces the expected output.


```sql
-- Q1
select 
    385044.16250000/179.99 as v1, 
    385044.16250000 * (1/179.99) as v2,
    385044.16250000 * (1.00000/179.99) as v3;

+-------------------+---------------------+--------------------------+
| v1                | v2                  | v3                       |
+-------------------+---------------------+--------------------------+
| 2139.253083504639 | 2139.30536685000000 | 2139.2530817031741250000 |
+-------------------+---------------------+--------------------------+


-- Q2
select 
    0 as c1,
    0.0 as c2,
    0.0000000000000000000000000000 as c3;

+----+-----+-------+
| c1 | c2  | c3    |
+----+-----+-------+
| 0  | 0.0 | 0E-28 |
+----+-----+-------+

-- Q3
select 1000000000.1111111111111111111111111111 * 100;

+-----------------------------------------------+
| 1000000000.1111111111111111111111111111 * 100 |
+-----------------------------------------------+
| <null>                                        |
+-----------------------------------------------+
```
