### PR TITLE
[Enhancment] Assign tablet ranges for one-phase aggregate without partition and colocate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -126,6 +126,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // Enable shared_scan for this fragment: OlapScanOperator could share the output data to avoid data skew
     protected boolean enableSharedScan = true;
 
+    // Whether to assign scan ranges to each driver sequence of pipeline,
+    // for the normal backend assignment (not colocate, bucket, and replicated join).
     protected boolean assignScanRangesPerDriverSeq = false;
 
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -126,6 +126,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // Enable shared_scan for this fragment: OlapScanOperator could share the output data to avoid data skew
     protected boolean enableSharedScan = true;
 
+    protected boolean assignScanRangesPerDriverSeq = false;
+
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
 
@@ -247,6 +249,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean isEnableSharedScan() {
         return enableSharedScan;
+    }
+
+    public boolean isAssignScanRangesPerDriverSeq() {
+        return assignScanRangesPerDriverSeq;
+    }
+
+    public void setAssignScanRangesPerDriverSeq(boolean assignScanRangesPerDriverSeq) {
+        this.assignScanRangesPerDriverSeq = assignScanRangesPerDriverSeq;
     }
 
     public void computeLocalRfWaitingSet(PlanNode root, boolean clearGlobalRuntimeFilter) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -465,7 +465,6 @@ public class Coordinator {
                     DebugUtil.printId(queryId), descTable);
         }
 
-
         // prepare information
         prepare();
 
@@ -1708,6 +1707,7 @@ public class Coordinator {
                         parallelExecInstanceNum, pipelineDop, enablePipeline, params);
                 computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
             } else {
+                boolean assignScanRangesPerDriverSeq = enablePipeline && fragment.isAssignScanRangesPerDriverSeq();
                 for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> tNetworkAddressMapEntry :
                         fragmentExecParamsMap.get(fragment.getFragmentId()).scanRangeAssignment.entrySet()) {
                     TNetworkAddress key = tNetworkAddressMapEntry.getKey();
@@ -1729,8 +1729,21 @@ public class Coordinator {
 
                         for (List<TScanRangeParams> scanRangeParams : perInstanceScanRanges) {
                             FInstanceExecParam instanceParam = new FInstanceExecParam(null, key, 0, params);
-                            instanceParam.perNodeScanRanges.put(planNodeId, scanRangeParams);
                             params.instanceExecParams.add(instanceParam);
+
+                            if (!assignScanRangesPerDriverSeq) {
+                                instanceParam.perNodeScanRanges.put(planNodeId, scanRangeParams);
+                            } else {
+                                int expectedDop = Math.max(1, Math.min(pipelineDop, scanRangeParams.size()));
+                                List<List<TScanRangeParams>> scanRangeParamsPerDriverSeq =
+                                        ListUtil.splitBySize(scanRangeParams, expectedDop);
+                                instanceParam.pipelineDop = scanRangeParamsPerDriverSeq.size();
+                                Map<Integer, List<TScanRangeParams>> scanRangesPerDriverSeq = new HashMap<>();
+                                instanceParam.nodeToPerDriverSeqScanRanges.put(planNodeId, scanRangesPerDriverSeq);
+                                for (int driverSeq = 0; driverSeq < scanRangeParamsPerDriverSeq.size(); ++driverSeq) {
+                                    scanRangesPerDriverSeq.put(driverSeq, scanRangeParamsPerDriverSeq.get(driverSeq));
+                                }
+                            }
                         }
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1295,8 +1295,9 @@ public class PlanFragmentBuilder {
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
-            if (node.isOnePhaseAgg() && aggregationNode.isColocate()) {
+            if (node.isOnePhaseAgg() && hasNoExchangeNodes(inputFragment.getPlanRoot())) {
                 inputFragment.setEnableSharedScan(false);
+                inputFragment.setAssignScanRangesPerDriverSeq(true);
             }
 
             inputFragment.setPlanRoot(aggregationNode);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The scan node succeeded by one-phase aggregation should satisfy any following condition:
1. The table distribution is without partition.
2. The table distribution is with partition, and has the colocate property.

#7593 tries to assign scan ranges to each scan operator, which is stored in `FInstanceExecParam#nodeToPerDriverSeqScanRanges`, but it only deal with the second condition in `Coordinator#computeColocatedJoinInstanceParam`.

Therefore, this PR deals with the first condition.




