### PR TITLE
rectify wildcard decimal types of multi_distinct_sum converted from sum(distinct) and avg(distinct)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -742,4 +742,6 @@ public class Function implements Writable {
         }
         return obj != null && obj.getClass() == this.getClass() && isIdentical((Function) obj);
     }
+
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedSet;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.Expr;
@@ -18,6 +19,8 @@ import com.starrocks.sql.common.TypeManager;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 
 public class DecimalV3FunctionAnalyzer {
     public static final Set<String> DECIMAL_UNARY_FUNCTION_SET =
@@ -191,6 +194,54 @@ public class DecimalV3FunctionAnalyzer {
         AggregateFunction newFn = new AggregateFunction(fn.getFunctionName(), Arrays.asList(argType), returnType,
                 fn.getIntermediateType(), fn.hasVarArgs());
 
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
+    }
+
+    // This function is used to convert the sum(distinct) function to the multi_distinct_sum function in
+    // optimizing phase and PlanFragment building phase.
+    // Decimal types of multi_distinct_sum must be rectified because the function signature registered in
+    // FunctionSet contains wildcard decimal types which is invalid in BE, so it is forbidden to be used
+    // without decimal type rectification.
+    public static Function convertSumToMultiDistinctSum(Function sumFn, Type argType) {
+        AggregateFunction fn = (AggregateFunction) Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
+                new Type[]{argType},
+                IS_NONSTRICT_SUPERTYPE_OF);
+        Preconditions.checkArgument(fn != null);
+        ScalarType decimal128Type = ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(sumFn.getArgs()), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
+
+        newFn.setFunctionId(fn.getFunctionId());
+        newFn.setChecksum(fn.getChecksum());
+        newFn.setBinaryType(fn.getBinaryType());
+        newFn.setHasVarArgs(fn.hasVarArgs());
+        newFn.setId(fn.getId());
+        newFn.setUserVisible(fn.isUserVisible());
+        newFn.setisAnalyticFn(fn.isAnalyticFn());
+        return newFn;
+    }
+
+    // When converting avg(distinct) into sum(distinct)/count(distinct), invoke this function to
+    // rectify the sum function(is_distinct flag is on) that contains wildcard decimal types.
+    public static Function rectifySumDistinct(Function sumFn, Type argType) {
+        if (!argType.isDecimalV3()) {
+            return sumFn;
+        }
+        ScalarType decimalType = (ScalarType) argType;
+        AggregateFunction fn = (AggregateFunction) sumFn;
+        ScalarType decimal128Type = ScalarType.createDecimalV3Type(
+                PrimitiveType.DECIMAL128, 38, decimalType.getScalarScale());
+        AggregateFunction newFn = new AggregateFunction(
+                fn.getFunctionName(), Arrays.asList(decimalType), decimal128Type,
+                fn.getIntermediateType(), fn.hasVarArgs());
         newFn.setFunctionId(fn.getFunctionId());
         newFn.setChecksum(fn.getChecksum());
         newFn.setBinaryType(fn.getBinaryType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -6,7 +6,9 @@ import com.starrocks.analysis.FunctionName;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.AggType;
@@ -15,6 +17,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteRule;
@@ -116,12 +119,19 @@ public class RewriteMultiDistinctRule extends TransformationRule {
                 sumColRef = sumColRef == null ?
                         context.getColumnRefFactory().create(sum, sum.getType(), sum.isNullable()) : sumColRef;
                 newAggMapWithAvg.put(sumColRef, sum);
-
-                CallOperator multiAgv = (CallOperator) scalarRewriter.rewrite(
-                        new CallOperator("divide", oldFunctionCall.getType(),
-                                Lists.newArrayList(sumColRef, countColRef)),
-                        DEFAULT_TYPE_CAST_RULE);
-                projections.put(aggMap.getKey(), multiAgv);
+                CallOperator multiAvg = new CallOperator(FunctionSet.DIVIDE, oldFunctionCall.getType(),
+                        Lists.newArrayList(sumColRef, countColRef));
+                if (multiAvg.getType().isDecimalV3()) {
+                    // There is not need to apply ImplicitCastRule to divide operator of decimal types.
+                    // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
+                    ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+                    multiAvg.getChildren().set(
+                            1, new CastOperator(decimal128p38s0, multiAvg.getChild(1), true));
+                } else {
+                    multiAvg = (CallOperator) scalarRewriter.rewrite(multiAvg,
+                            Lists.newArrayList(new ImplicitCastRule()));
+                }
+                projections.put(aggMap.getKey(), multiAvg);
             } else {
                 projections.put(aggMap.getKey(), aggMap.getKey());
                 newAggMapWithAvg.put(aggMap.getKey(), aggMap.getValue());
@@ -157,12 +167,11 @@ public class RewriteMultiDistinctRule extends TransformationRule {
     }
 
     private CallOperator buildMultiSumDistinct(CallOperator oldFunctionCall) {
-        Function searchDesc = new Function(new FunctionName(FunctionSet.MULTI_DISTINCT_SUM),
-                oldFunctionCall.getFunction().getArgs(), Type.INVALID, false);
-        Function fn = Catalog.getCurrentCatalog().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
-
+        Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                oldFunctionCall.getFunction(), oldFunctionCall.getChild(0).getType());
         return (CallOperator) scalarRewriter.rewrite(
-                new CallOperator(FunctionSet.MULTI_DISTINCT_SUM, fn.getReturnType(), oldFunctionCall.getChildren(), fn),
-                DEFAULT_TYPE_CAST_RULE);
+                new CallOperator(
+                        FunctionSet.MULTI_DISTINCT_SUM, multiDistinctSum.getReturnType(),
+                        oldFunctionCall.getChildren(), multiDistinctSum), DEFAULT_TYPE_CAST_RULE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -12,6 +12,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -275,10 +276,11 @@ public class SplitAggregateRule extends TransformationRule {
             return new CallOperator(FunctionSet.MULTI_DISTINCT_COUNT, fnCall.getType(), fnCall.getChildren(),
                     Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT, new Type[] {fnCall.getChild(0).getType()},
                             IS_NONSTRICT_SUPERTYPE_OF), false);
-        } else if (functionName.equalsIgnoreCase("SUM")) {
-            return new CallOperator(FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(),
-                    Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM, new Type[] {fnCall.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF), false);
+        } else if (functionName.equals(FunctionSet.SUM)) {
+            Function multiDistinctSumFn = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                    fnCall.getFunction(), fnCall.getChild(0).getType());
+            return new CallOperator(
+                    FunctionSet.MULTI_DISTINCT_SUM, fnCall.getType(), fnCall.getChildren(), multiDistinctSumFn, false);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -19,6 +19,7 @@ import com.starrocks.analysis.TupleId;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
@@ -65,6 +66,7 @@ import com.starrocks.planner.TableFunctionNode;
 import com.starrocks.planner.UnionNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -1317,9 +1319,9 @@ public class PlanFragmentBuilder {
                     replaceExpr.getParams().setIsDistinct(false);
                 } else if (functionName.equalsIgnoreCase("SUM")) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_SUM, functionCallExpr.getParams());
-                    replaceExpr.setFn(Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_SUM,
-                            new Type[] {functionCallExpr.getChild(0).getType()},
-                            IS_NONSTRICT_SUPERTYPE_OF));
+                    Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
+                            functionCallExpr.getFn(), functionCallExpr.getChild(0).getType());
+                    replaceExpr.setFn(multiDistinctSum);
                     replaceExpr.getParams().setIsDistinct(false);
                 }
                 Preconditions.checkState(replaceExpr != null);


### PR DESCRIPTION
In optimize-phase, sum(distinct c) is converted into multi_distinct_sum(c), and avg(distinct c) is converted into multi_distinct_sum(c) / multi_distinct_count(c), the resloved function signature of decimal types carries wildcard decimal, which is illegal in BE, so we must rectify wildcard decimal types by replace it with real decimal types as we do in analyze-phase.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
