### PR TITLE
[WIP][BugFix] Fix the bug of LocalTabletsChannel heap-use-after-free

### DIFF
--- a/be/src/runtime/lake_tablets_channel.h
+++ b/be/src/runtime/lake_tablets_channel.h
@@ -11,6 +11,6 @@ class MemTracker;
 class TabletsChannelKey;
 
 scoped_refptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                       MemTracker* mem_tracker);
+                                                       std::shared_ptr<MemTracker> mem_tracker);
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -66,8 +66,8 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
         std::lock_guard l(_lock);
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
             TabletsChannelKey key(request.id(), index_id);
-            channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker.get())
-                                     : new_local_tablets_channel(this, key, _mem_tracker.get());
+            channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker)
+                                     : new_local_tablets_channel(this, key, _mem_tracker);
             if (st = channel->open(request); st.ok()) {
                 _tablets_channels.insert({index_id, std::move(channel)});
             }

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -94,7 +94,7 @@ private:
     LoadChannelMgr* _load_mgr;
     UniqueId _load_id;
     int64_t _timeout_s;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::atomic<time_t> _last_updated_time;
 
     // lock protect the tablets channel map

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -13,6 +13,6 @@ namespace starrocks {
 class MemTracker;
 
 scoped_refptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                        MemTracker* mem_tracker);
+                                                        std::shared_ptr<MemTracker> mem_tracker);
 
 } // namespace starrocks

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -53,8 +53,8 @@ int AsyncDeltaWriter::_execute(void* meta, bthread::TaskIterator<AsyncDeltaWrite
 }
 
 StatusOr<std::unique_ptr<AsyncDeltaWriter>> AsyncDeltaWriter::open(const DeltaWriterOptions& opt,
-                                                                   MemTracker* mem_tracker) {
-    auto res = DeltaWriter::open(opt, mem_tracker);
+                                                                   std::shared_ptr<MemTracker> mem_tracker) {
+    auto res = DeltaWriter::open(opt, std::move(mem_tracker));
     if (!res.ok()) {
         return res.status();
     }

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -30,7 +30,8 @@ public:
     constexpr static uint64_t kInvalidQueueId = (uint64_t)-1;
 
     // Create a new transaction in TxnManager and return a AsyncDeltaWriter for write.
-    static StatusOr<std::unique_ptr<AsyncDeltaWriter>> open(const DeltaWriterOptions& opt, MemTracker* mem_tracker);
+    static StatusOr<std::unique_ptr<AsyncDeltaWriter>> open(const DeltaWriterOptions& opt,
+                                                            std::shared_ptr<MemTracker> mem_tracker);
 
     AsyncDeltaWriter(private_type, std::unique_ptr<DeltaWriter> writer)
             : _writer(std::move(writer)), _queue_id{kInvalidQueueId} {}

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -30,8 +30,8 @@ public:
     constexpr static uint64_t kInvalidQueueId = (uint64_t)-1;
 
     AsyncDeltaWriterImpl(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                         const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker)
-            : _writer(DeltaWriter::create(tablet_id, txn_id, partition_id, slots, mem_tracker)),
+                         const std::vector<SlotDescriptor*>* slots, std::shared_ptr<MemTracker> mem_tracker)
+            : _writer(DeltaWriter::create(tablet_id, txn_id, partition_id, slots, std::move(mem_tracker))),
               _queue_id{kInvalidQueueId},
               _open_mtx(),
               _status(),
@@ -219,8 +219,8 @@ int64_t AsyncDeltaWriter::txn_id() const {
 
 std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                                                            const std::vector<SlotDescriptor*>* slots,
-                                                           MemTracker* mem_tracker) {
-    auto impl = new AsyncDeltaWriterImpl(tablet_id, txn_id, partition_id, slots, mem_tracker);
+                                                           std::shared_ptr<MemTracker> mem_tracker) {
+    auto impl = new AsyncDeltaWriterImpl(tablet_id, txn_id, partition_id, slots, std::move(mem_tracker));
     return std::make_unique<AsyncDeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -34,7 +34,7 @@ public:
 
     // |slots| and |mem_tracker| must outlive the AsyncDeltaWriter
     static Ptr create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker);
+                      const std::vector<SlotDescriptor*>* slots, std::shared_ptr<MemTracker> mem_tracker);
 
     explicit AsyncDeltaWriter(AsyncDeltaWriterImpl* impl) : _impl(impl) {}
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -28,7 +28,7 @@ public:
     using Ptr = std::unique_ptr<DeltaWriter>;
 
     static Ptr create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker);
