### PR TITLE
[BugFix] allow deprecated variables forward to master by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -553,7 +553,14 @@ public class VariableMgr {
     }
 
     public static boolean shouldForwardToLeader(String name) {
-        return (getVarContext(name).getFlag() & DISABLE_FORWARD_TO_LEADER) == 0;
+        VarContext varContext = getVarContext(name);
+        if (varContext == null) {
+            // DEPRECATED_VARIABLES like enable_cbo don't have flag
+            // we simply assume they all can forward to leader
+            return true;
+        } else {
+            return (varContext.getFlag() & DISABLE_FORWARD_TO_LEADER) == 0;
+        }
     }
 
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/839

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix NPE when trying to get flag from deprecated variables such as 'enable_vectorized_engine' and 'enable_cbo'