### PR TITLE
[Bugfix] Use different OlapScanPrepareOperators for non-shared morsel queue

### DIFF
--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -22,18 +22,16 @@ namespace pipeline {
 
 class OlapScanContext;
 using OlapScanContextPtr = std::shared_ptr<OlapScanContext>;
+class OlapScanContextFactory;
+using OlapScanContextFactoryPtr = std::shared_ptr<OlapScanContextFactory>;
 
 using namespace vectorized;
 
 class OlapScanContext final : public ContextWithDependency {
 public:
     explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop, bool shared_scan,
-                             ChunkBufferLimiterPtr chunk_buffer_limiter)
-            : _scan_node(scan_node),
-              _chunk_buffer(shared_scan ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect, dop,
-                            std::move(chunk_buffer_limiter)),
-              _shared_scan(shared_scan),
-              _scan_dop(dop) {}
+                             BalancedChunkBuffer& chunk_buffer)
+            : _scan_node(scan_node), _chunk_buffer(chunk_buffer), _shared_scan(shared_scan), _scan_dop(dop) {}
 
     Status prepare(RuntimeState* state);
     void close(RuntimeState* state) override;
@@ -74,12 +72,36 @@ private:
     using ActiveInputSet = phmap::parallel_flat_hash_set<
             ActiveInputKey, typename phmap::Hash<ActiveInputKey>, typename phmap::EqualTo<ActiveInputKey>,
             typename std::allocator<ActiveInputKey>, NUM_LOCK_SHARD_LOG, std::mutex, true>;
-    BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all scan operator
-    ActiveInputSet _active_inputs;     // Maintain the active chunksource
-    bool _shared_scan;                 // Enable shared_scan
-    int32_t _scan_dop;                 // DOP of scan operator
+    BalancedChunkBuffer& _chunk_buffer; // Shared Chunk buffer for all scan operators, owned by OlapScanContextFactory.
+    ActiveInputSet _active_inputs;      // Maintain the active chunksource
+    bool _shared_scan;                  // Enable shared_scan
+    int32_t _scan_dop;                  // DOP of scan operator
 
     std::atomic<bool> _is_prepare_finished{false};
+};
+
+// OlapScanContextFactory creates different contexts for each scan operator, if _shared_scan is false.
+// Otherwise, it outputs the same context for each scan operator.
+class OlapScanContextFactory {
+public:
+    OlapScanContextFactory(vectorized::OlapScanNode* const scan_node, int32_t dop, bool shared_scan,
+                           ChunkBufferLimiterPtr chunk_buffer_limiter)
+            : _scan_node(scan_node),
+              _dop(dop),
+              _shared_scan(shared_scan),
+              _chunk_buffer(shared_scan ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect, dop,
+                            std::move(chunk_buffer_limiter)),
+              _contexts(shared_scan ? 1 : dop) {}
+
+    OlapScanContextPtr get_or_create(int32_t driver_sequence);
+
+private:
+    vectorized::OlapScanNode* const _scan_node;
+    const int32_t _dop;
+    const bool _shared_scan;           // Whether the scan operators share one morsel and chunk buffer.
+    BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all the scan operators.
+
+    std::vector<OlapScanContextPtr> _contexts;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -18,8 +18,8 @@ namespace starrocks::pipeline {
 
 // ==================== OlapScanOperatorFactory ====================
 
-OlapScanOperatorFactory::OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextPtr ctx)
-        : ScanOperatorFactory(id, scan_node), _ctx(std::move(ctx)) {}
+OlapScanOperatorFactory::OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextFactoryPtr ctx_factory)
+        : ScanOperatorFactory(id, scan_node), _ctx_factory(std::move(ctx_factory)) {}
 
 Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
     return Status::OK();
