### PR TITLE
[BugFix] FE connect Kafka directly to avoid BRPC call blocking

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -600,6 +600,12 @@ under the License.
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>7.0.1-ccs</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -769,29 +775,29 @@ under the License.
                         <phase>generate-sources</phase>
                         <configuration>
                             <tasks>
-                                <mkdir dir="${basedir}/target/generated-sources/proto"/>
+                                <mkdir dir="${basedir}/target/generated-sources/proto" />
                                 <exec executable="${java.home}/bin/java">
-                                    <arg value="-jar"/>
-                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
-                                    <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
-                                    <arg value="${starrocks.home}/gensrc/proto/internal_service.proto"/>
+                                    <arg value="-jar" />
+                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar" />
+                                    <arg value="--java_out=${basedir}/target/generated-sources/proto" />
+                                    <arg value="${starrocks.home}/gensrc/proto/internal_service.proto" />
                                 </exec>
                                 <exec executable="${java.home}/bin/java">
-                                    <arg value="-jar"/>
-                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
-                                    <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
-                                    <arg value="${starrocks.home}/gensrc/proto/lake_service.proto"/>
+                                    <arg value="-jar" />
+                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar" />
+                                    <arg value="--java_out=${basedir}/target/generated-sources/proto" />
+                                    <arg value="${starrocks.home}/gensrc/proto/lake_service.proto" />
                                 </exec>
                                 <exec executable="python">
-                                    <arg value="${starrocks.home}/build-support/gen_build_version.py"/>
-                                    <arg value="--cpp"/>
-                                    <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
-                                    <arg value="--java"/>
-                                    <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
+                                    <arg value="${starrocks.home}/build-support/gen_build_version.py" />
+                                    <arg value="--cpp" />
+                                    <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build" />
+                                    <arg value="--java" />
+                                    <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build" />
                                 </exec>
-                                <mkdir dir="${starrocks.home}gensrc/build/python/vectorized"/>
+                                <mkdir dir="${starrocks.home}gensrc/build/python/vectorized" />
                                 <exec executable="python" dir="${starrocks.home}gensrc/build/python/vectorized">
