### PR TITLE
[Enhancement] use `append_continuous_strings` in FLBAPlainDecoder

### DIFF
--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -338,7 +338,7 @@ public:
             _offset += _type_length;
         }
 
-        dst->append_strings(slices);
+        dst->append_continuous_strings(slices);
         return Status::OK();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Strings in `FLBAPlainDecoder` are continuous.

```
    Status next_batch(size_t count, ColumnContentType content_type, vectorized::Column* dst) override {
        if (_offset + _type_length * count > _data.size) {
            return Status::InternalError(strings::Substitute(
                    "going to read out-of-bounds data, offset=$0,count=$1,size=$2", _offset, count, _data.size));
        }
        std::vector<Slice> slices;
        slices.resize(count);
        for (int i = 0; i < count; ++i) {
            slices[i] = Slice(_data.data + _offset, _type_length);
            _offset += _type_length;
        }

        dst->append_continuous_strings(slices);
        return Status::OK();
    }
```
