### PR TITLE
[Enhancement] Improving memory locality of traversal tables

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -31,7 +31,7 @@ Status AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                   \
     else if (_aggregator->hash_map_variant().type == vectorized::AggHashMapVariant::Type::NAME) \
-            _aggregator->it_hash() = _aggregator->hash_map_variant().NAME->hash_map.begin();
+            _aggregator->it_hash() = _aggregator->_state_allocator.begin();
         APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     } else if (_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -79,7 +79,7 @@ void AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::C
         }
 #define HASH_MAP_METHOD(NAME)                                                                   \
     else if (_aggregator->hash_map_variant().type == vectorized::AggHashMapVariant::Type::NAME) \
-            _aggregator->it_hash() = _aggregator->hash_map_variant().NAME->hash_map.begin();
+            _aggregator->it_hash() = _aggregator->_state_allocator.begin();
         APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         else {

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -117,7 +117,7 @@ struct AggHashMapWithOneNumberKey {
 
             FieldType key = column->get_data()[i];
             auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
-                AggDataPtr pv = allocate_func();
+                AggDataPtr pv = allocate_func(key);
                 ctor(key, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -131,7 +131,7 @@ struct AggHashMapWithOneNumberKey {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             FieldType key = column->get_data()[i];
-            auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) { ctor(key, allocate_func()); });
+            auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) { ctor(key, allocate_func(key)); });
             (*agg_states)[i] = iter->second;
         }
     }
