### PR TITLE
[Lake] Support lake table storage cache property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -29,6 +29,7 @@ import com.starrocks.analysis.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.lake.StorageInfo;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
@@ -157,8 +158,14 @@ public class SingleRangePartitionDesc extends PartitionDesc {
                 properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
                 properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, 0);
+        if (storageCacheTtlS < -1) {
+            throw new AnalysisException("Storage cache ttl should not be less than -1");
+        }
+        if (!enableStorageCache && storageCacheTtlS != 0) {
+            throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
+        }
         if (enableStorageCache && storageCacheTtlS == 0) {
-            throw new AnalysisException("Storage cache ttl should not be 0 when cache is enabled");
+            storageCacheTtlS = Config.storage_cooldown_second;
         }
         storageInfo = new StorageInfo(null, enableStorageCache, storageCacheTtlS);
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.lake.StorageCacheInfo;
 import com.starrocks.catalog.lake.StorageInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -167,7 +168,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         if (enableStorageCache && storageCacheTtlS == 0) {
             storageCacheTtlS = Config.storage_cooldown_second;
         }
-        storageInfo = new StorageInfo(null, enableStorageCache, storageCacheTtlS);
+        storageInfo = new StorageInfo(null, new StorageCacheInfo(enableStorageCache, storageCacheTtlS));
 
         if (otherProperties == null) {
             // check unknown properties

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -23,6 +23,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.lake.StorageInfo;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.io.Text;
@@ -68,11 +69,16 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
     // so we defer adding meta serialization until memory engine feature is more complete.
     protected Map<Long, TTabletType> idToTabletType;
 
+    // for lake table storage cache and ttl
+    @SerializedName(value = "idToStorageInfo")
+    protected Map<Long, StorageInfo> idToStorageInfo;
+
     public PartitionInfo() {
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
+        this.idToStorageInfo = new HashMap<>();
     }
 
     public PartitionInfo(PartitionType type) {
@@ -81,6 +87,7 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
+        this.idToStorageInfo = new HashMap<>();
     }
 
     public PartitionType getType() {
@@ -131,6 +138,14 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
             idToTabletType = new HashMap<>();
         }
         idToTabletType.put(partitionId, tabletType);
+    }
+
+    public StorageInfo getStorageInfo(long partitionId) {
+        return idToStorageInfo.get(partitionId);
+    }
+
+    public void setStorageInfo(long partitionId, StorageInfo storageInfo) {
+        idToStorageInfo.put(partitionId, storageInfo);
     }
 
     public void dropPartition(long partitionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -195,6 +195,7 @@ public class RangePartitionInfo extends PartitionInfo {
         idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
         idToReplicationNum.put(partitionId, desc.getReplicationNum());
         idToInMemory.put(partitionId, desc.isInMemory());
+        idToStorageInfo.put(partitionId, desc.getStorageInfo());
         return range;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -23,6 +23,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.lake.StorageInfo;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -75,6 +76,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private boolean hasDelete = false;
 
     private boolean hasForbitGlobalDict = false;
+
+    @SerializedName(value = "storageInfo")
+    private StorageInfo storageInfo;
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
@@ -189,6 +193,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public void setHasForbitGlobalDict(boolean hasForbitGlobalDict) {
         this.hasForbitGlobalDict = hasForbitGlobalDict;
+    }
+
+    public void setStorageInfo(StorageInfo storageInfo) {
+        this.storageInfo = storageInfo;
+    }
+
+    public StorageInfo getStorageInfo() {
+        return storageInfo;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.catalog.lake;
 
-import com.google.gson.annotations.SerializedName;
 import com.staros.proto.ObjectStorageInfo;
 import com.staros.proto.ShardStorageInfo;
 import com.starrocks.catalog.Column;
@@ -11,9 +10,9 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.TableIndexes;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
-import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -22,21 +21,18 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * Metadata for StarRocks lake table
  * <p>
+ * Currently, storage group is table level, which stores all the tablets data and metadata of this table.
+ * Format: service storage uri (from StarOS) + table id
+ * <p>
  * TODO: support table api like Iceberg
  */
-public class LakeTable extends OlapTable implements GsonPreProcessable {
-    // Currently, storage group is table level, which stores all the tablets data and metadata of this table.
-    // Format: service storage uri (from StarOS) + table id
-    //
-    // "shardStorageInfoBytes" is used for serialization of "shardStorageInfo".
-    @SerializedName(value = "shardStorageInfoBytes")
-    private byte[] shardStorageInfoBytes;
-    private ShardStorageInfo shardStorageInfo;
+public class LakeTable extends OlapTable {
 
     public LakeTable(long id, String tableName, List<Column> baseSchema, KeysType keysType, PartitionInfo partitionInfo,
                      DistributionInfo defaultDistributionInfo, TableIndexes indexes) {
@@ -50,16 +46,16 @@ public class LakeTable extends OlapTable implements GsonPreProcessable {
     }
 
     public String getStorageGroup() {
-        return shardStorageInfo.getObjectStorageInfo().getObjectUri();
+        return getShardStorageInfo().getObjectStorageInfo().getObjectUri();
     }
 
     public ShardStorageInfo getShardStorageInfo() {
-        return shardStorageInfo;
+        return tableProperty.getStorageInfo().getShardStorageInfo();
     }
 
-    public void setShardStorageInfo(ShardStorageInfo shardStorageInfo) throws DdlException {
+    public void setStorageInfo(ShardStorageInfo shardStorageInfo, boolean enableCache, long cacheTtlS)
+            throws DdlException {
         String storageGroup = null;
-
         // s3://bucket/serviceId/tableId/
         String path = String.format("%s/%d/", shardStorageInfo.getObjectStorageInfo().getObjectUri(), id);
         try {
@@ -76,19 +72,13 @@ public class LakeTable extends OlapTable implements GsonPreProcessable {
         ObjectStorageInfo objectStorageInfo =
                 ObjectStorageInfo.newBuilder(shardStorageInfo.getObjectStorageInfo()).setObjectUri(storageGroup)
                         .build();
-        this.shardStorageInfo =
+        ShardStorageInfo newShardStorageInfo =
                 ShardStorageInfo.newBuilder(shardStorageInfo).setObjectStorageInfo(objectStorageInfo).build();
-    }
 
-    @Override
-    public void gsonPreProcess() throws IOException {
-        shardStorageInfoBytes = shardStorageInfo.toByteArray();
-    }
-
-    @Override
-    public void gsonPostProcess() throws IOException {
-        super.gsonPostProcess();
-        shardStorageInfo = ShardStorageInfo.parseFrom(shardStorageInfoBytes);
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.setStorageInfo(new StorageInfo(newShardStorageInfo, enableCache, cacheTtlS));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/LakeTable.java
@@ -78,7 +78,8 @@ public class LakeTable extends OlapTable {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());
         }
-        tableProperty.setStorageInfo(new StorageInfo(newShardStorageInfo, enableCache, cacheTtlS));
+        tableProperty
+                .setStorageInfo(new StorageInfo(newShardStorageInfo, new StorageCacheInfo(enableCache, cacheTtlS)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageCacheInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageCacheInfo.java
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.catalog.lake;
+
+import com.google.gson.annotations.SerializedName;
+
+public class StorageCacheInfo {
+    @SerializedName(value = "enableCache")
+    private boolean enableCache = false;
+
+    // -1 indicates "cache forever"
+    // 0 indicates "disable cache"
+    @SerializedName(value = "cacheTtlS")
+    private long cacheTtlS = 0;
+
+    public StorageCacheInfo(boolean enableCache, long cacheTtlS) {
+        this.enableCache = enableCache;
+        this.cacheTtlS = cacheTtlS;
+    }
+
+    public boolean isEnableCache() {
+        return enableCache;
+    }
+
+    public long getCacheTtlS() {
+        return cacheTtlS;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
@@ -10,33 +10,26 @@ import com.starrocks.persist.gson.GsonPreProcessable;
 import java.io.IOException;
 
 public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
-
     // "shardStorageInfoBytes" is used for serialization of "shardStorageInfo".
     @SerializedName(value = "shardStorageInfoBytes")
     private byte[] shardStorageInfoBytes;
     // Currently, storage group is table level, so "shardStorageInfo" is null in partition property.
     private ShardStorageInfo shardStorageInfo;
 
-    @SerializedName(value = "enableStorageCache")
-    private boolean enableStorageCache = false;
+    @SerializedName(value = "storageCacheInfo")
+    private StorageCacheInfo storageCacheInfo;
 
-    // -1 indicates "cache forever"
-    // 0 indicates "disable cache"
-    @SerializedName(value = "storageCacheTtlS")
-    private long storageCacheTtlS = 0;
-
-    public StorageInfo(ShardStorageInfo shardStorageInfo, boolean enableStorageCache, long storageCacheTtlS) {
+    public StorageInfo(ShardStorageInfo shardStorageInfo, StorageCacheInfo storageCacheInfo) {
         this.shardStorageInfo = shardStorageInfo;
-        this.enableStorageCache = enableStorageCache;
-        this.storageCacheTtlS = storageCacheTtlS;
+        this.storageCacheInfo = storageCacheInfo;
     }
 
     public boolean isEnableStorageCache() {
-        return enableStorageCache;
+        return storageCacheInfo.isEnableCache();
     }
 
     public long getStorageCacheTtlS() {
-        return storageCacheTtlS;
+        return storageCacheInfo.getCacheTtlS();
     }
 
     public ShardStorageInfo getShardStorageInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
@@ -1,0 +1,57 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.catalog.lake;
+
+import com.google.gson.annotations.SerializedName;
+import com.staros.proto.ShardStorageInfo;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonPreProcessable;
+
+import java.io.IOException;
+
+public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
+
+    // "shardStorageInfoBytes" is used for serialization of "shardStorageInfo".
+    @SerializedName(value = "shardStorageInfoBytes")
+    private byte[] shardStorageInfoBytes;
+    // Currently, storage group is table level, so "shardStorageInfo" is null in partition property.
+    private ShardStorageInfo shardStorageInfo;
+
+    @SerializedName(value = "enableStorageCache")
+    private boolean enableStorageCache = false;
+
+    @SerializedName(value = "storageCacheTtlS")
+    private long storageCacheTtlS = 0;
+
+    public StorageInfo(ShardStorageInfo shardStorageInfo, boolean enableStorageCache, long storageCacheTtlS) {
+        this.shardStorageInfo = shardStorageInfo;
+        this.enableStorageCache = enableStorageCache;
+        this.storageCacheTtlS = storageCacheTtlS;
+    }
+
+    public boolean isEnableStorageCache() {
+        return enableStorageCache;
+    }
+
+    public long getStorageCacheTtlS() {
+        return storageCacheTtlS;
+    }
+
+    public ShardStorageInfo getShardStorageInfo() {
+        return shardStorageInfo;
+    }
+
+    @Override
+    public void gsonPreProcess() throws IOException {
+        if (shardStorageInfo != null) {
+            shardStorageInfoBytes = shardStorageInfo.toByteArray();
+        }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (shardStorageInfoBytes != null) {
+            shardStorageInfo = ShardStorageInfo.parseFrom(shardStorageInfoBytes);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/lake/StorageInfo.java
@@ -20,6 +20,8 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
     @SerializedName(value = "enableStorageCache")
     private boolean enableStorageCache = false;
 
+    // -1 indicates "cache forever"
+    // 0 indicates "disable cache"
     @SerializedName(value = "storageCacheTtlS")
     private long storageCacheTtlS = 0;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -44,8 +44,8 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.lake.StorageInfo;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.ListComparator;
@@ -91,15 +91,13 @@ public class PartitionsProcDir implements ProcDirInterface {
             builder.add("Range");
         }
 
-        builder.add("DistributionKey")
-                .add("Buckets").add("ReplicationNum").add("StorageMedium").add("CooldownTime")
-                .add("LastConsistencyCheckTime").add("DataSize").add("IsInMemory");
-
-        if (Config.use_staros) {
-            builder.add("UseStarOS");
+        builder.add("DistributionKey").add("Buckets").add("ReplicationNum");
+        if (olapTable.isLakeTable()) {
+            builder.add("EnableStorageCache").add("StorageCacheTtlSecond").add("DataSize").add("RowCount");
+        } else {
+            builder.add("StorageMedium").add("CooldownTime").add("LastConsistencyCheckTime").add("DataSize")
+                    .add("IsInMemory").add("RowCount");
         }
-
-        builder.add("RowCount");
         this.titleNames = builder.build();
     }
 
@@ -285,20 +283,23 @@ public class PartitionsProcDir implements ProcDirInterface {
                 short replicationNum = tblPartitionInfo.getReplicationNum(partitionId);
                 partitionInfo.add(String.valueOf(replicationNum));
 
-                DataProperty dataProperty = tblPartitionInfo.getDataProperty(partitionId);
-                partitionInfo.add(dataProperty.getStorageMedium().name());
-                partitionInfo.add(TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs()));
-
-                partitionInfo.add(TimeUtils.longToTimeString(partition.getLastCheckTime()));
-
                 long dataSize = partition.getDataSize();
                 ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
-                partitionInfo.add(byteSizeValue);
-                partitionInfo.add(tblPartitionInfo.getIsInMemory(partitionId));
-                if (Config.use_staros) {
-                    partitionInfo.add(partition.isUseStarOS());
+                if (olapTable.isLakeTable()) {
+                    StorageInfo storageInfo = tblPartitionInfo.getStorageInfo(partitionId);
+                    partitionInfo.add(storageInfo.isEnableStorageCache());
+                    partitionInfo.add(storageInfo.getStorageCacheTtlS());
+                    partitionInfo.add(byteSizeValue);
+                    partitionInfo.add(partition.getRowCount());
+                } else {
+                    DataProperty dataProperty = tblPartitionInfo.getDataProperty(partitionId);
+                    partitionInfo.add(dataProperty.getStorageMedium().name());
+                    partitionInfo.add(TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs()));
+                    partitionInfo.add(TimeUtils.longToTimeString(partition.getLastCheckTime()));
+                    partitionInfo.add(byteSizeValue);
+                    partitionInfo.add(tblPartitionInfo.getIsInMemory(partitionId));
+                    partitionInfo.add(partition.getRowCount());
                 }
-                partitionInfo.add(partition.getRowCount());
 
                 partitionInfos.add(partitionInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -93,6 +93,9 @@ public class PropertyAnalyzer {
     public static final String ABLE_LOW_CARD_DICT = "1";
     public static final String DISABLE_LOW_CARD_DICT = "0";
 
+    public static final String PROPERTIES_ENABLE_STORAGE_CACHE = "enable_storage_cache";
+    public static final String PROPERTIES_STORAGE_CACHE_TTL = "storage_cache_ttl";
+
     public static DataProperty analyzeDataProperty(Map<String, String> properties, DataProperty oldDataProperty)
             throws AnalysisException {
         if (properties == null) {
@@ -430,5 +433,20 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_TYPE);
         }
         return type;
+    }
+
+    public static long analyzeLongProp(Map<String, String> properties, String propKey, long defaultVal)
+            throws AnalysisException {
+        long val = defaultVal;
+        if (properties != null && properties.containsKey(propKey)) {
+            String valStr = properties.get(propKey);
+            try {
+                val = Long.parseLong(valStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid " + propKey + " format: " + valStr);
+            }
+            properties.remove(propKey);
+        }
+        return val;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1680,8 +1680,14 @@ public class LocalMetastore implements ConnectorMetadata {
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
+                if (storageCacheTtlS < -1) {
+                    throw new DdlException("Storage cache ttl should not be less than -1");
+                }
+                if (!enableStorageCache && storageCacheTtlS != 0) {
+                    throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
+                }
                 if (enableStorageCache && storageCacheTtlS == 0) {
-                    throw new DdlException("Storage cache ttl should not be 0 when cache is enabled");
+                    storageCacheTtlS = Config.storage_cooldown_second;
                 }
 
                 // get service shard storage info from StarMgr

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/lake/CreateLakeTableTest.java
@@ -186,8 +186,7 @@ public class CreateLakeTableTest {
                         "engine = starrocks unique key (key1, key2)\n" +
                         "partition by range(key1)\n" +
                         "(partition p1 values less than (\"10\"),\n" +
-                        " partition p2 values less than (\"20\") ('enable_storage_cache' = 'true', " +
-                        "                                         'storage_cache_ttl' = '10800'))\n" +
+                        " partition p2 values less than (\"20\") ('enable_storage_cache' = 'true'))\n" +
                         "distributed by hash(key2) buckets 1\n" +
                         "properties('replication_num' = '1');"));
         {
@@ -204,7 +203,7 @@ public class CreateLakeTableTest {
             long partition2Id = lakeTable.getPartition("p2").getId();
             StorageInfo partition2StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition2Id);
             Assert.assertTrue(partition2StorageInfo.isEnableStorageCache());
-            Assert.assertEquals(10800, partition2StorageInfo.getStorageCacheTtlS());
+            Assert.assertEquals(Config.storage_cooldown_second, partition2StorageInfo.getStorageCacheTtlS());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/lake/CreateLakeTableTest.java
@@ -61,6 +61,14 @@ public class CreateLakeTableTest {
         Assert.assertTrue(table.isLakeTable());
     }
 
+    private LakeTable getLakeTable(String dbName, String tableName) {
+        String fullDbName = ClusterNamespace.getFullName(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getDb(fullDbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isLakeTable());
+        return (LakeTable) table;
+    }
+
     @Test
     public void testCreateLakeTable(@Mocked StarOSAgent agent) throws UserException {
         ObjectStorageInfo objectStorageInfo = ObjectStorageInfo.newBuilder().setObjectUri("s3://bucket/1/").build();
@@ -107,5 +115,96 @@ public class CreateLakeTableTest {
                         "distributed by hash(key2) buckets 1\n" +
                         "properties('replication_num' = '1');"));
         checkLakeTable("lake_test", "multi_partition_unique_key");
+    }
+
+    @Test
+    public void testCreateLakeTableWithStorageCache(@Mocked StarOSAgent agent) throws UserException {
+        ObjectStorageInfo objectStorageInfo = ObjectStorageInfo.newBuilder().setObjectUri("s3://bucket/1/").build();
+        ShardStorageInfo shardStorageInfo =
+                ShardStorageInfo.newBuilder().setObjectStorageInfo(objectStorageInfo).build();
+
+        new Expectations() {
+            {
+                agent.getServiceShardStorageInfo();
+                result = shardStorageInfo;
+                agent.createShards(anyInt, (ShardStorageInfo) any);
+                returns(Lists.newArrayList(20001L, 20002L, 20003L),
+                        Lists.newArrayList(20004L, 20005L), Lists.newArrayList(20006L, 20007L),
+                        Lists.newArrayList(20008L), Lists.newArrayList(20009L));
+                agent.getPrimaryBackendIdByShard(anyLong);
+                result = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).get(0);
+            }
+        };
+
+        Deencapsulation.setField(GlobalStateMgr.getCurrentState(), "starOSAgent", agent);
+
+        // normal
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.single_partition_duplicate_key_cache (key1 int, key2 varchar(10))\n" +
+                        "engine = starrocks distributed by hash(key1) buckets 3\n" +
+                        "properties('enable_storage_cache' = 'true', 'storage_cache_ttl' = '3600');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "single_partition_duplicate_key_cache");
+            // check table property
+            StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
+            Assert.assertTrue(storageInfo.isEnableStorageCache());
+            Assert.assertEquals(3600, storageInfo.getStorageCacheTtlS());
+            // check partition property
+            long partitionId = lakeTable.getPartition("single_partition_duplicate_key_cache").getId();
+            StorageInfo partitionStorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partitionId);
+            Assert.assertTrue(partitionStorageInfo.isEnableStorageCache());
+            Assert.assertEquals(3600, partitionStorageInfo.getStorageCacheTtlS());
+        }
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.multi_partition_aggregate_key_cache \n" +
+                        "(key1 date, key2 varchar(10), v bigint sum)\n" +
+                        "engine = starrocks partition by range(key1)\n" +
+                        "(partition p1 values less than (\"2022-03-01\"),\n" +
+                        " partition p2 values less than (\"2022-04-01\"))\n" +
+                        "distributed by hash(key2) buckets 2\n" +
+                        "properties('enable_storage_cache' = 'true', 'storage_cache_ttl' = '7200');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "multi_partition_aggregate_key_cache");
+            // check table property
+            StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
+            Assert.assertTrue(storageInfo.isEnableStorageCache());
+            Assert.assertEquals(7200, storageInfo.getStorageCacheTtlS());
+            // check partition property
+            long partition1Id = lakeTable.getPartition("p1").getId();
+            StorageInfo partition1StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition1Id);
+            Assert.assertTrue(partition1StorageInfo.isEnableStorageCache());
+            Assert.assertEquals(7200, partition1StorageInfo.getStorageCacheTtlS());
+            long partition2Id = lakeTable.getPartition("p2").getId();
+            StorageInfo partition2StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition2Id);
+            Assert.assertTrue(partition2StorageInfo.isEnableStorageCache());
+            Assert.assertEquals(7200, partition2StorageInfo.getStorageCacheTtlS());
+        }
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.multi_partition_unique_key_cache (key1 int, key2 varchar(10), v bigint)\n" +
+                        "engine = starrocks unique key (key1, key2)\n" +
+                        "partition by range(key1)\n" +
+                        "(partition p1 values less than (\"10\"),\n" +
+                        " partition p2 values less than (\"20\") ('enable_storage_cache' = 'true', " +
+                        "                                         'storage_cache_ttl' = '10800'))\n" +
+                        "distributed by hash(key2) buckets 1\n" +
+                        "properties('replication_num' = '1');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "multi_partition_unique_key_cache");
+            // check table property
+            StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
+            Assert.assertFalse(storageInfo.isEnableStorageCache());
+            Assert.assertEquals(0, storageInfo.getStorageCacheTtlS());
+            // check partition property
+            long partition1Id = lakeTable.getPartition("p1").getId();
+            StorageInfo partition1StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition1Id);
+            Assert.assertFalse(partition1StorageInfo.isEnableStorageCache());
+            Assert.assertEquals(0, partition1StorageInfo.getStorageCacheTtlS());
+            long partition2Id = lakeTable.getPartition("p2").getId();
+            StorageInfo partition2StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition2Id);
+            Assert.assertTrue(partition2StorageInfo.isEnableStorageCache());
+            Assert.assertEquals(10800, partition2StorageInfo.getStorageCacheTtlS());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/lake/LakeTableTest.java
@@ -87,7 +87,7 @@ public class LakeTableTest {
                 ObjectStorageInfo.newBuilder().setObjectUri(serviceStorageUri).setEndpoint(endpoint).build();
         ShardStorageInfo shardStorageInfo =
                 ShardStorageInfo.newBuilder().setObjectStorageInfo(objectStorageInfo).build();
-        table.setShardStorageInfo(shardStorageInfo);
+        table.setStorageInfo(shardStorageInfo, false, 0);
 
         // Test serialize and deserialize
         FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Refactor: move ShardStorageInfo from LakeTable to StorageInfo that is
   used in TableProperty and PartitionInfo.

2. Support enable storage cache and ttl.
a. enable_storage_cache is false, never cache.
b. enable_storage_cache is true and ttl is -1, cache forever.
c. enable_storage_cache is true and ttl is 0, use default cache ttl.

3. Add lake table information in TablesProcDir and PartitionsProcDir.