### PR TITLE
[Enhancement] Reduce lock: locking once and reference it, not locking twice.

### DIFF
--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -285,7 +285,7 @@ private:
 
     // wait a version to be applied, so reader can read this version
     // assuming _lock already hold
-    Status _wait_for_version(const EditVersion& version, int64_t timeout_ms);
+    Status _wait_for_version(const EditVersion& version, int64_t timeout_ms, std::unique_lock<std::mutex>& lock);
 
     Status _commit_compaction(std::unique_ptr<CompactionInfo>* info, const RowsetSharedPtr& rowset,
                               EditVersion* commit_version);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8606

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
## Enhancement
one lock:
https://github.com/StarRocks/starrocks/blob/f674d92dca0e9ac06cfd8c126d084601c6ab9509/be/src/storage/tablet_updates.cpp#L1047-L1090
one more lock
https://github.com/StarRocks/starrocks/blob/f674d92dca0e9ac06cfd8c126d084601c6ab9509/be/src/storage/tablet_updates.cpp#L2168-L2170
can just lock once.