### PR TITLE
[BugFix] Validate varchar length when alter json column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -347,6 +347,11 @@ public class Column implements Writable {
                 throw new DdlException("Cannot shorten string length");
             }
         }
+        if (getPrimitiveType().isJsonType() && other.getPrimitiveType().isCharFamily()) {
+            if (other.getStrLen() <= getPrimitiveType().getTypeSize()) {
+                throw new DdlException("JSON needs minimum length of " + getPrimitiveType().getTypeSize());
+            }
+        }
     }
 
     private boolean isSameDefaultValue(Column other) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -117,6 +117,24 @@ public class ColumnTest {
     }
 
     @Test
+    public void testSchemaChangeNotAllow() throws DdlException {
+        Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.JSON), false, null, false,
+                NULL_DEFAULT_VALUE, "");
+        Column newColumn = new Column("user", ScalarType.createVarcharType(1), true, null, false,
+                NULL_DEFAULT_VALUE, "");
+        try {
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail();
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("JSON needs minimum length of "));
+        }
+
+        Column largeColumn = new Column("user", ScalarType.createVarcharType(1025), true, null, false,
+                NULL_DEFAULT_VALUE, "");
+        oldColumn.checkSchemaChangeAllowed(largeColumn);
+    }
+
+    @Test
     public void testSchemaChangeAllowNormal() throws DdlException {
         Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
                 NULL_DEFAULT_VALUE, "");


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8661

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


When alter table change JSON column to varchar, the length should be validated, to avoid overflow of varchar length.

Currently only validate the minimum length for `varchar(1024)`, the actual length of JSON string should be validated in the future.
