### PR TITLE
[Bugfix] Fix DictMappingExpr rewrite multi times

### DIFF
--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -6,6 +6,7 @@
 #include "column/column_builder.h"
 #include "column/column_viewer.h"
 #include "common/global_types.h"
+#include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/column_ref.h"
@@ -241,9 +242,11 @@ Status DictOptimizeParser::eval_expression(ExprContext* expr_ctx, DictOptimizeCo
 Status DictOptimizeParser::rewrite_expr(ExprContext* ctx, Expr* expr, SlotId slot_id) {
     // call rewrite for each DictMappingExpr
     if (auto f = dynamic_cast<DictMappingExpr*>(expr)) {
-        auto* dict_ctx_handle = _free_pool.add(new DictOptimizeContext());
-        RETURN_IF_ERROR(_eval_and_rewrite(ctx, f, dict_ctx_handle, slot_id));
-        f->rewrite(_free_pool.add(new DictFuncExpr(*f, dict_ctx_handle)));
+        f->rewrite([&]() -> StatusOr<Expr*> {
+            auto* dict_ctx_handle = _free_pool.add(new DictOptimizeContext());
+            RETURN_IF_ERROR(_eval_and_rewrite(ctx, f, dict_ctx_handle, slot_id));
+            return _free_pool.add(new DictFuncExpr(*f, dict_ctx_handle));
+        });
         return Status::OK();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes https://github.com/StarRocks/StarRocksBenchmark/issues/173

## Problem Summary(Required) ：
Because Expr and ExprContext are shared in OlapScanOperator.
And OlapScanPrepareOperator::pull_chunk() will be executed concurrently,
which can cause the rewrite function to be executed multiple times.
We should use std::call_once to avoid multiple rewrites
