### PR TITLE
[BugFix] speed up when replaying too many journals

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -274,9 +274,9 @@ public class GlobalStateMgr {
     public static final long NEXT_ID_INIT_VALUE = 10000;
     private static final int REPLAY_INTERVAL_MS = 1;
     private static final String IMAGE_DIR = "/image";
-    // will break the loop and refresh in-memory data after at most 1k logs or at most 1 seconds
+    // will break the loop and refresh in-memory data after at most 10w logs or at most 1 seconds
     private static final long REPLAYER_MAX_MS_PER_LOOP = 1000L;
-    private static final long REPLAYER_MAX_LOGS_PER_LOOP = 1000L;
+    private static final long REPLAYER_MAX_LOGS_PER_LOOP = 100000L;
 
     private String metaDir;
     private String imageDir;
@@ -1554,6 +1554,9 @@ public class GlobalStateMgr {
     public void createReplayer() {
         replayer = new Daemon("replayer", REPLAY_INTERVAL_MS) {
             private JournalCursor cursor = null;
+            // avoid numerous 'meta out of date' log
+            private long lastMetaOutOfDateLogTime = 0;
+            private long META_OUT_OF_DATE_LOG_INTERVAL_SECONDS = 5;
 
             @Override
             @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
@@ -1589,54 +1592,50 @@ public class GlobalStateMgr {
 
                 setCanRead(hasLog, err);
             }
+
+            private void setCanRead(boolean hasLog, boolean err) {
+                if (err) {
+                    canRead.set(false);
+                    isReady.set(false);
+                    return;
+                }
+
+                if (Config.ignore_meta_check) {
+                    // can still offer read, but is not ready
+                    canRead.set(true);
+                    isReady.set(false);
+                    return;
+                }
+
+                long currentTimeMs = System.currentTimeMillis();
+                if (currentTimeMs - synchronizedTimeMs > Config.meta_delay_toleration_second * 1000L) {
+                    if (currentTimeMs - lastMetaOutOfDateLogTime > META_OUT_OF_DATE_LOG_INTERVAL_SECONDS * 1000L) {
+                        // we still need this log to observe this situation
+                        // but service may be continued when there is no log being replayed.
+                        LOG.warn("meta out of date. current time: {}, synchronized time: {}, has log: {}, fe type: {}",
+                                currentTimeMs, synchronizedTimeMs, hasLog, feType);
+                    }
+                    if (hasLog || feType == FrontendNodeType.UNKNOWN) {
+                        // 1. if we read log from BDB, which means master is still alive.
+                        // So we need to set meta out of date.
+                        // 2. if we didn't read any log from BDB and feType is UNKNOWN,
+                        // which means this non-master node is disconnected with master.
+                        // So we need to set meta out of date either.
+                        metaReplayState.setOutOfDate(currentTimeMs, synchronizedTimeMs);
+                        canRead.set(false);
+                        isReady.set(false);
+                    }
+                } else {
+                    canRead.set(true);
+                    isReady.set(true);
+                }
+            }
         };
 
         replayer.setMetaContext(metaContext);
     }
 
-    private void setCanRead(boolean hasLog, boolean err) {
-        if (err) {
-            canRead.set(false);
-            isReady.set(false);
-            return;
-        }
 
-        if (Config.ignore_meta_check) {
-            // can still offer read, but is not ready
-            canRead.set(true);
-            isReady.set(false);
-            return;
-        }
-
-        long currentTimeMs = System.currentTimeMillis();
-        if (currentTimeMs - synchronizedTimeMs > Config.meta_delay_toleration_second * 1000L) {
-            // we still need this log to observe this situation
-            // but service may be continued when there is no log being replayed.
-            LOG.warn("meta out of date. current time: {}, synchronized time: {}, has log: {}, fe type: {}",
-                    currentTimeMs, synchronizedTimeMs, hasLog, feType);
-            if (hasLog || feType == FrontendNodeType.UNKNOWN) {
-                // 1. if we read log from BDB, which means master is still alive.
-                // So we need to set meta out of date.
-                // 2. if we didn't read any log from BDB and feType is UNKNOWN,
-                // which means this non-master node is disconnected with master.
-                // So we need to set meta out of date either.
-                metaReplayState.setOutOfDate(currentTimeMs, synchronizedTimeMs);
-                canRead.set(false);
-                isReady.set(false);
-            }
-
-            // sleep 5s to avoid numerous 'meta out of date' log
-            try {
-                Thread.sleep(5000L);
-            } catch (InterruptedException e) {
-                LOG.error("unhandled exception when sleep", e);
-            }
-
-        } else {
-            canRead.set(true);
-            isReady.set(true);
-        }
-    }
     /**
       * Replay journal from replayedJournalId + 1 to toJournalId
       * used by checkpointer/replay after state change

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1556,7 +1556,6 @@ public class GlobalStateMgr {
             private JournalCursor cursor = null;
             // avoid numerous 'meta out of date' log
             private long lastMetaOutOfDateLogTime = 0;
-            private long metaOutOfDateLogIntervalSeconds = 5;
 
             @Override
             @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
@@ -1609,7 +1608,7 @@ public class GlobalStateMgr {
 
                 long currentTimeMs = System.currentTimeMillis();
                 if (currentTimeMs - synchronizedTimeMs > Config.meta_delay_toleration_second * 1000L) {
-                    if (currentTimeMs - lastMetaOutOfDateLogTime > metaOutOfDateLogIntervalSeconds * 1000L) {
+                    if (currentTimeMs - lastMetaOutOfDateLogTime > 5 * 1000L) {
                         // we still need this log to observe this situation
                         // but service may be continued when there is no log being replayed.
                         LOG.warn("meta out of date. current time: {}, synchronized time: {}, has log: {}, fe type: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1556,7 +1556,7 @@ public class GlobalStateMgr {
             private JournalCursor cursor = null;
             // avoid numerous 'meta out of date' log
             private long lastMetaOutOfDateLogTime = 0;
-            private long META_OUT_OF_DATE_LOG_INTERVAL_SECONDS = 5;
+            private long metaOutOfDateLogIntervalSeconds = 5;
 
             @Override
             @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
@@ -1609,7 +1609,7 @@ public class GlobalStateMgr {
 
                 long currentTimeMs = System.currentTimeMillis();
                 if (currentTimeMs - synchronizedTimeMs > Config.meta_delay_toleration_second * 1000L) {
-                    if (currentTimeMs - lastMetaOutOfDateLogTime > META_OUT_OF_DATE_LOG_INTERVAL_SECONDS * 1000L) {
+                    if (currentTimeMs - lastMetaOutOfDateLogTime > metaOutOfDateLogIntervalSeconds * 1000L) {
                         // we still need this log to observe this situation
                         // but service may be continued when there is no log being replayed.
                         LOG.warn("meta out of date. current time: {}, synchronized time: {}, has log: {}, fe type: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1613,6 +1613,7 @@ public class GlobalStateMgr {
                         // but service may be continued when there is no log being replayed.
                         LOG.warn("meta out of date. current time: {}, synchronized time: {}, has log: {}, fe type: {}",
                                 currentTimeMs, synchronizedTimeMs, hasLog, feType);
+                        lastMetaOutOfDateLogTime = currentTimeMs;
                     }
                     if (hasLog || feType == FrontendNodeType.UNKNOWN) {
                         // 1. if we read log from BDB, which means master is still alive.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Replaying 800,000 journals cost 7min, because for each 1000 journals, the replayer thread will print a 'meta out of date' log and then sleep for 5 seconds. This PR speed up this by 
* Change `REPLAYER_MAX_LOGS_PER_LOOP` from 1000 to 100,000, which will cost less than 1 seconds in our test environment.
* Check for interval before printing 'meta out of date' log instead of sleeping.