### PR TITLE
[BugFix] Primary key length is inconsistent with be

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1535,7 +1535,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                 return false;
             }
             // calculate key size
-            keyLength += column.getPrimitiveType().getSlotSize();
+            keyLength += column.getPrimitiveType().getOlapColumnIndexSize();
         }
         if (keyLength > 64) {
             LOG.warn("Primary key size of primaryKey table using persistent index should be no more than 64Bytes");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1535,7 +1535,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                 return false;
             }
             // calculate key size
-            keyLength += column.getPrimitiveType().getOlapColumnIndexSize();
+            keyLength += column.getOlapColumnIndexSize();
         }
         if (keyLength > 64) {
             LOG.warn("Primary key size of primaryKey table using persistent index should be no more than 64Bytes");


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PersistentIndex is available in version 2.3, but there are many limitations in key columns. For example, key column is not supported as varchar(char) type, and the length of key columns cannot exceed 64 bytes.

However, the calculate logic in fe is inconsistent with be right now(DATE/DATETIME), so we may reject some create request actually we can do.