### PR TITLE
[Cherry-pick 2.1][BugFix] allow skip authorization and reset root password (#7361)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -105,7 +106,9 @@ public class MysqlProto {
             return false;
         }
         context.setAuthDataSalt(randomString);
-        context.setCurrentUserIdentity(currentUserIdentity.get(0));
+        if (Config.enable_auth_check) {
+            context.setCurrentUserIdentity(currentUserIdentity.get(0));
+        }
         context.setQualifiedUser(qualifiedUser);
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -411,6 +411,9 @@ public class Auth implements Writable {
      * This method will check the given privilege levels
      */
     public boolean checkHasPriv(ConnectContext ctx, PrivPredicate priv, PrivLevel... levels) {
+        if (!Config.enable_auth_check) {
+            return true;
+        }
         return checkHasPrivInternal(ctx.getRemoteIP(), ctx.getQualifiedUser(), priv, levels);
     }
 


### PR DESCRIPTION
There must be other bugs somewhere once we set enable_auth_check to false, but this time I am only trying to make sure root password can be changed. The rest scenerios are off my consideration for now.

Fixes #7359