### PR TITLE
[StarRocks On ES] generate match_all query when all predicates cannot…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/QueryConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/QueryConverter.java
@@ -41,6 +41,7 @@ public class QueryConverter extends AstVisitor<QueryBuilders.QueryBuilder, Void>
         return remoteConjuncts;
     }
 
+    // used for test
     public QueryBuilders.QueryBuilder convert(Expr conjunct) {
         return visit(conjunct);
     }
@@ -59,6 +60,9 @@ public class QueryConverter extends AstVisitor<QueryBuilders.QueryBuilder, Void>
             } catch (Exception e) {
                 localConjuncts.add(conjunct.clone());
             }
+        }
+        if (remoteConjuncts.size() == 0) {
+            return QueryBuilders.matchAllQuery();
         }
         return boolQueryBuilder;
     }


### PR DESCRIPTION
… push-down

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
if all predicate can not push down , match_all query would generated



