### PR TITLE
[cherry-pick][branch-2.1][BugFix] memory-scratch-sink output order error (backport #8578) 

### DIFF
--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -47,12 +47,14 @@ MemoryScratchSink::MemoryScratchSink(const RowDescriptor& row_desc, const std::v
 
 MemoryScratchSink::~MemoryScratchSink() = default;
 
-void MemoryScratchSink::convert_to_slot_types_and_ids() {
+void MemoryScratchSink::_prepare_id_to_col_name_map() {
     for (auto* tuple_desc : _row_desc.tuple_descriptors()) {
         auto& slots = tuple_desc->slots();
+        int64_t tuple_id = tuple_desc->id();
         for (auto slot : slots) {
-            _slot_types.push_back(&slot->type());
-            _slot_ids.push_back(slot->id());
+            int64_t slot_id = slot->id();
+            int64_t id = tuple_id << 32 | slot_id;
+            _id_to_col_name.emplace(id, slot->col_name());
         }
     }
 }
@@ -62,9 +64,10 @@ Status MemoryScratchSink::prepare_exprs(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
     // Prepare the exprs to run.
     RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc));
+    // Prepare id_to_col_name map
+    _prepare_id_to_col_name_map();
     // generate the arrow schema
-    RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, &_arrow_schema));
-    convert_to_slot_types_and_ids();
+    RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, _id_to_col_name, &_arrow_schema, _output_expr_ctxs));
     return Status::OK();
 }
 
@@ -88,8 +91,8 @@ Status MemoryScratchSink::send_chunk(RuntimeState* state, vectorized::Chunk* chu
         return Status::OK();
     }
     std::shared_ptr<arrow::RecordBatch> result;
-    RETURN_IF_ERROR(convert_chunk_to_arrow_batch(chunk, _slot_types, _slot_ids, _arrow_schema,
-                                                 arrow::default_memory_pool(), &result));
+    RETURN_IF_ERROR(convert_chunk_to_arrow_batch(chunk, _output_expr_ctxs, _arrow_schema, arrow::default_memory_pool(),
+                                                 &result));
     _queue->blocking_put(result);
     return Status::OK();
 }

--- a/be/src/runtime/memory_scratch_sink.h
+++ b/be/src/runtime/memory_scratch_sink.h
@@ -69,16 +69,19 @@ public:
 
     RuntimeProfile* profile() override { return _profile; }
 
+    // only for ut
+    std::shared_ptr<arrow::Schema> schema() { return _arrow_schema; }
+
 private:
     Status prepare_exprs(RuntimeState* state);
-    void convert_to_slot_types_and_ids();
+
+    void _prepare_id_to_col_name_map();
 
     ObjectPool* _obj_pool = nullptr;
     // Owned by the RuntimeState.
     const RowDescriptor& _row_desc;
     std::shared_ptr<arrow::Schema> _arrow_schema;
-    std::vector<const TypeDescriptor*> _slot_types;
-    std::vector<SlotId> _slot_ids;
+    std::unordered_map<int64_t, std::string> _id_to_col_name;
 
     BlockQueueSharedPtr _queue;
 

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -40,6 +40,7 @@
 
 #include "common/logging.h"
 #include "exprs/slot_ref.h"
+#include "exprs/vectorized/column_ref.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
@@ -99,21 +100,39 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     return Status::OK();
 }
 
