### PR TITLE
[BugFix] fix runtime filter cache use: hold shared pointer to avoid invalid pointer.

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -489,8 +489,8 @@ void RuntimeFilterProbeCollector::wait(bool on_scan_node) {
                     VLOG_FILE << "RuntimeFilterCollector::wait: rf found in cache. filter_id = " << (*it)->filter_id()
                               << ", plan_node_id = " << _plan_node_id
                               << ", finst_id  = " << _runtime_state->fragment_instance_id();
+                    (*it)->set_shared_runtime_filter(t);
                     rf = t.get();
-                    (*it)->set_runtime_filter(rf);
                 }
             }
             if (rf != nullptr) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -372,7 +372,6 @@ void PlanFragmentExecutor::cancel() {
     if (_is_runtime_filter_merge_node) {
         _runtime_state->exec_env()->runtime_filter_worker()->close_query(_query_id);
     }
-    _exec_env->runtime_filter_cache()->remove(_query_id);
 }
 
 const RowDescriptor& PlanFragmentExecutor::row_desc() {
@@ -415,7 +414,6 @@ void PlanFragmentExecutor::close() {
     if (_is_runtime_filter_merge_node) {
         _exec_env->runtime_filter_worker()->close_query(_query_id);
     }
-    _exec_env->runtime_filter_cache()->remove(_query_id);
     _exec_env->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
 
     // Prepare may not have been called, which sets _runtime_state


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Got following exception

```
*** Aborted at 1658293232 (unix time) try "date -d @1658293232" if you are using GNU date ***
PC: @          0x5cc1f60 __dynamic_cast
*** SIGSEGV (@0xfffffffffffffff0) received by PID 32857 (TID 0x7f1df458d700) from PID 18446744073709551600; stack trace: ***
    @          0x41c0692 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f1e2fe6be9b os::Linux::chained_handler()
    @     0x7f1e2fe7090c JVM_handle_linux_signal
    @     0x7f1e2fe63858 signalHandler()
    @     0x7f1e2f34b630 (unknown)
    @          0x5cc1f60 __dynamic_cast
    @          0x29a8031 starrocks::vectorized::OrcChunkReader::_add_runtime_filter()
    @          0x29ba656 starrocks::vectorized::OrcChunkReader::set_conjuncts_and_runtime_filters()
    @          0x1b1e41a starrocks::vectorized::HdfsOrcScanner::do_open()
    @          0x1b17259 starrocks::vectorized::HdfsScanner::open()
    @          0x173ceae starrocks::connector::HiveDataSource::_init_scanner()
    @          0x173f6e0 starrocks::connector::HiveDataSource::open()
    @          0x1c5ef30 starrocks::vectorized::ConnectorScanNode::_scanner_thread()
    @          0x314c348 starrocks::PriorityThreadPool::work_thread()
    @          0x414ccc7 thread_proxy
    @     0x7f1e2f343ea5 start_thread
    @     0x7f1e2e95eb0d __clone
    @                0x0 (unknown)
```

It's because we just use  runtime filter raw pointer. But runtime filter could be released by runtime filte cache, but we probably are still using it. The robust way is to hold share ptr of runtime filter. 


----

the reason why we don't need following code is because, if there are multiple fragment instances executed, some of them  finish early and close queyr(clean runtime filter cache), following fragment instance won't get runtime filter from cache.

There is a `clean_thread` in runtime filter cache, and that will clean runtime filter has not retrived used for a long time 

```
_exec_env->runtime_filter_cache()->remove(_query_id);
```
