### PR TITLE
[Feature] support `max-execution-time` for long query

### DIFF
--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -198,6 +198,7 @@ StatusOr<vectorized::ChunkPtr> CrossJoinLeftOperator::pull_chunk(RuntimeState* s
     _init_chunk(&chunk, state);
 
     for (;;) {
+        if (state->exceed_max_execution_time()) break;
         // need row_count to fill in chunk.
         size_t row_count = state->chunk_size() - chunk->num_rows();
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -132,7 +132,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 auto& next_op = _operators[i + 1];
 
                 // Check curr_op finished firstly
-                if (curr_op->is_finished() || runtime_state->exceed_max_excution_time()) {
+                if (curr_op->is_finished() || runtime_state->exceed_max_execution_time()) {
                     if (i == 0) {
                         // For source operators
                         RETURN_IF_ERROR(return_status = _mark_operator_finishing(curr_op, runtime_state));

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -132,7 +132,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 auto& next_op = _operators[i + 1];
 
                 // Check curr_op finished firstly
-                if (curr_op->is_finished()) {
+                if (curr_op->is_finished() || runtime_state->exceed_max_excution_time()) {
                     if (i == 0) {
                         // For source operators
                         RETURN_IF_ERROR(return_status = _mark_operator_finishing(curr_op, runtime_state));

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -300,6 +300,7 @@ Status CrossJoinNode::get_next_internal(RuntimeState* state, ChunkPtr* chunk, bo
     }
 
     for (;;) {
+        if (state->exceed_max_execution_time()) break;
         // need to get probe_chunk
         if (_probe_chunk == nullptr || _probe_chunk->num_rows() == 0) {
             probe_timer.stop();

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -324,7 +324,7 @@ Status PlanFragmentExecutor::_get_next_internal_vectorized(vectorized::ChunkPtr*
     // If we set chunk to nullptr, means this fragment read done
     while (!_done) {
         SCOPED_TIMER(profile()->total_time_counter());
-        if (_runtime_state->exceed_max_excution_time()) {
+        if (_runtime_state->exceed_max_execution_time()) {
             return Status::EndOfFile("");
         }
         RETURN_IF_ERROR(_plan->get_next(_runtime_state, &_chunk, &_done));

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -324,6 +324,9 @@ Status PlanFragmentExecutor::_get_next_internal_vectorized(vectorized::ChunkPtr*
     // If we set chunk to nullptr, means this fragment read done
     while (!_done) {
         SCOPED_TIMER(profile()->total_time_counter());
+        if (_runtime_state->exceed_max_excution_time()) {
+            return Status::EndOfFile("");
+        }
         RETURN_IF_ERROR(_plan->get_next(_runtime_state, &_chunk, &_done));
         if (_done) {
             *chunk = nullptr;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -159,7 +159,7 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
 
     if (_query_options.__isset.max_execution_time) {
         _max_execution_time = _query_options.max_execution_time;
-        _expired_wall_time = WallTime_Now() + _max_execution_time;
+        _expired_wall_time = GetCurrentTimeNanos() + _max_execution_time * 1000000000;
     }
 
     return Status::OK();
@@ -285,9 +285,9 @@ Status RuntimeState::check_mem_limit(const std::string& msg) {
     return Status::OK();
 }
 
-bool RuntimeState::exceed_max_excution_time() const {
-    if (_max_execution_time >= 0) {
-        double now = WallTime_Now();
+bool RuntimeState::exceed_max_execution_time() const {
+    if (_max_execution_time > 0) {
+        int64_t now = GetCurrentTimeNanos();
         if (now > _expired_wall_time) {
             return true;
         }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -282,7 +283,7 @@ public:
     void set_enable_pipeline_engine(bool enable_pipeline_engine) { _enable_pipeline_engine = enable_pipeline_engine; }
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
 
-    bool exceed_max_excution_time() const;
+    bool exceed_max_execution_time() const;
 
 private:
     Status create_error_log_file();
@@ -388,8 +389,8 @@ private:
 
     bool _enable_pipeline_engine = false;
 
-    int _max_execution_time = -1;
-    double _expired_wall_time = 0;
+    int64_t _max_execution_time = 0;
+    int64_t _expired_wall_time = 0;
 };
 
 #define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -282,6 +282,8 @@ public:
     void set_enable_pipeline_engine(bool enable_pipeline_engine) { _enable_pipeline_engine = enable_pipeline_engine; }
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
 
+    bool exceed_max_excution_time() const;
+
 private:
     Status create_error_log_file();
 
@@ -385,6 +387,9 @@ private:
     pipeline::QueryContext* _query_ctx = nullptr;
 
     bool _enable_pipeline_engine = false;
+
+    int _max_execution_time = -1;
+    double _expired_wall_time = 0;
 };
 
 #define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -566,7 +566,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private double cboPruneShuffleColumnRate = 0.1;
 
     @VarAttr(name = MAX_EXECUTION_TIME, flag = VariableMgr.INVISIBLE)
-    private int maxExecutionTime = -1;
+    private int maxExecutionTime = 0;
 
     public double getCboPruneShuffleColumnRate() {
         return cboPruneShuffleColumnRate;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -565,6 +565,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_SHUFFLE_COLUMN_RATE, flag = VariableMgr.INVISIBLE)
     private double cboPruneShuffleColumnRate = 0.1;
 
+    @VarAttr(name = MAX_EXECUTION_TIME, flag = VariableMgr.INVISIBLE)
+    private int maxExecutionTime = -1;
+
     public double getCboPruneShuffleColumnRate() {
         return cboPruneShuffleColumnRate;
     }
@@ -1038,6 +1041,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setBatch_size(chunkSize);
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
+        tResult.setMax_execution_time(maxExecutionTime);
 
         if (maxScanKeyNum > -1) {
             tResult.setMax_scan_key_num(maxScanKeyNum);
@@ -1054,9 +1058,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
 
         tResult.setRuntime_join_filter_pushdown_limit(runtimeJoinFilterPushDownLimit);
-        final int global_runtime_filter_wait_timeout = 20;
         final int global_runtime_filter_rpc_timeout = 400;
-        tResult.setRuntime_filter_wait_timeout_ms(global_runtime_filter_wait_timeout);
+        tResult.setRuntime_filter_wait_timeout_ms((int) runtimeFilterScanWaitTime);
         tResult.setRuntime_filter_send_timeout_ms(global_runtime_filter_rpc_timeout);
         tResult.setRuntime_filter_scan_wait_time_ms(runtimeFilterScanWaitTime);
         tResult.setPipeline_dop(pipelineDop);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -169,6 +169,8 @@ struct TQueryOptions {
   59: optional bool enable_tablet_internal_parallel;
 
   60: optional i32 query_delivery_timeout;
+
+  61: optional i32 max_execution_time;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [X] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The reason to add `max_execution_time` is to diagnose long query. 

For long query, sometime it's very long, we are not sure when it will complete. And if query does not complete, we don't have any profile.

The variable `max_execution_time` is to control max execution time of query.  And when the query exceeds max_execution_time, we just return EOF. We don't get right result, but we can get profile and spot bottleneck.
