### PR TITLE
[Enhancement] Commit offset if the kafka offset moved

### DIFF
--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -155,7 +155,7 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                 // we do not allow finishing stream load pipe without data.
                 //
                 // But if the offset have already moved, such as the control msg,
-                // we need to commit and tell fe to move offset to the newest offset, otherwise, fe we retry consume.
+                // we need to commit and tell fe to move offset to the newest offset, otherwise, fe will retry consume.
                 for (auto& item : cmt_offset) {
                     if (item.second > ctx->kafka_info->cmt_offset[item.first]) {
                         kafka_pipe->finish();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If the producer start one transaction, and then write two msg (offset 0, offset 1) to kafka but not commit, then sr consumer use read-uncommitted to read, it will consume two msg (offset 0, offset 1). 

Then producer commit, it will write one control msg (offset 2) to kafka.

In the next schedule, sr consumer consume 0 message, it will cancel the transaction, so the fe will keep retrying.

So if will consume no messages but offset is changed, we should commit one empty transaction to let fe change it's record offset
