### PR TITLE
[Actions] fix pr and run_id cannot use together

### DIFF
--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -22,12 +22,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
 
+      - run: sleep 15 # wait the pr review upload artifact finished
+
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: review-pr-trigger.yml
           run_id: ${{ github.event.workflow_run.id }}
           path: ${{ github.workspace }}
-#           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+#           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }} # pr number, commit, run_id, branch cannot use together
 
       - name: Read Properties
         id: read_property

--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: review-pr-trigger.yml
-          run_id: ${{ github.event.workflow_run.id }}
           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           path: ${{ github.workspace }}
 

--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -25,8 +25,9 @@ jobs:
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: review-pr-trigger.yml
-          pr: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+          run_id: ${{ github.event.workflow_run.id }}
           path: ${{ github.workspace }}
+#           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }}
 
       - name: Read Properties
         id: read_property


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Error: The following inputs cannot be used together: pr, commit, branch, run_id

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) --> use run_id to trigger, not the pr number
