### PR TITLE
[BugFix] Fix analyze status state replay bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -144,9 +144,6 @@ public class AnalyzeManager implements Writable {
     }
 
     public void replayAddAnalyzeStatus(AnalyzeStatus status) {
-        if (status.getStatus().equals(StatsConstants.ScheduleStatus.RUNNING)) {
-            status.setStatus(StatsConstants.ScheduleStatus.FAILED);
-        }
         analyzeStatusMap.put(status.getId(), status);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -208,8 +208,12 @@ public class StatisticExecutor {
                 db.getId(), table.getId(), columns,
                 statsJob.getType(), statsJob.getScheduleType(), statsJob.getProperties(),
                 LocalDateTime.now());
-        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);
+        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
         GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+
+        //Only update running status without edit log, make restart job status is failed
+        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);
+        GlobalStateMgr.getCurrentAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
 
         try {
             statsJob.collect();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In order to prevent the sudden interruption of the process, we first set the task state to FAIL. If the process is not interrupted, there must be an end state setting, such as SUCCESS or FAIL. The RUNNING in the next line only modifies the state in memory and does not record the log. In this way, after the FE restarts, the unfinished statistics collection task will be FAIL instead of RUNNING.