+                      const std::vector<SlotDescriptor*>* slots, std::shared_ptr<MemTracker> mem_tracker);
 
     explicit DeltaWriter(DeltaWriterImpl* impl) : _impl(impl) {}
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -44,30 +44,30 @@ void MemTable::_init_aggregator_if_needed() {
 }
 
 MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<SlotDescriptor*>* slot_descs,
-                   MemTableSink* sink, MemTracker* mem_tracker)
+                   std::shared_ptr<MemTableSink> sink, std::shared_ptr<MemTracker> mem_tracker)
         : _tablet_id(tablet_id),
           _vectorized_schema(schema),
           _slot_descs(slot_descs),
           _keys_type(schema->keys_type()),
-          _sink(sink),
+          _sink(std::move(sink)),
           _aggregator(nullptr),
-          _mem_tracker(mem_tracker) {
+          _mem_tracker(std::move(mem_tracker)) {
     if (_keys_type == KeysType::PRIMARY_KEYS && _slot_descs->back()->col_name() == LOAD_OP_COLUMN) {
         _has_op_slot = true;
     }
     _init_aggregator_if_needed();
 }
 
-MemTable::MemTable(int64_t tablet_id, const Schema* schema, MemTableSink* sink, int64_t max_buffer_size,
-                   MemTracker* mem_tracker)
+MemTable::MemTable(int64_t tablet_id, const Schema* schema, std::shared_ptr<MemTableSink> sink, int64_t max_buffer_size,
+                   std::shared_ptr<MemTracker> mem_tracker)
         : _tablet_id(tablet_id),
           _vectorized_schema(schema),
           _slot_descs(nullptr),
           _keys_type(schema->keys_type()),
-          _sink(sink),
+          _sink(std::move(sink)),
           _aggregator(nullptr),
           _max_buffer_size(max_buffer_size),
-          _mem_tracker(mem_tracker) {
+          _mem_tracker(std::move(mem_tracker)) {
     _init_aggregator_if_needed();
 }
 

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -22,10 +22,10 @@ class MemTableSink;
 class MemTable {
 public:
     MemTable(int64_t tablet_id, const Schema* schema, const std::vector<SlotDescriptor*>* slot_descs,
-             MemTableSink* sink, MemTracker* mem_tracker);
+             std::shared_ptr<MemTableSink> sink, std::shared_ptr<MemTracker> mem_tracker);
 
-    MemTable(int64_t tablet_id, const Schema* schema, MemTableSink* sink, int64_t max_buffer_size,
-             MemTracker* mem_tracker);
+    MemTable(int64_t tablet_id, const Schema* schema, std::shared_ptr<MemTableSink> sink, int64_t max_buffer_size,
+             std::shared_ptr<MemTracker> mem_tracker);
 
     ~MemTable();
 
@@ -33,7 +33,7 @@ public:
 
     // the total memory used (contain tmp chunk and aggregator chunk)
     size_t memory_usage() const;
-    MemTracker* mem_tracker() { return _mem_tracker; }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
 
     // buffer memory usage for write segment
     size_t write_buffer_size() const;
@@ -75,7 +75,7 @@ private:
     const std::vector<SlotDescriptor*>* _slot_descs;
     KeysType _keys_type;
 
-    MemTableSink* _sink;
+    std::shared_ptr<MemTableSink> _sink;
 
     // aggregate
     std::unique_ptr<ChunkAggregator> _aggregator;
@@ -88,7 +88,7 @@ private:
     int64_t _max_buffer_size = config::write_buffer_size;
 
     // memory statistic
-    MemTracker* _mem_tracker = nullptr;
+    std::shared_ptr<MemTracker> _mem_tracker;
     // memory usage and bytes usage calculation cost of object column is high,
     // so cache calculated memory usage and bytes usage to avoid repeated calculation.
     size_t _chunk_memory_usage = 0;

--- a/be/src/storage/memtable_rowset_writer_sink.h
+++ b/be/src/storage/memtable_rowset_writer_sink.h
@@ -9,7 +9,7 @@ namespace starrocks::vectorized {
 
 class MemTableRowsetWriterSink : public MemTableSink {
 public:
-    explicit MemTableRowsetWriterSink(RowsetWriter* w) : _rowset_writer(w) {}
+    explicit MemTableRowsetWriterSink(std::shared_ptr<RowsetWriter> w) : _rowset_writer(std::move(w)) {}
     ~MemTableRowsetWriterSink() override = default;
 
     DISALLOW_COPY(MemTableRowsetWriterSink);
@@ -21,7 +21,7 @@ public:
     }
 
 private:
-    RowsetWriter* _rowset_writer;
+    std::shared_ptr<RowsetWriter> _rowset_writer;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -40,6 +40,13 @@ Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::strin
     return Status::OK();
 }
 
+Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, std::shared_ptr<RowsetWriter>* output) {
+    std::unique_ptr<RowsetWriter> writer;
+    RETURN_IF_ERROR(create_rowset_writer(context, &writer));
+    *output = std::move(writer);
+    return Status::OK();
+}
+
 Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, std::unique_ptr<RowsetWriter>* output) {
     auto tablet_schema = context.tablet_schema;
     auto memory_format_version = context.memory_format_version;

--- a/be/src/storage/rowset/rowset_factory.h
+++ b/be/src/storage/rowset/rowset_factory.h
@@ -41,6 +41,8 @@ public:
     // return OK on success and set `*output` to inited rowset writer.
     // return error if failed
     static Status create_rowset_writer(const RowsetWriterContext& context, std::unique_ptr<RowsetWriter>* output);
+
+    static Status create_rowset_writer(const RowsetWriterContext& context, std::shared_ptr<RowsetWriter>* output);
 };
 
 } // namespace starrocks

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -46,7 +46,7 @@ namespace vectorized {
 
 class ChunkChanger {
 public:
-    ChunkChanger(const TabletSchema& tablet_schema);
+    explicit ChunkChanger(const TabletSchema& tablet_schema);
 
     virtual ~ChunkChanger();
 
@@ -99,8 +99,8 @@ public:
     virtual bool process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet,
                          TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
 
-    virtual Status processV2(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet,
-                             TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
+    virtual Status processV2(TabletReader* reader, std::shared_ptr<RowsetWriter> new_rowset_writer,
+                             TabletSharedPtr tablet, TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
 };
 
 class LinkedSchemaChange : public SchemaChange {
@@ -111,7 +111,7 @@ public:
     bool process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
-    Status processV2(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+    Status processV2(TabletReader* reader, std::shared_ptr<RowsetWriter> new_rowset_writer, TabletSharedPtr new_tablet,
                      TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
 private:
@@ -128,7 +128,7 @@ public:
     bool process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
-    Status processV2(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+    Status processV2(TabletReader* reader, std::shared_ptr<RowsetWriter> new_rowset_writer, TabletSharedPtr new_tablet,
                      TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
 private:
@@ -145,7 +145,7 @@ public:
     bool process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
-    Status processV2(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+    Status processV2(TabletReader* reader, std::shared_ptr<RowsetWriter> new_rowset_writer, TabletSharedPtr new_tablet,
                      TabletSharedPtr base_tablet, RowsetSharedPtr rowset);
 
 private:
@@ -173,7 +173,6 @@ public:
     };
 
     struct SchemaChangeParams {
-        AlterTabletType alter_tablet_type;
         TabletSharedPtr base_tablet;
         TabletSharedPtr new_tablet;
         std::vector<std::unique_ptr<TabletReader>> rowset_readers;

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -39,7 +39,7 @@ EngineAlterTabletTask::EngineAlterTabletTask(MemTracker* mem_tracker, const TAlt
           _process_name(process_name) {
     size_t mem_limit = static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
     _mem_tracker =
-            std::make_unique<MemTracker>(MemTracker::SCHEMA_CHANGE_TASK, mem_limit, "schema change task", mem_tracker);
+            std::make_shared<MemTracker>(MemTracker::SCHEMA_CHANGE_TASK, mem_limit, "schema change task", mem_tracker);
 }
 
 Status EngineAlterTabletTask::execute() {

--- a/be/src/storage/task/engine_alter_tablet_task.h
+++ b/be/src/storage/task/engine_alter_tablet_task.h
@@ -39,7 +39,7 @@ public:
     ~EngineAlterTabletTask() override = default;
 
 private:
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
 
     const TAlterTabletReqV2& _alter_tablet_req;
     int64_t _signature;

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -185,7 +185,7 @@ protected:
         _load_channel = scoped_refptr<LoadChannel>(new LoadChannel(_load_channel_mgr.get(), UniqueId::gen_uid(),
                                                                    string(), 1000, std::move(load_mem_tracker)));
         TabletsChannelKey key{UniqueId::gen_uid().to_proto(), 99999};
-        _tablets_channel = new_lake_tablets_channel(_load_channel.get(), key, _load_channel->mem_tracker());
+        _tablets_channel = new_lake_tablets_channel(_load_channel.get(), key, nullptr);
     }
 
     void TearDown() override {

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -185,7 +185,8 @@ protected:
         _load_channel = scoped_refptr<LoadChannel>(new LoadChannel(_load_channel_mgr.get(), UniqueId::gen_uid(),
                                                                    string(), 1000, std::move(load_mem_tracker)));
         TabletsChannelKey key{UniqueId::gen_uid().to_proto(), 99999};
-        _tablets_channel = new_lake_tablets_channel(_load_channel.get(), key, nullptr);
+        auto lake_load_mem_tracker = std::make_shared<MemTracker>(-1, "", _mem_tracker.get());
+        _tablets_channel = new_lake_tablets_channel(_load_channel.get(), key, lake_load_mem_tracker);
     }
 
     void TearDown() override {

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -122,7 +122,7 @@ protected:
 
     TabletManager* _tablet_manager;
     std::unique_ptr<MemTracker> _parent_mem_tracker;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<FixedLocationProvider> _location_provider;
     LocationProvider* _backup_location_provider;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
@@ -136,7 +136,7 @@ TEST_F(AsyncDeltaWriterTest, test_open) {
     // Invalid tablet id
     {
         auto tablet_id = -1;
-        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_ERROR(delta_writer->open());
         ASSERT_ERROR(delta_writer->open());
         delta_writer->close();
@@ -144,7 +144,7 @@ TEST_F(AsyncDeltaWriterTest, test_open) {
     // Call open() multiple times
     {
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->open());
@@ -153,7 +153,7 @@ TEST_F(AsyncDeltaWriterTest, test_open) {
     // Call open() concurrently
     {
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         auto t1 = std::thread([&]() {
             for (int i = 0; i < 10000; i++) {
                 ASSERT_OK(delta_writer->open());
@@ -181,7 +181,7 @@ TEST_F(AsyncDeltaWriterTest, test_write) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
     // Call open() again
     ASSERT_OK(delta_writer->open());
@@ -258,7 +258,7 @@ TEST_F(AsyncDeltaWriterTest, test_write_concurrently) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
 
     ASSERT_OK(delta_writer->open());
 
@@ -353,7 +353,7 @@ TEST_F(AsyncDeltaWriterTest, test_write_after_close) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // close()
@@ -381,7 +381,7 @@ TEST_F(AsyncDeltaWriterTest, test_write_after_close) {
 TEST_F(AsyncDeltaWriterTest, test_finish_after_close) {
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // close()
@@ -399,7 +399,7 @@ TEST_F(AsyncDeltaWriterTest, test_close) {
     // Call close() multiple times
     {
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_OK(delta_writer->open());
 
         delta_writer->close();
@@ -408,7 +408,7 @@ TEST_F(AsyncDeltaWriterTest, test_close) {
     // Call close() concurrently
     {
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_OK(delta_writer->open());
         auto t1 = std::thread([&]() {
             for (int i = 0; i < 10000; i++) {

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -121,7 +121,7 @@ protected:
 
     TabletManager* _tablet_manager;
     std::unique_ptr<MemTracker> _parent_mem_tracker;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<FixedLocationProvider> _location_provider;
     LocationProvider* _backup_location_provider;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
@@ -135,7 +135,7 @@ TEST_F(DeltaWriterTest, test_open) {
     // Invalid tablet id
     {
         auto tablet_id = -1;
-        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_ERROR(delta_writer->open());
         delta_writer->close();
     }
@@ -152,7 +152,7 @@ TEST_F(DeltaWriterTest, test_write) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // Write and flush
@@ -224,7 +224,7 @@ TEST_F(DeltaWriterTest, test_close) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // write()
@@ -255,7 +255,7 @@ TEST_F(DeltaWriterTest, test_memory_limit_unreached) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // Write three times
@@ -298,7 +298,7 @@ TEST_F(DeltaWriterTest, test_reached_memory_limit) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // Write tree times
@@ -341,7 +341,7 @@ TEST_F(DeltaWriterTest, test_reached_parent_memory_limit) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // Write tree times
@@ -385,7 +385,7 @@ TEST_F(DeltaWriterTest, test_memtable_full) {
 
     // Create and open DeltaWriter
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+    auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
     ASSERT_OK(delta_writer->open());
 
     // Write tree times

--- a/be/test/storage/lake/horizontal_compaction_task_test.cpp
+++ b/be/test/storage/lake/horizontal_compaction_task_test.cpp
@@ -41,7 +41,7 @@ public:
         _tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
 
         _parent_mem_tracker = std::make_unique<MemTracker>(-1);
-        _mem_tracker = std::make_unique<MemTracker>(-1, "", _parent_mem_tracker.get());
+        _mem_tracker = std::make_shared<MemTracker>(-1, "", _parent_mem_tracker.get());
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
         _backup_location_provider = _tablet_manager->TEST_set_location_provider(_location_provider.get());
 
@@ -140,7 +140,7 @@ protected:
 
     TabletManager* _tablet_manager;
     std::unique_ptr<MemTracker> _parent_mem_tracker;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<FixedLocationProvider> _location_provider;
     LocationProvider* _backup_location_provider;
     std::shared_ptr<TabletMetadata> _tablet_metadata;
@@ -162,7 +162,7 @@ TEST_F(DuplicateKeyHorizontalCompactionTest, test1) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         _txn_id++;
-        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -294,7 +294,7 @@ protected:
 
     TabletManager* _tablet_manager;
     std::unique_ptr<MemTracker> _parent_mem_tracker;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<FixedLocationProvider> _location_provider;
     LocationProvider* _backup_location_provider;
     std::shared_ptr<TabletMetadata> _tablet_metadata;
@@ -316,7 +316,7 @@ TEST_F(UniqueKeyHorizontalCompactionTest, test1) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         _txn_id++;
-        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -599,11 +599,10 @@ TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = VISIBLE;
     writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
+    std::shared_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(
-            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer, new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1101);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1102);
@@ -668,11 +667,10 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = VISIBLE;
     writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
+    std::shared_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(
-            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer, new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1103);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1104);
@@ -732,11 +730,10 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = VISIBLE;
     writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
+    std::shared_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(
-            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer, new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1203);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1204);

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -237,8 +237,8 @@ TEST_F(EngineStorageMigrationTaskTest, test_concurrent_ingestion_and_migration) 
     writer_options.slots = &tuple_desc->slots();
 
     {
-        MemTracker mem_checker(1024 * 1024 * 1024);
-        auto writer_status = vectorized::DeltaWriter::open(writer_options, &mem_checker);
+        auto mem_checker = std::make_shared<MemTracker>(1024 * 1024 * 1024);
+        auto writer_status = vectorized::DeltaWriter::open(writer_options, mem_checker);
         ASSERT_TRUE(writer_status.ok());
         auto delta_writer = std::move(writer_status.value());
         ASSERT_TRUE(delta_writer != nullptr);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8906 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

MemTable is asynchronous flush, if the sender actively cancel, the target end of load will not wait for memtable flush to complete, it will destroy `LoadChannel`, and some data structures will be destroyed at this time, such as `RowsetWriter`, `MemTableSink`, `MemTracker` for Load, etc. The items will be used in memtable flush, so it will be crash because of `heap-use-after-free`. 

So we modify this from raw ptr to shared ptr.



```
==137244==ERROR: AddressSanitizer: heap-use-after-free on address 0x6020002c62d0 at pc 0x000005b3b188 bp 0x7f01d6dc9450 sp 0x7f01d6dc9448
READ of size 8 at 0x6020002c62d0 thread T134 (mem_tab_flush)
    #0 0x5b3b187 in starrocks::vectorized::MemTable::flush() /home/disk2/lxh/doris/be/src/storage/memtable.cpp:237
    #1 0x5c4fe39 in starrocks::FlushToken::_flush_memtable(starrocks::vectorized::MemTable*) /home/disk2/lxh/doris/be/src/storage/memtable_flush_executor.cpp:82
    #2 0x5c51c54 in starrocks::MemtableFlushTask::run() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x5c51c54)
    #3 0x6f9517f in starrocks::ThreadPool::dispatch_thread() /home/disk2/lxh/doris/be/src/util/threadpool.cpp:516
    #4 0x6fb340b in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/b
its/invoke.h:73
    #5 0x6fb2d64 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolcha
in/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #6 0x6fb215b in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #7 0x6fb0abb in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #8 0x6fad9bd in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/inclu
de/c++/10.3.0/bits/invoke.h:60
    #9 0x6faaf0d in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPoo
l::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #10 0x6fa6d1a in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #11 0x533400d in std::function<void ()>::operator()() const /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #12 0x6f809ec in starrocks::Thread::supervise_thread(void*) /home/disk2/lxh/doris/be/src/util/thread.cpp:326
    #13 0x7f0206abfea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #14 0x7f02060dab0c in clone (/lib64/libc.so.6+0xfeb0c)
```