### PR TITLE
[Enhancement] Adjust downgrade strategy of chunks_partitioner

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -59,14 +59,6 @@ private:
     // The output chunk stream is unordered
     StatusOr<vectorized::ChunkPtr> pull_one_chunk_from_sorters();
 
-    // TODO(hcf) set this value properly, maybe based on cache size
-    static const int32_t MAX_PARTITION_NUM;
-
-    bool _is_downgrade = false;
-    // We simply offer chunk to this buffer when number of partition reaches the threshould MAX_PARTITION_NUM
-    std::queue<vectorized::ChunkPtr> _downgrade_buffer;
-    std::mutex _buffer_lock;
-
     const std::vector<TExpr>& _t_partition_exprs;
     std::vector<ExprContext*> _partition_exprs;
     std::vector<vectorized::PartitionColumnType> _partition_types;

--- a/be/src/exec/vectorized/partition/chunks_partitioner.cpp
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.cpp
@@ -28,21 +28,36 @@ Status ChunksPartitioner::prepare(RuntimeState* state) {
 Status ChunksPartitioner::offer(const ChunkPtr& chunk) {
     DCHECK(!_partition_it.has_value());
 
-    for (size_t i = 0; i < _partition_exprs.size(); i++) {
-        ASSIGN_OR_RETURN(_partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
+    if (!_is_downgrade) {
+        for (size_t i = 0; i < _partition_exprs.size(); i++) {
+            ASSIGN_OR_RETURN(_partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
+        }
     }
 
     if (false) {
     }
-#define HASH_MAP_METHOD(NAME)                                                                         \
-    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                         \
-        TRY_CATCH_BAD_ALLOC(split_chunk_by_partition<decltype(_hash_map_variant.NAME)::element_type>( \
-                *_hash_map_variant.NAME, chunk));                                                     \
+#define HASH_MAP_METHOD(NAME)                                                                          \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                          \
+        TRY_CATCH_BAD_ALLOC(_split_chunk_by_partition<decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, chunk));                                                      \
     }
     APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
 
     return Status::OK();
+}
+
+ChunkPtr ChunksPartitioner::consume_from_downgrade_buffer() {
+    vectorized::ChunkPtr chunk = nullptr;
+    if (_downgrade_buffer.empty()) {
+        return chunk;
+    }
+    {
+        std::lock_guard<std::mutex> l(_buffer_lock);
+        chunk = _downgrade_buffer.front();
+        _downgrade_buffer.pop();
+    }
+    return chunk;
 }
 
 int32_t ChunksPartitioner::num_partitions() {

--- a/be/src/exec/vectorized/partition/chunks_partitioner.h
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <any>
+#include <queue>
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
@@ -36,18 +37,22 @@ public:
     // Number of partitions
     int32_t num_partitions();
 
+    bool is_downgrade() const { return _is_downgrade; }
+
+    bool is_downgrade_buffer_empty() const { return _downgrade_buffer.empty(); }
+
     // Consumers consume from the hash map
     // method signature is: bool consumer(int32_t partition_idx, const ChunkPtr& chunk)
     // The return value of the consumer denote whether to continue or not
     template <typename Consumer>
-    Status accept(Consumer&& consumer) {
+    Status consume_from_hash_map(Consumer&& consumer) {
         // First, fetch chunks from hash map
         if (false) {
         }
-#define HASH_MAP_METHOD(NAME)                                                                                    \
-    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                                    \
-        TRY_CATCH_BAD_ALLOC(fetch_chunks_from_hash_map<typename decltype(_hash_map_variant.NAME)::element_type>( \
-                *_hash_map_variant.NAME, consumer));                                                             \
+#define HASH_MAP_METHOD(NAME)                                                                                     \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                                     \
+        TRY_CATCH_BAD_ALLOC(_fetch_chunks_from_hash_map<typename decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, consumer));                                                              \
     }
         APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
@@ -66,6 +71,9 @@ public:
         return Status::OK();
     }
 
+    // Fetch one chunk from downgrade buffer if any
+    ChunkPtr consume_from_downgrade_buffer();
+
 private:
     bool _is_partition_columns_fixed_size(const std::vector<ExprContext*>& partition_expr_ctxs,
                                           const std::vector<PartitionColumnType>& partition_types, size_t* max_size,
@@ -73,13 +81,17 @@ private:
     void _init_hash_map_variant();
 
     template <typename HashMapWithKey>
-    void split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
-        hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool);
+    void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
+        _is_downgrade = hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool);
+        if (_is_downgrade) {
+            std::lock_guard<std::mutex> l(_buffer_lock);
+            _downgrade_buffer.push(chunk);
+        }
     }
 
     // Fetch chunks from hash map, return true if reaches eos
     template <typename HashMapWithKey, typename Consumer>
-    bool fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+    bool _fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
         if (_hash_map_eos) {
             return true;
         }
@@ -176,6 +188,11 @@ private:
     Columns _partition_columns;
     // Hash map which holds chunks of different partitions
     PartitionHashMapVariant _hash_map_variant;
+
+    bool _is_downgrade = false;
+    // We simply buffer chunks when partition cardinality is high
+    std::queue<ChunkPtr> _downgrade_buffer;
+    std::mutex _buffer_lock;
 
     // Iterator of partitions
     std::any _partition_it;

