### PR TITLE
[Enhancement] set enable.partition.eof default to true

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -228,7 +228,10 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
             if (!queue->blocking_put(msg.get())) {
                 done = true;
             } else if (_eof_count == _partition_count) {
+                msg.release();
                 done = true;
+            } else {
+                msg.release();
             }
             break;
         }

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -146,6 +146,8 @@ private:
     std::string _topic;
     std::unordered_map<std::string, std::string> _custom_properties;
 
+    size_t _eof_count = 0;
+    size_t _partition_count = 0;
     KafkaEventCb _k_event_cb;
     RdKafka::KafkaConsumer* _k_consumer = nullptr;
 };

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -146,8 +146,7 @@ private:
     std::string _topic;
     std::unordered_map<std::string, std::string> _custom_properties;
 
-    size_t _eof_count = 0;
-    size_t _partition_count = 0;
+    size_t _non_eof_partition_count = 0;
     KafkaEventCb _k_event_cb;
     RdKafka::KafkaConsumer* _k_consumer = nullptr;
 };

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -131,7 +131,7 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     }
 
     // create the context
-    StreamLoadContext* ctx = new StreamLoadContext(_exec_env);
+    auto* ctx = new StreamLoadContext(_exec_env);
     ctx->load_type = TLoadType::ROUTINE_LOAD;
     ctx->load_src_type = task.type;
     ctx->job_id = task.job_id;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For transaction producer, producer will append one control msg to the group of msgs, but the control msg will not return to consumer, so we can't to judge whether the consumption has been completed by offset comparison.

So we set `enable.partition.eof=true`, if we find current partition is already reach end, we will direct return instead of wait consume until timeout.

Another advantage of doing this is that for topics with little data, there is no need to wait until the timeout and occupy a lot of consumer threads.

