### PR TITLE
[Bugfix] fix be crash when call DictMappingExpr::evaluate

### DIFF
--- a/be/src/exprs/vectorized/dictmapping_expr.cpp
+++ b/be/src/exprs/vectorized/dictmapping_expr.cpp
@@ -6,8 +6,14 @@ namespace starrocks::vectorized {
 DictMappingExpr::DictMappingExpr(const TExprNode& node) : Expr(node, false) {}
 
 ColumnPtr DictMappingExpr::evaluate(ExprContext* context, Chunk* ptr) {
-    DCHECK(dict_func_expr != nullptr);
-    return dict_func_expr->evaluate(context, ptr);
+    // If dict_func_expr is nullptr, then it means that this DictExpr has not been rewritten.
+    // But in some cases we need to evaluate the original expression directly
+    // (usually column_expr_predicate).
+    if (dict_func_expr == nullptr) {
+        return get_child(1)->evaluate(context, ptr);
+    } else {
+        return dict_func_expr->evaluate(context, ptr);
+    }
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #8853

## Problem Summary(Required) ：
when we rewrite ColumnExprPredicate as DictConjunctPredicate. we will call evaluate for ColumnExprPredicate.
but in this time DictMappingExpr has not been rewrite. And we need evaluate result from origin expression
