### PR TITLE
[Bugfix] use morsel_queue_factory before moving it

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -297,11 +297,12 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
         ASSIGN_OR_RETURN(auto morsel_queue_factory, scan_node->convert_scan_range_to_morsel_queue_factory(
                                                             scan_ranges, scan_ranges_per_driver_seq, scan_node->id(),
                                                             dop, enable_tablet_internal_parallel));
-        morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
 
         if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
             olap_scan->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
         }
+
+        morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
     }
 
     int64_t logical_scan_limit = 0;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8695, fixes #8686.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Use `morsel_queue_factory` before moving it, in `FragmentExecutor::_prepare_exec_plan`.

