### PR TITLE
[BugFix] Fix bug of rename materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -132,6 +132,11 @@ public class TableName implements Writable {
         this.catalog = catalog;
     }
 
+    // for rename table
+    public void setTbl(String tbl) {
+        this.tbl = tbl;
+    }
+
     public boolean isEmpty() {
         return tbl.isEmpty();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -72,7 +72,15 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo {
     }
 
     public void renameTableName(String newTableName) {
-        AstVisitor renameVisitor = new AstVisitor<Void, Void>() {
+        AstVisitor<Void, Void> renameVisitor = new AstVisitor<Void, Void>() {
+            @Override
+            public Void visitExpression(Expr expr, Void context) {
+                for (Expr child : expr.getChildren()) {
+                    child.accept(this, context);
+                }
+                return null;
+            }
+
             @Override
             public Void visitSlot(SlotRef node, Void context) {
                 TableName tableName = node.getTblNameWithoutAnalyzed();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -302,6 +302,13 @@ public class OlapTable extends Table implements GsonPostProcessable {
                 nameToPartition.put(newName, partition);
             }
         }
+
+        // change ExpressionRangePartitionInfo
+        if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+            ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+            Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
+            expressionRangePartitionInfo.renameTableName(newName);
+        }
     }
 
     public boolean hasMaterializedIndex(String indexName) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.io.FastByteArrayOutputStream;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
@@ -381,5 +382,46 @@ public class MaterializedViewTest {
         Assert.assertTrue(distributionInfo2 instanceof HashDistributionInfo);
         Assert.assertEquals(10, distributionInfo2.getBucketNum());
         Assert.assertEquals(1, ((HashDistributionInfo) distributionInfo2).getDistributionColumns().size());
+    }
+
+    @Test
+    public void testRenameMaterializedView() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.enable_experimental_mv = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withNewMaterializedView("create materialized view mv_to_rename\n" +
+                        "PARTITION BY k1\n" +
+                        "distributed by hash(k2) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+        String alterSql = "alter materialized view mv_to_rename rename mv_new_name;";
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, alterSql);
+        stmtExecutor.execute();
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+        MaterializedView mv = ((MaterializedView) testDb.getTable("mv_new_name"));
+        Assert.assertNotNull(mv);
+        Assert.assertEquals(mv.getName(), "mv_new_name");
+        ExpressionRangePartitionInfo partitionInfo = (ExpressionRangePartitionInfo) mv.getPartitionInfo();
+        List<Expr> exprs = partitionInfo.getPartitionExprs();
+        Assert.assertEquals(1, exprs.size());
+        Assert.assertTrue(exprs.get(0) instanceof SlotRef);
+        SlotRef slotRef = (SlotRef) exprs.get(0);
+        Assert.assertEquals("mv_new_name", slotRef.getTblNameWithoutAnalyzed().getTbl());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix bug of rename materialized view, which will lead to fail to restart of FE.
The reason for the bug is that SlotRef in ExpressionRangePartitionInfo do
 not change name accordingly when table is renamed.