### PR TITLE
[Bugfix] Fix window_funnel crash when input array has null

### DIFF
--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -99,7 +99,7 @@ public:
         _null_column->resize(n);
     }
 
-    void resize_uninitialized(size_t n) {
+    void resize_uninitialized(size_t n) override {
         _data_column->resize_uninitialized(n);
         _null_column->resize_uninitialized(n);
     }

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -144,6 +144,8 @@ struct WindowFunnelState {
                 ++curr;
             }
             array_column->append_datum(array);
+        } else {
+            array_column->append_default();
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #9190 

## Problem Summary(Required) ：
if event_list was empty, serialize should append a empty array