### PR TITLE
[Bugfix] Retry when fail to start a local bdb cluster in UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -118,7 +118,23 @@ public class BDBEnvironmentTest {
     private File[] followerPaths = new File[2];
     private String[] followerNames = new String[2];
 
+
     private void initClusterMasterFollower() throws Exception {
+        for (int i = 0; i != 3; ++ i) {
+            // might fail on high load, will sleep and retry
+            try {
+                initClusterMasterFollowerNoRetry();
+                return;
+            } catch (Exception e) {
+                // sleep 5 ~ 15 seconds
+                int sleepSeconds = new Random().nextInt() % 10 + 5;
+                LOG.warn("failed to initClusterMasterFollower! will sleep {} seconds and retry", sleepSeconds);
+                Thread.sleep(sleepSeconds * 1000L);
+            }
+        }
+
+    }
+    private void initClusterMasterFollowerNoRetry() throws Exception {
         // setup master
         masterNodeHostPort = findUnbindHostPort();
         masterPath = createTmpDir();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
UT on the BDB cluster will sometimes fail when there are a lot of job running and the load are very high and will succeed most of the time after retry. I'm adding an automatic retry when creating the cluster.