### PR TITLE
[Bugfix] detach chunk source when scan operator short-circuited

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -71,8 +71,9 @@ void ScanOperator::close(RuntimeState* state) {
     set_buffer_finished();
     // For the running io task, we close its chunk sources in ~ScanOperator not in ScanOperator::close.
     for (size_t i = 0; i < _chunk_sources.size(); i++) {
+        std::lock_guard guard(_task_mutex);
         if (!_is_io_task_running[i]) {
-            _close_chunk_source(state, i);
+            _close_chunk_source_unlocked(state, i);
         }
     }
 
@@ -160,6 +161,7 @@ bool ScanOperator::is_finished() const {
 }
 
 Status ScanOperator::set_finishing(RuntimeState* state) {
+    std::lock_guard guard(_task_mutex);
     _is_finished = true;
     return Status::OK();
 }
@@ -227,13 +229,17 @@ inline bool is_uninitialized(const std::weak_ptr<QueryContext>& ptr) {
     return !ptr.owner_before(wp{}) && !wp{}.owner_before(ptr);
 }
 
-void ScanOperator::_close_chunk_source(RuntimeState* state, int chunk_source_index) {
-    std::unique_lock guard(_task_mutex);
+void ScanOperator::_close_chunk_source_unlocked(RuntimeState* state, int chunk_source_index) {
     if (_chunk_sources[chunk_source_index] != nullptr) {
         _chunk_sources[chunk_source_index]->close(state);
         _chunk_sources[chunk_source_index] = nullptr;
         detach_chunk_source(chunk_source_index);
     }
+}
+
+void ScanOperator::_close_chunk_source(RuntimeState* state, int chunk_source_index) {
+    std::lock_guard guard(_task_mutex);
+    _close_chunk_source_unlocked(state, chunk_source_index);
 }
 
 void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns,
@@ -244,11 +250,19 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
     _num_running_io_tasks--;
 
     DCHECK(_chunk_sources[chunk_source_index] != nullptr);
-    if (!_chunk_sources[chunk_source_index]->has_next_chunk()) {
-        _close_chunk_source(state, chunk_source_index);
-    }
 
-    _is_io_task_running[chunk_source_index] = false;
+    {
+        // - close() closes the chunk source which is not running.
+        // - _finish_chunk_source_task() closes the chunk source conditionally and then make it as not running.
+        // Therefore, closing chunk source and storing/loading `_is_finished` and `_is_io_task_running`
+        // must be protected by lock
+        std::lock_guard guard(_task_mutex);
+        if (!_chunk_sources[chunk_source_index]->has_next_chunk() || _is_finished) {
+            _close_chunk_source_unlocked(state, chunk_source_index);
+        }
+
+        _is_io_task_running[chunk_source_index] = false;
+    }
 }
 
 Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
@@ -361,11 +375,12 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
     ASSIGN_OR_RETURN(auto morsel, _morsel_queue->try_get());
     if (morsel != nullptr) {
         COUNTER_UPDATE(_morsels_counter, 1);
+
         _chunk_sources[chunk_source_index] = create_chunk_source(std::move(morsel), chunk_source_index);
         auto status = _chunk_sources[chunk_source_index]->prepare(state);
         if (!status.ok()) {
             _chunk_sources[chunk_source_index] = nullptr;
-            _is_finished = true;
+            set_finishing(state);
             return status;
         }
         need_detach = false;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -79,6 +79,7 @@ private:
     Status _pickup_morsel(RuntimeState* state, int chunk_source_index);
     Status _trigger_next_scan(RuntimeState* state, int chunk_source_index);
     Status _try_to_trigger_next_scan(RuntimeState* state);
+    void _close_chunk_source_unlocked(RuntimeState* state, int index);
     void _close_chunk_source(RuntimeState* state, int index);
     void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns, int64_t scan_rows,
                                    int64_t scan_bytes);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8719.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
A scan operator will become finished, when all the attached chunk sources to all the scan operators detached.

A chunk source could be detached by io tasks or exec threads.
- When the io task finished, it will detach the chunk source if the chunk source able to produce more chunks.
- When the scan operator closing, it will detach the chunk source which is not running in io task.

However, when the scan operator is short-circuited by the limit operator, there is a situation where both io tasks and exec threads don't detach the chunk source.
1. `ScanOperator::close` finds the chunk source is running, so doesn't detach it.
2. When the io task finished, it finds the chunk source can produce more chunks, so doesn't detach it either.

## Modification
- When the io task finished, it detach the chunk source if `_is_finished==true`.
- Closing chunk source and storing/loading `_is_finished` and `_is_io_task_running` must be protected by lock.


