### PR TITLE
[Feature] Support use catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.starrocks.analysis.KillStmt;
 import com.starrocks.analysis.QueryStmt;
@@ -84,8 +85,11 @@ public class ConnectProcessor {
     private void handleInitDb() {
         String identifier = new String(packetBuf.array(), 1, packetBuf.limit() - 1);
         try {
-            if (isChangeCatalog(identifier)) {
-                ctx.getGlobalStateMgr().changeCatalog(ctx, identifier);
+            String[] parts = identifier.trim().split("\\s+");
+            if (parts.length == 2) {
+                Preconditions.checkState(parts[0].equalsIgnoreCase("catalog"),
+                        "You might want to use \"USE 'CATALOG <catalog_name>'\"");
+                ctx.getGlobalStateMgr().changeCatalog(ctx, parts[1]);
             } else {
                 ctx.getGlobalStateMgr().changeCatalogDb(ctx, identifier);
             }
@@ -636,9 +640,5 @@ public class ConnectProcessor {
                 break;
             }
         }
-    }
-
-    private boolean isChangeCatalog(String identifier) {
-        return identifier.trim().split("\\s+").length == 2;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -31,7 +31,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
@@ -85,8 +84,12 @@ public class ConnectProcessor {
     private void handleInitDb() {
         String identifier = new String(packetBuf.array(), 1, packetBuf.limit() - 1);
         try {
-            ctx.getGlobalStateMgr().changeCatalogDb(ctx, identifier);
-        } catch (DdlException e) {
+            if (isChangeCatalog(identifier)) {
+                ctx.getGlobalStateMgr().changeCatalog(ctx, identifier);
+            } else {
+                ctx.getGlobalStateMgr().changeCatalogDb(ctx, identifier);
+            }
+        } catch (Exception e) {
             ctx.getState().setError(e.getMessage());
             return;
         }
@@ -633,5 +636,9 @@ public class ConnectProcessor {
                 break;
             }
         }
+    }
+
+    private boolean isChangeCatalog(String identifier) {
+        return identifier.trim().split("\\s+").length == 2;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -873,7 +873,7 @@ public class StmtExecutor {
     private void handleUseCatalogStmt() throws AnalysisException {
         UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
         try {
-            context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getIdentifier());
+            context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getCatalogName());
         } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -102,7 +102,8 @@ import com.starrocks.sql.ast.DropHistogramStmt;
 import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
-import com.starrocks.sql.ast.UseStmt;
+import com.starrocks.sql.ast.UseCatalogStmt;
+import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -432,8 +433,10 @@ public class StmtExecutor {
                 }
             } else if (parsedStmt instanceof SetStmt) {
                 handleSetStmt();
-            } else if (parsedStmt instanceof UseStmt) {
-                handleUseStmt();
+            } else if (parsedStmt instanceof UseDbStmt) {
+                handleUseDbStmt();
+            } else if (parsedStmt instanceof UseCatalogStmt) {
+                handleUseCatalogStmt();
             } else if (parsedStmt instanceof CreateTableAsSelectStmt) {
                 if (execPlanBuildByNewPlanner) {
                     handleCreateTableAsSelectStmt(beginTimeInNanoSecond);
@@ -854,12 +857,24 @@ public class StmtExecutor {
         context.getState().setOk();
     }
 
-    // Process use statement.
-    private void handleUseStmt() throws AnalysisException {
-        UseStmt useStmt = (UseStmt) parsedStmt;
+    // Process use [catalog].db statement.
+    private void handleUseDbStmt() throws AnalysisException {
+        UseDbStmt useDbStmt = (UseDbStmt) parsedStmt;
         try {
-            context.getGlobalStateMgr().changeCatalogDb(context, useStmt.getIdentifier());
-        } catch (DdlException e) {
+            context.getGlobalStateMgr().changeCatalogDb(context, useDbStmt.getIdentifier());
+        } catch (Exception e) {
+            context.getState().setError(e.getMessage());
+            return;
+        }
+        context.getState().setOk();
+    }
+
+    // Process use catalog statement
+    private void handleUseCatalogStmt() throws AnalysisException {
+        UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
+        try {
+            context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getIdentifier());
+        } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2795,12 +2795,7 @@ public class GlobalStateMgr {
 
     // Change current catalog of this session.
     // We can support "use 'catalog <catalog_name>'" from mysql client or "use catalog <catalog_name>" from jdbc.
-    public void changeCatalog(ConnectContext ctx, String identifier) throws AnalysisException {
-        String[] parts = identifier.trim().split("\\s+");
-        Preconditions.checkState(parts.length == 2, "Invalid identifier " + identifier);
-        Preconditions.checkState(parts[0].equalsIgnoreCase("catalog"),
-                "You might want to use \"USE 'CATALOG <catalog_name>'\"");
-        String newCatalogName = parts[1];
+    public void changeCatalog(ConnectContext ctx, String newCatalogName) throws AnalysisException {
         if (!catalogMgr.catalogExists(newCatalogName)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR, newCatalogName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2793,6 +2793,20 @@ public class GlobalStateMgr {
         this.alter.getClusterHandler().cancel(stmt);
     }
 
+    // Change current catalog of this session.
+    // We can support "use 'catalog <catalog_name>'" from mysql client or "use catalog <catalog_name>" from jdbc.
+    public void changeCatalog(ConnectContext ctx, String identifier) throws AnalysisException {
+        String[] parts = identifier.trim().split("\\s+");
+        Preconditions.checkState(parts.length == 2, "Invalid identifier " + identifier);
+        Preconditions.checkState(parts[0].equalsIgnoreCase("catalog"),
+                "You might want to use \"USE 'CATALOG <catalog_name>'\"");
+        String newCatalogName = parts[1];
+        if (!catalogMgr.catalogExists(newCatalogName)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR, newCatalogName);
+        }
+        ctx.setCurrentCatalog(newCatalogName);
+    }
+
     // Change current catalog and database of this session.
     // We can support 'USE CATALOG.DB'
     public void changeCatalogDb(ConnectContext ctx, String identifier) throws DdlException {
@@ -2818,7 +2832,7 @@ public class GlobalStateMgr {
 
         // Check auth for internal catalog.
         // Here we check the request permission that sent by the mysql client or jdbc.
-        // So we didn't check UseStmt permission in PrivilegeChecker.
+        // So we didn't check UseDbStmt permission in PrivilegeChecker.
         if (CatalogMgr.isInternalCatalog(ctx.getCurrentCatalog()) &&
                 !auth.checkDbPriv(ctx, dbName, PrivPredicate.SHOW)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_DB_ACCESS_DENIED,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -330,7 +330,11 @@ public abstract class AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
-    public R visitUseStatement(UseStmt statement, C context) {
+    public R visitUseDbStatement(UseDbStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    public R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
         return visitStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -12,8 +12,8 @@ public class UseCatalogStmt extends StatementBase {
         this.catalogName = catalogName;
     }
 
-    public String getIdentifier() {
-        return "catalog " + catalogName;
+    public String getCatalogName() {
+        return catalogName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -1,0 +1,33 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.RedirectStatus;
+import com.starrocks.analysis.StatementBase;
+
+public class UseCatalogStmt extends StatementBase {
+    private final String catalogName;
+
+    public UseCatalogStmt(String catalogName) {
+        this.catalogName = catalogName;
+    }
+
+    public String getIdentifier() {
+        return "catalog " + catalogName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitUseCatalogStatement(this, context);
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.NO_FORWARD;
+    }
+
+    @Override
+    public boolean isSupportNewPlanner() {
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseDbStmt.java
@@ -9,19 +9,19 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Representation of a USE [catalog.]db statement.
- * Queries from MySQL client will not generate UseStmt, it will be handled by the COM_INIT_DB protocol.
- * Queries from JDBC will be handled by COM_QUERY protocol, it will generate UseStmt.
+ * Queries from MySQL client will not generate UseDbStmt, it will be handled by the COM_INIT_DB protocol.
+ * Queries from JDBC will be handled by COM_QUERY protocol, it will generate UseDbStmt.
  */
-public class UseStmt extends StatementBase {
-    private static final Logger LOG = LogManager.getLogger(UseStmt.class);
+public class UseDbStmt extends StatementBase {
+    private static final Logger LOG = LogManager.getLogger(UseDbStmt.class);
     private final String catalog;
     private final String database;
 
-    public UseStmt(String db) {
+    public UseDbStmt(String db) {
         this(null, db);
     }
 
-    public UseStmt(String catalog, String database) {
+    public UseDbStmt(String catalog, String database) {
         this.catalog = catalog;
         this.database = database;
     }
@@ -36,7 +36,7 @@ public class UseStmt extends StatementBase {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitUseStatement(this, context);
+        return visitor.visitUseDbStatement(this, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -223,7 +223,8 @@ import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UnionRelation;
 import com.starrocks.sql.ast.UnitIdentifier;
-import com.starrocks.sql.ast.UseStmt;
+import com.starrocks.sql.ast.UseCatalogStmt;
+import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.ast.UserAuthOption;
 import com.starrocks.sql.ast.UserIdentifier;
 import com.starrocks.sql.ast.ValuesRelation;
@@ -2150,16 +2151,22 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitUse(StarRocksParser.UseContext context) {
+    public ParseNode visitUseDb(StarRocksParser.UseDbContext context) {
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         List<String> parts = qualifiedName.getParts();
         if (parts.size() == 1) {
-            return new UseStmt(null, parts.get(0));
+            return new UseDbStmt(null, parts.get(0));
         } else if (parts.size() == 2) {
-            return new UseStmt(parts.get(0), parts.get(1));
+            return new UseDbStmt(parts.get(0), parts.get(1));
         } else {
             throw new ParsingException("error catalog.database");
         }
+    }
+
+    public ParseNode visitUseCatalog(StarRocksParser.UseCatalogContext context) {
+        Identifier identifier = (Identifier) visit(context.identifierOrString());
+        String catalogName = identifier.getValue();
+        return new UseCatalogStmt(catalogName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -112,7 +112,8 @@ statement
 
 
     // Other statement
-    | USE qualifiedName                                                                     #use
+    | USE qualifiedName                                                                     #useDb
+    | USE CATALOG identifierOrString                                                        #useCatalog
     | showDatabasesStatement                                                                #showDatabases
     | showVariablesStatement                                                                #showVariables
     | showProcesslistStatement                                                              #showProcesslist

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
@@ -1,0 +1,80 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UseCatalogStmtTest {
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db1").useDatabase("tbl1");
+        String createCatalog = "create external catalog hive_catalog properties(" +
+                "\"type\" = \"hive\", \"hive.metastore.uris\" = \"thrift://127.0.0.1:3333\")";
+        starRocksAssert.withCatalog(createCatalog);
+        ctx = new ConnectContext(null);
+        ctx.setGlobalStateMgr(AccessTestUtil.fetchAdminCatalog());
+    }
+
+    @Test
+    public void testParserAndAnalyzer() {
+        String sql = "USE catalog hive_catalog";
+        AnalyzeTestUtil.analyzeSuccess(sql);
+
+        String sql_2 = "USE catalog default_catalog";
+        AnalyzeTestUtil.analyzeSuccess(sql_2);
+
+        String sql_3 = "USE xxxx default_catalog";
+        AnalyzeTestUtil.analyzeFail(sql_3);
+    }
+
+    @Test
+    public void testUse(@Mocked CatalogMgr catalogMgr) throws Exception {
+        new Expectations() {
+            {
+                catalogMgr.catalogExists("hive_catalog");
+                result = true;
+                minTimes = 0;
+
+                catalogMgr.catalogExists("default_catalog");
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        ctx.setQueryId(UUIDUtil.genUUID());
+        StmtExecutor executor = new StmtExecutor(ctx, "use catalog hive_catalog");
+        executor.execute();
+
+        Assert.assertEquals("hive_catalog", ctx.getCurrentCatalog());
+
+        executor = new StmtExecutor(ctx, "use catalog default_catalog");
+        executor.execute();
+
+        Assert.assertEquals("default_catalog", ctx.getCurrentCatalog());
+
+        executor = new StmtExecutor(ctx, "use xxx default_catalog");
+        executor.execute();
+        Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+
+        executor = new StmtExecutor(ctx, "use catalog default_catalog xxx");
+        executor.execute();
+        Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseDbStmtTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class UseStmtTest {
+public class UseDbStmtTest {
     private static StarRocksAssert starRocksAssert;
     private static ConnectContext ctx;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
we want to support "use catalog <catalog_name>".
If you send query "use catalog <catalog_name>" from mysql client, it will be parsed by mysql client to "use catalog" due to COM_INIT_DB protocol.  so you need to execute "**use 'catalog <catalog_name>'**".
The query from jdbc or bi tools will be parsed normally by COM_QUERY protocol.