### PR TITLE
[BugFix] BE blocked in starrocks::KafkaDataConsumer::get_partition_offset

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -255,7 +255,7 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
         int64_t latest_offset;
 
         //When all kafka brokers are down,  query_watermark_offsets would block until timeout, which make the bthread unable to be preemptive.
-        // Here, we make 2 attempt to query_watermark_offsets. 
+        // Here, we make 2 attempt to query_watermark_offsets.
         // When all brokers are down, the 1st query_watermark_offsets with 1s timeout would fail quickly and return RdKafka::ERR__ALL_BROKERS_DOWN.
         // When the 1st query_watermark_offsets fails but not due to all brokers are down, the 2nd query_watermark_offsets would try with timeout config::routine_load_kafka_timeout_second.
 
@@ -270,8 +270,8 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
                 return Status::ServiceUnavailable("failed to query watermark offset, err: " + RdKafka::err2str(err));
             }
 
-            LOG(WARNING) << "failed to query watermark offset in fast path, topic: " << _topic
-                         << " partition: " << p_id << ", timeout: 1s"
+            LOG(WARNING) << "failed to query watermark offset in fast path, topic: " << _topic << " partition: " << p_id
+                         << ", timeout: 1s"
                          << " , err: " << RdKafka::err2str(err);
 
             // slow path


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8947

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`starrocks::KafkaDataConsumer::get_partition_offset` queries the partition offset from kafka.
The previous implementation would blocks many bthreads in `starrocks::KafkaDataConsumer::get_partition_offset` when all brokers of kafka are down. `starrocks::KafkaDataConsumer::get_partition_offset` would release bthread when the set timeout interval is reached.
This PR makes 2 attemp for the query. The first one is with 1s timeout, which would fail quickly when all brokers of kafka are down. The second one is with `routine_load_kafka_timeout_second` timeout, which would query more patiently when there's a real timeout.