### PR TITLE
rectify wildcard decimal types of multi_distinct_sum converted from sum(distinct) and avg(distinct) (#8425)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -742,4 +742,6 @@ public class Function implements Writable {
         }
         return obj != null && obj.getClass() == this.getClass() && isIdentical((Function) obj);
     }
+
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -5,8 +5,10 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.AggType;
@@ -16,6 +18,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteRule;
@@ -115,12 +118,19 @@ public class RewriteMultiDistinctRule extends TransformationRule {
                 sumColRef = sumColRef == null ?
                         context.getColumnRefFactory().create(sum, sum.getType(), sum.isNullable()) : sumColRef;
                 newAggMapWithAvg.put(sumColRef, sum);
-
-                CallOperator multiAgv = (CallOperator) scalarRewriter.rewrite(
-                        new CallOperator("divide", oldFunctionCall.getType(),
-                                Lists.newArrayList(sumColRef, countColRef)),
-                        DEFAULT_TYPE_CAST_RULE);
-                projections.put(aggMap.getKey(), multiAgv);
+                CallOperator multiAvg = new CallOperator(FunctionSet.DIVIDE, oldFunctionCall.getType(),
+                        Lists.newArrayList(sumColRef, countColRef));
+                if (multiAvg.getType().isDecimalV3()) {
+                    // There is not need to apply ImplicitCastRule to divide operator of decimal types.
+                    // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
+                    ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+                    multiAvg.getChildren().set(
+                            1, new CastOperator(decimal128p38s0, multiAvg.getChild(1), true));
+                } else {
+                    multiAvg = (CallOperator) scalarRewriter.rewrite(multiAvg,
+                            Lists.newArrayList(new ImplicitCastRule()));
+                }
+                projections.put(aggMap.getKey(), multiAvg);
             } else {
                 projections.put(aggMap.getKey(), aggMap.getKey());
                 newAggMapWithAvg.put(aggMap.getKey(), aggMap.getValue());
@@ -161,12 +171,11 @@ public class RewriteMultiDistinctRule extends TransformationRule {
     }
 
     private CallOperator buildMultiSumDistinct(CallOperator oldFunctionCall) {
-        Function searchDesc = new Function(new FunctionName(FunctionSet.MULTI_DISTINCT_SUM),
-                oldFunctionCall.getFunction().getArgs(), Type.INVALID, false);
-        Function fn = GlobalStateMgr.getCurrentState().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
-
+        Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                oldFunctionCall.getFunction(), oldFunctionCall.getChild(0).getType());
         return (CallOperator) scalarRewriter.rewrite(
-                new CallOperator(FunctionSet.MULTI_DISTINCT_SUM, fn.getReturnType(), oldFunctionCall.getChildren(), fn),
-                DEFAULT_TYPE_CAST_RULE);
+                new CallOperator(
+                        FunctionSet.MULTI_DISTINCT_SUM, multiDistinctSum.getReturnType(),
+                        oldFunctionCall.getChildren(), multiDistinctSum), DEFAULT_TYPE_CAST_RULE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -12,6 +12,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -274,10 +275,11 @@ public class SplitAggregateRule extends TransformationRule {
             return new CallOperator(FunctionSet.MULTI_DISTINCT_COUNT, fnCall.getType(), fnCall.getChildren(),
                     Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT, new Type[] {fnCall.getChild(0).getType()},
                             IS_NONSTRICT_SUPERTYPE_OF), false);
-        } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
-            return new CallOperator(FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(),
-                    Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM, new Type[] {fnCall.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF), false);
+        } else if (functionName.equals(FunctionSet.SUM)) {
+            Function multiDistinctSumFn = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                    fnCall.getFunction(), fnCall.getChild(0).getType());
+            return new CallOperator(
+                    FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(), multiDistinctSumFn, false);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
@@ -67,6 +68,7 @@ import com.starrocks.planner.UnionNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -1342,9 +1344,9 @@ public class PlanFragmentBuilder {
                     replaceExpr.getParams().setIsDistinct(false);
                 } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_SUM, functionCallExpr.getParams());
