### PR TITLE
[Enhancement] Upgrade librdkafka from 1.7.0 to 1.8.2

### DIFF
--- a/thirdparty/patches/librdkafka.patch
+++ b/thirdparty/patches/librdkafka.patch
@@ -1,6 +1,6 @@
 --- src/rdkafka_broker.c
 +++ src/rdkafka_broker.c
-@@ -5409,7 +5409,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
+@@ -5467,7 +5467,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
   */
  void rd_kafka_broker_destroy_final (rd_kafka_broker_t *rkb) {
  

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -185,10 +185,10 @@ ROCKSDB_SOURCE=rocksdb-6.22.1
 ROCKSDB_MD5SUM="02727e52cdb94fa6a9dbbd68d157e619"
 
 # librdkafka
-LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.7.0.tar.gz"
-LIBRDKAFKA_NAME=librdkafka-1.7.0.tar.gz
-LIBRDKAFKA_SOURCE=librdkafka-1.7.0
-LIBRDKAFKA_MD5SUM="fe3c45deb182bd9c644b6bc6375bffc3"
+LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.8.2.tar.gz"
+LIBRDKAFKA_NAME=librdkafka-1.8.2.tar.gz
+LIBRDKAFKA_SOURCE=librdkafka-1.8.2
+LIBRDKAFKA_MD5SUM="0abec0888d10c9553cdcbcbf9172d558"
 
 # zstd
 ZSTD_DOWNLOAD="https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

On version 1.7.0, query_watermark call is not transaction-aware. If we use read-committed, we will get the `MaxOffset` not the `Last Stable offset`. FE recorded the `Last Stable offset` but got `MaxOffset`, FE try to consume Kafka because of the lag of offset. But the read-committed transaction level will not consume any data. FE will retrying again and again. This comes from the producer write large of message but not committed. libkafka 1.8.2 resolves this problem and we upgrade to it.

https://github.com/edenhill/librdkafka/issues/3423
