### PR TITLE
[UT] Fix two unstable FE UT

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -248,6 +248,11 @@ public abstract class AlterHandler extends MasterDaemon {
         return this.alterJobs.remove(tableId);
     }
 
+    // For UT
+    public void clearJobs() {
+        this.alterJobsV2.clear();
+    }
+
     @Deprecated
     public void removeDbAlterJob(long dbId) {
         Iterator<Map.Entry<Long, AlterJob>> iterator = alterJobs.entrySet().iterator();
@@ -274,32 +279,6 @@ public abstract class AlterHandler extends MasterDaemon {
             throw new MetaNotFoundException("Cannot find " + task.getTaskType().name() + " job[" + tableId + "]");
         }
         alterJob.handleFinishedReplica(task, finishTabletInfo, reportVersion);
-    }
-
-    /*
-     * cancel alter job when drop table
-     * olapTable:
-     *      table which is being dropped
-     */
-    public void cancelWithTable(OlapTable olapTable) {
-        // make sure to hold to db write lock before calling this
-        AlterJob alterJob = getAlterJob(olapTable.getId());
-        if (alterJob == null) {
-            return;
-        }
-        alterJob.cancel(olapTable, "table is dropped");
-
-        // remove from alterJobs and add to finishedOrCancelledAlterJobs operation should be perform atomically
-        lock();
-        try {
-            alterJob = alterJobs.remove(olapTable.getId());
-            if (alterJob != null) {
-                alterJob.clear();
-                finishedOrCancelledAlterJobs.add(alterJob);
-            }
-        } finally {
-            unlock();
-        }
     }
 
     protected void cancelInternal(AlterJob alterJob, OlapTable olapTable, String msg) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/MasterDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/MasterDaemon.java
@@ -52,12 +52,11 @@ public class MasterDaemon extends Daemon {
             try {
                 // not return, but sleep a while. to avoid some thread with large running interval will
                 // wait for a long time to start again.
-                Thread.sleep(10 * 1000);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
                 LOG.warn("interrupted exception. thread: {}", getName(), e);
             }
         }
-
         runAfterCatalogReady();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -22,11 +22,8 @@
 package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
-import com.starrocks.alter.AlterJobV2.JobState;
-import com.starrocks.analysis.AccessTestUtil;
 import com.starrocks.analysis.AddRollupClause;
 import com.starrocks.analysis.AlterClause;
-import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.ColumnDef;
 import com.starrocks.analysis.CreateMaterializedViewStmt;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -34,13 +31,10 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.FakeEditLog;
-import com.starrocks.catalog.FakeGlobalStateMgr;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -49,21 +43,17 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TStorageFormat;
 import com.starrocks.thrift.TTaskType;
-import com.starrocks.transaction.FakeTransactionIDGenerator;
-import com.starrocks.transaction.GlobalTransactionMgr;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,151 +65,104 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class RollupJobV2Test {
-    private static String fileName = "./RollupJobV2Test";
-
-    private static FakeTransactionIDGenerator fakeTransactionIDGenerator;
-    private static GlobalTransactionMgr masterTransMgr;
-    private static GlobalTransactionMgr slaveTransMgr;
-    private static GlobalStateMgr masterGlobalStateMgr;
-    private static GlobalStateMgr slaveGlobalStateMgr;
-
-    private static String transactionSource = "localfe";
-    private static Analyzer analyzer;
+public class RollupJobV2Test extends DDLTestBase {
     private static AddRollupClause clause;
     private static AddRollupClause clause2;
 
-    private FakeGlobalStateMgr fakeGlobalStateMgr;
-    private FakeEditLog fakeEditLog;
-
     @Before
-    public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, NoSuchMethodException, SecurityException, AnalysisException {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        fakeEditLog = new FakeEditLog();
-        fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
-        masterGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
-        slaveGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
-        MetaContext metaContext = new MetaContext();
-        metaContext.setMetaVersion(FeMetaVersion.VERSION_61);
-        metaContext.setThreadLocalInfo();
-        masterTransMgr = masterGlobalStateMgr.getGlobalTransactionMgr();
-        masterTransMgr.setEditLog(masterGlobalStateMgr.getEditLog());
-
-        slaveTransMgr = slaveGlobalStateMgr.getGlobalTransactionMgr();
-        slaveTransMgr.setEditLog(slaveGlobalStateMgr.getEditLog());
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
-        clause = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex2, Lists.newArrayList("k1", "v"), null,
-                GlobalStateMgrTestUtil.testIndex1, null);
+    public void setUp() throws Exception {
+        super.setUp();
+        clause = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex2, Lists.newArrayList("v1"), null,
+                GlobalStateMgrTestUtil.testTable1, null);
         clause.analyze(analyzer);
 
-        clause2 = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex3, Lists.newArrayList("k1", "v"), null,
-                GlobalStateMgrTestUtil.testIndex1, null);
+        clause2 = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex3, Lists.newArrayList("v1", "v2"), null,
+                GlobalStateMgrTestUtil.testTable1, null);
         clause2.analyze(analyzer);
