### PR TITLE
[fix test] Fix a unstable test case

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -359,6 +359,7 @@ public class PrivilegeCheckerTest {
 
         String sql = "select count(*) from db1.tbl1 as a";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        auth.revokePrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), true);
         PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
 
         auth.revokePrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -351,17 +351,18 @@ public class PrivilegeCheckerTest {
     @Test
     public void testSelectTable() throws Exception {
         auth = starRocksAssert.getCtx().getGlobalStateMgr().getAuth();
-        TablePattern db1TablePattern = new TablePattern("db1", "*");
-        db1TablePattern.analyze("default_cluster");
         starRocksAssert.getCtx().setQualifiedUser("test");
         starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
         starRocksAssert.getCtx().setRemoteIP("%");
 
+        TablePattern db1TablePattern = new TablePattern("db1", "*");
+        db1TablePattern.analyze("default_cluster");
+
         String sql = "select count(*) from db1.tbl1 as a";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        auth.revokePrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), true);
-        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
 
+        auth.grantPrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), true);
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
         auth.revokePrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), true);
         Assert.assertThrows(SemanticException.class,
                 () -> PrivilegeChecker.check(statementBase, starRocksAssert.getCtx()));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

com.starrocks.sql.analyzer.SemanticException: SELECT command denied to user 'test'@'%' for table 'tbl1'
	at com.starrocks.common.ErrorReport.reportSemanticException(ErrorReport.java:60)
	at com.starrocks.common.ErrorReport.reportSemanticException(ErrorReport.java:56)
	at com.starrocks.sql.analyzer.PrivilegeChecker$PrivilegeCheckerVisitor.visitQueryStatement(PrivilegeChecker.java:281)
	at com.starrocks.sql.analyzer.PrivilegeChecker$PrivilegeCheckerVisitor.visitQueryStatement(PrivilegeChecker.java:111)
	at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:36)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:95)
	at com.starrocks.sql.analyzer.PrivilegeChecker$PrivilegeCheckerVisitor.check(PrivilegeChecker.java:113)
	at com.starrocks.sql.analyzer.PrivilegeChecker.check(PrivilegeChecker.java:83)
	at com.starrocks.sql.analyzer.PrivilegeCheckerTest.testSelectTable(PrivilegeCheckerTest.java:362)