### PR TITLE
[BugFix] Fix the bug of not set need_rollback to false

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -198,7 +198,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
         return Status::ServiceUnavailable(fmt::format(
                 "Commit transaction fail cause {}, Transaction status unknown, you can retry with same label.",
                 st.get_error_msg()));
-    } else {
+    } else if (!st.ok()){
         return st;
     }
 #else

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -198,7 +198,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
         return Status::ServiceUnavailable(fmt::format(
                 "Commit transaction fail cause {}, Transaction status unknown, you can retry with same label.",
                 st.get_error_msg()));
-    } else if (!st.ok()){
+    } else if (!st.ok()) {
         return st;
     }
 #else


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9113 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the `ctx->need_rollback = false;` will not reach
