### PR TITLE
[Refactor]Adapt to refresh hive external table when processing some consistent cases.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTable.java
@@ -33,7 +33,4 @@ public interface HiveMetaStoreTable {
     void refreshPartCache(List<String> partNames) throws DdlException;
 
     void refreshTableColumnStats() throws DdlException;
-
-    default void modifyTableSchema(String dbName, String tableName) throws DdlException {
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -23,6 +23,8 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -208,16 +210,15 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         org.apache.hadoop.hive.metastore.api.Table table;
         try {
             table = hiveRepository.getTable(resourceName, this.hiveDbName, this.hiveTableName);
-            Map<String, FieldSchema> updatedTableSchemas = HiveMetaStoreTableUtils.getAllHiveColumns(table);
+            List<FieldSchema> updatedTableSchemas = HiveMetaStoreTableUtils.getAllHiveColumns(table);
             boolean needRefreshColumn = isRefreshColumn(updatedTableSchemas);
 
             if (!needRefreshColumn) {
                 refreshTableCache(nameToColumn);
             } else {
                 if (HiveMetaStoreTableUtils.isInternalCatalog(resourceName)) {
-                    refreshSchemaCache(table.getSd().getCols(), HiveMetaStoreTableUtils.getAllColumns(table));
+                    modifyTableSchema(dbName, tableName, table.getSd().getCols(), updatedTableSchemas);
                     refreshTableCache(nameToColumn);
-                    modifyTableSchema(dbName, tableName);
                 } else {
                     hiveRepository.refreshConnectorTable(resourceName, hiveDbName, hiveTableName);
                 }
@@ -238,7 +239,9 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         hiveRepository.refreshTableCache(hmsTableInfo);
     }
 
-    public boolean isRefreshColumn(Map<String, FieldSchema> updatedTableSchemas) throws DdlException {
+    public boolean isRefreshColumn(List<FieldSchema> tableSchemas) throws DdlException {
+        Map<String, FieldSchema> updatedTableSchemas = tableSchemas.stream()
+                .collect(Collectors.toMap(FieldSchema::getName, fieldSchema -> fieldSchema));
         boolean needRefreshColumn = updatedTableSchemas.size() != nameToColumn.size();
         if (!needRefreshColumn) {
             for (Column column : nameToColumn.values()) {
@@ -257,42 +260,43 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         return needRefreshColumn;
     }
 
-    private void refreshSchemaCache(List<FieldSchema> unpartHiveCols, List<FieldSchema> allHiveColumns)
+    private void modifyTableSchema(String dbName, String tableName,
+                                    List<FieldSchema> unpartHiveCols, List<FieldSchema> allHiveColumns)
             throws DdlException {
-        fullSchema.clear();
-        nameToColumn.clear();
+        ImmutableList.Builder<Column> fullSchemaTemp = ImmutableList.builder();
+        ImmutableMap.Builder<String, Column> nameToColumnTemp = ImmutableMap.builder();
+        ImmutableList.Builder<String> dataColumnNamesTemp = ImmutableList.builder();
+
+        // TODO: Column type conversion should not throw an exception, use invalidate type instead.
         for (FieldSchema fieldSchema : allHiveColumns) {
             Type srType = convertColumnType(fieldSchema.getType());
             Column column = new Column(fieldSchema.getName(), srType, true);
-            fullSchema.add(column);
-            nameToColumn.put(column.getName(), column);
+            fullSchemaTemp.add(column);
+            nameToColumnTemp.put(column.getName(), column);
         }
 
-        dataColumnNames.clear();
-        for (FieldSchema s : unpartHiveCols) {
-            this.dataColumnNames.add(s.getName());
-        }
-    }
-
-    @Override
-    public void modifyTableSchema(String dbName, String tableName) throws DdlException {
-        if (!GlobalStateMgr.getCurrentState().isLeader()) {
-            return;
-        }
+        unpartHiveCols.forEach(fieldSchema -> dataColumnNamesTemp.add(fieldSchema.getName()));
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
         if (db == null) {
             throw new DdlException("Not found database " + dbName);
         }
-        db.readLock();
+
+        db.writeLock();
         try {
-            Table hiveTable = db.getTable(tableName);
-            if (hiveTable == null) {
-                throw new DdlException("Not found table " + dbName + "." + tableName);
+            fullSchema.clear();
+            nameToColumn.clear();
+            dataColumnNames.clear();
+
+            fullSchema.addAll(fullSchemaTemp.build());
+            nameToColumn.putAll(nameToColumnTemp.build());
+            dataColumnNames.addAll(dataColumnNamesTemp.build());
+
+            if (GlobalStateMgr.getCurrentState().isLeader()) {
+                ModifyTableColumnOperationLog log = new ModifyTableColumnOperationLog(dbName, tableName, fullSchema);
+                GlobalStateMgr.getCurrentState().getEditLog().logModifyTableColumn(log);
             }
-            ModifyTableColumnOperationLog log = new ModifyTableColumnOperationLog(dbName, tableName, fullSchema);
-            GlobalStateMgr.getCurrentState().getEditLog().logModifyTableColumn(log);
         } finally {
-            db.readUnlock();
+            db.writeUnlock();
         }
     }
 
@@ -379,7 +383,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         }
         List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
         List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();
-        Map<String, FieldSchema> allHiveColumns = HiveMetaStoreTableUtils.getAllHiveColumns(hiveTable);
+        Map<String, FieldSchema> allHiveColumns = HiveMetaStoreTableUtils.getAllHiveColumns(hiveTable).stream()
+                .collect(Collectors.toMap(FieldSchema::getName, fieldSchema -> fieldSchema));
         for (Column column : this.fullSchema) {
             FieldSchema hiveColumn = allHiveColumns.get(column.getName());
             if (hiveColumn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3785,13 +3785,13 @@ public class LocalMetastore implements ConnectorMetadata {
         List<Column> columns = info.getColumns();
         Database db = getDb(hiveExternalDb);
         HiveTable table;
-        db.readLock();
+        db.writeLock();
         try {
             Table tbl = db.getTable(hiveExternalTable);
             table = (HiveTable) tbl;
             table.setNewFullSchema(columns);
         } finally {
-            db.readUnlock();
+            db.writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveTableTest.java
@@ -32,23 +32,23 @@ public class HiveTableTest {
         Map<String, FieldSchema> col1HiveSchemaMap = new HashMap<>();
         col1HiveSchemaMap.put(col1Schema.getName(), col1Schema);
         // no fresh
-        Assert.assertFalse(hiveTable.isRefreshColumn(col1HiveSchemaMap));
+        Assert.assertFalse(hiveTable.isRefreshColumn(Lists.newArrayList(col1Schema)));
 
         FieldSchema col2Schema = new FieldSchema("col2", "BIGINT", "");
         Map<String, FieldSchema> col2HiveSchemaMap = new HashMap<>();
         col2HiveSchemaMap.put(col2Schema.getName(), col2Schema);
         // different col name
-        Assert.assertTrue(hiveTable.isRefreshColumn(col2HiveSchemaMap));
+        Assert.assertTrue(hiveTable.isRefreshColumn(Lists.newArrayList(col2Schema)));
 
         // different col type
         FieldSchema col3Schema = new FieldSchema("col2", "INT", "");
         Map<String, FieldSchema> col3HiveSchemaMap = new HashMap<>();
         col2HiveSchemaMap.put(col3Schema.getName(), col3Schema);
-        Assert.assertTrue(hiveTable.isRefreshColumn(col3HiveSchemaMap));
+        Assert.assertTrue(hiveTable.isRefreshColumn(Lists.newArrayList(col3Schema)));
 
         col1HiveSchemaMap.put(col3Schema.getName(), col3Schema);
         // different col size
         col2HiveSchemaMap.put(col1Schema.getName(), col1Schema);
-        Assert.assertTrue(hiveTable.isRefreshColumn(col1HiveSchemaMap));
+        Assert.assertTrue(hiveTable.isRefreshColumn(Lists.newArrayList(col1Schema, col3Schema)));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Add writelock to prevent dirty read when processing hive external table schema change.
2. Prevent data race when refreshing at the same time. 
3. Prevent schema of table be cleared caused by type conversion failure

 