### PR TITLE
[BugFix] fix the thread-safety of regex prepare

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -2539,12 +2539,17 @@ struct StringFunctionsState {
         if (driver_id == 0) {
             return regex.get();
         }
-        auto iter = driver_regex_map.lazy_emplace(driver_id, [&](auto build) {
-            auto regex = std::make_unique<re2::RE2>(pattern, *options);
-            DCHECK(regex->ok());
-            build(driver_id, std::move(regex));
-        });
-        return iter->second.get();
+        re2::RE2* res = nullptr;
+        driver_regex_map.lazy_emplace_l(
+                driver_id, [&](auto& value) { res = value.get(); },
+                [&](auto build) {
+                    auto regex = std::make_unique<re2::RE2>(pattern, *options);
+                    DCHECK(regex->ok());
+                    res = regex.get();
+                    build(driver_id, std::move(regex));
+                });
+        DCHECK(!!res);
+        return res;
     }
 };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- `parallel_flat_hash_map::lazy_emplace` returns a iterator, which is not safe to read cause following insert would invalid it
- `parallel_flat_hash_map::lazy_emplace_l` 
  - It is safe to read if exists, or insert a value if not exists
  - This function would exclusively lock the inner map during the lookup or insert
