### PR TITLE
[Feature]add support for be graceful exit

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -769,4 +769,10 @@ CONF_mBool(dependency_librdkafka_debug_enable, "false");
 // admin, eos, mock, assigner, conf
 CONF_String(dependency_librdkafka_debug, "all");
 
+// max loop count when be waiting its fragments finish
+CONF_Int64(be_loop_count_wait_fragments_finish, "0");
+
+// max loop count when cn waiting its fragments finish
+CONF_Int64(cn_loop_count_wait_fragments_finish, "0");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -770,9 +770,6 @@ CONF_mBool(dependency_librdkafka_debug_enable, "false");
 CONF_String(dependency_librdkafka_debug, "all");
 
 // max loop count when be waiting its fragments finish
-CONF_Int64(be_loop_count_wait_fragments_finish, "0");
-
-// max loop count when cn waiting its fragments finish
-CONF_Int64(cn_loop_count_wait_fragments_finish, "0");
+CONF_Int64(loop_count_wait_fragments_finish, "0");
 
 } // namespace starrocks::config

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -54,7 +54,7 @@
 namespace starrocks {
 DEFINE_bool(cn, false, "start as compute node");
 
-// NOTE: when BE receiving SIGTERM, this flag will be set to true. Then BE will reject 
+// NOTE: when BE receiving SIGTERM, this flag will be set to true. Then BE will reject
 // all ExecPlanFragments call by returning a fail status(brpc::EINTERNAL).
 // After all existing fragments executed, BE will exit.
 std::atomic<bool> k_starrocks_exit = false;

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -54,7 +54,10 @@
 namespace starrocks {
 DEFINE_bool(cn, false, "start as compute node");
 
-bool k_starrocks_exit = false;
+// NOTE: when BE receiving SIGTERM, this flag will be set to true. Then BE will reject 
+// all ExecPlanFragments call by returning a fail status(brpc::EINTERNAL).
+// After all existing fragments executed, BE will exit.
+std::atomic<bool> k_starrocks_exit = false;
 
 class ReleaseColumnPool {
 public:
@@ -208,7 +211,7 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
 }
 
 void sigterm_handler(int signo) {
-    k_starrocks_exit = true;
+    k_starrocks_exit.store(true);
 }
 
 int install_signal(int signo, void (*handler)(int)) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -88,7 +88,10 @@ public:
     // execute external query, all query info are packed in TScanOpenParams
     Status exec_external_plan_fragment(const TScanOpenParams& params, const TUniqueId& fragment_instance_id,
                                        std::vector<TScanColumnDesc>* selected_columns);
-    size_t running_fragment_count() const { return _fragment_map.size(); }
+    size_t running_fragment_count() const {
+        std::lock_guard<std::mutex> lock(_lock);
+        return _fragment_map.size();
+    }
 
 private:
     void exec_actual(std::shared_ptr<FragmentExecState> exec_state, const FinishCallback& cb);
@@ -96,7 +99,7 @@ private:
     // This is input params
     ExecEnv* _exec_env;
 
-    std::mutex _lock;
+    mutable std::mutex _lock;
 
     // Make sure that remove this before no data reference FragmentExecState
     std::unordered_map<TUniqueId, std::shared_ptr<FragmentExecState>> _fragment_map;

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -88,6 +88,7 @@ public:
     // execute external query, all query info are packed in TScanOpenParams
     Status exec_external_plan_fragment(const TScanOpenParams& params, const TUniqueId& fragment_instance_id,
                                        std::vector<TScanColumnDesc>* selected_columns);
+    size_t running_fragment_count() const { return _fragment_map.size(); }
 
 private:
     void exec_actual(std::shared_ptr<FragmentExecState> exec_state, const FinishCallback& cb);

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -33,7 +33,9 @@ set(EXEC_FILES
     backend_base.cpp
     internal_service.cpp
     staros_worker.cpp
-    mem_hook.cpp)
+    mem_hook.cpp
+    service.cpp
+)
 
 add_library(Service
         ${EXEC_FILES}

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -152,6 +152,7 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     if (k_starrocks_exit.load(std::memory_order_relaxed)) {
         cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
+        LOG(WARNING) << "reject exec plan fragment because of exit";
         return;
     }
 
@@ -171,6 +172,7 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     if (k_starrocks_exit.load(std::memory_order_relaxed)) {
         cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
+        LOG(WARNING) << "reject exec multi plan fragment because of exit";
         return;
     }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -20,6 +20,7 @@
 // under the License.
 
 #include "service/internal_service.h"
+
 #include <atomic>
 
 #include "brpc/errno.pb.h"

--- a/be/src/service/service.cpp
+++ b/be/src/service/service.cpp
@@ -1,0 +1,24 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "service/service.h"
+
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+
+namespace starrocks {
+void wait_for_fragments_finish(ExecEnv* exec_env, size_t max_loop_cnt_cfg) {
+    if (max_loop_cnt_cfg == 0) {
+        return;
+    }
+
+    size_t running_fragments = exec_env->fragment_mgr()->running_fragment_count();
+    size_t loop_cnt = 0;
+
+    while (running_fragments && loop_cnt < max_loop_cnt_cfg) {
+        DLOG(INFO) << running_fragments << " fragment(s) are still running...";
+        sleep(10);
+        running_fragments = exec_env->fragment_mgr()->running_fragment_count();
+        loop_cnt++;
+    }
+}
+} // namespace starrocks

--- a/be/src/service/service.h
+++ b/be/src/service/service.h
@@ -2,10 +2,16 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "util/logging.h"
 
 namespace starrocks {
-extern bool k_starrocks_exit;
+class ExecEnv;
+
+extern std::atomic<bool> k_starrocks_exit;
+
+void wait_for_fragments_finish(ExecEnv* exec_env, size_t max_loop_cnt_cfg);
 } // namespace starrocks
 
 void start_cn();

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -84,7 +84,7 @@ void start_be() {
         sleep(10);
     }
 
-    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::be_loop_count_wait_fragments_finish);
+    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::loop_count_wait_fragments_finish);
 
     http_service.reset();
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -15,6 +15,7 @@
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
 #include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
 #include "service/brpc.h"
 #include "service/service.h"
 #include "service/service_be/http_service.h"
