### PR TITLE
[BugFix] Vectical rowset writer final flush need writer finalize footer for partial columns.

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -127,6 +127,8 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
         // if load only has delete, we can skip the partial update logic
         if (_context.partial_update_tablet_schema && _flush_chunk_state != FlushChunkState::DELETE) {
             DCHECK(_context.referenced_column_ids.size() == _context.partial_update_tablet_schema->columns().size());
+            RETURN_IF(_num_segment != _rowset_txn_meta_pb->partial_rowset_footers().size(),
+                      Status::InternalError("segment number not equal to partial_rowset_footers size"));
             for (auto i = 0; i < _context.partial_update_tablet_schema->columns().size(); ++i) {
                 const auto& tablet_column = _context.partial_update_tablet_schema->column(i);
                 _rowset_txn_meta_pb->add_partial_update_column_ids(_context.referenced_column_ids[i]);

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -242,7 +242,10 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
     return Status::OK();
 }
 
-Status SegmentWriter::finalize_footer(uint64_t* segment_file_size) {
+Status SegmentWriter::finalize_footer(uint64_t* segment_file_size, uint64_t* footer_position) {
+    if (footer_position != nullptr) {
+        *footer_position = _wfile->size();
+    }
     RETURN_IF_ERROR(_write_footer());
     *segment_file_size = _wfile->size();
     return _wfile->close();

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -109,7 +109,7 @@ public:
     // finalize columns data and index
     Status finalize_columns(uint64_t* index_size);
     // finalize footer
-    Status finalize_footer(uint64_t* segment_file_size);
+    Status finalize_footer(uint64_t* segment_file_size, uint64_t* footer_position = nullptr);
 
     uint32_t segment_id() const { return _segment_id; }
 

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -549,7 +549,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
     const uint32_t rows_per_segment = 1024;
     config::vertical_compaction_max_columns_per_group = 1;
     RowsetWriterContext writer_context(kDataFormatV2, kDataFormatV2);
-    std::vector<int32_t> column_indexes = {0, 1, 2};
+    std::vector<int32_t> column_indexes = {0, 1, 2, 3};
     std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
     create_partial_rowset_writer_context(column_indexes, partial_schema, &writer_context);
     writer_context.segments_overlap = OVERLAP_UNKNOWN;

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -34,6 +34,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/data_dir.h"
+#include "storage/empty_iterator.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/rowset_writer.h"
@@ -41,7 +42,9 @@
 #include "storage/rowset/segment_options.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
+#include "storage/tablet_reader.h"
 #include "storage/tablet_schema.h"
+#include "storage/union_iterator.h"
 #include "storage/vectorized_column_predicate.h"
 #include "testutil/assert.h"
 #include "util/defer_op.h"
@@ -217,13 +220,14 @@ protected:
         v2.column_name = "v2";
         v2.__set_is_key(false);
         v2.column_type.type = TPrimitiveType::INT;
-        v1.aggregation_type = TAggregationType::REPLACE;
+        v2.aggregation_type = TAggregationType::REPLACE;
         request.tablet_schema.columns.push_back(v2);
 
         TColumn v3;
         v3.column_name = "v3";
         v3.__set_is_key(false);
         v3.column_type.type = TPrimitiveType::INT;
+        v3.aggregation_type = TAggregationType::REPLACE;
         request.tablet_schema.columns.push_back(v3);
 
         auto st = StorageEngine::instance()->create_tablet(request);
@@ -245,6 +249,24 @@ protected:
         rowset_writer_context->version.second = 0;
     }
 
+    void create_partial_rowset_writer_context(const std::vector<int32_t>& column_indexes,
+                                              std::shared_ptr<TabletSchema> partial_schema,
+                                              RowsetWriterContext* rowset_writer_context) {
+        RowsetId rowset_id;
+        rowset_id.init(10000);
+        rowset_writer_context->rowset_id = rowset_id;
+        rowset_writer_context->tablet_id = 12345;
+        rowset_writer_context->tablet_schema_hash = 1111;
+        rowset_writer_context->partition_id = 10;
+        rowset_writer_context->rowset_path_prefix = config::storage_root_path + "/data/rowset_test";
+        rowset_writer_context->rowset_state = VISIBLE;
+        rowset_writer_context->partial_update_tablet_schema = partial_schema;
+        rowset_writer_context->tablet_schema = partial_schema.get();
+        rowset_writer_context->referenced_column_ids = column_indexes;
+        rowset_writer_context->version.first = 0;
+        rowset_writer_context->version.second = 0;
+    }
+
 private:
     std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _schema_change_mem_tracker = nullptr;
@@ -256,97 +278,94 @@ TEST_F(RowsetTest, FinalMergeTest) {
     create_primary_tablet_schema(&tablet_schema);
     RowsetSharedPtr rowset;
     const uint32_t rows_per_segment = 1024;
+
+    RowsetWriterContext writer_context(kDataFormatV2, kDataFormatV2);
+    create_rowset_writer_context(&tablet_schema, &writer_context);
+    writer_context.segments_overlap = OVERLAP_UNKNOWN;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+
+    auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+
     {
-        RowsetWriterContext writer_context(kDataFormatV2, kDataFormatV2);
-        create_rowset_writer_context(&tablet_schema, &writer_context);
-        writer_context.segments_overlap = OVERLAP_UNKNOWN;
-
-        std::unique_ptr<RowsetWriter> rowset_writer;
-        ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
-
-        auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema);
-
-        {
-            auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
-            auto& cols = chunk->columns();
-            for (auto i = 0; i < rows_per_segment; i++) {
-                cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
-            }
-            ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
-            ASSERT_OK(rowset_writer->flush());
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = 0; i < rows_per_segment; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
         }
-
-        {
-            auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
-            auto& cols = chunk->columns();
-            for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
-                cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
-            }
-            ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
-            ASSERT_OK(rowset_writer->flush());
-        }
-
-        {
-            auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
-            auto& cols = chunk->columns();
-            for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
-                cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
-                cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
-            }
-            ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
-            ASSERT_OK(rowset_writer->flush());
-        }
-
-        rowset = rowset_writer->build().value();
-        ASSERT_TRUE(rowset != nullptr);
-        ASSERT_EQ(1, rowset->rowset_meta()->num_segments());
-        ASSERT_EQ(rows_per_segment * 2, rowset->rowset_meta()->num_rows());
-
-        vectorized::SegmentReadOptions seg_options;
-        ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
-        seg_options.stats = &_stats;
-
-        std::string segment_file =
-                Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
-
-        auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet_schema);
-        ASSERT_NE(segment->num_rows(), 0);
-        auto res = segment->new_iterator(schema, seg_options);
-        ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
-        auto seg_iterator = res.value();
-
-        seg_iterator->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
-
-        auto chunk = ChunkHelper::new_chunk(seg_iterator->schema(), 100);
-
-        size_t count = 0;
-
-        while (true) {
-            auto st = seg_iterator->get_next(chunk.get());
-            if (st.is_end_of_file()) {
-                break;
-            }
-            ASSERT_FALSE(!st.ok());
-            for (auto i = 0; i < chunk->num_rows(); i++) {
-                auto index = count + i;
-                if (0 <= index && index < rows_per_segment / 2) {
-                    EXPECT_EQ(1, chunk->get(i)[2].get_int32());
-                } else if (rows_per_segment / 2 <= index && index < rows_per_segment) {
-                    EXPECT_EQ(2, chunk->get(i)[2].get_int32());
-                } else if (rows_per_segment <= index && index < rows_per_segment * 2) {
-                    EXPECT_EQ(3, chunk->get(i)[2].get_int32());
-                }
-            }
-            count += chunk->num_rows();
-            chunk->reset();
-        }
-        EXPECT_EQ(count, rows_per_segment * 2);
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
     }
