### PR TITLE
[Enhancement] add chunk_accumulate_operator

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -193,6 +193,7 @@ set(EXEC_FILES
     pipeline/set/intersect_build_sink_operator.cpp
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
+    pipeline/chunk_accumulate_operator.cpp
     workgroup/work_group.cpp
     workgroup/scan_executor.cpp
     workgroup/scan_task_queue.cpp

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -22,6 +22,7 @@
 #include "exec/exchange_node.h"
 
 #include "column/chunk.h"
+#include "exec/pipeline/chunk_accumulate_operator.h"
 #include "exec/pipeline/exchange/exchange_merge_sort_source_operator.h"
 #include "exec/pipeline/exchange/exchange_source_operator.h"
 #include "exec/pipeline/limit_operator.h"

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -234,6 +234,7 @@ void ExchangeNode::debug_string(int indentation_level, std::stringstream* out) c
 
 pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
+
     OpFactories operators;
     if (!_is_merging) {
         auto exchange_source_op = std::make_shared<ExchangeSourceOperatorFactory>(
@@ -247,10 +248,16 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
         exchange_merge_sort_source_operator->set_degree_of_parallelism(1);
         operators.emplace_back(std::move(exchange_merge_sort_source_operator));
     }
+
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(operators.back().get(), context, rc_rf_probe_collector);
+
+    if (operators.back()->has_runtime_filters()) {
+        operators.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
+    }
+
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }

--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -1,0 +1,54 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/chunk_accumulate_operator.h"
+
+#include "column/chunk.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+namespace pipeline {
+
+Status ChunkAccumulateOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    DCHECK(_out_chunk == nullptr);
+
+    if (_in_chunk == nullptr) {
+        _in_chunk = chunk;
+    } else if (_in_chunk->num_rows() + chunk->num_rows() > state->chunk_size()) {
+        _out_chunk = std::move(_in_chunk);
+        _in_chunk = chunk;
+    } else {
+        _in_chunk->append(*chunk);
+    }
+
+    if (_out_chunk == nullptr && _in_chunk->num_rows() >= state->chunk_size() * LOW_WAITER_CHUNK) {
+        _out_chunk = std::move(_in_chunk);
+    }
+
+    return Status::OK();
+}
+
+StatusOr<vectorized::ChunkPtr> ChunkAccumulateOperator::pull_chunk(RuntimeState*) {
+    // If there isn't more input chunk and _out_chunk has been outputted, output _in_chunk this time.
+    if (_is_finished && _out_chunk == nullptr) {
+        return std::move(_in_chunk);
+    }
+
+    return std::move(_out_chunk);
+}
+
+Status ChunkAccumulateOperator::set_finishing(RuntimeState* state) {
+    _is_finished = true;
+
+    return Status::OK();
+}
+
+Status ChunkAccumulateOperator::set_finished(RuntimeState*) {
+    _is_finished = true;
+    _in_chunk.reset();
+    _out_chunk.reset();
+
+    return Status::OK();
+}
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -20,7 +20,8 @@ Status ChunkAccumulateOperator::push_chunk(RuntimeState* state, const vectorized
         _in_chunk->append(*chunk);
     }
 
