### PR TITLE
[Enhancement] reduce eq conjunct count for building global runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BeLoadRebalancer.java
@@ -106,7 +106,7 @@ public class BeLoadRebalancer extends Rebalancer {
                 b -> b.getAvailPathNum(medium)).sum();
         LOG.info("get number of low load paths: {}, with medium: {}", numOfLowPaths, medium);
 
-        int clusterAvailableBEnum = infoService.getBackendIds(true).size();
+        int clusterAvailableBEnum = infoService.getAliveBackendSize();
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentColocateIndex();
         // choose tablets from high load backends.
         // BackendLoadStatistic is sorted by load score in ascend order,

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
@@ -44,7 +44,7 @@ public class HealthAction extends RestBaseAction {
 
         RestResult result = new RestResult();
         result.addResultEntry("total_backend_num", GlobalStateMgr.getCurrentSystemInfo().getBackendIds(false).size());
-        result.addResultEntry("online_backend_num", GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
+        result.addResultEntry("online_backend_num", GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
         sendResult(request, response, result);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -196,7 +196,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public int calculateCurrentConcurrentTaskNum() throws MetaNotFoundException {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        int aliveBeNum = systemInfoService.getBackendIds(true).size();
+        int aliveBeNum = systemInfoService.getAliveBackendSize();
         int partitionNum = currentKafkaPartitions.size();
         if (desireTaskConcurrentNum == 0) {
             desireTaskConcurrentNum = Config.max_routine_load_task_concurrent_num;

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
@@ -33,7 +33,7 @@ public class ScheduleRule {
     private static int deadBeCount(String clusterName) {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         int total = systemInfoService.getBackendIds(false).size();
-        int alive = systemInfoService.getBackendIds(true).size();
+        int alive = systemInfoService.getAliveBackendSize();
         return total - alive;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
@@ -208,7 +208,7 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         sb.append(NODE_INFO).append("{type=\"be_node_num\", state=\"total\"} ")
                 .append(GlobalStateMgr.getCurrentSystemInfo().getBackendIds(false).size()).append("\n");
         sb.append(NODE_INFO).append("{type=\"be_node_num\", state=\"alive\"} ")
-                .append(GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size()).append("\n");
+                .append(GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize()).append("\n");
         sb.append(NODE_INFO).append("{type=\"be_node_num\", state=\"decommissioned\"} ")
                 .append(GlobalStateMgr.getCurrentSystemInfo().getDecommissionedBackendIds().size()).append("\n");
         sb.append(NODE_INFO).append("{type=\"broker_node_num\", state=\"dead\"} ").append(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -209,7 +209,6 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         }
 
         int equalCount = computeEqualCount(eqJoinConjuncts);
-
         for (int i = 0; i < eqJoinConjuncts.size(); ++i) {
             BinaryPredicate joinConjunct = eqJoinConjuncts.get(i);
             Preconditions.checkArgument(BinaryPredicate.IS_EQ_NULL_PREDICATE.apply(joinConjunct) ||

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -892,6 +892,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return globalRuntimeFilterProbeMinSelectivity;
     }
 
+    public void setGlobalRuntimeFilterBuildMaxSize(long v) {
+        globalRuntimeFilterBuildMaxSize = v;
+    }
+
+    public void setGlobalRuntimeFilterProbeMinSize(long v) {
+        globalRuntimeFilterProbeMinSize = v;
+    }
+
+    public void setGlobalRuntimeFilterProbeMinSelectivity(float v) {
+        globalRuntimeFilterProbeMinSelectivity = v;
+    }
+
     public boolean isEnableDeliverBatchFragments() {
         return enableDeliverBatchFragments;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1518,7 +1518,7 @@ public class LocalMetastore implements ConnectorMetadata {
         if (partitions.isEmpty()) {
             return;
         }
-        int numAliveBackends = systemInfoService.getBackendIds(true).size();
+        int numAliveBackends = systemInfoService.getAliveBackendSize();
         int numReplicas = 0;
         for (Partition partition : partitions) {
             numReplicas += partition.getReplicaCount();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -447,7 +447,7 @@ public class Utils {
                                               Collection<Long> selectedPartitionId,
                                               Collection<Long> selectedTabletId) {
         int backendSize = GlobalStateMgr.getCurrentSystemInfo().backendSize();
-        int aliveBackendSize = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size();
+        int aliveBackendSize = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize();
         int schemaHash = table.getSchemaHashByIndexId(selectedIndexId);
         for (Long partitionId : selectedPartitionId) {
             Partition partition = table.getPartition(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -210,9 +210,8 @@ public class CostModel {
                 case BROADCAST:
                     int parallelExecInstanceNum = Math.max(1, getParallelExecInstanceNum(context));
                     // beNum is the number of right table should broadcast, now use alive backends
-                    int beNum = Math.max(1, GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
-                    result = CostEstimate.of(statistics.getOutputSize(outputColumns) *
-                                    GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size(),
+                    int beNum = Math.max(1, GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
+                    result = CostEstimate.of(statistics.getOutputSize(outputColumns) * beNum,
                             statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum,
                             Math.max(statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum, 1));
                     if (statistics.getOutputSize(outputColumns) > sessionVariable.getMaxExecMemByte()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
@@ -78,7 +78,7 @@ public class QueryDumpSerializer implements JsonSerializer<QueryDumpInfo> {
         }
         dumpJson.add("column_statistics", tableColumnStatistics);
         // 7. BE number
-        long beNum = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size();
+        long beNum = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize();
         dumpJson.addProperty("be_number", beNum);
         // 8. exception
         JsonArray exceptions = new JsonArray();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -246,7 +246,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         int parallelExecInstance = Math.max(1,
                 Math.min(groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum(),
                         ConnectContext.get().getSessionVariable().getDegreeOfParallelism()));
-        int beNum = Math.max(1, GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
+        int beNum = Math.max(1, GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
         Statistics leftChildStats = groupExpression.getInputs().get(curChildIndex - 1).getStatistics();
         Statistics rightChildStats = groupExpression.getInputs().get(curChildIndex).getStatistics();
         if (leftChildStats == null || rightChildStats == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -135,7 +135,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
     }
 
     private boolean checkReplicateNormal(String tableName) {
-        int aliveSize = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size();
+        int aliveSize = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize();
         int total = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(false).size();
         // maybe cluster just shutdown, ignore
         if (aliveSize <= total / 2) {
@@ -185,7 +185,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3,
-                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
+                GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName, SAMPLE_STATISTICS_COLUMNS, "olap",
@@ -213,7 +213,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 StatsConstants.FULL_STATISTICS_TABLE_NAME);
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3,
-                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
+                GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName, FULL_STATISTICS_COLUMNS, "olap",
@@ -241,7 +241,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3,
-                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size());
+                GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName, HISTOGRAM_STATISTICS_COLUMNS, "olap",

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -52,6 +52,7 @@ import com.starrocks.common.util.NetUtils;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.DropComputeNodeLog;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
@@ -251,8 +252,8 @@ public class SystemInfoService {
                 formatSb.append(be.getHost() + ":" + be.getHeartbeatPort() + "\n");
             }
             opMessage = String.format(
-                formatSb.toString(), willBeModifiedHost,
-                updateBackend.getHeartbeatPort(), fqdn, candidateBackends.size() - 1);
+                    formatSb.toString(), willBeModifiedHost,
+                    updateBackend.getHeartbeatPort(), fqdn, candidateBackends.size() - 1);
         } else {
             opMessage = String.format(formatSb.toString(), willBeModifiedHost, updateBackend.getHeartbeatPort(), fqdn);
         }
@@ -564,6 +565,10 @@ public class SystemInfoService {
             }
             return backendIds;
         }
+    }
+
+    public int getAliveBackendSize() {
+        return getBackendIds(true).size();
     }
 
     public int backendSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -52,7 +52,6 @@ import com.starrocks.common.util.NetUtils;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.DropComputeNodeLog;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -422,7 +422,7 @@ public class UtFrameUtils {
         connectContext.setSessionVariable(replayDumpInfo.getSessionVariable());
         // create table
         int backendId = 10002;
-        int backendIdSize = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size();
+        int backendIdSize = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize();
         for (int i = 1; i < backendIdSize; ++i) {
             UtFrameUtils.dropMockBackend(backendId++);
         }
@@ -482,7 +482,7 @@ public class UtFrameUtils {
 
     private static void tearMockEnv() {
         int backendId = 10002;
-        int backendIdSize = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).size();
+        int backendIdSize = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendSize();
         for (int i = 1; i < backendIdSize; ++i) {
             try {
                 UtFrameUtils.dropMockBackend(backendId++);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Sometimes we come across following join 

```
  |  join op: INNER JOIN (PARTITIONED)
  |  equal join conjunct: [3: ss_sold_date_sk, INT, true] = [28: cc_closed_date_sk, INT, true]
  |  equal join conjunct: [3: ss_sold_date_sk, INT, true] = [59: cc_closed_date_sk, INT, true]
  |  build runtime filters:
  |  - filter_id = 1, build_expr = (28: cc_closed_date_sk), remote = true
  |  - filter_id = 2, build_expr = (59: cc_closed_date_sk), remote = true
```

You can see jon conjuncts are transitive, we can we reduce them into one equal conjunct, which is good for global runtime filter(current implementation)
