### PR TITLE
[Enhancement] support BIGINT/INT argument for window_funnel (#9032)

### DIFF
--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -352,9 +352,10 @@ public:
                 auto retentoin = AggregateFactory::MakeRetentionAggregateFunction();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState>(retentoin);
             } else if (name == "window_funnel") {
-                if constexpr (arg_type == TYPE_DATETIME || arg_type == TYPE_DATE) {
-                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
-                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<arg_type>>(
+                if constexpr (ArgPT == TYPE_INT || ArgPT == TYPE_BIGINT || ArgPT == TYPE_DATE ||
+                              ArgPT == TYPE_DATETIME) {
+                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
+                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<ArgPT>>(
                             windowfunnel);
                 }
             }
@@ -364,8 +365,9 @@ public:
             } else if (name == "retention") {
                 return AggregateFactory::MakeRetentionAggregateFunction();
             } else if (name == "window_funnel") {
-                if constexpr (arg_type == TYPE_DATETIME || arg_type == TYPE_DATE) {
-                    return AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
+                if constexpr (ArgPT == TYPE_INT || ArgPT == TYPE_BIGINT || ArgPT == TYPE_DATE ||
+                              ArgPT == TYPE_DATETIME) {
+                    return AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
                 }
             }
         }
@@ -941,6 +943,8 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
     // This first type is the 4th type input of windowfunnel.
     // And the 1st type is BigInt, 2nd is datetime, 3rd is mode(default 0).
+    add_array_mapping<TYPE_INT, TYPE_INT>("window_funnel");
+    add_array_mapping<TYPE_BIGINT, TYPE_INT>("window_funnel");
     add_array_mapping<TYPE_DATETIME, TYPE_INT>("window_funnel");
     add_array_mapping<TYPE_DATE, TYPE_INT>("window_funnel");
 }

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -352,10 +352,10 @@ public:
                 auto retentoin = AggregateFactory::MakeRetentionAggregateFunction();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState>(retentoin);
             } else if (name == "window_funnel") {
-                if constexpr (ArgPT == TYPE_INT || ArgPT == TYPE_BIGINT || ArgPT == TYPE_DATE ||
-                              ArgPT == TYPE_DATETIME) {
-                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
-                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<ArgPT>>(
+                if constexpr (arg_type == TYPE_INT || arg_type == TYPE_BIGINT || arg_type == TYPE_DATE ||
+                              arg_type == TYPE_DATETIME) {
+                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
+                    return AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<arg_type>>(
                             windowfunnel);
                 }
             }
@@ -365,9 +365,9 @@ public:
             } else if (name == "retention") {
                 return AggregateFactory::MakeRetentionAggregateFunction();
             } else if (name == "window_funnel") {
-                if constexpr (ArgPT == TYPE_INT || ArgPT == TYPE_BIGINT || ArgPT == TYPE_DATE ||
-                              ArgPT == TYPE_DATETIME) {
-                    return AggregateFactory::MakeWindowfunnelAggregateFunction<ArgPT>();
+                if constexpr (arg_type == TYPE_INT || arg_type == TYPE_BIGINT || arg_type == TYPE_DATE ||
+                              arg_type == TYPE_DATETIME) {
+                    return AggregateFactory::MakeWindowfunnelAggregateFunction<arg_type>();
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -799,6 +799,12 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin(WINDOW_FUNNEL,
                 Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.INT, Type.ARRAY_BOOLEAN),
                 Type.INT, Type.ARRAY_BIGINT, false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(WINDOW_FUNNEL,
+                Lists.newArrayList(Type.BIGINT, Type.INT, Type.INT, Type.ARRAY_BOOLEAN),
+                Type.INT, Type.ARRAY_BIGINT, false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(WINDOW_FUNNEL,
+                Lists.newArrayList(Type.BIGINT, Type.BIGINT, Type.INT, Type.ARRAY_BOOLEAN),
+                Type.INT, Type.ARRAY_BIGINT, false, false, false));
 
         // analytic functions
         // Rank

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -822,6 +822,11 @@ public class AggregateTest extends PlanTestBase {
                 "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 3, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "window_funnel(1800, 11: L_SHIPDATE, 3, 18: expr)");
+
+        sql =
+                "select L_ORDERKEY,window_funnel(1800, L_LINENUMBER, 3, [L_PARTKEY = 1]) from lineitem_partition_colocate group by L_ORDERKEY;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "window_funnel(1800, 4: L_LINENUMBER, 3, 18: expr)");
         FeConstants.runningUnitTest = false;
     }
 


### PR DESCRIPTION
Reduce copy when access array daum.
Add BIGINT and INT as argument of window_funnel to remove cast costs.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
support BIGINT/INT and improve window_funnel