### PR TITLE
Fix stats npe with unknown column when query with low card optimize

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -1,0 +1,30 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.statistic;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+public class StatisticExecutorTest extends PlanTestBase {
+    @Test
+    public void testEmpty() throws Exception {
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
+        Database db = GlobalStateMgr.getCurrentState().getDb(10002);
+        OlapTable olapTable = (OlapTable) db.getTable("t0");
+
+        GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(10002, olapTable.getId(),
+                StatsConstants.AnalyzeType.FULL,
+                LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+                Maps.newHashMap()));
+
+        Assert.assertThrows(IllegalStateException.class,
+                () -> statisticExecutor.queryStatisticSync(db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
http://39.101.206.100:8090/view/Daily/job/master_release/1192/testReport/test_query/TestLowCard/test_query_lowcard_npe/
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When low cardinality query optimization is turned on, there may be columns that do not exist in the table, which will lead to NPE when the statistics sql is built

During low cardinality optimization, a new type of columnRef of type agg+column_name will be constructed and filled into LogicalMetaScan. resulting in columns that are not present in the table. Currently modified to column name to get statistics