### PR TITLE
[BugFix] Support shuffle broker load for non duplicate keys table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1498,6 +1498,12 @@ public class Config extends ConfigBase {
     public static boolean enable_pipeline_load = true;
 
     /**
+     * Enable shuffle load
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_shuffle_load = true;
+
+    /**
      * Unused config field, leave it here for backward compatibility
      */
     @Deprecated


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8707 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Before we unify the ingestion interface, we solved the multi-replica inconsistency problem of non duplicate key table by adding shuffle service.