-    if (_out_chunk == nullptr && _in_chunk->num_rows() >= state->chunk_size() * LOW_WAITER_CHUNK) {
+    if (_out_chunk == nullptr && (_in_chunk->num_rows() >= state->chunk_size() * LOW_WATERMARK_ROWS_RATE ||
+                                  _in_chunk->memory_usage() >= LOW_WATERMARK_BYTES)) {
         _out_chunk = std::move(_in_chunk);
     }
 

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -1,0 +1,52 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+
+namespace starrocks {
+
+class RuntimeState;
+
+namespace pipeline {
+
+// Accumulate chunks and output a chunk, until the number of rows of the input chunks is large enough.
+class ChunkAccumulateOperator final : public Operator {
+public:
+    ChunkAccumulateOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence)
+            : Operator(factory, id, "chunk_accumulate", plan_node_id, driver_sequence) {}
+
+    ~ChunkAccumulateOperator() override = default;
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    bool has_output() const override { return _out_chunk != nullptr || (_is_finished && _in_chunk != nullptr); }
+    bool need_input() const override { return !_is_finished && _out_chunk == nullptr; }
+    bool is_finished() const override { return _is_finished && _in_chunk == nullptr && _out_chunk == nullptr; }
+
+    Status set_finishing(RuntimeState* state) override;
+    Status set_finished(RuntimeState* state) override;
+
+private:
+    static constexpr double LOW_WAITER_CHUNK = 0.75;
+
+    bool _is_finished = false;
+    vectorized::ChunkPtr _in_chunk = nullptr;
+    vectorized::ChunkPtr _out_chunk = nullptr;
+};
+
+class ChunkAccumulateOperatorFactory final : public OperatorFactory {
+public:
+    ChunkAccumulateOperatorFactory(int32_t id, int32_t plan_node_id)
+            : OperatorFactory(id, "chunk_accumulate", plan_node_id) {}
+
+    ~ChunkAccumulateOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<ChunkAccumulateOperator>(this, _id, _plan_node_id, driver_sequence);
+    }
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -29,7 +29,8 @@ public:
     Status set_finished(RuntimeState* state) override;
 
 private:
-    static constexpr double LOW_WAITER_CHUNK = 0.75;
+    static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
+    static constexpr size_t LOW_WATERMARK_BYTES = 256 * 1024 * 1024; // 256MB.
 
     bool _is_finished = false;
     vectorized::ChunkPtr _in_chunk = nullptr;

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -13,6 +13,7 @@
 
 namespace starrocks::pipeline {
 
+/// Operator.
 const int32_t Operator::s_pseudo_plan_node_id_for_olap_table_sink = -98;
 const int32_t Operator::s_pseudo_plan_node_id_for_result_sink = -99;
 const int32_t Operator::s_pseudo_plan_node_id_upper_bound = -100;
@@ -205,6 +206,7 @@ Status OperatorFactory::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
+/// OperatorFactory.
 void OperatorFactory::close(RuntimeState* state) {
     if (_runtime_filter_collector) {
         _runtime_filter_collector->close(state);
@@ -226,6 +228,20 @@ void OperatorFactory::_prepare_runtime_in_filters(RuntimeState* state) {
             _runtime_in_filters.push_back(filter);
         }
     }
+}
+
+bool OperatorFactory::has_runtime_filters() const {
+    // Check runtime in-filters.
+    if (!_rf_waiting_set.empty()) {
+        return true;
+    }
+
+    // Check runtime bloom-filters.
+    if (_runtime_filter_collector == nullptr) {
+        return false;
+    }
+    auto* global_rf_collector = _runtime_filter_collector->get_rf_probe_collector();
+    return global_rf_collector != nullptr && !global_rf_collector->descriptors().empty();
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -269,6 +269,10 @@ public:
 
     RowDescriptor* row_desc() { return &_row_desc; }
 
+    // Whether it has any runtime in-filter or bloom-filter.
+    // MUST be invoked after init_runtime_filter.
+    bool has_runtime_filters() const;
+
 protected:
     void _prepare_runtime_in_filters(RuntimeState* state);
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -3,6 +3,7 @@
 #include "exec/pipeline/scan/scan_operator.h"
 
 #include "column/chunk.h"
+#include "exec/pipeline/chunk_accumulate_operator.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/scan/connector_scan_operator.h"
@@ -430,6 +431,8 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
         ops.emplace_back(
                 std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
     }
+
+    ops.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), scan_node->id()));
 
     return ops;
 }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -426,13 +426,16 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
 
     ops.emplace_back(std::move(scan_operator));
 
+    if (!scan_node->conjunct_ctxs().empty() || ops.back()->has_runtime_filters()) {
+        ops.emplace_back(
+                std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), scan_node->id()));
+    }
+
     size_t limit = scan_node->limit();
     if (limit != -1) {
         ops.emplace_back(
                 std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
     }
-
-    ops.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), scan_node->id()));
 
     return ops;
 }

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -4,6 +4,7 @@
 
 #include "exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h"
 #include "exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h"
