### PR TITLE
[Enhancement] ThreadPoolToken releasing the tasks outside of lock

### DIFF
--- a/be/src/util/priority_queue.h
+++ b/be/src/util/priority_queue.h
@@ -16,16 +16,6 @@ public:
     using const_reference = const T&;
     using size_type = typename Container::size_type;
 
-    PriorityQueue() = default;
-    ~PriorityQueue() = default;
-
-    // std::array is not movable, so we manually implement the move constructor
-    PriorityQueue(PriorityQueue&& src) noexcept {
-        for (size_t i = 0; i < NUM_PRIORITY; i++) {
-            _queues[i] = std::move(src._queues[i]);
-        }
-    }
-
     // Checks if the container has no elements
     [[nodiscard]] bool empty() const noexcept;
 

--- a/be/src/util/priority_queue.h
+++ b/be/src/util/priority_queue.h
@@ -16,7 +16,15 @@ public:
     using const_reference = const T&;
     using size_type = typename Container::size_type;
 
+    PriorityQueue() = default;
     ~PriorityQueue() = default;
+
+    // std::array is not movable, so we manually implement the move constructor
+    PriorityQueue(PriorityQueue&& src) noexcept {
+        for (size_t i = 0; i < NUM_PRIORITY; i++) {
+            _queues[i] = std::move(src._queues[i]);
+        }
+    }
 
     // Checks if the container has no elements
     [[nodiscard]] bool empty() const noexcept;

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -137,7 +137,7 @@ void ThreadPoolToken::shutdown() {
             break;
         }
         transition(State::QUIESCING);
-        FALLTHROUGH_INTENDED;
+        [[fallthrough]];
     case State::QUIESCING:
         // The token is already quiescing. Just wait for a worker thread to
         // switch it to QUIESCED.
@@ -146,6 +146,8 @@ void ThreadPoolToken::shutdown() {
     default:
         break;
     }
+    // releasing the tasks outside of lock
+    l.unlock();
 }
 
 void ThreadPoolToken::wait() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the `threadpool` is from kudu: https://github.com/apache/kudu/blob/master/src/kudu/util/threadpool.cc

```
    // Clear the queue under the lock, but defer the releasing of the tasks
    // outside the lock, in case there are concurrent threads wanting to access
    // the ThreadPool. The task's destructors may acquire locks, etc, so this
    // also prevents lock inversions.
```

```
F0720 10:02:59.244752 123894 threadpool.cpp:183] Check failed: _entries.empty()
```

if we declare `destructor = default`，compiler will disable the compiler-generated move constructor and move assignment operator.

![f0ovjmcan9](https://user-images.githubusercontent.com/11428742/179882193-0bdadca7-2bd0-4671-86a7-47612a90e660.png)

