### PR TITLE
fixup avg(distinct non-decimal-type) bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -214,6 +214,10 @@ public class DecimalV3FunctionAnalyzer {
                 new Type[]{argType},
                 IS_NONSTRICT_SUPERTYPE_OF);
         Preconditions.checkArgument(fn != null);
+        // Only rectify decimal typed functions.
+        if (!argType.isDecimalV3()) {
+            return fn;
+        }
         ScalarType decimal128Type = ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
         AggregateFunction newFn = new AggregateFunction(
                 fn.getFunctionName(), Arrays.asList(sumFn.getArgs()), decimal128Type,


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksTest/issues/738

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
select avg(distinct non-decimal-type(i.e.BIGINT)) from table gives a invalid multi_distinct_sum signature.
expected: multi_distinct_count[([multi_distinct_count, VARCHAR, false]); args: INT; result: BIGINT
unexpected: multi_distinct_count[([multi_distinct_count, VARCHAR, false]); args: INT; result: DECIMAL128(38,0).