### PR TITLE
[Enhance] introduce unplug mechanism to improve scalability

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -657,8 +657,6 @@ CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // The number of threads for preparing fragment instances in pipeline engine, vCPUs by default.
 CONF_Int64(pipeline_prepare_thread_pool_thread_num, "0");
 CONF_Int64(pipeline_prepare_thread_pool_queue_size, "102400");
-// The buffer size of io task.
-CONF_Int64(pipeline_io_buffer_size, "64");
 // The buffer size of SinkBuffer.
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // The degree of parallelism of brpc.

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -31,14 +31,14 @@ void ConnectorScanOperatorFactory::do_close(RuntimeState* state) {
 }
 
 OperatorPtr ConnectorScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, _scan_node);
+    return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, dop, _scan_node);
 }
 
 // ==================== ConnectorScanOperator ====================
 
-ConnectorScanOperator::ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence,
+ConnectorScanOperator::ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop,
                                              ScanNode* scan_node)
-        : ScanOperator(factory, id, driver_sequence, scan_node) {}
+        : ScanOperator(factory, id, driver_sequence, dop, scan_node) {}
 
 Status ConnectorScanOperator::do_prepare(RuntimeState* state) {
     return Status::OK();
@@ -75,10 +75,10 @@ bool ConnectorScanOperator::has_shared_chunk_source() const {
     return !active_inputs.empty();
 }
 
-bool ConnectorScanOperator::has_buffer_output() const {
+size_t ConnectorScanOperator::num_buffered_chunks() const {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     auto& buffer = factory->get_chunk_buffer();
-    return !buffer.empty(_driver_sequence);
+    return buffer.size(_driver_sequence);
 }
 
 ChunkPtr ConnectorScanOperator::get_chunk_from_buffer() {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -39,7 +39,8 @@ private:
 
 class ConnectorScanOperator final : public ScanOperator {
 public:
-    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node);
+    ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop,
+                          ScanNode* scan_node);
 
     ~ConnectorScanOperator() override = default;
 
@@ -52,12 +53,12 @@ public:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
-    bool has_buffer_output() const override;
     ChunkPtr get_chunk_from_buffer() override;
+    size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
     size_t default_buffer_capacity() const override;
-    ChunkBufferTokenPtr pin_chunk(int num_chunks);
+    ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;
     void set_buffer_finished() override;
 };

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -28,15 +28,15 @@ Status OlapScanOperatorFactory::do_prepare(RuntimeState* state) {
 void OlapScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr OlapScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, _scan_node,
+    return std::make_shared<OlapScanOperator>(this, _id, driver_sequence, dop, _scan_node,
                                               _ctx_factory->get_or_create(driver_sequence));
 }
 
 // ==================== OlapScanOperator ====================
 
-OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
-                                   OlapScanContextPtr ctx)
-        : ScanOperator(factory, id, driver_sequence, scan_node), _ctx(std::move(ctx)) {
+OlapScanOperator::OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop,
+                                   ScanNode* scan_node, OlapScanContextPtr ctx)
+        : ScanOperator(factory, id, driver_sequence, dop, scan_node), _ctx(std::move(ctx)) {
     _ctx->ref();
 }
 
@@ -98,8 +98,8 @@ bool OlapScanOperator::has_shared_chunk_source() const {
     return _ctx->has_active_input();
 }
 
