### PR TITLE
[Bugfix] Cancel query when throwing any exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -100,6 +100,10 @@ public class QueryState {
         this.errorMessage = errorMsg;
     }
 
+    public boolean isError() {
+        return stateType == MysqlStateType.ERR;
+    }
+
     public void setStateType(MysqlStateType stateType) {
         this.stateType = stateType;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -495,6 +495,10 @@ public class StmtExecutor {
                 context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
             }
         } finally {
+            if (context.getState().isError() && coord != null) {
+                coord.cancel();
+            }
+
             if (parsedStmt instanceof InsertStmt) {
                 InsertStmt insertStmt = (InsertStmt) parsedStmt;
                 // The transaction of an insert operation begin at analyze phase.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the codes outside `Coordinator` throw exceptions, the query isn't cancelled for some cases.
For example, `StmtExecutor#handleQueryStmt()` sends result data to MySQL client and some network errors throw, it will never cancel the query in BE.


