### PR TITLE
[Enhance] take the fragment prepare time into account of vruntime

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -71,6 +71,7 @@ private:
 
 class FragmentExecutor {
 public:
+    FragmentExecutor();
     Status prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request,
                    const TExecPlanFragmentParams& unique_request);
     Status execute(ExecEnv* exec_env);
@@ -100,6 +101,7 @@ private:
                                             const UnifiedExecPlanFragmentParams& request,
                                             std::unique_ptr<starrocks::DataSink>& datasink);
 
+    int64_t _fragment_start_time = 0;
     QueryContext* _query_ctx = nullptr;
     FragmentContextPtr _fragment_ctx = nullptr;
     workgroup::WorkGroupPtr _wg = nullptr;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -260,10 +260,10 @@ Status PInternalServiceImplBase<T>::_exec_batch_plan_fragments(brpc::Controller*
 template <typename T>
 Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_param,
                                                                     const TExecPlanFragmentParams& t_unique_request) {
-    auto fragment_executor = std::make_unique<starrocks::pipeline::FragmentExecutor>();
-    auto status = fragment_executor->prepare(_exec_env, t_common_param, t_unique_request);
+    pipeline::FragmentExecutor fragment_executor;
+    auto status = fragment_executor.prepare(_exec_env, t_common_param, t_unique_request);
     if (status.ok()) {
-        return fragment_executor->execute(_exec_env);
+        return fragment_executor.execute(_exec_env);
     } else {
         return status.is_duplicate_rpc_invocation() ? Status::OK() : status;
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The vruntime should consider all CPU usage of a resource group, not only the query running time, but also network time, prepare time.
