### PR TITLE
[BugFix] Fix potential dangling pointer of TabletSchema in Segment

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -82,7 +82,7 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(location));
     ASSIGN_OR_RETURN(segment, Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs, location, seg_id,
-                                            tablet_schema.get(), footer_size_hint));
+                                            std::move(tablet_schema), footer_size_hint));
     if (fill_cache) {
         _mgr->cache_segment(segment_name, segment);
     }


### PR DESCRIPTION
For lake tablet, the raw pointer of TabletSchema in Segment may point
to a memory location that has been deleted, if the cached TabletSchema
has been evicted from the in-memory cache of lake::TabletManager.

Use a std::shared_ptr to manage the ownership of TabletSchema in Segment
to fix the issue.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

