### PR TITLE
[Enhancement] Add PseudoCluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
@@ -40,11 +40,10 @@ public class ThriftServerEventProcessor implements TServerEventHandler {
 
     private ThriftServer thriftServer;
 
-    private static ThreadLocal<ThriftServerContext> connectionContext;
+    private static ThreadLocal<ThriftServerContext> connectionContext = new ThreadLocal<>();
 
     public ThriftServerEventProcessor(ThriftServer thriftServer) {
         this.thriftServer = thriftServer;
-        connectionContext = new ThreadLocal<>();
     }
 
     public static ThriftServerContext getConnectionContext() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -115,9 +115,10 @@ public final class QeProcessorImpl implements QeProcessor {
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);
         if (info == null) {
-            result.setStatus(new TStatus(TStatusCode.NOT_FOUND));
             LOG.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
                     DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+            result.setStatus(new TStatus(TStatusCode.NOT_FOUND));
+            result.status.addToError_msgs("query id " + DebugUtil.printId(params.query_id) + " not found");
             return result;
         }
         try {
@@ -125,6 +126,9 @@ public final class QeProcessorImpl implements QeProcessor {
         } catch (Exception e) {
             LOG.warn("ReportExecStatus() failed, fragment_instance_id={}, query_id={}, error: {}",
                     DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id), e.getMessage());
+            LOG.warn("stack:", e);
+            result.setStatus(new TStatus(TStatusCode.INTERNAL_ERROR));
+            result.status.addToError_msgs(e.getMessage());
             return result;
         }
         result.setStatus(new TStatus(TStatusCode.OK));

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
@@ -25,7 +25,7 @@ public class BrpcProxy {
                 .setCompiler(new JdkCompiler(JdkCompiler.class.getClassLoader(), String.valueOf(javaRuntimeVersion)));
     }
 
-    private BrpcProxy() {
+    public BrpcProxy() {
         final RpcClientOptions rpcOptions = new RpcClientOptions();
         // If false, different methods to a service endpoint use different connection pool,
         // which will create too many connections.
@@ -46,6 +46,13 @@ public class BrpcProxy {
 
     public static BrpcProxy getInstance() {
         return BrpcProxy.SingletonHolder.INSTANCE;
+    }
+
+    /**
+     * Only used for pseudo cluster or unittest
+     */
+    public static void setInstance(BrpcProxy proxy) {
+        BrpcProxy.SingletonHolder.INSTANCE = proxy;
     }
 
     public PBackendService getBackendService(TNetworkAddress address) {
@@ -71,6 +78,6 @@ public class BrpcProxy {
     }
 
     private static class SingletonHolder {
-        private static final BrpcProxy INSTANCE = new BrpcProxy();
+        private static BrpcProxy INSTANCE = new BrpcProxy();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeTabletManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeTabletManager.java
@@ -1,0 +1,71 @@
+package com.starrocks.pseudocluster;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.UserException;
+import com.starrocks.thrift.TCreateTabletReq;
+import com.starrocks.thrift.TTablet;
+import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTabletStat;
+import com.starrocks.thrift.TTabletStatResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+public class BeTabletManager {
+    private static final Logger LOG = LogManager.getLogger(BeTabletManager.class);
+    PseudoBackend backend;
+    Map<Long, Tablet> tablets;
+
+    public BeTabletManager(PseudoBackend backend) {
+        this.backend = backend;
+        tablets = Maps.newHashMap();
+    }
+
+    public synchronized Tablet createTablet(TCreateTabletReq request) throws UserException {
+        if (tablets.get(request.tablet_id) != null) {
+            throw new AlreadyExistsException("Tablet already exists");
+        }
+        Tablet tablet = new Tablet(request.tablet_id, request.table_id, request.partition_id,
+                request.tablet_schema.getSchema_hash(), request.enable_persistent_index);
+        tablets.put(request.tablet_id, tablet);
+        LOG.info("created tablet {}", tablet.id);
+        return tablet;
+    }
+
+    public synchronized void dropTablet(long tabletId, boolean force) {
+        Tablet removed = tablets.remove(tabletId);
+        if (removed != null) {
+            LOG.info("Dropped tablet {} force:{}", removed.id, force);
+        } else {
+            LOG.info("Drop Tablet {} not found", tabletId);
+        }
+    }
+
+    public synchronized Tablet getTablet(long tabletId) {
+        return tablets.get(tabletId);
+    }
+
+    void getTabletStat(TTabletStatResult result) {
+        Map<Long, TTabletStat> statMap = Maps.newHashMap();
+        for (Tablet tablet : tablets.values()) {
+            statMap.put(tablet.id, tablet.getStats());
+        }
+        result.tablets_stats = statMap;
+    }
+
+    void getTabletInfo(TTabletInfo info) {
+
+    }
+
+    public synchronized Map<Long, TTablet> getAllTabletInfo() {
+        Map<Long, TTablet> tabletInfo = Maps.newHashMap();
+        for (Tablet tablet : tablets.values()) {
+            TTablet tTablet = new TTablet();
+            tTablet.addToTablet_infos(tablet.toThrift());
+            tabletInfo.put(tablet.id, tTablet);
+        }
+        return tabletInfo;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeTxnManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeTxnManager.java
@@ -1,0 +1,103 @@
+package com.starrocks.pseudocluster;
+
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.UserException;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TPartitionVersionInfo;
+import com.starrocks.thrift.TTabletVersionPair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BeTxnManager {
+    private static final Logger LOG = LogManager.getLogger(BeTxnManager.class);
+
+    static class TxnTabletInfo {
+        long tabletId;
+        Rowset rowset;
+
+        public TxnTabletInfo(long tabletId) {
+            this.tabletId = tabletId;
+        }
+    }
+
+    static class TxnInfo {
+        long txnId;
+        Map<Long, Map<Long, TxnTabletInfo>> partitions;
+
+        TxnInfo(long txnId) {
+            this.txnId = txnId;
+            partitions = new HashMap<>();
+        }
+    }
+
+    PseudoBackend backend;
+    Map<Long, TxnInfo> txns = new HashMap<>();
+
+    BeTxnManager(PseudoBackend backend) {
+        this.backend = backend;
+    }
+
+    public synchronized void commit(long txnId, long partitionId, Tablet tablet, Rowset rowset) throws UserException {
+        TxnInfo tinfo = txns.computeIfAbsent(txnId, k -> new TxnInfo(k));
+        Map<Long, TxnTabletInfo> tablets = tinfo.partitions.computeIfAbsent(partitionId, k -> new HashMap<>());
+        TxnTabletInfo tabletInfo = tablets.get(tablet.id);
+        if (tabletInfo != null) {
+            throw new AlreadyExistsException("txn:" + txnId + " tablet:" + tablet.id + " already exists");
+        }
+        tabletInfo = tablets.computeIfAbsent(tablet.id, id -> new TxnTabletInfo(id));
+        tabletInfo.rowset = rowset;
+    }
+
+    public synchronized void publish(long txnId, List<TPartitionVersionInfo> partitions, TFinishTaskRequest finish) {
+        TxnInfo tinfo = txns.get(txnId);
+        if (tinfo == null) {
+            return;
+        }
+        Exception e = null;
+        int totalTablets = 0;
+        List<Long> errorTabletIds = new ArrayList<>();
+        List<TTabletVersionPair> tabletVersions = new ArrayList<>();
+        for (TPartitionVersionInfo pInfo : partitions) {
+            Map<Long, TxnTabletInfo> tablets = tinfo.partitions.get(pInfo.partition_id);
+            if (tablets == null) {
+                LOG.warn("publish version txn:" + txnId + " partition:" + pInfo.partition_id + " not found");
+                continue;
+            }
+            for (TxnTabletInfo tabletInfo : tablets.values()) {
+                totalTablets++;
+                Tablet tablet = backend.getTabletManager().getTablet(tabletInfo.tabletId);
+                if (tablet == null) {
+                    errorTabletIds.add(tablet.id);
+                    if (e == null) {
+                        e = new UserException(
+                                "publish version failed txn:" + txnId + " partition:" + pInfo.partition_id + " tablet:" +
+                                        tablet.id + " not found");
+                    }
+                } else {
+                    try {
+                        tablet.commitRowset(tabletInfo.rowset, pInfo.version);
+                    } catch (Exception ex) {
+                        errorTabletIds.add(tablet.id);
+                        e = ex;
+                    }
+                    TTabletVersionPair p = new TTabletVersionPair();
+                    p.tablet_id = tablet.id;
+                    p.version = tablet.max_continuous_version();
+                    tabletVersions.add(p);
+                }
+            }
+        }
+        LOG.info("publish version error:{} / total:{} {}", errorTabletIds.size(), totalTablets, e == null ? "" : e.getMessage());
+        finish.setError_tablet_ids(errorTabletIds);
+        finish.setTablet_versions(tabletVersions);
+        if (e != null) {
+            finish.setTask_status(PseudoBackend.toStatus(e));
+        }
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -1,0 +1,745 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.pseudocluster;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.NotImplementedException;
+import com.starrocks.common.UserException;
+import com.starrocks.proto.PCancelPlanFragmentRequest;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.PFetchDataResult;
+import com.starrocks.proto.PProxyRequest;
+import com.starrocks.proto.PProxyResult;
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.proto.PTabletInfo;
+import com.starrocks.proto.PTabletWithPartition;
+import com.starrocks.proto.PTabletWriterAddBatchResult;
+import com.starrocks.proto.PTabletWriterAddChunkRequest;
+import com.starrocks.proto.PTabletWriterCancelRequest;
+import com.starrocks.proto.PTabletWriterCancelResult;
+import com.starrocks.proto.PTabletWriterOpenRequest;
+import com.starrocks.proto.PTabletWriterOpenResult;
+import com.starrocks.proto.PTriggerProfileReportResult;
+import com.starrocks.proto.PUniqueId;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.rpc.PBackendService;
+import com.starrocks.rpc.PExecPlanFragmentRequest;
+import com.starrocks.rpc.PFetchDataRequest;
+import com.starrocks.rpc.PTriggerProfileReportRequest;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.BackendService;
+import com.starrocks.thrift.FrontendService;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.HeartbeatService;
+import com.starrocks.thrift.TAgentPublishRequest;
+import com.starrocks.thrift.TAgentResult;
+import com.starrocks.thrift.TAgentTaskRequest;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TBackendInfo;
+import com.starrocks.thrift.TCancelPlanFragmentParams;
+import com.starrocks.thrift.TCancelPlanFragmentResult;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
+import com.starrocks.thrift.TDeleteEtlFilesRequest;
+import com.starrocks.thrift.TDisk;
+import com.starrocks.thrift.TEtlState;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TExecPlanFragmentResult;
+import com.starrocks.thrift.TExportState;
+import com.starrocks.thrift.TExportStatusResult;
+import com.starrocks.thrift.TExportTaskRequest;
+import com.starrocks.thrift.TFetchDataParams;
+import com.starrocks.thrift.TFetchDataResult;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.THeartbeatResult;
+import com.starrocks.thrift.TMasterInfo;
+import com.starrocks.thrift.TMasterResult;
+import com.starrocks.thrift.TMiniLoadEtlStatusRequest;
+import com.starrocks.thrift.TMiniLoadEtlStatusResult;
+import com.starrocks.thrift.TMiniLoadEtlTaskRequest;
+import com.starrocks.thrift.TPublishVersionRequest;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TReportExecStatusResult;
+import com.starrocks.thrift.TReportRequest;
+import com.starrocks.thrift.TRoutineLoadTask;
+import com.starrocks.thrift.TScanBatchResult;
+import com.starrocks.thrift.TScanCloseParams;
+import com.starrocks.thrift.TScanCloseResult;
+import com.starrocks.thrift.TScanNextBatchParams;
+import com.starrocks.thrift.TScanOpenParams;
+import com.starrocks.thrift.TScanOpenResult;
+import com.starrocks.thrift.TSnapshotRequest;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.thrift.TTabletStatResult;
+import com.starrocks.thrift.TTransmitDataParams;
+import com.starrocks.thrift.TTransmitDataResult;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PseudoBackend {
+    private static final Logger LOG = LogManager.getLogger(PseudoBackend.class);
+    private static final int REPORT_INTERVAL_SEC = 60;
+    private static final int REPORT_TASK_INTERVAL_SEC = 10;
+
+    private final PseudoCluster cluster;
+    private final String runPath;
+    private final String host;
+    private final int brpcPort;
+    private final int heartBeatPort;
+    private final int beThriftPort;
+    private final int httpPort;
+    private final FrontendService.Iface frontendService;
+
+    private final TBackend tBackend;
+    private AtomicLong reportVersion = new AtomicLong(0);
+    private final BeTabletManager tabletManager = new BeTabletManager(this);
+    private final BeTxnManager txnManager = new BeTxnManager(this);
+
+    private volatile boolean stopped = false;
+    private Thread reportTabletsWorker;
+    private Thread reportDisksWorker;
+    private Thread reportTasksWorker;
+
+    Backend be;
+    HeartBeatClient heatBeatClient;
+    BeThriftClient backendClient;
+    PseudoPBackendService pBackendService;
+
+    private AtomicLong nextRowsetId = new AtomicLong(0);
+
+    String genRowsetId() {
+        return String.format("rowset-%d-%d", be.getId(), nextRowsetId.incrementAndGet());
+    }
+
+    public PseudoBackend(PseudoCluster cluster, String runPath, long backendId, String host, int brpcPort, int heartBeatPort,
+                         int beThriftPort, int httpPort,
+                         FrontendService.Iface frontendService) {
+        this.cluster = cluster;
+        this.runPath = runPath;
+        this.host = host;
+        this.brpcPort = brpcPort;
+        this.heartBeatPort = heartBeatPort;
+        this.beThriftPort = beThriftPort;
+        this.httpPort = httpPort;
+        this.frontendService = frontendService;
+
+        this.be = new Backend(backendId, host, heartBeatPort);
+        this.tBackend = new TBackend(host, beThriftPort, httpPort);
+
+        Map<String, DiskInfo> disks = Maps.newHashMap();
+        DiskInfo diskInfo1 = new DiskInfo(runPath + "/storage");
+        // TODO: maintain disk info with tablet/rowset count
+        diskInfo1.setTotalCapacityB(100000000000L);
+        diskInfo1.setAvailableCapacityB(50000000000L);
+        diskInfo1.setDataUsedCapacityB(20000000000L);
+        diskInfo1.setPathHash(backendId);
+        diskInfo1.setStorageMedium(TStorageMedium.SSD);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+        be.setDisks(ImmutableMap.copyOf(disks));
+        be.setAlive(true);
+        be.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
+        be.setBePort(beThriftPort);
+        be.setBrpcPort(brpcPort);
+        be.setHttpPort(httpPort);
+        GlobalStateMgr.getCurrentSystemInfo().addBackend(be);
+        this.heatBeatClient = new HeartBeatClient();
+        this.backendClient = new BeThriftClient();
+        this.pBackendService = new PseudoPBackendService();
+
+        reportTabletsWorker = new Thread(() -> {
+            while (!stopped) {
+                try {
+                    Random r = new Random();
+                    int wait = REPORT_INTERVAL_SEC + r.nextInt(7) - 3;
+                    for (int i = 0; i < wait; i++) {
+                        Thread.sleep(1000);
+                        if (stopped) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    LOG.error("reportWorker interrupted", e);
+                }
+                if (stopped) {
+                    break;
+                }
+                try {
+                    reportTablets();
+                } catch (Exception e) {
+                    LOG.error("reportWorker error", e);
+                }
+            }
+        }, "reportTablets" + be.getId());
+        reportTabletsWorker.start();
+
+        reportDisksWorker = new Thread(() -> {
+            while (!stopped) {
+                try {
+                    Random r = new Random();
+                    int wait = REPORT_INTERVAL_SEC + r.nextInt(7) - 3;
+                    for (int i = 0; i < wait; i++) {
+                        Thread.sleep(1000);
+                        if (stopped) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    LOG.error("reportWorker interrupted", e);
+                }
+                if (stopped) {
+                    break;
+                }
+                try {
+                    reportDisks();
+                } catch (Exception e) {
+                    LOG.error("reportWorker error", e);
+                }
+            }
+        }, "reportDisks" + be.getId());
+        reportDisksWorker.start();
+
+        reportTasksWorker = new Thread(() -> {
+            while (!stopped) {
+                try {
+                    Random r = new Random();
+                    int wait = REPORT_INTERVAL_SEC + r.nextInt(7) - 3;
+                    for (int i = 0; i < wait; i++) {
+                        Thread.sleep(1000);
+                        if (stopped) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    LOG.error("reportWorker interrupted", e);
+                }
+                if (stopped) {
+                    break;
+                }
+                try {
+                    reportTasks();
+                } catch (Exception e) {
+                    LOG.error("reportWorker error", e);
+                }
+            }
+        }, "reportTasks" + be.getId());
+        reportTasksWorker.start();
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public BeTxnManager getTxnManager() {
+        return txnManager;
+    }
+
+    public BeTabletManager getTabletManager() {
+        return tabletManager;
+    }
+
+    private void reportTablets() {
+        // report tablets
+        TReportRequest request = new TReportRequest();
+        request.setTablets(tabletManager.getAllTabletInfo());
+        request.setTablet_max_compaction_score(100);
+        request.setBackend(tBackend);
+        request.setReport_version(reportVersion.get());
+        TMasterResult result;
+        try {
+            result = frontendService.report(request);
+        } catch (TException e) {
+            LOG.error("report tablets error", e);
+            return;
+        }
+    }
+
+    private void reportDisks() {
+        // report disks
+        TReportRequest request = new TReportRequest();
+        Map<String, TDisk> tdisks = new HashMap<>();
+        ImmutableMap<String, DiskInfo> diskInfos = be.getDisks();
+        for (Map.Entry<String, DiskInfo> entry : diskInfos.entrySet()) {
+            TDisk tdisk = new TDisk();
+            tdisk.setRoot_path(entry.getKey());
+            tdisk.setPath_hash(entry.getValue().getPathHash());
+            tdisk.setDisk_total_capacity(entry.getValue().getTotalCapacityB());
+            tdisk.setDisk_available_capacity(entry.getValue().getAvailableCapacityB());
+            tdisk.setData_used_capacity(entry.getValue().getDataUsedCapacityB());
+            tdisk.setStorage_medium(entry.getValue().getStorageMedium());
+            tdisk.setUsed(true);
+            tdisks.put(entry.getKey(), tdisk);
+        }
+        request.setDisks(tdisks);
+        request.setBackend(tBackend);
+        request.setReport_version(reportVersion.get());
+        TMasterResult result;
+        try {
+            result = frontendService.report(request);
+        } catch (TException e) {
+            LOG.error("report disk error", e);
+            return;
+        }
+    }
+
+    private void reportTasks() {
+        // report tasks
+        TReportRequest request = new TReportRequest();
+        request.setTasks(new HashMap<>());
+        request.setBackend(tBackend);
+        request.setReport_version(reportVersion.get());
+        TMasterResult result;
+        try {
+            result = frontendService.report(request);
+        } catch (TException e) {
+            LOG.error("report tasks error", e);
+            return;
+        }
+    }
+
+    public static TStatus toStatus(Exception e) {
+        TStatus ts = new TStatus();
+        ts.setError_msgs(Lists.newArrayList(e.getMessage()));
+        if (e instanceof NotImplementedException) {
+            ts.setStatus_code(TStatusCode.NOT_IMPLEMENTED_ERROR);
+        } else if (e instanceof AlreadyExistsException) {
+            ts.setStatus_code(TStatusCode.ALREADY_EXIST);
+        } else {
+            ts.setStatus_code(TStatusCode.INTERNAL_ERROR);
+        }
+        return ts;
+    }
+
+    void handleCreateTablet(TAgentTaskRequest request, TFinishTaskRequest finish) throws UserException {
+        Tablet t = tabletManager.createTablet(request.create_tablet_req);
+    }
+
+    void handleDropTablet(TAgentTaskRequest request, TFinishTaskRequest finish) {
+        tabletManager.dropTablet(request.drop_tablet_req.tablet_id, request.drop_tablet_req.force);
+    }
+
+    void handlePublish(TAgentTaskRequest request, TFinishTaskRequest finish) {
+        TPublishVersionRequest task = request.publish_version_req;
+        txnManager.publish(task.transaction_id, task.partition_version_infos, finish);
+    }
+
+    void handleTask(TAgentTaskRequest request) {
+        TFinishTaskRequest finishTaskRequest = new TFinishTaskRequest(tBackend,
+                request.getTask_type(), request.getSignature(), new TStatus(TStatusCode.OK));
+        long v = reportVersion.incrementAndGet();
+        finishTaskRequest.setReport_version(v);
+        try {
+            switch (finishTaskRequest.task_type) {
+                case CREATE:
+                    handleCreateTablet(request, finishTaskRequest);
+                    break;
+                case DROP:
+                    handleDropTablet(request, finishTaskRequest);
+                    break;
+                case PUBLISH_VERSION:
+                    handlePublish(request, finishTaskRequest);
+                    break;
+                default:
+                    LOG.info("ignore task type:" + finishTaskRequest.task_type + " signature:" + finishTaskRequest.signature);
+            }
+        } catch (Exception e) {
+            LOG.warn("Exception in handleTask", e);
+            finishTaskRequest.setTask_status(toStatus(e));
+        }
+        try {
+            frontendService.finishTask(finishTaskRequest);
+        } catch (TException e) {
+            LOG.warn("error call finishTask", e);
+        }
+    }
+
+    private class HeartBeatClient extends HeartbeatService.Client {
+        public HeartBeatClient() {
+            super(null);
+        }
+
+        @Override
+        public THeartbeatResult heartbeat(TMasterInfo master_info) throws TException {
+            TBackendInfo backendInfo = new TBackendInfo(beThriftPort, httpPort);
+            backendInfo.setBrpc_port(brpcPort);
+            return new THeartbeatResult(new TStatus(TStatusCode.OK), backendInfo);
+        }
+    }
+
+    private class BeThriftClient extends BackendService.Client {
+        private final BlockingQueue<TAgentTaskRequest> taskQueue = Queues.newLinkedBlockingQueue();
+
+        BeThriftClient() {
+            super(null);
+            new Thread(() -> {
+                while (true) {
+                    try {
+                        TAgentTaskRequest request = taskQueue.take();
+                        handleTask(request);
+                    } catch (InterruptedException e) {
+                        LOG.warn("error get task", e);
+                    }
+                }
+            }).start();
+        }
+
+        @Override
+        public TAgentResult submit_tasks(List<TAgentTaskRequest> tasks) {
+            taskQueue.addAll(tasks);
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TExecPlanFragmentResult exec_plan_fragment(TExecPlanFragmentParams params) {
+            return null;
+        }
+
+        @Override
+        public TCancelPlanFragmentResult cancel_plan_fragment(TCancelPlanFragmentParams params) {
+            return null;
+        }
+
+        @Override
+        public TTransmitDataResult transmit_data(TTransmitDataParams params) {
+            return null;
+        }
+
+        @Override
+        public TFetchDataResult fetch_data(TFetchDataParams params) {
+            return null;
+        }
+
+        @Override
+        public TAgentResult make_snapshot(TSnapshotRequest snapshot_request) {
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TAgentResult release_snapshot(String snapshot_path) {
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TAgentResult publish_cluster_state(TAgentPublishRequest request) {
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TAgentResult submit_etl_task(TMiniLoadEtlTaskRequest request) {
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TMiniLoadEtlStatusResult get_etl_status(TMiniLoadEtlStatusRequest request) {
+            return new TMiniLoadEtlStatusResult(new TStatus(TStatusCode.OK), TEtlState.FINISHED);
+        }
+
+        @Override
+        public TAgentResult delete_etl_files(TDeleteEtlFilesRequest request) {
+            return new TAgentResult(new TStatus(TStatusCode.OK));
+        }
+
+        @Override
+        public TStatus submit_export_task(TExportTaskRequest request) {
+            return new TStatus(TStatusCode.OK);
+        }
+
+        @Override
+        public TExportStatusResult get_export_status(TUniqueId task_id) {
+            return new TExportStatusResult(new TStatus(TStatusCode.OK), TExportState.FINISHED);
+        }
+
+        @Override
+        public TStatus erase_export_task(TUniqueId task_id) {
+            return new TStatus(TStatusCode.OK);
+        }
+
+        @Override
+        public TTabletStatResult get_tablet_stat() {
+            TTabletStatResult stats = new TTabletStatResult();
+            tabletManager.getTabletStat(stats);
+            return stats;
+        }
+
+        @Override
+        public TStatus submit_routine_load_task(List<TRoutineLoadTask> tasks) {
+            return new TStatus(TStatusCode.OK);
+        }
+
+        @Override
+        public TScanOpenResult open_scanner(TScanOpenParams params) {
+            return null;
+        }
+
+        @Override
+        public TScanBatchResult get_next(TScanNextBatchParams params) {
+            return null;
+        }
+
+        @Override
+        public TScanCloseResult close_scanner(TScanCloseParams params) {
+            return null;
+        }
+
+    }
+
+    private class PseudoPBackendService implements PBackendService {
+        private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        @Override
+        public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+            TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
+            final TExecPlanFragmentParams params = new TExecPlanFragmentParams();
+            PExecPlanFragmentResult result = new PExecPlanFragmentResult();
+            result.status = new StatusPB();
+            result.status.statusCode = 0;
+            try {
+                deserializer.deserialize(params, request.getSerializedRequest());
+            } catch (TException e) {
+                LOG.warn("error deserialize request", e);
+                result.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                result.status.errorMsgs = Lists.newArrayList(e.getMessage());
+                return CompletableFuture.completedFuture(result);
+            }
+            executor.submit(() -> {
+                try {
+                    execPlanFragment(params);
+                } catch (Exception e) {
+                    LOG.warn("error execPlanFragment", e);
+                }
+            });
+            return CompletableFuture.completedFuture(result);
+        }
+
+        @Override
+        public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request) {
+            return executor.submit(() -> {
+                PCancelPlanFragmentResult result = new PCancelPlanFragmentResult();
+                StatusPB pStatus = new StatusPB();
+                pStatus.statusCode = 0;
+                result.status = pStatus;
+                return result;
+            });
+        }
+
+        @Override
+        public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+            return executor.submit(() -> {
+                PFetchDataResult result = new PFetchDataResult();
+                StatusPB pStatus = new StatusPB();
+                pStatus.statusCode = 0;
+
+                PQueryStatistics pQueryStatistics = new PQueryStatistics();
+                pQueryStatistics.scanRows = 0L;
+                pQueryStatistics.scanBytes = 0L;
+                pQueryStatistics.cpuCostNs = 0L;
+                pQueryStatistics.memCostBytes = 0L;
+
+                result.status = pStatus;
+                result.packetSeq = 0L;
+                result.queryStatistics = pQueryStatistics;
+                result.eos = true;
+                return result;
+            });
+        }
+
+        @Override
+        public Future<PTriggerProfileReportResult> triggerProfileReport(PTriggerProfileReportRequest request) {
+            return null;
+        }
+
+        @Override
+        public Future<PProxyResult> getInfo(PProxyRequest request) {
+            return null;
+        }
+    }
+
+    void execPlanFragment(TExecPlanFragmentParams params) {
+        LOG.info("exec_plan_fragment {}", params.params.fragment_instance_id.toString());
+        TReportExecStatusParams report = new TReportExecStatusParams();
+        report.setProtocol_version(FrontendServiceVersion.V1);
+        report.setQuery_id(params.params.query_id);
+        report.setBackend_num(params.backend_num);
+        report.setBackend_id(be.getId());
+        report.setFragment_instance_id(params.params.fragment_instance_id);
+        report.setDone(true);
+        // TODO: support error injection
+        report.setStatus(new TStatus(TStatusCode.OK));
+        if (params.fragment.output_sink != null) {
+            TDataSink tDataSink = params.fragment.output_sink;
+            runSink(report, tDataSink);
+        }
+        try {
+            TReportExecStatusResult ret = frontendService.reportExecStatus(report);
+            if (ret.status.status_code != TStatusCode.OK) {
+                LOG.warn("error report exec status " + (ret.status.error_msgs.isEmpty() ? "" : ret.status.error_msgs.get(0)));
+            }
+        } catch (TException e) {
+            LOG.warn("error report exec status", e);
+        }
+    }
+
+    private void runSink(TReportExecStatusParams report, TDataSink tDataSink) {
+        if (tDataSink.type != TDataSinkType.OLAP_TABLE_SINK) {
+            return;
+        }
+        PseudoOlapTableSink sink = new PseudoOlapTableSink(cluster, tDataSink);
+        if (!sink.open()) {
+            sink.cancel();
+            report.setDone(false);
+            return;
+        }
+        if (!sink.close()) {
+            report.setDone(false);
+            sink.cancel();
+            return;
+        }
+        List<TTabletCommitInfo> commitInfos = sink.getTabletCommitInfos();
+        report.setCommitInfos(commitInfos);
+        report.setLoad_counters(sink.getLoadCounters());
+    }
+
+    class LoadChannel {
+        class TabletsChannel {
+            long indexId;
+            List<PTabletWithPartition> tablets;
+
+            TabletsChannel(long indexId) {
+                this.indexId = indexId;
+            }
+
+            void open(PTabletWriterOpenRequest request) {
+                tablets = request.tablets;
+            }
+
+            void cancel() {
+            }
+
+            void buildAndCommitRowset(long txnId, Tablet tablet) throws UserException {
+                Rowset rowset = new Rowset(genRowsetId());
+                txnManager.commit(txnId, tablet.partitionId, tablet, rowset);
+            }
+
+            void close(PTabletWriterAddChunkRequest request, PTabletWriterAddBatchResult result) throws UserException {
+                result.tabletVec = new ArrayList<>();
+                for (PTabletWithPartition tabletWithPartition : tablets) {
+                    Tablet tablet = tabletManager.getTablet(tabletWithPartition.tabletId);
+                    if (tablet == null) {
+                        LOG.warn("tablet not found {}", tabletWithPartition.tabletId);
+                        continue;
+                    }
+                    buildAndCommitRowset(txnId, tablet);
+                    PTabletInfo info = new PTabletInfo();
+                    info.tabletId = tablet.id;
+                    info.schemaHash = tablet.schemaHash;
+                    result.tabletVec.add(info);
+                }
+            }
+        }
+
+        PUniqueId id;
+        long txnId;
+        Map<Long, TabletsChannel> indexToTabletsChannel = new HashMap<>();
+
+        LoadChannel(PUniqueId id) {
+            this.id = id;
+        }
+
+        void open(PTabletWriterOpenRequest request, PTabletWriterOpenResult result) {
+            this.txnId = request.txnId;
+            if (indexToTabletsChannel.containsKey(request.indexId)) {
+                return;
+            }
+            TabletsChannel tabletsChannel = indexToTabletsChannel.computeIfAbsent(request.indexId, k -> new TabletsChannel(k));
+            tabletsChannel.open(request);
+        }
+
+        void cancel() {
+            for (TabletsChannel tabletsChannel : indexToTabletsChannel.values()) {
+                tabletsChannel.cancel();
+            }
+        }
+
+        void close(PTabletWriterAddChunkRequest request, PTabletWriterAddBatchResult result) throws UserException {
+            TabletsChannel tabletsChannel = indexToTabletsChannel.get(request.indexId);
+            if (tabletsChannel == null) {
+                result.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                result.status.errorMsgs.add("cannot find the tablets channel associated with the index id");
+            } else {
+                tabletsChannel.close(request, result);
+            }
+        }
+    }
+
+    Map<String, LoadChannel> loadChannels = new HashMap<>();
+
+    synchronized PTabletWriterOpenResult tabletWriterOpen(PTabletWriterOpenRequest request) {
+        PTabletWriterOpenResult result = new PTabletWriterOpenResult();
+        result.status = new StatusPB();
+        result.status.statusCode = 0;
+        String loadIdString = String.format("%d-%d", request.id.hi, request.id.lo);
+        LoadChannel loadChannel = loadChannels.computeIfAbsent(loadIdString, k -> new LoadChannel(request.id));
+        loadChannel.open(request, result);
+        return result;
+    }
+
+    synchronized PTabletWriterCancelResult tabletWriterCancel(PTabletWriterCancelRequest request) {
+        PTabletWriterCancelResult result = new PTabletWriterCancelResult();
+        String loadIdString = String.format("%d-%d", request.id.hi, request.id.lo);
+        LoadChannel loadChannel = loadChannels.get(loadIdString);
+        if (loadChannel != null) {
+            loadChannel.cancel();
+        }
+        return result;
+    }
+
+    synchronized PTabletWriterAddBatchResult tabletWriterAddChunk(PTabletWriterAddChunkRequest request) {
+        PTabletWriterAddBatchResult result = new PTabletWriterAddBatchResult();
+        result.status = new StatusPB();
+        result.status.statusCode = 0;
+        if (request.eos) {
+            String loadIdString = String.format("%d-%d", request.id.hi, request.id.lo);
+            LoadChannel channel = loadChannels.get(loadIdString);
+            if (channel != null) {
+                try {
+                    channel.close(request, result);
+                } catch (UserException e) {
+                    LOG.warn("error close load channel", e);
+                    channel.cancel();
+                    loadChannels.remove(loadIdString);
+                    result.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                    result.status.errorMsgs.add(e.getMessage());
+                }
+            } else {
+                result.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                result.status.errorMsgs.add("no associated load channel");
+            }
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -1,0 +1,137 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.pseudocluster;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.starrocks.common.ClientPool;
+import com.starrocks.common.Config;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.PBackendService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.BackendService;
+import com.starrocks.thrift.HeartbeatService;
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PseudoCluster {
+    private static final Logger LOG = LogManager.getLogger(PseudoCluster.class);
+
+    private static volatile PseudoCluster instance;
+
+    PseudoFrontend frontend;
+    Map<String, PseudoBackend> backends;
+    Map<Long, String> backendIdToHost = new HashMap<>();
+    HeatBeatPool heartBeatPool = new HeatBeatPool("heartbeat");
+    BackendThriftPool backendThriftPool = new BackendThriftPool("backend");
+    PseudoBrpcRroxy brpcProxy = new PseudoBrpcRroxy();
+
+    private class HeatBeatPool extends PseudoGenericPool<HeartbeatService.Client> {
+        public HeatBeatPool(String name) {
+            super(name);
+        }
+
+        @Override
+        public HeartbeatService.Client borrowObject(TNetworkAddress address) throws Exception {
+            Preconditions.checkState(backends.containsKey(address.getHostname()));
+            return backends.get(address.getHostname()).heatBeatClient;
+        }
+    }
+
+    private class BackendThriftPool extends PseudoGenericPool<BackendService.Client> {
+        public BackendThriftPool(String name) {
+            super(name);
+        }
+
+        @Override
+        public BackendService.Client borrowObject(TNetworkAddress address) throws Exception {
+            Preconditions.checkState(backends.containsKey(address.getHostname()));
+            return backends.get(address.getHostname()).backendClient;
+        }
+
+    }
+
+    private class PseudoBrpcRroxy extends BrpcProxy {
+        public PBackendService getBackendService(TNetworkAddress address) {
+            Preconditions.checkState(backends.containsKey(address.getHostname()));
+            LOG.warn("get PseudoBrpcRroxy: {}", address.getHostname());
+            return backends.get(address.getHostname()).pBackendService;
+        }
+
+        public LakeService getLakeService(TNetworkAddress address) {
+            Preconditions.checkState(backends.containsKey(address.getHostname()));
+            Preconditions.checkState(false, "not implemented");
+            return null;
+        }
+    }
+
+    public PseudoBackend getBackend(long beId) {
+        return backends.get(backendIdToHost.get(beId));
+    }
+
+    /**
+     * build cluster at specified dir
+     *
+     * @param runDir      must be an absolute path
+     * @param numBackends num backends
+     * @return PseudoCluster
+     * @throws Exception
+     */
+    private static PseudoCluster build(String runDir, int numBackends) throws Exception {
+        PseudoCluster cluster = new PseudoCluster();
+        cluster.frontend = PseudoFrontend.getInstance();
+
+        ClientPool.heartbeatPool = cluster.heartBeatPool;
+        ClientPool.backendPool = cluster.backendThriftPool;
+        BrpcProxy.setInstance(cluster.brpcProxy);
+
+        Config.plugin_dir = runDir + "/plugins";
+        Map<String, String> feConfMap = Maps.newHashMap();
+
+        feConfMap.put("tablet_create_timeout_second", "10");
+        cluster.frontend.init(runDir + "/fe", feConfMap);
+        cluster.frontend.start(new String[0]);
+
+        cluster.backends = Maps.newConcurrentMap();
+        long backendIdStart = 10001;
+        int port = 12100;
+        for (int i = 0; i < numBackends; i++) {
+            String host = String.format("127.0.0.%d", i + 10);
+            long beId = backendIdStart + i;
+            String beRunPath = runDir + "/be" + beId;
+            PseudoBackend backend = new PseudoBackend(cluster, beRunPath, beId, host, port++, port++, port++, port++,
+                    cluster.frontend.getFrontendService());
+            cluster.backends.put(backend.getHost(), backend);
+            cluster.backendIdToHost.put(beId, backend.getHost());
+        }
+        int retry = 0;
+        while (GlobalStateMgr.getCurrentSystemInfo().getBackend(10001).getBePort() == -1 &&
+                retry++ < 600) {
+            Thread.sleep(100);
+        }
+        return cluster;
+    }
+
+    public static synchronized PseudoCluster getOrCreate(String runDir, int numBackends) throws Exception {
+        if (instance == null) {
+            instance = build(runDir, numBackends);
+        }
+        return instance;
+    }
+
+    public static void main(String[] args) throws Exception {
+        String currentPath = new java.io.File(".").getCanonicalPath();
+        String runDir = currentPath + "/pseudo_cluster";
+        PseudoCluster cluster = PseudoCluster.getOrCreate(runDir, 3);
+        for (int i = 0; i < 3; i++) {
+            System.out.println(GlobalStateMgr.getCurrentSystemInfo().getBackend(10001 + i).getBePort());
+        }
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.pseudocluster;
+
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.Test;
+
+public class PseudoClusterTest {
+    @Test
+    public void testStartCluster() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getOrCreate("pseudo_cluster", 3);
+        for (int i = 0; i < 3; i++) {
+            System.out.println(GlobalStateMgr.getCurrentSystemInfo().getBackend(10001 + i).getBePort());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
@@ -1,0 +1,248 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.pseudocluster;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
+import com.starrocks.common.Log4jConfig;
+import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.common.util.JdkUtils;
+import com.starrocks.common.util.PrintableMap;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.qe.QeService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.service.FrontendOptions;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.thrift.FrontendService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class PseudoFrontend {
+    public static final String FE_PROCESS = "fe";
+
+    // the running dir of this mocked frontend.
+    // log/ starrocks-meta/ and conf/ dirs will be created under this dir.
+    private String runningDir;
+    // the min set of fe.conf.
+    private static final Map<String, String> MIN_FE_CONF;
+
+    private FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
+
+    static {
+        MIN_FE_CONF = Maps.newHashMap();
+        MIN_FE_CONF.put("sys_log_level", "INFO");
+        MIN_FE_CONF.put("http_port", "8030");
+        MIN_FE_CONF.put("rpc_port", "9020");
+        MIN_FE_CONF.put("query_port", "9030");
+        MIN_FE_CONF.put("edit_log_port", "9010");
+        MIN_FE_CONF.put("priority_networks", "127.0.0.1/24");
+
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        context.start();
+    }
+
+    private static class SingletonHolder {
+        private static final PseudoFrontend INSTANCE = new PseudoFrontend();
+    }
+
+    public static PseudoFrontend getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    private boolean isInit = false;
+
+    private final Lock initLock = new ReentrantLock();
+
+    // init the fe process. This must be called before starting the frontend process.
+    // 1. check if all neccessary environment variables are set.
+    // 2. clear and create 3 dirs: runningDir/log/, runningDir/starrocks-meta/, runningDir/conf/
+    // 3. init fe.conf
+    //      The content of "fe.conf" is a merge set of input `feConf` and MIN_FE_CONF
+    public void init(String runningDir, Map<String, String> feConf) throws EnvVarNotSetException, IOException {
+        initLock.lock();
+        if (isInit) {
+            return;
+        }
+
+        if (Strings.isNullOrEmpty(runningDir)) {
+            System.err.println("running dir is not set for mocked frontend");
+            throw new EnvVarNotSetException("running dir is not set for mocked frontend");
+        }
+
+        this.runningDir = runningDir;
+        System.out.println("mocked frontend running in dir: " + this.runningDir);
+
+        // root running dir
+        createAndClearDir(this.runningDir);
+        // clear and create log dir
+        createAndClearDir(runningDir + "/log/");
+        // clear and create meta dir
+        createAndClearDir(runningDir + "/starrocks-meta/");
+        // clear and create conf dir
+        createAndClearDir(runningDir + "/conf/");
+        // init fe.conf
+        initFeConf(runningDir + "/conf/", feConf);
+
+        isInit = true;
+        initLock.unlock();
+    }
+
+    private void initFeConf(String confDir, Map<String, String> feConf) throws IOException {
+        Map<String, String> finalFeConf = Maps.newHashMap(MIN_FE_CONF);
+        // these 2 configs depends on running dir, so set them here.
+        finalFeConf.put("LOG_DIR", this.runningDir + "/log");
+        finalFeConf.put("meta_dir", this.runningDir + "/starrocks-meta");
+        finalFeConf.put("sys_log_dir", this.runningDir + "/log");
+        finalFeConf.put("audit_log_dir", this.runningDir + "/log");
+        finalFeConf.put("tmp_dir", this.runningDir + "/temp_dir");
+        // use custom config to add or override default config
+        finalFeConf.putAll(feConf);
+
+        PrintableMap<String, String> map = new PrintableMap<>(finalFeConf, "=", false, true, "");
+        File confFile = new File(confDir + "fe.conf");
+        if (!confFile.exists()) {
+            confFile.createNewFile();
+        }
+        try (PrintWriter printWriter = new PrintWriter(confFile)) {
+            printWriter.print(map.toString());
+            printWriter.flush();
+        }
+    }
+
+    public static void createAndClearDir(String dir) throws IOException {
+        File localDir = new File(dir);
+        if (!localDir.exists()) {
+            localDir.mkdirs();
+        } else {
+            Files.walk(Paths.get(dir)).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            if (!localDir.exists()) {
+                localDir.mkdirs();
+            }
+        }
+    }
+
+    public String getRunningDir() {
+        return runningDir;
+    }
+
+    public FrontendService.Iface getFrontendService() {
+        return service;
+    }
+
+    private static class FERunnable implements Runnable {
+        private final PseudoFrontend frontend;
+        private final String[] args;
+
+        public FERunnable(PseudoFrontend frontend, String[] args) {
+            this.frontend = frontend;
+            this.args = args;
+        }
+
+        @Override
+        public void run() {
+            if (Strings.isNullOrEmpty(frontend.getRunningDir())) {
+                System.err.println("env STARROCKS_HOME is not set.");
+                return;
+            }
+
+            try {
+                // init config
+                new Config().init(frontend.getRunningDir() + "/conf/fe.conf");
+
+                // check it after Config is initialized, otherwise the config 'check_java_version' won't work.
+                if (!JdkUtils.checkJavaVersion()) {
+                    //                    throw new IllegalArgumentException("Java version doesn't match");
+                }
+
+                Log4jConfig.initLogging();
+
+                // set dns cache ttl
+                java.security.Security.setProperty("networkaddress.cache.ttl", "60");
+
+                FrontendOptions.init(new String[0]);
+                ExecuteEnv.setup();
+
+                GlobalStateMgr.getCurrentState().initialize(args);
+                GlobalStateMgr.getCurrentState().notifyNewFETypeTransfer(FrontendNodeType.MASTER);
+                FrontendOptions.saveStartType();
+
+                GlobalStateMgr.getCurrentState().waitForReady();
+
+                QeService qeService = new QeService(Config.query_port, Config.mysql_service_nio_enabled,
+                        ExecuteEnv.getInstance().getScheduler());
+                qeService.start();
+
+                ThreadPoolManager.registerAllThreadPoolMetric();
+
+                while (true) {
+                    Thread.sleep(2000);
+                }
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    // must call init() before start.
+    public void start(String[] args) throws FeStartException, NotInitException {
+        initLock.lock();
+        if (!isInit) {
+            throw new NotInitException("fe process is not initialized");
+        }
+        initLock.unlock();
+
+        Thread feThread = new Thread(new FERunnable(this, args), FE_PROCESS);
+        feThread.start();
+        waitForCatalogReady();
+        System.out.println("Fe process is started");
+    }
+
+    private void waitForCatalogReady() throws FeStartException {
+        int tryCount = 0;
+        while (!GlobalStateMgr.getCurrentState().isReady() && tryCount < 600) {
+            try {
+                tryCount++;
+                Thread.sleep(1000);
+                System.out.println("globalStateMgr is not ready, wait for 1 second");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (!GlobalStateMgr.getCurrentState().isReady()) {
+            System.err.println("globalStateMgr is not ready");
+            throw new FeStartException("fe start failed");
+        }
+    }
+
+    public static class FeStartException extends Exception {
+        public FeStartException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class EnvVarNotSetException extends Exception {
+        public EnvVarNotSetException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class NotInitException extends Exception {
+        public NotInitException(String msg) {
+            super(msg);
+        }
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoGenericPool.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoGenericPool.java
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.pseudocluster;
+
+import com.starrocks.common.GenericPool;
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+
+public class PseudoGenericPool<VALUE extends org.apache.thrift.TServiceClient> extends GenericPool<VALUE> {
+    public PseudoGenericPool(String name) {
+        super(name, new GenericKeyedObjectPoolConfig(), 100);
+    }
+
+    @Override
+    public boolean reopen(VALUE object, int timeoutMs) {
+        return true;
+    }
+
+    @Override
+    public boolean reopen(VALUE object) {
+        return true;
+    }
+
+    @Override
+    public void clearPool(TNetworkAddress addr) {
+    }
+
+    @Override
+    public boolean peak(VALUE object) {
+        return true;
+    }
+
+    @Override
+    public VALUE borrowObject(TNetworkAddress address) throws Exception {
+        return null;
+    }
+
+    @Override
+    public VALUE borrowObject(TNetworkAddress address, int timeoutMs) throws Exception {
+        return borrowObject(address);
+    }
+
+    @Override
+    public void returnObject(TNetworkAddress address, VALUE object) {
+    }
+
+    @Override
+    public void invalidateObject(TNetworkAddress address, VALUE object) {
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoOlapTableSink.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoOlapTableSink.java
@@ -1,0 +1,236 @@
+package com.starrocks.pseudocluster;
+
+import com.starrocks.proto.PTabletWithPartition;
+import com.starrocks.proto.PTabletWriterAddBatchResult;
+import com.starrocks.proto.PTabletWriterAddChunkRequest;
+import com.starrocks.proto.PTabletWriterCancelRequest;
+import com.starrocks.proto.PTabletWriterOpenRequest;
+import com.starrocks.proto.PTabletWriterOpenResult;
+import com.starrocks.proto.PUniqueId;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TOlapTableSink;
+import com.starrocks.thrift.TTabletCommitInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PseudoOlapTableSink {
+    private static final Logger LOG = LogManager.getLogger(PseudoOlapTableSink.class);
+
+    static class PartitionTablet {
+        long partitionId;
+        long tabletId;
+
+        PartitionTablet(long partitionId, long tabletId) {
+            this.partitionId = partitionId;
+            this.tabletId = tabletId;
+        }
+    }
+
+    static class Partition {
+        long id;
+        Map<Long, List<Long>> indexToTabletIds;
+    }
+
+    class NodeChannel {
+        long indexId;
+        long nodeId;
+        List<PartitionTablet> tablets = new ArrayList<>();
+
+        NodeChannel(long indexId, long nodeId) {
+            this.indexId = indexId;
+            this.nodeId = nodeId;
+        }
+
+        boolean open() {
+            PTabletWriterOpenRequest request = new PTabletWriterOpenRequest();
+            request.id = loadId;
+            request.indexId = indexId;
+            request.txnId = txnId;
+            request.isLakeTablet = false;
+            request.tablets = tablets.stream().map(pt -> {
+                PTabletWithPartition tablet = new PTabletWithPartition();
+                tablet.partitionId = pt.partitionId;
+                tablet.tabletId = pt.tabletId;
+                return tablet;
+            }).collect(Collectors.toList());
+            request.isVectorized = true;
+            PTabletWriterOpenResult result = cluster.getBackend(nodeId).tabletWriterOpen(request);
+            if (result.status.statusCode != 0) {
+                LOG.warn("open tablet writer failed: node:{} {}", nodeId, result.status.errorMsgs.get(0));
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        void cancel() {
+            PTabletWriterCancelRequest request = new PTabletWriterCancelRequest();
+            request.id = loadId;
+            request.indexId = indexId;
+            request.txnId = txnId;
+            cluster.getBackend(nodeId).tabletWriterCancel(request);
+        }
+
+        boolean close() {
+            PTabletWriterAddChunkRequest request = new PTabletWriterAddChunkRequest();
+            request.id = loadId;
+            request.indexId = indexId;
+            request.txnId = txnId;
+            request.partitionIds = partitionsWithData;
+            request.eos = true;
+            PTabletWriterAddBatchResult result = cluster.getBackend(nodeId).tabletWriterAddChunk(request);
+            result.tabletVec.forEach(tablet -> {
+                TTabletCommitInfo commitInfo = new TTabletCommitInfo();
+                commitInfo.backendId = nodeId;
+                commitInfo.tabletId = tablet.tabletId;
+                tabletCommitInfos.add(commitInfo);
+            });
+            if (result.status.statusCode != 0) {
+                LOG.warn("close tablet writer failed: node:{} {}", nodeId, result.status.errorMsgs.get(0));
+                return false;
+            } else {
+                return true;
+            }
+        }
+    }
+
+    class IndexChannel {
+        long indexId;
+        // nodeId -> list of tablets with partition information
+        Map<Long, NodeChannel> nodeChannels;
+        Set<Long> errorNodes = new HashSet<>();
+
+        private boolean has_intolerable_failure() {
+            return errorNodes.size() >= (numReplica + 1) / 2;
+        }
+
+        boolean open() {
+            for (NodeChannel ch : nodeChannels.values()) {
+                if (!ch.open()) {
+                    errorNodes.add(ch.nodeId);
+                    if (has_intolerable_failure()) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        void cancel() {
+            for (NodeChannel ch : nodeChannels.values()) {
+                ch.cancel();
+            }
+        }
+
+        boolean close() {
+            for (NodeChannel ch : nodeChannels.values()) {
+                if (!ch.close()) {
+                    errorNodes.add(ch.nodeId);
+                    if (has_intolerable_failure()) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+    }
+
+    PseudoCluster cluster;
+    PUniqueId loadId;
+    long txnId;
+    int numReplica;
+    List<Long> indexes;
+    List<Partition> partitions;
+    Map<Long, List<Long>> tabletIdToNodeIds;
+    Map<Long, String> nodeIdToHost;
+
+    List<IndexChannel> indexChannels;
+    List<Long> partitionsWithData;
+
+    List<TTabletCommitInfo> tabletCommitInfos = new ArrayList<>();
+
+    public PseudoOlapTableSink(PseudoCluster cluster, TDataSink tDataSink) {
+        this.cluster = cluster;
+        TOlapTableSink tOlapTableSink = tDataSink.olap_table_sink;
+        loadId = new PUniqueId();
+        loadId.hi = tOlapTableSink.load_id.hi;
+        loadId.lo = tOlapTableSink.load_id.lo;
+        txnId = tOlapTableSink.txn_id;
+        numReplica = tOlapTableSink.num_replicas;
+        indexes = tOlapTableSink.schema.indexes.stream().map(i -> i.id).collect(Collectors.toList());
+        partitions = tOlapTableSink.partition.partitions.stream().map(p -> {
+            Partition partition = new Partition();
+            partition.id = p.id;
+            partition.indexToTabletIds = p.indexes.stream().collect(Collectors.toMap(e -> e.index_id, e -> e.tablets));
+            return partition;
+        }).collect(Collectors.toList());
+        tabletIdToNodeIds = tOlapTableSink.location.tablets.stream().collect(Collectors.toMap(e -> e.tablet_id, e -> e.node_ids));
+        nodeIdToHost = tOlapTableSink.nodes_info.nodes.stream().collect(Collectors.toMap(e -> e.id, e -> e.host));
+
+        indexChannels = new ArrayList<>();
+        for (long indexId : indexes) {
+            IndexChannel indexChannel = new IndexChannel();
+            indexChannel.indexId = indexId;
+            indexChannel.nodeChannels = new HashMap<>();
+            for (Partition partition : partitions) {
+                partition.indexToTabletIds.get(indexId).forEach(tabletId -> {
+                    List<Long> nodeIds = tabletIdToNodeIds.get(tabletId);
+                    nodeIds.forEach(nodeId -> {
+                        NodeChannel nodeChannel = indexChannel.nodeChannels.computeIfAbsent(
+                                nodeId, k -> new NodeChannel(indexId, nodeId));
+                        nodeChannel.tablets.add(new PartitionTablet(partition.id, tabletId));
+                    });
+                });
+            }
+            indexChannels.add(indexChannel);
+        }
+
+        partitionsWithData = partitions.stream().map(p -> p.id).collect(Collectors.toList());
+    }
+
+    public boolean open() {
+        for (IndexChannel indexChannel : indexChannels) {
+            if (!indexChannel.open()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void cancel() {
+        for (IndexChannel indexChannel : indexChannels) {
+            indexChannel.cancel();
+        }
+    }
+
+    public boolean close() {
+        for (IndexChannel indexChannel : indexChannels) {
+            if (!indexChannel.close()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public List<TTabletCommitInfo> getTabletCommitInfos() {
+        return tabletCommitInfos;
+    }
+
+    public Map<String, String> getLoadCounters() {
+        Map result = new HashMap();
+        int nrows = 1000;
+        result.put("dpp.norm.ALL", Integer.toString(nrows));
+        result.put("dpp.abnorm.ALL", Integer.toString(0));
+        result.put("unselected.rows", Integer.toString(0));
+        result.put("loaded.bytes", Integer.toString(nrows * 1000));
+        return result;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Rowset.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Rowset.java
@@ -1,0 +1,22 @@
+package com.starrocks.pseudocluster;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Rowset {
+    @SerializedName(value = "id")
+    int id = -1;
+    @SerializedName(value = "rowsetid")
+    String rowsetid;
+    @SerializedName(value = "numRows")
+    long numRows = 0;
+    @SerializedName(value = "dataSize")
+    long dataSize = 0;
+
+    Rowset(String rowsetid) {
+        this.rowsetid = rowsetid;
+    }
+
+    void setId(int id) {
+        this.id = id;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
@@ -1,0 +1,140 @@
+package com.starrocks.pseudocluster;
+
+import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTabletStat;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class Tablet {
+    private static final Logger LOG = LogManager.getLogger(Tablet.class);
+
+    @SerializedName(value = "id")
+    long id;
+    @SerializedName(value = "tableId")
+    long tableId;
+    @SerializedName(value = "partitionId")
+    long partitionId;
+    @SerializedName(value = "schemaHash")
+    int schemaHash;
+    @SerializedName(value = "enablePersistentIndex")
+    boolean enablePersistentIndex;
+
+    public synchronized TTabletInfo toThrift() {
+        TTabletInfo info = new TTabletInfo();
+        info.setTablet_id(id);
+        info.setPartition_id(partitionId);
+        info.setSchema_hash(schemaHash);
+        info.setStorage_medium(TStorageMedium.SSD);
+        info.setPath_hash(1);
+        info.setIs_in_memory(false);
+        info.setVersion(max_continuous_version());
+        info.setVersion_miss(!pendingRowsets.isEmpty());
+        info.setRow_count(getRowCount());
+        info.setData_size(getDataSize());
+        // TODO: fill expire txn ids
+        return info;
+    }
+
+    static class EditVersion {
+        @SerializedName(value = "major")
+        long major;
+        @SerializedName(value = "minor")
+        long minor;
+        @SerializedName(value = "rowsets")
+        List<Rowset> rowsets = Lists.newArrayList();
+
+        EditVersion(long major, long minor) {
+            this.major = major;
+            this.minor = minor;
+        }
+    }
+
+    @SerializedName(value = "versions")
+    List<EditVersion> versions;
+
+    @SerializedName(value = "nextRssId")
+    int nextRssId = 0;
+
+    @SerializedName(value = "pendingRowsets")
+    TreeMap<Long, Rowset> pendingRowsets = new TreeMap<>();
+
+    public Tablet(long id, long tableId, long partitionId, int schemaHash, boolean enablePersistentIndex) {
+        this.id = id;
+        this.tableId = tableId;
+        this.partitionId = partitionId;
+        this.schemaHash = schemaHash;
+        this.enablePersistentIndex = enablePersistentIndex;
+        versions = Lists.newArrayList(new EditVersion(1, 0));
+    }
+
+    public synchronized int num_rowsets() {
+        return versions.get(versions.size() - 1).rowsets.size();
+    }
+
+    public long getRowCount() {
+        return num_rowsets() * 1000;
+    }
+
+    public long getDataSize() {
+        return num_rowsets() * 100000;
+    }
+
+    public synchronized long max_continuous_version() {
+        return versions.get(versions.size() - 1).major;
+    }
+
+    public synchronized void commitRowset(Rowset rowset, long version) throws Exception {
+        EditVersion lastVersion = versions.get(versions.size() - 1);
+        if (version <= lastVersion.major) {
+            LOG.info("tablet:{} ignore rowset commit, version {} <= {}", id, version, lastVersion.major);
+        } else if (version == lastVersion.major + 1) {
+            commitNextRowset(rowset, version, lastVersion);
+            while (!pendingRowsets.isEmpty()) {
+                lastVersion = versions.get(versions.size() - 1);
+                Map.Entry<Long, Rowset> e = pendingRowsets.firstEntry();
+                if (e.getKey() == lastVersion.major + 1) {
+                    commitNextRowset(e.getValue(), e.getKey(), lastVersion);
+                    pendingRowsets.remove(e.getKey());
+                } else {
+                    break;
+                }
+            }
+        } else {
+            // TODO: simulate number of pending rowset limit reached
+            pendingRowsets.put(version, rowset);
+            LOG.info("tablet:{} add rowset {} to pending #{}, version {}", id, rowset.rowsetid, pendingRowsets.size(), version);
+        }
+    }
+
+    private void commitNextRowset(Rowset rowset, long version, EditVersion lastVersion) {
+        rowset.id = ++nextRssId;
+        EditVersion ev = new EditVersion(version, 0);
+        ev.rowsets.addAll(lastVersion.rowsets);
+        ev.rowsets.add(rowset);
+        versions.add(ev);
+        LOG.info("tablet:{} rowset commit, version:{} rowset:{} #rowset:{}", id, version, rowset.id, ev.rowsets.size());
+    }
+
+    public TTabletStat getStats() {
+        TTabletStat stat = new TTabletStat();
+        stat.setTablet_id(id);
+        stat.setData_size(getDataSize());
+        stat.setRow_num(getRowCount());
+        return stat;
+    }
+
+    public static void main(String[] args) {
+        Tablet tablet = new Tablet(1, 1, 1, 1, true);
+        String json = GsonUtils.GSON.toJson(tablet);
+        System.out.println(json);
+        Tablet newTablet = GsonUtils.GSON.fromJson(json, Tablet.class);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8212

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds an PseudoCluster, it includes PseudoBackend and PseduFront. PseudoBackend simulates basic BE functions like tablet/txn management, task execution, and reporting, etc. The purpose of this is to facilitate some FE function/feature testing, like load/txn, ddl & dml execution, clone/balance behavior etc.
Currently, it conflict with the existing UT code (mainly because their are too many singletons in FE code), so to use it, the user should invoke a separate new process:

```
mvn compile exec:java -Dexec.mainClass="com.starrocks.pseudocluster.PseudoCluster"

this will create a 3 node pseudo cluster, then connect to this cluster using MySQL client

mysql -h 127.0.0.1 -P 9030 -uroot
// create table & insert into
```
