### PR TITLE
[Enhance] Estimate chunk memory with max chunk rows

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -6,7 +6,8 @@
 
 namespace starrocks::pipeline {
 
-void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) {
+void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows,
+                                                     size_t max_chunk_rows) {
     std::lock_guard<std::mutex> lock(_mutex);
 
     _sum_row_bytes += added_sum_row_bytes;
@@ -19,7 +20,7 @@ void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes,
         return;
     }
 
-    size_t chunk_mem_usage = avg_row_bytes * _chunk_size;
+    size_t chunk_mem_usage = avg_row_bytes * max_chunk_rows;
     size_t new_capacity = std::max<size_t>(_mem_limit / chunk_mem_usage, 1);
     _capacity = std::min(new_capacity, _max_capacity);
 }

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -29,7 +29,7 @@ public:
     // Update the chunk memory usage statistics.
     // `added_sum_row_bytes` is the bytes of the new reading rows.
     // `added_num_rows` is the number of the new read rows.
-    virtual void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) = 0;
+    virtual void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows, size_t max_chunk_rows) {}
 
     // Pin a position in the buffer and return a token.
     // When desctructing the token, the position will be unpinned.
@@ -55,8 +55,6 @@ public:
 
 public:
     ~UnlimitedChunkBufferLimiter() override = default;
-
-    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override {}
 
     ChunkBufferTokenPtr pin(int num_chunks) override { return std::make_unique<Token>(); }
 
@@ -96,7 +94,7 @@ public:
               _chunk_size(chunk_size) {}
     ~DynamicChunkBufferLimiter() override = default;
 
-    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows) override;
+    void update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows, size_t max_chunk_rows) override;
 
     ChunkBufferTokenPtr pin(int num_chunks) override;
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -462,8 +462,9 @@ void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
     // Update local counters.
     _local_sum_row_bytes += chunk->memory_usage();
     _local_num_rows += chunk->num_rows();
+    _local_max_chunk_rows = std::max(_local_max_chunk_rows, chunk->num_rows());
     if (_local_sum_chunks++ % UPDATE_AVG_ROW_BYTES_FREQUENCY == 0) {
-        _buffer_limiter->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows);
+        _buffer_limiter->update_avg_row_bytes(_local_sum_row_bytes, _local_num_rows, _local_max_chunk_rows);
         _local_sum_row_bytes = 0;
         _local_num_rows = 0;
     }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -125,6 +125,7 @@ private:
     size_t _local_sum_row_bytes = 0;
     size_t _local_num_rows = 0;
     size_t _local_sum_chunks = 0;
+    size_t _local_max_chunk_rows = 0;
 
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Current use `CHUNK_SIZE=4096` to estimate chunk memory usage, but in some cases the real chunk rows is very small, which would got a wrong estimation.