### PR TITLE
[SR SQL Planner Summer Camp][Feature] alter table statement support of add list partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
@@ -43,18 +43,32 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
         this.partitionProperties = partitionProperties;
     }
 
+    @Override
+    public Map<String, String> getProperties() {
+        return this.partitionProperties;
+    }
+
+    @Override
     public short getReplicationNum() {
         return this.replicationNum;
     }
 
+    @Override
     public DataProperty getPartitionDataProperty() {
         return this.partitionDataProperty;
     }
 
+    @Override
+    public Long getVersionInfo() {
+        return versionInfo;
+    }
+
+    @Override
     public TTabletType getTabletType() {
         return this.tabletType;
     }
 
+    @Override
     public boolean isInMemory() {
         return this.isInMemory;
     }
@@ -63,8 +77,14 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
         return this.multiValues;
     }
 
+    @Override
     public String getPartitionName() {
         return this.partitionName;
+    }
+
+    @Override
+    public boolean isSetIfNotExists() {
+        return this.ifNotExists;
     }
 
     public List<List<LiteralExpr>> getMultiLiteralExprValues() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/PartitionDesc.java
@@ -22,10 +22,12 @@
 package com.starrocks.analysis;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.thrift.TTabletType;
 import org.apache.commons.lang.NotImplementedException;
 
 import java.util.List;
