### PR TITLE
[BugFix] Should normalize predicate when load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1512,7 +1512,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expr);
         ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
         // Add cast and constant fold
-        scalarOperator = scalarRewriter.rewrite(scalarOperator, ScalarOperatorRewriter.CAST_AND_FOLD_RULES);
+        scalarOperator = scalarRewriter.rewrite(scalarOperator, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
         return ScalarOperatorToExpr.buildExprIgnoreSlot(scalarOperator,
                 new ScalarOperatorToExpr.FormatterContext(Maps.newHashMap()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -23,12 +23,6 @@ public class ScalarOperatorRewriter {
             new ImplicitCastRule()
     );
 
-    public static final List<ScalarOperatorRewriteRule> CAST_AND_FOLD_RULES = Lists.newArrayList(
-            new ImplicitCastRule(),
-            new ReduceCastRule(),
-            new FoldConstantsRule()
-    );
-
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

for https://github.com/StarRocks/starrocks/issues/8733

for BetweenPredicate in load, we should rewrite it to CompoundPredicate use NormalizePredicateRule.

Besides, For simplicity and unity，directly use DEFAULT_REWRITE_RULES (which is superset)to replace CAST_AND_FOLD_RULES.