### PR TITLE
[Enhancement] Optimize exchange sink shuffle performance

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -10,6 +10,7 @@
 #include <random>
 
 #include "common/config.h"
+#include "exec/pipeline/exchange/shuffler.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
 #include "exprs/expr.h"
 #include "gen_cpp/Types_types.h"
@@ -337,6 +338,9 @@ ExchangeSinkOperator::ExchangeSinkOperator(OperatorFactory* factory, int32_t id,
     _num_shuffles = _channels.size() * _num_shuffles_per_channel;
 
     _is_pipeline_level_shuffle = is_pipeline_level_shuffle && (_num_shuffles > 1);
+
+    _shuffler = std::make_unique<Shuffler>(runtime_state()->func_version() <= 3, !_is_channel_bound_driver_sequence,
+                                           _part_type, _channels.size(), _num_shuffles_per_channel);
 }
 
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {
@@ -388,8 +392,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
         RETURN_IF_ERROR(channel->init(state));
     }
 
-    _channel_ids.resize(state->chunk_size());
-    _shuffle_ids.resize(state->chunk_size());
+    _shuffle_channel_ids.resize(state->chunk_size());
     _row_indexes.resize(state->chunk_size());
 
     return Status::OK();
@@ -496,7 +499,6 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
     } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
                _part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
         // hash-partition batch's rows across channels
-        const size_t num_channels = _channels.size();
         {
             SCOPED_TIMER(_shuffle_hash_timer);
             for (size_t i = 0; i < _partitions_columns.size(); ++i) {
@@ -521,20 +523,10 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
             // Compute row indexes for each channel's each shuffle
             _channel_row_idx_start_points.assign(_num_shuffles + 1, 0);
+            _shuffler->exchange_shuffle(_shuffle_channel_ids, _hash_values, num_rows);
 
             for (size_t i = 0; i < num_rows; ++i) {
-                size_t channel_id = _hash_values[i] % num_channels;
-                size_t shuffle_id;
-                if (_is_channel_bound_driver_sequence) {
-                    shuffle_id = channel_id;
-                } else {
-                    // Note that xorshift32 rehash must be applied for both local shuffle and exchange sink here.
-                    uint32_t driver_sequence = HashUtil::xorshift32(_hash_values[i]) % _num_shuffles_per_channel;
-                    shuffle_id = channel_id * _num_shuffles_per_channel + driver_sequence;
-                }
-                _channel_ids[i] = channel_id;
-                _shuffle_ids[i] = shuffle_id;
-                _channel_row_idx_start_points[shuffle_id]++;
+                _channel_row_idx_start_points[_shuffle_channel_ids[i]]++;
             }
             // NOTE:
             // we make the last item equal with number of rows of this chunk
@@ -543,8 +535,8 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
             }
 
             for (int32_t i = num_rows - 1; i >= 0; --i) {
-                _row_indexes[_channel_row_idx_start_points[_shuffle_ids[i]] - 1] = i;
-                _channel_row_idx_start_points[_shuffle_ids[i]]--;
+                _row_indexes[_channel_row_idx_start_points[_shuffle_channel_ids[i]] - 1] = i;
+                _channel_row_idx_start_points[_shuffle_channel_ids[i]]--;
             }
         }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include "column/column.h"
@@ -9,6 +10,7 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/data_sink.h"
+#include "exec/pipeline/exchange/shuffler.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/operator.h"
@@ -167,8 +169,7 @@ private:
     const std::vector<ExprContext*>& _partition_expr_ctxs; // compute per-row partition values
     vectorized::Columns _partitions_columns;
     std::vector<uint32_t> _hash_values;
-    std::vector<uint32_t> _channel_ids;
-    std::vector<uint32_t> _shuffle_ids;
+    std::vector<uint32_t> _shuffle_channel_ids;
     std::vector<int> _driver_sequence_per_shuffle;
     // This array record the channel start point in _row_indexes
     // And the last item is the number of rows of the current shuffle chunk.
@@ -184,6 +185,8 @@ private:
     FragmentContext* const _fragment_ctx;
 
     const std::vector<int32_t>& _output_columns;
+
+    std::unique_ptr<Shuffler> _shuffler;
 };
 
 class ExchangeSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -3,6 +3,7 @@
 #include "exec/pipeline/exchange/local_exchange.h"
 
 #include "column/chunk.h"
+#include "exec/pipeline/exchange/shuffler.h"
 #include "exprs/expr_context.h"
 
 namespace starrocks::pipeline {
@@ -11,6 +12,11 @@ Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkP
                                                         std::vector<uint32_t>& partition_row_indexes) {
     int32_t num_rows = chunk->num_rows();
     int32_t num_partitions = _source->get_sources().size();
+
+    if (_shuffler == nullptr) {
+        _shuffler = std::make_unique<Shuffler>(_source->runtime_state()->func_version() <= 3, false, _part_type, -1,
+                                               _source->get_sources().size());
+    }
 
     for (size_t i = 0; i < _partitions_columns.size(); ++i) {
         ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()));
@@ -32,23 +38,13 @@ Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkP
         }
     }
 