+#include "exec/pipeline/chunk_accumulate_operator.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
@@ -132,6 +133,7 @@ Status DistinctBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool
 std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::decompose_to_pipeline(
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
+
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
 
     // Create a shared RefCountedRuntimeFilterCollector
@@ -146,7 +148,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(sink_operator.get(), context, rc_rf_probe_collector);
 
-    OpFactories operators_with_source;
+    OpFactories ops_with_source;
     auto source_operator = std::make_shared<AggregateDistinctBlockingSourceOperatorFactory>(context->next_operator_id(),
                                                                                             id(), aggregator_factory);
     // Initialize OperatorFactory's fields involving runtime filters.
@@ -160,15 +162,21 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     context->add_pipeline(ops_with_sink);
 
     // Aggregator must be used by a pair of sink and source operators,
-    // so operators_with_source's degree of parallelism must be equal with operators_with_sink's
+    // so ops_with_source's degree of parallelism must be equal with operators_with_sink's
     auto degree_of_parallelism = ((SourceOperatorFactory*)(ops_with_sink[0].get()))->degree_of_parallelism();
     source_operator->set_degree_of_parallelism(degree_of_parallelism);
-    operators_with_source.push_back(std::move(source_operator));
+    ops_with_source.push_back(std::move(source_operator));
+
+    if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
+        ops_with_source.emplace_back(
+                std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
+    }
+
     if (limit() != -1) {
-        operators_with_source.emplace_back(
+        ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
-    return operators_with_source;
+    return ops_with_source;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -9,6 +9,7 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/chunk_accumulate_operator.h"
 #include "exec/pipeline/exchange/exchange_source_operator.h"
 #include "exec/pipeline/hashjoin/hash_join_build_operator.h"
 #include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
@@ -509,6 +510,8 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
     if (limit() != -1) {
         lhs_operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+
+    lhs_operators.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
 
     return lhs_operators;
 }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -512,7 +512,6 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
         lhs_operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
 
-
     return lhs_operators;
 }
 

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -407,24 +407,6 @@ Status HashJoinNode::close(RuntimeState* state) {
     return ExecNode::close(state);
 }
 
-bool _is_left_join(TJoinOp::type join_type) {
-    switch (join_type) {
-    case TJoinOp::LEFT_OUTER_JOIN:
-    case TJoinOp::LEFT_SEMI_JOIN:
-    case TJoinOp::LEFT_ANTI_JOIN:
-    case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
-        return true;
-    case TJoinOp::INNER_JOIN:
-    case TJoinOp::FULL_OUTER_JOIN:
-    case TJoinOp::CROSS_JOIN:
-    case TJoinOp::RIGHT_OUTER_JOIN:
-    case TJoinOp::RIGHT_SEMI_JOIN:
-    case TJoinOp::RIGHT_ANTI_JOIN:
-    default:
-        return false;
-    }
-}
-
 pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
 
@@ -526,12 +508,10 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
     lhs_operators.emplace_back(std::move(probe_op));
 
     // Use ChunkAccumulateOperator, when any following condition occurs:
-    // - inner join or right join.
-    // - left join, with conjuncts or runtime in filters or runtime bloom filters.
-    const auto* global_rf_collector = rc_rf_probe_collector->get_rf_probe_collector();
-    bool need_accumulate_chunk = !_is_left_join(_join_type) || !_conjunct_ctxs.empty() ||
-                                 !_other_join_conjunct_ctxs.empty() || !local_rf_waiting_set().empty() ||
-                                 (global_rf_collector != nullptr && !global_rf_collector->descriptors().empty());
+    // - not left outer join,
+    // - left outer join, with conjuncts or runtime filters.
+    bool need_accumulate_chunk = _join_type != TJoinOp::LEFT_OUTER_JOIN || !_conjunct_ctxs.empty() ||
+                                 !_other_join_conjunct_ctxs.empty() || lhs_operators.back()->has_runtime_filters();
     if (need_accumulate_chunk) {
         lhs_operators.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
     }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -507,11 +507,11 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
 
     lhs_operators.emplace_back(std::move(probe_op));
 
+    lhs_operators.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
     if (limit() != -1) {
         lhs_operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
 
-    lhs_operators.emplace_back(std::make_shared<ChunkAccumulateOperatorFactory>(context->next_operator_id(), id()));
 
     return lhs_operators;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8533.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The scan operator and hash_join_probe operator may output many small chunks, which will influent the compute efficiency of the subsequent operators and network transmitting efficiency of the result sink.

Therefore, add a new operator `ChunkAccumulateOperator` for some cases:
- `AggregateBlockingSourceOperator` with having or runtime in/bloom filters.
- `AggregateDistinctBlockingSourceOperator` with having or runtime in/bloom filters.
- `HashJoinProbeOperator`
    - not left outer join.
    - left outer join with conjuncts or runtime in/bloom filters.
- `ExchangeSourceOperator` with runtime in/bloom filters.
- `ScanOperator` with conjuncts or runtime in/bloom filters.

When can `ChunkAccumulateOperator` output a chunk?
- the number of rows >= `chunk_size*0.75`.
- or the bytes of chunk >= `256MB`.

## Test
### Environment
- 8 BE (each 16vCPUs and 64GB RAM)
- tpcds_10t

### Query
```sql
-- broadcast
select c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date  
from  customer join[broadcast] customer_address 
on ca_address_sk = c_current_addr_sk 
where ca_state = 'GA'

-- shuffle
select c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date  
from  customer join[shuffle] customer_address 
on ca_address_sk = c_current_addr_sk 
where ca_state = 'GA'
```
### Result

|                  | Latency |
| ---------------- | ------- |
| Broadcast-before | 5s947ms |
| Shuffle-before   | 3.245ms |
| Broadcast-after  | 2s326ms |
| Shuffle-after    | 2.989ms |







