### PR TITLE
[BugFix] No error in routine load when there's invalid JSON message

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -71,7 +71,7 @@ StatusOr<ChunkPtr> JsonScanner::get_next() {
         RETURN_IF_ERROR(_create_src_chunk(&src_chunk));
 
         if (_cur_file_eof) {
-            // If all readers have been read, a EOF would be returned.
+            // If all readers have been read, an EOF would be returned.
             RETURN_IF_ERROR(_open_next_reader());
             _cur_file_eof = false;
         }

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -107,10 +107,12 @@ StatusOr<ChunkPtr> JsonScanner::get_next() {
                 // Set _cur_file_eof to open a new reader.
                 _cur_file_eof = true;
             } else {
+                if (++_error_chunk_num <= _kMaxErrorChunkNum) {
+                    LOG(WARNING) << "read chunk failed: : " << status;
+                }
                 // To read all readers, we just log and ignore the error returned by read_chunk.
                 // Set _cur_file_eof to open a new reader, since the error is not recoverable by retrying.
                 _cur_file_eof = true;
-                LOG(WARNING) << "read chunk failed: : " << status;
             }
         }
     } while (src_chunk->num_rows() == 0);

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -58,6 +58,9 @@ private:
     std::vector<std::vector<SimpleJsonPath>> _json_paths;
     std::vector<SimpleJsonPath> _root_paths;
     bool _strip_outer_array = false;
+
+    constexpr static const size_t _kMaxErrorChunkNum = 10;
+    size_t _error_chunk_num = 0;
 };
 
 // Reader to parse the json.

--- a/be/test/exec/test_data/json_scanner/illegal.json
+++ b/be/test/exec/test_data/json_scanner/illegal.json
@@ -1,3 +1,12 @@
+{   
+   "f_float": 3.14,
+   "f_bool": true,
+   "f_int": 123,
+   "f_float_in_string": "3.14",
+   "f_bool_in_string": "1",
+   "f_int_in_string": "123"
+}
+
    "f_float": 3.14,
    "f_bool": true,
    "f_int": 123,

--- a/be/test/exec/test_data/json_scanner/invalid_test1.json
+++ b/be/test/exec/test_data/json_scanner/invalid_test1.json
@@ -1,0 +1,13 @@
+[
+   {
+      "category": "reference",
+      "author": "NigelRees",
+      "title": "SayingsoftheCentury",
+      "price": 8.95
+   },
+   {
+      "category": "fiction",
+      "author": "EvelynWaugh",
+      "title": "SwordofHonour",
+      "price": 12.99
+   }

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -932,4 +932,81 @@ TEST_F(JsonScannerTest, test_illegal_input) {
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
 }
 
+TEST_F(JsonScannerTest, test_multi_invalid_json) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_DOUBLE);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/invalid_test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/invalid_test1.json");
+        ranges.emplace_back(range);
+    }
+
+    {
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_JSON;
+        range.strip_outer_array = true;
+        range.__isset.strip_outer_array = true;
+        range.__isset.jsonpaths = false;
+        range.__isset.json_root = false;
+        range.__set_path("./be/test/exec/test_data/json_scanner/test1.json");
+        ranges.emplace_back(range);
+    }
+
+    auto scanner = create_json_scanner(types, ranges, {"category", "author", "title", "price"});
+
+    ASSERT_TRUE(scanner->open().ok());
+
+    // 2 row from 1st test1.json.
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(2, chunk->num_rows());
+
+    // the data from invalid_test.json is skipped.
+
+    EXPECT_EQ("['reference', 'NigelRees', 'SayingsoftheCentury', 8.95]", chunk->debug_row(0));
+    EXPECT_EQ("['fiction', 'EvelynWaugh', 'SwordofHonour', 12.99]", chunk->debug_row(1));
+
+    // 2 row from 2nd test1.json.
+    chunk = scanner->get_next().value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(2, chunk->num_rows());
+
+    EXPECT_EQ("['reference', 'NigelRees', 'SayingsoftheCentury', 8.95]", chunk->debug_row(0));
+    EXPECT_EQ("['fiction', 'EvelynWaugh', 'SwordofHonour', 12.99]", chunk->debug_row(1));
+
+    EXPECT_TRUE(scanner->get_next().status().is_end_of_file());
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -929,7 +929,9 @@ TEST_F(JsonScannerTest, test_illegal_input) {
             create_json_scanner(types, ranges, {"f_float", "f_bool", "f_int", "f_float_in_string", "f_int_in_string"});
 
     ASSERT_OK(scanner->open());
-    ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
+    auto res = scanner->get_next();
+    ASSERT_TRUE(res.status().ok());
+    ASSERT_EQ(res.value()->num_rows(), 1);
 }
 
 TEST_F(JsonScannerTest, test_multi_invalid_json) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8790

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The previous implementation of routine load would report no error when there's an invalid JSON message. The new implement would skip invalid JSON messages in parsing and pause the routine load later.