### PR TITLE
[BugFix] Multi invalid messages leads data lost in routine load

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -74,7 +74,7 @@ StatusOr<ChunkPtr> JsonScanner::get_next() {
         RETURN_IF_ERROR(_create_src_chunk(&src_chunk));
 
         if (_cur_file_eof) {
-            // If all readers have been read, a EOF would be returned.
+            // If all readers have been read, an EOF would be returned.
             RETURN_IF_ERROR(_open_next_reader());
             _cur_file_eof = false;
         }

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -65,6 +65,9 @@ private:
     std::vector<std::vector<JsonPath>> _json_paths;
     std::vector<JsonPath> _root_paths;
     bool _strip_outer_array = false;
+
+    constexpr static const size_t _kMaxErrorChunkNum = 10;
+    size_t _error_chunk_num = 0;
 };
 
 // Reader to parse the json.

--- a/be/test/exec/test_data/json_scanner/invalid_test1.json
+++ b/be/test/exec/test_data/json_scanner/invalid_test1.json
@@ -1,0 +1,13 @@
+[
+   {
+      "category": "reference",
+      "author": "NigelRees",
+      "title": "SayingsoftheCentury",
+      "price": 8.95
+   },
+   {
+      "category": "fiction",
+      "author": "EvelynWaugh",
+      "title": "SwordofHonour",
+      "price": 12.99
+   }

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -327,4 +327,81 @@ TEST_F(JsonScannerTest, test_empty) {
     ASSERT_TRUE(scanner->get_next().status().is_end_of_file());
 }
 
+TEST_F(JsonScannerTest, test_multi_invalid_json) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_DOUBLE);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/invalid_test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/invalid_test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/test1.json");
+        ranges.emplace_back(range);
+    }
+
+    auto scanner = create_json_scanner(types, ranges, {"category", "author", "title", "price"});
+
+    ASSERT_TRUE(scanner->open().ok());
+
+    // 2 row from 1st test1.json.
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(2, chunk->num_rows());
+
+    // the data from invalid_test.json is skipped.
+
+    EXPECT_EQ("['reference', 'NigelRees', 'SayingsoftheCentury', 8.95]", chunk->debug_row(0));
+    EXPECT_EQ("['fiction', 'EvelynWaugh', 'SwordofHonour', 12.99]", chunk->debug_row(1));
+
+    // 2 row from 2nd test1.json.
+    chunk = scanner->get_next().value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(2, chunk->num_rows());
+
+    EXPECT_EQ("['reference', 'NigelRees', 'SayingsoftheCentury', 8.95]", chunk->debug_row(0));
+    EXPECT_EQ("['fiction', 'EvelynWaugh', 'SwordofHonour', 12.99]", chunk->debug_row(1));
+
+    EXPECT_TRUE(scanner->get_next().status().is_end_of_file());
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8545 #7849

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This fixes the data lost problem when there're multi invalid message in routine load.
The previous implement of `JsonScanner::get_next()` would return EOF when the `chunk->num_rows == 0`. However, if there's more than 1 invalid message, the 2nd invalid message would make the chunk empty, which leads that the left valid messages are abandonded.