### PR TITLE
[Feature] Support MaxCompute Table for Spark Load

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -461,7 +461,7 @@ under the License.
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+            <artifactId>spark-core_${spark.scala.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -481,13 +481,13 @@ under the License.
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-launcher_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-launcher_2.12</artifactId>
+            <artifactId>spark-launcher_${spark.scala.version}</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
+            <artifactId>spark-sql_${spark.scala.version}</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -9,6 +9,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.proc.BaseProcResult;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.starrocks.common.util.Util.validateMetastoreUris;
@@ -28,11 +29,18 @@ import static com.starrocks.common.util.Util.validateMetastoreUris;
  */
 public class HiveResource extends Resource {
 
+    private static final String MAX_COMPUTE_ENABLE = "maxcompute.enable";
     // require only one property currently
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
 
+    @SerializedName(value = "isMaxComputeResource")
+    private boolean isMaxComputeResource = false;
+
+    @SerializedName(value = "resourceOptions")
+    private final Map<String, String> resourceOptions = new HashMap<>();
+
     @SerializedName(value = "metastoreURIs")
-    private String metastoreURIs;
+    private String metastoreURIs = "null";
 
     public HiveResource(String name) {
         super(name, ResourceType.HIVE);
@@ -42,21 +50,42 @@ public class HiveResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null, "properties can not be null");
 
-        metastoreURIs = properties.get(HIVE_METASTORE_URIS);
-        if (StringUtils.isBlank(metastoreURIs)) {
-            throw new DdlException(HIVE_METASTORE_URIS + " must be set in properties");
+        isMaxComputeResource = Boolean.parseBoolean(properties.getOrDefault(MAX_COMPUTE_ENABLE, "false"));
+        if (!isMaxComputeResource) {
+            metastoreURIs = properties.get(HIVE_METASTORE_URIS);
+            if (StringUtils.isBlank(metastoreURIs)) {
+                throw new DdlException(HIVE_METASTORE_URIS + " must be set in properties");
+            }
+            validateMetastoreUris(metastoreURIs);
+        } else {
+            properties.remove(HIVE_METASTORE_URIS);
+            resourceOptions.putAll(properties);
         }
-        validateMetastoreUris(metastoreURIs);
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        result.addRow(Lists.newArrayList(name, lowerCaseType, HIVE_METASTORE_URIS, metastoreURIs));
+        if (isMaxComputeResource) {
+            result.addRow(Lists.newArrayList(name, lowerCaseType, HIVE_METASTORE_URIS, metastoreURIs));
+        } else {
+            result.addRow(Lists.newArrayList(name, lowerCaseType, MAX_COMPUTE_ENABLE, "true"));
+            for (Map.Entry<String, String> entry : resourceOptions.entrySet()) {
+                result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+            }
+        }
     }
 
     public String getHiveMetastoreURIs() {
         return metastoreURIs;
+    }
+
+    public boolean isMaxComputeResource() {
+        return isMaxComputeResource;
+    }
+
+    public Map<String, String> getResourceOptions() {
+        return resourceOptions;
     }
 
     /**
@@ -70,17 +99,25 @@ public class HiveResource extends Resource {
     public void alterProperties(Map<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null, "properties can not be null");
 
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            if (HIVE_METASTORE_URIS.equals(key)) {
-                if (StringUtils.isBlank(value)) {
-                    throw new DdlException(HIVE_METASTORE_URIS + " can not be null");
+        if (isMaxComputeResource) {
+            if (properties.containsKey(HIVE_METASTORE_URIS)) {
+                throw new DdlException("Couldn't add " + HIVE_METASTORE_URIS +
+                    " when this resource is actually a MaxCompute resource.");
+            }
+            resourceOptions.putAll(properties);
+        } else {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                if (HIVE_METASTORE_URIS.equals(key)) {
+                    if (StringUtils.isBlank(value)) {
+                        throw new DdlException(HIVE_METASTORE_URIS + " can not be null");
+                    }
+                    validateMetastoreUris(value);
+                    this.metastoreURIs = value;
+                } else {
+                    throw new DdlException(String.format("property %s has not support yet", key));
                 }
-                validateMetastoreUris(value);
-                this.metastoreURIs = value;
-            } else {
-                throw new DdlException(String.format("property %s has not support yet", key));
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -66,7 +66,7 @@ public class HiveResource extends Resource {
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        if (isMaxComputeResource) {
+        if (!isMaxComputeResource) {
             result.addRow(Lists.newArrayList(name, lowerCaseType, HIVE_METASTORE_URIS, metastoreURIs));
         } else {
             result.addRow(Lists.newArrayList(name, lowerCaseType, MAX_COMPUTE_ENABLE, "true"));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -102,6 +102,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     private String hiveTableName;
     private String resourceName;
     private String hdfsPath;
+    private boolean isMaxComputeTable = false;
     private final List<String> partColumnNames = Lists.newArrayList();
     // dataColumnNames stores all the non-partition columns of the hive table,
     // consistent with the order defined in the hive table
@@ -174,7 +175,12 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         Resource resource = GlobalStateMgr.getCurrentState().getResourceMgr().getResource(resourceName);
         if (resource != null) {
             HiveResource hiveResource = (HiveResource) resource;
-            hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+            isMaxComputeTable = hiveResource.isMaxComputeResource();
+            if (!isMaxComputeTable) {
+                hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+            } else {
+                hiveProperties.putAll(hiveResource.getResourceOptions());
+            }
         }
         return hiveProperties;
     }
@@ -361,6 +367,10 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
         this.resourceName = resourceName;
 
+        if (isMaxComputeTable) {
+            return;
+        }
+
         // check column
         // 1. check column exists in hive table
         // 2. check column type mapping
@@ -434,7 +444,12 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             throw new DdlException("resource [" + resourceName + "] is not hive resource");
         }
         HiveResource hiveResource = (HiveResource) resource;
-        hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+        isMaxComputeTable = hiveResource.isMaxComputeResource();
+        if (!isMaxComputeTable) {
+            hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+        } else {
+            hiveProperties.putAll(hiveResource.getResourceOptions());
+        }
     }
 
     @Override

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -45,6 +45,8 @@ under the License.
         <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.12.6</jackson.version>
         <spark.version>2.4.6</spark.version>
+        <spark.scala.version>2.11</spark.scala.version>
+        <scala.version>2.11.12</scala.version>
         <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.10.1</parquet.version>
         <hadoop.version>3.3.2</hadoop.version>
@@ -537,7 +539,7 @@ under the License.
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12 -->
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.12</artifactId>
+                <artifactId>spark-core_${spark.scala.version}</artifactId>
                 <version>${spark.version}</version>
                 <exclusions>
                     <exclusion>
@@ -554,14 +556,14 @@ under the License.
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-launcher_2.12 -->
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-launcher_2.12</artifactId>
+                <artifactId>spark-launcher_${spark.scala.version}</artifactId>
                 <version>${spark.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql_2.12 -->
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.12</artifactId>
+                <artifactId>spark-sql_${spark.scala.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>
@@ -569,7 +571,7 @@ under the License.
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-catalyst -->
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-catalyst_2.12</artifactId>
+                <artifactId>spark-catalyst_${spark.scala.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>
@@ -636,7 +638,7 @@ under the License.
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
-                <version>2.12.10</version>
+                <version>${scala.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -95,14 +95,20 @@ under the License.
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+            <artifactId>spark-core_${spark.scala.version}</artifactId>
             <scope>provided</scope>
         </dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
+            <artifactId>spark-sql_${spark.scala.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_${spark.scala.version}</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -149,20 +155,13 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.12</artifactId>
-            <version>2.4.5</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 
     <build>
-        <finalName>spark-dpp-${version}</finalName>
+        <finalName>spark-dpp-${project.version}</finalName>
 
         <plugins>
             <!-- jmockit -->

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/DataSource.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/DataSource.java
@@ -1,0 +1,92 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.load.loadv2.datasource;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class DataSource {
+
+    public static DataSource fromProperties(SparkSession spark, Map<String, String> properties) {
+        String format = properties.getOrDefault("format", "hive");
+        switch (format.toLowerCase()) {
+            case "odps":
+            case "org.apache.spark.aliyun.odps.datasource":
+                return new MaxComputeDataSource(spark, format, properties);
+            case "hive":
+            default:
+                return new HiveDataSource(spark, format, properties);
+        }
+    }
+
+    protected final SparkSession spark;
+    protected final Map<String, String> dataSourceOptions;
+
+    private final String format;
+    // "database.table" => dataset
+    private final Map<String, Dataset<Row>> fullTableNameToDatasets;
+    // "database.table" => dataSourceOptions
+    private final Map<String, Map<String, String>> fullTableNameToDataSourceOptions;
+
+    public DataSource(SparkSession spark, String format, Map<String, String> dataSourceOptions) {
+        this.spark = spark;
+        this.format = format;
+        this.dataSourceOptions = dataSourceOptions;
+        this.fullTableNameToDatasets = new HashMap<>();
+        this.fullTableNameToDataSourceOptions = new HashMap<>();
+    }
+
+    protected abstract Map<String, String> getDataSourceOptions(String fullTableName);
+
+    protected abstract Dataset<Row> readTable(String fullTableName, String format, Map<String, String> options);
+
+    protected abstract void writeData(
+            Dataset<Row> data,
+            String fullTableName,
+            String format,
+            SaveMode saveMode,
+            List<String> partitionBy,
+            Map<String, String> options);
+
+    private Map<String, String> getOrCreateDataSourceOptions(String fullTableName) {
+        return fullTableNameToDataSourceOptions.computeIfAbsent(fullTableName, this::getDataSourceOptions);
+    }
+
+    public Dataset<Row> getOrLoadTable(String database, String table) {
+        return getOrLoadTable(database + "." + table);
+    }
+
+    public Dataset<Row> getOrLoadTable(String fullTableName) {
+        return fullTableNameToDatasets.computeIfAbsent(fullTableName,
+                name -> readTable(name, format, getOrCreateDataSourceOptions(name)));
+    }
+
+    public void writeTable(Dataset<Row> data, SaveMode mode, String partitionSpec, String database, String table) {
+        writeTable(data, mode, partitionSpec, database + "." + table);
+    }
+
+    public void writeTable(Dataset<Row> data, SaveMode mode, String partitionSpec, String fullTableName) {
+        Map<String, String> options = getOrCreateDataSourceOptions(fullTableName);
+        List<String> partitions = new ArrayList<>();
+        if (partitionSpec != null && !partitionSpec.isEmpty()) {
+            partitions.addAll(Arrays.stream(partitionSpec.split(",")).map(spec -> {
+                String[] pair = spec.split("=");
+                if (pair.length != 2) {
+                    throw new IllegalArgumentException("");
+                }
+                return pair[0];
+            }).collect(Collectors.toList()));
+            options.put("partitionSpec", partitionSpec);
+        }
+        writeData(data, fullTableName, format, mode, partitions, options);
+    }
+}

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/HiveDataSource.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/HiveDataSource.java
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.load.loadv2.datasource;
+
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import scala.collection.JavaConverters;
+
+import java.util.List;
+import java.util.Map;
+
+public class HiveDataSource extends DataSource {
+
+    public HiveDataSource(SparkSession spark, String format, Map<String, String> dataSourceOptions) {
+        super(spark, format, dataSourceOptions);
+    }
+
+    @Override
+    protected Map<String, String> getDataSourceOptions(String fullTableName) {
+        return dataSourceOptions;
+    }
+
+    @Override
+    protected Dataset<Row> readTable(String fullTableName, String format, Map<String, String> options) {
+        return spark.read().format(format).options(options).table(fullTableName);
+    }
+
+    @Override
+    protected void writeData(
+            Dataset<Row> data,
+            String fullTableName,
+            String format,
+            SaveMode saveMode,
+            List<String> partitionBy,
+            Map<String, String> options) {
+        DataFrameWriter<Row> writer = data.write();
+        if (partitionBy != null && !partitionBy.isEmpty()) {
+            writer = writer.partitionBy(JavaConverters.asScalaBufferConverter(partitionBy).asScala());
+        }
+        writer.format(format).mode(saveMode).options(options).saveAsTable(fullTableName);
+    }
+}

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/MaxComputeDataSource.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/datasource/MaxComputeDataSource.java
@@ -1,0 +1,58 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.load.loadv2.datasource;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import scala.collection.JavaConverters;
+
+import java.util.List;
+import java.util.Map;
+
+public class MaxComputeDataSource extends DataSource {
+
+    private static final String LEGACY_PASS_PARTITION_BY_AS_OPTIONS =
+            "spark.sql.legacy.sources.write.passPartitionByAsOptions";
+
+    public MaxComputeDataSource(SparkSession spark, String format, Map<String, String> dataSourceOptions) {
+        super(spark, format, dataSourceOptions);
+        this.spark.conf().set(LEGACY_PASS_PARTITION_BY_AS_OPTIONS, "true");
+    }
+
+    @Override
+    protected Map<String, String> getDataSourceOptions(String fullTableName) {
+        String[] databaseAndTable = fullTableName.split("\\.");
+        if (databaseAndTable.length != 2) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid table name %s, should be specified as database.table", fullTableName));
+        }
+        Map<String, String> copiedOptions = Maps.newHashMap(dataSourceOptions);
+        copiedOptions.put("project", databaseAndTable[0]);
+        copiedOptions.put("table", databaseAndTable[1]);
+        return copiedOptions;
+    }
+
+    @Override
+    protected Dataset<Row> readTable(String fullTableName, String format, Map<String, String> options) {
+        return spark.read().format(format).options(options).load();
+    }
+
+    @Override
+    protected void writeData(
+            Dataset<Row> data,
+            String fullTableName,
+            String format,
+            SaveMode saveMode,
+            List<String> partitionBy,
+            Map<String, String> options) {
+        DataFrameWriter<Row> writer = data.write();
+        if (partitionBy != null && !partitionBy.isEmpty()) {
+            writer = writer.partitionBy(JavaConverters.asScalaBufferConverter(partitionBy).asScala());
+        }
+        writer.format(format).mode(saveMode).options(options).save();
+    }
+}

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
@@ -144,7 +144,8 @@ public class SparkEtlJob {
         sparkDpp.doDpp();
     }
 
-    private String buildGlobalDictAndEncodeSourceTable(EtlTable table, long tableId) {
+    private String buildGlobalDictAndEncodeSourceTable(
+            EtlTable table, Map<String, String> hiveTableProperties, long tableId) {
         // dict column map
         MultiValueMap dictColumnMap = new MultiValueMap();
         for (String dictColumn : tableToBitmapDictColumns.get(tableId)) {
@@ -179,10 +180,20 @@ public class SparkEtlJob {
                 + ", starrocksIntermediateHiveTable: " + starrocksIntermediateHiveTable);
         try {
             GlobalDictBuilder globalDictBuilder = new GlobalDictBuilder(
-                    dictColumnMap, intermediateTableColumnList, mapSideJoinColumns, sourceHiveDBTableName,
-                    sourceHiveFilter, starrocksHiveDB, distinctKeyTableName, globalDictTableName,
+                    dictColumnMap,
+                    intermediateTableColumnList,
+                    mapSideJoinColumns,
+                    sourceHiveDBTableName,
+                    sourceHiveFilter,
+                    starrocksHiveDB,
+                    distinctKeyTableName,
+                    globalDictTableName,
                     starrocksIntermediateHiveTable,
-                    buildConcurrency, veryHighCardinalityColumn, veryHighCardinalityColumnSplitNum, spark);
+                    buildConcurrency,
+                    veryHighCardinalityColumn,
+                    veryHighCardinalityColumnSplitNum,
+                    spark,
+                    hiveTableProperties);
             globalDictBuilder.checkGlobalDictTableName(dorisGlobalDictTableName);
             globalDictBuilder.createHiveIntermediateTable();
             globalDictBuilder.extractDistinctColumn();
@@ -213,7 +224,8 @@ public class SparkEtlJob {
 
             // build global dict and encode source hive table if has bitmap dict columns
             if (!tableToBitmapDictColumns.isEmpty() && tableToBitmapDictColumns.containsKey(tableId)) {
-                String starrocksIntermediateHiveDbTableName = buildGlobalDictAndEncodeSourceTable(table, tableId);
+                String starrocksIntermediateHiveDbTableName = buildGlobalDictAndEncodeSourceTable(
+                        table, fileGroup.hiveTableProperties, tableId);
                 // set with starrocksIntermediateHiveDbTable
                 fileGroup.dppHiveDbTableName = starrocksIntermediateHiveDbTableName;
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

MaxCompute is a data warehouse solution developed by Alibaba Cloud and has a large number of users.

Currently, users usually use DataX when they want to import data from MaxCompute into StarRocks. If users want to build a global dictionary at the same time, the DataX cannot be satisfied.

While Spark Load of StarRocks can directly help users build a global dictionary, Spark can also access MaxCompute through its own DataSource mechanism. But Spark Load in StarRocks cannot use Spark's Data Source mechanism, it only allows Hive tables to be read using Spark.

This PR extends the capabilities of StarRocks Spark Load by modifying the way Spark Load is written, and allows other Data Sources to access.