### PR TITLE
[WIP] [BugFix] Fix the bug of LocalTabletsChannel heap-use-after-free

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -354,7 +354,7 @@ void LocalTabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterA
             (void)tablet_id;
             if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
                 // no data load, abort txn without printing log
-                delta_writer->abort(false);
+                delta_writer->abort(false, false);
             } else {
                 auto cb = new WriteCallback(context.get());
                 delta_writer->commit(cb);
@@ -493,7 +493,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
 
 void LocalTabletsChannel::cancel() {
     for (auto& it : _delta_writers) {
-        (void)it.second->abort();
+        (void)it.second->abort(false, true);
     }
 }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -493,7 +493,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
 
 void LocalTabletsChannel::cancel() {
     for (auto& it : _delta_writers) {
-        (void)it.second->abort(false, true);
+        (void)it.second->abort(true, true);
     }
 }
 

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -108,8 +108,8 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     }
 }
 
-void AsyncDeltaWriter::abort(bool with_log) {
-    _writer->abort(with_log);
+void AsyncDeltaWriter::abort(bool with_log, bool wait_flush) {
+    _writer->abort(with_log, wait_flush);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -53,7 +53,7 @@ public:
     void commit(AsyncDeltaWriterCallback* cb);
 
     // [thread-safe and wait-free]
-    void abort(bool with_log = true);
+    void abort(bool with_log = true, bool wait_flush = false);
 
     int64_t partition_id() const { return _writer->partition_id(); }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -344,9 +344,8 @@ void DeltaWriter::abort(bool with_log, bool wait_flush) {
     _with_rollback_log = with_log;
 
     if (wait_flush) {
-        if (auto st = _flush_token->wait(); !st.ok()) {
-            LOG(WARNING) << st;
-        }
+        // Any queued tasks not yet running are destroyed. If tasks are in flight, cancel() will wait
+        _flush_token->cancel();
     }
 }
 

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -65,7 +65,7 @@ public:
     // with_log is used to control whether to print the log when rollback txn.
     // with_log is false when there is no data load into one partition and abort
     // the related txn.
-    void abort(bool with_log = true);
+    void abort(bool with_log = true, bool wait_flush = false);
 
     int64_t txn_id() const { return _opt.txn_id; }
 
@@ -104,7 +104,7 @@ private:
     Status _init();
     Status _flush_memtable_async();
     Status _flush_memtable();
-    const char* _state_name(State state) const;
+    static const char* _state_name(State state) ;
 
     void _garbage_collection();
 

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -65,6 +65,13 @@ public:
     // with_log is used to control whether to print the log when rollback txn.
     // with_log is false when there is no data load into one partition and abort
     // the related txn.
+    //
+    // wait_flush is used to control whether to wait the flush of memtablea.
+    // MemTable is asynchronous flush, if the sender actively cancel,
+    // the target end of load will not wait for memtable flush to complete,
+    // it will destroy LoadChannel, and some data structures will be destroyed at this time,
+    // such as RowsetWriter, MemTableSink, MemTracker for Load, etc.
+    // The items will be used in memtable flush, so it will be crash because of heap-use-after-free
     void abort(bool with_log = true, bool wait_flush = false);
 
     int64_t txn_id() const { return _opt.txn_id; }

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -104,7 +104,7 @@ private:
     Status _init();
     Status _flush_memtable_async();
     Status _flush_memtable();
-    static const char* _state_name(State state) ;
+    static const char* _state_name(State state);
 
     void _garbage_collection();
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8906 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

MemTable is asynchronous flush, if the sender actively cancel, the target end of load will not wait for memtable flush to complete, it will destroy `LoadChannel`, and some data structures will be destroyed at this time, such as `RowsetWriter`, `MemTableSink`, `MemTracker` for Load, etc. The items will be used in memtable flush, so it will be crash because of `heap-use-after-free`. 



```
==137244==ERROR: AddressSanitizer: heap-use-after-free on address 0x6020002c62d0 at pc 0x000005b3b188 bp 0x7f01d6dc9450 sp 0x7f01d6dc9448
READ of size 8 at 0x6020002c62d0 thread T134 (mem_tab_flush)
    #0 0x5b3b187 in starrocks::vectorized::MemTable::flush() /home/disk2/lxh/doris/be/src/storage/memtable.cpp:237
    #1 0x5c4fe39 in starrocks::FlushToken::_flush_memtable(starrocks::vectorized::MemTable*) /home/disk2/lxh/doris/be/src/storage/memtable_flush_executor.cpp:82
    #2 0x5c51c54 in starrocks::MemtableFlushTask::run() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x5c51c54)
    #3 0x6f9517f in starrocks::ThreadPool::dispatch_thread() /home/disk2/lxh/doris/be/src/util/threadpool.cpp:516
    #4 0x6fb340b in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/b
its/invoke.h:73
    #5 0x6fb2d64 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolcha
in/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #6 0x6fb215b in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #7 0x6fb0abb in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #8 0x6fad9bd in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/inclu
de/c++/10.3.0/bits/invoke.h:60
    #9 0x6faaf0d in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPoo
l::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #10 0x6fa6d1a in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #11 0x533400d in std::function<void ()>::operator()() const /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #12 0x6f809ec in starrocks::Thread::supervise_thread(void*) /home/disk2/lxh/doris/be/src/util/thread.cpp:326
    #13 0x7f0206abfea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #14 0x7f02060dab0c in clone (/lib64/libc.so.6+0xfeb0c)
```