### PR TITLE
[BugFix] Fix consistency problem

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -546,12 +546,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         if (sender->get_partition_type() == TPartitionType::HASH_PARTITIONED ||
             sender->get_partition_type() == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
             dest_dop = t_stream_sink.dest_dop;
-
-            // UNPARTITIONED mode will be performed if both num of destination and dest dop is 1
-            // So we only enable pipeline level shuffle when num of destination or dest dop is greater than 1
-            if (sender->destinations().size() > 1 || dest_dop > 1) {
-                is_pipeline_level_shuffle = true;
-            }
+            is_pipeline_level_shuffle = true;
             DCHECK_GT(dest_dop, 0);
         }
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -150,7 +150,9 @@ private:
 
     typedef std::list<ChunkItem> ChunkQueue;
     ChunkQueue _chunk_queue;
+#ifdef DEBUG
     bool _is_pipeline_level_shuffle_init = false;
+#endif
     bool _is_pipeline_level_shuffle = false;
     std::vector<bool> _has_chunks_per_driver_sequence;
     serde::ProtobufChunkMeta _chunk_meta;
@@ -471,12 +473,21 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
     ChunkQueue chunks;
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
-    bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
+
+#ifdef DEBUG
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
+        _is_pipeline_level_shuffle =
+                _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+        // _is_pipeline_level_shuffle must be stable after first assignment
+        DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
+        _is_pipeline_level_shuffle_init = true;
+    }
+#else
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-    // _is_pipeline_level_shuffle must be stable after first assignment
-    DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
-    _is_pipeline_level_shuffle_init = true;
+#endif
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;
@@ -604,12 +615,20 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
     ChunkQueue local_chunk_queue;
-    bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
+#ifdef DEBUG
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
+        _is_pipeline_level_shuffle =
+                _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+        // _is_pipeline_level_shuffle must be stable after first assignment
+        DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
+        _is_pipeline_level_shuffle_init = true;
+    }
+#else
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-    // _is_pipeline_level_shuffle must be stable after first assignment
-    DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
-    _is_pipeline_level_shuffle_init = true;
+#endif
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -150,9 +150,6 @@ private:
 
     typedef std::list<ChunkItem> ChunkQueue;
     ChunkQueue _chunk_queue;
-#ifdef DEBUG
-    bool _is_pipeline_level_shuffle_init = false;
-#endif
     bool _is_pipeline_level_shuffle = false;
     std::vector<bool> _has_chunks_per_driver_sequence;
     serde::ProtobufChunkMeta _chunk_meta;
@@ -474,20 +471,8 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
 
-#ifdef DEBUG
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
-        _is_pipeline_level_shuffle =
-                _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-        // _is_pipeline_level_shuffle must be stable after first assignment
-        DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
-        _is_pipeline_level_shuffle_init = true;
-    }
-#else
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-#endif
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;
@@ -615,20 +600,9 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
     ChunkQueue local_chunk_queue;
-#ifdef DEBUG
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        bool prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle;
-        _is_pipeline_level_shuffle =
-                _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-        // _is_pipeline_level_shuffle must be stable after first assignment
-        DCHECK(!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle));
-        _is_pipeline_level_shuffle_init = true;
-    }
-#else
+
     _is_pipeline_level_shuffle =
             _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
-#endif
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8593

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Considering we are processing two packets concurrently, and one of the time sequences are list as follows:

1. thread_1 receive packet, `prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle = false`
2. thread_2 receive packet `prev_is_pipeline_level_shuffle = _is_pipeline_level_shuffle = false`
3. thread_1 set `_is_pipeline_level_shuffle = true` and set `_is_pipeline_level_shuffle_init = true`
4. thread_2 set `_is_pipeline_level_shuffle = true`
5. thread_2 failed the check `!_is_pipeline_level_shuffle_init || (prev_is_pipeline_level_shuffle == _is_pipeline_level_shuffle)`

It can be recreated by the following demo program

```cpp
#include <iostream>
#include <thread>

int main() {
    while (true) {
        bool is_pipeline_level_shuffle = false;
        bool is_pipeline_level_shuffle_init = false;

        std::thread t1([&]() {
            bool prev_is_pipeline_level_shuffle = is_pipeline_level_shuffle;
            is_pipeline_level_shuffle = true;
            if (is_pipeline_level_shuffle_init && (prev_is_pipeline_level_shuffle != is_pipeline_level_shuffle)) {
                std::cout << "error" << std::endl;
                exit(1);
            }
            is_pipeline_level_shuffle_init = true;
        });
        std::thread t2([&]() {
            bool prev_is_pipeline_level_shuffle = is_pipeline_level_shuffle;
            is_pipeline_level_shuffle = true;
            if (is_pipeline_level_shuffle_init && (prev_is_pipeline_level_shuffle != is_pipeline_level_shuffle)) {
                std::cout << "error" << std::endl;
                exit(1);
            }
            is_pipeline_level_shuffle_init = true;
        });

        t1.join();
        t2.join();
    }
    return 0;
}
```