### PR TITLE
[Enhancement] Optimize default configuration which may cause balance problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -756,6 +756,15 @@ public class Config extends ConfigBase {
     public static int alter_max_worker_queue_size = 4096;
 
     /**
+     * If set to true, FE will check backend available capacity by storage medium when create table
+     *
+     * The default value is true because if user has a deployment with only SSD or HDD medium storage paths,
+     * create an incompatible table with cause balance problem(SSD tablet cannot move to HDD path, vice versa).
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_strict_storage_medium_check = true;
+
+    /**
      * When create a table(or partition), you can specify its storage medium(HDD or SSD).
      * If not set, this specifies the default medium when creat.
      */
@@ -767,8 +776,8 @@ public class Config extends ConfigBase {
      * After that, tablets will be moved to HDD automatically.
      * You can set storage cooldown time in CREATE TABLE stmt.
      */
-    @ConfField
-    public static long storage_cooldown_second = 30 * 24 * 3600L; // 30 days
+    @ConfField(mutable = true)
+    public static long storage_cooldown_second = -1L; // won't cool down by default
     /**
      * After dropping database(table/partition), you can recover it by using RECOVER stmt.
      * And this specifies the maximal data retention time. After time, the data will be deleted permanently.
@@ -1164,12 +1173,6 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int max_running_rollup_job_num_per_table = 1;
-
-    /**
-     * If set to true, FE will check backend available capacity by storage medium when create table
-     */
-    @ConfField(mutable = true)
-    public static boolean enable_strict_storage_medium_check = false;
 
     /**
      * if set to false, auth check will be disable, in case some goes wrong with the new privilege system.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -150,7 +150,9 @@ public class PropertyAnalyzer {
 
         if (storageMedium == TStorageMedium.SSD && !hasCooldown) {
             // set default cooldown time
-            coolDownTimeStamp = Config.storage_cooldown_second <= 0 ? DataProperty.MAX_COOLDOWN_TIME_MS :
+            coolDownTimeStamp = ((Config.storage_cooldown_second <= 0) ||
+                    ((DataProperty.MAX_COOLDOWN_TIME_MS - currentTimeMs) / 1000L < Config.storage_cooldown_second)) ?
+                    DataProperty.MAX_COOLDOWN_TIME_MS :
                     currentTimeMs + Config.storage_cooldown_second * 1000L;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -150,7 +150,7 @@ public class PropertyAnalyzer {
 
         if (storageMedium == TStorageMedium.SSD && !hasCooldown) {
             // set default cooldown time
-            coolDownTimeStamp = Config.storage_cooldown_second == -1 ? DataProperty.MAX_COOLDOWN_TIME_MS :
+            coolDownTimeStamp = Config.storage_cooldown_second <= 0 ? DataProperty.MAX_COOLDOWN_TIME_MS :
                     currentTimeMs + Config.storage_cooldown_second * 1000L;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -150,7 +150,8 @@ public class PropertyAnalyzer {
 
         if (storageMedium == TStorageMedium.SSD && !hasCooldown) {
             // set default cooldown time
-            coolDownTimeStamp = currentTimeMs + Config.storage_cooldown_second * 1000L;
+            coolDownTimeStamp = Config.storage_cooldown_second == -1 ? DataProperty.MAX_COOLDOWN_TIME_MS :
+                    currentTimeMs + Config.storage_cooldown_second * 1000L;
         }
 
         Preconditions.checkNotNull(storageMedium);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2390,8 +2390,12 @@ public class LocalMetastore implements ConnectorMetadata {
                 true, true, storageMedium);
         if (chosenBackendIds == null) {
             throw new DdlException(
-                    "Failed to find enough host with storage medium is " + storageMedium + " in all backends. need: " +
-                            replicationNum);
+                    "Failed to find enough hosts with storage medium " + storageMedium +
+                            " at all backends, number of replicas needed: " +
+                            replicationNum + ". You can forcefully ignore this error by executing " +
+                            "'ADMIN SET FRONTEND CONFIG (\"enable_strict_storage_medium_check\" = \"false\");', " +
+                            "but incompatible medium type can cause balance problem, so we strongly recommend" +
+                            " creating table with compatible 'storage_medium' property set.");
         }
         return chosenBackendIds;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2392,7 +2392,7 @@ public class LocalMetastore implements ConnectorMetadata {
             throw new DdlException(
                     "Failed to find enough hosts with storage medium " + storageMedium +
                             " at all backends, number of replicas needed: " +
-                            replicationNum + ". You can forcefully ignore this error by executing " +
+                            replicationNum + ". Storage medium check failure can be forcefully ignored by executing " +
                             "'ADMIN SET FRONTEND CONFIG (\"enable_strict_storage_medium_check\" = \"false\");', " +
                             "but incompatible medium type can cause balance problem, so we strongly recommend" +
                             " creating table with compatible 'storage_medium' property set.");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -75,6 +75,7 @@ public class AlterTest {
         FeConstants.default_scheduler_interval_millisecond = 100;
         Config.dynamic_partition_enable = true;
         Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_strict_storage_medium_check = false;
         UtFrameUtils.createMinStarRocksCluster();
 
         // create connect context

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -152,7 +152,8 @@ public class CreateTableTest {
                         + "properties('replication_num' = '1', 'short_key' = '4');"));
 
         ExceptionChecker
-                .expectThrowsWithMsg(DdlException.class, "Failed to find enough host in all backends. need: 3",
+                .expectThrowsWithMsg(DdlException.class, "Failed to find enough hosts with storage " +
+                                "medium HDD at all backends, number of replicas needed: 3",
                         () -> createTable("create table test.atbl5\n" + "(k1 int, k2 int, k3 int)\n"
                                 + "duplicate key(k1, k2, k3)\n" + "distributed by hash(k1) buckets 1\n"
                                 + "properties('replication_num' = '3');"));
@@ -170,7 +171,8 @@ public class CreateTableTest {
         ConfigBase.setMutableConfig("enable_strict_storage_medium_check", "true");
         ExceptionChecker
                 .expectThrowsWithMsg(DdlException.class,
-                        "Failed to find enough host with storage medium is SSD in all backends. need: 1",
+                        "Failed to find enough hosts with storage " +
+                                "medium SSD at all backends, number of replicas needed: 1",
                         () -> createTable(
                                 "create table test.tb7(key1 int, key2 varchar(10)) distributed by hash(key1) \n"
                                         + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -145,4 +145,38 @@ public class PropertyAnalyzerTest {
         DateLiteral dateLiteral = new DateLiteral(tomorrowTimeStr, Type.DATETIME);
         Assert.assertEquals(dateLiteral.unixTimestamp(TimeUtils.getTimeZone()), dataProperty.getCooldownTimeMs());
     }
+
+    @Test
+    public void testCoolDownTime() throws AnalysisException {
+        Map<String, String> properties1 = Maps.newHashMap();
+        properties1.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        DataProperty dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties1, new DataProperty(TStorageMedium.SSD));
+        // Cooldown is disabled(with maximum cooldown timestamp) by default
+        Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+
+        Config.storage_cooldown_second = -2;
+        Map<String, String> properties2 = Maps.newHashMap();
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties2, new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+
+        Config.storage_cooldown_second = 253402271999L;
+        Map<String, String> properties3 = Maps.newHashMap();
+        properties3.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties3, new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, dataProperty.getCooldownTimeMs());
+
+        Map<String, String> properties4 = Maps.newHashMap();
+        properties4.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        Config.storage_cooldown_second = 600;
+        long start = System.currentTimeMillis();
+        dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties4, new DataProperty(TStorageMedium.SSD));
+        long end = System.currentTimeMillis();
+        Assert.assertTrue(dataProperty.getCooldownTimeMs() >= start + 600 * 1000L &&
+                dataProperty.getCooldownTimeMs() <= end + 600 * 1000L);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8579 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Storage cool down is enabled by default, but many users don't have a notice of this feature and have deployments with only SSD storage paths, so after some time (1 month by default), its SSD table will change to HDD, and these HDD tables cannot balance when adding new BE to cluster because currently we balance tablets with different medium separately.

`enable_strict_storage_medium_check` is also turned on by default, this will also cause similar balance problem like above.
