### PR TITLE
[BugFix] potential dead lock in stream_load_pipe

### DIFF
--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -72,10 +72,11 @@ public:
 private:
     Status _append(const ByteBufferPtr& buf);
 
-    // called when `no_block_read(uint8_t* data, size_t* data_size, bool* eof)`
-    // timeout in the mid of read, we will push the read data back to the
-    // _buf_queue
-    Status _push_front(const ByteBufferPtr& buf);
+    // Called when `no_block_read(uint8_t* data, size_t* data_size, bool* eof)`
+    // timeout in the mid of read, we will push the read data back to the _buf_queue.
+    // The lock is already acquired before calling this function
+    // and there is no need to acquire the lock again in the function
+    Status _push_front_unlocked(const ByteBufferPtr& buf);
 
     // Blocking queue
     std::mutex _lock;


### PR DESCRIPTION


Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8646

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


_push_front is only called when no_block_read is timeout, we already acquire lock
at that time(condition variable will immediately acquire lock after wait for).
so there is no need to acquire the lock again in _push_front