### PR TITLE
[Enhancement] Keep dop of clone task handling in sync with fe scheduling

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -129,11 +129,9 @@ void AgentServer::Impl::init_or_die() {
     // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
     // But it seems that there's no limit for the number of tablets of a partition.
     // Since a large queue size brings a little overhead, a big one is chosen here.
-    BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version",
+    BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", config::transaction_publish_version_worker_count,
                                    config::transaction_publish_version_worker_count,
-                                   config::transaction_publish_version_worker_count,
-                                   DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
-                                   _thread_pool_publish_version);
+                                   DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_publish_version);
 #ifndef BE_TEST
     // Currently FE can have at most num_of_storage_path * schedule_slot_num_per_path(default 2) clone tasks
     // scheduled simultaneously, but previously we have only 3 clone worker threads by default,

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -41,6 +41,11 @@
 
 namespace starrocks {
 
+namespace {
+constexpr size_t DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE = 2048;
+constexpr size_t MIN_CLONE_TASK_THREADS_IN_POOL = 2;
+} // namespace
+
 const uint32_t REPORT_TASK_WORKER_COUNT = 1;
 const uint32_t REPORT_DISK_STATE_WORKER_COUNT = 1;
 const uint32_t REPORT_OLAP_TABLE_WORKER_COUNT = 1;
@@ -70,6 +75,7 @@ private:
     ExecEnv* _exec_env;
 
     std::unique_ptr<ThreadPool> _thread_pool_publish_version;
+    std::unique_ptr<ThreadPool> _thread_pool_clone;
 
     std::unique_ptr<TaskWorkerPool> _create_tablet_workers;
     std::unique_ptr<TaskWorkerPool> _drop_tablet_workers;
@@ -110,25 +116,45 @@ void AgentServer::Impl::init_or_die() {
         }
     }
 
-    auto st =
-            ThreadPoolBuilder("publish_version")
-                    .set_min_threads(config::transaction_publish_version_worker_count)
-                    .set_max_threads(config::transaction_publish_version_worker_count)
-                    // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
-                    // But it seems that there's no limit for the number of tablets of a partition.
-                    // Since a large queue size brings a little overhead, a big one is chosen here.
-                    .set_max_queue_size(2048)
-                    .build(&_thread_pool_publish_version);
-    CHECK(st.ok()) << st;
+#define BUILD_DYNAMIC_TASK_THREAD_POOL(name, min_threads, max_threads, queue_size, pool) \
+    do {                                                                                 \
+        auto st = ThreadPoolBuilder(name)                                                \
+                          .set_min_threads(min_threads)                                  \
+                          .set_max_threads(max_threads)                                  \
+                          .set_max_queue_size(queue_size)                                \
+                          .build(&(pool));                                               \
+        CHECK(st.ok()) << st;                                                            \
+    } while (false)
+
+    // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
+    // But it seems that there's no limit for the number of tablets of a partition.
+    // Since a large queue size brings a little overhead, a big one is chosen here.
+    BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version",
+                                   config::transaction_publish_version_worker_count,
+                                   config::transaction_publish_version_worker_count,
+                                   DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
+                                   _thread_pool_publish_version);
+#ifndef BE_TEST
+    // Currently FE can have at most num_of_storage_path * schedule_slot_num_per_path(default 2) clone tasks
+    // scheduled simultaneously, but previously we have only 3 clone worker threads by default,
+    // so this is to keep the dop of clone task handling in sync with FE.
+    //
+    // TODO(shangyiming): using dynamic thread pool to handle task directly instead of using TaskThreadPool
+    // Currently, the task submission and processing logic is deeply coupled with TaskThreadPool, change that will
+    // need to modify many interfaces. So for now we still use TaskThreadPool to submit clone tasks, but with
+    // only a single worker thread, then we use dynamic thread pool to handle the task concurrently in clone task
+    // callback, so that we can match the dop of FE clone task scheduling.
+    BUILD_DYNAMIC_TASK_THREAD_POOL("clone", MIN_CLONE_TASK_THREADS_IN_POOL,
+                                   _exec_env->store_paths().size() * config::parallel_clone_task_per_path,
+                                   DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_clone);
+#endif
 
     // It is the same code to create workers of each type, so we use a macro
     // to make code to be more readable.
-
 #ifndef BE_TEST
 #define CREATE_AND_START_POOL(type, pool_name, worker_num)                                            \
     pool_name.reset(new TaskWorkerPool(TaskWorkerPool::TaskWorkerType::type, _exec_env, worker_num)); \
     pool_name->start();