+
+    {
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    {
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    rowset = rowset_writer->build().value();
+    ASSERT_TRUE(rowset != nullptr);
+    ASSERT_EQ(1, rowset->rowset_meta()->num_segments());
+    ASSERT_EQ(rows_per_segment * 2, rowset->rowset_meta()->num_rows());
+
+    vectorized::SegmentReadOptions seg_options;
+    ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
+    seg_options.stats = &_stats;
+
+    std::string segment_file =
+            Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
+
+    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet_schema);
+    ASSERT_NE(segment->num_rows(), 0);
+    auto res = segment->new_iterator(schema, seg_options);
+    ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
+    auto seg_iterator = res.value();
+
+    seg_iterator->init_encoded_schema(vectorized::EMPTY_GLOBAL_DICTMAPS);
+
+    auto chunk = ChunkHelper::new_chunk(seg_iterator->schema(), 100);
+    size_t count = 0;
+    while (true) {
+        auto st = seg_iterator->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_FALSE(!st.ok());
+        for (auto i = 0; i < chunk->num_rows(); i++) {
+            auto index = count + i;
+            if (0 <= index && index < rows_per_segment / 2) {
+                EXPECT_EQ(1, chunk->get(i)[2].get_int32());
+            } else if (rows_per_segment / 2 <= index && index < rows_per_segment) {
+                EXPECT_EQ(2, chunk->get(i)[2].get_int32());
+            } else if (rows_per_segment <= index && index < rows_per_segment * 2) {
+                EXPECT_EQ(3, chunk->get(i)[2].get_int32());
+            }
+        }
+        count += chunk->num_rows();
+        chunk->reset();
+    }
+    EXPECT_EQ(count, rows_per_segment * 2);
 }
 
 TEST_F(RowsetTest, FinalMergeVerticalTest) {
@@ -438,16 +457,155 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
             auto index = count + i;
             if (0 <= index && index < rows_per_segment / 2) {
                 EXPECT_EQ(1, chunk->get(i)[2].get_int32());
+                EXPECT_EQ(1, chunk->get(i)[3].get_int32());
+                EXPECT_EQ(1, chunk->get(i)[4].get_int32());
             } else if (rows_per_segment / 2 <= index && index < rows_per_segment) {
                 EXPECT_EQ(2, chunk->get(i)[2].get_int32());
+                EXPECT_EQ(2, chunk->get(i)[3].get_int32());
+                EXPECT_EQ(2, chunk->get(i)[4].get_int32());
             } else if (rows_per_segment <= index && index < rows_per_segment * 2) {
                 EXPECT_EQ(3, chunk->get(i)[2].get_int32());
+                EXPECT_EQ(3, chunk->get(i)[3].get_int32());
+                EXPECT_EQ(3, chunk->get(i)[4].get_int32());
             }
         }
         count += chunk->num_rows();
         chunk->reset();
     }
     EXPECT_EQ(count, rows_per_segment * 2);
