### PR TITLE
[Enhancement] Add invisible session variable 'profile_timeout'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/MarkedCountDownLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MarkedCountDownLatch.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class MarkedCountDownLatch<K, V> extends CountDownLatch {
 
-    private Multimap<K, V> marks;
+    private final Multimap<K, V> marks;
     private Status st = Status.OK;
 
     public MarkedCountDownLatch(int count) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2149,9 +2149,11 @@ public class Coordinator {
         // wait for all backends
         if (needReport) {
             try {
-                profileDoneSignal.await(2, TimeUnit.SECONDS);
-            } catch (InterruptedException e1) {
-                LOG.warn("signal await error", e1);
+                if (!profileDoneSignal.await(1, TimeUnit.HOURS)) {
+                    LOG.warn("failed to get profile within 1 hour");
+                }
+            } catch (InterruptedException e) {
+                LOG.warn("signal await error", e);
             }
         }
         lock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2149,6 +2149,8 @@ public class Coordinator {
         // wait for all backends
         if (needReport) {
             try {
+                // Waiting for other fragment instances to finish execution
+                // Ideally, it should wait indefinitely, but out of defense, set timeout to 1 minute
                 if (!profileDoneSignal.await(1, TimeUnit.MINUTES)) {
                     LOG.warn("failed to get profile within 1 minute");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2149,10 +2149,11 @@ public class Coordinator {
         // wait for all backends
         if (needReport) {
             try {
+                int timeout = connectContext.getSessionVariable().getProfileTimeout();
                 // Waiting for other fragment instances to finish execution
-                // Ideally, it should wait indefinitely, but out of defense, set timeout to 1 minute
-                if (!profileDoneSignal.await(1, TimeUnit.MINUTES)) {
-                    LOG.warn("failed to get profile within 1 minute");
+                // Ideally, it should wait indefinitely, but out of defense, set timeout
+                if (!profileDoneSignal.await(timeout, TimeUnit.SECONDS)) {
+                    LOG.warn("failed to get profile within {} seconds", timeout);
                 }
             } catch (InterruptedException e) {
                 LOG.warn("signal await error", e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2149,8 +2149,8 @@ public class Coordinator {
         // wait for all backends
         if (needReport) {
             try {
-                if (!profileDoneSignal.await(1, TimeUnit.HOURS)) {
-                    LOG.warn("failed to get profile within 1 hour");
+                if (!profileDoneSignal.await(1, TimeUnit.MINUTES)) {
+                    LOG.warn("failed to get profile within 1 minute");
                 }
             } catch (InterruptedException e) {
                 LOG.warn("signal await error", e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -157,7 +157,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
-    public static final String PROFILE_TIMEOUT = "profile_level";
+    public static final String PROFILE_TIMEOUT = "profile_timeout";
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
 
     public static final String RESOURCE_GROUP_ID = "workgroup_id";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -157,6 +157,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
+    public static final String PROFILE_TIMEOUT = "profile_level";
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
 
     public static final String RESOURCE_GROUP_ID = "workgroup_id";
@@ -259,7 +260,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             .add("prefer_join_method")
             .add("rewrite_count_distinct_to_bitmap_hll").build();
 
-
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
 
@@ -273,7 +273,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      * If enable this variable (only take effect for pipeline), it will deliver fragment instances
      * to BE in batch and concurrently.
      * - Uses `exec_batch_plan_fragments` instead of `exec_plan_fragment` RPC API, which all the instances
-     *   of a fragment to the same destination host are delivered in the same request.
+     * of a fragment to the same destination host are delivered in the same request.
      * - Send different fragments concurrently according to topological order of the fragment tree
      */
     @VariableMgr.VarAttr(name = ENABLE_DELIVER_BATCH_FRAGMENTS)
@@ -438,6 +438,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
+
+    @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
+    private int profileTimeout = 2;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_LEVEL)
     private int pipelineProfileLevel = 1;
@@ -926,6 +929,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getResourceGroupId() {
         return resourceGroupId;
+    }
+
+    public int getProfileTimeout() {
+        return profileTimeout;
     }
 
     public int getPipelineProfileLevel() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8984

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When the root fragment(the one with RESULT_SINK) finished it's execution, then fe will begin the profile collection procedure(if is_report_success is true). 

But when the pipeline which `RESULT_SINK` belongs to finished execution, some other fragment instances may be still under execution, such as doing the cleanup jobs, and we will get an incomplete profile if it does not end within 2s, 

Here is the issue case,

```sql
select level, count(*) uv from ( select lo_orderkey, window_funnel(3600000, lo_orderdate, 0, [lo_linenumber=1, lo_linenumber=2]) as level from ssb_100g.lineorder group by lo_orderkey ) AS x group by level
```

For the inner aggregation,`Aggregator::_is_only_group_by_columns` will be set to false, and the following function will be invoded when aggregator is colsing.  

```cpp
    template <typename HashMapWithKey>
    void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
        if (hash_map_with_key != nullptr) {
            auto null_data_ptr = hash_map_with_key->get_null_key_data();
            if (null_data_ptr != nullptr) {
                for (int i = 0; i < _agg_functions.size(); i++) {
                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], null_data_ptr + _agg_states_offsets[i]);
                }
            }

            auto it = hash_map_with_key->hash_map.begin();
            auto end = hash_map_with_key->hash_map.end();
            while (it != end) {
                for (int i = 0; i < _agg_functions.size(); i++) {
                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], it->second + _agg_states_offsets[i]);
                }
                ++it;
            }
        }
    }
```

Besides, aggregate function `window_funnel::destroy` is a little bit slow compared with `sum/avg/count` etc (may be the different memory access pattern). So in the high cardinality situations, this method will take a few seconds, which resulting in fe waiting for profiles to timeout.


~So we change the waiting time from 2s to 1 minute to avoid this problem. Ideally, it should have waited indefinitely, but set the timeout to 1 minute out of defense.~

So I add an invisible variable `profile_timeout` to dynamically tune the profile waiting timeout