### PR TITLE
[BugFix] fix shared-scan check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/AggType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/AggType.java
@@ -33,6 +33,10 @@ public enum AggType {
         return this.equals(AggType.DISTINCT_GLOBAL);
     }
 
+    public boolean isDistinct() {
+        return this.equals(AggType.DISTINCT_LOCAL) || this.equals(AggType.DISTINCT_GLOBAL);
+    }
+
     public boolean isDistinctLocal() {
         return this.equals(AggType.DISTINCT_LOCAL);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -78,7 +78,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     }
 
     public boolean isOnePhaseAgg() {
-        return type.isGlobal() && !isSplit;
+        return (type.isGlobal() || type.isDistinctGlobal()) && !isSplit;
     }
 
     public List<ColumnRefOperator> getPartitionByColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -78,7 +78,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     }
 
     public boolean isOnePhaseAgg() {
-        return (type.isGlobal() || type.isDistinctGlobal()) && !isSplit;
+        return type.isGlobal() && !isSplit;
     }
 
     public List<ColumnRefOperator> getPartitionByColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1295,8 +1295,10 @@ public class PlanFragmentBuilder {
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
-            if (node.isOnePhaseAgg() && hasNoExchangeNodes(inputFragment.getPlanRoot())) {
+            if ((node.isOnePhaseAgg() || node.getType().isDistinct())) {
                 inputFragment.setEnableSharedScan(false);
+            }
+            if ((node.isOnePhaseAgg() || node.getType().isDistinct()) && hasNoExchangeNodes(inputFragment.getPlanRoot())) {
                 inputFragment.setAssignScanRangesPerDriverSeq(true);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1297,8 +1297,6 @@ public class PlanFragmentBuilder {
 
             if ((node.isOnePhaseAgg() || node.getType().isDistinct())) {
                 inputFragment.setEnableSharedScan(false);
-            }
-            if ((node.isOnePhaseAgg() || node.getType().isDistinct()) && hasNoExchangeNodes(inputFragment.getPlanRoot())) {
                 inputFragment.setAssignScanRangesPerDriverSeq(true);
             }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```sql
set enable_shared_scan = true;
set new_planner_agg_stage =3;
select avg(id_int), count(distinct id_int) from test_basic;
```

The `shared_scan` should be disabled for this case. So we just disable shared scan for distinct aggregation.
