### PR TITLE
[Bugfix] fix "unsupport decode_dict_codes" error in late_materized

### DIFF
--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -3,6 +3,7 @@
 #include "storage/rowset/dictcode_column_iterator.h"
 
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
@@ -82,53 +83,12 @@ Status GlobalDictCodeColumnIterator::build_code_convert_map(ScalarColumnIterator
     return Status::OK();
 }
 
-void GlobalDictCodeColumnIterator::_init_local_dict_col() {
-    _local_dict_code_col = std::make_unique<vectorized::Int32Column>();
+vectorized::ColumnPtr GlobalDictCodeColumnIterator::_new_local_dict_col(bool nullable) {
+    vectorized::ColumnPtr res = std::make_unique<vectorized::Int32Column>();
     if (_opts.is_nullable) {
-        _local_dict_code_col =
-                vectorized::NullableColumn::create(std::move(_local_dict_code_col), vectorized::NullColumn::create());
+        res = vectorized::NullableColumn::create(std::move(res), vectorized::NullColumn::create());
     }
-}
-
-auto GlobalDictCodeColumnIterator::_get_local_dict_col_container(Column* column)
-        -> const LowCardDictColumn::Container& {
-    LowCardDictColumn* dict_column = nullptr;
-    if (column->is_nullable()) {
-        auto nullable_column = down_cast<vectorized::NullableColumn*>(column);
-        dict_column = down_cast<LowCardDictColumn*>(nullable_column->data_column().get());
-        const auto& null_data = nullable_column->immutable_null_column_data();
-        int row_sz = null_data.size();
-        // TODO: If we can ensure that the null value of data is the default value,
-        // then this loop can be removed
-        for (int i = 0; i < row_sz; ++i) {
-            dict_column->get_data()[i] = null_data[i] ? 0 : dict_column->get_data()[i];
-        }
-    } else {
-        dict_column = down_cast<LowCardDictColumn*>(column);
-    }
-    return dict_column->get_data();
-}
-
-void GlobalDictCodeColumnIterator::_acquire_null_data(Column* global_dict_column, Column* local_dict_column) {
-#ifndef NDEBUG
-    // if global_dict_column was no-nullable but local_dict_column was nullable
-    // local_dict_column shouldn't has null
-    if (_opts.is_nullable && !global_dict_column->is_nullable()) {
-        auto src_column = down_cast<vectorized::NullableColumn*>(local_dict_column);
-        src_column->update_has_null();
-        DCHECK(!src_column->has_null());
-    }
-#endif
-
-    // TODO: give the nullable property an accurate value
-    // now _opts.is_nullable was always true
-    if (_opts.is_nullable && global_dict_column->is_nullable()) {
-        DCHECK(local_dict_column->is_nullable());
-        auto dst_column = down_cast<vectorized::NullableColumn*>(global_dict_column);
-        auto src_column = down_cast<vectorized::NullableColumn*>(local_dict_column);
-        dst_column->null_column_data() = std::move(src_column->null_column_data());
-        dst_column->set_has_null(src_column->has_null());
-    }
+    return res;
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -6,6 +6,8 @@
 
 #include "column/column.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/expr_context.h"
 #include "runtime/global_dict/config.h"
 #include "runtime/global_dict/dict_column.h"
 #include "runtime/global_dict/types.h"
@@ -103,6 +105,7 @@ public:
         _local_dict_code_col->reset_column();
         RETURN_IF_ERROR(_col_iter->fetch_dict_codes_by_rowid(rowids, size, _local_dict_code_col.get()));
         RETURN_IF_ERROR(decode_dict_codes(*_local_dict_code_col, values));
+        _swap_null_columns(_local_dict_code_col.get(), values);
         return Status::OK();
     }
 
@@ -142,7 +145,10 @@ public:
                                          std::vector<int16_t>* code_convert_map);
 
 private:
+    // create a new empty local dict column
     vectorized::ColumnPtr _new_local_dict_col(bool nullable);
+    // swap null column between src and dst column
+    void _swap_null_columns(Column* src, Column* dst);
 
     ColumnId _cid;
     ColumnIterator* _col_iter;

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -98,13 +98,11 @@ public:
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         if (_local_dict_code_col == nullptr) {
-            _init_local_dict_col();
+            _local_dict_code_col = _new_local_dict_col(values->is_nullable());
         }
         _local_dict_code_col->reset_column();
         RETURN_IF_ERROR(_col_iter->fetch_dict_codes_by_rowid(rowids, size, _local_dict_code_col.get()));
-        const auto& container = _get_local_dict_col_container(_local_dict_code_col.get());
-        RETURN_IF_ERROR(decode_dict_codes(container.data(), container.size(), values));
-        _acquire_null_data(values, _local_dict_code_col.get());
+        RETURN_IF_ERROR(decode_dict_codes(*_local_dict_code_col, values));
         return Status::OK();
     }
 
@@ -144,9 +142,7 @@ public:
                                          std::vector<int16_t>* code_convert_map);
 
 private:
-    void _init_local_dict_col();
-    void _acquire_null_data(Column* global_dict_column, Column* local_dict_column);
-    const LowCardDictColumn::Container& _get_local_dict_col_container(Column* column);
+    vectorized::ColumnPtr _new_local_dict_col(bool nullable);
 
     ColumnId _cid;
     ColumnIterator* _col_iter;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes https://github.com/StarRocks/StarRocksTest/issues/807

## Problem Summary(Required) ：
After PR #8869, GlobalDictCodeColumnIterator won't support `decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words)`,
we need to decode_dict_codes(const vectorized::Column& codes, vectorized::Column* words) instead it.

In the meantime some of the functions that get the local dictionary codes are no longer needed and we need to remove them.

