### PR TITLE
[Enhancement] Unable to filter NULL data by WHERE to build NOT NULL column

### DIFF
--- a/be/src/connector/file_connector.h
+++ b/be/src/connector/file_connector.h
@@ -77,5 +77,7 @@ private:
     void _init_counter();
 
     void _update_counter();
+
+    void _validate_nullable_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk);
 };
 } // namespace starrocks::connector

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1191,15 +1191,6 @@ void OlapTableSink::_validate_data(RuntimeState* state, vectorized::Chunk* chunk
                 for (size_t j = 0; j < num_rows; ++j) {
                     if (nulls[j]) {
                         _validate_selection[j] = VALID_SEL_FAILED;
-                        std::stringstream ss;
-                        ss << "NULL value in non-nullable column '" << desc->col_name() << "'";
-#if BE_TEST
-                        LOG(INFO) << ss.str();
-#else
-                        if (!state->has_reached_max_error_msg_num()) {
-                            state->append_error_msg_to_file(chunk->debug_row(j), ss.str());
-                        }
-#endif
                     }
                 }
             }

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -190,25 +190,6 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPt
                     _state->append_error_msg_to_file(src->debug_row(i), error_msg.str());
                 }
             }
-
-            if (!slot->is_nullable()) {
-                for (int i = 0; i < col->size(); ++i) {
-                    if (!col->is_null(i) || !filter[i]) {
-                        continue;
-                    }
-
-                    filter[i] = 0;
-                    _error_counter++;
-
-                    // avoid print too many debug log
-                    if (_error_counter > 50) {
-                        continue;
-                    }
-                    _state->append_error_msg_to_file(
-                            src->debug_row(i),
-                            strings::Substitute("NULL value in non-nullable column '$0'", slot->col_name()));
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8785

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The previous implementation check whether the not-null column with null data before the conjunct evaluating, which leads we cannot filter null record by setting `WHERE KEY IS NOT NULL` in load.
The new implementation move the check after the conjunct evaluating to let it work.