+}
+
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
+        return nullptr;
+    }
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
+        return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
+    }
+    return vectorized::new_union_iterator(seg_iters);
+}
+
+static ssize_t read_and_compare(const vectorized::ChunkIteratorPtr& iter, int64_t nkeys) {
+    auto full_chunk = ChunkHelper::new_chunk(iter->schema(), nkeys);
+    auto& cols = full_chunk->columns();
+    for (size_t i = 0; i < nkeys / 4; i++) {
+        cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+        cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+    }
+    for (size_t i = nkeys / 4; i < nkeys / 2; i++) {
+        cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+        cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+    }
+    for (size_t i = nkeys / 2; i < nkeys; i++) {
+        cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+        cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+        cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+    }
+    size_t count = 0;
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            for (auto i = 0; i < chunk->num_rows(); i++) {
+                EXPECT_EQ(full_chunk->get(count + i).compare(iter->schema(), chunk->get(i)), 0);
+            }
+            count += chunk->num_rows();
+            chunk->reset();
+        } else {
+            return -1;
+        }
+    }
+    return count;
+}
+
+static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, std::shared_ptr<TabletSchema> partial_schema,
+                                       int64_t version, int64_t nkeys) {
+    vectorized::Schema schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema.get());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    if (iter == nullptr) {
+        return -1;
+    }
+    return read_and_compare(iter, nkeys);
+}
+
+TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
+    auto tablet = create_tablet(12345, 1111);
+    const uint32_t rows_per_segment = 1024;
+    config::vertical_compaction_max_columns_per_group = 1;
+    RowsetWriterContext writer_context(kDataFormatV2, kDataFormatV2);
+    std::vector<int32_t> column_indexes = {0, 1, 2};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    create_partial_rowset_writer_context(column_indexes, partial_schema, &writer_context);
+    writer_context.segments_overlap = OVERLAP_UNKNOWN;
+    writer_context.rowset_path_prefix = tablet->schema_hash_path();
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+
+    auto schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema.get());
+
+    {
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = 0; i < rows_per_segment; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(1)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    {
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(2)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    {
+        auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
+        auto& cols = chunk->columns();
+        for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+            cols[3]->append_datum(vectorized::Datum(static_cast<int32_t>(3)));
+        }
+        ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
+        ASSERT_OK(rowset_writer->flush());
+    }
+
+    auto rowset = rowset_writer->build().value();
+    ASSERT_TRUE(rowset != nullptr);
+    ASSERT_EQ(1, rowset->rowset_meta()->num_segments());
+    ASSERT_EQ(rows_per_segment * 2, rowset->rowset_meta()->num_rows());
+
+    ASSERT_TRUE(tablet->rowset_commit(2, rowset).ok());
+    EXPECT_EQ(rows_per_segment * 2, read_tablet_and_compare(tablet, partial_schema, 2, rows_per_segment * 2));
 }
 
 TEST_F(RowsetTest, VerticalWriteTest) {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -45,6 +45,7 @@
 #include "storage/tablet_reader.h"
 #include "storage/tablet_schema.h"
 #include "storage/union_iterator.h"
+#include "storage/update_manager.h"
 #include "storage/vectorized_column_predicate.h"
 #include "testutil/assert.h"
 #include "util/defer_op.h"
@@ -606,6 +607,8 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 
     ASSERT_TRUE(tablet->rowset_commit(2, rowset).ok());
     EXPECT_EQ(rows_per_segment * 2, read_tablet_and_compare(tablet, partial_schema, 2, rows_per_segment * 2));
+    ASSERT_OK(starrocks::ExecEnv::GetInstance()->storage_engine()->update_manager()->on_rowset_finished(tablet.get(),
+                                                                                                        rowset.get()));
 }
 
 TEST_F(RowsetTest, VerticalWriteTest) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8968

