### PR TITLE
[BugFix] Fix complex exists/in subquery bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
@@ -46,12 +46,23 @@ public class Subquery extends Expr {
     // A subquery has its own analysis context
     protected Analyzer analyzer;
 
+    // mark work way
+    protected boolean useSemiAnti;
+
     public Analyzer getAnalyzer() {
         return analyzer;
     }
 
     public QueryStmt getStatement() {
         return stmt;
+    }
+
+    public boolean isUseSemiAnti() {
+        return useSemiAnti;
+    }
+
+    public void setUseSemiAnti(boolean useSemiAnti) {
+        this.useSemiAnti = useSemiAnti;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
@@ -82,13 +82,19 @@ public class SubqueryTransformer {
             if (!(e.getChild(1) instanceof Subquery)) {
                 continue;
             }
-            ColumnRefOperator columnRefOperator = subOpt.getExpressionMapping().get(e);
-            s.remove(columnRefOperator);
+
+            if (((Subquery) e.getChild(1)).isUseSemiAnti()) {
+                ColumnRefOperator columnRefOperator = subOpt.getExpressionMapping().get(e);
+                s.remove(columnRefOperator);
+            }
         }
 
         for (ExistsPredicate e : existsSubquerys) {
-            ColumnRefOperator columnRefOperator = subOpt.getExpressionMapping().get(e);
-            s.remove(columnRefOperator);
+            Preconditions.checkState(e.getChild(0) instanceof Subquery);
+            if (((Subquery) e.getChild(0)).isUseSemiAnti()) {
+                ColumnRefOperator columnRefOperator = subOpt.getExpressionMapping().get(e);
+                s.remove(columnRefOperator);
+            }
         }
 
         scalarPredicate = Utils.compoundAnd(s);
@@ -184,6 +190,7 @@ public class SubqueryTransformer {
                     new OptExprBuilder(applyOperator, Arrays.asList(context.builder, subqueryPlan.getRootBuilder()),
                             context.builder.getExpressionMapping());
 
+            ((Subquery) inPredicate.getChild(1)).setUseSemiAnti(context.useSemiAnti);
             return context.builder;
         }
 
@@ -212,6 +219,7 @@ public class SubqueryTransformer {
                     new OptExprBuilder(applyOperator, Arrays.asList(context.builder, subqueryPlan.getRootBuilder()),
                             context.builder.getExpressionMapping());
 
+            ((Subquery) existsPredicate.getChild(0)).setUseSemiAnti(context.useSemiAnti);
             return context.builder;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -245,7 +245,6 @@ public class SubqueryTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
-
     @Test
     public void testCTEAnchorProperty() throws Exception {
         String sql = "explain SELECT\n" +
@@ -307,5 +306,12 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other predicates: CASE WHEN (18: countRows IS NULL) OR (18: countRows = 0) THEN FALSE WHEN 1: v1 IS NULL THEN NULL WHEN 16: v4 IS NOT NULL THEN TRUE WHEN 19: countNotNulls < 18: countRows THEN NULL ELSE FALSE END");
+
+        sql = "select * from t0 where exists (select v4 from t1) or (1=0 and exists (select v7 from t2));";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:AGGREGATE (update finalize)\n" +
+                "  |  output: count(1)\n" +
+                "  |  group by: \n" +
+                "  |  having: 13: COUNT(1) > 0");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -298,4 +298,14 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  equal join conjunct: 6: v9 = 14: v4\n" +
                 "  |  equal join conjunct: 21: cast = 15: cast");
     }
+
+    @Test
+    public void testComplexInAndExistsPredicate() throws Exception {
+        String sql = "select * from t0 where t0.v1 in (select v4 from t1) or (1=0 and t0.v1 in (select v7 from t2));";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  16:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  other predicates: CASE WHEN (18: countRows IS NULL) OR (18: countRows = 0) THEN FALSE WHEN 1: v1 IS NULL THEN NULL WHEN 16: v4 IS NOT NULL THEN TRUE WHEN 19: countNotNulls < 18: countRows THEN NULL ELSE FALSE END");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we do subquery by outer join ways, we need the output of subquery to do predicate.
But when the predicate has been simplified to only one predicate, like `xxx in (subquery) or (1=0 and xxxx)`, will simple to `xxx in (subquery)`

The predicate will be remove now, then the node is none predicate.

The error plan:
```
MySQL td> explain  select * from t1 where ( 1=1 and v1 in (select v1 from t2 where v2 = 50)) or (1=0  and  v1 in (select v1 from t3 where v2 = 20));
+------------------------------------------------+
| Explain String                                 |
+------------------------------------------------+
| PLAN FRAGMENT 0                                |
|  OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3            |
|   PARTITION: UNPARTITIONED                     |
|                                                |
|   RESULT SINK                                  |
|                                                |
|   35:EXCHANGE                                  |
|                                                |
| PLAN FRAGMENT 1                                |
|  OUTPUT EXPRS:                                 |
|   PARTITION: RANDOM                            |
|                                                |
|   STREAM DATA SINK                             |
|     EXCHANGE ID: 35                            |
|     UNPARTITIONED                              |
|                                                |
|   34:Project                                   |
|   |  <slot 1> : 1: v1                          |
|   |  <slot 2> : 2: v2                          |
|   |  <slot 3> : 3: v3                          |
|   |                                            |
|   33:NESTLOOP JOIN                             |
|   |  join op: CROSS JOIN                       |
|   |  colocate: false, reason:                  |
|   |                                            |
|   |----32:EXCHANGE                             |
|   |                                            |
|   26:HASH JOIN                                 |
|   |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE) |
|   |  colocate: false, reason:                  |
|   |  equal join conjunct: 1: v1 = 12: v1       |
|   |                                            |
|   |----25:EXCHANGE                             |
|   |                                            |
|   19:Project                                   |
|   |  <slot 1> : 1: v1                          |
|   |  <slot 2> : 2: v2                          |
|   |  <slot 3> : 3: v3                          |
|   |                                            |
|   18:NESTLOOP JOIN                             |
|   |  join op: CROSS JOIN                       |
|   |  colocate: false, reason:                  |
|   |                                            |
|   |----17:EXCHANGE                             |
|   |                                            |
|   11:HASH JOIN                                 |
|   |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE) |
|   |  colocate: false, reason:                  |
|   |  equal join conjunct: 1: v1 = 16: v1       |
|   |                                            |
|   |----10:EXCHANGE                             |
|   |                                            |
|   4:OlapScanNode                               |
|      TABLE: t1                                 |
|      ...............                                |
+------------------------------------------------+
238 rows in set

```