@@ -201,7 +201,7 @@ struct AggHashMapWithOneNullableNumberKey {
                             Buffer<AggDataPtr>* agg_states) {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
-                null_key_data = allocate_func();
+                null_key_data = allocate_func(nullptr);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -225,7 +225,7 @@ struct AggHashMapWithOneNullableNumberKey {
             for (size_t i = 0; i < data_column->size(); i++) {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
-                        null_key_data = allocate_func();
+                        null_key_data = allocate_func(nullptr);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -245,7 +245,7 @@ struct AggHashMapWithOneNullableNumberKey {
 
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
-                null_key_data = allocate_func();
+                null_key_data = allocate_func(nullptr);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -268,7 +268,7 @@ struct AggHashMapWithOneNullableNumberKey {
             for (size_t i = 0; i < data_column->size(); i++) {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
-                        null_key_data = allocate_func();
+                        null_key_data = allocate_func(nullptr);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -283,7 +283,7 @@ struct AggHashMapWithOneNullableNumberKey {
                                  Buffer<AggDataPtr>* agg_states) {
         auto key = data_column->get_data()[row];
         auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
-            AggDataPtr pv = allocate_func();
+            AggDataPtr pv = allocate_func(key);
             ctor(key, pv);
         });
         (*agg_states)[row] = iter->second;
@@ -333,7 +333,7 @@ struct AggHashMapWithOneStringKey {
                 uint8_t* pos = pool->allocate(key.size);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
-                AggDataPtr pv = allocate_func();
+                AggDataPtr pv = allocate_func(pk);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -350,7 +350,7 @@ struct AggHashMapWithOneStringKey {
                 uint8_t* pos = pool->allocate(key.size);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
-                AggDataPtr pv = allocate_func();
+                AggDataPtr pv = allocate_func(pk);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -416,7 +416,7 @@ struct AggHashMapWithOneNullableStringKey {
                             Buffer<AggDataPtr>* agg_states) {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
-                null_key_data = allocate_func();
+                null_key_data = allocate_func(nullptr);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -440,7 +440,7 @@ struct AggHashMapWithOneNullableStringKey {
             for (size_t i = 0; i < data_column->size(); i++) {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
-                        null_key_data = allocate_func();
+                        null_key_data = allocate_func(nullptr);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -459,7 +459,7 @@ struct AggHashMapWithOneNullableStringKey {
         not_founds->assign(chunk_size, 0);
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
-                null_key_data = allocate_func();
+                null_key_data = allocate_func(nullptr);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -480,7 +480,7 @@ struct AggHashMapWithOneNullableStringKey {
             for (size_t i = 0; i < data_column->size(); i++) {
                 if (nullable_column->is_null(i)) {
                     if (null_key_data == nullptr) {
-                        null_key_data = allocate_func();
+                        null_key_data = allocate_func(nullptr);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -498,7 +498,7 @@ struct AggHashMapWithOneNullableStringKey {
             uint8_t* pos = pool->allocate(key.size);
             strings::memcpy_inlined(pos, key.data, key.size);
             Slice pk{pos, key.size};
-            AggDataPtr pv = allocate_func();
+            AggDataPtr pv = allocate_func(pk);
             ctor(pk, pv);
         });
         (*agg_states)[row] = iter->second;
@@ -567,7 +567,7 @@ struct AggHashMapWithSerializedKey {
                 uint8_t* pos = pool->allocate(key.size);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
-                AggDataPtr pv = allocate_func();
+                AggDataPtr pv = allocate_func(pk);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -698,7 +698,7 @@ struct AggHashMapWithSerializedKeyFixedSize {
             }
             FixedSizeSliceKey& key = caches[i].key;
             auto iter = hash_map.lazy_emplace_with_hash(key, caches[i].hashval, [&](const auto& ctor) {
-                AggDataPtr pv = allocate_func();
+                AggDataPtr pv = allocate_func(key);
                 ctor(key, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -720,7 +720,7 @@ struct AggHashMapWithSerializedKeyFixedSize {
             }
         }
         for (size_t i = 0; i < chunk_size; ++i) {
-            auto iter = hash_map.lazy_emplace(key[i], [&](const auto& ctor) { ctor(key[i], allocate_func()); });
+            auto iter = hash_map.lazy_emplace(key[i], [&](const auto& ctor) { ctor(key[i], allocate_func(key[i])); });
             (*agg_states)[i] = iter->second;
         }
     }

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -105,7 +105,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                                \
     else if (_aggregator->hash_map_variant().type == AggHashMapVariant::Type::NAME) _aggregator->it_hash() = \
-            _aggregator->hash_map_variant().NAME->hash_map.begin();
+            _aggregator->_state_allocator.begin();
         APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     } else if (_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -224,7 +224,7 @@ void AggregateStreamingNode::_output_chunk_from_hash_map(ChunkPtr* chunk) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                                \
     else if (_aggregator->hash_map_variant().type == AggHashMapVariant::Type::NAME) _aggregator->it_hash() = \
-            _aggregator->hash_map_variant().NAME->hash_map.begin();
+            _aggregator->_state_allocator.begin();
         APPLY_FOR_AGG_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         else {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -225,7 +225,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     }
     // we need to allocate contiguous memory, so we need some alignment operations
     _max_agg_state_align_size = std::max(_max_agg_state_align_size, HashTableKeyAllocator::aligned);
-    _agg_states_total_size = (_agg_states_total_size + _max_agg_state_align_size) / _max_agg_state_align_size *
+    _agg_states_total_size = (_agg_states_total_size + _max_agg_state_align_size - 1) / _max_agg_state_align_size *
                              _max_agg_state_align_size;
     _state_allocator.aggregate_key_size = _agg_states_total_size;
     _state_allocator.pool = _mem_pool.get();

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -204,7 +204,10 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
         _agg_intput_columns[i].resize(desc.nodes[0].num_children);
         _agg_input_raw_columns[i].resize(desc.nodes[0].num_children);
     }
-
+    _mem_pool = std::make_unique<MemPool>();
+    // TODO: use hashtable key size as align
+    // reserve size for hash table key
+    _agg_states_total_size = 16;
     // compute agg state total size and offsets
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
         _agg_states_offsets[i] = _agg_states_total_size;
@@ -220,6 +223,12 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
                                      next_state_align_size;
         }
     }
+    // we need to allocate contiguous memory, so we need some alignment operations
+    _max_agg_state_align_size = std::max(_max_agg_state_align_size, HashTableKeyAllocator::aligned);
+    _agg_states_total_size = (_agg_states_total_size + _max_agg_state_align_size) / _max_agg_state_align_size *
+                             _max_agg_state_align_size;
+    _state_allocator.aggregate_key_size = _agg_states_total_size;
+    _state_allocator.pool = _mem_pool.get();
 
     _is_only_group_by_columns = _agg_expr_ctxs.empty() && !_group_by_expr_ctxs.empty();
 
@@ -249,8 +258,6 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
         RETURN_IF_ERROR(Expr::prepare(ctx, state));
     }
     RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state));
-
-    _mem_pool = std::make_unique<MemPool>();
 
     // Initial for FunctionContext of every aggregate functions
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -52,12 +52,12 @@ struct HashTableKeyAllocator {
 
     RawHashTableIterator end() { return {this, vecs.size(), 0}; }
 
-    uint8_t* allocate() {
+    vectorized::AggDataPtr allocate() {
         if (vecs.empty() || vecs.back().second == link) {
             uint8_t* mem = pool->allocate_aligned(link * aggregate_key_size, aligned);
             vecs.emplace_back(mem, 0);
         }
-        return static_cast<uint8_t*>(vecs.back().first) + aggregate_key_size * vecs.back().second++;
+        return static_cast<vectorized::AggDataPtr>(vecs.back().first) + aggregate_key_size * vecs.back().second++;
     }
 
     uint8_t* allocate_null_key_data() { return pool->allocate_aligned(link * aggregate_key_size, aligned); }

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -4,23 +4,90 @@
 
 #include <any>
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <queue>
+#include <utility>
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
+#include "common/statusor.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/aggregate/agg_hash_variant.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/expr.h"
+#include "gen_cpp/QueryPlanExtra_constants.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
+#include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
 
 namespace starrocks {
+
+struct HashTableKeyAllocator;
+
+struct RawHashTableIterator {
+    RawHashTableIterator(HashTableKeyAllocator* alloc_, size_t x_, int y_) : alloc(alloc_), x(x_), y(y_) {}
+    bool operator==(const RawHashTableIterator& other) { return x == other.x && y == other.y; }
+    bool operator!=(const RawHashTableIterator& other) { return !this->operator==(other); }
+    inline void next();
+    inline uint8_t* value();
+    HashTableKeyAllocator* alloc;
+    size_t x;
+    int y;
+};
+
+struct HashTableKeyAllocator {
+    static auto constexpr link = 1024;
+    static size_t constexpr aligned = 16;
+    int aggregate_key_size = 0;
+    std::vector<std::pair<void*, int>> vecs;
+    MemPool* pool = nullptr;
+
+    RawHashTableIterator begin() { return {this, 0, 0}; }
+
+    RawHashTableIterator end() { return {this, vecs.size(), 0}; }
+
+    uint8_t* allocate() {
+        if (vecs.empty() || vecs.back().second == link) {
+            uint8_t* mem = pool->allocate_aligned(link * aggregate_key_size, aligned);
+            vecs.emplace_back(mem, 0);
+        }
+        return static_cast<uint8_t*>(vecs.back().first) + aggregate_key_size * vecs.back().second++;
+    }
+
+    uint8_t* allocate_null_key_data() { return pool->allocate_aligned(link * aggregate_key_size, aligned); }
+};
+
+inline void RawHashTableIterator::next() {
+    if (y < alloc->vecs[x].second) {
+        y++;
+        if (y == alloc->vecs[x].second) {
+            y = 0;
+            x++;
+        }
+    }
+}
+
+inline uint8_t* RawHashTableIterator::value() {
+    return static_cast<uint8_t*>(alloc->vecs[x].first) + alloc->aggregate_key_size * y;
+}
+
+class Aggregator;
+
+template <class HashMapWithKey>
+struct AllocateState {
+    AllocateState(Aggregator* aggregator_) : aggregator(aggregator_) {}
+    inline vectorized::AggDataPtr operator()(const typename HashMapWithKey::KeyType& key);
+    inline vectorized::AggDataPtr operator()(std::nullptr_t);
+
+private:
+    Aggregator* aggregator;
+};
 
 struct AggFunctionTypes {
     TypeDescriptor result_type;
@@ -51,7 +118,6 @@ static const StreamingHtMinReductionEntry STREAMING_HT_MIN_REDUCTION[] = {
 static const int STREAMING_HT_MIN_REDUCTION_SIZE =
         sizeof(STREAMING_HT_MIN_REDUCTION) / sizeof(STREAMING_HT_MIN_REDUCTION[0]);
 
-class Aggregator;
 using AggregatorPtr = std::shared_ptr<Aggregator>;
 
 // Component used to process aggregation including bloking aggregate and streaming aggregate
@@ -149,6 +215,7 @@ public:
     static constexpr size_t two_level_memory_threshold = 64;
     static constexpr size_t streaming_hash_table_size_threshold = 4;
 #endif
+    HashTableKeyAllocator _state_allocator;
 
 private:
     bool _is_closed = false;
@@ -266,32 +333,14 @@ public:
                 _streaming_selection.assign(chunk_size, 0);
             }
         }
-        hash_map_with_key.compute_agg_states(
-                chunk_size, _group_by_columns, _mem_pool.get(),
-                [this]() {
-                    vectorized::AggDataPtr agg_state =
-                            _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    for (int i = 0; i < _agg_functions.size(); i++) {
-                        _agg_functions[i]->create(_agg_fn_ctxs[i], agg_state + _agg_states_offsets[i]);
-                    }
-                    return agg_state;
-                },
-                &_tmp_agg_states);
+        hash_map_with_key.compute_agg_states(chunk_size, _group_by_columns, _mem_pool.get(),
+                                             AllocateState<HashMapWithKey>(this), &_tmp_agg_states);
     }
 
     template <typename HashMapWithKey>
     void build_hash_map_with_selection(HashMapWithKey& hash_map_with_key, size_t chunk_size) {
-        hash_map_with_key.compute_agg_states(
-                chunk_size, _group_by_columns,
-                [this]() {
-                    vectorized::AggDataPtr agg_state =
-                            _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    for (int i = 0; i < _agg_functions.size(); i++) {
-                        _agg_functions[i]->create(_agg_fn_ctxs[i], agg_state + _agg_states_offsets[i]);
-                    }
-                    return agg_state;
-                },
-                &_tmp_agg_states, &_streaming_selection);
+        hash_map_with_key.compute_agg_states(chunk_size, _group_by_columns, AllocateState<HashMapWithKey>(this),
+                                             &_tmp_agg_states, &_streaming_selection);
     }
 
     template <typename HashSetWithKey>
@@ -307,9 +356,9 @@ public:
     template <typename HashMapWithKey>
     void convert_hash_map_to_chunk(HashMapWithKey& hash_map_with_key, int32_t chunk_size, vectorized::ChunkPtr* chunk) {
         SCOPED_TIMER(_get_results_timer);
-        using Iterator = typename HashMapWithKey::Iterator;
-        auto it = std::any_cast<Iterator>(_it_hash);
-        auto end = hash_map_with_key.hash_map.end();
+
+        auto it = std::any_cast<RawHashTableIterator>(_it_hash);
+        auto end = _state_allocator.end();
 
         vectorized::Columns group_by_columns = _create_group_by_columns();
         vectorized::Columns agg_result_columns = _create_agg_result_columns();
@@ -318,11 +367,13 @@ public:
         {
             SCOPED_TIMER(_iter_timer);
             hash_map_with_key.results.resize(chunk_size);
+            // get key/value from hashtable
             while ((it != end) & (read_index < chunk_size)) {
-                hash_map_with_key.results[read_index] = it->first;
-                _tmp_agg_states[read_index] = it->second;
+                auto* value = it.value();
+                hash_map_with_key.results[read_index] = *reinterpret_cast<typename HashMapWithKey::KeyType*>(value);
+                _tmp_agg_states[read_index] = value;
                 ++read_index;
-                ++it;
+                it.next();
             }
         }
 
@@ -499,7 +550,30 @@ private:
             }
         }
     }
+    template <class HashMapWithKey>
+    friend struct AllocateState;
 };
+
+template <class HashMapWithKey>
+inline vectorized::AggDataPtr AllocateState<HashMapWithKey>::operator()(const typename HashMapWithKey::KeyType& key) {
+    vectorized::AggDataPtr agg_state = aggregator->_state_allocator.allocate();
+    *reinterpret_cast<typename HashMapWithKey::KeyType*>(agg_state) = key;
+    for (int i = 0; i < aggregator->_agg_fn_ctxs.size(); i++) {
+        aggregator->_agg_functions[i]->create(aggregator->_agg_fn_ctxs[i],
+                                              agg_state + aggregator->_agg_states_offsets[i]);
+    }
+    return agg_state;
+}
+
+template <class HashMapWithKey>
+inline vectorized::AggDataPtr AllocateState<HashMapWithKey>::operator()(std::nullptr_t) {
+    vectorized::AggDataPtr agg_state = aggregator->_state_allocator.allocate_null_key_data();
+    for (int i = 0; i < aggregator->_agg_fn_ctxs.size(); i++) {
+        aggregator->_agg_functions[i]->create(aggregator->_agg_fn_ctxs[i],
+                                              agg_state + aggregator->_agg_states_offsets[i]);
+    }
+    return agg_state;
+}
 
 class AggregatorFactory;
 using AggregatorFactoryPtr = std::shared_ptr<AggregatorFactory>;

--- a/be/test/exec/vectorized/agg_hash_map_test.cpp
+++ b/be/test/exec/vectorized/agg_hash_map_test.cpp
@@ -211,7 +211,7 @@ TEST(HashMapTest, Insert) {
             key_columns.back()->append_default();
         }
         key.compute_agg_states(
-                key_columns[0]->size(), key_columns, &pool, [&]() { return pool.allocate(16); }, &agg_states);
+                key_columns[0]->size(), key_columns, &pool, [&](auto& key) { return pool.allocate(16); }, &agg_states);
         using TestHashMapKey = TestAggHashMap::key_type;
         std::vector<TestHashMapKey> resv;
         for (auto [key, _] : key.hash_map) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
#9118

Now the order in which we traverse the hash table is directly to the hash table.
Although direct access to flat hash table is a fast operation. He has very good memory locality.
but in fact, the value of hash table is a pointer.
eg:
[(k1, s1), (k2, s2)]
the access order is (k1,s1), (k2, s2).
But s1 and s2 may be farther apart from each other.
Because the order of our hash insertion is not a fixed order.
To improve the speed of hash table traversal. We choose to save both keys of the hash table in the state (maximum sizeof(key)==16).
At the same time we save the creation order of the states (states are allocated consecutively from the pool, the same creation order has better memory locality).
When outputting the hash table, we output the hash table by the traversal order of the states

performance case:
baseline 2.3-rc02
```
1FE 1BE pipeline items:99997497
SELECT SUM(a), COUNT(*) AS c, AVG(b) FROM tablex GROUP BY x, y ORDER BY c DESC LIMIT 10;
6.58 -> 4.85
SELECT u, COUNT(*) AS c FROM tablex GROUP BY URL ORDER BY c DESC LIMIT 10;
6.53 -> 5.44
```
