### PR TITLE
[Enhancement] avoid same table inner join when use heuristic method in left deep join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
@@ -54,7 +54,8 @@ public class JoinReorderLeftDeep extends JoinOrder {
                 // search the next group which:
                 // 1. has never been used
                 // 2. can inner join with leftGroup
-                // 3. not same table join (happens only the first time)
+                // 3. not same table inner join (happens only the first time).
+                // inner join on same tables possibly degrades to cross join.
                 for (; index < atomSize; ++index) {
                     GroupInfo rightGroup = atoms.get(index);
                     if (next == 1 && isSameTableJoin(leftGroup, rightGroup)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 
 import java.util.BitSet;
 import java.util.List;
@@ -15,6 +16,18 @@ public class JoinReorderLeftDeep extends JoinOrder {
 
     public JoinReorderLeftDeep(OptimizerContext context) {
         super(context);
+    }
+
+    public boolean isSameTableJoin(GroupInfo left, GroupInfo right) {
+        if (!(left.bestExprInfo.expr.getOp() instanceof LogicalScanOperator)) {
+            return false;
+        }
+        if (!(right.bestExprInfo.expr.getOp() instanceof LogicalScanOperator)) {
+            return false;
+        }
+        LogicalScanOperator l = (LogicalScanOperator) left.bestExprInfo.expr.getOp();
+        LogicalScanOperator r = (LogicalScanOperator) right.bestExprInfo.expr.getOp();
+        return l.getTable().getId() == r.getTable().getId();
     }
 
     @Override
@@ -41,8 +54,13 @@ public class JoinReorderLeftDeep extends JoinOrder {
                 // search the next group which:
                 // 1. has never been used
                 // 2. can inner join with leftGroup
+                // 3. not same table join (happens only the first time)
                 for (; index < atomSize; ++index) {
-                    if (!used[index] && canBuildInnerJoinPredicate(leftGroup, atoms.get(index))) {
+                    GroupInfo rightGroup = atoms.get(index);
+                    if (next == 1 && isSameTableJoin(leftGroup, rightGroup)) {
+                        continue;
+                    }
+                    if (!used[index] && canBuildInnerJoinPredicate(leftGroup, rightGroup)) {
                         break;
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
@@ -642,4 +642,37 @@ public class TPCDSPlanTest extends TPCDSPlanTestBase {
         String plan = getFragmentPlan(Q20);
         assertNotContains(plan, "CROSS JOIN");
     }
+
+    @Test
+    public void testQuery33LeftDeepJoinReorderAvoidInnerJoinOnSameTable() throws Exception {
+        setTPCDSFactor(1);
+        String plan = getFragmentPlan(Q33);
+        assertContains(plan, "  16:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 44: wr_returning_cdemo_sk = 82: cd_demo_sk\n" +
+                "  |  equal join conjunct: 75: cd_marital_status = 84: cd_marital_status\n" +
+                "  |  equal join conjunct: 76: cd_education_status = 85: cd_education_status\n" +
+                "  |  \n" +
+                "  |----15:EXCHANGE");
+        assertContains(plan, "  12:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 40: wr_refunded_cdemo_sk = 73: cd_demo_sk\n" +
+                "  |  other join predicates: ((((75: cd_marital_status = 'D') AND (76: cd_education_status = 'Primary')) AND ((22: ws_sales_price >= 100.00) AND (22: ws_sales_price <= 150.00))) OR (((75: cd_marital_status = 'U') AND (76: cd_education_status = 'Unknown')) AND ((22: ws_sales_price >= 50.00) AND (22: ws_sales_price <= 100.00)))) OR (((75: cd_marital_status = 'M') AND (76: cd_education_status = 'Advanced Degree')) AND ((22: ws_sales_price >= 150.00) AND (22: ws_sales_price <= 200.00)))\n" +
+                "  |  \n" +
+                "  |----11:EXCHANGE");
+        assertContains(plan, "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 15\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  14:OlapScanNode\n" +
+                "     TABLE: customer_demographics");
+        assertContains(plan, "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 11\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  10:OlapScanNode\n" +
+                "     TABLE: customer_demographics");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

It's about tpcds query85 with heuristic method. The bad case is like following: inner join two same tables, which degrades  to cross join.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/1081215/180336333-73e95a6f-0866-44d6-b8af-f0c08f1ef870.png">


Inner join on samle table works like cross join. Tha'ts what we want to avoid.
