### PR TITLE
[Refactor] Force reorder columns of chunk

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -283,6 +283,12 @@ Status HiveDataSource::get_next(RuntimeState* state, vectorized::ChunkPtr* chunk
     do {
         RETURN_IF_ERROR(_scanner->get_next(state, chunk));
     } while ((*chunk)->num_rows() == 0);
+
+    // The column order of chunk is required to be invariable. In order to simplify the logic of each scanner,
+    // we force to reorder the columns of chunk, so scanner doesn't have to care about the column order anymore.
+    // The overhead of reorder is negligible because we only swap columns.
+    ChunkHelper::reorder_chunk(*_tuple_desc, chunk->get());
+
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -484,25 +484,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
-    ChunkPtr temp_chunk = std::make_shared<vectorized::Chunk>();
-    ChunkPtr result_chunk = *chunk;
-    // The column order of chunk is required to be invariable. When a table performs schema change,
-    // say we want to add a new column to table A, the reader of old files of table A will append new
-    // column to the tail of the chunk, while the reader of new files of table A will put the new column
-    // in the chunk according to the order it's stored. This will lead two chunk from different file to
-    // different column order, so we need to adjust the column order according to the input chunk to make
-    // sure every chunk has same column order
-    auto output_result_chunk = [&result_chunk, &temp_chunk]() {
-        const auto& slot_id_to_index_map = result_chunk->get_slot_id_to_index_map();
-        for (auto iter = slot_id_to_index_map.begin(); iter != slot_id_to_index_map.end(); iter++) {
-            auto ck_iter = temp_chunk->get_slot_id_to_index_map().find(iter->first);
-            if (ck_iter == temp_chunk->get_slot_id_to_index_map().end()) {
-                continue;
-            }
-            result_chunk->columns()[iter->second]->swap_column(*temp_chunk->columns()[ck_iter->second]);
-        }
-    };
-
+    ChunkPtr& ck = *chunk;
     // this infinite for loop is for retry.
     for (;;) {
         orc::RowReader::ReadPosition position;
@@ -531,14 +513,14 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                     ret = _orc_reader->get_active_chunk();
                 }
                 RETURN_IF_ERROR(ret);
-                temp_chunk = std::move(ret.value());
+                *chunk = std::move(ret.value());
             }
 
             // important to add columns before evaluation
             // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _scanner_ctx.append_not_existed_columns_to_chunk(&temp_chunk, temp_chunk->num_rows());
-            _scanner_ctx.append_partition_column_to_chunk(&temp_chunk, temp_chunk->num_rows());
-            chunk_size = temp_chunk->num_rows();
+            _scanner_ctx.append_not_existed_columns_to_chunk(chunk, ck->num_rows());
+            _scanner_ctx.append_partition_column_to_chunk(chunk, ck->num_rows());
+            chunk_size = ck->num_rows();
             // do stats before we filter rows which does not match.
             _stats.raw_rows_read += chunk_size;
             _chunk_filter.assign(chunk_size, 1);
@@ -550,20 +532,19 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                         continue;
                     }
                     ASSIGN_OR_RETURN(chunk_size,
-                                     ExecNode::eval_conjuncts_into_filter(it.second, temp_chunk.get(), &_chunk_filter));
+                                     ExecNode::eval_conjuncts_into_filter(it.second, ck.get(), &_chunk_filter));
                     if (chunk_size == 0) {
                         break;
                     }
                 }
             }
-            if (chunk_size != 0 && chunk_size != temp_chunk->num_rows()) {
-                temp_chunk->filter(_chunk_filter);
+            if (chunk_size != 0 && chunk_size != ck->num_rows()) {
+                ck->filter(_chunk_filter);
             }
         }
-        temp_chunk->set_num_rows(chunk_size);
+        ck->set_num_rows(chunk_size);
 
         if (!_orc_reader->has_lazy_load_context()) {
-            output_result_chunk();
             return Status::OK();
         }
 
@@ -585,9 +566,8 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             StatusOr<ChunkPtr> ret = _orc_reader->get_lazy_chunk();
             RETURN_IF_ERROR(ret);
             Chunk& ret_ck = *(ret.value());
-            temp_chunk->merge(std::move(ret_ck));
+            ck->merge(std::move(ret_ck));
         }
