### PR TITLE
[Enhancement] Support rewrite window function sort partition by in lowcardinality optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -125,6 +125,14 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             }
         }
 
+        // if column ref is an applied optimized string column, return the dictionary column.
+        // else return column ref itself
+        ColumnRefOperator getMappedOperator(ColumnRefOperator columnRef) {
+            int id = columnRef.getId();
+            Integer mapped = stringColumnIdToDictColumnIds.getOrDefault(id, id);
+            return columnRefFactory.getColumnRef(mapped);
+        }
+
         public void clear() {
             stringColumnIdToDictColumnIds.clear();
             stringFunctions.clear();
@@ -473,6 +481,14 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     orderingList.add(orderDesc);
                 }
             }
+
+            List<ColumnRefOperator> partitionByColumns = null;
+            if (operator.getPartitionByColumns() != null) {
+                partitionByColumns =
+                        operator.getPartitionByColumns().stream().map(context::getMappedOperator)
+                                .collect(Collectors.toList());
+            }
+
             OrderSpec newOrderSpec = new OrderSpec(orderingList);
 
             ScalarOperator predicate = operator.getPredicate();
@@ -487,7 +503,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
 
             return new PhysicalTopNOperator(newOrderSpec, operator.getLimit(),
                     operator.getOffset(),
-                    null,
+                    partitionByColumns,
                     Operator.DEFAULT_LIMIT,
                     operator.getSortPhase(),
                     operator.getTopNType(),


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
relation with #6119

## Problem Summary(Required) ：

for some window function query with predicate
```
explain SELECT SUM(wv) FROM (
    SELECT row_number() OVER (PARTITION BY par_str_low ORDER BY fn_int) AS wv FROM analytic.t0
) AS sub
WHERE wv <= 10;
```

it will change 
```
|   1:SORT                                                                                  |
|   |  order by: <slot 9> 9: par_str_low ASC, <slot 1> 1: fn_int ASC                        |
|   |  offset: 0                                                                            |
|   |                                                                                       |
```
to
```
|   1:PARTITION-TOP-N                                                                       |
|   |  partition by: 5: par_str_low                                                         |
|   |  partition limit: 10                                                                  |
|   |  order by: <slot 5> 5: par_str_low ASC, <slot 1> 1: fn_int ASC                        |
|   |  offset: 0                                                                            |
|   |                                                                                       |
```
