### PR TITLE
[Bugfix] clear rowsets before load (#9193)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -169,6 +169,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     // Load all rowsets of this tablet into memory.
     // NOTE: This may change in a near future, e.g, manage rowsets in a separate module and load
     // them on demand.
+    _rowsets.clear();
     RETURN_IF_ERROR(TabletMetaManager::rowset_iterate(
             _tablet.data_dir(), _tablet.tablet_id(), [&](const RowsetMetaSharedPtr& rowset_meta) -> bool {
                 RowsetSharedPtr rowset;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

Cherrypick: #9193
Fixes: #9192

SchemaChange will call _load_from_pb to reload metadata, but _load_from_pb forgets to reset _rowsets vector, so some old rowsets may still be stored in _rowsets, causing no delvec found error, because the delvec corresponds to the old rowset is already removed. This PR clears _rowsets vector before load new rowsets from meta.
