### PR TITLE
fixup avg(distinct non-decimal-type) bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -218,6 +218,10 @@ public class DecimalV3FunctionAnalyzer {
                 new Type[]{argType},
                 IS_NONSTRICT_SUPERTYPE_OF);
         Preconditions.checkArgument(fn != null);
+        // Only rectify decimal typed functions.
+        if (!argType.isDecimalV3()) {
+            return fn;
+        }
         ScalarType decimal128Type = ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
         AggregateFunction newFn = new AggregateFunction(
                 fn.getFunctionName(), Arrays.asList(sumFn.getArgs()), decimal128Type,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -718,5 +718,36 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
         ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
     }
+
+    @Test
+    public void testAvgDistinctNonDecimalTypeWithRewriteMultiDistinctRuleTakeEffect() throws Exception {
+        int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
+        boolean oldCboCteReUse = ctx.getSessionVariable().isCboCteReuse();
+        ctx.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select avg(distinct key0) from db1.decimal_table";
+        String[] snippets = new String[]{
+                "cast([multi_distinct_sum, BIGINT, true] as DOUBLE) / " +
+                        "cast([multi_distinct_count, BIGINT, false] as DOUBLE)",
+                "multi_distinct_count[([multi_distinct_count, VARCHAR, false]); " +
+                        "args: INT; result: BIGINT; args nullable: true; result nullable: false]",
+                "multi_distinct_sum[([multi_distinct_sum, VARCHAR, true]); " +
+                        "args: INT; result: BIGINT; args nullable: true; result nullable: true]",
+                "multi_distinct_count[([key0, INT, false]); args: INT; result: VARCHAR; " +
+                        "args nullable: false; result nullable: false]",
+                "multi_distinct_sum[([key0, INT, false]); " +
+                        "args: INT; result: VARCHAR; args nullable: false; result nullable: true]",
+        };
+
+        ctx.getSessionVariable().setCboCteReuse(false);
+        String disableCtePlan = removeSlotIds(UtFrameUtils.getVerboseFragmentPlan(ctx, sql));
+        Assert.assertTrue(Arrays.asList(snippets).stream().anyMatch(s -> disableCtePlan.contains(s)));
+
+        ctx.getSessionVariable().setCboCteReuse(true);
+        String enableCtePlan = removeSlotIds(UtFrameUtils.getVerboseFragmentPlan(ctx, sql));
+        Assert.assertTrue(Arrays.asList(snippets).stream().anyMatch(s -> enableCtePlan.contains(s)));
+
+        ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        ctx.getSessionVariable().setCboCteReuse(oldCboCteReUse);
+    }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksTest/issues/738

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
select avg(distinct non-decimal-type(i.e.BIGINT)) from table gives a invalid multi_distinct_sum signature.
expected: multi_distinct_count[([multi_distinct_count, VARCHAR, false]); args: INT; result: BIGINT
unexpected: multi_distinct_count[([multi_distinct_count, VARCHAR, false]); args: INT; result: DECIMAL128(38,0).