## Problem Summary(Required) ：
Once the following conditions are met, a data load will cause the final merge in the rowset writer.
1. partial update
2. large data load in one batch to cause final merge
3. the number of partial columns large than config::vertical_compaction_max_columns_per_group [default = 5]

final merge will do vertical write under some circumstances, will clear partial_rowset_footers array at first, need to create new partial_rowset_footers for newly merged segments, old code of horizontal rowset writer did this, but the newly added VerticalRowsetWriter didn't, which will cause the partial_rowset_footers is empty. null pointer error will occur in rowset load like this:
```
#0  0x0000000001f8f7a0 in starrocks::BetaRowset::do_load() ()
#1  0x0000000001f8790c in starrocks::Rowset::load() ()
#2  0x0000000001f8e1d6 in starrocks::BetaRowset::get_segment_iterators2(starrocks::vectorized::Schema const&, starrocks::KVStore*, long, starrocks::OlapReaderStatistics*) ()
#3  0x0000000001c40c68 in starrocks::RowsetUpdateState::_do_load(starrocks::Tablet*, starrocks::Rowset*) ()
#4  0x0000000001c41775 in void std::call_once<starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{lambda()#1}>(std::once_flag&, starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{lambda()#1}&&)::{lambda()#2}::_FUN() ()
#5  0x00007fd681f9f1cb in __pthread_once_slow () from /lib64/libpthread.so.0
#6  0x0000000001c3d9b3 in starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*) ()
#7  0x0000000001ad7203 in starrocks::UpdateManager::on_rowset_finished(starrocks::Tablet*, starrocks::Rowset*) ()
#8  0x00000000032ff75b in starrocks::vectorized::DeltaWriter::commit() ()
#9  0x00000000032f03c1 in starrocks::vectorized::AsyncDeltaWriter::_execute(void*, bthread::TaskIterator<starrocks::vectorized::AsyncDeltaWriter::Task>&) ()
#10 0x00000000040581ec in bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*) ()
#11 0x0000000004058fb8 in bthread::ExecutionQueueBase::_execute_tasks(void*) ()
#12 0x00000000021257e9 in starrocks::ThreadPool::dispatch_thread() ()
#13 0x000000000212139a in starrocks::Thread::supervise_thread(void*) ()
#14 0x00007fd681fa0e65 in start_thread () from /lib64/libpthread.so.0
#15 0x00007fd6815bb88d in __libc_ifunc_impl_list () from /lib64/libc.so.6
#16 0x0000000000000000 in ?? ()
```

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000000001f8f7a0 in google::protobuf::internal::RepeatedPtrFieldBase::Get<google::protobuf::RepeatedPtrField<starrocks::FooterPointerPB>::TypeHandler> (index=0, this=<optimized out>) at /root/starrocks/be/../gensrc/build/gen_cpp/olap_file.pb.h:4467
4467	/root/starrocks/be/../gensrc/build/gen_cpp/olap_file.pb.h: No such file or directory.
[Current thread is 1 (LWP 51456)]
(gdb) bt
#0  0x0000000001f8f7a0 in google::protobuf::internal::RepeatedPtrFieldBase::Get<google::protobuf::RepeatedPtrField<starrocks::FooterPointerPB>::TypeHandler> (index=0, this=<optimized out>) at /root/starrocks/be/../gensrc/build/gen_cpp/olap_file.pb.h:4467
#1  google::protobuf::RepeatedPtrField<starrocks::FooterPointerPB>::Get (index=0, this=<optimized out>) at /var/local/thirdparty/installed/include/google/protobuf/repeated_field.h:2173
#2  starrocks::RowsetTxnMetaPB::_internal_partial_rowset_footers (index=0, this=<optimized out>) at /root/starrocks/be/../gensrc/build/gen_cpp/olap_file.pb.h:4463
#3  starrocks::RowsetTxnMetaPB::partial_rowset_footers (index=0, this=<optimized out>) at /root/starrocks/be/../gensrc/build/gen_cpp/olap_file.pb.h:4467
#4  starrocks::RowsetMeta::partial_rowset_footer (segment_id=0, this=0x11ccc910) at /root/starrocks/be/src/storage/rowset/rowset_meta.h:174
#5  starrocks::BetaRowset::do_load (this=0xfd993f0) at /root/starrocks/be/src/storage/rowset/beta_rowset.cpp:81
#6  0x0000000001f8790c in starrocks::Rowset::load (this=this@entry=0xfd993f0) at /root/starrocks/be/src/storage/rowset/rowset.cpp:50
#7  0x0000000001f8e1d6 in starrocks::BetaRowset::get_segment_iterators2 (this=this@entry=0xfd993f0, schema=..., meta=meta@entry=0x0, version=version@entry=0, stats=stats@entry=0x7fd6619bc070) at /root/starrocks/be/src/storage/rowset/beta_rowset.cpp:358
#8  0x0000000001c40c68 in starrocks::RowsetUpdateState::_do_load (this=0x10576d50, tablet=0xf130380, rowset=0xfd993f0) at /root/starrocks/be/src/storage/rowset_update_state.cpp:81
#9  0x0000000001c41775 in operator() (__closure=0x7fd6619bc2b0) at /root/starrocks/be/src/storage/rowset_update_state.cpp:38
#10 std::__invoke_impl<void, starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::<lambda()> > (__f=...) at /usr/include/c++/10.3.0/bits/invoke.h:60
#11 std::__invoke<starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::<lambda()> > (__fn=...) at /usr/include/c++/10.3.0/bits/invoke.h:95
#12 operator() (this=<optimized out>) at /usr/include/c++/10.3.0/mutex:717
#13 operator() (this=0x0) at /usr/include/c++/10.3.0/mutex:722
#14 _FUN () at /usr/include/c++/10.3.0/mutex:722
#15 0x00007fd681f9f1cb in __pthread_once_slow () from /lib64/libpthread.so.0
#16 0x0000000001c3d9b3 in __gthread_once (__func=<optimized out>, __once=0x10576d50) at /usr/include/c++/10.3.0/x86_64-pc-linux-gnu/bits/gthr-default.h:700
#17 std::call_once<starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::<lambda()> > (__f=..., __once=...) at /usr/include/c++/10.3.0/mutex:729
#18 starrocks::RowsetUpdateState::load (this=this@entry=0x10576d50, tablet=tablet@entry=0xf130380, rowset=rowset@entry=0xfd993f0) at /root/starrocks/be/src/storage/rowset_update_state.cpp:36
#19 0x0000000001ad7203 in starrocks::UpdateManager::on_rowset_finished (this=0x94a3a40, tablet=0xf130380, rowset=0xfd993f0) at /root/starrocks/be/src/storage/update_manager.cpp:260
#20 0x00000000032ff75b in starrocks::vectorized::DeltaWriter::commit (this=this@entry=0xfc5f790) at /root/starrocks/be/src/storage/storage_engine.h:164
#21 0x00000000032f03c1 in starrocks::vectorized::AsyncDeltaWriter::_execute (meta=0xfc5f790, iter=...) at /root/starrocks/be/src/storage/async_delta_writer.cpp:38
#22 0x00000000040581ec in bthread::ExecutionQueueBase::_execute (this=0xabbe600, head=<optimized out>, high_priority=<optimized out>, niterated=0x0) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/bthread/execution_queue.cpp:272
#23 0x0000000004058fb8 in bthread::ExecutionQueueBase::_execute_tasks (arg=<optimized out>) at /var/local/thirdparty/src/incubator-brpc-0.9.7/src/bthread/execution_queue.cpp:151
#24 0x00000000021257e9 in std::function<void ()>::operator()() const (this=<optimized out>) at /usr/include/c++/10.3.0/bits/std_function.h:248
#25 starrocks::FunctionRunnable::run (this=<optimized out>) at /root/starrocks/be/src/util/threadpool.cpp:44
#26 starrocks::ThreadPool::dispatch_thread (this=0xac36540) at /root/starrocks/be/src/util/threadpool.cpp:513
#27 0x000000000212139a in std::function<void ()>::operator()() const (this=0x9e02c58) at /usr/include/c++/10.3.0/bits/std_function.h:248
#28 starrocks::Thread::supervise_thread (arg=0x9e02c40) at /root/starrocks/be/src/util/thread.cpp:326
#29 0x00007fd681fa0e65 in start_thread () from /lib64/libpthread.so.0
#30 0x00007fd6815bb88d in __libc_ifunc_impl_list () from /lib64/libc.so.6
#31 0x0000000000000000 in ?? ()
```

this PR fixes it by writing partial_rowset_footers properly, and adding some consistency checks and unit tests for this case.