### PR TITLE
[BugFix] Fix compile failure issue

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -1651,8 +1651,8 @@ ColumnPtr StringFunctions::upper(FunctionContext* context, const Columns& column
 
 static inline void ascii_reverse_per_slice(const char* src_begin, const char* src_end, char* dst_curr) {
     auto src_curr = src_begin;
-    auto const size = src_end - src_begin;
 #if defined(__SSSE3__) && defined(__SSE2__)
+    auto const size = src_end - src_begin;
     constexpr auto SSE2_SIZE = sizeof(__m128i);
     const auto ctrl_masks = _mm_set_epi64((__m64)0x00'01'02'03'04'05'06'07ull, (__m64)0x08'09'0a'0b'0c'0d'0e'0full);
     const auto sse2_end = src_begin + (size & ~(SSE2_SIZE - 1));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

starrocks/be/src/exprs/vectorized/string_functions.cpp:1654:16: error: unused variable ‘size’ [-Werror=unused-variable]
 1654 |     auto const size = src_end - src_begin;
      |                ^~~~
cc1plus: all warnings being treated as errors