### PR TITLE
[BugFix] fix error of THRIFT_RPC_ERROR with CN

### DIFF
--- a/be/src/service/backend_base.h
+++ b/be/src/service/backend_base.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include <thrift/protocol/TDebugProtocol.h>
-
 #include <ctime>
 #include <map>
 #include <memory>
@@ -43,16 +41,8 @@ class TMiniLoadEtlStatusRequest;
 class TDeleteEtlFilesRequest;
 class TExecPlanFragmentParams;
 class TExecPlanFragmentResult;
-class TInsertResult;
-class TReportExecStatusParams;
-class TReportExecStatusResult;
 class TCancelPlanFragmentResult;
 class TTransmitDataResult;
-class TNetworkAddress;
-class TClientRequest;
-class TExecRequest;
-class TSessionState;
-class TQueryOptions;
 class TExportTaskRequest;
 class TExportStatusResult;
 
@@ -63,6 +53,10 @@ public:
     explicit BackendServiceBase(ExecEnv* exec_env);
 
     ~BackendServiceBase() override = default;
+
+    // NOTE: now we do not support multiple backend in one process
+    template <class Service>
+    static std::unique_ptr<ThriftServer> create(ExecEnv* exec_env, int port);
 
     // Agent service
     void submit_tasks(TAgentResult& return_value, const std::vector<TAgentTaskRequest>& tasks) override {

--- a/be/src/service/service_be/backend_service.h
+++ b/be/src/service/service_be/backend_service.h
@@ -26,11 +26,6 @@
 namespace starrocks {
 
 class AgentServer;
-class ExecEnv;
-class ThriftServer;
-class TAgentResult;
-class TAgentTaskRequest;
-class TAgentPublishRequest;
 
 // This class just forward rpc requests to actual handlers, used
 // to bind multiple services on single port.
@@ -39,9 +34,6 @@ public:
     explicit BackendService(ExecEnv* exec_env);
 
     ~BackendService() override;
-
-    // NOTE: now we do not support multiple backend in one process
-    static std::unique_ptr<ThriftServer> create(ExecEnv* exec_env, int port);
 
     void submit_tasks(TAgentResult& return_value, const std::vector<TAgentTaskRequest>& tasks) override;
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -32,13 +32,13 @@ DECLARE_int64(socket_max_unwritten_bytes);
 } // namespace brpc
 
 void start_be() {
-    using starrocks::Status;
+    using starrocks::BackendService;
 
     auto* exec_env = starrocks::ExecEnv::GetInstance();
 
     // Begin to start services
     // 1. Start thrift server with 'be_port'.
-    auto thrift_server = starrocks::BackendService::create(exec_env, starrocks::config::be_port);
+    auto thrift_server = BackendService::create<BackendService>(exec_env, starrocks::config::be_port);
     if (auto status = thrift_server->start(); !status.ok()) {
         LOG(ERROR) << "Fail to start BackendService thrift server on port " << starrocks::config::be_port << ": "
                    << status;

--- a/be/src/service/service_cn/compute_service.cpp
+++ b/be/src/service/service_cn/compute_service.cpp
@@ -21,49 +21,10 @@
 
 #include "compute_service.h"
 
-#include <arrow/record_batch.h>
-#include <thrift/concurrency/ThreadFactory.h>
-#include <thrift/processor/TMultiplexedProcessor.h>
-
-#include <memory>
-
-#include "common/config.h"
-#include "common/logging.h"
-#include "common/status.h"
-#include "gen_cpp/TStarrocksExternalService.h"
-#include "runtime/data_stream_mgr.h"
-#include "runtime/descriptors.h"
-#include "runtime/exec_env.h"
-#include "runtime/external_scan_context_mgr.h"
-#include "runtime/fragment_mgr.h"
-#include "runtime/result_buffer_mgr.h"
-#include "runtime/result_queue_mgr.h"
-#include "runtime/routine_load/routine_load_task_executor.h"
-#include "storage/storage_engine.h"
-#include "util/blocking_queue.hpp"
-#include "util/thrift_server.h"
-
 namespace starrocks {
-
-using apache::thrift::TProcessor;
-using apache::thrift::concurrency::ThreadFactory;
 
 ComputeService::ComputeService(ExecEnv* exec_env) : BackendServiceBase(exec_env) {}
 
-Status ComputeService::create_service(ExecEnv* exec_env, int port, ThriftServer** server) {
-    std::shared_ptr<ComputeService> handler(new ComputeService(exec_env));
-    // TODO: do we want a BoostThreadFactory?
-    // TODO: we want separate thread factories here, so that fe requests can't starve
-    // cn requests
-    std::shared_ptr<ThreadFactory> thread_factory(new ThreadFactory());
-
-    std::shared_ptr<TProcessor> cn_processor(new BackendServiceProcessor(handler));
-
-    *server = new ThriftServer("computer", cn_processor, port, exec_env->metrics(), config::be_service_threads);
-
-    LOG(INFO) << "StarRocksInternalService listening on " << port;
-
-    return Status::OK();
-}
+ComputeService::~ComputeService() = default;
 
 } // namespace starrocks

--- a/be/src/service/service_cn/compute_service.h
+++ b/be/src/service/service_cn/compute_service.h
@@ -21,16 +21,6 @@
 
 #pragma once
 
-#include <thrift/protocol/TDebugProtocol.h>
-
-#include <ctime>
-#include <map>
-#include <memory>
-
-#include "common/status.h"
-#include "gen_cpp/BackendService.h"
-#include "gen_cpp/StarrocksExternalService_types.h"
-#include "gen_cpp/TStarrocksExternalService.h"
 #include "service/backend_base.h"
 
 namespace starrocks {
@@ -41,8 +31,7 @@ class ComputeService : public BackendServiceBase {
 public:
     explicit ComputeService(ExecEnv* exec_env);
 
-    // NOTE: now we do not support multiple backend in one process
-    static Status create_service(ExecEnv* exec_env, int port, ThriftServer** server);
+    ~ComputeService() override;
 };
 
 } // namespace starrocks

--- a/be/src/service/service_cn/starrocks_cn.cpp
+++ b/be/src/service/service_cn/starrocks_cn.cpp
@@ -26,16 +26,15 @@ DECLARE_int64(socket_max_unwritten_bytes);
 } // namespace brpc
 
 void start_cn() {
-    using starrocks::Status;
+    using starrocks::ComputeService;
     auto* exec_env = starrocks::ExecEnv::GetInstance();
 
     // Begin to start services
     // 1. Start thrift server with 'thrift_port'.
-    starrocks::ThriftServer* cn_server = nullptr;
-    EXIT_IF_ERROR(starrocks::ComputeService::create_service(exec_env, starrocks::config::thrift_port, &cn_server));
-    Status status = cn_server->start();
-    if (!status.ok()) {
-        LOG(ERROR) << "StarRocks CN server did not start correctly, exiting";
+    auto thrift_server = ComputeService::create<ComputeService>(exec_env, starrocks::config::thrift_port);
+    if (auto status = thrift_server->start(); !status.ok()) {
+        LOG(ERROR) << "Fail to start ComputeService thrift server on port " << starrocks::config::be_port << ": "
+                   << status;
         starrocks::shutdown_logging();
         exit(1);
     }
@@ -45,7 +44,10 @@ void start_cn() {
     brpc::FLAGS_socket_max_unwritten_bytes = starrocks::config::brpc_socket_max_unwritten_bytes;
     brpc::Server brpc_server;
 
-    starrocks::ComputeNodeInternalServiceImpl<starrocks::PInternalService> compute_service(exec_env);
+    starrocks::ComputeNodeInternalServiceImpl<starrocks::PInternalService> internal_service(exec_env);
+    starrocks::ComputeNodeInternalServiceImpl<doris::PBackendService> compute_service(exec_env);
+
+    brpc_server.AddService(&internal_service, brpc::SERVER_DOESNT_OWN_SERVICE);
     brpc_server.AddService(&compute_service, brpc::SERVER_DOESNT_OWN_SERVICE);
 
     brpc::ServerOptions options;
@@ -61,8 +63,7 @@ void start_cn() {
     // 3. Start http service.
     std::unique_ptr<starrocks::HttpServiceCN> http_service = std::make_unique<starrocks::HttpServiceCN>(
             exec_env, starrocks::config::webserver_port, starrocks::config::webserver_num_workers);
-    status = http_service->start();
-    if (!status.ok()) {
+    if (auto status = http_service->start(); !status.ok()) {
         LOG(ERROR) << "Internal Error:" << status.message();
         LOG(ERROR) << "StarRocks CN http service did not start correctly, exiting";
         starrocks::shutdown_logging();
@@ -78,7 +79,6 @@ void start_cn() {
     brpc_server.Stop(0);
     brpc_server.Join();
 
-    cn_server->stop();
-    cn_server->join();
-    delete cn_server;
+    thrift_server->stop();
+    thrift_server->join();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7364
```
2022-07-14 14:03:25,819 WARN (starrocks-mysql-nio-pool-11|414) [Coordinator.exec():628] catch a execute exception
java.util.concurrent.ExecutionException: A error occurred: errorCode=1001 errorMessage:[10.x.x.x:8060][E1001]Fail to find service=PBackendService
	at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy$2.get(ProtobufRpcProxy.java:578) ~[jprotobuf-rpc-core-4.2.1.jar:?]
	at com.starrocks.qe.Coordinator.exec(Coordinator.java:622) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:722) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:424) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:277) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:395) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:631) ~[starrocks-fe.jar:?]
	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_60]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_60]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_60]
Caused by: com.baidu.jprotobuf.pbrpc.ErrorDataException: A error occurred: errorCode=1001 errorMessage:[10.192.55.94:8060][E1001]Fail to find service=PBackendService
	at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.doWaitCallback(ProtobufRpcProxy.java:651) ~[jprotobuf-rpc-core-4.2.1.jar:?]
	at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.access$0(ProtobufRpcProxy.java:611) ~[jprotobuf-rpc-core-4.2.1.jar:?]
	at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy$2.get(ProtobufRpcProxy.java:576) ~[jprotobuf-rpc-core-4.2.1.jar:?]
	... 10 more
2022-07-14 14:03:25,819 WARN (starrocks-mysql-nio-pool-11|414) [Coordinator.exec():643] exec plan fragment failed, errmsg=exec rpc error. backend id: 10002, code: THRIFT_RPC_ERROR, fragmentId=F01, backend=10.x.x.x:9060

```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
