### PR TITLE
[Bugfix] Fix mv task sync partition issues

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -150,9 +150,11 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
                 refreshAllPartitions = true;
             }
         }
+        if (materializedView.getPartitions().isEmpty()) {
+            return;
+        }
         // if all partition need refresh
-        if (materializedView.getPartitions().size() > 0 &&
-                needRefreshPartitionNames.size() == materializedView.getPartitions().size()) {
+        if (needRefreshPartitionNames.size() == materializedView.getPartitions().size()) {
             refreshAllPartitions = true;
         }
         // 4. refresh mv

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -432,7 +432,7 @@ public class CreateMaterializedViewTest {
         Table tbl2 = testDb.getTable("tbl2");
         Assert.assertNotNull(baseTableVisibleVersionMap.get(tbl2.getId()).get("p1"));
         Assert.assertNotNull(baseTableVisibleVersionMap.get(tbl2.getId()).get("p2"));
-        // add partition p3
+        // add tbl1 partition p3
         String addPartitionSql = "ALTER TABLE test.tbl1 ADD PARTITION p3 values less than('2020-04-01');";
         new StmtExecutor(connectContext, addPartitionSql).execute();
         taskManager.executeTask(mvTaskName);
@@ -445,7 +445,7 @@ public class CreateMaterializedViewTest {
         Assert.assertEquals("p3",
                 materializedView.getMvTablePartitionNameRefMap("p20200301_20200401").iterator().next());
         Assert.assertNotNull(baseTableVisibleVersionMap.get(baseTable.getId()).get("p3"));
-        // delete partition p3
+        // delete tbl2 partition p3
         String dropPartitionSql = "ALTER TABLE test.tbl1 DROP PARTITION p3\n";
         new StmtExecutor(connectContext, dropPartitionSql).execute();
         taskManager.executeTask(mvTaskName);
@@ -454,6 +454,18 @@ public class CreateMaterializedViewTest {
         Assert.assertEquals(0, materializedView.getTableMvPartitionNameRefMap("p3").size());
         Assert.assertEquals(0, materializedView.getMvTablePartitionNameRefMap("p20200301_20200401").size());
         Assert.assertNull(baseTableVisibleVersionMap.get(baseTable.getId()).get("p3"));
+        // add tbl2 partition p3
+        addPartitionSql = "ALTER TABLE test.tbl2 ADD PARTITION p3 values less than('30');";
+        new StmtExecutor(connectContext, addPartitionSql).execute();
+        taskManager.executeTask(mvTaskName);
+        waitingTaskFinish();
+        Assert.assertNotNull(baseTableVisibleVersionMap.get(tbl2.getId()).get("p3"));
+        // drop tbl2 partition p3
+        dropPartitionSql = "ALTER TABLE test.tbl2 DROP PARTITION p3\n";
+        new StmtExecutor(connectContext, dropPartitionSql).execute();
+        taskManager.executeTask(mvTaskName);
+        waitingTaskFinish();
+        Assert.assertNull(baseTableVisibleVersionMap.get(tbl2.getId()).get("p3"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -445,7 +445,7 @@ public class CreateMaterializedViewTest {
         Assert.assertEquals("p3",
                 materializedView.getMvTablePartitionNameRefMap("p20200301_20200401").iterator().next());
         Assert.assertNotNull(baseTableVisibleVersionMap.get(baseTable.getId()).get("p3"));
-        // delete tbl2 partition p3
+        // delete tbl1 partition p3
         String dropPartitionSql = "ALTER TABLE test.tbl1 DROP PARTITION p3\n";
         new StmtExecutor(connectContext, dropPartitionSql).execute();
         taskManager.executeTask(mvTaskName);


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Fix if mv has no partitions, mv task still refresh partitions.
2. Fix if a non-partitioned associated table deletes a partition, the association between mv and the table  is not removed.