### PR TITLE
[Enhancement] Analytor performance optimization

### DIFF
--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -94,7 +94,11 @@ public:
     size_t current_chunk_size() const;
     void update_input_rows(int64_t increment) { _input_rows += increment; }
     bool has_output() const { return _output_chunk_index < _input_chunks.size(); }
-    bool is_current_chunk_finished_eval() { return _window_result_position >= current_chunk_size(); }
+    // This method will be used frequently, so it is better to get chunk_size through "current_chunk_size"
+    // outside the method, because "current_chunk_size" contains a virtual function call which cannot be optimized out
+    bool is_current_chunk_finished_eval(const int64_t current_chunk_size) {
+        return _window_result_position >= current_chunk_size;
+    }
     int64_t window_result_position() const { return _window_result_position; }
     void set_window_result_position(int64_t window_result_position) {
         _window_result_position = window_result_position;
@@ -120,8 +124,6 @@ public:
 
     const std::vector<ExprContext*>& order_ctxs() { return _order_ctxs; }
     const vectorized::Columns& order_columns() { return _order_columns; }
-
-    RuntimeProfile::Counter* compute_timer() { return _compute_timer; }
 
     FrameRange get_sliding_frame_range();
 
@@ -177,7 +179,6 @@ private:
     RuntimeProfile* _runtime_profile;
     RuntimeProfile::Counter* _rows_returned_counter = nullptr;
     RuntimeProfile::Counter* _column_resize_timer = nullptr;
-    RuntimeProfile::Counter* _compute_timer = nullptr;
     RuntimeProfile::Counter* _partition_search_timer = nullptr;
     RuntimeProfile::Counter* _peer_group_search_timer = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Enhancement


There is a timer (`compute_timer`) inside the following three functions, which is introduced by #7682

1. `Analytor::update_window_batch`
2. `Analytor::reset_window_state`
3. `Analytor::get_window_function_result`

In some situations, such as half unbounded frame or slide frame, the above functions will be invoked every single row, which lead to a sharp drop in performance (from 20ms to 100ms, when processing 1M rows)

```sql
SELECT SUM(wv) FROM (
    SELECT row_number() OVER (ORDER BY fn_int) AS wv FROM t0
) AS sub;
```

And second, `is_current_chunk_finished_eval`, which is also introduced by #7682,  can be further optimized by adding `current_chunk_size` as parameter rather than getting it through method `current_chunk_size`, which is a virtual function call that cannot be optimized out by compiler.