### PR TITLE
[BugFix] skip create agent server when start cn

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -254,16 +254,16 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
         _lake_location_provider = new lake::StarletLocationProvider();
 #endif
         _lake_tablet_manager = new lake::TabletManager(_lake_location_provider, config::lake_metadata_cache_limit);
+
+        // agent_server is not needed for cn
+        _agent_server = new AgentServer(this);
+        _agent_server->init_or_die();
     }
     _broker_mgr->init();
     _small_file_mgr->init();
 
     RETURN_IF_ERROR(_load_channel_mgr->init(_load_mem_tracker));
     _heartbeat_flags = new HeartbeatFlags();
-
-    _agent_server = new AgentServer(this);
-    _agent_server->init_or_die();
-
     return Status::OK();
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7992

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
*** Check failure stack trace: ***
    @          0x8852fbd  google::LogMessage::Fail()
    @          0x885542f  google::LogMessage::SendToLog()
    @          0x8852b0e  google::LogMessage::Flush()
    @          0x8855a39  google::LogMessageFatal::~LogMessageFatal()
    @          0x5f097b9  starrocks::ThreadPoolBuilder::set_max_threads()
    @          0x6310a3e  starrocks::AgentServer::Impl::init_or_die()
    @          0x6314830  starrocks::AgentServer::init_or_die()
    @          0x5ca2236  starrocks::ExecEnv::_init()
    @          0x5ca0a6b  starrocks::ExecEnv::init()
    @          0x52c6d4b  main
    @     0x7ffff68487fd  __libc_start_main
    @          0x52c58fa  _start
    @              (nil)  (unknown)

```