@@ -79,9 +80,11 @@ void start_be() {
         exit(1);
     }
 
-    while (!starrocks::k_starrocks_exit) {
+    while (!starrocks::k_starrocks_exit.load()) {
         sleep(10);
     }
+
+    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::be_loop_count_wait_fragments_finish);
 
     http_service.reset();
 

--- a/be/src/service/service_cn/starrocks_cn.cpp
+++ b/be/src/service/service_cn/starrocks_cn.cpp
@@ -69,9 +69,11 @@ void start_cn() {
         exit(1);
     }
 
-    while (!starrocks::k_starrocks_exit) {
+    while (!starrocks::k_starrocks_exit.load()) {
         sleep(10);
     }
+
+    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::cn_loop_count_wait_fragments_finish);
 
     http_service.reset();
 

--- a/be/src/service/service_cn/starrocks_cn.cpp
+++ b/be/src/service/service_cn/starrocks_cn.cpp
@@ -73,7 +73,7 @@ void start_cn() {
         sleep(10);
     }
 
-    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::cn_loop_count_wait_fragments_finish);
+    starrocks::wait_for_fragments_finish(exec_env, starrocks::config::loop_count_wait_fragments_finish);
 
     http_service.reset();
 

--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -16,6 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+#############################################################################
+# This script is used to stop BE process
+# Usage:
+#     sh stop_be.sh [option]
+#
+# Options:
+#     -h, --help              display this usage only
+#     -g, --graceful          send SIGTERM to BE process instead of SIGKILL
+#    
+#############################################################################
+
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
@@ -30,6 +41,33 @@ export_env_from_conf $STARROCKS_HOME/conf/be.conf
 
 pidfile=$PID_DIR/be.pid
 
+sig=9
+
+usage() {
+    echo "
+This script is used to stop BE process
+Usage:
+    sh stop_be.sh [option]
+
+Options:
+    -h, --help              display this usage only
+    -g, --graceful          send SIGTERM to BE process instead of SIGKILL
+"
+    exit 0
+}
+
+for arg in "$@"
+do
+    case $arg in
+        --help|-h)
+            usage
+        ;;
+        --graceful|-g)
+            sig=15
+        ;;
+    esac
+done
+
 if [ -f $pidfile ]; then
     pid=`cat $pidfile`
     pidcomm=`ps -p $pid -o comm=`
@@ -39,8 +77,8 @@ if [ -f $pidfile ]; then
     fi
 
     if kill -0 $pid; then
-        if kill -9 $pid > /dev/null 2>&1; then
-            echo "stop $pidcomm, and remove pid file. "
+        if kill -${sig} $pid > /dev/null 2>&1; then
+            echo "stop $pidcomm using signal $sig, and remove pid file. "
             rm $pidfile
             exit 0
         else


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

change graceful exit behaviour to:
1. BE tell FE it will exit soon
2. FE won't dispatch new fragments to BE exiting
3. BE loop wait all fragments done (maximum loop count is configurable), then stop servers and exit