### PR TITLE
[BugFix] Fix CompoundPredicateOperator not equals when same children with different order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -2,12 +2,14 @@
 package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class CompoundPredicateOperator extends PredicateOperator {
     private final CompoundType type;
@@ -71,16 +73,22 @@ public class CompoundPredicateOperator extends PredicateOperator {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        CompoundPredicateOperator that = (CompoundPredicateOperator) o;
+        if (type != that.type) {
             return false;
         }
-        CompoundPredicateOperator that = (CompoundPredicateOperator) o;
-        return type == that.type;
+        if (type.equals(CompoundType.OR) || type.equals(CompoundType.AND)) {
+            Set<ScalarOperator> thisArgs = Sets.newHashSet(this.getChildren());
+            Set<ScalarOperator> thatArgs = Sets.newHashSet(that.getChildren());
+            return thisArgs.equals(thatArgs);
+        } else {
+            return Objects.equals(this.getChildren(), that.getChildren());
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type);
+        return Objects.hash(opType, type, Sets.newHashSet(this.getChildren()).hashCode());
     }
 
     public static ScalarOperator or(List<ScalarOperator> nodes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -14,8 +14,6 @@ import java.util.stream.Collectors;
 
 public class CompoundPredicateOperator extends PredicateOperator {
     private final CompoundType type;
-    private int hash = 0;
-    private boolean hashIsZero = false;
 
     public CompoundPredicateOperator(CompoundType compoundType, ScalarOperator... arguments) {
         super(OperatorType.COMPOUND, arguments);
@@ -92,16 +90,7 @@ public class CompoundPredicateOperator extends PredicateOperator {
 
     @Override
     public int hashCode() {
-        int h = hash;
-        if (h == 0 && !hashIsZero) {
-            h = Objects.hash(opType, type, Sets.newHashSet(this.getChildren()).hashCode());
-            if (h == 0) {
-                hashIsZero = true;
-            } else {
-                hash = h;
-            }
-        }
-        return h;
+        return Objects.hash(opType, type, Sets.newHashSet(this.getChildren()).hashCode());
     }
 
     public static ScalarOperator or(List<ScalarOperator> nodes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -7,9 +7,10 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CompoundPredicateOperator extends PredicateOperator {
     private final CompoundType type;
@@ -65,6 +66,10 @@ public class CompoundPredicateOperator extends PredicateOperator {
         }
     }
 
+    private List<ScalarOperator> normalizeChildren() {
+        return getChildren().stream().sorted(Comparator.comparingInt(ScalarOperator::hashCode)).collect(Collectors.toList());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -78,9 +83,9 @@ public class CompoundPredicateOperator extends PredicateOperator {
             return false;
         }
         if (type.equals(CompoundType.OR) || type.equals(CompoundType.AND)) {
-            Set<ScalarOperator> thisArgs = Sets.newHashSet(this.getChildren());
-            Set<ScalarOperator> thatArgs = Sets.newHashSet(that.getChildren());
-            return thisArgs.equals(thatArgs);
+            List<ScalarOperator> thisArgs = this.normalizeChildren();
+            List<ScalarOperator> thatArgs = that.normalizeChildren();
+            return Objects.equals(thisArgs, thatArgs);
         } else {
             return Objects.equals(this.getChildren(), that.getChildren());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 
 public class CompoundPredicateOperator extends PredicateOperator {
     private final CompoundType type;
+    private int hash = 0;
+    private boolean hashIsZero = false;
 
     public CompoundPredicateOperator(CompoundType compoundType, ScalarOperator... arguments) {
         super(OperatorType.COMPOUND, arguments);
@@ -82,18 +84,24 @@ public class CompoundPredicateOperator extends PredicateOperator {
         if (type != that.type) {
             return false;
         }
-        if (type.equals(CompoundType.OR) || type.equals(CompoundType.AND)) {
-            List<ScalarOperator> thisArgs = this.normalizeChildren();
-            List<ScalarOperator> thatArgs = that.normalizeChildren();
-            return Objects.equals(thisArgs, thatArgs);
-        } else {
-            return Objects.equals(this.getChildren(), that.getChildren());
-        }
+
+        List<ScalarOperator> thisArgs = this.normalizeChildren();
+        List<ScalarOperator> thatArgs = that.normalizeChildren();
+        return Objects.equals(thisArgs, thatArgs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(opType, type, Sets.newHashSet(this.getChildren()).hashCode());
+        int h = hash;
+        if (h == 0 && !hashIsZero) {
+            h = Objects.hash(opType, type, Sets.newHashSet(this.getChildren()).hashCode());
+            if (h == 0) {
+                hashIsZero = true;
+            } else {
+                hash = h;
+            }
+        }
+        return h;
     }
 
     public static ScalarOperator or(List<ScalarOperator> nodes) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -601,12 +601,6 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
     }
 
-    // TODO(ywb): require any type property could consider parent required property
-    //          join1
-    //         /    \
-    //      join2
-    //    /(any) \(broadcast)
-    // Such any type property could prefer choose group expression which is could satisfy the join1 required property
     @Test
     public void testEvalPredicateCardinality() throws Exception {
         String sql = "select\n" +
@@ -627,16 +621,15 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getCostExplain(sql);
 
         // eval predicate cardinality in scan node
-        assertContains(plan, "4:OlapScanNode\n" +
+        assertContains(plan, "0:OlapScanNode\n" +
                 "     table: nation, rollup: nation\n" +
                 "     preAggregation: on\n" +
                 "     Predicates: 23: N_NATIONKEY IN (2, 1)\n" +
-                "     partitionsRatio=1/1, tabletsRatio=1/1\n");
+                "     partitionsRatio=1/1, tabletsRatio=1/1");
         // eval predicate cardinality in join node
-        assertContains(plan, "  6:NESTLOOP JOIN\n" +
+        assertContains(plan, "3:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
-                "  |  cardinality: 2\n" +
-                "  |  column statistics: \n");
+                "  |  cardinality: 2");
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q17.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q17.sql
@@ -150,56 +150,60 @@ AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] 
                         SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
 [end]
 [plan-11]
-AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(48: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [5: L_QUANTITY < multiply(0.2, 45: avg) AND 2: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-            SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
-            EXCHANGE BROADCAST
-                INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
-                        EXCHANGE SHUFFLE[29]
-                            SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
-                    EXCHANGE BROADCAST
-                        SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
+        AGGREGATE ([LOCAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+            INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY AND 5: L_QUANTITY < multiply(0.2, 45: avg)] post-join-predicate [null])
+                SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
+                EXCHANGE BROADCAST
+                    INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
+                        AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
+                            EXCHANGE SHUFFLE[29]
+                                SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
 [end]
 [plan-12]
-AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(48: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [5: L_QUANTITY < multiply(0.2, 45: avg) AND 2: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-            SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
-            EXCHANGE BROADCAST
-                INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(45: avg)}] group by [[29: L_PARTKEY]] having [null]
-                        EXCHANGE SHUFFLE[29]
-                            AGGREGATE ([LOCAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
-                                SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
-                    EXCHANGE BROADCAST
-                        SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
+        AGGREGATE ([LOCAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+            INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY AND 5: L_QUANTITY < multiply(0.2, 45: avg)] post-join-predicate [null])
+                SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
+                EXCHANGE BROADCAST
+                    INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
+                        AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(45: avg)}] group by [[29: L_PARTKEY]] having [null]
+                            EXCHANGE SHUFFLE[29]
+                                AGGREGATE ([LOCAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
+                                    SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
 [end]
 [plan-13]
-AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(48: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [5: L_QUANTITY < multiply(0.2, 45: avg) AND 2: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-            SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
-            EXCHANGE BROADCAST
-                INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
-                        EXCHANGE SHUFFLE[29]
-                            SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
-                    EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
+        AGGREGATE ([LOCAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+            INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY AND 5: L_QUANTITY < multiply(0.2, 45: avg)] post-join-predicate [null])
+                SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
+                EXCHANGE BROADCAST
+                    INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
+                        AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
+                            EXCHANGE SHUFFLE[29]
+                                SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
+                        EXCHANGE SHUFFLE[18]
+                            SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
 [end]
 [plan-14]
-AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+AGGREGATE ([GLOBAL] aggregate [{48: sum=sum(48: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [5: L_QUANTITY < multiply(0.2, 45: avg) AND 2: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-            SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
-            EXCHANGE BROADCAST
-                INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(45: avg)}] group by [[29: L_PARTKEY]] having [null]
-                        EXCHANGE SHUFFLE[29]
-                            AGGREGATE ([LOCAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
-                                SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
-                    EXCHANGE SHUFFLE[18]
-                        SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
+        AGGREGATE ([LOCAL] aggregate [{48: sum=sum(6: L_EXTENDEDPRICE)}] group by [[]] having [null]
+            INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY AND 5: L_QUANTITY < multiply(0.2, 45: avg)] post-join-predicate [null])
+                SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE] predicate[null])
+                EXCHANGE BROADCAST
+                    INNER JOIN (join-predicate [29: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
+                        AGGREGATE ([GLOBAL] aggregate [{45: avg=avg(45: avg)}] group by [[29: L_PARTKEY]] having [null]
+                            EXCHANGE SHUFFLE[29]
+                                AGGREGATE ([LOCAL] aggregate [{45: avg=avg(32: L_QUANTITY)}] group by [[29: L_PARTKEY]] having [null]
+                                    SCAN (columns[29: L_PARTKEY, 32: L_QUANTITY] predicate[null])
+                        EXCHANGE SHUFFLE[18]
+                            SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 24: P_CONTAINER] predicate[21: P_BRAND = Brand#35 AND 24: P_CONTAINER = JUMBO CASE])
 [end]

--- a/fe/fe-core/src/test/resources/sql/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q2.sql
@@ -54,7 +54,7 @@ TOP-N (order by [[16: S_ACCTBAL DESC NULLS LAST, 26: N_NAME ASC NULLS FIRST, 12:
                         INNER JOIN (join-predicate [11: S_SUPPKEY = 20: PS_SUPPKEY] post-join-predicate [null])
                             SCAN (columns[17: S_COMMENT, 11: S_SUPPKEY, 12: S_NAME, 13: S_ADDRESS, 14: S_NATIONKEY, 15: S_PHONE, 16: S_ACCTBAL] predicate[null])
                             EXCHANGE BROADCAST
-                                INNER JOIN (join-predicate [19: PS_PARTKEY = 1: P_PARTKEY AND 22: PS_SUPPLYCOST = 57: min] post-join-predicate [null])
+                                INNER JOIN (join-predicate [22: PS_SUPPLYCOST = 57: min AND 19: PS_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
                                     SCAN (columns[19: PS_PARTKEY, 20: PS_SUPPKEY, 22: PS_SUPPLYCOST] predicate[null])
                                     EXCHANGE SHUFFLE[1]
                                         INNER JOIN (join-predicate [1: P_PARTKEY = 34: PS_PARTKEY] post-join-predicate [null])

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
@@ -86,11 +86,11 @@ OutPut Exchange Id: 25
 |
 22:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [4: C_NATIONKEY, INT, false] = [40: S_NATIONKEY, INT, false]
 |  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
+|  equal join conjunct: [4: C_NATIONKEY, INT, false] = [40: S_NATIONKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (40: S_NATIONKEY), remote = true
-|  - filter_id = 5, build_expr = (37: S_SUPPKEY), remote = false
+|  - filter_id = 4, build_expr = (37: S_SUPPKEY), remote = false
+|  - filter_id = 5, build_expr = (40: S_NATIONKEY), remote = true
 |  output columns: 25, 26, 46
 |  cardinality: 16390852
 |  column statistics:
@@ -137,7 +137,7 @@ OutPut Exchange Id: 25
 |----8:EXCHANGE
 |       cardinality: 22765073
 |       probe runtime filters:
-|       - filter_id = 4, probe_expr = (4: C_NATIONKEY)
+|       - filter_id = 5, probe_expr = (4: C_NATIONKEY)
 |
 0:OlapScanNode
 table: lineitem, rollup: lineitem
@@ -147,7 +147,7 @@ actualRows=0, avgRowSize=28.0
 cardinality: 600000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (20: L_ORDERKEY)
-- filter_id = 5, probe_expr = (22: L_SUPPKEY)
+- filter_id = 4, probe_expr = (22: L_SUPPKEY)
 column statistics:
 * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
@@ -312,7 +312,7 @@ partitionsRatio=1/1, tabletsRatio=10/10
 actualRows=0, avgRowSize=12.0
 cardinality: 15000000
 probe runtime filters:
-- filter_id = 4, probe_expr = (4: C_NATIONKEY)
+- filter_id = 5, probe_expr = (4: C_NATIONKEY)
 column statistics:
 * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
 * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8675 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
CompoundPredicateOperator like a=b and c=d not equals c=d and a=b, this will result in operator not equals which use CompoundPredicateOperator as predicate or on predicate 