### PR TITLE
[BugFix] fix the deadlock of resource group

### DIFF
--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -272,10 +272,14 @@ public:
     void update_metrics();
 
 private:
+    using MutexType = std::shared_mutex;
+    using UniqueLockType = std::unique_lock<MutexType>;
+    using SharedLockType = std::shared_lock<MutexType>;
+
     // {create, alter,delete}_workgroup_unlocked is used to replay WorkGroupOps.
     // WorkGroupManager::_mutex is held when invoking these method.
-    void create_workgroup_unlocked(const WorkGroupPtr& wg);
-    void alter_workgroup_unlocked(const WorkGroupPtr& wg);
+    void create_workgroup_unlocked(const WorkGroupPtr& wg, UniqueLockType& lock);
+    void alter_workgroup_unlocked(const WorkGroupPtr& wg, UniqueLockType& lock);
     void delete_workgroup_unlocked(const WorkGroupPtr& wg);
 
     // Label each executor thread to a specific workgroup by cpu limit.
@@ -306,7 +310,7 @@ private:
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_concurrency_overflow_count;
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_bigquery_count;
 
-    void add_metrics_unlocked(const WorkGroupPtr& wg);
+    void add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockType& unique_lock);
     void update_metrics_unlocked();
 };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9142

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Deadlock:
- When register metric for resource group: take the `WorkGroupManager::mutex`, then `MetricRegistry::mutex`
- When update metric for resource group: take the `MetricRegistry::mutex`, then `WorkGroupManager::mutex`

As a fix, release the `WorkGroupManager::mutex` when registering metric, and using the return value to indicate register success or not.