-bool OlapScanOperator::has_buffer_output() const {
-    return !_ctx->get_chunk_buffer().empty(_driver_sequence);
+size_t OlapScanOperator::num_buffered_chunks() const {
+    return !_ctx->get_chunk_buffer().size(_driver_sequence);
 }
 
 ChunkPtr OlapScanOperator::get_chunk_from_buffer() {

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -99,7 +99,7 @@ bool OlapScanOperator::has_shared_chunk_source() const {
 }
 
 size_t OlapScanOperator::num_buffered_chunks() const {
-    return !_ctx->get_chunk_buffer().size(_driver_sequence);
+    return _ctx->get_chunk_buffer().size(_driver_sequence);
 }
 
 ChunkPtr OlapScanOperator::get_chunk_from_buffer() {

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -34,7 +34,7 @@ private:
 
 class OlapScanOperator final : public ScanOperator {
 public:
-    OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, ScanNode* scan_node,
+    OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop, ScanNode* scan_node,
                      OlapScanContextPtr ctx);
 
     ~OlapScanOperator() override;
@@ -50,12 +50,12 @@ protected:
     void attach_chunk_source(int32_t source_index) override;
     void detach_chunk_source(int32_t source_index) override;
     bool has_shared_chunk_source() const override;
-    bool has_buffer_output() const override;
     ChunkPtr get_chunk_from_buffer() override;
+    size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
     size_t default_buffer_capacity() const override;
-    ChunkBufferTokenPtr pin_chunk(int num_chunks);
+    ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;
     void set_buffer_finished() override;
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -103,11 +103,6 @@ size_t ScanOperator::_buffer_unplug_threshold() const {
     threshold = std::max<size_t>(1, std::min<size_t>(kIOTaskBatchSize, threshold));
     return threshold;
 }
-size_t ScanOperator::_buffer_submit_threshold() const {
-    size_t threshold = buffer_capacity() / _dop / 4;
-    threshold = std::max<size_t>(1, std::min<size_t>(kIOTaskBatchSize, threshold));
-    return threshold;
-}
 
 bool ScanOperator::has_output() const {
     if (_is_finished) {
@@ -231,7 +226,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     if (_num_running_io_tasks >= _io_tasks_per_scan_operator) {
         return Status::OK();
     }
-    if (_unpluging && num_buffered_chunks() >= _buffer_submit_threshold()) {
+    if (_unpluging && num_buffered_chunks() >= _buffer_unplug_threshold()) {
         return Status::OK();
     }
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -84,7 +84,8 @@ private:
     void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns, int64_t scan_rows,
                                    int64_t scan_bytes);
     void _merge_chunk_source_profiles();
-    size_t buffer_unplug_threshold() const;
+    size_t _buffer_unplug_threshold() const;
+    size_t _buffer_submit_threshold() const;
 
     inline void _set_scan_status(const Status& status) {
         std::lock_guard<SpinLock> l(_scan_status_mutex);
@@ -140,6 +141,7 @@ private:
     // A tablet may be divided into multiple morsels.
     RuntimeProfile::Counter* _morsels_counter = nullptr;
     RuntimeProfile::Counter* _buffer_unplug_counter = nullptr;
+    RuntimeProfile::Counter* _submit_task_counter = nullptr;
 };
 
 class ScanOperatorFactory : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -85,7 +85,6 @@ private:
                                    int64_t scan_bytes);
     void _merge_chunk_source_profiles();
     size_t _buffer_unplug_threshold() const;
-    size_t _buffer_submit_threshold() const;
 
     inline void _set_scan_status(const Status& status) {
         std::lock_guard<SpinLock> l(_scan_status_mutex);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


For scan-bottleneck scenario, that the producer speed is slower than consumer, which would make the exec-thread consume   chunks one by one. And that would introduce more much scheduling overhead.

This PR try to accumulate as many chunks, then unplug it to exec-thread, to balance the speed of consumer and producer. Specifically, try to buffer as many as `BufferCapacity/DOP/2` chunks for each operator before `pull_chunk`.

Furthermore, this issue also exists in ExchangeOperator, which would be optimized in the future.

## Experiment Result

Run such SQL, which has data skew, only few ScanOperator contains data:
- `mysqlslap --number-of-queries=100   --query="select lo_orderkey from lineorder_24 order by lo_orderkey limit 10;"   `
- In non-pipeline mode, the `parallel_fragment_exec_instance_num=8`
- The result is total time to run all of queries

| Concurrency | non-pipeline  | shared_scan=false(Before/After)  | shared_scan=true(Before/After) | 
| --- | --- | --- | --- | 
| 1 | 13.325 | 66.304/9.798 | 66.413 / 10.316 | 
| 2 | 14.422 |  62.767 / 7.382 | 70.937 / 8.421 |
| 4 | 10.526 |  54.713 / 6.591 | 68.165 / 29.034 |
| 8 | 7.889 | 37.658 / 6.209| 67.362 / 32.015 |
| 16 | 7.445 |26.969 / 6.070 | 68.078 / 37.894 |
| 32 | 7.922 | 29.419 / 6.013 | 68.700 / 39.103 |
