### PR TITLE
Add compress debug info when disable minidump

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -71,7 +71,7 @@ message(STATUS "make test: ${MAKE_TEST}")
 
 option(WITH_GCOV "Build binary with gcov to get code coverage" OFF)
 
-option(WITHOUT_MINIDUMP "Build binary with compresss debug section" ON)
+option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
 option(USE_STAROS "Use StarOS to manager tablet info" OFF)
 
@@ -405,7 +405,7 @@ if (WITH_GCOV)
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
-if (WITHOUT_MINIDUMP)
+if (WITH_COMPRESS)
     # to compresss debug section. https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -gz=zlib")
 endif()

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -71,6 +71,8 @@ message(STATUS "make test: ${MAKE_TEST}")
 
 option(WITH_GCOV "Build binary with gcov to get code coverage" OFF)
 
+option(WITHOUT_MINIDUMP "Build binary with compresss debug section" ON)
+
 option(USE_STAROS "Use StarOS to manager tablet info" OFF)
 
 # Check gcc
@@ -401,6 +403,11 @@ set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -g -Wno-unused-local-typedefs")
 if (WITH_GCOV)
     # To generate flags to code coverage
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fprofile-arcs -ftest-coverage")
+endif()
+
+if (WITHOUT_MINIDUMP)
+    # to compresss debug section. https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -gz=zlib")
 endif()
 
 if (ENABLE_QUERY_DEBUG_TRACE)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Compress debug info to reduce file size(1.7GB) to 600MB.