-
-        FeConstants.runningUnitTest = true;
-        AgentTaskQueue.clearAllTasks();
-
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public GlobalStateMgr getCurrentState() {
-                return masterGlobalStateMgr;
-            }
-        };
     }
 
     @After
     public void tearDown() {
-        File file = new File(fileName);
-        file.delete();
+        GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
     }
 
     @Test
     public void testRunRollupJobConcurrentLimit() throws UserException {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        fakeEditLog = new FakeEditLog();
-        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
         alterClauses.add(clause2);
-        Database db = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTableId1);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:" + GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
 
         materializedViewHandler.runAfterCatalogReady();
 
-        Assert.assertEquals(Config.max_running_rollup_job_num_per_table,
-                materializedViewHandler.getTableRunningJobMap().get(GlobalStateMgrTestUtil.testTableId1).size());
-        Assert.assertEquals(2, alterJobsV2.size());
-        Assert.assertEquals(OlapTableState.ROLLUP, olapTable.getState());
+        assertEquals(Config.max_running_rollup_job_num_per_table,
+                materializedViewHandler.getTableRunningJobMap().get(olapTable.getId()).size());
+        assertEquals(2, alterJobsV2.size());
+        assertEquals(OlapTableState.ROLLUP, olapTable.getState());
     }
 
     @Test
     public void testAddSchemaChange() throws UserException {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        fakeEditLog = new FakeEditLog();
-        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTableId1);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:" + GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
-        Assert.assertEquals(1, alterJobsV2.size());
-        Assert.assertEquals(OlapTableState.ROLLUP, olapTable.getState());
+        assertEquals(1, alterJobsV2.size());
+        assertEquals(OlapTableState.ROLLUP, olapTable.getState());
     }
 
     // start a schema change, then finished
     @Test
     public void testSchemaChange1() throws Exception {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        fakeEditLog = new FakeEditLog();
-        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
 
         // add a rollup job
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTableId1);
-        Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testPartitionId1);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:" + GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
-        Assert.assertEquals(1, alterJobsV2.size());
+        assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
 
         // runPendingJob
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
-        Assert.assertEquals(2, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
-        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.VISIBLE).size());
-        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.SHADOW).size());
+        assertEquals(AlterJobV2.JobState.WAITING_TXN, rollupJob.getJobState());
+        assertEquals(2, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).size());
+        assertEquals(1, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size());
+        assertEquals(1, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW).size());
 
         // runWaitingTxnJob
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.RUNNING, rollupJob.getJobState());
 
         // runWaitingTxnJob, task not finished
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.RUNNING, rollupJob.getJobState());
 
         // finish all tasks
         List<AgentTask> tasks = AgentTaskQueue.getTask(TTaskType.ALTER);
-        Assert.assertEquals(3, tasks.size());
+        assertEquals(3, tasks.size());
         for (AgentTask agentTask : tasks) {
             agentTask.setFinished(true);
         }
-        MaterializedIndex shadowIndex = testPartition.getMaterializedIndices(IndexExtState.SHADOW).get(0);
+        MaterializedIndex shadowIndex =
+                testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW).get(0);
         for (Tablet shadowTablet : shadowIndex.getTablets()) {
             for (Replica shadowReplica : ((LocalTablet) shadowTablet).getReplicas()) {
                 shadowReplica.updateRowCount(testPartition.getVisibleVersion(),
@@ -229,25 +172,24 @@ public class RollupJobV2Test {
         }
 
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.FINISHED, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.FINISHED, rollupJob.getJobState());
     }
 
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        fakeEditLog = new FakeEditLog();
-        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
 
         // add a rollup job
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTableId1);
-        Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testPartitionId1);
+
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:" + GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
+
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
-        Assert.assertEquals(1, alterJobsV2.size());
+        assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
 
         MaterializedIndex baseIndex = testPartition.getBaseIndex();
