### PR TITLE
[docs][branch-1.19] fix the relative links under docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Docs repository
 
 ## Tips
 
-- Images should be put into `./assets`, and used like: `![test image](../../assets/test.png)` or `![test image](/assets/test.png)`
+- Images should be put into `./assets`, and used like: `![test image](../../assets/test.png)` or `![test image](./assets/test.png)`
 - All markdown files are indexed in `TOC.md`which is used to render the sidebar of the website. `File links in the TOC.md should be absolute path.`
 - Code blocks writen with no language specified are forbiddened.
 - Docs that need to be used as `help xxx` in StarRocks should be put into `./sql-referernce`.

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -2,20 +2,20 @@
 
 ## Index
 
-+ [Introduction](/introduction/StarRocks_intro.md)
++ [Introduction](./introduction/StarRocks_intro.md)
 + Quick Start
-  + [Concepts](/quick_start/Concepts.md)
-  + [Architecture](/quick_start/Architecture.md)
-  + [Deploy](/quick_start/Deploy.md)
-  + [Data flow and control flow](/quick_start/Data_flow_and_control_flow.md)
-  + [Import and query](/quick_start/Import_and_query.md)
-  + [Test FAQs](/quick_start/Test_faq.md)
+  + [Concepts](./quick_start/Concepts.md)
+  + [Architecture](./quick_start/Architecture.md)
+  + [Deploy](./quick_start/Deploy.md)
+  + [Data flow and control flow](./quick_start/Data_flow_and_control_flow.md)
+  + [Import and query](./quick_start/Import_and_query.md)
+  + [Test FAQs](./quick_start/Test_faq.md)
 + Table design
-  + [StarRocks table design](/table_design/StarRocks_table_design.md)
-  + [Data model](/table_design/Data_model.md)
-  + [Data distribution](/table_design/Data_distribution.md)
-  + [Sort key and shortkey index](/table_design/Sort_key.md)
+  + [StarRocks table design](./table_design/StarRocks_table_design.md)
+  + [Data model](./table_design/Data_model.md)
+  + [Data distribution](./table_design/Data_distribution.md)
+  + [Sort key and shortkey index](./table_design/Sort_key.md)
 + Development
-  + [Build in docker](/development/Build_in_docker.md)
+  + [Build in docker](./development/Build_in_docker.md)
 + Release Notes
-  + [v1.19](/release_notes/release-1.19.md)
+  + [v1.19](./release_notes/release-1.19.md)

--- a/docs/loading/SparkLoad.md
+++ b/docs/loading/SparkLoad.md
@@ -25,7 +25,7 @@ The execution of the spark load task is divided into the following main phases.
 
 The following diagram illustrates the main flow of spark load.
 
-![Spark load](/assets/4.3.2-1.png)
+![Spark load](../assets/4.3.2-1.png)
 
 ---
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8792

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
It's wrong to continue to use those absolute link paths after we moved
all the docs under docs/ directory.
Now, it uses relative link paths.