### PR TITLE
[BugFix] return status error when `partition_id` not found in map

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -50,8 +50,8 @@ Status HiveDataSource::open(RuntimeState* state) {
 
     _runtime_state = state;
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(hdfs_scan_node.tuple_id);
-    _lake_table = dynamic_cast<const LakeTableDescriptor*>(_tuple_desc->table_desc());
-    if (_lake_table == nullptr) {
+    _hive_table = dynamic_cast<const HiveTableDescriptor*>(_tuple_desc->table_desc());
+    if (_hive_table == nullptr) {
         return Status::RuntimeError("Invalid table type. Only hive/iceberg/hudi table are supported");
     }
 
@@ -87,9 +87,9 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
 }
 
 Status HiveDataSource::_init_partition_values() {
-    if (!(_lake_table != nullptr && _has_partition_columns)) return Status::OK();
+    if (!(_hive_table != nullptr && _has_partition_columns)) return Status::OK();
 
-    auto* partition_desc = _lake_table->get_partition(_scan_range.partition_id);
+    auto* partition_desc = _hive_table->get_partition(_scan_range.partition_id);
     const auto& partition_values = partition_desc->partition_key_value_evals();
     _partition_values = partition_values;
 
@@ -129,10 +129,10 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
 
     const auto& slots = _tuple_desc->slots();
     for (int i = 0; i < slots.size(); i++) {
-        if (_lake_table != nullptr && _lake_table->is_partition_col(slots[i])) {
+        if (_hive_table != nullptr && _hive_table->is_partition_col(slots[i])) {
             _partition_slots.push_back(slots[i]);
             _partition_index_in_chunk.push_back(i);
-            _partition_index_in_hdfs_partition_columns.push_back(_lake_table->get_partition_col_index(slots[i]));
+            _partition_index_in_hdfs_partition_columns.push_back(_hive_table->get_partition_col_index(slots[i]));
             _has_partition_columns = true;
         } else {
             _materialize_slots.push_back(slots[i]);
@@ -209,8 +209,13 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
 Status HiveDataSource::_init_scanner(RuntimeState* state) {
     const auto& scan_range = _scan_range;
     std::string native_file_path = scan_range.full_path;
-    if (_lake_table != nullptr && _lake_table->has_partition()) {
-        auto* partition_desc = _lake_table->get_partition(scan_range.partition_id);
+    if (_hive_table != nullptr && _hive_table->has_partition()) {
+        auto* partition_desc = _hive_table->get_partition(scan_range.partition_id);
+        if (partition_desc == nullptr) {
+            return Status::InternalError(fmt::format(
+                    "Plan inconsistency. scan_range.partition_id = {} not found in partition description map",
+                    scan_range.partition_id));
+        }
 
         SCOPED_TIMER(_profile.open_file_timer);
 

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -100,7 +100,7 @@ private:
     bool _has_partition_columns = false;
 
     std::vector<std::string> _hive_column_names;
-    const LakeTableDescriptor* _lake_table = nullptr;
+    const HiveTableDescriptor* _hive_table = nullptr;
 
     // ======================================
     // The following are profile metrics

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -123,7 +123,7 @@ Status HdfsPartitionDescriptor::create_part_key_exprs(ObjectPool* pool, int32_t 
 }
 
 HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : LakeTableDescriptor(tdesc, pool) {
+        : HiveTableDescriptor(tdesc, pool) {
     _hdfs_base_path = tdesc.hdfsTable.hdfs_base_dir;
     _columns = tdesc.hdfsTable.columns;
     _partition_columns = tdesc.hdfsTable.partition_columns;
@@ -134,13 +134,13 @@ HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
 }
 
 IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : LakeTableDescriptor(tdesc, pool) {
+        : HiveTableDescriptor(tdesc, pool) {
     _table_location = tdesc.icebergTable.location;
     _columns = tdesc.icebergTable.columns;
 }
 
 HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : LakeTableDescriptor(tdesc, pool) {
+        : HiveTableDescriptor(tdesc, pool) {
     _table_location = tdesc.hudiTable.location;
     _columns = tdesc.hudiTable.columns;
     _partition_columns = tdesc.hudiTable.partition_columns;
@@ -150,13 +150,13 @@ HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     }
 }
 
-LakeTableDescriptor::LakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool) : TableDescriptor(tdesc) {}
+HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool) : TableDescriptor(tdesc) {}
 
-bool LakeTableDescriptor::is_partition_col(const SlotDescriptor* slot) const {
+bool HiveTableDescriptor::is_partition_col(const SlotDescriptor* slot) const {
     return get_partition_col_index(slot) >= 0;
 }
 
-HdfsPartitionDescriptor* LakeTableDescriptor::get_partition(int64_t partition_id) const {
+HdfsPartitionDescriptor* HiveTableDescriptor::get_partition(int64_t partition_id) const {
     auto it = _partition_id_to_desc_map.find(partition_id);
     if (it == _partition_id_to_desc_map.end()) {
         return nullptr;
@@ -164,7 +164,7 @@ HdfsPartitionDescriptor* LakeTableDescriptor::get_partition(int64_t partition_id
     return it->second;
 }
 
-int LakeTableDescriptor::get_partition_col_index(const SlotDescriptor* slot) const {
+int HiveTableDescriptor::get_partition_col_index(const SlotDescriptor* slot) const {
     int idx = 0;
     for (const auto& partition_column : _partition_columns) {
         if (partition_column.column_name == slot->col_name()) {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -188,9 +188,9 @@ private:
     std::vector<ExprContext*> _partition_key_value_evals;
 };
 
-class LakeTableDescriptor : public TableDescriptor {
+class HiveTableDescriptor : public TableDescriptor {
 public:
-    LakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     virtual bool has_partition() const = 0;
     virtual bool is_partition_col(const SlotDescriptor* slot) const;
     virtual int get_partition_col_index(const SlotDescriptor* slot) const;
@@ -211,21 +211,21 @@ protected:
     std::string _table_location;
 };
 
-class HdfsTableDescriptor : public LakeTableDescriptor {
+class HdfsTableDescriptor : public HiveTableDescriptor {
 public:
     HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     ~HdfsTableDescriptor() override = default;
     bool has_partition() const override { return true; }
 };
 
-class IcebergTableDescriptor : public LakeTableDescriptor {
+class IcebergTableDescriptor : public HiveTableDescriptor {
 public:
     IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     ~IcebergTableDescriptor() override = default;
     bool has_partition() const override { return false; }
 };
 
-class HudiTableDescriptor : public LakeTableDescriptor {
+class HudiTableDescriptor : public HiveTableDescriptor {
 public:
     HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     ~HudiTableDescriptor() override = default;


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/718

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Since the [case](https://github.com/StarRocks/StarRocksTest/issues/718) is not reproducible, and we can not find root cause of it in short time, what we can do is to avoid crash now.

__NOTE__ : this root cause has not been identified yet, so this pr is just to mitigate problem.

And the reason why I rename `LakeTableDescriptor` to  `HiveTableDescriptor` is because `lake` has been used by another team in new scenario, and to avoid ambiguity.