@@ -49,6 +51,38 @@ public class PartitionDesc implements ParseNode {
 
     public PartitionInfo toPartitionInfo(List<Column> columns, Map<String, Long> partitionNameToId, boolean isTemp)
             throws DdlException {
+        throw new NotImplementedException();
+    }
+
+    public String getPartitionName() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public boolean isSetIfNotExists() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public Map<String, String> getProperties() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public short getReplicationNum() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public DataProperty getPartitionDataProperty() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public Long getVersionInfo() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public TTabletType getTabletType() throws NotImplementedException {
+        throw new NotImplementedException();
+    }
+
+    public boolean isInMemory() throws NotImplementedException {
         throw new NotImplementedException();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
@@ -43,18 +43,32 @@ public class SingleItemListPartitionDesc extends PartitionDesc {
         this.partitionProperties = partitionProperties;
     }
 
+    @Override
+    public Map<String, String> getProperties() {
+        return this.partitionProperties;
+    }
+
+    @Override
     public short getReplicationNum() {
         return this.replicationNum;
     }
 
+    @Override
     public DataProperty getPartitionDataProperty() {
         return this.partitionDataProperty;
     }
 
+    @Override
+    public Long getVersionInfo() {
+        return versionInfo;
+    }
+
+    @Override
     public TTabletType getTabletType() {
         return this.tabletType;
     }
 
+    @Override
     public boolean isInMemory() {
         return this.isInMemory;
     }
@@ -63,8 +77,14 @@ public class SingleItemListPartitionDesc extends PartitionDesc {
         return this.values;
     }
 
+    @Override
     public String getPartitionName() {
         return this.partitionName;
+    }
+
+    @Override
+    public boolean isSetIfNotExists() {
+        return ifNotExists;
     }
 
     public List<LiteralExpr> getLiteralExprValues() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -1,8 +1,12 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.SingleRangePartitionDesc;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MultiItemListPartitionDesc;
+import com.starrocks.analysis.PartitionDesc;
+import com.starrocks.analysis.SingleItemListPartitionDesc;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
@@ -13,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CatalogUtils {
 
@@ -41,13 +46,13 @@ public class CatalogUtils {
     }
 
     public static Set<String> checkPartitionNameExistForAddPartitions(OlapTable olapTable,
-                                                                      List<SingleRangePartitionDesc> singleRangePartitionDescs)
+                                                                      List<PartitionDesc> partitionDescs)
             throws DdlException {
         Set<String> existPartitionNameSet = Sets.newHashSet();
-        for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            String partitionName = singleRangePartitionDesc.getPartitionName();
+        for (PartitionDesc partitionDesc : partitionDescs) {
+            String partitionName = partitionDesc.getPartitionName();
             if (olapTable.checkPartitionNameExist(partitionName)) {
-                if (singleRangePartitionDesc.isSetIfNotExists()) {
+                if (partitionDesc.isSetIfNotExists()) {
                     existPartitionNameSet.add(partitionName);
                 } else {
                     ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
@@ -75,6 +80,55 @@ public class CatalogUtils {
             }
         } finally {
             db.readUnlock();
+        }
+    }
+
+    public static void checkPartitionValuesExistForAddListPartition(OlapTable olapTable, PartitionDesc partitionDesc)
+            throws DdlException {
+        try {
+            ListPartitionInfo listPartitionInfo = (ListPartitionInfo) olapTable.getPartitionInfo();
+            if (partitionDesc instanceof SingleItemListPartitionDesc) {
+                listPartitionInfo.setBatchLiteralExprValues(listPartitionInfo.getIdToValues());
+                List<LiteralExpr> allLiteralExprValues = Lists.newArrayList();
+                listPartitionInfo.getLiteralExprValues().forEach((k, v) -> allLiteralExprValues.addAll(v));
+
+                SingleItemListPartitionDesc singleItemListPartitionDesc = (SingleItemListPartitionDesc) partitionDesc;
+                for (LiteralExpr item : singleItemListPartitionDesc.getLiteralExprValues()) {
+                    for (LiteralExpr value : allLiteralExprValues) {
+                        if (item.getStringValue().equals(value.getStringValue())) {
+                            throw new DdlException("Duplicate partition value %s");
+                        }
+                    }
+                }
+            } else if (partitionDesc instanceof MultiItemListPartitionDesc) {
+                listPartitionInfo.setBatchMultiLiteralExprValues(listPartitionInfo.getIdToMultiValues());
+                List<List<LiteralExpr>> allMultiLiteralExprValues = Lists.newArrayList();
+                listPartitionInfo.getMultiLiteralExprValues().forEach((k, v) -> allMultiLiteralExprValues.addAll(v));
+
+                int partitionColSize = listPartitionInfo.getPartitionColumns().size();
+                MultiItemListPartitionDesc multiItemListPartitionDesc = (MultiItemListPartitionDesc) partitionDesc;
+                for (List<LiteralExpr> itemExpr : multiItemListPartitionDesc.getMultiLiteralExprValues()) {
+                    for (List<LiteralExpr> valueExpr : allMultiLiteralExprValues) {
+                        int duplicatedSize = 0;
+                        for (int i = 0; i < itemExpr.size(); i++) {
+                            String itemValue = itemExpr.get(i).getStringValue();
+                            String value = valueExpr.get(i).getStringValue();
+                            if (value.equals(itemValue)) {
+                                duplicatedSize++;
+                            }
+                        }
+                        if (duplicatedSize == partitionColSize) {
+                            List<String> msg = itemExpr.stream()
+                                    .map(value -> ("\"" + value.getStringValue() + "\""))
+                                    .collect(Collectors.toList());
+                            throw new DdlException("Duplicate values " +
+                                    "(" + String.join(",", msg) + ") ");
+                        }
+                    }
+                }
+            }
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -4,10 +4,15 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MultiItemListPartitionDesc;
+import com.starrocks.analysis.PartitionDesc;
 import com.starrocks.analysis.PartitionValue;
+import com.starrocks.analysis.SingleItemListPartitionDesc;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Text;
+import com.starrocks.persist.ListPartitionPersistInfo;
 import com.starrocks.persist.gson.GsonUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -21,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
@@ -39,6 +45,8 @@ public class ListPartitionInfo extends PartitionInfo {
     @SerializedName("idToValues")
     private Map<Long, List<String>> idToValues;
     private Map<Long, List<LiteralExpr>> idToLiteralExprValues;
+    @SerializedName("idToTemp")
+    private Map<Long, Boolean> idToIsTempPartition;
 
     public ListPartitionInfo(PartitionType partitionType,
                              List<Column> partitionColumns) {
@@ -50,6 +58,7 @@ public class ListPartitionInfo extends PartitionInfo {
         this.idToLiteralExprValues = new HashMap<>();
         this.idToMultiValues = new HashMap<>();
         this.idToMultiLiteralExprValues = new HashMap<>();
+        this.idToIsTempPartition = new HashMap<>();
     }
 
     public ListPartitionInfo() {
@@ -59,6 +68,7 @@ public class ListPartitionInfo extends PartitionInfo {
         this.idToMultiValues = new HashMap<>();
         this.idToMultiLiteralExprValues = new HashMap<>();
         this.partitionColumns = new ArrayList<>();
+        this.idToIsTempPartition = new HashMap<>();
     }
 
     public void setValues(long partitionId, List<String> values) {
@@ -74,6 +84,18 @@ public class ListPartitionInfo extends PartitionInfo {
             partitionValues.add(partitionValue);
         }
         this.idToLiteralExprValues.put(partitionId, partitionValues);
+    }
+
+    public void setBatchLiteralExprValues(Map<Long, List<String>> batchValues) throws AnalysisException {
+        for (Map.Entry<Long, List<String>> entry : batchValues.entrySet()) {
+            long partitionId = entry.getKey();
+            List<String> values = entry.getValue();
+            this.setLiteralExprValues(partitionId, values);
+        }
+    }
+
+    public Map<Long, List<LiteralExpr>> getLiteralExprValues() {
+        return this.idToLiteralExprValues;
     }
 
     public void setMultiValues(long partitionId, List<List<String>> multiValues) {
@@ -93,6 +115,19 @@ public class ListPartitionInfo extends PartitionInfo {
             multiPartitionValues.add(partitionValues);
         }
         this.idToMultiLiteralExprValues.put(partitionId, multiPartitionValues);
+    }
+
+    public void setBatchMultiLiteralExprValues(Map<Long, List<List<String>>> batchMultiValues)
+            throws AnalysisException {
+        for (Map.Entry<Long, List<List<String>>> entry : batchMultiValues.entrySet()) {
+            long partitionId = entry.getKey();
+            List<List<String>> multiValues = entry.getValue();
+            this.setMultiLiteralExprValues(partitionId, multiValues);
+        }
+    }
+
+    public Map<Long, List<List<LiteralExpr>>> getMultiLiteralExprValues() {
+        return this.idToMultiLiteralExprValues;
     }
 
     private void setIsMultiColumnPartition() {
@@ -240,5 +275,62 @@ public class ListPartitionInfo extends PartitionInfo {
             return this.multiValuesToString(this.idToMultiLiteralExprValues.get(partitionId));
         }
         return "";
+    }
+
+    public void handleNewListPartitionDescs(List<PartitionDesc> partitionDescs, List<Partition> partitionList,
+                                            Set<String> existPartitionNameSet, boolean isTempPartition)
+            throws DdlException {
+        try {
+            for (int i = 0; i < partitionDescs.size(); i++) {
+                Partition partition = partitionList.get(i);
+                String name = partition.getName();
+                if (!existPartitionNameSet.contains(name)) {
+                    long partitionId = partition.getId();
+                    PartitionDesc partitionDesc = partitionDescs.get(i);
+                    this.idToDataProperty.put(partitionId, partitionDesc.getPartitionDataProperty());
+                    this.idToReplicationNum.put(partitionId, partitionDesc.getReplicationNum());
+                    this.idToInMemory.put(partitionId, partitionDesc.isInMemory());
+                    if (partitionDesc instanceof MultiItemListPartitionDesc) {
+                        MultiItemListPartitionDesc multiItemListPartitionDesc =
+                                (MultiItemListPartitionDesc) partitionDesc;
+                        this.idToMultiValues.put(partitionId, multiItemListPartitionDesc.getMultiValues());
+                        this.setMultiLiteralExprValues(partitionId, multiItemListPartitionDesc.getMultiValues());
+                    } else if (partitionDesc instanceof SingleItemListPartitionDesc) {
+                        SingleItemListPartitionDesc singleItemListPartitionDesc =
+                                (SingleItemListPartitionDesc) partitionDesc;
+                        this.idToValues.put(partitionId, singleItemListPartitionDesc.getValues());
+                        this.setLiteralExprValues(partitionId, singleItemListPartitionDesc.getValues());
+                    } else {
+                        throw new DdlException(
+                                "add list partition only support single item or multi item list partition now");
+                    }
+                    this.idToIsTempPartition.put(partitionId, isTempPartition);
+                }
+            }
+        } catch (Exception e) {
+            throw new DdlException(e.getMessage());
+        }
+    }
+
+    public void unprotectHandleNewPartitionDesc(ListPartitionPersistInfo partitionPersistInfo)
+            throws AnalysisException {
+        Partition partition = partitionPersistInfo.getPartition();
+        long partitionId = partition.getId();
+        this.idToDataProperty.put(partitionId, partitionPersistInfo.getDataProperty());
+        this.idToReplicationNum.put(partitionId, partitionPersistInfo.getReplicationNum());
+        this.idToInMemory.put(partitionId, partitionPersistInfo.isInMemory());
+        this.idToIsTempPartition.put(partitionId, partitionPersistInfo.isTempPartition());
+
+        List<List<String>> multiValues = partitionPersistInfo.getMultiValues();
+        if (multiValues != null && multiValues.size() > 0) {
+            this.idToMultiValues.put(partitionId, multiValues);
+            this.setMultiLiteralExprValues(partitionId, multiValues);
+        }
+
+        List<String> values = partitionPersistInfo.getValues();
+        if (values != null && values.size() > 0) {
+            this.idToValues.put(partitionId, values);
+            this.setLiteralExprValues(partitionId, values);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.PartitionDesc;
 import com.starrocks.analysis.PartitionKeyDesc;
 import com.starrocks.analysis.SingleRangePartitionDesc;
 import com.starrocks.common.AnalysisException;
@@ -33,6 +34,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.util.RangeUtils;
+import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -199,18 +201,18 @@ public class RangePartitionInfo extends PartitionInfo {
         return range;
     }
 
-    public void handleNewRangePartitionDescs(List<SingleRangePartitionDesc> listDesc,
+    public void handleNewRangePartitionDescs(List<PartitionDesc> partitionDescs,
                                              List<Partition> partitionList, Set<String> existPartitionNameSet,
                                              boolean isTemp) throws DdlException {
-        int len = listDesc.size();
+        int len = partitionDescs.size();
         for (int i = 0; i < len; i++) {
             if (!existPartitionNameSet.contains(partitionList.get(i).getName())) {
                 long partitionId = partitionList.get(i).getId();
-                SingleRangePartitionDesc desc = listDesc.get(i);
+                SingleRangePartitionDesc desc = (SingleRangePartitionDesc) partitionDescs.get(i);
                 Preconditions.checkArgument(desc.isAnalyzed());
                 Range<PartitionKey> range;
                 try {
-                    range = checkAndCreateRange(listDesc.get(i), isTemp);
+                    range = checkAndCreateRange((SingleRangePartitionDesc) partitionDescs.get(i), isTemp);
                     setRangeInternal(partitionId, isTemp, range);
                 } catch (IllegalArgumentException e) {
                     // Range.closedOpen may throw this if (lower > upper)
@@ -230,6 +232,14 @@ public class RangePartitionInfo extends PartitionInfo {
         idToDataProperty.put(partitionId, dataProperty);
         idToReplicationNum.put(partitionId, replicationNum);
         idToInMemory.put(partitionId, isInMemory);
+    }
+
+    /**
+     * @param info
+     * @TODO This method may be used in future
+     */
+    public void unprotectHandleNewSinglePartitionDesc(RangePartitionPersistInfo info) {
+
     }
 
     public void setRange(long partitionId, boolean isTemp, Range<PartitionKey> range) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -81,6 +81,7 @@ import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.MultiEraseTableInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PartitionPersistInfo;
+import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.persist.PrivInfo;
 import com.starrocks.persist.RecoverInfo;
 import com.starrocks.persist.RemoveAlterJobV2OperationLog;
@@ -204,6 +205,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_ERASE_MULTI_TABLES: {
                 data = MultiEraseTableInfo.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_ADD_PARTITION_V2: {
+                data = PartitionPersistInfoV2.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -185,6 +185,14 @@ public class EditLog {
                     globalStateMgr.replayCreateMaterializedView(info.getDbName(), ((MaterializedView) info.getTable()));
                     break;
                 }
+                case OperationType.OP_ADD_PARTITION_V2: {
+                    PartitionPersistInfoV2 info = (PartitionPersistInfoV2) journal.getData();
+                    LOG.info("Begin to unprotect add partition. db = " + info.getDbId()
+                            + " table = " + info.getTableId()
+                            + " partitionName = " + info.getPartition().getName());
+                    globalStateMgr.replayAddPartition(info);
+                    break;
+                }
                 case OperationType.OP_ADD_PARTITION: {
                     PartitionPersistInfo info = (PartitionPersistInfo) journal.getData();
                     LOG.info("Begin to unprotect add partition. db = " + info.getDbId()
@@ -1035,6 +1043,10 @@ public class EditLog {
 
     public void logUpdateTaskRun(TaskRunStatusChange statusChange) {
         logEdit(OperationType.OP_UPDATE_TASK_RUN, statusChange);
+    }
+
+    public void logAddPartition(PartitionPersistInfoV2 info) {
+        logEdit(OperationType.OP_ADD_PARTITION_V2, info);
     }
 
     public void logAddPartition(PartitionPersistInfo info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ListPartitionPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ListPartitionPersistInfo.java
@@ -1,0 +1,35 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Partition;
+
+import java.util.List;
+
+public class ListPartitionPersistInfo extends PartitionPersistInfoV2 {
+
+    @SerializedName("values")
+    private List<String> values;
+    @SerializedName("multiValues")
+    private List<List<String>> multiValues;
+
+    public ListPartitionPersistInfo(Long dbId, Long tableId, Partition partition,
+                                    DataProperty dataProperty, short replicationNum,
+                                    boolean isInMemory, boolean isTempPartition,
+                                    List<String> values, List<List<String>> multiValues) {
+        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition);
+        this.multiValues = multiValues;
+        this.values = values;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public List<List<String>> getMultiValues() {
+        return multiValues;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -247,4 +247,8 @@ public class OperationType {
     // shard operate 10221 ~ 10240
     public static final short OP_ADD_UNUSED_SHARD = 10221;
     public static final short OP_DELETE_UNUSED_SHARD = 10222;
+
+    // new operator for add partition 10241 ~ 10260
+    // only used in list partition currently
+    public static final short OP_ADD_PARTITION_V2 = 10241;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/PartitionPersistInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/PartitionPersistInfoV2.java
@@ -1,0 +1,100 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class PartitionPersistInfoV2 implements Writable {
+
+    @SerializedName("dbId")
+    private Long dbId;
+    @SerializedName("tableId")
+    private Long tableId;
+    @SerializedName("partition")
+    private Partition partition;
+    @SerializedName("dataProperty")
+    private DataProperty dataProperty;
+    @SerializedName("replicationNum")
+    private short replicationNum;
+    @SerializedName("isInMemory")
+    private boolean isInMemory;
+    @SerializedName("isTempPartition")
+    private boolean isTempPartition;
+
+    public PartitionPersistInfoV2(Long dbId, Long tableId, Partition partition,
+                                  DataProperty dataProperty, short replicationNum,
+                                  boolean isInMemory, boolean isTempPartition) {
+        this.dbId = dbId;
+        this.tableId = tableId;
+        this.partition = partition;
+        this.dataProperty = dataProperty;
+        this.replicationNum = replicationNum;
+        this.isInMemory = isInMemory;
+        this.isTempPartition = isTempPartition;
+    }
+
+    public final boolean isListPartitionPersistInfo() {
+        return this.getClass() == ListPartitionPersistInfo.class;
+    }
+
+    public final boolean isRangePartitionPersistInfo() {
+        return this.getClass() == RangePartitionPersistInfo.class;
+    }
+
+    public final ListPartitionPersistInfo asListPartitionPersistInfo() {
+        return (ListPartitionPersistInfo) this;
+    }
+
+    public final RangePartitionPersistInfo asRangePartitionPersistInfo() {
+        return (RangePartitionPersistInfo) this;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    public static PartitionPersistInfoV2 read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, PartitionPersistInfoV2.class);
+    }
+
+    public Long getDbId() {
+        return this.dbId;
+    }
+
+    public Long getTableId() {
+        return this.tableId;
+    }
+
+    public Partition getPartition() {
+        return this.partition;
+    }
+
+    public DataProperty getDataProperty() {
+        return this.dataProperty;
+    }
+
+    public short getReplicationNum() {
+        return this.replicationNum;
+    }
+
+    public boolean isInMemory() {
+        return this.isInMemory;
+    }
+
+    public boolean isTempPartition() {
+        return this.isTempPartition;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/RangePartitionPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/RangePartitionPersistInfo.java
@@ -1,0 +1,57 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.persist;
+
+import com.google.common.collect.Range;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.common.util.RangeUtils;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonPreProcessable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RangePartitionPersistInfo extends PartitionPersistInfoV2
+        implements GsonPreProcessable, GsonPostProcessable {
+
+    private Range<PartitionKey> range;
+
+    @SerializedName(value = "serializedRange")
+    private byte[] serializedRange;
+
+    public RangePartitionPersistInfo(Long dbId, Long tableId, Partition partition,
+                                     DataProperty dataProperty, short replicationNum,
+                                     boolean isInMemory, boolean isTempPartition,
+                                     Range<PartitionKey> range) {
+        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition);
+        this.range = range;
+    }
+
+    public Range<PartitionKey> getRange() {
+        return range;
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        InputStream inputStream = new ByteArrayInputStream(serializedRange);
+        DataInput dataInput = new DataInputStream(inputStream);
+        this.range = RangeUtils.readRange(dataInput);
+    }
+
+    @Override
+    public void gsonPreProcess() throws IOException {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(stream);
+        RangeUtils.writeRange(dos, range);
+        this.serializedRange = stream.toByteArray();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -79,6 +79,9 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.loadv2.LoadJob.LoadJobStateUpdateInfo;
 import com.starrocks.load.loadv2.SparkLoadJob.SparkLoadJobStateUpdateInfo;
+import com.starrocks.persist.ListPartitionPersistInfo;
+import com.starrocks.persist.PartitionPersistInfoV2;
+import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.optimizer.dump.QueryDumpDeserializer;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
@@ -177,6 +180,11 @@ public class GsonUtils {
             .registerSubtype(FrontendHbResponse.class, FrontendHbResponse.class.getSimpleName())
             .registerSubtype(BrokerHbResponse.class, BrokerHbResponse.class.getSimpleName());
 
+    private static final RuntimeTypeAdapterFactory<PartitionPersistInfoV2> partitionPersistInfoV2AdapterFactory
+            = RuntimeTypeAdapterFactory.of(PartitionPersistInfoV2.class, "clazz")
+            .registerSubtype(ListPartitionPersistInfo.class, ListPartitionPersistInfo.class.getSimpleName())
+            .registerSubtype(RangePartitionPersistInfo.class, RangePartitionPersistInfo.class.getSimpleName());
+
     private static final JsonSerializer<LocalDateTime> localDateTimeTypeSerializer =
             (dateTime, type, jsonSerializationContext) -> new JsonPrimitive(dateTime.toEpochSecond(ZoneOffset.UTC));
 
@@ -210,6 +218,7 @@ public class GsonUtils {
             .registerTypeAdapterFactory(tabletTypeAdapterFactory)
             .registerTypeAdapterFactory(heartbeatResponseAdapterFactor)
             .registerTypeAdapterFactory(partitionInfoTypeAdapterFactory)
+            .registerTypeAdapterFactory(partitionPersistInfoV2AdapterFactory)
             .registerTypeAdapter(LocalDateTime.class, localDateTimeTypeSerializer)
             .registerTypeAdapter(LocalDateTime.class, localDateTimeTypeDeserializer)
             .registerTypeAdapter(QueryDumpInfo.class, dumpInfoSerializer)

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -192,6 +192,7 @@ import com.starrocks.persist.ModifyTableColumnOperationLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.MultiEraseTableInfo;
 import com.starrocks.persist.PartitionPersistInfo;
+import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.persist.RecoverInfo;
 import com.starrocks.persist.RenameMaterializedViewLog;
 import com.starrocks.persist.ReplacePartitionOperationLog;
@@ -1783,6 +1784,10 @@ public class GlobalStateMgr {
     }
 
     public void replayAddPartition(PartitionPersistInfo info) throws DdlException {
+        localMetastore.replayAddPartition(info);
+    }
+
+    public void replayAddPartition(PartitionPersistInfoV2 info) throws DdlException {
         localMetastore.replayAddPartition(info);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -43,6 +43,7 @@ import com.starrocks.analysis.AlterDatabaseRename;
 import com.starrocks.analysis.AlterTableStmt;
 import com.starrocks.analysis.AlterViewStmt;
 import com.starrocks.analysis.CancelAlterTableStmt;
+import com.starrocks.analysis.ColumnDef;
 import com.starrocks.analysis.ColumnRenameClause;
 import com.starrocks.analysis.CreateMaterializedViewStmt;
 import com.starrocks.analysis.CreateTableLikeStmt;
@@ -55,6 +56,7 @@ import com.starrocks.analysis.DropTableStmt;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.KeysDesc;
 import com.starrocks.analysis.ListPartitionDesc;
+import com.starrocks.analysis.MultiItemListPartitionDesc;
 import com.starrocks.analysis.MultiRangePartitionDesc;
 import com.starrocks.analysis.PartitionDesc;
 import com.starrocks.analysis.PartitionRenameClause;
@@ -66,6 +68,7 @@ import com.starrocks.analysis.ReplacePartitionClause;
 import com.starrocks.analysis.RollupRenameClause;
 import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.ShowAlterStmt;
+import com.starrocks.analysis.SingleItemListPartitionDesc;
 import com.starrocks.analysis.SingleRangePartitionDesc;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.StringLiteral;
@@ -73,6 +76,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TableRenameClause;
 import com.starrocks.analysis.TruncateTableStmt;
+import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.ColocateGroupSchema;
@@ -91,6 +95,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InfoSchemaDb;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -125,6 +130,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
 import com.starrocks.common.UserException;
@@ -145,12 +151,14 @@ import com.starrocks.persist.DatabaseInfo;
 import com.starrocks.persist.DropDbInfo;
 import com.starrocks.persist.DropPartitionInfo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ListPartitionPersistInfo;
 import com.starrocks.persist.ModifyPartitionInfo;
 import com.starrocks.persist.ModifyTableColumnOperationLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.MultiEraseTableInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PartitionPersistInfo;
+import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.persist.RecoverInfo;
 import com.starrocks.persist.ReplacePartitionOperationLog;
 import com.starrocks.persist.ReplicaPersistInfo;
@@ -794,8 +802,10 @@ public class LocalMetastore implements ConnectorMetadata {
     public void addPartitions(Database db, String tableName, AddPartitionClause addPartitionClause)
             throws DdlException, AnalysisException {
         PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
-        if (partitionDesc instanceof SingleRangePartitionDesc) {
-            addPartitions(db, tableName, ImmutableList.of((SingleRangePartitionDesc) partitionDesc),
+        if (partitionDesc instanceof SingleItemListPartitionDesc
+                || partitionDesc instanceof MultiItemListPartitionDesc
+                || partitionDesc instanceof SingleRangePartitionDesc) {
+            addPartitions(db, tableName, ImmutableList.of(partitionDesc),
                     addPartitionClause);
         } else if (partitionDesc instanceof MultiRangePartitionDesc) {
             db.readLock();
@@ -834,95 +844,359 @@ public class LocalMetastore implements ConnectorMetadata {
             }
             List<SingleRangePartitionDesc> singleRangePartitionDescs = multiRangePartitionDesc
                     .convertToSingle(firstPartitionColumn.getType(), properties);
-            addPartitions(db, tableName, singleRangePartitionDescs, addPartitionClause);
+            List<PartitionDesc> partitionDescs = singleRangePartitionDescs.stream().map(item -> {
+                PartitionDesc desc = item;
+                return desc;
+            }).collect(Collectors.toList());
+            addPartitions(db, tableName, partitionDescs, addPartitionClause);
         }
     }
 
-    private void addPartitions(Database db, String tableName, List<SingleRangePartitionDesc> singleRangePartitionDescs,
+    private OlapTable checkTable(Database db, String tableName) throws DdlException {
+        CatalogUtils.checkTableExist(db, tableName);
+        Table table = db.getTable(tableName);
+        CatalogUtils.checkTableTypeOLAP(db, table);
+        OlapTable olapTable = (OlapTable) table;
+        CatalogUtils.checkTableState(olapTable, tableName);
+        return olapTable;
+    }
+
+    private void checkPartitionType(PartitionInfo partitionInfo) throws DdlException {
+        PartitionType partitionType = partitionInfo.getType();
+        if (partitionType != PartitionType.RANGE && partitionType != PartitionType.LIST) {
+            throw new DdlException("Only support adding partition to range/list partitioned table");
+        }
+    }
+
+    private void analyzeAddPartition(OlapTable olapTable, List<PartitionDesc> partitionDescs,
+                                     AddPartitionClause addPartitionClause, PartitionInfo partitionInfo)
+            throws DdlException, AnalysisException, NotImplementedException {
+
+        Set<String> existPartitionNameSet =
+                CatalogUtils.checkPartitionNameExistForAddPartitions(olapTable, partitionDescs);
+        // partition properties is prior to clause properties
+        // clause properties is prior to table properties
+        Map<String, String> properties = Maps.newHashMap();
+        properties = getOrSetDefaultProperties(olapTable, properties);
+        Map<String, String> clauseProperties = addPartitionClause.getProperties();
+        if (clauseProperties != null && !clauseProperties.isEmpty()) {
+            properties.putAll(clauseProperties);
+        }
+
+        for (PartitionDesc partitionDesc : partitionDescs) {
+            Map<String, String> cloneProperties = Maps.newHashMap(properties);
+            Map<String, String> sourceProperties = partitionDesc.getProperties();
+            if (sourceProperties != null && !sourceProperties.isEmpty()) {
+                cloneProperties.putAll(sourceProperties);
+            }
+
+            if (partitionDesc instanceof SingleRangePartitionDesc) {
+                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+                SingleRangePartitionDesc singleRangePartitionDesc = ((SingleRangePartitionDesc) partitionDesc);
+                singleRangePartitionDesc.analyze(rangePartitionInfo.getPartitionColumns().size(), cloneProperties);
+                if (!existPartitionNameSet.contains(singleRangePartitionDesc.getPartitionName())) {
+                    rangePartitionInfo.checkAndCreateRange(singleRangePartitionDesc,
+                            addPartitionClause.isTempPartition());
+                }
+            } else if (partitionDesc instanceof SingleItemListPartitionDesc
+                    || partitionDesc instanceof MultiItemListPartitionDesc) {
+                List<ColumnDef> columnDefList = partitionInfo.getPartitionColumns().stream()
+                        .map(item -> new ColumnDef(item.getName(), new TypeDef(item.getType())))
+                        .collect(Collectors.toList());
+                partitionDesc.analyze(columnDefList, cloneProperties);
+                CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable, partitionDesc);
+            } else {
+                throw new DdlException("Only support adding partition to range/list partitioned table");
+            }
+        }
+    }
+
+    private DistributionInfo getDistributionInfo(OlapTable olapTable, AddPartitionClause addPartitionClause)
+            throws DdlException {
+        DistributionInfo distributionInfo;
+        List<Column> baseSchema = olapTable.getBaseSchema();
+        DistributionInfo defaultDistributionInfo = olapTable.getDefaultDistributionInfo();
+        DistributionDesc distributionDesc = addPartitionClause.getDistributionDesc();
+        if (distributionDesc != null) {
+            distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
+            // for now. we only support modify distribution's bucket num
+            if (distributionInfo.getType() != defaultDistributionInfo.getType()) {
+                throw new DdlException("Cannot assign different distribution type. default is: "
+                        + defaultDistributionInfo.getType());
+            }
+
+            if (distributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH) {
+                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+                List<Column> newDistriCols = hashDistributionInfo.getDistributionColumns();
+                List<Column> defaultDistriCols = ((HashDistributionInfo) defaultDistributionInfo)
+                        .getDistributionColumns();
+                if (!newDistriCols.equals(defaultDistriCols)) {
+                    throw new DdlException("Cannot assign hash distribution with different distribution cols. "
+                            + "default is: " + defaultDistriCols);
+                }
+                if (hashDistributionInfo.getBucketNum() <= 0) {
+                    throw new DdlException("Cannot assign hash distribution buckets less than 1");
+                }
+            }
+        } else {
+            distributionInfo = defaultDistributionInfo;
+        }
+        return distributionInfo;
+    }
+
+    private void checkColocation(Database db, OlapTable olapTable, DistributionInfo distributionInfo,
+                                 List<PartitionDesc> partitionDescs)
+            throws DdlException {
+        if (colocateTableIndex.isColocateTable(olapTable.getId())) {
+            String fullGroupName = db.getId() + "_" + olapTable.getColocateGroup();
+            ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(fullGroupName);
+            Preconditions.checkNotNull(groupSchema);
+            groupSchema.checkDistribution(distributionInfo);
+            for (PartitionDesc partitionDesc : partitionDescs) {
+                groupSchema.checkReplicationNum(partitionDesc.getReplicationNum());
+            }
+        }
+    }
+
+    private void checkDataProperty(List<PartitionDesc> partitionDescs) {
+        for (PartitionDesc partitionDesc : partitionDescs) {
+            DataProperty dataProperty = partitionDesc.getPartitionDataProperty();
+            Preconditions.checkNotNull(dataProperty);
+        }
+    }
+
+    private List<Partition> createPartitionList(Database db, OlapTable copiedTable, List<PartitionDesc> partitionDescs,
+                                                HashMap<String, Set<Long>> partitionNameToTabletSet,
+                                                Set<Long> tabletIdSetForAll)
+            throws DdlException {
+        List<Partition> partitionList = Lists.newArrayListWithCapacity(partitionDescs.size());
+        for (PartitionDesc partitionDesc : partitionDescs) {
+            long partitionId = getNextId();
+            DataProperty dataProperty = partitionDesc.getPartitionDataProperty();
+            String partitionName = partitionDesc.getPartitionName();
+            Long version = partitionDesc.getVersionInfo();
+            Set<Long> tabletIdSet = Sets.newHashSet();
+
+            copiedTable.getPartitionInfo().setDataProperty(partitionId, dataProperty);
+            copiedTable.getPartitionInfo().setTabletType(partitionId, partitionDesc.getTabletType());
+            copiedTable.getPartitionInfo()
+                    .setReplicationNum(partitionId, partitionDesc.getReplicationNum());
+            copiedTable.getPartitionInfo().setIsInMemory(partitionId, partitionDesc.isInMemory());
+
+            Partition partition =
+                    createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet);
+
+            partitionList.add(partition);
+            tabletIdSetForAll.addAll(tabletIdSet);
+            partitionNameToTabletSet.put(partitionName, tabletIdSet);
+        }
+        return partitionList;
+    }
+
+    private void checkIfMetaChange(OlapTable olapTable, OlapTable copiedTable, String tableName) throws DdlException {
+        // rollup index may be added or dropped during add partition operation.
+        // schema may be changed during add partition operation.
+        boolean metaChanged = false;
+        if (olapTable.getIndexNameToId().size() != copiedTable.getIndexNameToId().size()) {
+            metaChanged = true;
+        } else {
+            // compare schemaHash
+            for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getIndexIdToMeta().entrySet()) {
+                long indexId = entry.getKey();
+                if (!copiedTable.getIndexIdToMeta().containsKey(indexId)) {
+                    metaChanged = true;
+                    break;
+                }
+                if (copiedTable.getIndexIdToMeta().get(indexId).getSchemaHash() !=
+                        entry.getValue().getSchemaHash()) {
+                    metaChanged = true;
+                    break;
+                }
+            }
+        }
+
+        if (metaChanged) {
+            throw new DdlException("Table[" + tableName + "]'s meta has been changed. try again.");
+        }
+    }
+
+    private void updatePartitionInfo(PartitionInfo partitionInfo, List<Partition> partitionList,
+                                     List<PartitionDesc> partitionDescs, Set<String> existPartitionNameSet,
+                                     AddPartitionClause addPartitionClause, OlapTable olapTable)
+            throws DdlException {
+        boolean isTempPartition = addPartitionClause.isTempPartition();
+        if (partitionInfo instanceof RangePartitionInfo) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+            rangePartitionInfo.handleNewRangePartitionDescs(partitionDescs,
+                    partitionList, existPartitionNameSet, isTempPartition);
+        } else if (partitionInfo instanceof ListPartitionInfo) {
+            ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+            listPartitionInfo.handleNewListPartitionDescs(partitionDescs,
+                    partitionList, existPartitionNameSet, isTempPartition);
+        } else {
+            throw new DdlException("Only support adding partition to range/list partitioned table");
+        }
+
+        if (isTempPartition) {
+            for (Partition partition : partitionList) {
+                if (!existPartitionNameSet.contains(partition.getName())) {
+                    olapTable.addTempPartition(partition);
+                }
+            }
+        } else {
+            for (Partition partition : partitionList) {
+                if (!existPartitionNameSet.contains(partition.getName())) {
+                    olapTable.addPartition(partition);
+                }
+            }
+        }
+    }
+
+    private void addRangePartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
+                                      AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                      List<Partition> partitionList, Set<String> existPartitionNameSet) {
+        boolean isTempPartition = addPartitionClause.isTempPartition();
+        int partitionLen = partitionList.size();
+        // Forward compatible with previous log formats
+        // Version 1.15 is compatible if users only use single-partition syntax.
+        // Otherwise, the followers will be crash when reading the new log
+        if (partitionLen == 1) {
+            Partition partition = partitionList.get(0);
+            if (existPartitionNameSet.contains(partition.getName())) {
+                LOG.info("add partition[{}] which already exists", partition.getName());
+                return;
+            }
+            long partitionId = partition.getId();
+            PartitionPersistInfo info = new PartitionPersistInfo(db.getId(), olapTable.getId(), partition,
+                    ((RangePartitionInfo) partitionInfo).getRange(partitionId),
+                    partitionDescs.get(0).getPartitionDataProperty(),
+                    partitionInfo.getReplicationNum(partitionId),
+                    partitionInfo.getIsInMemory(partitionId),
+                    isTempPartition);
+            editLog.logAddPartition(info);
+
+            LOG.info("succeed in creating partition[{}], name: {}, temp: {}", partitionId,
+                    partition.getName(), isTempPartition);
+        } else {
+            List<PartitionPersistInfo> partitionInfoList = Lists.newArrayListWithCapacity(partitionLen);
+            for (int i = 0; i < partitionLen; i++) {
+                Partition partition = partitionList.get(i);
+                if (!existPartitionNameSet.contains(partition.getName())) {
+                    PartitionPersistInfo info =
+                            new PartitionPersistInfo(db.getId(), olapTable.getId(), partition,
+                                    ((RangePartitionInfo) partitionInfo).getRange(partition.getId()),
+                                    partitionDescs.get(i).getPartitionDataProperty(),
+                                    partitionInfo.getReplicationNum(partition.getId()),
+                                    partitionInfo.getIsInMemory(partition.getId()),
+                                    isTempPartition);
+                    partitionInfoList.add(info);
+                }
+            }
+
+            AddPartitionsInfo infos = new AddPartitionsInfo(partitionInfoList);
+            editLog.logAddPartitions(infos);
+
+            for (Partition partition : partitionList) {
+                LOG.info("succeed in creating partitions[{}], name: {}, temp: {}", partition.getId(),
+                        partition.getName(), isTempPartition);
+            }
+        }
+    }
+
+    private void addListPartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
+                                     AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                     List<Partition> partitionList, Set<String> existPartitionNameSet)
+            throws DdlException {
+        if (partitionList == null || partitionList.size() != 1) {
+            throw new DdlException("Only support add one partition when add list partition now");
+        }
+
+        boolean isTempPartition = addPartitionClause.isTempPartition();
+        Partition partition = partitionList.get(0);
+        if (existPartitionNameSet.contains(partition.getName())) {
+            LOG.info("add partition[{}] which already exists", partition.getName());
+            return;
+        }
+        long partitionId = partition.getId();
+        PartitionPersistInfoV2 info = new ListPartitionPersistInfo(db.getId(), olapTable.getId(), partition,
+                partitionDescs.get(0).getPartitionDataProperty(),
+                partitionInfo.getReplicationNum(partitionId),
+                partitionInfo.getIsInMemory(partitionId),
+                isTempPartition,
+                ((ListPartitionInfo) partitionInfo).getIdToValues().get(partitionId),
+                ((ListPartitionInfo) partitionInfo).getIdToMultiValues().get(partitionId));
+        editLog.logAddPartition(info);
+
+        LOG.info("succeed in creating list partition[{}], name: {}, temp: {}", partitionId,
+                partition.getName(), isTempPartition);
+    }
+
+    private void addPartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
+                                 AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                 List<Partition> partitionList, Set<String> existPartitionNameSet)
+            throws DdlException {
+        PartitionType partitionType = partitionInfo.getType();
+        if (partitionType == PartitionType.RANGE) {
+            addRangePartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+                    existPartitionNameSet);
+        } else if (partitionType == PartitionType.LIST) {
+            addListPartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+                    existPartitionNameSet);
+        } else {
+            throw new DdlException("Only support adding partition log to range/list partitioned table");
+        }
+    }
+
+    private void cleanExistPartitionNameSet(Set<String> existPartitionNameSet,
+                                            HashMap<String, Set<Long>> partitionNameToTabletSet) {
+        for (String partitionName : existPartitionNameSet) {
+            Set<Long> existPartitionTabletSet = partitionNameToTabletSet.get(partitionName);
+            if (existPartitionTabletSet == null) {
+                // should not happen
+                continue;
+            }
+            for (Long tabletId : existPartitionTabletSet) {
+                // createPartitionWithIndices create duplicate tablet that if not exists scenario
+                // so here need to clean up those created tablets which partition already exists from invert index
+                GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tabletId);
+            }
+        }
+    }
+
+    private void cleanTabletIdSetForAll(Set<Long> tabletIdSetForAll) {
+        for (Long tabletId : tabletIdSetForAll) {
+            GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tabletId);
+        }
+    }
+
+    private void addPartitions(Database db, String tableName, List<PartitionDesc> partitionDescs,
                                AddPartitionClause addPartitionClause) throws DdlException {
         DistributionInfo distributionInfo;
         OlapTable olapTable;
         OlapTable copiedTable;
 
-        boolean isTempPartition = addPartitionClause.isTempPartition();
         db.readLock();
         try {
-            Table table = db.getTable(tableName);
-            CatalogUtils.checkTableExist(db, tableName);
-            CatalogUtils.checkTableTypeOLAP(db, table);
-            olapTable = (OlapTable) table;
-            CatalogUtils.checkTableState(olapTable, tableName);
-            // check partition type
+            olapTable = checkTable(db, tableName);
+
+            // get partition info
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-            if (partitionInfo.getType() != PartitionType.RANGE) {
-                throw new DdlException("Only support adding partition to range partitioned table");
-            }
-            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-            Set<String> existPartitionNameSet =
-                    CatalogUtils.checkPartitionNameExistForAddPartitions(olapTable, singleRangePartitionDescs);
-            // partition properties is prior to clause properties
-            // clause properties is prior to table properties
-            Map<String, String> properties = Maps.newHashMap();
-            properties = getOrSetDefaultProperties(olapTable, properties);
-            Map<String, String> clauseProperties = addPartitionClause.getProperties();
-            if (clauseProperties != null && !clauseProperties.isEmpty()) {
-                properties.putAll(clauseProperties);
-            }
-            for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                Map<String, String> cloneProperties = Maps.newHashMap(properties);
-                Map<String, String> sourceProperties = singleRangePartitionDesc.getProperties();
-                if (sourceProperties != null && !sourceProperties.isEmpty()) {
-                    cloneProperties.putAll(sourceProperties);
-                }
-                singleRangePartitionDesc.analyze(rangePartitionInfo.getPartitionColumns().size(), cloneProperties);
-                if (!existPartitionNameSet.contains(singleRangePartitionDesc.getPartitionName())) {
-                    rangePartitionInfo.checkAndCreateRange(singleRangePartitionDesc, isTempPartition);
-                }
-            }
+
+            // check partition type
+            checkPartitionType(partitionInfo);
+
+            // analyze add partition
+            analyzeAddPartition(olapTable, partitionDescs, addPartitionClause, partitionInfo);
 
             // get distributionInfo
-            List<Column> baseSchema = olapTable.getBaseSchema();
-            DistributionInfo defaultDistributionInfo = olapTable.getDefaultDistributionInfo();
-            DistributionDesc distributionDesc = addPartitionClause.getDistributionDesc();
-            if (distributionDesc != null) {
-                distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-                // for now. we only support modify distribution's bucket num
-                if (distributionInfo.getType() != defaultDistributionInfo.getType()) {
-                    throw new DdlException("Cannot assign different distribution type. default is: "
-                            + defaultDistributionInfo.getType());
-                }
-
-                if (distributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH) {
-                    HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
-                    List<Column> newDistriCols = hashDistributionInfo.getDistributionColumns();
-                    List<Column> defaultDistriCols = ((HashDistributionInfo) defaultDistributionInfo)
-                            .getDistributionColumns();
-                    if (!newDistriCols.equals(defaultDistriCols)) {
-                        throw new DdlException("Cannot assign hash distribution with different distribution cols. "
-                                + "default is: " + defaultDistriCols);
-                    }
-                    if (hashDistributionInfo.getBucketNum() <= 0) {
-                        throw new DdlException("Cannot assign hash distribution buckets less than 1");
-                    }
-                }
-            } else {
-                distributionInfo = defaultDistributionInfo;
-            }
+            distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
 
             // check colocation
-            if (colocateTableIndex.isColocateTable(olapTable.getId())) {
-                String fullGroupName = db.getId() + "_" + olapTable.getColocateGroup();
-                ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(fullGroupName);
-                Preconditions.checkNotNull(groupSchema);
-                groupSchema.checkDistribution(distributionInfo);
-                for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                    groupSchema.checkReplicationNum(singleRangePartitionDesc.getReplicationNum());
-                }
-            }
+            checkColocation(db, olapTable, distributionInfo, partitionDescs);
 
             copiedTable = olapTable.selectiveCopy(null, false, MaterializedIndex.IndexExtState.VISIBLE);
             copiedTable.setDefaultDistributionInfo(distributionInfo);
-        } catch (AnalysisException e) {
+        } catch (AnalysisException | NotImplementedException e) {
             throw new DdlException(e.getMessage());
         } finally {
             db.readUnlock();
@@ -933,51 +1207,25 @@ public class LocalMetastore implements ConnectorMetadata {
         Preconditions.checkNotNull(copiedTable);
 
         // create partition outside db lock
-        for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-            DataProperty dataProperty = singleRangePartitionDesc.getPartitionDataProperty();
-            Preconditions.checkNotNull(dataProperty);
-        }
+        checkDataProperty(partitionDescs);
 
         Set<Long> tabletIdSetForAll = Sets.newHashSet();
         HashMap<String, Set<Long>> partitionNameToTabletSet = Maps.newHashMap();
         try {
-            List<Partition> partitionList = Lists.newArrayListWithCapacity(singleRangePartitionDescs.size());
+            // create partition list
+            List<Partition> partitionList =
+                    createPartitionList(db, copiedTable, partitionDescs, partitionNameToTabletSet, tabletIdSetForAll);
 
-            for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
-                long partitionId = getNextId();
-                DataProperty dataProperty = singleRangePartitionDesc.getPartitionDataProperty();
-                String partitionName = singleRangePartitionDesc.getPartitionName();
-                Long version = singleRangePartitionDesc.getVersionInfo();
-                Set<Long> tabletIdSet = Sets.newHashSet();
-
-                copiedTable.getPartitionInfo().setDataProperty(partitionId, dataProperty);
-                copiedTable.getPartitionInfo().setTabletType(partitionId, singleRangePartitionDesc.getTabletType());
-                copiedTable.getPartitionInfo()
-                        .setReplicationNum(partitionId, singleRangePartitionDesc.getReplicationNum());
-                copiedTable.getPartitionInfo().setIsInMemory(partitionId, singleRangePartitionDesc.isInMemory());
-
-                Partition partition =
-                        createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet);
-
-                partitionList.add(partition);
-                tabletIdSetForAll.addAll(tabletIdSet);
-                partitionNameToTabletSet.put(partitionName, tabletIdSet);
-            }
-
+            // build partitions
             buildPartitions(db, copiedTable, partitionList);
 
             // check again
             db.writeLock();
             Set<String> existPartitionNameSet = Sets.newHashSet();
             try {
-                CatalogUtils.checkTableExist(db, tableName);
-                Table table = db.getTable(tableName);
-                CatalogUtils.checkTableTypeOLAP(db, table);
-                olapTable = (OlapTable) table;
-                CatalogUtils.checkTableState(olapTable, tableName);
+                olapTable = checkTable(db, tableName);
                 existPartitionNameSet = CatalogUtils.checkPartitionNameExistForAddPartitions(olapTable,
-                        singleRangePartitionDescs);
-
+                        partitionDescs);
                 if (existPartitionNameSet.size() > 0) {
                     for (String partitionName : existPartitionNameSet) {
                         LOG.info("add partition[{}] which already exists", partitionName);
@@ -985,121 +1233,27 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
 
                 // check if meta changed
-                // rollup index may be added or dropped during add partition operation.
-                // schema may be changed during add partition operation.
-                boolean metaChanged = false;
-                if (olapTable.getIndexNameToId().size() != copiedTable.getIndexNameToId().size()) {
-                    metaChanged = true;
-                } else {
-                    // compare schemaHash
-                    for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getIndexIdToMeta().entrySet()) {
-                        long indexId = entry.getKey();
-                        if (!copiedTable.getIndexIdToMeta().containsKey(indexId)) {
-                            metaChanged = true;
-                            break;
-                        }
-                        if (copiedTable.getIndexIdToMeta().get(indexId).getSchemaHash() !=
-                                entry.getValue().getSchemaHash()) {
-                            metaChanged = true;
-                            break;
-                        }
-                    }
-                }
+                checkIfMetaChange(olapTable, copiedTable, tableName);
 
-                if (metaChanged) {
-                    throw new DdlException("Table[" + tableName + "]'s meta has been changed. try again.");
-                }
+                // get partition info
+                PartitionInfo partitionInfo = olapTable.getPartitionInfo();
 
                 // check partition type
-                PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-                if (partitionInfo.getType() != PartitionType.RANGE) {
-                    throw new DdlException("Only support adding partition to range partitioned table");
-                }
+                checkPartitionType(partitionInfo);
 
                 // update partition info
-                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-                rangePartitionInfo.handleNewRangePartitionDescs(singleRangePartitionDescs,
-                        partitionList, existPartitionNameSet, isTempPartition);
+                updatePartitionInfo(partitionInfo, partitionList, partitionDescs, existPartitionNameSet,
+                        addPartitionClause, olapTable);
 
-                if (isTempPartition) {
-                    for (Partition partition : partitionList) {
-                        if (!existPartitionNameSet.contains(partition.getName())) {
-                            olapTable.addTempPartition(partition);
-                        }
-                    }
-                } else {
-                    for (Partition partition : partitionList) {
-                        if (!existPartitionNameSet.contains(partition.getName())) {
-                            olapTable.addPartition(partition);
-                        }
-                    }
-                }
-
-                // log
-                int partitionLen = partitionList.size();
-                // Forward compatible with previous log formats
-                // Version 1.15 is compatible if users only use single-partition syntax.
-                // Otherwise, the followers will be crash when reading the new log
-                if (partitionLen == 1) {
-                    Partition partition = partitionList.get(0);
-                    if (existPartitionNameSet.contains(partition.getName())) {
-                        LOG.info("add partition[{}] which already exists", partition.getName());
-                        return;
-                    }
-                    long partitionId = partition.getId();
-                    PartitionPersistInfo info = new PartitionPersistInfo(db.getId(), olapTable.getId(), partition,
-                            rangePartitionInfo.getRange(partitionId),
-                            singleRangePartitionDescs.get(0).getPartitionDataProperty(),
-                            rangePartitionInfo.getReplicationNum(partitionId),
-                            rangePartitionInfo.getIsInMemory(partitionId),
-                            isTempPartition);
-                    editLog.logAddPartition(info);
-
-                    LOG.info("succeed in creating partition[{}], name: {}, temp: {}", partitionId,
-                            partition.getName(), isTempPartition);
-                } else {
-                    List<PartitionPersistInfo> partitionInfoList = Lists.newArrayListWithCapacity(partitionLen);
-                    for (int i = 0; i < partitionLen; i++) {
-                        Partition partition = partitionList.get(i);
-                        if (!existPartitionNameSet.contains(partition.getName())) {
-                            PartitionPersistInfo info =
-                                    new PartitionPersistInfo(db.getId(), olapTable.getId(), partition,
-                                            rangePartitionInfo.getRange(partition.getId()),
-                                            singleRangePartitionDescs.get(i).getPartitionDataProperty(),
-                                            rangePartitionInfo.getReplicationNum(partition.getId()),
-                                            rangePartitionInfo.getIsInMemory(partition.getId()),
-                                            isTempPartition);
-                            partitionInfoList.add(info);
-                        }
-                    }
-
-                    AddPartitionsInfo infos = new AddPartitionsInfo(partitionInfoList);
-                    editLog.logAddPartitions(infos);
-
-                    for (Partition partition : partitionList) {
-                        LOG.info("succeed in creating partitions[{}], name: {}, temp: {}", partition.getId(),
-                                partition.getName(), isTempPartition);
-                    }
-                }
+                // add partition log
+                addPartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+                        existPartitionNameSet);
             } finally {
-                for (String partitionName : existPartitionNameSet) {
-                    Set<Long> existPartitionTabletSet = partitionNameToTabletSet.get(partitionName);
-                    if (existPartitionTabletSet == null) {
-                        // should not happen
-                        continue;
-                    }
-                    for (Long tabletId : existPartitionTabletSet) {
-                        // createPartitionWithIndices create duplicate tablet that if not exists scenario
-                        // so here need to clean up those created tablets which partition already exists from invert index
-                        GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tabletId);
-                    }
-                }
+                cleanExistPartitionNameSet(existPartitionNameSet, partitionNameToTabletSet);
                 db.writeUnlock();
             }
         } catch (DdlException e) {
-            for (Long tabletId : tabletIdSetForAll) {
-                GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tabletId);
-            }
+            cleanTabletIdSetForAll(tabletIdSetForAll);
             throw e;
         }
     }
@@ -1122,6 +1276,57 @@ public class LocalMetastore implements ConnectorMetadata {
                     tableProperty.get(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM));
         }
         return sourceProperties;
+    }
+
+    public void replayAddPartition(PartitionPersistInfoV2 info) throws DdlException {
+        Database db = this.getDb(info.getDbId());
+        db.writeLock();
+        try {
+            OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
+            Partition partition = info.getPartition();
+
+            PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+            if (info.isTempPartition()) {
+                olapTable.addTempPartition(partition);
+            } else {
+                olapTable.addPartition(partition);
+            }
+
+            PartitionType partitionType = partitionInfo.getType();
+            if (partitionType == PartitionType.LIST) {
+                try {
+                    ((ListPartitionInfo) partitionInfo).unprotectHandleNewPartitionDesc(
+                            info.asListPartitionPersistInfo());
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
+            } else if (partitionType == PartitionType.RANGE) {
+                ((RangePartitionInfo) partitionInfo).unprotectHandleNewSinglePartitionDesc(
+                        info.asRangePartitionPersistInfo());
+            } else {
+                throw new DdlException("Only support adding partition to range/list partitioned table");
+            }
+
+            if (!isCheckpointThread()) {
+                // add to inverted index
+                TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
+                for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    long indexId = index.getId();
+                    int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
+                    TabletMeta tabletMeta = new TabletMeta(info.getDbId(), info.getTableId(), partition.getId(),
+                            index.getId(), schemaHash, info.getDataProperty().getStorageMedium());
+                    for (Tablet tablet : index.getTablets()) {
+                        long tabletId = tablet.getId();
+                        invertedIndex.addTablet(tabletId, tabletMeta);
+                        for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                            invertedIndex.addReplica(tabletId, replica);
+                        }
+                    }
+                }
+            }
+        } finally {
+            db.writeUnlock();
+        }
     }
 
     public void replayAddPartition(PartitionPersistInfo info) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -32,9 +32,13 @@ import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.DropMaterializedViewStmt;
 import com.starrocks.analysis.DropTableStmt;
 import com.starrocks.analysis.GrantStmt;
+import com.starrocks.analysis.MultiItemListPartitionDesc;
+import com.starrocks.analysis.PartitionDesc;
+import com.starrocks.analysis.SingleItemListPartitionDesc;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -46,6 +50,8 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.persist.ListPartitionPersistInfo;
+import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.server.GlobalStateMgr;
@@ -61,6 +67,13 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -1426,6 +1439,380 @@ public class AlterTest {
         String renameDb = "alter database test rename test0";
         AlterDatabaseRename renameDbStmt =
                 (AlterDatabaseRename) UtFrameUtils.parseAndAnalyzeStmt(renameDb, starRocksAssert.getCtx());
+    }
+
+    @Test
+    public void testAddMultiItemListPartition() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (dt,province) (\n" +
+                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values = Lists.newArrayList("2022-04-01", "shandong");
+        List<List<String>> multiValues = Lists.newArrayList();
+        multiValues.add(values);
+        PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p3", multiValues, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition", addPartitionClause);
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("default_cluster:test")
+                .getTable("test_partition");
+        ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
+        Map<Long, List<List<String>>> idToValues = partitionInfo.getIdToMultiValues();
+
+        long id3 = table.getPartition("p3").getId();
+        List<List<String>> list3 = idToValues.get(id3);
+        Assert.assertEquals("2022-04-01", list3.get(0).get(0));
+        Assert.assertEquals("shandong", list3.get(0).get(1));
+
+        String dropSQL = "drop table test_partition";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testAddSingleItemListPartition() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values = Lists.newArrayList("shanxi", "shanghai");
+        PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p3", values, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition", addPartitionClause);
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("default_cluster:test")
+                .getTable("test_partition");
+        ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
+        Map<Long, List<String>> idToValues = partitionInfo.getIdToValues();
+
+        long id3 = table.getPartition("p3").getId();
+        List<String> list3 = idToValues.get(id3);
+        Assert.assertEquals("shanxi", list3.get(0));
+        Assert.assertEquals("shanghai", list3.get(1));
+
+        String dropSQL = "drop table test_partition";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testSingleItemPartitionPersistInfo() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+        OlapTable table = (OlapTable) db.getTable("test_partition");
+        ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
+
+        long dbId = db.getId();
+        long tableId = table.getId();
+        Partition partition = table.getPartition("p1");
+        long partitionId = partition.getId();
+        List<String> values = partitionInfo.getIdToValues().get(partitionId);
+        DataProperty dataProperty = partitionInfo.getDataProperty(partitionId);
+        short replicationNum = partitionInfo.getReplicationNum(partitionId);
+        boolean isInMemory = partitionInfo.getIsInMemory(partitionId);
+        boolean isTempPartition = false;
+        ListPartitionPersistInfo partitionPersistInfoOut = new ListPartitionPersistInfo(dbId, tableId, partition,
+                dataProperty, replicationNum, isInMemory, isTempPartition, values, new ArrayList<>());
+
+        // write log
+        File file = new File("./test_serial.log");
+        if (file.exists()) {
+            file.delete();
+        }
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+        partitionPersistInfoOut.write(out);
+
+        // read log
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+        PartitionPersistInfoV2 partitionPersistInfoIn = PartitionPersistInfoV2.read(in);
+
+        Assert.assertEquals(dbId, partitionPersistInfoIn.getDbId().longValue());
+        Assert.assertEquals(tableId, partitionPersistInfoIn.getTableId().longValue());
+        Assert.assertEquals(partitionId, partitionPersistInfoIn.getPartition().getId());
+        Assert.assertEquals(partition.getName(), partitionPersistInfoIn.getPartition().getName());
+        Assert.assertEquals(replicationNum, partitionPersistInfoIn.getReplicationNum());
+        Assert.assertEquals(isInMemory, partitionPersistInfoIn.isInMemory());
+        Assert.assertEquals(isTempPartition, partitionPersistInfoIn.isTempPartition());
+        Assert.assertEquals(dataProperty, partitionPersistInfoIn.getDataProperty());
+
+        List<String> assertValues = partitionPersistInfoIn.asListPartitionPersistInfo().getValues();
+        Assert.assertEquals(values.size(), assertValues.size());
+        for (int i = 0; i < values.size(); i++) {
+            Assert.assertEquals(values.get(i), assertValues.get(i));
+        }
+
+        // replay log
+        partitionInfo.setValues(partitionId, null);
+        GlobalStateMgr.getCurrentState().replayAddPartition(partitionPersistInfoIn);
+        Assert.assertNotNull(partitionInfo.getIdToValues().get(partitionId));
+
+        String dropSQL = "drop table test_partition";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+        file.delete();
+    }
+
+    @Test
+    public void testMultiItemPartitionPersistInfo() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (dt , province) (\n" +
+                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+        OlapTable table = (OlapTable) db.getTable("test_partition");
+        ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
+
+        long dbId = db.getId();
+        long tableId = table.getId();
+        Partition partition = table.getPartition("p1");
+        long partitionId = partition.getId();
+        List<List<String>> multiValues = partitionInfo.getIdToMultiValues().get(partitionId);
+        DataProperty dataProperty = partitionInfo.getDataProperty(partitionId);
+        short replicationNum = partitionInfo.getReplicationNum(partitionId);
+        boolean isInMemory = partitionInfo.getIsInMemory(partitionId);
+        boolean isTempPartition = false;
+        ListPartitionPersistInfo partitionPersistInfoOut = new ListPartitionPersistInfo(dbId, tableId, partition,
+                dataProperty, replicationNum, isInMemory, isTempPartition, new ArrayList<>(), multiValues);
+
+        // write log
+        File file = new File("./test_serial.log");
+        if (file.exists()) {
+            file.delete();
+        }
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+        partitionPersistInfoOut.write(out);
+
+        // replay log
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+        PartitionPersistInfoV2 partitionPersistInfoIn = PartitionPersistInfoV2.read(in);
+
+        Assert.assertEquals(dbId, partitionPersistInfoIn.getDbId().longValue());
+        Assert.assertEquals(tableId, partitionPersistInfoIn.getTableId().longValue());
+        Assert.assertEquals(partitionId, partitionPersistInfoIn.getPartition().getId());
+        Assert.assertEquals(partition.getName(), partitionPersistInfoIn.getPartition().getName());
+        Assert.assertEquals(replicationNum, partitionPersistInfoIn.getReplicationNum());
+        Assert.assertEquals(isInMemory, partitionPersistInfoIn.isInMemory());
+        Assert.assertEquals(isTempPartition, partitionPersistInfoIn.isTempPartition());
+        Assert.assertEquals(dataProperty, partitionPersistInfoIn.getDataProperty());
+
+        List<List<String>> assertMultiValues = partitionPersistInfoIn.asListPartitionPersistInfo().getMultiValues();
+        Assert.assertEquals(multiValues.size(), assertMultiValues.size());
+        for (int i = 0; i < multiValues.size(); i++) {
+            List<String> valueItem = multiValues.get(i);
+            List<String> assertValueItem = assertMultiValues.get(i);
+            for (int j = 0; j < valueItem.size(); j++) {
+                Assert.assertEquals(valueItem.get(i), assertValueItem.get(i));
+            }
+        }
+
+        // replay log
+        partitionInfo.setMultiValues(partitionId, null);
+        GlobalStateMgr.getCurrentState().replayAddPartition(partitionPersistInfoIn);
+        Assert.assertNotNull(partitionInfo.getIdToMultiValues().get(partitionId));
+
+        String dropSQL = "drop table test_partition";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+        file.delete();
+    }
+
+    @Test(expected = DdlException.class)
+    public void testAddSingleListPartitionSamePartitionNameShouldThrowError() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition_1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values = Lists.newArrayList("shanxi", "heilongjiang");
+        PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p1", values, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition_1", addPartitionClause);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testAddMultiListPartitionSamePartitionNameShouldThrowError() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition_2 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (dt,province) (\n" +
+                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values1 = Lists.newArrayList("2022-04-01", "beijing");
+        List<String> values2 = Lists.newArrayList("2022-04-01", "chongqing");
+        List<List<String>> multiValues = Lists.newArrayList();
+        multiValues.add(values1);
+        multiValues.add(values2);
+        PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p1", multiValues, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition_2", addPartitionClause);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testAddSingleListPartitionSamePartitionValueShouldThrowError() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition_3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values = Lists.newArrayList("beijing", "chongqing");
+        PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p3", values, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition_3", addPartitionClause);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testAddMultiItemListPartitionSamePartitionValueShouldThrowError() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test.test_partition_4 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (dt, province) (\n" +
+                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+
+        List<String> values = Lists.newArrayList("2022-04-01", "shanghai");
+        List<List<String>> multiValues = Lists.newArrayList();
+        multiValues.add(values);
+        PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p3", multiValues, new HashMap<>());
+        AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
+        GlobalStateMgr.getCurrentState().addPartitions(db, "test_partition_4", addPartitionClause);
     }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [X] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

issue #4035 

#### Create Table for single column partition

```sql
create database example_db  ;
use example_db ;

CREATE TABLE t_recharge_detail_single(
    id bigint  ,
    user_id  bigint  ,
    recharge_money decimal(32,2) , 
    province varchar ,
    dt varchar
) ENGINE=OLAP
DUPLICATE KEY(id)
PARTITION BY LIST (province) (
   PARTITION p1 VALUES IN ("beijing","chongqing"),
   PARTITION p2 VALUES IN ("shanghai","tianjing")
)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES(
    "replication_num" = "1"
) ;

alter table t_recharge_detail_single add partition p3 values in ("shanxi","guangdong") ;

show partitions  from  t_recharge_detail_single  \G; 

show create table t_recharge_detail_single  ;

```

#### Result
![image](https://user-images.githubusercontent.com/39675622/169983727-8a2ea28d-1a99-4245-bcf2-fe50b5f45618.png)
![image](https://user-images.githubusercontent.com/39675622/169984369-847d689e-97c2-43bf-8816-8c8cad455b91.png)

#### Create Table for multi column partition  

```sql
CREATE TABLE t_recharge_detail_multi(
    id bigint  ,
    user_id  bigint  ,
    recharge_money decimal(32,2) , 
    province varchar ,
    dt varchar
) ENGINE=OLAP
DUPLICATE KEY(id)
PARTITION BY LIST (dt,province) (
   PARTITION p1 VALUES IN (("2022-04-01", "beijing"),("2022-04-01", "chongqing")),
   PARTITION p2 VALUES IN (("2022-04-01", "shanghai"))
)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES(
    "replication_num" = "1"
);

alter table t_recharge_detail_multi add partition p3 values in (("2022-04-01", "shanxi"),("2022-04-01", "neimenggu"));
show partitions from t_recharge_detail_multi  \G;
show create table t_recharge_detail_multi  ;

```
#### Result
![image](https://user-images.githubusercontent.com/39675622/169984002-0248ca02-642a-4797-98fa-fb1a2fd9e870.png)
![image](https://user-images.githubusercontent.com/39675622/169984047-1af18481-7fe1-4413-86b6-acb767c83b92.png)
