### PR TITLE
[Actions] fix download the expired artifact with pr number

### DIFF
--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: review-pr-trigger.yml
+          run_id: ${{ github.event.workflow_run.id }}
           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           path: ${{ github.workspace }}
 


### PR DESCRIPTION
add workflow run_id to get the most recent pr information

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # add workflow id to specify the most recent workflow which uploads the most recent pr information

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) --> the download step will download artifact according pr number, in rare occasion, the download artifact is not the most recent one.
