### PR TITLE
[Cherry-pick 2.0][BugFix] Late recycle if repair tablet from recycle bin (#8254)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -45,11 +45,14 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.lang.Math.max;
 
 public class CatalogRecycleBin extends MasterDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(CatalogRecycleBin.class);
@@ -61,7 +64,15 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     private Map<Long, RecycleTableInfo> idToTable;
     private Map<Long, RecyclePartitionInfo> idToPartition;
 
-    private Map<Long, Long> idToRecycleTime;
+    protected Map<Long, Long> idToRecycleTime;
+
+    // The real recycle time will extend by LATE_RECYCLE_INTERVAL_SECONDS when enable `eraseLater`.
+    // It is only take effect on master when the tablet scheduler repairs a tablet that is about to expire.
+    // Assume that the repair task will be done within LATE_RECYCLE_INTERVAL_SECONDS.
+    // We should check DB/table/partition that was about to expire in LATE_RECYCLE_INTERVAL_SECONDS, and make sure
+    // they stay longer until the asynchronous agent task finish.
+    protected static int LATE_RECYCLE_INTERVAL_SECONDS = 60;
+    protected Set<Long> enableEraseLater;
 
     public CatalogRecycleBin() {
         super("recycle bin");
@@ -69,6 +80,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         idToTable = Maps.newHashMap();
         idToPartition = Maps.newHashMap();
         idToRecycleTime = Maps.newHashMap();
+        enableEraseLater = new HashSet<>();
+    }
+
+    private void removeRecycleMarkers(Long id) {
+        idToRecycleTime.remove(id);
+        enableEraseLater.remove(id);
     }
 
     public synchronized boolean recycleDatabase(Database db, Set<String> tableNames) {
@@ -200,21 +217,51 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 .collect(Collectors.toList());
     }
 
-    private synchronized boolean isExpire(long id, long currentTimeMs) {
-        long latency = currentTimeMs - idToRecycleTime.get(id);
-        return latency > minEraseLatency && latency > Config.catalog_trash_expire_second * 1000L;
+    /**
+     * if we can erase this instance, we should check if anyone enable erase later.
+     * Only used by main loop.
+     */
+    private synchronized boolean canErase(long id, long currentTimeMs) {
+        long latencyMs = currentTimeMs - idToRecycleTime.get(id);
+        long expireMs = max(Config.catalog_trash_expire_second * 1000L, minEraseLatency);
+        if (enableEraseLater.contains(id)) {
+            // if enableEraseLater is set, extend the timeout by LATE_RECYCLE_INTERVAL_SECONDS
+            expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;
+        }
+        return latencyMs > expireMs;
     }
 
-    private synchronized void eraseDatabase(long currentTimeMs) {
+    /**
+     * make sure there are still some time before the subject is erased
+     */
+    public synchronized boolean ensureEraseLater(long id, long currentTimeMs) {
+        // 1. not in idToRecycleTime, maybe already erased, sorry it's too late!
+        if (!idToRecycleTime.containsKey(id)) {
+            return false;
+        }
+        // 2. will expire after quite a long time, don't worry
+        long latency = currentTimeMs - idToRecycleTime.get(id);
+        if (latency < (Config.catalog_trash_expire_second - LATE_RECYCLE_INTERVAL_SECONDS) * 1000L) {
+            return true;
+        }
+        // 3. already expired, sorry.
+        if (latency > Config.catalog_trash_expire_second * 1000L) {
+            return false;
+        }
+        enableEraseLater.add(id);
+        return true;
+    }
+
+    protected synchronized void eraseDatabase(long currentTimeMs) {
         Iterator<Map.Entry<Long, RecycleDatabaseInfo>> dbIter = idToDatabase.entrySet().iterator();
         while (dbIter.hasNext()) {
             Map.Entry<Long, RecycleDatabaseInfo> entry = dbIter.next();
             RecycleDatabaseInfo dbInfo = entry.getValue();
             Database db = dbInfo.getDb();
-            if (isExpire(db.getId(), currentTimeMs)) {
+            if (canErase(db.getId(), currentTimeMs)) {
                 // erase db
                 dbIter.remove();
-                idToRecycleTime.remove(entry.getKey());
+                removeRecycleMarkers(entry.getKey());
 
                 Catalog.getCurrentCatalog().onEraseDatabase(db.getId());
                 Catalog.getCurrentCatalog().getEditLog().logEraseDb(db.getId());
@@ -231,7 +278,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Database db = dbInfo.getDb();
             if (db.getFullName().equals(dbName)) {
                 iterator.remove();
-                idToRecycleTime.remove(entry.getKey());
+                removeRecycleMarkers(entry.getKey());
 
                 Catalog.getCurrentCatalog().onEraseDatabase(db.getId());
                 LOG.info("erase database[{}-{}], because db with the same name db is recycled", db.getId(), dbName);
@@ -247,7 +294,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         LOG.info("replay erase db[{}] finished", dbId);
     }
 
-    private synchronized void eraseTable(long currentTimeMs) {
+    protected synchronized void eraseTable(long currentTimeMs) {
         Iterator<Map.Entry<Long, RecycleTableInfo>> tableIter = idToTable.entrySet().iterator();
         while (tableIter.hasNext()) {
             Map.Entry<Long, RecycleTableInfo> entry = tableIter.next();
@@ -255,15 +302,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Table table = tableInfo.getTable();
             long tableId = table.getId();
 
-            if (isExpire(tableId, currentTimeMs)) {
+            if (canErase(tableId, currentTimeMs)) {
                 if (table.getType() == TableType.OLAP) {
                     Catalog.getCurrentCatalog().onEraseOlapTable((OlapTable) table, false);
                 }
 
                 // erase table
                 tableIter.remove();
-                idToRecycleTime.remove(tableId);
-
+                removeRecycleMarkers(tableId);
                 // log
                 Catalog.getCurrentCatalog().getEditLog().logEraseTable(tableId);
                 LOG.info("erase table[{}-{}] finished", tableId, table.getName());
@@ -287,7 +333,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 }
 
                 iterator.remove();
-                idToRecycleTime.remove(table.getId());
+                removeRecycleMarkers(table.getId());
                 LOG.info("erase table[{}-{}], because table with the same name is recycled", table.getId(), tableName);
             }
         }
@@ -305,7 +351,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         LOG.info("replay erase table[{}] finished", tableId);
     }
 
-    private synchronized void erasePartition(long currentTimeMs) {
+    protected synchronized void erasePartition(long currentTimeMs) {
         Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator = idToPartition.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Long, RecyclePartitionInfo> entry = iterator.next();
@@ -313,11 +359,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Partition partition = partitionInfo.getPartition();
 
             long partitionId = entry.getKey();
-            if (isExpire(partitionId, currentTimeMs)) {
+            if (canErase(partitionId, currentTimeMs)) {
                 Catalog.getCurrentCatalog().onErasePartition(partition);
                 // erase partition
                 iterator.remove();
-                idToRecycleTime.remove(partitionId);
+                removeRecycleMarkers(partitionId);
 
                 // log
                 Catalog.getCurrentCatalog().getEditLog().logErasePartition(partitionId);
@@ -339,7 +385,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (partition.getName().equals(partitionName)) {
                 Catalog.getCurrentCatalog().onErasePartition(partition);
                 iterator.remove();
-                idToRecycleTime.remove(entry.getKey());
+                removeRecycleMarkers(entry.getKey());
 
                 LOG.info("erase partition[{}-{}] finished, because partition with the same name is recycled",
                         partition.getId(), partitionName);
@@ -380,7 +426,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         Database db = dbInfo.getDb();
         // 2. remove db from idToDatabase and idToRecycleTime
         idToDatabase.remove(db.getId());
-        idToRecycleTime.remove(db.getId());
+        removeRecycleMarkers(db.getId());
 
         return db;
     }
@@ -417,7 +463,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             db.createTable(table);
             LOG.info("recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
             iterator.remove();
-            idToRecycleTime.remove(table.getId());
+            removeRecycleMarkers(table.getId());
             tableNames.remove(table.getName());
         }
 
@@ -443,9 +489,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
 
             db.createTable(table);
-
             iterator.remove();
-            idToRecycleTime.remove(table.getId());
+            removeRecycleMarkers(table.getId());
 
             // log
             RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), -1L);
@@ -523,7 +568,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
         // remove from recycle bin
         idToPartition.remove(partitionId);
-        idToRecycleTime.remove(partitionId);
+        removeRecycleMarkers(partitionId);
 
         // log
         RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.DataProperty;
@@ -382,6 +383,34 @@ public class TabletScheduler extends MasterDaemon {
         LOG.info("adjust priority for all tablets. changed: {}, total: {}", changedNum, size);
     }
 
+    private boolean checkIfTabletExpired(TabletSchedCtx ctx) {
+        return checkIfTabletExpired(ctx, Catalog.getCurrentCatalog().getCurrentRecycleBin(), System.currentTimeMillis());
+    }
+
+    /**
+     * make sure tablet won't expired and erased soon
+     */
+    protected boolean checkIfTabletExpired(TabletSchedCtx ctx, CatalogRecycleBin recycleBin, long currentTimeMs) {
+        // check if about to erase
+        long dbId = ctx.getDbId();
+        if (recycleBin.getDatabase(dbId) != null && !recycleBin.ensureEraseLater(dbId, currentTimeMs)) {
+            LOG.warn("discard ctx because db {} will erase soon: {}", dbId, ctx);
+            return true;
+        }
+        long tableId = ctx.getTblId();
+        if (recycleBin.getTable(tableId) != null && !recycleBin.ensureEraseLater(tableId, currentTimeMs)) {
+            LOG.warn("discard ctx because table {} will erase soon: {}", tableId, ctx);
+            return true;
+        }
+        long partitionId = ctx.getPartitionId();
+        if (recycleBin.getPartition(partitionId) != null
+                && !recycleBin.ensureEraseLater(partitionId, currentTimeMs)) {
+            LOG.warn("discard ctx because partition {} will erase soon: {}", partitionId, ctx);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * get at most BATCH_NUM tablets from queue, and try to schedule them.
      * After handle, the tablet info should be
@@ -401,7 +430,6 @@ public class TabletScheduler extends MasterDaemon {
             try {
                 // reset errMsg for new scheduler round
                 tabletCtx.setErrMsg(null);
-
                 scheduleTablet(tabletCtx, batchTask);
             } catch (SchedException e) {
                 tabletCtx.increaseFailedSchedCounter();
@@ -1220,6 +1248,10 @@ public class TabletScheduler extends MasterDaemon {
             if (tablet == null) {
                 // no more tablets
                 break;
+            }
+            // ignore tablets that will expire and erase soon
+            if (checkIfTabletExpired(tablet)) {
+                continue;
             }
             list.add(tablet);
             count--;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -7,10 +7,20 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.PartitionValue;
+import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.EditLog;
 import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 public class CatalogRecycleBinTest {
@@ -78,5 +88,316 @@ public class CatalogRecycleBinTest {
         List<Partition> partitions = bin.getPartitions(22L);
         Assert.assertEquals(1, partitions.size());
         Assert.assertEquals(2L, partitions.get(0).getId());
+    }
+
+    @Test
+    public void testReplayEraseTable() {
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        Table table1 = new Table(1L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
+        Table table2 = new Table(2L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
+        bin.recycleTable(11, table1);
+        bin.recycleTable(12, table2);
+
+        List<Table> tables = bin.getTables(11L);
+        Assert.assertEquals(1, tables.size());
+
+        bin.replayEraseTable(2);
+        tables = bin.getTables(11);
+        Assert.assertEquals(1, tables.size());
+
+        bin.replayEraseTable(1);
+        tables = bin.getTables(11);
+        Assert.assertEquals(0, tables.size());
+    }
+
+    @Test
+    public void testReplayEraseTableEx(@Mocked Catalog globalStateMgr) {
+
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                result = globalStateMgr;
+
+                globalStateMgr.getEditLog().logEraseTable(anyLong);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        Table table = new Table(1L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
+        bin.recycleTable(11, table);
+        Table table2 = new Table(2L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
+        bin.recycleTable(12, table2);
+        Table table3 = new Table(3L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
+        bin.recycleTable(13, table3);
+
+        bin.eraseTable(System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
+
+        Assert.assertEquals(0, bin.getTables(11L).size());
+        Assert.assertEquals(0, bin.getTables(12L).size());
+        Assert.assertEquals(0, bin.getTables(13L).size());
+    }
+
+    @Test
+    public void testEnsureEraseLater() {
+        Config.catalog_trash_expire_second = 600; // set expire in 10 minutes
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        Database db = new Database(111, "uno");
+        recycleBin.recycleDatabase(db, new HashSet<>());
+
+        // no need to set enable erase later if there are a lot of time left
+        long now = System.currentTimeMillis();
+        Assert.assertTrue(recycleBin.ensureEraseLater(db.getId(), now));
+        Assert.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
+
+        // no need to set enable erase later if already exipre
+        long moreThanTenMinutesLater = now + 620 * 1000L;
+        Assert.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assert.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
+
+        // now we should set enable erase later because we are about to expire
+        long moreThanNineMinutesLater = now + 550 * 1000L;
+        Assert.assertTrue(recycleBin.ensureEraseLater(db.getId(), moreThanNineMinutesLater));
+        Assert.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
+
+        // if already expired, we should return false but won't erase the flag
+        Assert.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assert.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
+     }
+
+    @Test
+    public void testRecycleDb(@Mocked Catalog globalStateMgr, @Mocked EditLog editLog) {
+        Database db1 = new Database(111, "uno");
+        Database db2SameName = new Database(22, "dos"); // samename
+        Database db2 = new Database(222, "dos");
+
+        // 1. recycle 2 dbs
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        recycleBin.recycleDatabase(db1, new HashSet<>());
+        recycleBin.recycleDatabase(db2SameName, new HashSet<>());  // will remove same name
+        recycleBin.recycleDatabase(db2, new HashSet<>());
+
+        Assert.assertEquals(recycleBin.getDatabase(db1.getId()), db1);
+        Assert.assertEquals(recycleBin.getDatabase(db2.getId()), db2);
+        Assert.assertEquals(recycleBin.getDatabase(999), null);
+        Assert.assertEquals(2, recycleBin.idToRecycleTime.size());
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+
+        // 2. manually set db expire time & recycle db1
+        Config.catalog_trash_expire_second = 3600;
+        long now = System.currentTimeMillis();
+        long expireFromNow = now - 3600 * 1000L;
+        recycleBin.idToRecycleTime.put(db1.getId(), expireFromNow - 1000);
+
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+        new Expectations() {
+            {
+                globalStateMgr.onEraseDatabase(anyLong);
+                minTimes = 0;
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+            }
+        };
+        new Expectations() {
+            {
+                editLog.logEraseDb(anyLong);
+                minTimes = 0;
+            }
+        };
+
+        recycleBin.eraseDatabase(now);
+
+        Assert.assertEquals(recycleBin.getDatabase(db1.getId()), null);
+        Assert.assertEquals(recycleBin.getDatabase(db2.getId()), db2);
+        Assert.assertEquals(1, recycleBin.idToRecycleTime.size());
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+
+        // 3. set recyle later, check if recycle now
+        CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
+        Assert.assertFalse(recycleBin.ensureEraseLater(db1.getId(), now));  // already erased
+        Assert.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+        recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow + 1000);
+        Assert.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assert.assertEquals(1, recycleBin.enableEraseLater.size());
+        Assert.assertTrue(recycleBin.enableEraseLater.contains(db2.getId()));
+
+        // 4. won't erase on expire time
+        recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow - 1000);
+        recycleBin.eraseDatabase(now);
+        Assert.assertEquals(recycleBin.getDatabase(db2.getId()), db2);
+        Assert.assertEquals(1, recycleBin.idToRecycleTime.size());
+
+        // 5. will erase after expire time + latency time
+        recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow - 11000);
+        Assert.assertFalse(recycleBin.ensureEraseLater(db2.getId(), now));
+        recycleBin.eraseDatabase(now);
+        Assert.assertEquals(recycleBin.getDatabase(db2.getId()), null);
+        Assert.assertEquals(0, recycleBin.idToRecycleTime.size());
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+    }
+
+    @Test
+    public void testRecycleTable(@Mocked Catalog globalStateMgr, @Mocked EditLog editLog) {
+        Table table1 = new Table(111, "uno", Table.TableType.VIEW, null);
+        Table table2SameName = new Table(22, "dos", Table.TableType.VIEW, null);
+        Table table2 = new Table(222, "dos", Table.TableType.VIEW, null);
+
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+        new Expectations() {
+            {
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+            }
+        };
+        new Expectations() {
+            {
+                editLog.logEraseTable(anyLong);
+                minTimes = 0;
+            }
+        };
+
+        // 1. add 2 tables
+        long DB_ID = 1;
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        recycleBin.recycleTable(DB_ID, table1);
+        recycleBin.recycleTable(DB_ID, table2SameName);
+        recycleBin.recycleTable(DB_ID, table2);
+
+        Assert.assertEquals(new HashSet(recycleBin.getTables(DB_ID)), new HashSet(Arrays.asList(table1, table2)));
+        Assert.assertEquals(recycleBin.getTable(table1.getId()), table1);
+        Assert.assertEquals(recycleBin.getTable(table2.getId()), table2);
+        Assert.assertTrue(recycleBin.idToRecycleTime.containsKey(table1.getId()));
+        Assert.assertTrue(recycleBin.idToRecycleTime.containsKey(table2.getId()));
+
+        // 2. manually set table expire time & recycle table1
+        Config.catalog_trash_expire_second = 3600;
+        long now = System.currentTimeMillis();
+        long expireFromNow = now - 3600 * 1000L;
+        recycleBin.idToRecycleTime.put(table1.getId(), expireFromNow - 1000);
+        recycleBin.eraseTable(now);
+
+        Assert.assertEquals(recycleBin.getTables(DB_ID), Arrays.asList(table2));
+        Assert.assertEquals(recycleBin.getTable(table1.getId()), null);
+        Assert.assertEquals(recycleBin.getTable(table2.getId()), table2);
+
+        // 3. set recyle later, check if recycle now
+        CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
+        Assert.assertFalse(recycleBin.ensureEraseLater(table1.getId(), now));  // already erased
+        Assert.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+        recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow + 1000);
+        Assert.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assert.assertEquals(1, recycleBin.enableEraseLater.size());
+        Assert.assertTrue(recycleBin.enableEraseLater.contains(table2.getId()));
+
+        // 4. won't erase on expire time
+        recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow - 1000);
+        recycleBin.eraseTable(now);
+        Assert.assertEquals(recycleBin.getTable(table2.getId()), table2);
+        Assert.assertEquals(1, recycleBin.idToRecycleTime.size());
+
+        // 5. will erase after expire time + latency time
+        recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow - 11000);
+        Assert.assertFalse(recycleBin.ensureEraseLater(table2.getId(), now));
+        recycleBin.eraseTable(now);
+        Assert.assertEquals(recycleBin.getTable(table2.getId()), null);
+        Assert.assertEquals(0, recycleBin.idToRecycleTime.size());
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+    }
+
+    @Test
+    public void testRecyclePartition(@Mocked Catalog globalStateMgr, @Mocked EditLog editLog) {
+        Partition p1 = new Partition(111, "uno", null, null);
+        Partition p2SameName = new Partition(22, "dos", null, null);
+        Partition p2 = new Partition(222, "dos", null, null);
+
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+        new Expectations() {
+            {
+                globalStateMgr.onErasePartition((Partition)any);
+                minTimes = 0;
+
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+            }
+        };
+        new Expectations() {
+            {
+                editLog.logErasePartition(anyLong);
+                minTimes = 0;
+            }
+        };
+
+        // 1. add 2 partitions
+        long DB_ID = 1;
+        long TABLE_ID = 2;
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+
+        recycleBin.recyclePartition(DB_ID, TABLE_ID, p1, null, dataProperty, (short) 2, false);
+        recycleBin.recyclePartition(DB_ID, TABLE_ID, p2SameName, null, dataProperty, (short) 2, false);
+        recycleBin.recyclePartition(DB_ID, TABLE_ID, p2, null, dataProperty, (short) 2, false);
+
+        Assert.assertEquals(recycleBin.getPartition(p1.getId()), p1);
+        Assert.assertEquals(recycleBin.getPartition(p2.getId()), p2);
+        Assert.assertTrue(recycleBin.idToRecycleTime.containsKey(p1.getId()));
+        Assert.assertTrue(recycleBin.idToRecycleTime.containsKey(p2.getId()));
+
+        // 2. manually set table expire time & recycle table1
+        Config.catalog_trash_expire_second = 3600;
+        long now = System.currentTimeMillis();
+        long expireFromNow = now - 3600 * 1000L;
+        recycleBin.idToRecycleTime.put(p1.getId(), expireFromNow - 1000);
+        recycleBin.erasePartition(now);
+
+        Assert.assertEquals(recycleBin.getPartition(p1.getId()), null);
+        Assert.assertEquals(recycleBin.getPartition(p2.getId()), p2);
+
+        // 3. set recyle later, check if recycle now
+        CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
+        Assert.assertFalse(recycleBin.ensureEraseLater(p1.getId(), now));  // already erased
+        Assert.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
+        recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow + 1000);
+        Assert.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assert.assertEquals(1, recycleBin.enableEraseLater.size());
+        Assert.assertTrue(recycleBin.enableEraseLater.contains(p2.getId()));
+
+        // 4. won't erase on expire time
+        recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow - 1000);
+        recycleBin.erasePartition(now);
+        Assert.assertEquals(recycleBin.getPartition(p2.getId()), p2);
+        Assert.assertEquals(1, recycleBin.idToRecycleTime.size());
+
+        // 5. will erase after expire time + latency time
+        recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow - 11000);
+        Assert.assertFalse(recycleBin.ensureEraseLater(p2.getId(), now));
+        recycleBin.erasePartition(now);
+        Assert.assertEquals(recycleBin.getPartition(p2.getId()), null);
+        Assert.assertEquals(0, recycleBin.idToRecycleTime.size());
+        Assert.assertEquals(0, recycleBin.enableEraseLater.size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -1,0 +1,93 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.clone;
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.common.Config;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class TabletSchedulerTest {
+    @Mocked
+    Catalog globalStateMgr;
+
+    @Before
+    public void setup() throws Exception {
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getColocateTableIndex();
+                minTimes = 0;
+                result = new ColocateTableIndex();
+            }
+        };
+    }
+
+    TabletInvertedIndex tabletInvertedIndex = new TabletInvertedIndex();
+    TabletSchedulerStat tabletSchedulerStat = new TabletSchedulerStat();
+    @Test
+    public void testSubmitBatchTaskIfNotExpired() throws Exception {
+        Database badDb = new Database(1, "mal");
+        Database goodDB = new Database(2, "bueno");
+        Table badTable = new Table(3, "mal", Table.TableType.OLAP, new ArrayList<>());
+        Table goodTable = new Table(4, "bueno", Table.TableType.OLAP, new ArrayList<>());
+        Partition badPartition = new Partition(5, "mal", null, null);
+        Partition goodPartition = new Partition(6, "bueno", null, null);
+
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        recycleBin.recycleDatabase(badDb, new HashSet<>());
+        recycleBin.recycleTable(goodDB.getId(), badTable);
+        recycleBin.recyclePartition(goodDB.getId(), goodTable.getId(), badPartition,
+                null, new DataProperty(TStorageMedium.HDD), (short)2, false);
+
+        List<TabletSchedCtx> allCtxs = new ArrayList<>();
+        List<Triple<Database, Table, Partition>> arguments = Arrays.asList(
+                Triple.of(badDb, goodTable, goodPartition), // will discard
+                Triple.of(goodDB, badTable, goodPartition), // will discard
+                Triple.of(goodDB, goodTable, badPartition), // will discard
+                Triple.of(goodDB, goodTable, goodPartition) // only submit this
+        );
+        for (Triple<Database, Table, Partition> triple : arguments) {
+            allCtxs.add(new TabletSchedCtx(
+                    TabletSchedCtx.Type.REPAIR,
+                    SystemInfoService.DEFAULT_CLUSTER,
+                    triple.getLeft().getId(),
+                    triple.getMiddle().getId(),
+                    triple.getRight().getId(),
+                    1,
+                    1,
+                    System.currentTimeMillis()));
+        }
+
+        TabletScheduler tabletScheduler = new TabletScheduler(globalStateMgr, new SystemInfoService(), tabletInvertedIndex, tabletSchedulerStat);
+
+        long almostExpireTime = System.currentTimeMillis() + (Config.catalog_trash_expire_second - 1) * 1000L;
+        for (int i = 0; i != allCtxs.size(); ++ i) {
+            Assert.assertFalse(tabletScheduler.checkIfTabletExpired(allCtxs.get(i), recycleBin, almostExpireTime));
+        }
+
+        long expireTime = System.currentTimeMillis() + (Config.catalog_trash_expire_second + 600) * 1000L;
+        for (int i = 0; i != allCtxs.size() - 1; ++ i) {
+            Assert.assertTrue(tabletScheduler.checkIfTabletExpired(allCtxs.get(i), recycleBin, expireTime));
+        }
+        // only the last survive
+        Assert.assertFalse(tabletScheduler.checkIfTabletExpired(allCtxs.get(3), recycleBin, expireTime));
+    }
+}


### PR DESCRIPTION
Submitting repair tasks only if no expired db/table/partition involved to avoid NPE when tablet is added after its db/table/partition is dropped.

fixes #6776

Note: This is not exactly a cherry-pick from d0c8eb082eb6ca5fd2bf6b4543e3d351bafa66bb. Lots of conflicts are handled manually.