### PR TITLE
[BugFix] Fix join precedence error bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1641,8 +1641,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
         } else {
             StarRocksParser.FromContext fromContext = (StarRocksParser.FromContext) context.fromClause();
-            List<Relation> relations = visit(fromContext.relation(), Relation.class);
-            if (!relations.isEmpty()) {
+            if (fromContext.relations() != null) {
+                List<Relation> relations = visit(fromContext.relations().relation(), Relation.class);
                 Iterator<Relation> iterator = relations.iterator();
                 Relation relation = iterator.next();
                 while (iterator.hasNext()) {
@@ -1856,11 +1856,24 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
+    public ParseNode visitRelation(StarRocksParser.RelationContext context) {
+        Relation relation = (Relation) visit(context.relationPrimary());
+        List<JoinRelation> joinRelations = visit(context.joinRelation(), JoinRelation.class);
+
+        Relation leftChildRelation = relation;
+        for (JoinRelation joinRelation : joinRelations) {
+            joinRelation.setLeft(leftChildRelation);
+            leftChildRelation = joinRelation;
+        }
+        return leftChildRelation;
+    }
+
+    @Override
     public ParseNode visitParenthesizedRelation(StarRocksParser.ParenthesizedRelationContext context) {
-        if (context.relation().size() == 1) {
-            return visit(context.relation().get(0));
+        if (context.relations().relation().size() == 1) {
+            return visit(context.relations().relation().get(0));
         } else {
-            List<Relation> relations = visit(context.relation(), Relation.class);
+            List<Relation> relations = visit(context.relations().relation(), Relation.class);
             Iterator<Relation> iterator = relations.iterator();
             Relation relation = iterator.next();
             while (iterator.hasNext()) {
@@ -1871,7 +1884,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitTableName(StarRocksParser.TableNameContext context) {
+    public ParseNode visitTableAtom(StarRocksParser.TableAtomContext context) {
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName tableName = qualifiedNameToTableName(qualifiedName);
         PartitionNames partitionNames = null;
@@ -1893,24 +1906,21 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 }
             }
         }
+
+        if (context.alias != null) {
+            Identifier identifier = (Identifier) visit(context.alias);
+            tableRelation.setAlias(new TableName(null, identifier.getValue()));
+        }
         return tableRelation;
     }
 
     @Override
-    public ParseNode visitAliasedRelation(StarRocksParser.AliasedRelationContext context) {
-        Relation child = (Relation) visit(context.relationPrimary());
-
-        if (context.identifier() == null) {
-            return child;
-        }
-        Identifier identifier = (Identifier) visit(context.identifier());
-        child.setAlias(new TableName(null, identifier.getValue()));
-        return child;
-    }
-
-    @Override
     public ParseNode visitJoinRelation(StarRocksParser.JoinRelationContext context) {
-        Relation left = (Relation) visit(context.left);
+        // Because left recursion is required to parse the leftmost atom table first.
+        // Therefore, the parsed result does not contain the information of the left table,
+        // which is temporarily assigned to Null,
+        // and the information of the left table will be filled in visitRelation
+        Relation left = null;
         Relation right = (Relation) visit(context.rightRelation);
 
         JoinOperator joinType = JoinOperator.INNER_JOIN;
@@ -1976,13 +1986,26 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             colNames.add("column_" + i);
         }
 
-        return new ValuesRelation(rows, colNames);
+        ValuesRelation valuesRelation = new ValuesRelation(rows, colNames);
+
+        if (context.alias != null) {
+            Identifier identifier = (Identifier) visit(context.alias);
+            valuesRelation.setAlias(new TableName(null, identifier.getValue()));
+        }
+        return valuesRelation;
     }
 
     @Override
     public ParseNode visitTableFunction(StarRocksParser.TableFunctionContext context) {
-        return new TableFunctionRelation(getQualifiedName(context.qualifiedName()).toString(),
+        TableFunctionRelation tableFunctionRelation = new TableFunctionRelation(
+                getQualifiedName(context.qualifiedName()).toString(),
                 new FunctionParams(false, visit(context.expression(), Expr.class)));
+
+        if (context.alias != null) {
+            Identifier identifier = (Identifier) visit(context.alias);
+            tableFunctionRelation.setAlias(new TableName(null, identifier.getValue()));
+        }
+        return tableFunctionRelation;
     }
 
     @Override
@@ -2011,7 +2034,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitSubqueryRelation(StarRocksParser.SubqueryRelationContext context) {
-        return visit(context.subquery());
+        SubqueryRelation subqueryRelation = (SubqueryRelation) visit(context.subquery());
+        if (context.alias != null) {
+            Identifier identifier = (Identifier) visit(context.alias);
+            subqueryRelation.setAlias(new TableName(null, identifier.getValue()));
+        }
+        return subqueryRelation;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -721,7 +721,7 @@ querySpecification
     ;
 
 fromClause
-    : (FROM relation (',' LATERAL? relation)*)?                                         #from
+    : (FROM relations)?                                                                 #from
     | FROM DUAL                                                                         #dual
     ;
 
@@ -751,13 +751,31 @@ selectItem
     | ASTERISK_SYMBOL                                                                    #selectAll
     ;
 
+relations
+    : relation (',' LATERAL? relation)*
+    ;
+
 relation
-    : left=relation crossOrInnerJoinType bracketHint?
-            LATERAL? rightRelation=relation joinCriteria?                                #joinRelation
-    | left=relation outerAndSemiJoinType bracketHint?
-            LATERAL? rightRelation=relation joinCriteria                                 #joinRelation
-    | relationPrimary (AS? identifier columnAliases?)?                                   #aliasedRelation
-    | '(' relation (','relation)* ')'                                                    #parenthesizedRelation
+    : relationPrimary joinRelation*
+    | '(' relationPrimary joinRelation* ')'
+    ;
+
+relationPrimary
+    : qualifiedName partitionNames? tabletList? (
+        AS? alias=identifier columnAliases?)? bracketHint?                              #tableAtom
+    | '(' VALUES rowConstructor (',' rowConstructor)* ')'
+        (AS? alias=identifier columnAliases?)?                                          #inlineTable
+    | subquery (AS? alias=identifier columnAliases?)?                                   #subqueryRelation
+    | qualifiedName '(' expression (',' expression)* ')'
+        (AS? alias=identifier columnAliases?)?                                          #tableFunction
+    | '(' relations ')'                                                                 #parenthesizedRelation
+    ;
+
+joinRelation
+    : crossOrInnerJoinType bracketHint?
+            LATERAL? rightRelation=relationPrimary joinCriteria?
+    | outerAndSemiJoinType bracketHint?
+            LATERAL? rightRelation=relationPrimary joinCriteria
     ;
 
 crossOrInnerJoinType
@@ -792,13 +810,6 @@ joinCriteria
 
 columnAliases
     : '(' identifier (',' identifier)* ')'
-    ;
-
-relationPrimary
-    : qualifiedName partitionNames? tabletList? bracketHint?                              #tableName
-    | '(' VALUES rowConstructor (',' rowConstructor)* ')'                                 #inlineTable
-    | subquery                                                                            #subqueryRelation
-    | qualifiedName '(' expression (',' expression)* ')'                                  #tableFunction
     ;
 
 partitionNames

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2477,8 +2477,8 @@ public class JoinTest extends PlanTestBase {
                 "test_all_type1.t1c as right_int from (select * from test_all_type limit 0) " +
                 "test_all_type cross join (select * from test_all_type limit 0) test_all_type1 cross join (select * from test_all_type limit 0) test_all_type6) t;";
         String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:EMPTYSET");
         assertContains(plan, "1:EMPTYSET");
-        assertContains(plan, "2:EMPTYSET");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8939

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 //The precedence of the comma operator is less than that of INNER JOIN, CROSS JOIN, LEFT JOIN, and so on
In consecutive joins without on conditions, a left-deep tree should be generated, and if there is an on predicate in the last join, it should correspond to the join formed by all preceding tables and the join generated by the last table.