### PR TITLE
[Cherry-pick][Branch-2.3][Enhancement] Reject create table request if checkPersistentIndex failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1605,6 +1605,12 @@ public class SchemaChangeHandler extends AlterHandler {
             if (metaValue == olapTable.enablePersistentIndex()) {
                 return;
             }
+            if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS && metaValue) {
+                if (!olapTable.checkPersistentIndex()) {
+                    throw new DdlException("PrimaryKey table using persistent index don't support " + 
+                         "varchar(char) as key so far, and key length should be no more than 64 Bytes");
+                }
+            }
         } else {
             LOG.warn("meta type: {} does not support", metaType);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1506,6 +1506,28 @@ public class OlapTable extends Table {
         tableProperty.buildEnablePersistentIndex();
     }
 
+    public Boolean checkPersistentIndex() {
+        // check key type and length
+        int keyLength = 0;
+        for (Column column : getFullSchema()) {
+            if (!column.isKey()) {
+                continue;
+            }
+            if (column.getPrimitiveType() == PrimitiveType.VARCHAR 
+                    || column.getPrimitiveType() == PrimitiveType.CHAR) {
+                LOG.warn("PrimaryKey table using persistent index doesn't support varchar(char) so far");
+                return false;
+            }
+            // calculate key size
+            keyLength += column.getPrimitiveType().getSlotSize();
+        }
+        if (keyLength > 64) {
+            LOG.warn("Primary key size of primaryKey table using persistent index should be no more than 64Bytes");
+            return false;
+        }
+        return true;
+    }
+
     public void setStorageMedium(TStorageMedium storageMedium) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1785,6 +1785,13 @@ public class LocalMetastore implements ConnectorMetadata {
                         false);
         olapTable.setEnablePersistentIndex(enablePersistentIndex);
 
+        if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS && olapTable.enablePersistentIndex()) {
+            if (!olapTable.checkPersistentIndex()) {
+                throw new DdlException("PrimaryKey table using persistent index don't support varchar(char) as key so far," +
+                                       " and key length should be no more than 64 Bytes");
+            }
+        }
+
         TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
         try {
             tabletType = PropertyAnalyzer.analyzeTabletType(properties);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PersistentIndex is available in branch-2.3, but there are many limitations in key columns. For example, key column is not supported as varchar(char) type, and the length of key columns cannot exceed 64 bytes.

In the previous implementation, if we create a primary key table enable PersistentIndex but the restrictions are not met, we will use PrimaryIndex in memory but not PersistentIndex, and primary key table will be create successfully. This may be a bit confusing to the user.

So we will reject the create table request directly if we find that the restrictions are not met.

