### PR TITLE
[BugFix] Fix unknown error when having clause has subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
@@ -135,6 +135,9 @@ public class SubqueryTransformer {
         @Override
         public OptExprBuilder visitExpression(Expr node, SubqueryContext context) {
             OptExprBuilder builder = context.builder;
+            if (builder.getExpressionMapping().hasExpression(node)) {
+                return builder;
+            }
             for (Expr child : node.getChildren()) {
                 builder = visit(child, new SubqueryContext(builder, false, context.cteContext));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -263,4 +263,39 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  \n" +
                 "  |----29:EXCHANGE");
     }
+
+    @Test
+    public void testHavingSubquery() throws Exception {
+        String sql = "SELECT \n" +
+                "  LPAD('x', 1878790738, '') \n" +
+                "FROM \n" +
+                "  t1 AS t1_104, \n" +
+                "  t2 AS t2_105\n" +
+                "GROUP BY \n" +
+                "  t2_105.v7, \n" +
+                "  t2_105.v8 \n" +
+                "HAVING \n" +
+                "  (\n" +
+                "    (\n" +
+                "      MIN(\n" +
+                "        (t2_105.v9) IN (\n" +
+                "          (\n" +
+                "            SELECT \n" +
+                "              t1_104.v4 \n" +
+                "            FROM \n" +
+                "              t1 AS t1_104 \n" +
+                "            WHERE \n" +
+                "              (t2_105.v8) IN ('')\n" +
+                "          )\n" +
+                "        )\n" +
+                "      )\n" +
+                "    ) IS NULL\n" +
+                "  );";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "13:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 6: v9 = 14: v4\n" +
+                "  |  equal join conjunct: 21: cast = 15: cast");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8155 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
query transformer would trans query block to logical plan as the order :
table -> project -> agg -> having

When having clause has subquery，the subquery would transform to apply node at project phase which is below the agggregate node,  after aggregate，having clause should not generate apply node again, it could just use the expression which is already trans to apply node at project phase