### PR TITLE
[BugFix] Fix histogram statistics convert date type error bug

### DIFF
--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -170,17 +170,19 @@ Status StatisticResultWriter::_fill_statistic_data_v1(int version, const vectori
 Status StatisticResultWriter::_fill_statistic_histogram(int version, const vectorized::Columns& columns,
                                                         const vectorized::Chunk* chunk, TFetchDataResult* result) {
     SCOPED_TIMER(_serialize_timer);
-    DCHECK(columns.size() == 4);
+    DCHECK(columns.size() == 5);
 
-    auto& tableIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[1])->get_data();
-    BinaryColumn* nameColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[2].get()));
-    BinaryColumn* histogramColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[3].get()));
+    auto& dbIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[1])->get_data();
+    auto& tableIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[2])->get_data();
+    BinaryColumn* nameColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[3].get()));
+    BinaryColumn* histogramColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[4].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();
 
     data_list.resize(num_rows);
     for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_dbId(dbIds[i]);
         data_list[i].__set_tableId(tableIds[i]);
         data_list[i].__set_columnName(nameColumn->get_slice(i).to_string());
         data_list[i].__set_histogram(histogramColumn->get_slice(i).to_string());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -38,10 +38,13 @@ import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnStatsCacheKey, Optional<Histogram>> {
     private static final Logger LOG = LogManager.getLogger(ColumnBasicStatsCacheLoader.class);
     private final StatisticExecutor statisticExecutor = new StatisticExecutor();
+    private static DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     @Override
-    public @NonNull CompletableFuture<Optional<Histogram>> asyncLoad(@NonNull ColumnStatsCacheKey cacheKey,
-                                                                     @NonNull Executor executor) {
+    public @NonNull
+    CompletableFuture<Optional<Histogram>> asyncLoad(@NonNull ColumnStatsCacheKey cacheKey,
+                                                     @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 List<TStatisticData> statisticData =
@@ -129,13 +132,13 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
             double low;
             double high;
             if (type.isDate()) {
-                DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMdd");
-                low = (double) getLongFromDateTime(LocalDate.parse(bucketJsonArray.get(0).getAsString(), dtf).atStartOfDay());
-                high = (double) getLongFromDateTime(LocalDate.parse(bucketJsonArray.get(1).getAsString(), dtf).atStartOfDay());
+                low = (double) getLongFromDateTime(
+                        LocalDate.parse(bucketJsonArray.get(0).getAsString(), dateFormatter).atStartOfDay());
+                high = (double) getLongFromDateTime(
+                        LocalDate.parse(bucketJsonArray.get(1).getAsString(), dateFormatter).atStartOfDay());
             } else if (type.isDatetime()) {
-                DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-                low = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(0).getAsString(), dtf));
-                high = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(1).getAsString(), dtf));
+                low = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(0).getAsString(), dateTimeFormatter));
+                high = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(1).getAsString(), dateTimeFormatter));
             } else {
                 low = Double.parseDouble(bucketJsonArray.get(0).getAsString());
                 high = Double.parseDouble(bucketJsonArray.get(1).getAsString());
@@ -159,11 +162,10 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
 
             double key;
             if (type.isDate()) {
-                DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMdd");
-                key = (double) getLongFromDateTime(LocalDate.parse(bucketJsonArray.get(0).getAsString(), dtf).atStartOfDay());
+                key = (double) getLongFromDateTime(
+                        LocalDate.parse(bucketJsonArray.get(0).getAsString(), dateFormatter).atStartOfDay());
             } else if (type.isDatetime()) {
-                DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-                key = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(0).getAsString(), dtf));
+                key = (double) getLongFromDateTime(LocalDateTime.parse(bucketJsonArray.get(0).getAsString(), dateTimeFormatter));
             } else {
                 key = Double.parseDouble(bucketJsonArray.get(0).getAsString());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -13,8 +13,9 @@ import static com.starrocks.statistic.StatsConstants.HISTOGRAM_STATISTICS_TABLE_
 
 public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     private static final String COLLECT_HISTOGRAM_STATISTIC_TEMPLATE =
-            "SELECT $tableId, '$columnName', '$dbName.$tableName', histogram($columnName, $bucketNum, $sampleRatio, $topN )"
-                    + " FROM (SELECT * FROM $dbName.$tableName $sampleTabletHint ORDER BY $columnName LIMIT $totalRows) t";
+            "SELECT $tableId, '$columnName', $dbId, '$dbName.$tableName'," +
+                    " histogram($columnName, $bucketNum, $sampleRatio, $topN), NOW()" +
+                    " FROM (SELECT * FROM $dbName.$tableName $sampleTabletHint ORDER BY $columnName LIMIT $totalRows) t";
 
     public HistogramStatisticsCollectJob(Database db, OlapTable table, List<String> columns,
                                          StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
@@ -46,6 +47,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         VelocityContext context = new VelocityContext();
         context.put("tableId", table.getId());
         context.put("columnName", columnName);
+        context.put("dbId", database.getId());
         context.put("dbName", database.getOriginName());
         context.put("tableName", table.getName());
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -39,7 +39,7 @@ public class StatisticSQLBuilder {
                     + " GROUP BY db_id, table_id, column_name";
 
     private static final String QUERY_HISTOGRAM_STATISTIC_TEMPLATE =
-            "SELECT cast(" + STATISTIC_HISTOGRAM_VERSION + " as INT), table_id, column_name, histogram"
+            "SELECT cast(" + STATISTIC_HISTOGRAM_VERSION + " as INT), db_id, table_id, column_name, histogram"
                     + " FROM " + StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME
                     + " WHERE $predicate";
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -93,8 +93,10 @@ public class StatisticsMetaManager extends LeaderDaemon {
         HISTOGRAM_STATISTICS_COLUMNS = ImmutableList.of(
                 new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
                 new ColumnDef("column_name", new TypeDef(columnNameType)),
+                new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
                 new ColumnDef("table_name", new TypeDef(tableNameType)),
-                new ColumnDef("histogram", new TypeDef(histogramType))
+                new ColumnDef("histogram", new TypeDef(histogramType)),
+                new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
         );
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/HistogramCacheLoaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/HistogramCacheLoaderTest.java
@@ -1,0 +1,87 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.statistic;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.statistics.Bucket;
+import com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader;
+import com.starrocks.sql.optimizer.statistics.Histogram;
+import com.starrocks.thrift.TStatisticData;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HistogramCacheLoaderTest {
+    public static ConnectContext connectContext;
+    public static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        String DB_NAME = "test";
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+
+        starRocksAssert.withTable("CREATE TABLE `t0` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL COMMENT \"\",\n" +
+                "  `v4` date NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+    }
+
+    @Test
+    public void testCovertHistogramStatistics() {
+        Database db = connectContext.getGlobalStateMgr().getDb("default_cluster:test");
+        OlapTable table = (OlapTable) db.getTable("t0");
+        ColumnHistogramStatsCacheLoader columnHistogramStatsCacheLoader
+                = Deencapsulation.newInstance(ColumnHistogramStatsCacheLoader.class);
+
+        TStatisticData statisticData = new TStatisticData();
+        statisticData.setDbId(db.getId());
+        statisticData.setTableId(table.getId());
+        statisticData.setColumnName("v1");
+        statisticData.setHistogram("{ \"buckets\" : [[\"2\",\"7\",\"6\",\"1\"],[\"8\",\"13\",\"12\",\"1\"]," +
+                "[\"14\",\"21\",\"18\",\"1\"],[\"22\",\"28\",\"24\",\"1\"],[\"29\",\"35\",\"30\",\"1\"]], " +
+                "\"top-n\" : [[\"27\",\"8\"],[\"19\",\"5\"],[\"20\",\"4\"]] }");
+
+        Histogram histogram = Deencapsulation.invoke(columnHistogramStatsCacheLoader, "convert2Histogram", statisticData);
+        Assert.assertEquals(5, histogram.getBuckets().size());
+        Bucket bucket = histogram.getBuckets().get(0);
+        Assert.assertEquals(2, bucket.getLower(), 0.1);
+        Assert.assertEquals(7, bucket.getUpper(), 0.1);
+        Assert.assertEquals(6, bucket.getCount(), 0.1);
+        Assert.assertEquals(1, bucket.getUpperRepeats(), 0.1);
+
+        Assert.assertEquals(3, histogram.getTopN().size());
+        Assert.assertEquals("{19.0=5, 20.0=4, 27.0=8}", histogram.getTopN().toString());
+
+        statisticData.setColumnName("v4");
+        statisticData.setHistogram("{ \"buckets\" : [[\"20220102\",\"20220107\",\"6\",\"1\"],[\"20220108\",\"20220113\",\"12\",\"1\"]," +
+                "[\"20220114\",\"20220121\",\"18\",\"1\"],[\"20220122\",\"20220128\",\"24\",\"1\"],[\"20220129\",\"20220130\",\"30\",\"1\"]], " +
+                "\"top-n\" : [[\"20220127\",\"8\"],[\"20220119\",\"5\"],[\"20220120\",\"4\"]] }");
+
+        histogram = Deencapsulation.invoke(columnHistogramStatsCacheLoader, "convert2Histogram", statisticData);
+        bucket = histogram.getBuckets().get(0);
+        Assert.assertEquals(1.6410528E9, bucket.getLower(), 0.1);
+        Assert.assertEquals(1.6414848E9, bucket.getUpper(), 0.1);
+        Assert.assertEquals(6, bucket.getCount(), 0.1);
+        Assert.assertEquals(1, bucket.getUpperRepeats(), 0.1);
+        Assert.assertEquals("{1.6425216E9=5, 1.6432128E9=8, 1.642608E9=4}", histogram.getTopN().toString());
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Because the date toString type used in BE is a literal value of time, such as "20200101". When FE calculates statistics, EpochSecond is used. The conversion needs to be done when getting the stats, otherwise it won't correspond.
