### PR TITLE
[BugFix]  Fix duplicate refresh task after creating multi table materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3264,7 +3264,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
                 taskManager.createTask(task, false);
                 // for async type, run task
-                if (materializedView.getRefreshScheme().getType() == MaterializedView.RefreshType.ASYNC) {
+                if (materializedView.getRefreshScheme().getType() == MaterializedView.RefreshType.ASYNC &&
+                        task.getType() != Constants.TaskType.PERIODICAL) {
                     taskManager.executeTask(task.getName());
                 }
             }


### PR DESCRIPTION

[bugfix]  there is an duplicate refresh task after creating new materialized view. #8651

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8651

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When taskType is PERIODICAL, task will run once created successfully. 

