### PR TITLE
[BugFix] Empty kafka message leads data lost in routine load

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -364,13 +364,12 @@ Status JsonReader::_read_and_parse_json() {
     StreamPipeSequentialFile* stream_file = reinterpret_cast<StreamPipeSequentialFile*>(_file.get());
 
     // read until a non-empty message is returned.
-    while (true) {
+    do {
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
+        // If all messages have been read, an EOF is returned.
         RETURN_IF_ERROR(stream_file->read_one_message(&json_binary, &length));
-        if (length > 0) {
-            break;
-        }
-    }
+    } while (length == 0);
+
     _origin_json_doc.Parse((char*)json_binary.get(), length);
 #endif
 

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -362,9 +362,14 @@ Status JsonReader::_read_and_parse_json() {
     std::unique_ptr<uint8_t[]> json_binary = nullptr;
     size_t length = 0;
     StreamPipeSequentialFile* stream_file = reinterpret_cast<StreamPipeSequentialFile*>(_file.get());
-    {
+
+    // read until a non-empty message is returned.
+    while (true) {
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
         RETURN_IF_ERROR(stream_file->read_one_message(&json_binary, &length));
+        if (length > 0) {
+            break;
+        }
     }
     _origin_json_doc.Parse((char*)json_binary.get(), length);
 #endif

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -365,9 +365,6 @@ Status JsonReader::_read_and_parse_json() {
     {
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
         RETURN_IF_ERROR(stream_file->read_one_message(&json_binary, &length));
-        if (length == 0) {
-            return Status::EndOfFile("EOF of reading file");
-        }
     }
     _origin_json_doc.Parse((char*)json_binary.get(), length);
 #endif

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -201,7 +201,7 @@ private:
             DCHECK(_finished);
             data->reset();
             *length = 0;
-            return Status::OK();
+            return Status::EndOfFile("all data has been read");
         }
         auto buf = _buf_queue.front();
         *length = buf->remaining();

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -93,7 +93,7 @@ public:
         } else if (_total_length == 0) {
             // no data
             *length = 0;
-            return Status::OK();
+            return Status::EndOfFile("empty pipe");
         }
 
         if (_total_length == -1) {
@@ -107,6 +107,7 @@ public:
         Status st = read(data->get(), length, &eof);
         if (eof) {
             *length = 0;
+            return Status::EndOfFile("all data has been read");
         }
         return st;
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -35,7 +35,7 @@ set(EXEC_FILES
         #./exec/vectorized/csv_scanner_test.cpp
         ./exec/vectorized/chunks_sorter_test.cpp
         ./exec/vectorized/join_hash_map_test.cpp
-        #./exec/vectorized/json_scanner_test.cpp
+        ./exec/vectorized/json_scanner_test.cpp
         ./exec/vectorized/hdfs_scanner_test.cpp
         ./exec/vectorized/orc_scanner_adapter_test.cpp
         ./exec/vectorized/table_function_node_test.cpp

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -306,7 +306,7 @@ TEST_F(JsonScannerTest, test_invalid_nested_level2) {
     EXPECT_EQ("[[NULL, NULL]]", chunk->debug_row(0));
 }
 
-TEST_F(JsonScannerTest, test_json_with_long_string) {
+TEST_F(JsonScannerTest, test_empty) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TypeDescriptor::create_varchar_type(100));
     types.emplace_back(TypeDescriptor::create_varchar_type(100));
@@ -318,20 +318,13 @@ TEST_F(JsonScannerTest, test_json_with_long_string) {
     range.__isset.strip_outer_array = true;
     range.__isset.jsonpaths = false;
     range.__isset.json_root = false;
-    range.__set_path("./be/test/exec/test_data/json_scanner/test8.json");
+    range.__set_path("./be/test/exec/test_data/json_scanner/empty.json");
     ranges.emplace_back(range);
 
     auto scanner = create_json_scanner(types, ranges, {"request", "ids"});
 
-    Status st;
-    st = scanner->open();
-    ASSERT_TRUE(st.ok());
-
-    ChunkPtr chunk = scanner->get_next().value();
-    EXPECT_EQ(2, chunk->num_columns());
-    EXPECT_EQ(1, chunk->num_rows());
-
-    EXPECT_EQ("['{\"area\":\"beijing\",\"country\":\"china\"}', '[\"478472290\",\"478473274\"]']", chunk->debug_row(0));
+    ASSERT_TRUE(scanner->open().ok());
+    ASSERT_TRUE(scanner->get_next().status().is_end_of_file());
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/runtime/stream_load_pipe_test.cpp
+++ b/be/test/runtime/stream_load_pipe_test.cpp
@@ -260,15 +260,14 @@ TEST_F(StreamLoadPipeTest, close) {
 }
 
 TEST_F(StreamLoadPipeTest, read_one_message) {
-    StreamLoadPipe pipe(66, 64, -1);
+    StreamLoadPipe pipe(256, 256, 128);
 
     auto appender = [&pipe] {
-        int k = 0;
         for (int i = 0; i < 2; ++i) {
             auto byte_buf = ByteBuffer::allocate(64);
             char buf[64];
             for (int j = 0; j < 64; ++j) {
-                buf[j] = '0' + (k++ % 10);
+                buf[j] = '0' + (j % 10);
             }
             byte_buf->put_bytes(buf, 64);
             byte_buf->flip();
@@ -283,24 +282,58 @@ TEST_F(StreamLoadPipeTest, read_one_message) {
 
     auto st = pipe.read_one_message(&buf, &buf_len);
     ASSERT_EQ(128, buf_len);
-    for (int i = 0; i < 128; ++i) {
+
+    for (int i = 0; i < 64; ++i) {
         ASSERT_EQ('0' + (i % 10), buf[i]);
     }
 
+    for (int i = 0; i < 64; ++i) {
+        ASSERT_EQ('0' + (i % 10), buf[i + 64]);
+    }
+
+    st = pipe.read_one_message(&buf, &buf_len);
+    ASSERT_TRUE(st.is_end_of_file());
+
+    t1.join();
+}
+
+TEST_F(StreamLoadPipeTest, read_one_message_routine_load) {
+    // total_length = -1 means this pipe is for routine load.
+    StreamLoadPipe pipe(256, 256, -1);
+
+    auto appender = [&pipe] {
+        for (int i = 0; i < 2; ++i) {
+            auto byte_buf = ByteBuffer::allocate(64);
+            char buf[64];
+            for (int j = 0; j < 64; ++j) {
+                buf[j] = '0' + (j % 10);
+            }
+            byte_buf->put_bytes(buf, 64);
+            byte_buf->flip();
+            pipe.append_and_flush(byte_buf->ptr, byte_buf->limit);
+        }
+        pipe.finish();
+    };
+    std::thread t1(appender);
+
+    size_t buf_len = 64;
+    std::unique_ptr<uint8_t[]> buf(new uint8_t[64]);
+
     auto st = pipe.read_one_message(&buf, &buf_len);
-    ASSERT_EQ(128, buf_len);
-    for (int i = 0; i < 128; ++i) {
+    ASSERT_EQ(64, buf_len);
+    for (int i = 0; i < 64; ++i) {
         ASSERT_EQ('0' + (i % 10), buf[i]);
     }
 
     st = pipe.read_one_message(&buf, &buf_len);
-    ASSERT_EQ(128, buf_len);
-    for (int i = 0; i < 128; ++i) {
+    ASSERT_EQ(64, buf_len);
+    for (int i = 0; i < 64; ++i) {
         ASSERT_EQ('0' + (i % 10), buf[i]);
     }
 
     st = pipe.read_one_message(&buf, &buf_len);
     ASSERT_TRUE(st.is_end_of_file());
+    ASSERT_EQ(buf_len, 0);
 
     t1.join();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8534 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This fixes the data lost problem when there's empty kafka message.
The previous implement of `stream_load_pipe` determines the EOF by whether the data length = 0, which is incorrect when there's empty kafka message. As a result, the left message would be abandoned and the data would be lost. 