@@ -258,47 +200,40 @@ public class RollupJobV2Test {
         LocalTablet baseTablet = (LocalTablet) baseIndex.getTablets().get(0);
         List<Replica> replicas = baseTablet.getReplicas();
         Replica replica1 = replicas.get(0);
-        Replica replica2 = replicas.get(1);
-        Replica replica3 = replicas.get(2);
 
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica1.getVersion());
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica2.getVersion());
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica3.getVersion());
+        assertEquals(1, replica1.getVersion());
         assertEquals(-1, replica1.getLastFailedVersion());
-        assertEquals(-1, replica2.getLastFailedVersion());
-        assertEquals(-1, replica3.getLastFailedVersion());
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica1.getLastSuccessVersion());
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica2.getLastSuccessVersion());
-        assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica3.getLastSuccessVersion());
+        assertEquals(1, replica1.getLastSuccessVersion());
 
         // runPendingJob
         replica1.setState(Replica.ReplicaState.DECOMMISSION);
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.PENDING, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.PENDING, rollupJob.getJobState());
 
         // table is stable, runPendingJob again
         replica1.setState(Replica.ReplicaState.NORMAL);
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
-        Assert.assertEquals(2, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
-        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.VISIBLE).size());
-        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.SHADOW).size());
+        assertEquals(AlterJobV2.JobState.WAITING_TXN, rollupJob.getJobState());
+        assertEquals(2, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).size());
+        assertEquals(1, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size());
+        assertEquals(1, testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW).size());
 
         // runWaitingTxnJob
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.RUNNING, rollupJob.getJobState());
 
         // runWaitingTxnJob, task not finished
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.RUNNING, rollupJob.getJobState());
 
         // finish all tasks
         List<AgentTask> tasks = AgentTaskQueue.getTask(TTaskType.ALTER);
-        Assert.assertEquals(3, tasks.size());
+        assertEquals(3, tasks.size());
         for (AgentTask agentTask : tasks) {
             agentTask.setFinished(true);
         }
