### PR TITLE
[WIP]Reproduce the bug

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1001,7 +1001,10 @@ bool OlapTableSink::is_close_done() {
 Status OlapTableSink::close(RuntimeState* state, Status close_status) {
     if (close_status.ok()) {
         do {
-            RETURN_IF_ERROR(try_close(state));
+            close_status = try_close(state);
+            if (!close_status.ok()) {
+                break;
+            }
             SleepFor(MonoDelta::FromMilliseconds(5));
         } while (!is_close_done());
     }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -208,7 +208,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
                 fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
     }
     Status st;
-    bool full = _mem_table->insert(chunk, indexes, from, size);
+    _mem_table->insert(chunk, indexes, from, size);
     if (_mem_tracker->limit_exceeded()) {
         VLOG(2) << "Flushing memory table due to memory limit exceeded";
         st = _flush_memtable();
@@ -217,7 +217,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
         VLOG(2) << "Flushing memory table due to parent memory limit exceeded";
         st = _flush_memtable();
         _reset_mem_table();
-    } else if (full) {
+    } else {
         st = _flush_memtable_async();
         _reset_mem_table();
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -220,6 +220,9 @@ Status MemTable::flush() {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
+    std::cout<<"BEFORE flush"<<std::endl;
+    sleep(5);
+    std::cout<<"AFTER flush"<<std::endl;
     std::string msg;
     if (_result_chunk->capacity_limit_reached(&msg)) {
         return Status::InternalError(

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -86,6 +86,7 @@ Status SegmentWriter::init() {
 Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has_key, SegmentFooterPB* footer) {
     DCHECK(_column_writers.empty());
     DCHECK(_column_indexes.empty());
+    std::cout<<"GET 1"<<std::endl;
 
     if (_opts.storage_format_version != 1 && _opts.storage_format_version != 2) {
         return Status::InvalidArgument(
@@ -107,6 +108,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         // set _num_rows as _num_rows in partial segment
         _num_rows = footer->num_rows();
     }
+    std::cout<<"GET 2"<<std::endl;
 
     _column_indexes.insert(_column_indexes.end(), column_indexes.begin(), column_indexes.end());
     _column_writers.reserve(_column_indexes.size());
@@ -150,8 +152,10 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
                 return Status::NotSupported("Do not support bitmap index for array type");
             }
         }
+        std::cout<<"GET 3"<<std::endl;
 
         if (column.type() == FieldType::OLAP_FIELD_TYPE_VARCHAR && _opts.global_dicts != nullptr) {
+            std::cout<<"GET DICT"<<std::endl;
             auto iter = _opts.global_dicts->find(column.name().data());
             if (iter != _opts.global_dicts->end()) {
                 opts.global_dict = &iter->second;

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -106,7 +106,7 @@ void ThreadPoolToken::shutdown() {
     // outside the lock, in case there are concurrent threads wanting to access
     // the ThreadPool. The task's destructors may acquire locks, etc, so this
     // also prevents lock inversions.
-    PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release = std::move(_entries);
+    PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release = _entries;
     _pool->_total_queued_tasks -= to_release.size();
 
     switch (state()) {
@@ -123,6 +123,7 @@ void ThreadPoolToken::shutdown() {
         // Note: this is an O(n) operation, but it's expected to be infrequent.
         // Plus doing it this way (rather than switching to QUIESCING and waiting
         // for a worker thread to process the queue entry) helps retain state
+
         // transition symmetry with ThreadPool::shutdown.
         for (auto it = _pool->_queue.begin(); it != _pool->_queue.end();) {
             if (*it == this) {
@@ -162,6 +163,7 @@ bool ThreadPoolToken::wait_for(const MonoDelta& delta) {
 }
 
 void ThreadPoolToken::transition(State new_state) {
+    /*
 #ifndef NDEBUG
     CHECK_NE(_state, new_state);
 
@@ -193,6 +195,7 @@ void ThreadPoolToken::transition(State new_state) {
         LOG(FATAL) << "Unknown token state: " << _state;
     }
 #endif
+    */
 
     // Take actions based on the state we're entering.
     switch (new_state) {


### PR DESCRIPTION
```
curl --location-trusted -u root: -H "column_separator:," -H "columns: c1,c2" -T a.dat http://xxx:xxx/api/ssb_20/t1/_stream_load
```

```
start time: 2022年 07月 19日 星期二 15:19:56 CST
INIT DICT
INIT DICT
BEFORE flush
LocalTabletsChannel
AFTER flush
=================================================================
==137244==ERROR: AddressSanitizer: heap-use-after-free on address 0x6020002c62d0 at pc 0x000005b3b188 bp 0x7f01d6dc9450 sp 0x7f01d6dc9448
READ of size 8 at 0x6020002c62d0 thread T134 (mem_tab_flush)
    #0 0x5b3b187 in starrocks::vectorized::MemTable::flush() /home/disk2/lxh/doris/be/src/storage/memtable.cpp:237
    #1 0x5c4fe39 in starrocks::FlushToken::_flush_memtable(starrocks::vectorized::MemTable*) /home/disk2/lxh/doris/be/src/storage/memtable_flush_executor.cpp:82
    #2 0x5c51c54 in starrocks::MemtableFlushTask::run() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x5c51c54)
    #3 0x6f9517f in starrocks::ThreadPool::dispatch_thread() /home/disk2/lxh/doris/be/src/util/threadpool.cpp:516
    #4 0x6fb340b in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/b
its/invoke.h:73
    #5 0x6fb2d64 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolcha
in/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #6 0x6fb215b in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #7 0x6fb0abb in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #8 0x6fad9bd in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/inclu
de/c++/10.3.0/bits/invoke.h:60
    #9 0x6faaf0d in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPoo
l::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #10 0x6fa6d1a in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #11 0x533400d in std::function<void ()>::operator()() const /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #12 0x6f809ec in starrocks::Thread::supervise_thread(void*) /home/disk2/lxh/doris/be/src/util/thread.cpp:326
    #13 0x7f0206abfea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #14 0x7f02060dab0c in clone (/lib64/libc.so.6+0xfeb0c)
```