### PR TITLE
[Enhancement] use heuristic method to handle left deep join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -339,6 +339,27 @@ public abstract class JoinOrder {
         return new Pair<>(Utils.compoundAnd(equalOnPredicates), Utils.compoundAnd(otherPredicates));
     }
 
+    public boolean canBuildInnerJoinPredicate(GroupInfo leftGroup, GroupInfo rightGroup) {
+        BitSet left = leftGroup.atoms;
+        BitSet right = rightGroup.atoms;
+        BitSet joinBitSet = new BitSet();
+        joinBitSet.or(left);
+        joinBitSet.or(right);
+
+        for (int i = 0; i < edgeSize; ++i) {
+            Edge edge = edges.get(i);
+            if (!Utils.isEqualBinaryPredicate(edge.predicate)) {
+                continue;
+            }
+            if (contains(joinBitSet, edge.vertexes) &&
+                    left.intersects(edge.vertexes) &&
+                    right.intersects(edge.vertexes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean contains(BitSet left, BitSet right) {
         return right.stream().allMatch(left::get);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
@@ -24,29 +24,32 @@ public class JoinReorderLeftDeep extends JoinOrder {
             double diff = b.bestExprInfo.cost - a.bestExprInfo.cost;
             return (diff < 0 ? -1 : (diff > 0 ? 1 : 0));
         });
+
+        boolean useHeuristic = true;
         boolean[] used = new boolean[atomSize];
-        used[0] = true;
         GroupInfo leftGroup = atoms.get(0);
+        used[0] = true;
         int next = 1;
         while (next < atomSize) {
             if (used[next]) {
                 next++;
                 continue;
             }
-
-            // search the next group which:
-            // 1. has never been used
-            // 2. can inner join with leftGroup
             int index = next;
             Preconditions.checkState(!used[index]);
-            for (; index < atomSize; ++index) {
-                if (!used[index] && canBuildInnerJoinPredicate(leftGroup, atoms.get(index))) {
-                    break;
+            if (useHeuristic) {
+                // search the next group which:
+                // 1. has never been used
+                // 2. can inner join with leftGroup
+                for (; index < atomSize; ++index) {
+                    if (!used[index] && canBuildInnerJoinPredicate(leftGroup, atoms.get(index))) {
+                        break;
+                    }
                 }
-            }
-            // if not found, fallback to old strategy
-            if (index == atomSize) {
-                index = next;
+                // if not found, fallback to old strategy
+                if (index == atomSize) {
+                    index = next;
+                }
             }
             Preconditions.checkState(!used[index]);
             used[index] = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
@@ -3,14 +3,30 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Map;
+
 public class TPCDSPlanTest extends TPCDSPlanTestBase {
+    Map<String, Long> tpcdsStats = null;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         TPCDSPlanTestBase.beforeClass();
+    }
+
+    @Before
+    public void setUp() {
+        tpcdsStats = getTPCDSTableStats();
+    }
+
+    @After
+    public void tearDown() {
+        setTPCDSTableStats(tpcdsStats);
     }
 
     @Test
@@ -618,5 +634,12 @@ public class TPCDSPlanTest extends TPCDSPlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan,
                 "PREDICATES: 14: ss_sales_price >= 50.00, 14: ss_sales_price <= 200.00, 23: ss_net_profit >= 50, 23: ss_net_profit <= 300");
+    }
+
+    @Test
+    public void testQuery20LeftDeepJoinReorderNoCrossJoin() throws Exception {
+        setTPCDSFactor(1);
+        String plan = getFragmentPlan(Q20);
+        assertNotContains(plan, "CROSS JOIN");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTestBase.java
@@ -5,6 +5,9 @@ package com.starrocks.sql.plan;
 import com.starrocks.catalog.OlapTable;
 import org.junit.BeforeClass;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class TPCDSPlanTestBase extends PlanTestBase {
     final static protected String[] tpcdsTables =
             {"call_center", "catalog_page", "catalog_returns", "catalog_sales", "customer", "customer_address",
@@ -21,6 +24,28 @@ public class TPCDSPlanTestBase extends PlanTestBase {
             long v = tpcdsTablesRowCount[i];
             OlapTable table = getOlapTable(t);
             setTableStatistics(table, v * factor);
+        }
+    }
+
+    public Map<String, Long> getTPCDSTableStats() {
+        Map<String, Long> m = new HashMap<>();
+        for (int i = 0; i < tpcdsTables.length; i++) {
+            String t = tpcdsTables[i];
+            long v = tpcdsTablesRowCount[i];
+            OlapTable table = getOlapTable(t);
+            m.put(t, table.getRowCount());
+        }
+        return m;
+    }
+
+    public void setTPCDSTableStats(Map<String, Long> m) {
+        for (int i = 0; i < tpcdsTables.length; i++) {
+            String t = tpcdsTables[i];
+            if (m.containsKey(t)) {
+                long v = m.get(t);
+                OlapTable table = getOlapTable(t);
+                setTableStatistics(table, v);
+            }
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The main idea is to build inner join first. If there is no inner join, then fallback to cross join.

use tpcds-1g query64 as test case. thers is no column stats, only table row count information:
- without this PR, there are 4 cross joins. and estimated rows are 4930002698541411 (max rows are 12449931856073464)
- with this PR, there are no cross joins, and estimated rows are 914616 (max rows are 2333127)