-                    replaceExpr.setFn(Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
-                            new Type[] {functionCallExpr.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF));
+                    Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                            functionCallExpr.getFn(), functionCallExpr.getChild(0).getType());
+                    replaceExpr.setFn(multiDistinctSum);
                     replaceExpr.getParams().setIsDistinct(false);
                 }
                 Preconditions.checkState(replaceExpr != null);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -12,6 +12,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
 public class SelectStmtWithDecimalTypesNewPlannerTest {
     private static ConnectContext ctx;
     @Rule
@@ -57,6 +60,11 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                 "\"storage_format\" = \"DEFAULT\",\n" +
                 "\"enable_persistent_index\" = \"false\"\n" +
                 ");");
+    }
+
+    private static String removeSlotIds(String s) {
+        Pattern removeSlotIdPattern = Pattern.compile("((?<=\\[)\\b\\d+\\b:\\s*)|(\\b\\d+\\b\\s*<->\\s*)");
+        return s.replaceAll(removeSlotIdPattern.pattern(), "");
     }
 
     @Test
@@ -418,7 +426,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimalNullableProperties() throws Exception {
         String sql;
         String plan;
-        
+
         // test decimal count(no-nullable decimal)
         sql = "select count(`dec_18_0`) from `test_decimal_type6`;";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
@@ -434,6 +442,281 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         sql = "select round(`dec_18_0`) from `test_decimal_type6`";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         Assert.assertTrue(plan.contains("  |  4 <-> round[(cast([2: dec_18_0, DECIMAL64(18,0), false] as DECIMAL128(18,0))); args: DECIMAL128; result: DECIMAL128(38,0); args nullable: true; result nullable: true]"));
+    }
+
+    @Test
+    public void testOnePhaseSumDistinctDecimal() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        ctx.getSessionVariable().setNewPlanerAggStage(1);
+
+        String sql = "select sum(distinct col_decimal32p9s2) from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String expectSnippet = "aggregate: multi_distinct_sum[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2)";
+        Assert.assertTrue(plan.contains(expectSnippet));
+
+        sql = "select sum(distinct col_decimal64p13s0) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectSnippet = "aggregate: multi_distinct_sum[([3: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0)";
+        Assert.assertTrue(plan.contains(expectSnippet));
+
+
+        sql = "select sum(distinct col_decimal128p20s3) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectSnippet = "multi_distinct_sum[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3)";
+        Assert.assertTrue(plan.contains(expectSnippet));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+    }
+
+
+    @Test
+    public void testTwoPhaseSumDistinct() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select sum(distinct col_decimal32p9s2) from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String expectPhase1Snippet = "multi_distinct_sum[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: VARCHAR";
+        String expectPhase2Snippet = "multi_distinct_sum[([6: sum, VARCHAR, true]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2)";
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+        sql = "select sum(distinct col_decimal64p13s0) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectPhase1Snippet = "multi_distinct_sum[([3: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: VARCHAR";
+        expectPhase2Snippet = "multi_distinct_sum[([6: sum, VARCHAR, true]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0)";
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+
+        sql = "select sum(distinct col_decimal128p20s3) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectPhase1Snippet = "multi_distinct_sum[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: VARCHAR";
+        expectPhase2Snippet = "multi_distinct_sum[([6: sum, VARCHAR, true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3)";
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+    }
+
+    @Test
+    public void testSumDistinctWithRewriteMultiDistinctRuleTakeEffect() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        boolean oldCboCteReUse = ctx.getSessionVariable().isCboCteReuse();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        ctx.getSessionVariable().setCboCteReuse(false);
+        String sql = "select sum(distinct col_decimal32p9s2), sum(distinct col_decimal64p13s0), " +
+                "sum(distinct col_decimal128p20s3) from db1.decimal_table";
+        String expectPhase1Snippet = "multi_distinct_sum[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: VARCHAR; args nullable: false; result nullable: true], " +
+                "multi_distinct_sum[([3: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: VARCHAR; args nullable: false; result nullable: true], " +
+                "multi_distinct_sum[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: VARCHAR; args nullable: true; result nullable: true]";
+        String expectPhase2Snippet = "multi_distinct_sum[([6: sum, VARCHAR, true]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
+                "multi_distinct_sum[([7: sum, VARCHAR, true]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0); args nullable: true; result nullable: true], " +
+                "multi_distinct_sum[([8: sum, VARCHAR, true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3); " +
+                "args nullable: true; result nullable: true]";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
+    }
+
+    @Test
+    public void testSumDistinctWithRewriteMultiDistinctByCTERuleTakeEffect() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        boolean oldCboCteReUse = ctx.getSessionVariable().isCboCteReuse();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        ctx.getSessionVariable().setCboCteReuse(true);
+        String sql = "select sum(distinct col_decimal32p9s2), sum(distinct col_decimal64p13s0), " +
+                "sum(distinct col_decimal128p20s3) from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String[] expectSnippets = {
+                "multi_distinct_sum[([9: col_decimal32p9s2, DECIMAL32(9,2), false]); args: DECIMAL32; result: VARCHAR",
+                "multi_distinct_sum[([10: col_decimal64p13s0, DECIMAL64(13,0), false]); args: DECIMAL64; result: VARCHAR",
+                "multi_distinct_sum[([11: col_decimal128p20s3, DECIMAL128(20,3), true]); args: DECIMAL128; result: VARCHAR",
+                "multi_distinct_sum[([6: sum, VARCHAR, true]); args: DECIMAL32; result: DECIMAL128(38,2)",
+                "multi_distinct_sum[([7: sum, VARCHAR, true]); args: DECIMAL64; result: DECIMAL128(38,0)",
+                "multi_distinct_sum[([8: sum, VARCHAR, true]); args: DECIMAL128; result: DECIMAL128(38,3)",
+        };
+        Assert.assertTrue(Arrays.asList(expectSnippets).stream().allMatch(s -> plan.contains(s)));
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
+    }
+
+    @Test
+    public void testOnePhaseAvgDistinctDecimal() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        ctx.getSessionVariable().setNewPlanerAggStage(1);
+
+        String sql = "select avg(distinct col_decimal32p9s2) from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String multiDistinctSumSnippet = "multi_distinct_sum[([8: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2)";
+        String multiDistinctCountSnippet = "multi_distinct_count[([10: col_decimal32p9s2, DECIMAL32(9,2), false]);" +
+                " args: DECIMAL32; result: BIGINT";
+        plan = removeSlotIds(plan);
+        multiDistinctCountSnippet = removeSlotIds(multiDistinctCountSnippet);
+        multiDistinctSumSnippet = removeSlotIds(multiDistinctSumSnippet);
+        Assert.assertTrue(plan.contains(multiDistinctSumSnippet) && plan.contains(multiDistinctCountSnippet));
+
+        sql = "select avg(distinct col_decimal64p13s0) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        multiDistinctSumSnippet = "multi_distinct_sum[([8: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0)";
+        multiDistinctCountSnippet = "multi_distinct_count[([10: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: BIGINT";
+        plan = removeSlotIds(plan);
+        multiDistinctCountSnippet = removeSlotIds(multiDistinctCountSnippet);
+        multiDistinctSumSnippet = removeSlotIds(multiDistinctSumSnippet);
+        Assert.assertTrue(plan.contains(multiDistinctSumSnippet) && plan.contains(multiDistinctCountSnippet));
+
+        sql = "select avg(distinct col_decimal128p20s3) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        multiDistinctSumSnippet = "multi_distinct_sum[([8: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3)";
+        multiDistinctCountSnippet = "multi_distinct_count[([10: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: BIGINT";
+        plan = removeSlotIds(plan);
+        multiDistinctCountSnippet = removeSlotIds(multiDistinctCountSnippet);
+        multiDistinctSumSnippet = removeSlotIds(multiDistinctSumSnippet);
+        Assert.assertTrue(plan.contains(multiDistinctSumSnippet) && plan.contains(multiDistinctCountSnippet));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+    }
+
+
+    @Test
+    public void testTwoPhaseAvgDistinct() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select avg(distinct col_decimal32p9s2) from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String expectPhase1Snippet = "multi_distinct_sum[([col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: VARCHAR; args nullable: false; result nullable: true]";
+        String expectPhase2Snippet = "multi_distinct_sum[([multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2); args nullable: true; result nullable: true]";
+        plan = removeSlotIds(plan);
+        expectPhase1Snippet = removeSlotIds(expectPhase1Snippet);
+        expectPhase2Snippet = removeSlotIds(expectPhase2Snippet);
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+        sql = "select avg(distinct col_decimal64p13s0) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectPhase1Snippet = "multi_distinct_sum[([col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: VARCHAR; args nullable: false; result nullable: true]";
+        expectPhase2Snippet = "multi_distinct_sum[([multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0); args nullable: true; result nullable: true]";
+        plan = removeSlotIds(plan);
+        expectPhase1Snippet = removeSlotIds(expectPhase1Snippet);
+        expectPhase2Snippet = removeSlotIds(expectPhase2Snippet);
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+
+
+        sql = "select avg(distinct col_decimal128p20s3) from db1.decimal_table";
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        expectPhase1Snippet = "multi_distinct_sum[([col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: VARCHAR; args nullable: true; result nullable: true]";
+        expectPhase2Snippet = "multi_distinct_sum[([multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3); args nullable: true; result nullable: true]";
+        plan = removeSlotIds(plan);
+        expectPhase1Snippet = removeSlotIds(expectPhase1Snippet);
+        expectPhase2Snippet = removeSlotIds(expectPhase2Snippet);
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) && plan.contains(expectPhase2Snippet));
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+    }
+
+    @Test
+    public void testAvgDistinctWithRewriteMultiDistinctRuleTakeEffect() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        boolean oldCboCteReUse = ctx.getSessionVariable().isCboCteReuse();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        ctx.getSessionVariable().setCboCteReuse(false);
+        String sql = "select avg(distinct col_decimal32p9s2), avg(distinct col_decimal64p13s0), " +
+                "avg(distinct col_decimal128p20s3) from db1.decimal_table";
+        String expectPhase1Snippet = "aggregate: " +
+                "multi_distinct_count[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: VARCHAR; args nullable: false; result nullable: false], " +
+                "multi_distinct_sum[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); " +
+                "args: DECIMAL32; result: VARCHAR; args nullable: false; result nullable: true], " +
+                "multi_distinct_count[([3: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: VARCHAR; args nullable: false; result nullable: false], " +
+                "multi_distinct_sum[([3: col_decimal64p13s0, DECIMAL64(13,0), false]); " +
+                "args: DECIMAL64; result: VARCHAR; args nullable: false; result nullable: true], " +
+                "multi_distinct_count[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: VARCHAR; args nullable: true; result nullable: false], " +
+                "multi_distinct_sum[([5: col_decimal128p20s3, DECIMAL128(20,3), true]); " +
+                "args: DECIMAL128; result: VARCHAR; args nullable: true; result nullable: true]";
+
+        String expectPhase2Snippet = "aggregate: " +
+                "multi_distinct_count[([9: multi_distinct_count, VARCHAR, false]); " +
+                "args: DECIMAL32; result: BIGINT; args nullable: true; result nullable: false], " +
+                "multi_distinct_sum[([10: multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL32; result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
+                "multi_distinct_count[([11: multi_distinct_count, VARCHAR, false]); " +
+                "args: DECIMAL64; result: BIGINT; args nullable: true; result nullable: false], " +
+                "multi_distinct_sum[([12: multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL64; result: DECIMAL128(38,0); args nullable: true; result nullable: true], " +
+                "multi_distinct_count[([13: multi_distinct_count, VARCHAR, false]); " +
+                "args: DECIMAL128; result: BIGINT; args nullable: true; result nullable: false], " +
+                "multi_distinct_sum[([14: multi_distinct_sum, VARCHAR, true]); " +
+                "args: DECIMAL128; result: DECIMAL128(38,3); args nullable: true; result nullable: true]";
+        String projectOutputColumns = "" +
+                "  |  6 <-> [10: multi_distinct_sum, DECIMAL128(38,2), true] / " +
+                "cast([9: multi_distinct_count, BIGINT, false] as DECIMAL128(38,0))\n" +
+                "  |  7 <-> [12: multi_distinct_sum, DECIMAL128(38,0), true] / " +
+                "cast([11: multi_distinct_count, BIGINT, false] as DECIMAL128(38,0))\n" +
+                "  |  8 <-> [14: multi_distinct_sum, DECIMAL128(38,3), true] / " +
+                "cast([13: multi_distinct_count, BIGINT, false] as DECIMAL128(38,0))";
+
+        String plan = removeSlotIds(UtFrameUtils.getVerboseFragmentPlan(ctx, sql));
+        expectPhase1Snippet = removeSlotIds(expectPhase1Snippet);
+        expectPhase2Snippet = removeSlotIds(expectPhase2Snippet);
+        projectOutputColumns = removeSlotIds(projectOutputColumns);
+        Assert.assertTrue(plan.contains(expectPhase1Snippet) &&
+                plan.contains(expectPhase2Snippet) &&
+                plan.contains(projectOutputColumns));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
+    }
+
+    @Test
+    public void testAvgDistinctWithRewriteMultiDistinctByCTERuleTakeEffect() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        boolean oldCboCteReUse = ctx.getSessionVariable().isCboCteReuse();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        ctx.getSessionVariable().setCboCteReuse(true);
+        String sql = "select avg(distinct col_decimal32p9s2), avg(distinct col_decimal64p13s0), " +
+                "avg(distinct col_decimal128p20s3) from db1.decimal_table";
+        String plan = removeSlotIds(UtFrameUtils.getVerboseFragmentPlan(ctx, sql));
+        String[] expectSnippets = {
+                "  |  6 <-> [9: sum, DECIMAL128(38,2), true] / " +
+                        "cast([11: count, BIGINT, false] as DECIMAL128(38,0))\n" +
+                        "  |  7 <-> [13: sum, DECIMAL128(38,0), true] / " +
+                        "cast([15: count, BIGINT, false] as DECIMAL128(38,0))\n" +
+                        "  |  8 <-> [17: sum, DECIMAL128(38,3), true] / " +
+                        "cast([19: count, BIGINT, false] as DECIMAL128(38,0))",
+                "multi_distinct_sum[([10: col_decimal32p9s2, DECIMAL32(9,2), false]); args: DECIMAL32; result: VARCHAR",
+                "multi_distinct_sum[([14: col_decimal64p13s0, DECIMAL64(13,0), false]); args: DECIMAL64; result: VARCHAR",
+                "multi_distinct_sum[([18: col_decimal128p20s3, DECIMAL128(20,3), true]); args: DECIMAL128; result: VARCHAR",
+                "multi_distinct_sum[([9: sum, VARCHAR, true]); args: DECIMAL32; result: DECIMAL128(38,2)",
+                "multi_distinct_sum[([13: sum, VARCHAR, true]); args: DECIMAL64; result: DECIMAL128(38,0)",
+                "multi_distinct_sum[([17: sum, VARCHAR, true]); args: DECIMAL128; result: DECIMAL128(38,3)",
+        };
+        Assert.assertTrue(Arrays.asList(expectSnippets).stream().allMatch(s -> plan.contains(removeSlotIds(s))));
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
     }
 }
 


### PR DESCRIPTION
…

In optimize-phase, sum(distinct c) is converted into multi_distinct_sum(c), and avg(distinct c) is converted into multi_distinct_sum(c) / multi_distinct_count(c), the resloved function signature of decimal types carries wildcard decimal, which is illegal in BE, so we must rectify wildcard decimal types by replace it with real decimal types as we do in analyze-phase.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
