### PR TITLE
[Bugfix] fix checkState error when predicate don't support dictionary optimize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -356,7 +356,6 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     };
 
                     if (!checkColumnCouldApply.getAsBoolean()) {
-                        context.allStringColumnIds.remove(columnId);
                         continue;
                     }
 
@@ -396,8 +395,6 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     for (int i = 0; i < predicates.size(); i++) {
                         ScalarOperator predicate = predicates.get(i);
                         if (predicate.getUsedColumns().isIntersect(applyOptCols)) {
-                            Preconditions.checkState(
-                                    couldApplyDictOptimize(predicate, context.allStringColumnIds));
                             final DictMappingRewriter rewriter = new DictMappingRewriter(context);
                             final ScalarOperator newCallOperator = rewriter.rewrite(predicate.clone());
                             predicates.set(i, newCallOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/DictMappingRewriter.java
@@ -33,9 +33,7 @@ public class DictMappingRewriter {
 
     public DictMappingRewriter(AddDecodeNodeForDictStringRule.DecodeContext decodeContext) {
         this.decodeContext = decodeContext;
-        for (Integer allStringColumnId : decodeContext.allStringColumnIds) {
-            rewriterContext.stringColumnSet.union(allStringColumnId);
-        }
+        decodeContext.stringColumnIdToDictColumnIds.keySet().forEach(rewriterContext.stringColumnSet::union);
     }
 
     public ScalarOperator rewrite(ScalarOperator scalarOperator) {
@@ -194,7 +192,7 @@ public class DictMappingRewriter {
 
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator operator, RewriterContext context) {
-            context.hasAppliedOperator = decodeContext.allStringColumnIds.contains(operator.getId());
+            context.hasAppliedOperator = rewriterContext.stringColumnSet.contains(operator.getId());
             context.hasUnsupportedOperator = false;
             return operator;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -33,6 +33,11 @@ public class LowCardinalityTest extends PlanTestBase {
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE table_int (id_int INT, id_bigint BIGINT) " +
+                "DUPLICATE KEY(`id_int`) " +
+                "DISTRIBUTED BY HASH(`id_int`) BUCKETS 1 " +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
         starRocksAssert.withTable("CREATE TABLE part_v2  ( P_PARTKEY     INTEGER NOT NULL,\n" +
                 "                          P_NAME        VARCHAR(55) NOT NULL,\n" +
                 "                          P_MFGR        VARCHAR(25) NOT NULL,\n" +
@@ -678,7 +683,8 @@ public class LowCardinalityTest extends PlanTestBase {
         // test worth for rewrite
         sql = "select concat(S_ADDRESS, S_COMMENT) from supplier";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan.contains("  |  9 <-> concat[([3: S_ADDRESS, VARCHAR, false], [7: S_COMMENT, VARCHAR, false]); args: VARCHAR; result: VARCHAR; args nullable: false; result nullable: true]"));
+        Assert.assertTrue(plan.contains(
+                "  |  9 <-> concat[([3: S_ADDRESS, VARCHAR, false], [7: S_COMMENT, VARCHAR, false]); args: VARCHAR; result: VARCHAR; args nullable: false; result nullable: true]"));
         // Test common expression reuse 1
         // couldn't reuse case
         // DictExpr return varchar and int
@@ -701,7 +707,8 @@ public class LowCardinalityTest extends PlanTestBase {
         Assert.assertFalse(plan.contains("Decode"));
 
         // common expression reuse 3
-        sql = "select if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT), concat(upper(S_COMMENT), S_ADDRESS) from supplier";
+        sql =
+                "select if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT), concat(upper(S_COMMENT), S_ADDRESS) from supplier";
         plan = getVerboseExplain(sql);
         Assert.assertTrue(plan.contains("  |  output columns:\n" +
                 "  |  9 <-> if[(DictExpr(11: S_ADDRESS,[<place-holder> = 'kks']), [13: expr, VARCHAR, true], DictExpr(12: S_COMMENT,[<place-holder>])); args: BOOLEAN,VARCHAR,VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]\n" +
@@ -817,6 +824,10 @@ public class LowCardinalityTest extends PlanTestBase {
         Assert.assertFalse(plan.contains("Decode"));
         sql =
                 "select count(*) from supplier l join [broadcast] (select max(S_ADDRESS) as S_ADDRESS from supplier) r on l.S_ADDRESS = r.S_ADDRESS;";
+        plan = getVerboseExplain(sql);
+        Assert.assertFalse(plan.contains("Decode"));
+
+        sql =  "select count(*) from supplier l join [broadcast] (select max(id_int) as id_int from table_int) r on l.S_ADDRESS = r.id_int where l.S_ADDRESS not like '%key%'";
         plan = getVerboseExplain(sql);
         Assert.assertFalse(plan.contains("Decode"));
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
introduced by #7939

```
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:494) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.sql.optimizer.operator.Projection.needApplyStringDict(Projection.java:53) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitProjectionBefore(AddDecodeNodeForDictStringRule.java:168) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitPhysicalOlapScan(AddDecodeNodeForDictStringRule.java:317) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitPhysicalOlapScan(AddDecodeNodeForDictStringRule.java:152) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator.accept(PhysicalOlapScanOperator.java:138) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitPhysicalHashAggregate(AddDecodeNodeForDictStringRule.java:755) ~[starrocks-fe.jar:?]
```

## Problem Summary(Required) ：
 when predicate don't support dictionary optimize, we will remove it from context.allstringcolumns.
 but when we join it with a table without any string columns. checkState will get an error