-                                    <arg value="${starrocks.home}/gensrc/script/vectorized/gen_vectorized_functions.py"/>
+                                    <arg value="${starrocks.home}/gensrc/script/vectorized/gen_vectorized_functions.py" />
                                 </exec>
                             </tasks>
                         </configuration>

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -76,7 +76,8 @@ public class KafkaUtil {
                 partitions = consumer.partitionsFor(topic,
                         Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
             } catch (Exception e) {
-                String msg = String.format("failed to get partitions from Kafka, broker_list: %s, topic: %s, err: %s", brokerList , topic, e.getMessage());
+                String msg = String.format("failed to get partitions from Kafka, broker_list: %s, topic: %s, err: %s",
+                        brokerList, topic, e.getMessage());
                 LOG.warn(msg);
                 throw new UserException(msg);
             } finally {
@@ -111,7 +112,8 @@ public class KafkaUtil {
                 partitionEndOffsets = consumer.endOffsets(topicPartitions,
                         Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
             } catch (Exception e) {
-                String msg = String.format("failed to get end offsets from Kafka, broker_list: %s, topic: %s, err: %s", brokerList , topic, e.getMessage());
+                String msg = String.format("failed to get end offsets from Kafka, broker_list: %s, topic: %s, err: %s",
+                        brokerList, topic, e.getMessage());
                 LOG.warn(msg);
                 throw new UserException(msg);
             } finally {
@@ -147,7 +149,8 @@ public class KafkaUtil {
                 partitionBeginningOffsets = consumer.beginningOffsets(topicPartitions,
                         Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
             } catch (Exception e) {
-                String msg = String.format("failed to get beginning offsets from Kafka, broker_list: %s, topic: %s, err: %s", brokerList , topic, e.getMessage());
+                String msg = String.format("failed to get beginning offsets from Kafka, broker_list: %s, topic: %s, err: %s",
+                        brokerList, topic, e.getMessage());
                 LOG.warn(msg);
                 throw new UserException(msg);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -78,6 +78,8 @@ public class KafkaUtil {
                 partitionIDs.add(partition.partition());
             }
 
+            consumer.close();
+
             return partitionIDs;
         }
 
@@ -102,6 +104,8 @@ public class KafkaUtil {
             for (Map.Entry<TopicPartition, Long> entry : partitionNndOffsets.entrySet()) {
                 endOffsets.put(entry.getKey().partition(), entry.getValue());
             }
+
+            consumer.close();
             return endOffsets;
         }
 
@@ -126,6 +130,8 @@ public class KafkaUtil {
             for (Map.Entry<TopicPartition, Long> entry : partitionNndOffsets.entrySet()) {
                 beginningOffsets.put(entry.getKey().partition(), entry.getValue());
             }
+
+            consumer.close();
             return beginningOffsets;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -44,6 +44,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;  
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -108,8 +109,11 @@ public class KafkaUtil {
         public Map<Integer, Long> getLatestOffsets(String brokerList, String topic,
                                                    ImmutableMap<String, String> properties,
                                                    List<Integer> partitions) throws UserException {
+
             final Properties props = new Properties();
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());  
+            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());  
 
             final Consumer<String, String> consumer = new KafkaConsumer<>(props);
 
@@ -119,7 +123,7 @@ public class KafkaUtil {
             }
             final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(topicPartitions);
 
-            Map<Integer, Long> latestOffset = new HashMap<>();
+            final Map<Integer, Long> latestOffset = new HashMap<>();
             for (Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
                 latestOffset.put(entry.getKey().partition(), entry.getValue());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -22,19 +22,6 @@
 package com.starrocks.common.util;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
-import com.starrocks.proto.PKafkaLoadInfo;
-import com.starrocks.proto.PKafkaMetaProxyRequest;
-import com.starrocks.proto.PKafkaOffsetBatchProxyRequest;
-import com.starrocks.proto.PKafkaOffsetProxyRequest;
-import com.starrocks.proto.PKafkaOffsetProxyResult;
-import com.starrocks.proto.PProxyRequest;
-import com.starrocks.proto.PProxyResult;
-import com.starrocks.proto.PStringPair;
-import com.starrocks.rpc.BackendServiceClient;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
-import com.starrocks.thrift.TNetworkAddress;
-import com.starrocks.thrift.TStatusCode;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -46,13 +33,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 
 public class KafkaUtil {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -71,9 +71,10 @@ public class KafkaUtil {
             final Consumer<String, String> consumer = new KafkaConsumer<>(props);
 
             List<Integer> partitionIDs = new ArrayList<>();
-            final List<PartitionInfo> partitions = consumer.partitionsFor(topic, Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
+            final List<PartitionInfo> partitions = consumer.partitionsFor(topic, 
+                    Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
 
-            for(PartitionInfo partition : partitions) {
+            for (PartitionInfo partition : partitions) {
                 partitionIDs.add(partition.partition());
             }
 
@@ -94,7 +95,8 @@ public class KafkaUtil {
             for (Integer partitionID : partitions) {
                 topicPartitions.add(new TopicPartition(topic, partitionID));
             }
-            final Map<TopicPartition, Long> partitionNndOffsets = consumer.endOffsets(topicPartitions, Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
+            final Map<TopicPartition, Long> partitionNndOffsets = consumer.endOffsets(topicPartitions, 
+                    Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
 
             final Map<Integer, Long> endOffsets = new HashMap<>();
             for (Map.Entry<TopicPartition, Long> entry : partitionNndOffsets.entrySet()) {
@@ -117,7 +119,8 @@ public class KafkaUtil {
             for (Integer partitionID : partitions) {
                 topicPartitions.add(new TopicPartition(topic, partitionID));
             }
-            final Map<TopicPartition, Long> partitionNndOffsets = consumer.beginningOffsets(topicPartitions, Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
+            final Map<TopicPartition, Long> partitionNndOffsets = consumer.beginningOffsets(topicPartitions, 
+                    Duration.ofSeconds(Config.routine_load_kafka_timeout_second));
 
             final Map<Integer, Long> beginningOffsets = new HashMap<>();
             for (Map.Entry<TopicPartition, Long> entry : partitionNndOffsets.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -155,12 +155,12 @@ public class KafkaProgress extends RoutineLoadProgress {
 
         if (beginningPartitions.size() > 0) {
             Map<Integer, Long> partOffsets = KafkaUtil
-                    .getBeginningOffsets(brokerList, topic, ImmutableMap.copyOf(properties), beginningPartitions);
+                    .getBeginningOffsets(brokerList, topic, beginningPartitions);
             partitionIdToOffset.putAll(partOffsets);
         }
         if (endPartitions.size() > 0) {
             Map<Integer, Long> partOffsets =
-                    KafkaUtil.getLatestOffsets(brokerList, topic, ImmutableMap.copyOf(properties), endPartitions);
+                    KafkaUtil.getEndOffsets(brokerList, topic, endPartitions);
             partitionIdToOffset.putAll(partOffsets);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -359,7 +359,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     private List<Integer> getAllKafkaPartitions() throws UserException {
         convertCustomProperties(false);
-        return KafkaUtil.getAllKafkaPartitions(brokerList, topic, ImmutableMap.copyOf(convertedCustomProperties));
+        return KafkaUtil.getAllKafkaPartitions(brokerList, topic));
     }
 
     public static KafkaRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws UserException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -23,7 +23,6 @@ package com.starrocks.load.routineload;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -359,7 +358,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     private List<Integer> getAllKafkaPartitions() throws UserException {
         convertCustomProperties(false);
-        return KafkaUtil.getAllKafkaPartitions(brokerList, topic));
+        return KafkaUtil.getAllKafkaPartitions(brokerList, topic);
     }
 
     public static KafkaRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws UserException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -22,7 +22,6 @@
 package com.starrocks.load.routineload;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
@@ -83,9 +82,8 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         }
 
         KafkaRoutineLoadJob kafkaRoutineLoadJob = (KafkaRoutineLoadJob) routineLoadJob;
-        Map<Integer, Long> latestOffsets = KafkaUtil.getLatestOffsets(kafkaRoutineLoadJob.getBrokerList(),
+        Map<Integer, Long> latestOffsets = KafkaUtil.getEndOffsets(kafkaRoutineLoadJob.getBrokerList(),
                 kafkaRoutineLoadJob.getTopic(),
-                ImmutableMap.copyOf(kafkaRoutineLoadJob.getConvertedCustomProperties()),
                 new ArrayList<>(partitionIdToOffset.keySet()));
         for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
             int partitionId = entry.getKey();

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -117,6 +117,11 @@ under the License.
                     <id>oracleReleases</id>
                     <url>https://download.oracle.com/maven</url>
                 </repository>
+                <!-- for Kafka java client -->
+                <repository>
+                    <id>confluent</id>
+                    <url>https://packages.confluent.io/maven/</url>
+                </repository>
             </repositories>
 
             <pluginRepositories>


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/8947

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The FE gets Kafka partition offset by calling RPC of BE, then BE would forward the request to FE.  `starrocks::KafkaDataConsumer::get_partition_offset` on BE queries the partition offset from kafka.
The previous implementation would blocks many bthreads in `starrocks::KafkaDataConsumer::get_partition_offset` when all brokers of kafka are down, which is lead by the pthread lock in librdkafka. The blocked bthread cannot be scheduled, and the other operation like query would be influenced.
The new implementation let FE connect Kafka directly. It fixed the bthread blocked problem, and also eliminate the overhead brought by the request forwarding. 