-        MaterializedIndex shadowIndex = testPartition.getMaterializedIndices(IndexExtState.SHADOW).get(0);
+        MaterializedIndex shadowIndex =
+                testPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW).get(0);
         for (Tablet shadowTablet : shadowIndex.getTablets()) {
             for (Replica shadowReplica : ((LocalTablet) shadowTablet).getReplicas()) {
                 shadowReplica.updateRowCount(testPartition.getVisibleVersion(),
@@ -308,7 +243,7 @@ public class RollupJobV2Test {
         }
 
         materializedViewHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.FINISHED, rollupJob.getJobState());
+        assertEquals(AlterJobV2.JobState.FINISHED, rollupJob.getJobState());
     }
 
     @Test
@@ -316,6 +251,7 @@ public class RollupJobV2Test {
             AnalysisException {
         Config.enable_materialized_view = true;
         // prepare file
+        String fileName = "./RollupJobV2Test";
         File file = new File(fileName);
         file.createNewFile();
         DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
@@ -344,15 +280,14 @@ public class RollupJobV2Test {
 
         DataInputStream in = new DataInputStream(new FileInputStream(file));
         RollupJobV2 result = (RollupJobV2) AlterJobV2.read(in);
-        Assert.assertEquals(TStorageFormat.V2, Deencapsulation.getField(result, "storageFormat"));
+        assertEquals(TStorageFormat.V2, Deencapsulation.getField(result, "storageFormat"));
         List<Column> resultColumns = Deencapsulation.getField(result, "rollupSchema");
-        Assert.assertEquals(1, resultColumns.size());
+        assertEquals(1, resultColumns.size());
         Column resultColumn1 = resultColumns.get(0);
-        Assert.assertEquals(mvColumnName,
+        assertEquals(mvColumnName,
                 resultColumn1.getName());
         Assert.assertTrue(resultColumn1.getDefineExpr() instanceof FunctionCallExpr);
         FunctionCallExpr resultFunctionCall = (FunctionCallExpr) resultColumn1.getDefineExpr();
-        Assert.assertEquals("to_bitmap", resultFunctionCall.getFnName().getFunction());
-
+        assertEquals("to_bitmap", resultFunctionCall.getFnName().getFunction());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CancelAlterStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CancelAlterStmtTest.java
@@ -22,71 +22,26 @@
 package com.starrocks.analysis;
 
 import com.starrocks.analysis.ShowAlterStmt.AlterType;
-import com.starrocks.catalog.FakeGlobalStateMgr;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
+import com.starrocks.sql.analyzer.DDLTestBase;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-public class CancelAlterStmtTest {
-
-    private Analyzer analyzer;
-    private GlobalStateMgr globalStateMgr;
-
-    private ConnectContext ctx;
-
-    private static FakeGlobalStateMgr fakeGlobalStateMgr;
-
-    @Before
-    public void setUp() {
-        globalStateMgr = AccessTestUtil.fetchAdminCatalog();
-        ctx = new ConnectContext(null);
-        ctx.setQualifiedUser("root");
-        ctx.setRemoteIP("192.168.1.1");
-
-        analyzer = new Analyzer(globalStateMgr, ctx);
-        new Expectations(analyzer) {
-            {
-                analyzer.getDefaultDb();
-                minTimes = 0;
-                result = "testDb";
-
-                analyzer.getQualifiedUser();
-                minTimes = 0;
-                result = "testUser";
-            }
-        };
-
-        new MockUp<ConnectContext>() {
-            @Mock
-            public ConnectContext get() {
-                return ctx;
-            }
-        };
-    }
+public class CancelAlterStmtTest extends DDLTestBase {
 
     @Test
-    public void testNormal() throws UserException, AnalysisException {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        FakeGlobalStateMgr.setGlobalStateMgr(globalStateMgr);
-        // cancel alter column
+    public void testNormal() throws UserException {
         CancelAlterTableStmt stmt = new CancelAlterTableStmt(AlterType.COLUMN, new TableName(null, "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("CANCEL ALTER COLUMN FROM `testDb`.`testTbl`", stmt.toString());
-        Assert.assertEquals("testDb", stmt.getDbName());
+        Assert.assertEquals("CANCEL ALTER COLUMN FROM `testDb1`.`testTbl`", stmt.toString());
+        Assert.assertEquals("default_cluster:testDb1", stmt.getDbName());
         Assert.assertEquals(AlterType.COLUMN, stmt.getAlterType());
         Assert.assertEquals("testTbl", stmt.getTableName());
 
         stmt = new CancelAlterTableStmt(AlterType.ROLLUP, new TableName(null, "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("CANCEL ALTER ROLLUP FROM `testDb`.`testTbl`", stmt.toString());
-        Assert.assertEquals("testDb", stmt.getDbName());
+        Assert.assertEquals("CANCEL ALTER ROLLUP FROM `testDb1`.`testTbl`", stmt.toString());
+        Assert.assertEquals("default_cluster:testDb1", stmt.getDbName());
         Assert.assertEquals(AlterType.ROLLUP, stmt.getAlterType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RestrictOpMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RestrictOpMaterializedViewTest.java
@@ -124,8 +124,7 @@ public class RestrictOpMaterializedViewTest {
 
     }
 
-    // This test is temporarily removed because it is unstable,
-    // and it will be added back when the cause of the problem is found and fixed.
+    @Test
     public void testBrokerLoad() {
         String sql1 = "LOAD LABEL db1.label0 (DATA INFILE('/path/file1') INTO TABLE mv1) with broker 'broker0';";
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsStmtTest.java
@@ -21,61 +21,25 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.catalog.FakeGlobalStateMgr;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
-import com.starrocks.mysql.privilege.Auth;
-import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
-import mockit.Expectations;
-import mockit.Mocked;
+import com.starrocks.sql.analyzer.DDLTestBase;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class ShowFunctionsStmtTest {
-    @Mocked
-    private Analyzer analyzer;
-    private GlobalStateMgr globalStateMgr;
-
-    @Mocked
-    private Auth auth;
-    @Mocked
-    private ConnectContext ctx;
-    private FakeGlobalStateMgr fakeGlobalStateMgr;
+public class ShowFunctionsStmtTest extends DDLTestBase {
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
-
-    @Before
-    public void setUp() {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-        globalStateMgr = AccessTestUtil.fetchAdminCatalog();
-        MockedAuth.mockedAuth(auth);
-        MockedAuth.mockedConnectContext(ctx, "root", "192.188.3.1");
-        FakeGlobalStateMgr.setGlobalStateMgr(globalStateMgr);
-
-        new Expectations() {
-            {
-                analyzer.getDefaultDb();
-                minTimes = 0;
-                result = "testDb";
-
-                analyzer.getCatalog();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
-    }
 
     @Test
     public void testNormal() throws UserException {
         ShowFunctionsStmt stmt = new ShowFunctionsStmt(null, true, true, "%year%", null);
         stmt.analyze(analyzer);
-        Assert.assertEquals("SHOW FULL BUILTIN FUNCTIONS FROM `testDb` LIKE `%year%`", stmt.toString());
+        Assert.assertEquals("SHOW FULL BUILTIN FUNCTIONS FROM `default_cluster:testDb1` LIKE `%year%`",
+                stmt.toString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
@@ -22,11 +22,9 @@
 package com.starrocks.analysis;
 
 import com.starrocks.analysis.BinaryPredicate.Operator;
-import com.starrocks.catalog.FakeGlobalStateMgr;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,21 +32,10 @@ import org.junit.Test;
 
 public class ShowLoadStmtTest {
     private Analyzer analyzer;
-    private GlobalStateMgr globalStateMgr;
-
-    private SystemInfoService systemInfoService;
-
-    FakeGlobalStateMgr fakeGlobalStateMgr;
 
     @Before
     public void setUp() {
-        fakeGlobalStateMgr = new FakeGlobalStateMgr();
-
-        systemInfoService = AccessTestUtil.fetchSystemInfoService();
-        FakeGlobalStateMgr.setSystemInfo(systemInfoService);
-
-        globalStateMgr = AccessTestUtil.fetchAdminCatalog();
-        FakeGlobalStateMgr.setGlobalStateMgr(globalStateMgr);
+        UtFrameUtils.createMinStarRocksCluster();
 
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
         new Expectations(analyzer) {
@@ -60,10 +47,6 @@ public class ShowLoadStmtTest {
                 analyzer.getQualifiedUser();
                 minTimes = 0;
                 result = "testCluster:testUser";
-
-                analyzer.getCatalog();
-                minTimes = 0;
-                result = globalStateMgr;
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowPartitionsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowPartitionsStmtTest.java
@@ -32,10 +32,10 @@ import org.junit.Test;
 import java.util.Arrays;
 
 public class ShowPartitionsStmtTest {
-
     private ConnectContext ctx;
     private static StarRocksAssert starRocksAssert;
 
+    private Analyzer analyzer;
     @Before
     public void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -54,7 +54,6 @@ public class GlobalStateMgrTestUtil {
     public static String testPartition1 = "testPartition1";
     public static long testPartitionId1 = 3;
     public static String testIndex1 = "testIndex1";
-    public static String testIndex2 = "testIndex2";
     public static long testIndexId1 = 2; // the base indexid == tableid
     public static int testSchemaHash1 = 93423942;
     public static long testBackendId1 = 5;
@@ -65,21 +64,12 @@ public class GlobalStateMgrTestUtil {
     public static long testReplicaId3 = 10;
     public static long testTabletId1 = 11;
     public static long testStartVersion = 12;
-    public static long testRollupIndexId2 = 13;
     public static String testRollupIndex2 = "newRollupIndex";
     public static String testRollupIndex3 = "newRollupIndex2";
     public static String testTxnLable1 = "testTxnLable1";
     public static String testTxnLable2 = "testTxnLable2";
     public static String testTxnLable3 = "testTxnLable3";
     public static String testTxnLable4 = "testTxnLable4";
-    public static String testTxnLable5 = "testTxnLable5";
-    public static String testTxnLable6 = "testTxnLable6";
-    public static String testTxnLable7 = "testTxnLable7";
-    public static String testTxnLable8 = "testTxnLable8";
-    public static String testTxnLable9 = "testTxnLable9";
-    public static String testTxnLable10 = "testTxnLable10";
-    public static String testTxnLable11 = "testTxnLable11";
-    public static String testTxnLable12 = "testTxnLable12";
     public static String testEsTable1 = "partitionedEsTable1";
     public static long testEsTableId1 = 14;
 
@@ -222,9 +212,7 @@ public class GlobalStateMgrTestUtil {
         // add a es table to globalStateMgr
         try {
             createEsTable(db);
-        } catch (DdlException e) {
-            // TODO Auto-generated catch block
-            // e.printStackTrace();
+        } catch (DdlException ignored) {
         }
         return db;
     }
@@ -263,7 +251,6 @@ public class GlobalStateMgrTestUtil {
 
     public static Backend createBackend(long id, String host, int heartPort, int bePort, int httpPort) {
         Backend backend = new Backend(id, host, heartPort);
-        // backend.updateOnce(bePort, httpPort, 10000);
         backend.setAlive(true);
         return backend;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveRepositoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveRepositoryTest.java
@@ -3,21 +3,18 @@
 package com.starrocks.external.hive;
 
 import com.google.common.collect.Maps;
-import com.starrocks.analysis.AccessTestUtil;
-import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.CreateResourceStmt;
 import com.starrocks.catalog.HiveResource;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.ResourceMgr;
 import com.starrocks.common.DdlException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DDLTestBase;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
@@ -26,17 +23,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-public class HiveRepositoryTest {
-    private Analyzer analyzer;
-
-    @Before
-    public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
-    }
+public class HiveRepositoryTest extends DDLTestBase {
 
     @Test
-    public void testGetClient(@Mocked GlobalStateMgr globalStateMgr,
-                              @Mocked ResourceMgr resourceMgr) throws Exception {
+    public void testGetClient() throws Exception {
         String resourceName = "hive0";
         String metastoreURIs = "thrift://127.0.0.1:9380";
         Map<String, String> properties = Maps.newHashMap();
@@ -53,15 +43,9 @@ public class HiveRepositoryTest {
             }
         };
 
-        new Expectations() {
+        ResourceMgr resourceMgr = GlobalStateMgr.getCurrentState().getResourceMgr();
+        new Expectations(resourceMgr) {
             {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-                minTimes = 0;
-
-                globalStateMgr.getResourceMgr();
-                result = resourceMgr;
-
                 resourceMgr.getResource("hive0");
                 result = resource;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -22,8 +22,8 @@
 package com.starrocks.qe;
 
 import com.starrocks.analysis.AccessTestUtil;
+import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlCommand;
@@ -31,9 +31,11 @@ import com.starrocks.mysql.MysqlEofPacket;
 import com.starrocks.mysql.MysqlErrPacket;
 import com.starrocks.mysql.MysqlOkPacket;
 import com.starrocks.mysql.MysqlSerializer;
+import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.plugin.AuditEvent.AuditEventBuilder;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -46,7 +48,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 
-public class ConnectProcessorTest {
+public class ConnectProcessorTest extends DDLTestBase {
     private static ByteBuffer initDbPacket;
     private static ByteBuffer changeUserPacket;
     private static ByteBuffer resetConnectionPacket;
@@ -68,7 +70,7 @@ public class ConnectProcessorTest {
         {
             MysqlSerializer serializer = MysqlSerializer.newInstance();
             serializer.writeInt1(2);
-            serializer.writeEofString("testCluster:testDb");
+            serializer.writeEofString("default_cluster:testDb1");
             initDbPacket = serializer.toByteBuffer();
         }
 
@@ -127,19 +129,18 @@ public class ConnectProcessorTest {
         {
             MysqlSerializer serializer = MysqlSerializer.newInstance();
             serializer.writeInt1(4);
-            serializer.writeNulTerminateString("testTbl");
+            serializer.writeNulTerminateString("testTable1");
             serializer.writeEofString("");
             fieldListPacket = serializer.toByteBuffer();
         }
 
         statistics.scanBytes = 0L;
         statistics.scanRows = 0L;
-
-        MetricRepo.init();
     }
 
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         initDbPacket.clear();
         pingPacket.clear();
         quitPacket.clear();
@@ -175,8 +176,6 @@ public class ConnectProcessorTest {
                     times = 1;
 
                     // Mock send
-                    // channel.sendOnePacket((ByteBuffer) any);
-                    // minTimes = 0;
                     channel.sendAndFlush((ByteBuffer) any);
                     minTimes = 0;
 
@@ -284,7 +283,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testQuit() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(quitPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(quitPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -295,8 +294,9 @@ public class ConnectProcessorTest {
 
     @Test
     public void testInitDb() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(initDbPacket), AccessTestUtil.fetchAdminCatalog());
-
+        ConnectContext ctx = initMockContext(mockChannel(initDbPacket), GlobalStateMgr.getCurrentState());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setQualifiedUser(Auth.ROOT_USER);
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
         Assert.assertEquals(MysqlCommand.COM_INIT_DB, myContext.getCommand());
@@ -305,17 +305,18 @@ public class ConnectProcessorTest {
 
     @Test
     public void testInitDbFail() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(initDbPacket), AccessTestUtil.fetchBlockCatalog());
-
+        ConnectContext ctx = initMockContext(mockChannel(initDbPacket), GlobalStateMgr.getCurrentState());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setQualifiedUser(Auth.ROOT_USER);
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
         Assert.assertEquals(MysqlCommand.COM_INIT_DB, myContext.getCommand());
-        Assert.assertFalse(myContext.getState().toResponsePacket() instanceof MysqlOkPacket);
+        Assert.assertFalse(myContext.getState().toResponsePacket() instanceof MysqlErrPacket);
     }
 
     @Test
     public void testChangeUser() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(changeUserPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(changeUserPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -326,7 +327,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testResetConnection() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(resetConnectionPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(resetConnectionPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -337,7 +338,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testPing() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(pingPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(pingPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -348,7 +349,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testPingLoop() throws IOException {
-        ConnectContext ctx = initMockContext(mockChannel(pingPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(pingPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.loop();
@@ -359,7 +360,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testQuery(@Mocked StmtExecutor executor) throws Exception {
-        ConnectContext ctx = initMockContext(mockChannel(queryPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(queryPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
@@ -378,7 +379,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testQueryFail(@Mocked StmtExecutor executor) throws Exception {
-        ConnectContext ctx = initMockContext(mockChannel(queryPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(queryPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
@@ -400,7 +401,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testQueryFail2(@Mocked StmtExecutor executor) throws Exception {
-        ConnectContext ctx = initMockContext(mockChannel(queryPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(queryPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
@@ -423,9 +424,9 @@ public class ConnectProcessorTest {
 
     @Test
     public void testFieldList() throws Exception {
-        ConnectContext ctx = initMockContext(mockChannel(fieldListPacket), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(fieldListPacket), GlobalStateMgr.getCurrentState());
 
-        myContext.setDatabase("testCluster:testDb");
+        myContext.setDatabase("default_cluster:testDb1");
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
         Assert.assertEquals(MysqlCommand.COM_FIELD_LIST, myContext.getCommand());
@@ -440,7 +441,7 @@ public class ConnectProcessorTest {
         serializer.writeEofString("");
 
         ConnectContext ctx = initMockContext(mockChannel(serializer.toByteBuffer()),
-                AccessTestUtil.fetchAdminCatalog());
+                GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -474,9 +475,9 @@ public class ConnectProcessorTest {
         serializer.writeNulTerminateString("emptyTable");
         serializer.writeEofString("");
 
-        myContext.setDatabase("testCluster:testDb");
+        myContext.setDatabase("default_cluster:testDb1");
         ConnectContext ctx = initMockContext(mockChannel(serializer.toByteBuffer()),
-                AccessTestUtil.fetchAdminCatalog());
+                GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -490,7 +491,7 @@ public class ConnectProcessorTest {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         serializer.writeInt1(5);
         ByteBuffer packet = serializer.toByteBuffer();
-        ConnectContext ctx = initMockContext(mockChannel(packet), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -504,7 +505,7 @@ public class ConnectProcessorTest {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         serializer.writeInt1(101);
         ByteBuffer packet = serializer.toByteBuffer();
-        ConnectContext ctx = initMockContext(mockChannel(packet), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
@@ -515,7 +516,7 @@ public class ConnectProcessorTest {
 
     @Test
     public void testNullPacket() throws Exception {
-        ConnectContext ctx = initMockContext(mockChannel(null), AccessTestUtil.fetchAdminCatalog());
+        ConnectContext ctx = initMockContext(mockChannel(null), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.loop();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -503,7 +503,7 @@ public class ShowExecutorTest {
         Assert.fail("No Exception throws.");
     }
 
-    @Test(expected = AnalysisException.class)
+    @Test
     public void testShowCreateTableEmptyTbl() throws AnalysisException, DdlException {
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("default_cluster:testDb", "emptyTable"),
                 ShowCreateTableStmt.CreateTableType.TABLE);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DDLTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DDLTestBase.java
@@ -1,0 +1,43 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.Analyzer;
+import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Before;
+
+public class DDLTestBase {
+
+    protected static Analyzer analyzer;
+    protected static ConnectContext ctx;
+
+    @Before
+    public void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), ctx);
+
+        FeConstants.runningUnitTest = true;
+        StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(GlobalStateMgrTestUtil.testDb1)
+                .useDatabase(GlobalStateMgrTestUtil.testDb1);
+
+        starRocksAssert.withTable("CREATE TABLE `testTable1` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
@@ -10,7 +10,6 @@ import com.starrocks.journal.Journal;
 import com.starrocks.journal.JournalCursor;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalException;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.commons.collections.map.HashedMap;
 
 import java.io.ByteArrayInputStream;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
@@ -31,11 +31,9 @@ import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.Journal;
 import com.starrocks.journal.JournalException;
 import com.starrocks.journal.JournalFactory;
-import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.FrontendOptions;
-
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.Level;
@@ -245,6 +243,7 @@ public class MockedFrontend {
                 };
 
                 GlobalStateMgr.getCurrentState().initialize(args);
+
                 GlobalStateMgr.getCurrentState().notifyNewFETypeTransfer(FrontendNodeType.MASTER);
 
                 GlobalStateMgr.getCurrentState().waitForReady();
@@ -259,13 +258,12 @@ public class MockedFrontend {
     }
 
     // must call init() before start.
-    public void start(boolean startBDB, String[] args) throws FeStartException, NotInitException {
+    public void start(boolean startBDB, String[] args) throws FeStartException, NotInitException, InterruptedException {
         initLock.lock();
         if (!isInit) {
             throw new NotInitException("fe process is not initialized");
         }
         initLock.unlock();
-
         Thread feThread = new Thread(new FERunnable(this, startBDB, args), FE_PROCESS);
         feThread.start();
         waitForCatalogReady();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -74,9 +74,6 @@ import com.starrocks.statistic.StatsConstants;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TExplainLevel;
-import com.starrocks.utframe.MockedFrontend.EnvVarNotSetException;
-import com.starrocks.utframe.MockedFrontend.FeStartException;
-import com.starrocks.utframe.MockedFrontend.NotInitException;
 import org.apache.commons.codec.binary.Hex;
 
 import java.io.File;
@@ -204,8 +201,7 @@ public class UtFrameUtils {
         return statementBases;
     }
 
-    private static void startFEServer(String runningDir, boolean startBDB) throws EnvVarNotSetException, IOException,
-            FeStartException, NotInitException {
+    private static void startFEServer(String runningDir, boolean startBDB) throws Exception {
         // get STARROCKS_HOME
         String starRocksHome = System.getenv("STARROCKS_HOME");
         if (Strings.isNullOrEmpty(starRocksHome)) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

Unstable FE UT will waste a lot of time of our RDs, we should fix it.

https://github.com/StarRocks/starrocks/pull/8184 failed to fix com.starrocks.alter.RollupJobV2Test.testSchemaChange1, this PR should fix it once and for all.

Fix two unstable FE UT:
1. com.starrocks.alter.RollupJobV2Test.testSchemaChange1
2. RestrictOpMaterializedViewTest.testBrokerLoad

The core idea to fix these two UT:

### **Use real GlobalStateMgr, not mock GlobalStateMgr, ensure there is only one GlobalStateMgr in UT, then won't Missing invocations issue.**


