### PR TITLE
[Enhancement] Use object instead of pointer for HyperLogLog::_hash_set

### DIFF
--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -33,7 +33,7 @@
 #include "runtime/memory/chunk.h"
 #include "runtime/memory/chunk_allocator.h"
 #include "types/constexpr.h"
-#include "util/phmap/phmap_fwd_decl.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 
@@ -135,7 +135,7 @@ private:
     HllDataType _type = HLL_DATA_EMPTY;
 
     using ElementSet = phmap::flat_hash_set<uint64_t>;
-    std::unique_ptr<ElementSet> _hash_set;
+    ElementSet _hash_set;
 
     // This field is much space consumming(HLL_REGISTERS_COUNT), we create
     // it only when it is really needed.

--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -132,9 +132,12 @@ public:
     void clear();
 
 private:
-    HllDataType _type = HLL_DATA_EMPTY;
-
     using ElementSet = phmap::flat_hash_set<uint64_t>;
+
+    HllDataType _type = HLL_DATA_EMPTY;
+    // Use raw object instead of pointer to give a chance to create multiple
+    // _hash_sets of a HLL column in only one memory allocation,
+    // eg. by std::vector<ObjectColumn<HyperLogLog>>::resize/reserve.
     ElementSet _hash_set;
 
     // This field is much space consumming(HLL_REGISTERS_COUNT), we create


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
#6885 uses pointer instead of object for `HyperLogLog::_hash_set` to reduce memory usage of HLL and not include `phmap.h` in `hll.h`.

However, as for reading HLL column from disk, 
- using pointer will allocate memory 4096 times for  HLL hash_set of 4096 rows in a chunk,
- while using object only need allocate 1 times for a chunk by `_pool.reserve`.

```C++
template <typename T>
bool ObjectColumn<T>::append_strings(const Buffer<starrocks::Slice>& strs) {
    _pool.reserve(_pool.size() + strs.size());
    for (const Slice& s : strs) {
        _pool.emplace_back(s);
    }
```

And using object doesn't cost much more than using pointer.
- the empty `flat_hash_set<uint64_t>` is not very large, only with 32 bytes, 
- while using pointer costs 8 bytes.
```C++
    ctrl_t* ctrl_ = EmptyGroup(); // [(capacity + 1) * ctrl_t]
    slot_type* slots_ = nullptr;  // [capacity * slot_type]
    size_t size_ = 0;             // number of full slots
    size_t capacity_ = 0;         // total number of slots
```

Therefore, this PR uses object instead of pointer again.

## Test
### Environment
- 3 BE (each 16 vCPUs and 64GB RAM)
- ssb_100g
- Query is as follows, where `v2` is  a `HLL` column, table contains 6e8 rows.
```sql
select hll_union_agg(v2) / 2 as a from lineorder_flat_bitmap_hll
```

### Result
- 2.1: 1.5s
- main-Before PR: 3s
- main-After PR: 1.5s