-Status convert_to_arrow_field(SlotDescriptor* desc, std::shared_ptr<arrow::Field>* field) {
+Status convert_to_arrow_field(const TypeDescriptor& desc, const string& col_name, bool is_nullable,
+                              std::shared_ptr<arrow::Field>* field) {
     std::shared_ptr<arrow::DataType> type;
-    RETURN_IF_ERROR(convert_to_arrow_type(desc->type(), &type));
-    *field = arrow::field(desc->col_name(), type, desc->is_nullable());
+    RETURN_IF_ERROR(convert_to_arrow_type(desc, &type));
+    // we keep the col_name here just for compatibility, col_names are from the first RefSlot,
+    // users of arrow should not adjust the order of columns based on the colname.
+    *field = arrow::field(col_name, type, is_nullable);
     return Status::OK();
 }
 
-Status convert_to_arrow_schema(const RowDescriptor& row_desc, std::shared_ptr<arrow::Schema>* result) {
+Status convert_to_arrow_schema(const RowDescriptor& row_desc,
+                               const std::unordered_map<int64_t, std::string>& id_to_col_name,
+                               std::shared_ptr<arrow::Schema>* result,
+                               const std::vector<ExprContext*>& output_expr_ctxs) {
     std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (auto tuple_desc : row_desc.tuple_descriptors()) {
-        for (auto desc : tuple_desc->slots()) {
-            std::shared_ptr<arrow::Field> field;
-            RETURN_IF_ERROR(convert_to_arrow_field(desc, &field));
-            fields.push_back(field);
+    for (const auto& expr_context : output_expr_ctxs) {
+        Expr* expr = expr_context->root();
+        std::shared_ptr<arrow::Field> field;
+        string col_name;
+        vectorized::ColumnRef* col_ref = expr->get_column_ref();
+        DCHECK(col_ref != nullptr);
+        int64_t slot_id = col_ref->slot_id();
+        int64_t tuple_id = col_ref->tuple_id();
+        int64_t id = tuple_id << 32 | slot_id;
+        auto it = id_to_col_name.find(id);
+        if (it == id_to_col_name.end()) {
+            LOG(WARNING) << "Can't find the RefSlot in the row_desc.";
+        } else {
+            col_name = it->second;
         }
+
+        RETURN_IF_ERROR(convert_to_arrow_field(expr->type(), col_name, expr->is_nullable(), &field));
+        fields.push_back(field);
     }
     *result = arrow::schema(std::move(fields));
     return Status::OK();

--- a/be/src/util/arrow/row_batch.h
+++ b/be/src/util/arrow/row_batch.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "common/status.h"
+#include "exprs/expr.h"
 
 // This file will convert StarRocks RowBatch to/from Arrow's RecordBatch
 // RowBatch is used by StarRocks query engine to exchange data between
@@ -41,7 +42,10 @@ namespace starrocks {
 class RowDescriptor;
 
 // Convert StarRocks RowDescriptor to Arrow Schema.
-Status convert_to_arrow_schema(const RowDescriptor& row_desc, std::shared_ptr<arrow::Schema>* result);
+Status convert_to_arrow_schema(const RowDescriptor& row_desc,
+                               const std::unordered_map<int64_t, std::string>& id_to_col_name,
+                               std::shared_ptr<arrow::Schema>* result,
+                               const std::vector<ExprContext*>& output_expr_ctxs);
 
 Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::string* result);
 

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -5,6 +5,7 @@
 #include "column/type_traits.h"
 #include "common/statusor.h"
 #include "exec/vectorized/arrow_type_traits.h"
+#include "exprs/expr.h"
 #include "util/raw_container.h"
 
 namespace starrocks::vectorized {
@@ -282,6 +283,34 @@ private:
     std::shared_ptr<arrow::Array>& _array;
 };
 
+Status convert_chunk_to_arrow_batch(Chunk* chunk, std::vector<ExprContext*>& _output_expr_ctxs,
+                                    const std::shared_ptr<arrow::Schema>& schema, arrow::MemoryPool* pool,
+                                    std::shared_ptr<arrow::RecordBatch>* result) {
+    if (chunk->num_columns() != schema->num_fields()) {
+        return Status::InvalidArgument("number fields not match");
+    }
+
+    int result_num_column = _output_expr_ctxs.size();
+    std::vector<std::shared_ptr<arrow::Array>> arrays(result_num_column);
+
+    for (auto i = 0; i < result_num_column; ++i) {
+        ColumnPtr column = _output_expr_ctxs[i]->evaluate(chunk);
+        Expr* expr = _output_expr_ctxs[i]->root();
+        if (column->is_constant()) {
+            column = vectorized::ColumnHelper::unfold_const_column(expr->type(), chunk->num_rows(), column);
+        }
+        auto& array = arrays[i];
+        ColumnToArrowArrayConverter converter(column, pool, expr->type().type, array);
+        auto arrow_st = arrow::VisitTypeInline(*schema->field(i)->type(), &converter);
+        if (!arrow_st.ok()) {
+            return Status::InvalidArgument(arrow_st.ToString());
+        }
+    }
+    *result = arrow::RecordBatch::Make(schema, chunk->num_rows(), std::move(arrays));
+    return Status::OK();
+}
+
+// only used for UT test
 Status convert_chunk_to_arrow_batch(Chunk* chunk, const std::vector<const TypeDescriptor*>& slot_types,
                                     const std::vector<SlotId>& slot_ids, const std::shared_ptr<arrow::Schema>& schema,
                                     arrow::MemoryPool* pool, std::shared_ptr<arrow::RecordBatch>* result) {

--- a/be/src/util/arrow/starrocks_column_to_arrow.h
+++ b/be/src/util/arrow/starrocks_column_to_arrow.h
@@ -23,8 +23,13 @@
 namespace starrocks {
 namespace vectorized {
 
+Status convert_chunk_to_arrow_batch(Chunk* chunk, std::vector<ExprContext*>& _output_expr_ctxs,
+                                    const std::shared_ptr<arrow::Schema>& schema, arrow::MemoryPool* pool,
+                                    std::shared_ptr<arrow::RecordBatch>* result);
+
+// only used for UT test
 Status convert_chunk_to_arrow_batch(Chunk* chunk, const std::vector<const TypeDescriptor*>& _slot_types,
                                     const std::vector<SlotId>& _slot_ids, const std::shared_ptr<arrow::Schema>& schema,
                                     arrow::MemoryPool* pool, std::shared_ptr<arrow::RecordBatch>* result);
-}
+} // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8576

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In current implementation, the output of memory order is based on the tuple_descriptors.
This is not corrent, the right order should base on the output_expr.