-
 #else
 #define CREATE_AND_START_POOL(type, pool_name, worker_num)
 #endif // BE_TEST
@@ -144,7 +170,7 @@ void AgentServer::Impl::init_or_die() {
     CREATE_AND_START_POOL(DELETE, _delete_workers,
                           config::delete_worker_count_normal_priority + config::delete_worker_count_high_priority);
     CREATE_AND_START_POOL(ALTER_TABLE, _alter_tablet_workers, config::alter_tablet_worker_count);
-    CREATE_AND_START_POOL(CLONE, _clone_workers, config::clone_worker_count);
+    CREATE_AND_START_POOL(CLONE, _clone_workers, 1);
     CREATE_AND_START_POOL(STORAGE_MEDIUM_MIGRATE, _storage_medium_migrate_workers,
                           config::storage_medium_migrate_count);
     CREATE_AND_START_POOL(CHECK_CONSISTENCY, _check_consistency_workers, config::check_consistency_worker_count);
@@ -165,6 +191,7 @@ AgentServer::Impl::~Impl() {
     _thread_pool_publish_version->shutdown();
 
 #ifndef BE_TEST
+    _thread_pool_clone->shutdown();
 #define STOP_POOL(type, pool_name) pool_name->stop();
 #else
 #define STOP_POOL(type, pool_name)
@@ -191,8 +218,6 @@ AgentServer::Impl::~Impl() {
     STOP_POOL(MOVE, _move_dir_workers);
     STOP_POOL(UPDATE_TABLET_META_INFO, _update_tablet_meta_info_workers);
 #undef STOP_POOL
-
-    _thread_pool_publish_version->wait();
 }
 
 // TODO(lingbin): each task in the batch may have it own status or FE must check and
@@ -411,6 +436,7 @@ ThreadPool* AgentServer::Impl::get_thread_pool(int type) const {
     case TTaskType::DROP:
     case TTaskType::PUSH:
     case TTaskType::CLONE:
+        return _thread_pool_clone.get();
     case TTaskType::STORAGE_MEDIUM_MIGRATE:
     case TTaskType::ROLLUP:
     case TTaskType::SCHEMA_CHANGE:

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -430,11 +430,11 @@ ThreadPool* AgentServer::Impl::get_thread_pool(int type) const {
     switch (type) {
     case TTaskType::PUBLISH_VERSION:
         return _thread_pool_publish_version.get();
+    case TTaskType::CLONE:
+        return _thread_pool_clone.get();
     case TTaskType::CREATE:
     case TTaskType::DROP:
     case TTaskType::PUSH:
-    case TTaskType::CLONE:
-        return _thread_pool_clone.get();
     case TTaskType::STORAGE_MEDIUM_MIGRATE:
     case TTaskType::ROLLUP:
     case TTaskType::SCHEMA_CHANGE:

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1466,7 +1466,7 @@ void* TaskWorkerPool::_release_snapshot_thread_callback(void* arg_this) {
 }
 
 AgentStatus TaskWorkerPool::get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
-                                             TTabletInfo* tablet_info) {
+                                            TTabletInfo* tablet_info) {
     AgentStatus status = STARROCKS_SUCCESS;
 
     tablet_info->__set_tablet_id(tablet_id);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -287,13 +287,18 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
               << "], task_count_in_queue=" << queue_size;
 }
 
+size_t TaskWorkerPool::num_queued_tasks() const {
+    std::lock_guard l(_worker_thread_lock);
+    return _tasks.size();
+}
+
 bool TaskWorkerPool::_register_task_info(TTaskType::type task_type, int64_t signature) {
     std::lock_guard task_signatures_lock(_s_task_signatures_locks[task_type]);
     std::set<int64_t>& signature_set = _s_task_signatures[task_type];
     return signature_set.insert(signature).second;
 }
 
-void TaskWorkerPool::_remove_task_info(TTaskType::type task_type, int64_t signature) {
+void TaskWorkerPool::remove_task_info(TTaskType::type task_type, int64_t signature) {
     std::lock_guard task_signatures_lock(_s_task_signatures_locks[task_type]);
     _s_task_signatures[task_type].erase(signature);
 }
@@ -354,7 +359,7 @@ void* TaskWorkerPool::_create_tablet_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -398,7 +403,7 @@ void* TaskWorkerPool::_drop_tablet_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -435,7 +440,7 @@ void* TaskWorkerPool::_alter_tablet_worker_thread_callback(void* arg_this) {
             }
             finish_task(finish_task_request);
         }
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -493,7 +498,7 @@ void TaskWorkerPool::_alter_tablet(TaskWorkerPool* worker_pool_this, const TAgen
     std::vector<TTabletInfo> finish_tablet_infos;
     if (status == STARROCKS_SUCCESS) {
         TTabletInfo& tablet_info = finish_tablet_infos.emplace_back();
-        status = _get_tablet_info(new_tablet_id, new_schema_hash, signature, &tablet_info);
+        status = get_tablet_info(new_tablet_id, new_schema_hash, signature, &tablet_info);
 
         if (status != STARROCKS_SUCCESS) {
             LOG(WARNING) << process_name << " success, but get new tablet info failed."
@@ -572,7 +577,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
 
         if (status == STARROCKS_PUSH_HAD_LOADED) {
             // remove the task and not return to fe
-            worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+            worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
             continue;
         }
         // Return result to fe
@@ -607,7 +612,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_report_version(_s_report_version.load(std::memory_order_relaxed));
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
 
     return (void*)nullptr;
@@ -687,7 +692,7 @@ void* TaskWorkerPool::_delete_worker_thread_callback(void* arg_this) {
 
         if (status == STARROCKS_PUSH_HAD_LOADED) {
             // remove the task and not return to fe
-            worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+            worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
             continue;
         }
         // Return result to fe
@@ -727,7 +732,7 @@ void* TaskWorkerPool::_delete_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_report_version(_s_report_version.load(std::memory_order_relaxed));
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
 
     return (void*)nullptr;
@@ -792,7 +797,7 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
             // notify FE when all tasks of group have been finished.
             for (auto& finish_task_request : finish_task_requests) {
                 finish_task(finish_task_request);
-                worker_pool_this->_remove_task_info(finish_task_request.task_type, finish_task_request.signature);
+                worker_pool_this->remove_task_info(finish_task_request.task_type, finish_task_request.signature);
             }
             int64_t t2 = MonotonicMillis();
             LOG(INFO) << "batch flush " << finish_task_requests.size()
@@ -850,7 +855,7 @@ void* TaskWorkerPool::_clear_transaction_task_worker_thread_callback(void* arg_t
         finish_task_request.__set_signature(agent_task_req->signature);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -918,91 +923,27 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
         finish_task_request.__set_signature(agent_task_req->signature);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
 
 void* TaskWorkerPool::_clone_worker_thread_callback(void* arg_this) {
     auto* worker_pool_this = (TaskWorkerPool*)arg_this;
+    auto* agent_server = worker_pool_this->_env->agent_server();
 
     while (true) {
-        AgentStatus status = STARROCKS_SUCCESS;
         TAgentTaskRequestPtr agent_task_req = worker_pool_this->_pop_task();
         if (agent_task_req == nullptr) {
             break;
         }
-        const TCloneReq& clone_req = agent_task_req->clone_req;
         StarRocksMetrics::instance()->clone_requests_total.increment(1);
-        LOG(INFO) << "get clone task. signature:" << agent_task_req->signature;
-
-        // Return result to fe
-        TStatus task_status;
-        TFinishTaskRequest finish_task_request;
-        finish_task_request.__set_backend(BackendOptions::get_localBackend());
-        finish_task_request.__set_task_type(agent_task_req->task_type);
-        finish_task_request.__set_signature(agent_task_req->signature);
-
-        TStatusCode::type status_code = TStatusCode::OK;
-        std::vector<std::string> error_msgs;
-        std::vector<TTabletInfo> tablet_infos;
-        if (clone_req.__isset.is_local && clone_req.is_local) {
-            DataDir* dest_store = StorageEngine::instance()->get_store(clone_req.dest_path_hash);
-            if (dest_store == nullptr) {
-                LOG(WARNING) << "fail to get dest store. path_hash:" << clone_req.dest_path_hash;
-                status_code = TStatusCode::RUNTIME_ERROR;
-            } else {
-                EngineStorageMigrationTask engine_task(clone_req.tablet_id, clone_req.schema_hash, dest_store);
-                Status res = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
-                if (!res.ok()) {
-                    status_code = TStatusCode::RUNTIME_ERROR;
-                    LOG(WARNING) << "storage migrate failed. status:" << res
-                                 << ", signature:" << agent_task_req->signature;
-                    error_msgs.emplace_back("storage migrate failed.");
-                } else {
-                    LOG(INFO) << "storage migrate success. status:" << res
-                              << ", signature:" << agent_task_req->signature;
-
-                    TTabletInfo tablet_info;
-                    AgentStatus status = worker_pool_this->_get_tablet_info(clone_req.tablet_id, clone_req.schema_hash,
-                                                                            agent_task_req->signature, &tablet_info);
-                    if (status != STARROCKS_SUCCESS) {
-                        LOG(WARNING) << "storage migrate success, but get tablet info failed"
-                                     << ". status:" << status << ", signature:" << agent_task_req->signature;
-                    } else {
-                        tablet_infos.push_back(tablet_info);
-                    }
-                    finish_task_request.__set_finish_tablet_infos(tablet_infos);
-                }
-            }
-        } else {
-            EngineCloneTask engine_task(ExecEnv::GetInstance()->clone_mem_tracker(), clone_req,
-                                        agent_task_req->signature, &error_msgs, &tablet_infos, &status);
-            Status res = worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
-            if (!res.ok()) {
-                status_code = TStatusCode::RUNTIME_ERROR;
-                LOG(WARNING) << "clone failed. status:" << res << ", signature:" << agent_task_req->signature;
-                error_msgs.emplace_back("clone failed.");
-            } else {
-                if (status != STARROCKS_SUCCESS && status != STARROCKS_CREATE_TABLE_EXIST) {
-                    StarRocksMetrics::instance()->clone_requests_failed.increment(1);
-                    status_code = TStatusCode::RUNTIME_ERROR;
-                    LOG(WARNING) << "clone failed. signature: " << agent_task_req->signature;
-                    error_msgs.emplace_back("clone failed.");
-                } else {
-                    LOG(INFO) << "clone success, set tablet infos. status:" << status
-                              << ", signature:" << agent_task_req->signature;
-                    finish_task_request.__set_finish_tablet_infos(tablet_infos);
-                }
-            }
-        }
-
-        task_status.__set_status_code(status_code);
-        task_status.__set_error_msgs(error_msgs);
-        finish_task_request.__set_task_status(task_status);
-
-        finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        auto clone_thread_pool = agent_server->get_thread_pool(TTaskType::CLONE);
+        LOG(INFO) << "get clone task. signature:" << agent_task_req->signature
+                  << ", queued tasks in worker pool: " << worker_pool_this->num_queued_tasks()
+                  << ", queued tasks in dynamic thread pool: " << clone_thread_pool->num_queued_tasks()
+                  << ", running tasks in dynamic thread pool: " << clone_thread_pool->num_threads();
+        clone_thread_pool->submit_func(std::bind(run_clone_task, agent_task_req, worker_pool_this));
     }
 
     return (void*)nullptr;
@@ -1074,8 +1015,8 @@ void* TaskWorkerPool::_storage_medium_migrate_worker_thread_callback(void* arg_t
 
                 std::vector<TTabletInfo> tablet_infos;
                 TTabletInfo tablet_info;
-                AgentStatus status = worker_pool_this->_get_tablet_info(tablet_id, schema_hash,
-                                                                        agent_task_req->signature, &tablet_info);
+                AgentStatus status = worker_pool_this->get_tablet_info(tablet_id, schema_hash,
+                                                                       agent_task_req->signature, &tablet_info);
                 if (status != STARROCKS_SUCCESS) {
                     LOG(WARNING) << "storage migrate success, but get tablet info failed"
                                  << ". status:" << status << ", signature:" << agent_task_req->signature;
@@ -1091,7 +1032,7 @@ void* TaskWorkerPool::_storage_medium_migrate_worker_thread_callback(void* arg_t
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -1141,7 +1082,7 @@ void* TaskWorkerPool::_check_consistency_worker_thread_callback(void* arg_this) 
         finish_task_request.__set_request_version(check_consistency_req.version);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return nullptr;
 }
@@ -1366,7 +1307,7 @@ void* TaskWorkerPool::_upload_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_tablet_files(tablet_files);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 
         LOG(INFO) << "Uploaded task signature=" << agent_task_req->signature << " job id=" << upload_request.job_id;
     }
@@ -1412,7 +1353,7 @@ void* TaskWorkerPool::_download_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_downloaded_tablet_ids(downloaded_tablet_ids);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 
         LOG(INFO) << "Downloaded task signature=" << agent_task_req->signature << " job id=" << download_request.job_id;
     }
@@ -1477,7 +1418,7 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
@@ -1519,12 +1460,12 @@ void* TaskWorkerPool::_release_snapshot_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }
 
-AgentStatus TaskWorkerPool::_get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
+AgentStatus TaskWorkerPool::get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
                                              TTabletInfo* tablet_info) {
     AgentStatus status = STARROCKS_SUCCESS;
 
@@ -1577,7 +1518,7 @@ void* TaskWorkerPool::_move_dir_thread_callback(void* arg_this) {
         finish_task_request.__set_task_status(task_status);
 
         finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+        worker_pool_this->remove_task_info(agent_task_req->task_type, agent_task_req->signature);
     }
     return (void*)nullptr;
 }

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -88,6 +88,12 @@ public:
     void submit_task(const TAgentTaskRequest& task);
     void submit_tasks(std::vector<TAgentTaskRequest>* task);
 
+    AgentStatus get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
+                                TTabletInfo* tablet_info);
+    void remove_task_info(TTaskType::type task_type, int64_t signature);
+
+    size_t num_queued_tasks() const;
+
     TaskWorkerPool(const TaskWorkerPool&) = delete;
     const TaskWorkerPool& operator=(const TaskWorkerPool&) = delete;
 
@@ -114,7 +120,6 @@ private:
     static void* _update_tablet_meta_worker_thread_callback(void* arg_this);
 
     bool _register_task_info(TTaskType::type task_type, int64_t signature);
-    void _remove_task_info(TTaskType::type task_type, int64_t signature);
     void _spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func);
 
     using TAgentTaskRequestPtr = std::shared_ptr<TAgentTaskRequest>;
@@ -126,9 +131,6 @@ private:
     void _alter_tablet(TaskWorkerPool* worker_pool_this, const TAgentTaskRequest& alter_tablet_request,
                        int64_t signature, TTaskType::type task_type, TFinishTaskRequest* finish_task_request);
 
-    AgentStatus _get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
-                                 TTabletInfo* tablet_info);
-
     AgentStatus _move_dir(TTabletId tablet_id, TSchemaHash schema_hash, const std::string& src, int64_t job_id,
                           bool overwrite, std::vector<std::string>* error_msgs);
 
@@ -136,7 +138,7 @@ private:
     ExecEnv* _env;
 
     // Protect task queue
-    std::mutex _worker_thread_lock;
+    mutable std::mutex _worker_thread_lock;
     std::condition_variable* _worker_thread_condition_variable;
     std::deque<TAgentTaskRequestPtr> _tasks;
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -100,6 +100,8 @@ CONF_Int32(delete_worker_count_normal_priority, "2");
 CONF_Int32(delete_worker_count_high_priority, "1");
 // The count of thread to alter table.
 CONF_Int32(alter_tablet_worker_count, "3");
+// The count of parallel clone task per storage path
+CONF_Int32(parallel_clone_task_per_path, "2");
 // The count of thread to clone.
 CONF_Int32(clone_worker_count, "3");
 // The count of thread to clone.

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "agent/task_worker_pool.h"
 #include "agent/utils.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/HeartbeatService.h"
@@ -29,6 +30,9 @@
 #include "storage/task/engine_task.h"
 
 namespace starrocks {
+
+void run_clone_task(std::shared_ptr<TAgentTaskRequest> agent_task_req,
+                    TaskWorkerPool* clone_task_worker_pool);
 
 // base class for storage engine
 // add "Engine" as task prefix to prevent duplicate name with agent task

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -31,8 +31,7 @@
 
 namespace starrocks {
 
-void run_clone_task(std::shared_ptr<TAgentTaskRequest> agent_task_req,
-                    TaskWorkerPool* clone_task_worker_pool);
+void run_clone_task(std::shared_ptr<TAgentTaskRequest> agent_task_req, TaskWorkerPool* clone_task_worker_pool);
 
 // base class for storage engine
 // add "Engine" as task prefix to prevent duplicate name with agent task

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -207,6 +207,11 @@ public:
         return _num_threads + _num_threads_pending_start;
     }
 
+    int num_queued_tasks() const {
+        std::lock_guard l(_lock);
+        return _total_queued_tasks;
+    }
+
 private:
     friend class ThreadPoolBuilder;
     friend class ThreadPoolToken;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8346

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently FE can have at most num_of_storage_path * schedule_slot_num_per_path(default 2) clone tasks
scheduled simultaneously, but previously we have only 3 clone worker threads by default,
so this is to keep the dop of clone task handling in sync with FE.
Currently, the task submission and processing logic is deeply coupled with TaskThreadPool, change that will
need to modify many interfaces. So for now we still use TaskThreadPool to submit clone tasks, but with
only a single worker thread, then we use dynamic thread pool to handle the task concurrently in clone task
callback, so that we can match the dop of FE clone task scheduling.