-    // When the local exchange is the successor of ExchangeSourceOperator,
-    // the data flow is `exchange sink -> exchange source -> local exchange`.
-    // `exchange sink -> exchange source` (phase 1) determines which fragment instance to deliver each row,
-    // while `exchange source -> local exchange` (phase 2) determines which pipeline driver to deliver each row.
-    // To avoid hash two times and data skew due to hash one time, phase 1 hashes one time
-    // and phase 2 applies xorshift32 on the hash value.
-    // Note that xorshift32 rehash must be applied for both local shuffle here and exchange sink.
-    for (int32_t i = 0; i < num_rows; ++i) {
-        _hash_values[i] = HashUtil::xorshift32(_hash_values[i]);
-    }
+    _shuffle_channel_id.resize(num_rows);
 
-    // Compute row indexes for each channel.
+    _shuffler->local_exchange_shuffle(_shuffle_channel_id, _hash_values, num_rows);
+
     _partition_row_indexes_start_points.assign(num_partitions + 1, 0);
-    for (int32_t i = 0; i < num_rows; ++i) {
-        size_t partition_index = _hash_values[i] % num_partitions;
-        _partition_row_indexes_start_points[partition_index]++;
-        _hash_values[i] = partition_index;
+    for (size_t i = 0; i < num_rows; ++i) {
+        _partition_row_indexes_start_points[_shuffle_channel_id[i]]++;
     }
     // We make the last item equal with number of rows of this chunk.
     for (int32_t i = 1; i <= num_partitions; ++i) {
@@ -56,8 +52,8 @@ Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkP
     }
 
     for (int32_t i = num_rows - 1; i >= 0; --i) {
-        partition_row_indexes[_partition_row_indexes_start_points[_hash_values[i]] - 1] = i;
-        _partition_row_indexes_start_points[_hash_values[i]]--;
+        partition_row_indexes[_partition_row_indexes_start_points[_shuffle_channel_id[i]] - 1] = i;
+        _partition_row_indexes_start_points[_shuffle_channel_id[i]]--;
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -14,8 +14,8 @@ Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkP
     int32_t num_partitions = _source->get_sources().size();
 
     if (_shuffler == nullptr) {
-        _shuffler = std::make_unique<Shuffler>(_source->runtime_state()->func_version() <= 3, false, _part_type, -1,
-                                               _source->get_sources().size());
+        _shuffler = std::make_unique<Shuffler>(_source->runtime_state()->func_version() <= 3, false, _part_type,
+                                               _source->get_sources().size(), 1);
     }
 
     for (size_t i = 0; i < _partitions_columns.size(); ++i) {

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -2,11 +2,13 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/exchange/local_exchange_memory_manager.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/exchange/shuffler.h"
 #include "exprs/expr_context.h"
 
 namespace starrocks {
@@ -89,11 +91,13 @@ class PartitionExchanger final : public LocalExchanger {
 
         vectorized::Columns _partitions_columns;
         std::vector<uint32_t> _hash_values;
+        std::vector<uint32_t> _shuffle_channel_id;
         // This array record the channel start point in _row_indexes
         // And the last item is the number of rows of the current shuffle chunk.
         // It will easy to get number of rows belong to one channel by doing
         // _partition_row_indexes_start_points[i + 1] - _partition_row_indexes_start_points[i]
         std::vector<size_t> _partition_row_indexes_start_points;
+        std::unique_ptr<Shuffler> _shuffler;
     };
 
 public:

--- a/be/src/exec/pipeline/exchange/shuffler.h
+++ b/be/src/exec/pipeline/exchange/shuffler.h
@@ -9,13 +9,6 @@
 #include "util/hash_util.hpp"
 
 namespace starrocks::pipeline {
-struct ModuloOp {
-    uint32_t operator()(uint32_t l, uint32_t r) { return l % r; }
-};
-struct ReduceOp {
-    uint32_t operator()(uint32_t l, uint32_t r) { return ((uint64_t)l * (uint64_t)r) >> 32; }
-};
-
 class Shuffler {
 public:
     Shuffler(bool compatibility, bool is_two_level_shuffle, TPartitionType::type partition_type, size_t num_channels,
@@ -33,7 +26,7 @@ public:
             if (is_two_level_shuffle) {
                 _exchange_shuffle = &Shuffler::exchange_shuffle<true, ModuloOp>;
             } else {
-                _exchange_shuffle = &Shuffler::exchange_shuffle<true, ModuloOp>;
+                _exchange_shuffle = &Shuffler::exchange_shuffle<false, ModuloOp>;
             }
         }
 

--- a/be/src/exec/pipeline/exchange/shuffler.h
+++ b/be/src/exec/pipeline/exchange/shuffler.h
@@ -81,7 +81,7 @@ private:
     void local_exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, std::vector<uint32_t>& hash_values,
                                 size_t num_rows) {
         for (int32_t i = 0; i < num_rows; ++i) {
-            uint32_t driver_sequence = ReduceOp()(HashUtil::xorshift32(hash_values[i]), _num_shuffles_per_channel);
+            uint32_t driver_sequence = ReduceOp()(HashUtil::xorshift32(hash_values[i]), _num_channels);
             shuffle_channel_ids[i] = driver_sequence;
         }
     }

--- a/be/src/exec/pipeline/exchange/shuffler.h
+++ b/be/src/exec/pipeline/exchange/shuffler.h
@@ -1,0 +1,100 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "gen_cpp/Partitions_types.h"
+#include "util/hash_util.hpp"
+
+namespace starrocks::pipeline {
+struct ModuloOp {
+    uint32_t operator()(uint32_t l, uint32_t r) { return l % r; }
+};
+struct ReduceOp {
+    uint32_t operator()(uint32_t l, uint32_t r) { return ((uint64_t)l * (uint64_t)r) >> 32; }
+};
+
+class Shuffler {
+public:
+    Shuffler(bool compatibility, bool is_two_level_shuffle, TPartitionType::type partition_type, size_t num_channels,
+             int32_t num_shuffles_per_channel)
+            : _part_type(partition_type),
+              _num_channels(num_channels),
+              _num_shuffles_per_channel(num_shuffles_per_channel) {
+        if (_part_type == TPartitionType::HASH_PARTITIONED && !compatibility) {
+            if (is_two_level_shuffle) {
+                _exchange_shuffle = &Shuffler::exchange_shuffle<true, ReduceOp>;
+            } else {
+                _exchange_shuffle = &Shuffler::exchange_shuffle<false, ReduceOp>;
+            }
+        } else {
+            if (is_two_level_shuffle) {
+                _exchange_shuffle = &Shuffler::exchange_shuffle<true, ModuloOp>;
+            } else {
+                _exchange_shuffle = &Shuffler::exchange_shuffle<true, ModuloOp>;
+            }
+        }
+
+        if (_part_type == TPartitionType::HASH_PARTITIONED && !compatibility) {
+            _local_exchange_shuffle = &Shuffler::local_exchange_shuffle<ReduceOp>;
+        } else {
+            _local_exchange_shuffle = &Shuffler::local_exchange_shuffle<ModuloOp>;
+        }
+    }
+
+    void exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, const std::vector<uint32_t>& hash_values,
+                          size_t num_rows) {
+        (this->*_exchange_shuffle)(shuffle_channel_ids, hash_values, num_rows);
+    }
+
+    void local_exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, std::vector<uint32_t>& hash_values,
+                                size_t num_rows) {
+        (this->*_local_exchange_shuffle)(shuffle_channel_ids, hash_values, num_rows);
+    }
+
+private:
+    void (Shuffler::*_exchange_shuffle)(std::vector<uint32_t>& shuffle_channel_ids,
+                                        const std::vector<uint32_t>& hash_values, size_t num_rows) = nullptr;
+
+    void (Shuffler::*_local_exchange_shuffle)(std::vector<uint32_t>& shuffle_channel_ids,
+                                              std::vector<uint32_t>& hash_values, size_t num_rows) = nullptr;
+
+    template <bool two_level_shuffle, typename ReduceOp>
+    void exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, const std::vector<uint32_t>& hash_values,
+                          size_t num_rows) {
+        for (size_t i = 0; i < num_rows; ++i) {
+            size_t channel_id = ReduceOp()(hash_values[i], _num_channels);
+            size_t shuffle_id;
+            if constexpr (!two_level_shuffle) {
+                shuffle_id = channel_id;
+            } else {
+                uint32_t driver_sequence = ReduceOp()(HashUtil::xorshift32(hash_values[i]), _num_shuffles_per_channel);
+                shuffle_id = channel_id * _num_shuffles_per_channel + driver_sequence;
+            }
+            shuffle_channel_ids[i] = shuffle_id;
+        }
+    }
+
+    // When the local exchange is the successor of ExchangeSourceOperator,
+    // the data flow is `exchange sink -> exchange source -> local exchange`.
+    // `exchange sink -> exchange source` (phase 1) determines which fragment instance to deliver each row,
+    // while `exchange source -> local exchange` (phase 2) determines which pipeline driver to deliver each row.
+    // To avoid hash two times and data skew due to hash one time, phase 1 hashes one time
+    // and phase 2 applies xorshift32 on the hash value.
+    // Note that xorshift32 rehash must be applied for both local shuffle here and exchange sink.
+    template <typename ReduceOp>
+    void local_exchange_shuffle(std::vector<uint32_t>& shuffle_channel_ids, std::vector<uint32_t>& hash_values,
+                                size_t num_rows) {
+        for (int32_t i = 0; i < num_rows; ++i) {
+            uint32_t driver_sequence = ReduceOp()(HashUtil::xorshift32(hash_values[i]), _num_shuffles_per_channel);
+            shuffle_channel_ids[i] = driver_sequence;
+        }
+    }
+
+    const TPartitionType::type _part_type = TPartitionType::UNPARTITIONED;
+    const size_t _num_channels;
+    const size_t _num_shuffles_per_channel;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -204,6 +204,7 @@ public:
         bool use_merged_selection;
         std::vector<uint32_t> hash_values;
         const std::vector<int32_t>* bucketseq_to_partition;
+        bool compatibility;
     };
 
     virtual void evaluate(Column* input_column, RunningContext* ctx) const = 0;
@@ -354,11 +355,17 @@ public:
                                             std::vector<uint32_t>& hash_values, size_t num_rows) const {
         typedef void (Column::*HashFuncType)(uint32_t*, uint32_t, uint32_t) const;
 
-        auto compute_hash = [&input_column, &num_rows, &hash_values, this](HashFuncType hash_func,
-                                                                           size_t num_hash_partitions) {
+        auto compute_hash = [&input_column, &num_rows, &hash_values, this](
+                                    HashFuncType hash_func, size_t num_hash_partitions, bool fast_reduce) {
             (input_column->*hash_func)(hash_values.data(), 0, num_rows);
-            for (size_t i = 0; i < num_rows; i++) {
-                hash_values[i] %= num_hash_partitions;
+            if (fast_reduce) {
+                for (size_t i = 0; i < num_rows; i++) {
+                    hash_values[i] = ReduceOp()(hash_values[i], num_hash_partitions);
+                }
+            } else {
+                for (size_t i = 0; i < num_rows; i++) {
+                    hash_values[i] %= num_hash_partitions;
+                }
             }
         };
 
@@ -370,7 +377,7 @@ public:
         case TRuntimeFilterBuildJoinMode::PARTITIONED:
         case TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET: {
             hash_values.assign(num_rows, HashUtil::FNV_SEED);
-            compute_hash(&Column::fnv_hash, _num_hash_partitions);
+            compute_hash(&Column::fnv_hash, _num_hash_partitions, !running_ctx->compatibility);
             break;
         }
         case TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET:
@@ -380,7 +387,7 @@ public:
             // instances. we can use crc32_hash to compute out bucket_seq that the row belongs to, then use
             // the bucketseq_to_partition array to translate bucket_seq into partition index of the grf.
             const auto& bucketseq_to_partition = *running_ctx->bucketseq_to_partition;
-            compute_hash(&Column::crc32_hash, bucketseq_to_partition.size());
+            compute_hash(&Column::crc32_hash, bucketseq_to_partition.size(), false);
             for (auto i = 0; i < num_rows; ++i) {
                 hash_values[i] = bucketseq_to_partition[hash_values[i]];
             }

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -305,6 +305,8 @@ void RuntimeFilterProbeCollector::do_evaluate(vectorized::Chunk* chunk, RuntimeB
     if (!eval_context.selectivity.empty()) {
         auto& selection = eval_context.running_context.selection;
         eval_context.running_context.use_merged_selection = false;
+        eval_context.running_context.compatibility =
+                _runtime_state->func_version() <= 3 && _runtime_state->enable_pipeline_engine();
         for (auto& kv : eval_context.selectivity) {
             RuntimeFilterProbeDescriptor* rf_desc = kv.second;
             const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
@@ -369,6 +371,8 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
     size_t chunk_size = chunk->num_rows();
     auto& merged_selection = eval_context.running_context.merged_selection;
     auto& use_merged_selection = eval_context.running_context.use_merged_selection;
+    eval_context.running_context.compatibility =
+            _runtime_state->func_version() <= 3 && _runtime_state->enable_pipeline_engine();
     use_merged_selection = true;
     for (auto& it : _descriptors) {
         RuntimeFilterProbeDescriptor* rf_desc = it.second;

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -598,11 +598,13 @@ Status DataStreamSender::send_chunk(RuntimeState* state, vectorized::Chunk* chun
 
             // compute row indexes for each channel
             _channel_row_idx_start_points.assign(num_channels + 1, 0);
+
             for (uint16_t i = 0; i < num_rows; ++i) {
                 uint16_t channel_index = _hash_values[i] % num_channels;
                 _channel_row_idx_start_points[channel_index]++;
                 _hash_values[i] = channel_index;
             }
+
             // NOTE:
             // we make the last item equal with number of rows of this chunk
             for (int i = 1; i <= num_channels; ++i) {

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -431,6 +431,9 @@ struct ModuloOp {
 };
 
 // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+// avoid div/modulo operations
+// mapping l to the range [0, r]
+// we weed to ensure that l is randomly and uniformly distributed in [0, 2^32]
 struct ReduceOp {
     uint32_t operator()(uint32_t l, uint32_t r) { return ((uint64_t)l * (uint64_t)r) >> 32; }
 };

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include "common/logging.h"
 #include "common/compiler_util.h"
+#include "common/logging.h"
 
 // For cross compiling with clang, we need to be able to generate an IR file with
 // no sse instructions.  Attempting to load a precompiled IR file that contains
@@ -32,12 +32,13 @@
 #include <nmmintrin.h>
 #endif
 #include <zlib.h>
-#include "util/cpu_info.h"
-#include "util/murmur_hash3.h"
+
 #include "gen_cpp/Types_types.h"
-#include "storage/uint24.h"
 #include "storage/decimal12.h"
+#include "storage/uint24.h"
+#include "util/cpu_info.h"
 #include "util/int96.h"
+#include "util/murmur_hash3.h"
 
 namespace starrocks {
 
@@ -118,9 +119,7 @@ public:
     // refer to https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/digest/MurmurHash3.java
     static const uint32_t MURMUR3_32_SEED = 104729;
 
-    ALWAYS_INLINE static uint32_t rotl32(uint32_t x, int8_t r) {
-        return (x << r) | (x >> (32 - r));
-    }
+    ALWAYS_INLINE static uint32_t rotl32(uint32_t x, int8_t r) { return (x << r) | (x >> (32 - r)); }
 
     ALWAYS_INLINE static uint32_t fmix32(uint32_t h) {
         h ^= h >> 16;
@@ -140,27 +139,33 @@ public:
 
         const uint32_t c1 = 0xcc9e2d51;
         const uint32_t c2 = 0x1b873593;
-        const uint32_t * blocks = (const uint32_t *)(data + nblocks * 4);
+        const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
 
-        for(int i = -nblocks; i; i++) {
+        for (int i = -nblocks; i; i++) {
             uint32_t k1 = blocks[i];
 
             k1 *= c1;
-            k1 = rotl32(k1,15);
+            k1 = rotl32(k1, 15);
             k1 *= c2;
 
             h1 ^= k1;
-            h1 = rotl32(h1,13);
+            h1 = rotl32(h1, 13);
             h1 = h1 * 5 + 0xe6546b64;
         }
 
-        const uint8_t * tail = (const uint8_t*)(data + nblocks * 4);
+        const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
         uint32_t k1 = 0;
-        switch(len & 3) {
-            case 3: k1 ^= tail[2] << 16;
-            case 2: k1 ^= tail[1] << 8;
-            case 1: k1 ^= tail[0];
-                k1 *= c1; k1 = rotl32(k1,15); k1 *= c2; h1 ^= k1;
+        switch (len & 3) {
+        case 3:
+            k1 ^= tail[2] << 16;
+        case 2:
+            k1 ^= tail[1] << 8;
+        case 1:
+            k1 ^= tail[0];
+            k1 *= c1;
+            k1 = rotl32(k1, 15);
+            k1 *= c2;
+            h1 ^= k1;
         };
 
         h1 ^= len;
@@ -188,21 +193,21 @@ public:
 
         const uint8_t* data2 = reinterpret_cast<const uint8_t*>(data);
         switch (len & 7) {
-            case 7:
-                h ^= uint64_t(data2[6]) << 48;
-            case 6:
-                h ^= uint64_t(data2[5]) << 40;
-            case 5:
-                h ^= uint64_t(data2[4]) << 32;
-            case 4:
-                h ^= uint64_t(data2[3]) << 24;
-            case 3:
-                h ^= uint64_t(data2[2]) << 16;
-            case 2:
-                h ^= uint64_t(data2[1]) << 8;
-            case 1:
-                h ^= uint64_t(data2[0]);
-                h *= MURMUR_PRIME;
+        case 7:
+            h ^= uint64_t(data2[6]) << 48;
+        case 6:
+            h ^= uint64_t(data2[5]) << 40;
+        case 5:
+            h ^= uint64_t(data2[4]) << 32;
+        case 4:
+            h ^= uint64_t(data2[3]) << 24;
+        case 3:
+            h ^= uint64_t(data2[2]) << 16;
+        case 2:
+            h ^= uint64_t(data2[1]) << 8;
+        case 1:
+            h ^= uint64_t(data2[0]);
+            h *= MURMUR_PRIME;
         }
 
         h ^= h >> MURMUR_R;
@@ -212,7 +217,7 @@ public:
     }
 
     // default values recommended by http://isthe.com/chongo/tech/comp/fnv/
-    static const uint32_t FNV_PRIME = 0x01000193; //   16777619
+    static const uint32_t FNV_PRIME = 0x01000193;    //   16777619
     static constexpr uint32_t FNV_SEED = 0x811C9DC5; // 2166136261
     static const uint64_t FNV64_PRIME = 1099511628211UL;
     static const uint64_t FNV64_SEED = 14695981039346656037UL;
@@ -249,24 +254,24 @@ public:
     // Our hash function is MurmurHash2, 64 bit version.
     // It was modified in order to provide the same result in
     // big and little endian archs (endian neutral).
-    static uint64_t murmur_hash64A (const void* key, int32_t len, unsigned int seed) {
+    static uint64_t murmur_hash64A(const void* key, int32_t len, unsigned int seed) {
         const uint64_t m = MURMUR_PRIME;
         const int r = 47;
         uint64_t h = seed ^ (len * m);
-        const uint8_t *data = (const uint8_t *)key;
-        const uint8_t *end = data + (len-(len&7));
+        const uint8_t* data = (const uint8_t*)key;
+        const uint8_t* end = data + (len - (len & 7));
 
-        while(data != end) {
+        while (data != end) {
             uint64_t k;
 #if (BYTE_ORDER == BIG_ENDIAN)
-            k = (uint64_t) data[0];
-            k |= (uint64_t) data[1] << 8;
-            k |= (uint64_t) data[2] << 16;
-            k |= (uint64_t) data[3] << 24;
-            k |= (uint64_t) data[4] << 32;
-            k |= (uint64_t) data[5] << 40;
-            k |= (uint64_t) data[6] << 48;
-            k |= (uint64_t) data[7] << 56;
+            k = (uint64_t)data[0];
+            k |= (uint64_t)data[1] << 8;
+            k |= (uint64_t)data[2] << 16;
+            k |= (uint64_t)data[3] << 24;
+            k |= (uint64_t)data[4] << 32;
+            k |= (uint64_t)data[5] << 40;
+            k |= (uint64_t)data[6] << 48;
+            k |= (uint64_t)data[7] << 56;
 #else
             memcpy(&k, data, sizeof(k));
 #endif
@@ -279,15 +284,22 @@ public:
             data += 8;
         }
 
-        switch(len & 7) {
-            case 7: h ^= (uint64_t)data[6] << 48;
-            case 6: h ^= (uint64_t)data[5] << 40;
-            case 5: h ^= (uint64_t)data[4] << 32;
-            case 4: h ^= (uint64_t)data[3] << 24;
-            case 3: h ^= (uint64_t)data[2] << 16;
-            case 2: h ^= (uint64_t)data[1] << 8;
-            case 1: h ^= (uint64_t)data[0];
-                h *= m;
+        switch (len & 7) {
+        case 7:
+            h ^= (uint64_t)data[6] << 48;
+        case 6:
+            h ^= (uint64_t)data[5] << 40;
+        case 5:
+            h ^= (uint64_t)data[4] << 32;
+        case 4:
+            h ^= (uint64_t)data[3] << 24;
+        case 3:
+            h ^= (uint64_t)data[2] << 16;
+        case 2:
+            h ^= (uint64_t)data[1] << 8;
+        case 1:
+            h ^= (uint64_t)data[0];
+            h *= m;
         };
 
         h ^= h >> r;
@@ -329,97 +341,104 @@ public:
         murmur_hash3_x64_64(data, bytes, seed, &hash);
         return hash;
 #endif
-
     }
 
     template <typename T>
     static inline void hash_combine(std::size_t& seed, const T& v) {
-        seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+        seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
 
-template <typename T>
-static inline T unaligned_load(void const* ptr) noexcept {
-    // using memcpy so we don't get into unaligned load problems.
-    // compiler should optimize this very well anyways.
-    T t;
-    memcpy(&t, ptr, sizeof(T));
-    return t;
-}
+    template <typename T>
+    static inline T unaligned_load(void const* ptr) noexcept {
+        // using memcpy so we don't get into unaligned load problems.
+        // compiler should optimize this very well anyways.
+        T t;
+        memcpy(&t, ptr, sizeof(T));
+        return t;
+    }
 
-// Modify from https://github.com/martinus/robin-hood-hashing/blob/master/src/include/robin_hood.h
-// Hash an arbitrary amount of bytes. This is basically Murmur2 hash without caring about big
-// endianness. TODO(martinus) add a fallback for very large strings?
-static size_t hash_bytes(void const* ptr, size_t const len) noexcept {
-    static constexpr uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
-    static constexpr uint64_t seed = UINT64_C(0xe17a1465);
-    static constexpr unsigned int r = 47;
+    // Modify from https://github.com/martinus/robin-hood-hashing/blob/master/src/include/robin_hood.h
+    // Hash an arbitrary amount of bytes. This is basically Murmur2 hash without caring about big
+    // endianness. TODO(martinus) add a fallback for very large strings?
+    static size_t hash_bytes(void const* ptr, size_t const len) noexcept {
+        static constexpr uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+        static constexpr uint64_t seed = UINT64_C(0xe17a1465);
+        static constexpr unsigned int r = 47;
 
-    auto const data64 = static_cast<uint64_t const*>(ptr);
-    uint64_t h = seed ^ (len * m);
+        auto const data64 = static_cast<uint64_t const*>(ptr);
+        uint64_t h = seed ^ (len * m);
 
-    size_t const n_blocks = len / 8;
-    for (size_t i = 0; i < n_blocks; ++i) {
-        auto k = unaligned_load<uint64_t>(data64 + i);
+        size_t const n_blocks = len / 8;
+        for (size_t i = 0; i < n_blocks; ++i) {
+            auto k = unaligned_load<uint64_t>(data64 + i);
 
-        k *= m;
-        k ^= k >> r;
-        k *= m;
+            k *= m;
+            k ^= k >> r;
+            k *= m;
 
-        h ^= k;
+            h ^= k;
+            h *= m;
+        }
+
+        auto const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
+        switch (len & 7U) {
+        case 7:
+            h ^= static_cast<uint64_t>(data8[6]) << 48U;
+            break;
+        case 6:
+            h ^= static_cast<uint64_t>(data8[5]) << 40U;
+            break;
+        case 5:
+            h ^= static_cast<uint64_t>(data8[4]) << 32U;
+            break;
+        case 4:
+            h ^= static_cast<uint64_t>(data8[3]) << 24U;
+            break;
+        case 3:
+            h ^= static_cast<uint64_t>(data8[2]) << 16U;
+            break;
+        case 2:
+            h ^= static_cast<uint64_t>(data8[1]) << 8U;
+            break;
+        case 1:
+            h ^= static_cast<uint64_t>(data8[0]);
+            h *= m;
+            break;
+        default:
+            break;
+        }
+
+        h ^= h >> r;
         h *= m;
+        h ^= h >> r;
+        return static_cast<size_t>(h);
     }
 
-    auto const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
-    switch (len & 7U) {
-    case 7:
-        h ^= static_cast<uint64_t>(data8[6]) << 48U;
-        break;
-    case 6:
-        h ^= static_cast<uint64_t>(data8[5]) << 40U;
-        break;
-    case 5:
-        h ^= static_cast<uint64_t>(data8[4]) << 32U;
-        break;
-    case 4:
-        h ^= static_cast<uint64_t>(data8[3]) << 24U;
-        break;
-    case 3:
-        h ^= static_cast<uint64_t>(data8[2]) << 16U;
-        break;
-    case 2:
-        h ^= static_cast<uint64_t>(data8[1]) << 8U;
-        break;
-    case 1:
-        h ^= static_cast<uint64_t>(data8[0]);
-        h *= m;
-        break;
-    default:
-        break;
+    // Xorshift is a pseudorandom number generator, which is an implementation of
+    // linear-feedback shift registers (LFSRs). It generates next pseudorandom state from
+    // the current state, which can be easily repurposed as hash functions.
+    // The original paper: https://www.jstatsoft.org/article/view/v008i14
+    static uint32_t xorshift32(uint32_t x) {
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        return x;
     }
-
-    h ^= h >> r;
-    h *= m;
-    h ^= h >> r;
-    return static_cast<size_t>(h);
-}
-
-// Xorshift is a pseudorandom number generator, which is an implementation of
-// linear-feedback shift registers (LFSRs). It generates next pseudorandom state from
-// the current state, which can be easily repurposed as hash functions.
-// The original paper: https://www.jstatsoft.org/article/view/v008i14
-static uint32_t xorshift32(uint32_t x) {
-    x ^= x << 13;
-    x ^= x >> 17;
-    x ^= x << 5;
-    return x;
-}
-
 };
 
-}
+struct ModuloOp {
+    uint32_t operator()(uint32_t l, uint32_t r) { return l % r; }
+};
+
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+struct ReduceOp {
+    uint32_t operator()(uint32_t l, uint32_t r) { return ((uint64_t)l * (uint64_t)r) >> 32; }
+};
+
+} // namespace starrocks
 
 namespace std {
-template<>
+template <>
 struct hash<starrocks::TUniqueId> {
     std::size_t operator()(const starrocks::TUniqueId& id) const {
         std::size_t seed = 0;
@@ -429,7 +448,7 @@ struct hash<starrocks::TUniqueId> {
     }
 };
 
-template<>
+template <>
 struct hash<starrocks::TNetworkAddress> {
     size_t operator()(const starrocks::TNetworkAddress& address) const {
         std::size_t seed = 0;
@@ -441,36 +460,30 @@ struct hash<starrocks::TNetworkAddress> {
 
 #if !__clang__ && __GNUC__ < 6
 // Cause this is builtin function
-template<>
+template <>
 struct hash<__int128> {
-    std::size_t operator()(const __int128& val) const {
-        return starrocks::HashUtil::hash(&val, sizeof(val), 0);
-    }
+    std::size_t operator()(const __int128& val) const { return starrocks::HashUtil::hash(&val, sizeof(val), 0); }
 };
 #endif
 
-template<>
+template <>
 struct hash<starrocks::uint24_t> {
-    size_t operator()(const starrocks::uint24_t& val) const {
-        return starrocks::HashUtil::hash(&val, sizeof(val), 0);
-    }
+    size_t operator()(const starrocks::uint24_t& val) const { return starrocks::HashUtil::hash(&val, sizeof(val), 0); }
 };
 
-template<>
+template <>
 struct hash<starrocks::int96_t> {
-    size_t operator()(const starrocks::int96_t& val) const {
-        return starrocks::HashUtil::hash(&val, sizeof(val), 0);
-    }
+    size_t operator()(const starrocks::int96_t& val) const { return starrocks::HashUtil::hash(&val, sizeof(val), 0); }
 };
 
-template<>
+template <>
 struct hash<starrocks::decimal12_t> {
     size_t operator()(const starrocks::decimal12_t& val) const {
         return starrocks::HashUtil::hash(&val, sizeof(val), 0);
     }
 };
 
-template<>
+template <>
 struct hash<std::pair<starrocks::TUniqueId, int64_t>> {
     size_t operator()(const std::pair<starrocks::TUniqueId, int64_t>& pair) const {
         size_t seed = 0;
@@ -481,4 +494,4 @@ struct hash<std::pair<starrocks::TUniqueId, int64_t>> {
     }
 };
 
-}
+} // namespace std

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2736,7 +2736,7 @@ public class Coordinator {
             commonParams.setProtocol_version(InternalServiceVersion.V1);
             commonParams.setFragment(fragment.toThrift());
             commonParams.setDesc_tbl(descTable);
-            commonParams.setFunc_version(3);
+            commonParams.setFunc_version(4);
             commonParams.setCoord(coordAddress);
 
             commonParams.setParams(new TPlanFragmentExecParams());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
#9118

## Problem Summary(Required) ：
dataset is from tpcds 1T

for such query:
```
mysql>  select  count(*) c, sum(cs_item_sk) from catalog_sales group by cs_order_number order by c limit 10;
```

we need cost about 1sec for caculate shuffle hash, and it's a hotpot in CPU
```
- ShuffleHashTime: 841.121ms
  - __MAX_OF_ShuffleHashTime: 981.712ms
  - __MIN_OF_ShuffleHashTime: 623.501ms
```

perf:
```
  35.12%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vectorized::AggHashMapWithOneNumberKey<(starrocks::PrimitiveType)5, phmap::flat_hash_map<int, un   
  9.16%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::AggregateCountFunctionState<false>, starrocks::vectorized::CountAggreg   
  6.94%  starrocks_be        [.] starrocks::pipeline::ExchangeSinkOperator::push_chunk
   3.75%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::AggregateCountFunctionState<false>, starrocks::vectorized::CountAggreg   
   3.63%  [vdso]              [.] __vdso_clock_gettime
```

it was because modulo operator break auto vectorized when caculate hash:
```
     │      _ZN9starrocks8HashUtil10xorshift32Ej():                                                                                                                             ▒  
1.80 │        mov    %edi,%edx                                                                                                                                                  ▒  
0.01 │        shl    $0xd,%edx                                                                                                                                                  ▒  
0.01 │        xor    %edi,%edx                                                                                                                                                  ◆  
0.02 │        mov    %edx,%eax                                                                                                                                                  ▒  
1.75 │        shr    $0x11,%eax                                                                                                                                                 ▒  
0.02 │        xor    %eax,%edx                                                                                                                                                  ▒  
0.01 │        mov    %edx,%eax                                                                                                                                                  ▒
     │        shl    $0x5,%eax                                                                                                                                                  ▒  
1.46 │        xor    %edx,%eax                                                                                                                                                  ▒       
     │      _ZN9starrocks8pipeline20ExchangeSinkOperator10push_chunkEPNS_12RuntimeStateERKSt10shared_ptrINS_10vectorized5ChunkEE():                                             ▒  
0.05 │        xor    %edx,%edx                                                                                                                                                  ▒  
0.01 │        div    %r8d                                                                                                                                                       ▒ 
33.46│        mov    %edi,%eax                                                                                                                                                  ▒  
0.17 │        mov    %rdx,%r11                                                                                                                                                  ▒  
0.09 │        xor    %edx,%edx                                                                                                                                                  ▒
     │        div    %r12                                                                                                                                                       ▒
31.64│        imul   %rdx,%r8                                                                                                                                                   ▒
1.25 │        add    %r8,%r11                                                                                                                                                   ▒
0.63 │        mov    %r11d,(%rsi,%r9,4)                                                                                                                                         ▒
3.69 │        add    $0x1,%r9 
```


but we can avoid this operator:
https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/

```
uint32_t reduce(uint32_t x, uint32_t N) {
  return ((uint64_t) x * (uint64_t) N) >> 32 ;
}
```

after this change HashUtil::xorshift32 also could auto-vectorized:

profile:
```
- ShuffleHashTime: 299.518ms
- __MAX_OF_ShuffleHashTime: 347.797ms
- __MIN_OF_ShuffleHashTime: 229.225ms
```
```
  36.65%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vectorized::AggHashMapWithOneNumberKey<(starrocks::PrimitiveType)5, phmap::flat_hash_map<int, u◆
  10.18%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::AggregateCountFunctionState<false>, starrocks::vectorized::CountAggre▒
   5.17%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::AggregateCountFunctionState<false>, starrocks::vectorized::CountAggre▒   
   4.92%  [vdso]              [.] __vdso_clock_gettime                                                                                                                            ▒   
   2.86%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::SumAggregateState<long>, starrocks::vectorized::SumAggregateFunction<▒   
   2.42%  libc-2.17.so        [.] __memset_sse2                                                                                                                                   ▒   
   2.30%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<starrocks::vectorized::SumAggregateState<long>, starrocks::vectorized::SumAggregateFunction<▒   
   2.26%  libc-2.17.so        [.] __memcpy_ssse3_back                                                                                                                             ▒   
   1.97%  starrocks_be        [.] starrocks::pipeline::ExchangeSinkOperator::push_chunk                                                                                           ▒   
   1.91%  [kernel]            [k] copy_user_enhanced_fast_string                                                                                                                  ▒   
   1.78%  starrocks_be        [.] LZ4_compress_fast_continue                                                                                                                      ▒   
   1.77%  starrocks_be        [.] starrocks::pipeline::PipelineDriverPoller::run_internal                                                                                         ▒   
   1.69%  starrocks_be        [.] starrocks::vectorized::FixedLengthColumnBase<int>::append_selective                                                                             ▒   
   1.33%  libc-2.17.so        [.] __memmove_ssse3_back 
```

baseline: 
5.98 sec
patched:
5.76 sec
