### PR TITLE
[Bugfix] Non-local one-phase agg prefers pipeline parallel 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1294,7 +1294,7 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             // One phase aggregation prefer the inter-instance parallel to avoid local shuffle
-            if (node.isOnePhaseAgg()) {
+            if (node.isOnePhaseAgg() && hasNoExchangeNodes(inputFragment.getPlanRoot())) {
                 estimateDopOfOnePhaseAgg(inputFragment);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -5,11 +5,15 @@ package com.starrocks.sql.plan;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -1558,5 +1562,57 @@ public class AggregateTest extends PlanTestBase {
                 "  |  cross join:\n" +
                 "  |  predicates: CAST(12: sum AS DOUBLE) / CAST(14: count AS DOUBLE) > 3.0");
         connectContext.getSessionVariable().setCboCteReuse(false);
+    }
+
+    @Test
+    public void testParallelism() throws Exception {
+        int numCores = 8;
+        int expectedParallelism = numCores / 2;
+        new MockUp<BackendCoreStat>() {
+            @Mock
+            public int getAvgNumOfHardwareCoresOfBe() {
+                return numCores;
+            }
+        };
+
+        new MockUp<DistributionSpec.PropertyInfo>() {
+            @Mock
+            public boolean isSinglePartition() {
+                return true;
+            }
+        };
+
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        int prevNewPlannerAggStage = sessionVariable.getNewPlannerAggStage();
+        try {
+            sessionVariable.setNewPlanerAggStage(1);
+
+            // Local one-phase aggregation prefers instance parallel.
+            String sql = "SELECT v1, count(1) from t0 group by v1";
+            ExecPlan plan = getExecPlan(sql);
+            PlanFragment fragment = plan.getFragments().get(0);
+            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "1:AGGREGATE (update finalize)\n" +
+                    "  |  output: count(1)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+            Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
+            Assert.assertEquals(1, fragment.getPipelineDop());
+
+            // None-local one-phase aggregation prefers pipeline parallel.
+            sql = "SELECT v2, count(1) from t0 group by v2";
+            plan = getExecPlan(sql);
+            fragment = plan.getFragments().get(0);
+            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "2:AGGREGATE (update finalize)\n" +
+                    "  |  output: count(1)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  1:EXCHANGE");
+            Assert.assertEquals(1, fragment.getParallelExecNum());
+            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        } finally {
+            sessionVariable.setNewPlanerAggStage(prevNewPlannerAggStage);
+        }
+
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- The source node of non-local one-phase agg is exchange source.
- `parallel_fragment_exec_instance_num` of fragment with exchange source is set to 1 when `pipeline_dop==0` in `Coordinator::computeFragmentHosts()`.

```java
    private void computeFragmentHosts() throws Exception {
            if (!(leftMostNode instanceof ScanNode)) {
                if (dopAdaptionEnabled) {
                    Preconditions.checkArgument(leftMostNode instanceof ExchangeNode);
                    maxParallelism = hostSet.size();
                }
           }
    }
```


Therefore, Non-local one-phase aggregation should prefer pipeline parallel not instance parallel. Otherwise, it will set `parallel_fragment_exec_instance_num` to 1 by `Coordinator::computeFragmentHosts()` and `pipeline_dop` to 1 by `preferPipeline()`

In addition, distinct_blocking_node with exchange source needn't local shuffle.

Main branch doesn't have these two problems, which is fixed by "Assign tablet ranges for each scan operator" #7593.