@@ -28,7 +28,8 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node, _ctx);
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node,
+                                              _ctx_factory->get_or_create(driver_sequence));
 }
 
 // ==================== OlapScanOperator ====================

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -15,10 +15,12 @@ namespace pipeline {
 
 class OlapScanContext;
 using OlapScanContextPtr = std::shared_ptr<OlapScanContext>;
+class OlapScanContextFactory;
+using OlapScanContextFactoryPtr = std::shared_ptr<OlapScanContextFactory>;
 
 class OlapScanOperatorFactory final : public ScanOperatorFactory {
 public:
-    OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextPtr ctx);
+    OlapScanOperatorFactory(int32_t id, ScanNode* scan_node, OlapScanContextFactoryPtr _ctx_factory);
 
     ~OlapScanOperatorFactory() override = default;
 
@@ -27,7 +29,7 @@ public:
     OperatorPtr do_create(int32_t dop, int32_t driver_sequence) override;
 
 private:
-    OlapScanContextPtr _ctx;
+    OlapScanContextFactoryPtr _ctx_factory;
 };
 
 class OlapScanOperator final : public ScanOperator {

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -81,24 +81,39 @@ Status OlapScanPrepareOperator::_capture_tablet_rowsets() {
 }
 
 /// OlapScanPrepareOperatorFactory
-OlapScanPrepareOperatorFactory::OlapScanPrepareOperatorFactory(int32_t id, int32_t plan_node_id, OlapScanContextPtr ctx)
-        : SourceOperatorFactory(id, "olap_scan_prepare", plan_node_id), _ctx(std::move(ctx)) {}
+OlapScanPrepareOperatorFactory::OlapScanPrepareOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                               vectorized::OlapScanNode* const scan_node,
+                                                               OlapScanContextFactoryPtr ctx_factory)
+        : SourceOperatorFactory(id, "olap_scan_prepare", plan_node_id),
+          _scan_node(scan_node),
+          _ctx_factory(std::move(ctx_factory)) {}
 
 Status OlapScanPrepareOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperatorFactory::prepare(state));
 
-    const auto& conjunct_ctxs = _ctx->scan_node()->conjunct_ctxs();
-    auto* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_ctx->scan_node());
-    const auto& tolap_scan_node = olap_scan_node->thrift_olap_scan_node();
+    const auto& conjunct_ctxs = _scan_node->conjunct_ctxs();
+    const auto& tolap_scan_node = _scan_node->thrift_olap_scan_node();
     auto tuple_desc = state->desc_tbl().get_tuple_descriptor(tolap_scan_node.tuple_id);
 
     vectorized::DictOptimizeParser::rewrite_descriptor(state, conjunct_ctxs, tolap_scan_node.dict_string_id_to_int_ids,
                                                        &(tuple_desc->decoded_slots()));
+
+    RETURN_IF_ERROR(Expr::prepare(conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(conjunct_ctxs, state));
+
     return Status::OK();
 }
 
+void OlapScanPrepareOperatorFactory::close(RuntimeState* state) {
+    const auto& conjunct_ctxs = _scan_node->conjunct_ctxs();
+    Expr::close(conjunct_ctxs, state);
+
+    SourceOperatorFactory::close(state);
+}
+
 OperatorPtr OlapScanPrepareOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
-    return std::make_shared<OlapScanPrepareOperator>(this, _id, _name, _plan_node_id, driver_sequence, _ctx);
+    return std::make_shared<OlapScanPrepareOperator>(this, _id, _name, _plan_node_id, driver_sequence,
+                                                     _ctx_factory->get_or_create(driver_sequence));
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
@@ -44,17 +44,20 @@ private:
 
 class OlapScanPrepareOperatorFactory final : public SourceOperatorFactory {
 public:
-    OlapScanPrepareOperatorFactory(int32_t id, int32_t plan_node_id, OlapScanContextPtr ctx);
+    OlapScanPrepareOperatorFactory(int32_t id, int32_t plan_node_id, vectorized::OlapScanNode* const scan_node,
+                                   OlapScanContextFactoryPtr ctx_factory);
     ~OlapScanPrepareOperatorFactory() override = default;
 
     bool with_morsels() const { return true; }
 
     Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
 private:
-    OlapScanContextPtr _ctx;
+    vectorized::OlapScanNode* const _scan_node;
+    OlapScanContextFactoryPtr _ctx_factory;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

As for one-phase aggregate, local bucket shuffle, and collocate shuffle, each olap scan operator uses different `morsel_queue`, which created by `morsel_queue_factory.create(driver_sequence)`.

When enabling internal parallel on the tablet, the `OlapScanPrepareOperator` parses tablets and splits it to small morsels only from the 0-th morsel_queue by `morsel_queue_factory.create(0)`. The reason is that DOP of `OlapScanPrepareOperator` is 1.

Therefore, it will be incorrect for the olap scan operators uses different `morsel_queue`s.

## Modification
- When `_scan_shared==false`, create `DOP` `OlapScanContext`s, `OlapScanPrepareOperator`s, ` and OlapScanOperator`s. The i-th `OlapScanPrepareOperator` and `OlapScanOperator` uses the same context.


