### PR TITLE
[BugFix] Fix be crash in ASAN mode

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -153,6 +153,11 @@ Status ArrayColumnIterator::next_batch(const vectorized::SparseRange& range, vec
 
         RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
         size_t element_ordinal = _array_size_iterator->element_ordinal();
+        // if array column in nullable or element of array is empty, element_read_range may be empty.
+        // so we should reseek the element_ordinal
+        if (element_read_range.span_size() == 0) {
+            _element_iterator->seek_to_ordinal(element_ordinal);
+        }
         // 2. Read offset column
         // [1, 2, 3], [4, 5, 6]
         // In memory, it will be transformed to actual offset(0, 3, 6)

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -733,7 +733,6 @@ Status SegmentIterator::_read_columns(const Schema& schema, Chunk* chunk, size_t
 inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size_t n) {
     size_t read_num = 0;
     SparseRange range;
-    size_t cur_rowid = _cur_rowid;
 
     if (_cur_rowid != _range_iter.begin() || _cur_rowid == 0) {
         _cur_rowid = _range_iter.begin();
@@ -762,7 +761,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size
         }
     }
 
-    _cur_rowid = cur_rowid;
+    _cur_rowid = range.end();
     _opts.stats->raw_rows_read += read_num;
     chunk->check_or_die();
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8244

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If element of ArrayColumn is empty, we don't need to read data from `data_column` of ArrayColumn because data is empty. 
So we don't add an empty read_range into `element_read_ranges`, which will cause inconsistency between the begin of `element_read_range` and `element_ordinal` of element_iterator. That's why be crash in ASAN mode.