-        output_result_chunk();
         return Status::OK();
     }
     __builtin_unreachable();

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -373,4 +373,19 @@ std::shared_ptr<vectorized::Chunk> ChunkHelper::new_chunk(const std::vector<Slot
     return chunk;
 }
 
+void ChunkHelper::reorder_chunk(const TupleDescriptor& tuple_desc, vectorized::Chunk* chunk) {
+    return reorder_chunk(tuple_desc.slots(), chunk);
+}
+
+void ChunkHelper::reorder_chunk(const std::vector<SlotDescriptor*>& slots, vectorized::Chunk* chunk) {
+    DCHECK(chunk->columns().size() == slots.size());
+    auto reordered_chunk = vectorized::Chunk();
+    auto& original_chunk = (*chunk);
+    for (std::size_t idx = 0; idx < slots.size(); idx++) {
+        auto slot_id = slots[idx]->id();
+        reordered_chunk.append_column(original_chunk.get_column_by_slot_id(slot_id), slot_id);
+    }
+    original_chunk.swap_chunk(reordered_chunk);
+}
+
 } // namespace starrocks

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -62,6 +62,11 @@ public:
     // Padding char columns
     static void padding_char_columns(const std::vector<size_t>& char_column_indexes, const vectorized::Schema& schema,
                                      const TabletSchema& tschema, vectorized::Chunk* chunk);
+
+    // Reorder columns of `chunk` according to the order of |tuple_desc|.
+    static void reorder_chunk(const TupleDescriptor& tuple_desc, vectorized::Chunk* chunk);
+    // Reorder columns of `chunk` according to the order of |slots|.
+    static void reorder_chunk(const std::vector<SlotDescriptor*>& slots, vectorized::Chunk* chunk);
 };
 
 } // namespace starrocks

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -209,5 +209,38 @@ TEST_F(ChunkHelperTest, NewChunkWithTuple) {
     ASSERT_EQ(chunk->get_column_by_slot_id(8)->get_name(), "binary");
 }
 
+TEST_F(ChunkHelperTest, ReorderChunk) {
+    auto* tuple_desc = _create_tuple_desc();
+
+    auto reversed_slots = tuple_desc->slots();
+    std::reverse(reversed_slots.begin(), reversed_slots.end());
+    auto chunk = ChunkHelper::new_chunk(reversed_slots, 1024);
+
+    // check
+    ASSERT_EQ(chunk->num_columns(), 9);
+    ASSERT_EQ(chunk->columns()[8]->get_name(), "integral-1");
+    ASSERT_EQ(chunk->columns()[7]->get_name(), "integral-2");
+    ASSERT_EQ(chunk->columns()[6]->get_name(), "integral-4");
+    ASSERT_EQ(chunk->columns()[5]->get_name(), "integral-8");
+    ASSERT_EQ(chunk->columns()[4]->get_name(), "int128");
+    ASSERT_EQ(chunk->columns()[3]->get_name(), "float-4");
+    ASSERT_EQ(chunk->columns()[2]->get_name(), "float-8");
+    ASSERT_EQ(chunk->columns()[1]->get_name(), "binary");
+    ASSERT_EQ(chunk->columns()[0]->get_name(), "binary");
+
+    ChunkHelper::reorder_chunk(*tuple_desc, chunk.get());
+    // check
+    ASSERT_EQ(chunk->num_columns(), 9);
+    ASSERT_EQ(chunk->columns()[0]->get_name(), "integral-1");
+    ASSERT_EQ(chunk->columns()[1]->get_name(), "integral-2");
+    ASSERT_EQ(chunk->columns()[2]->get_name(), "integral-4");
+    ASSERT_EQ(chunk->columns()[3]->get_name(), "integral-8");
+    ASSERT_EQ(chunk->columns()[4]->get_name(), "int128");
+    ASSERT_EQ(chunk->columns()[5]->get_name(), "float-4");
+    ASSERT_EQ(chunk->columns()[6]->get_name(), "float-8");
+    ASSERT_EQ(chunk->columns()[7]->get_name(), "binary");
+    ASSERT_EQ(chunk->columns()[8]->get_name(), "binary");
+}
+
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The column order of chunk is required to be invariable. In order to simplify the logic of each scanner, we force to reorder the columns of chunk, so scanner doesn't have to care about the column order anymore. The overhead of reorder is negligible because we don't actually copy columns data.
