### PR TITLE
[Enhancement]Parallel refresh external table partitions 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1396,6 +1396,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static int hive_meta_load_concurrency = 4;
 
+    /**
+     * num of thread to refresh hive external table partition info
+     */
+    @ConfField
+    public static int hive_partition_refresh_concurrency = Runtime.getRuntime().availableProcessors();
+
     @ConfField
     public static long hive_meta_cache_refresh_interval_s = 3600L * 2L;
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -16,6 +16,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.external.HiveMetaStoreTableUtils;
 import com.starrocks.external.ObjectStorageUtils;
 import com.starrocks.server.GlobalStateMgr;
@@ -25,10 +26,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static com.google.common.cache.CacheLoader.asyncReloading;
@@ -68,6 +72,11 @@ public class HiveMetaCache {
 
     LoadingCache<String, List<String>> databaseNamesCache;
     LoadingCache<String, List<String>> tableNamesCache;
+
+    // hive partition refresh executors
+    private final ExecutorService partitionRefreshExecutor =
+            ThreadPoolManager.newDaemonFixedThreadPool(Config.hive_partition_refresh_concurrency,
+                    Integer.MAX_VALUE, "hive-partition-refresh-pool", true);
 
 
     public HiveMetaCache(HiveMetaClient hiveMetaClient, Executor executor) {
@@ -468,13 +477,31 @@ public class HiveMetaCache {
 
     public void refreshPartition(HiveMetaStoreTableInfo hmsTable, List<String> partNames) throws DdlException {
         GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().getEventProcessorLock().writeLock().lock();
+        Map<HivePartitionKey, Future<HivePartition>> hivePartitionFutures =
+                new HashMap<HivePartitionKey, Future<HivePartition>>();
+        Map<HivePartitionKey, Future<HivePartitionStats>> hivePartitionStatsFutures =
+                new HashMap<HivePartitionKey, Future<HivePartitionStats>>();
         try {
             for (String partName : partNames) {
                 List<String> partValues = client.partitionNameToVals(partName);
                 HivePartitionKey key = new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
                         hmsTable.getTableType(), partValues);
-                partitionsCache.put(key, loadPartition(key));
-                partitionStatsCache.put(key, loadPartitionStats(key));
+                Future<HivePartition> partitionFuture = partitionRefreshExecutor.submit(() -> loadPartition(key));
+                hivePartitionFutures.put(key, partitionFuture);
+            }
+            for (Map.Entry<HivePartitionKey, Future<HivePartition>> entry : hivePartitionFutures.entrySet()) {
+                partitionsCache.put(entry.getKey(), entry.getValue().get());
+            }
+            for (String partName : partNames) {
+                List<String> partValues = client.partitionNameToVals(partName);
+                HivePartitionKey key = new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
+                        hmsTable.getTableType(), partValues);
+                Future<HivePartitionStats> partitionStatsFuture = partitionRefreshExecutor.
+                        submit(() -> loadPartitionStats(key));
+                hivePartitionStatsFutures.put(key, partitionStatsFuture);
+            }
+            for (Map.Entry<HivePartitionKey, Future<HivePartitionStats>> entry : hivePartitionStatsFutures.entrySet()) {
+                partitionStatsCache.put(entry.getKey(), entry.getValue().get());
             }
         } catch (Exception e) {
             LOG.warn("refresh partition cache failed", e);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/7545

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Problems in current version of refreshing external table partitions
  * All partitions are refresh serially, when an external table has many partitions to refresh, it will cost much time.
2. Create an thread pool to refresh external tables' partition info parallelly, thread pool size is customized by config hive_partition_refresh_concurrency, default value is 50.