### PR TITLE
[BUG Fix] Fix BetweenPredicate clone with ExprSubstitutionMap

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BetweenPredicate.java
@@ -81,11 +81,6 @@ public class BetweenPredicate extends Predicate {
     }
 
     @Override
-    public Expr clone(ExprSubstitutionMap sMap) {
-        return new BetweenPredicate(this);
-    }
-
-    @Override
     public int hashCode() {
         return 31 * super.hashCode() + Boolean.hashCode(isNotBetween);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

for https://github.com/StarRocks/starrocks/issues/8699

The expr clone method is:
```
    /**
     * Create a deep copy of 'this'. If sMap is non-null,
     * use it to substitute 'this' or its subnodes.
     * <p/>
     * Expr subclasses that add non-value-type members must override this.
     */
    public Expr clone(ExprSubstitutionMap sMap) {
        if (sMap != null) {
            for (int i = 0; i < sMap.getLhs().size(); ++i) {
                if (this.equals(sMap.getLhs().get(i))) {
                    return sMap.getRhs().get(i).clone(null);
                }
            }
        }
        Expr result = (Expr) this.clone();
        result.children = Lists.newArrayList();
        for (Expr child : children) {
            result.children.add(((Expr) child).clone(sMap));
        }
        return result;
    }

```

but BetweenPredicate override it 
```
-    @Override
-    public Expr clone(ExprSubstitutionMap sMap) {
-        return new BetweenPredicate(this);
-    }
```

Which is needn't and unreasonable.

Why there is no issue before?

Because in old Analyzer, BetweenPredicate will be rewriten to CompoundPredicate.