### PR TITLE
[Bugfix] Fix mv partition by column expection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -236,6 +236,13 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         }
         LOG.info("The process of synchronizing partitions add range {} ", adds);
 
+        Map<String, Set<String>> baseToMvNameRef = SyncPartitionUtils
+                .generatePartitionRefMap(basePartitionMap, mvPartitionMap);
+        Map<String, Set<String>> mvToBaseNameRef = SyncPartitionUtils
+                .generatePartitionRefMap(mvPartitionMap, basePartitionMap);
+        context.setBaseToMvNameRef(baseToMvNameRef);
+        context.setMvToBaseNameRef(mvToBaseNameRef);
+
         if (partitionExpr instanceof SlotRef) {
             Set<String> baseChangedPartitionNames = mv.getNeedRefreshPartitionNames(base);
             needRefreshMvPartitionNames.addAll(baseChangedPartitionNames);
@@ -247,14 +254,6 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
                 mv.addBasePartition(baseTableId, base.getPartition(mvPartitionName));
             }
         }  else if (partitionExpr instanceof FunctionCallExpr) {
-            Map<String, Set<String>> baseToMvNameRef = SyncPartitionUtils
-                    .generatePartitionRefMap(basePartitionMap, mvPartitionMap);
-            Map<String, Set<String>> mvToBaseNameRef = SyncPartitionUtils
-                    .generatePartitionRefMap(mvPartitionMap, basePartitionMap);
-
-            context.setBaseToMvNameRef(baseToMvNameRef);
-            context.setMvToBaseNameRef(mvToBaseNameRef);
-
             Set<String> deleteBasePartitionNames = Sets.newHashSet();
             for (String mvPartitionName : deletes.keySet()) {
                 deleteBasePartitionNames.addAll(mvToBaseNameRef.get(mvPartitionName));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -96,6 +96,29 @@ public class SyncPartitionUtilsTest {
     }
 
     @Test
+    public void testGeneratePartitionRefMapOneByOne() throws AnalysisException {
+        Map<String, Range<PartitionKey>> srcRangeMap = Maps.newHashMap();
+        srcRangeMap.put("p202010_202011", createRange("2020-10-01", "2020-11-01"));
+        srcRangeMap.put("p202011_202012", createRange("2020-11-01", "2020-12-01"));
+        srcRangeMap.put("p202012_202101", createRange("2020-12-01", "2021-01-01"));
+
+        Map<String, Range<PartitionKey>> dstRangeMap = Maps.newHashMap();
+        dstRangeMap.put("p202010_202011", createRange("2020-10-01", "2020-11-01"));
+        dstRangeMap.put("p202011_202012", createRange("2020-11-01", "2020-12-01"));
+        dstRangeMap.put("p202012_202101", createRange("2020-12-01", "2021-01-01"));
+
+        Map<String, Set<String>> partitionRefMap = SyncPartitionUtils.generatePartitionRefMap(srcRangeMap, dstRangeMap);
+
+        Assert.assertEquals(1, partitionRefMap.get("p202010_202011").size());
+        Assert.assertEquals(1, partitionRefMap.get("p202011_202012").size());
+        Assert.assertEquals(1, partitionRefMap.get("p202012_202101").size());
+
+        Assert.assertTrue(partitionRefMap.get("p202010_202011").contains("p202010_202011"));
+        Assert.assertTrue(partitionRefMap.get("p202011_202012").contains("p202011_202012"));
+        Assert.assertTrue(partitionRefMap.get("p202012_202101").contains("p202012_202101"));
+    }
+
+    @Test
     public void testDiffRange() throws AnalysisException {
 
         // normal condition


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Create mv sql:
```
CREATE MATERIALIZED VIEW mv1_multi_tables_partition_by_column
PARTITION BY s1
distributed by hash(s2)
refresh async EVERY(INTERVAL 10 SECOND)
PROPERTIES('replication_num' = '1')
AS select t1.k1 s1, t2.k2 s2 from tbl1 t1 join tbl2 t2 on t1.k1 = t2.k1;
```
Exception in fe.log
```
2022-07-26 15:05:27,586 WARN (pool-21-thread-6|133) [TaskRunExecutor.lambda$executeTaskRun$0():42] failed to execute TaskRun.
java.lang.NullPointerException: null
        at com.starrocks.scheduler.MvTaskRunProcessor.refreshMv(MvTaskRunProcessor.java:382) ~[classes/:?]
        at com.starrocks.scheduler.MvTaskRunProcessor.processTaskRun(MvTaskRunProcessor.java:170) ~[classes/:?]
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:106) ~[classes/:?]
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:35) ~[classes/:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```
