### PR TITLE
[Enhance] make re2 driver-local to avoid contention

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -285,40 +285,39 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     query_trace_ctx.id = reinterpret_cast<int64_t>(_chunk_sources[chunk_source_index].get());
     int32_t driver_id = CurrentThread::current().get_driver_id();
     if (_workgroup != nullptr) {
-        workgroup::ScanTask task = workgroup::ScanTask(
-                _workgroup,
-                [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id](int worker_id) {
-                    if (auto sp = wp.lock()) {
-                        // Set driver_id here to share some driver-local contents.
-                        // Current it's used by ExprContext's driver-local state
-                        CurrentThread::current().set_pipeline_driver_id(driver_id);
-                        DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
-                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-                        [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);
-                        QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);
-                        auto& chunk_source = _chunk_sources[chunk_source_index];
-                        size_t num_read_chunks = 0;
-                        int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
-                        int64_t prev_scan_rows = chunk_source->get_scan_rows();
-                        int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
+        workgroup::ScanTask task = workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index,
+                                                                    query_trace_ctx, driver_id](int worker_id) {
+            if (auto sp = wp.lock()) {
+                // Set driver_id here to share some driver-local contents.
+                // Current it's used by ExprContext's driver-local state
+                CurrentThread::current().set_pipeline_driver_id(driver_id);
+                DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+                [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);
+                QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);
+                auto& chunk_source = _chunk_sources[chunk_source_index];
+                size_t num_read_chunks = 0;
+                int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
+                int64_t prev_scan_rows = chunk_source->get_scan_rows();
+                int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
 
-                        // Read chunk
-                        Status status = chunk_source->buffer_next_batch_chunks_blocking_for_workgroup(
-                                _buffer_size, state, &num_read_chunks, worker_id, _workgroup);
-                        if (!status.ok() && !status.is_end_of_file()) {
-                            _set_scan_status(status);
-                        }
+                // Read chunk
+                Status status = chunk_source->buffer_next_batch_chunks_blocking_for_workgroup(
+                        _buffer_size, state, &num_read_chunks, worker_id, _workgroup);
+                if (!status.ok() && !status.is_end_of_file()) {
+                    _set_scan_status(status);
+                }
 
-                        int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
-                        _workgroup->increment_real_runtime_ns(delta_cpu_time);
-                        _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
+                int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
+                _workgroup->increment_real_runtime_ns(delta_cpu_time);
+                _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
 
-                        _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
-                                                  chunk_source->get_scan_rows() - prev_scan_rows,
-                                                  chunk_source->get_scan_bytes() - prev_scan_bytes);
-                        QUERY_TRACE_ASYNC_FINISH("io_task", category, query_trace_ctx);
-                    }
-                });
+                _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
+                                          chunk_source->get_scan_rows() - prev_scan_rows,
+                                          chunk_source->get_scan_bytes() - prev_scan_bytes);
+                QUERY_TRACE_ASYNC_FINISH("io_task", category, query_trace_ctx);
+            }
+        });
         if (dynamic_cast<ConnectorScanOperator*>(this) != nullptr) {
             offer_task_success = ExecEnv::GetInstance()->connector_scan_executor()->submit(std::move(task));
         } else {

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -177,9 +177,6 @@ private:
 
         ColumnPtr _search_string_column;
 
-        /// Used for RLIKE and REGEXP predicates if the pattern is a constant argument.
-        std::unique_ptr<re2::RE2> regex;
-
         // a pointer to the generated database that responsible for parsed expression.
         hs_database_t* database = nullptr;
         // a type containing error details that is returned by the compile calls on failure.

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -2539,13 +2539,11 @@ struct StringFunctionsState {
         if (driver_id == 0) {
             return regex.get();
         }
-        // The driver would not execute concurrently, so it's safe to use the find-emplace pattern
-        auto iter = driver_regex_map.find(driver_id);
-        if (iter == driver_regex_map.end()) {
+        auto iter = driver_regex_map.lazy_emplace(driver_id, [&](auto build) {
             auto regex = std::make_unique<re2::RE2>(pattern, *options);
             DCHECK(regex->ok());
-            iter = driver_regex_map.emplace(driver_id, std::move(regex)).first;
-        }
+            build(driver_id, std::move(regex));
+        });
         return iter->second.get();
     }
 };

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -55,6 +55,7 @@ public:
         _fragment_instance_id = fragment_instance_id;
     }
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
+    int32_t get_driver_id() const { return _driver_id; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {

--- a/be/test/exprs/vectorized/string_fn_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_test.cpp
@@ -1509,7 +1509,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns);
 
@@ -1526,7 +1526,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1553,7 +1553,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractOnlyNullPattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns);
     for (int i = 0; i < length; ++i) {
@@ -1561,7 +1561,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractOnlyNullPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1591,7 +1591,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns);
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -1601,7 +1601,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1634,7 +1634,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns);
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -1644,7 +1644,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1680,7 +1680,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns);
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
@@ -1689,7 +1689,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
     ASSERT_TRUE(result->is_null(1));
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1719,7 +1719,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceOnlyNullPattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns);
 
@@ -1727,7 +1727,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceOnlyNullPattern) {
     ASSERT_TRUE(result->is_null(1));
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 
@@ -1757,7 +1757,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns);
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -1767,13 +1767,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 
     // Test Binary input data
     {
-        FunctionContext::FunctionStateScope scope =
-                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL;
+        FunctionContext::FunctionStateScope scope = FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL;
         std::unique_ptr<FunctionContext> ctx0(FunctionContext::create_test_context());
         int binary_size = 10;
         std::unique_ptr<char[]> binary_datas = std::make_unique<char[]>(binary_size);
@@ -1817,7 +1816,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
 
     context->impl()->set_constant_columns(columns);
 
-    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns);
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -1827,7 +1826,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                     .ok());
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`re2::RE2` is shared among all threads/drivers, which could introduce contention on the `re2::DFA::cache_mutex`.

The solution is to make it `pipeline-driver local`, to avoid any contention.

According to benchmark on a many-cores machine:
- SQL: `SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(length(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;`
- Before: 8.04s
- After: 1.07s