--- a/be/src/exec/vectorized/partition/partition_hash_map.h
+++ b/be/src/exec/vectorized/partition/partition_hash_map.h
@@ -60,6 +60,9 @@ using FixedSize16SlicePartitionHashMap =
 
 struct PartitionHashMapBase {
     const int32_t chunk_size;
+    bool is_downgrade = false;
+
+    int64_t total_num_rows = 0;
 
     PartitionHashMapBase(int32_t chunk_size) : chunk_size(chunk_size) {}
 
@@ -84,6 +87,17 @@ protected:
         }
     }
 
+    template <typename HashMap>
+    void check_downgrade(HashMap& hash_map) {
+        if (is_downgrade) {
+            return;
+        }
+        auto partition_num = hash_map.size();
+        if (partition_num > 512 && total_num_rows / partition_num < 10000) {
+            is_downgrade = true;
+        }
+    }
+
     // Append chunk to the hash_map for one non-nullable key
     // Each key mapped to a PartitionChunks which holds an array of chunks
     // chunk will be divided into multiply parts by partition key, and each parts will be append to the
@@ -92,11 +106,20 @@ protected:
     template <typename HashMap, typename KeyLoader, typename KeyAllocator>
     void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
                                   KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
+        if (is_downgrade) {
+            return;
+        }
         phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
                              typename HashMap::allocator_type>
                 visited_keys(chunk->num_rows());
         const auto size = chunk->num_rows();
-        for (uint32_t i = 0; i < size; i++) {
+        uint32_t i = 0;
+        for (; i < size; i++) {
+            check_downgrade(hash_map);
+            if (is_downgrade) {
+                break;
+            }
+
             const auto& key = key_loader(i);
             visited_keys.insert(key);
             auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
@@ -113,10 +136,18 @@ protected:
             }
             value.select_indexes.push_back(i);
             value.remain_size--;
+            total_num_rows++;
         }
 
         for (const auto& key : visited_keys) {
             flush(*(hash_map[key]), chunk);
+        }
+
+        // The first i rows has been pushed into hash_map
+        if (is_downgrade && i > 0) {
+            for (auto& column : chunk->columns()) {
+                column->remove_first_n_values(i);
+            }
         }
     }
 
@@ -130,6 +161,9 @@ protected:
     void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
                                            const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
                                            KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
+        if (is_downgrade) {
+            return;
+        }
         if (nullable_key_column->only_null()) {
             const auto size = chunk->num_rows();
             if (null_key_value.chunks.empty() || null_key_value.remain_size <= 0) {
@@ -151,6 +185,7 @@ protected:
             }
             null_key_value.chunks.back()->append(*chunk, offset, cur_remain_size);
             null_key_value.remain_size = chunk_size - null_key_value.chunks.back()->num_rows();
+            total_num_rows += size;
         } else {
             phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
                                  typename HashMap::allocator_type>
@@ -159,7 +194,12 @@ protected:
             const auto& null_flag_data = nullable_key_column->null_column()->get_data();
             const auto size = chunk->num_rows();
 
-            for (uint32_t i = 0; i < size; i++) {
+            uint32_t i = 0;
+            for (; i < size; i++) {
+                check_downgrade(hash_map);
+                if (is_downgrade) {
+                    break;
+                }
                 PartitionChunks* value_ptr = nullptr;
                 if (null_flag_data[i] == 1) {
                     value_ptr = &null_key_value;
@@ -183,12 +223,20 @@ protected:
                 }
                 value.select_indexes.push_back(i);
                 value.remain_size--;
+                total_num_rows++;
             }
 
             for (const auto& key : visited_keys) {
                 flush(*(hash_map[key]), chunk);
             }
             flush(null_key_value, chunk);
+
+            // The first i rows has been pushed into hash_map
+            if (is_downgrade && i > 0) {
+                for (auto& column : chunk->columns()) {
+                    column->remove_first_n_values(i);
+                }
+            }
         }
     }
 };
@@ -202,13 +250,14 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
         const auto& key_column_data = key_column->get_data();
         append_chunk_for_one_key(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
                 [](const FieldType& key) { return key; }, obj_pool);
+        return is_downgrade;
     }
 };
 
@@ -222,7 +271,7 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
@@ -230,6 +279,7 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
                 obj_pool);
+        return is_downgrade;
     }
 };
 
@@ -240,7 +290,7 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
         append_chunk_for_one_key(
@@ -251,6 +301,7 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
                     return Slice{pos, key.size};
                 },
                 obj_pool);
+        return is_downgrade;
     }
 };
 
@@ -262,7 +313,7 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
@@ -275,6 +326,7 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
                     return Slice{pos, key.size};
                 },
                 obj_pool);
+        return is_downgrade;
     }
 };
 
@@ -285,7 +337,9 @@ struct PartitionHashMapWithSerializedKey {
     HashMap hash_map;
 
     PartitionHashMapWithSerializedKey(int32_t chunk_size) {}
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {}
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+        return false;
+    }
 };
 
 // TODO(hcf) to be implemented
@@ -297,7 +351,9 @@ struct PartitionHashMapWithSerializedKeyFixedSize {
     int fixed_byte_size = -1; // unset state
 
     PartitionHashMapWithSerializedKeyFixedSize(int32_t chunk_size) {}
-    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {}
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+        return false;
+    }
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Enhancement

If we find the partition cardinality is high, then we will downgrade `chunks_partitioner` to streaming mode. But it only happens when we've done processing the entire chunk. 

Think about the situation that each partition has only one row, then the first comming chunk contains 4096 partitions, we need to first process the whole chunk, then we can decide whether to downgrade or not. And this downgrade procedure can happen more earlier.

So here is the idea, we can trigger downgrade process when we are processing the chunk, if we find the partition num is reaching the threshold, we can immediately stop the current process and switch to streaming mode.
