### PR TITLE
[Refactor] Unify i/o tasks of workgroup and non-workgroup

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -12,12 +12,13 @@
 namespace starrocks::pipeline {
 
 ChunkSource::ChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
-                         BalancedChunkBuffer& chunk_buffer)
+                         BalancedChunkBuffer& chunk_buffer, workgroup::ScanExecutorType executor_type)
         : _scan_operator_seq(scan_operator_id),
           _runtime_profile(runtime_profile),
           _morsel(std::move(morsel)),
           _chunk_buffer(chunk_buffer),
-          _chunk_token(nullptr) {}
+          _chunk_token(nullptr),
+          _executor_type(executor_type) {}
 
 StatusOr<vectorized::ChunkPtr> ChunkSource::get_next_chunk_from_buffer() {
     vectorized::ChunkPtr chunk = nullptr;
@@ -41,48 +42,23 @@ void ChunkSource::unpin_chunk_token() {
     _chunk_token.reset(nullptr);
 }
 
-Status ChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, RuntimeState* state) {
-    if (!_status.ok()) {
-        return _status;
-    }
+std::pair<Status, size_t> ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_t batch_size,
+                                                                         const workgroup::WorkGroupPtr& running_wg,
+                                                                         int worker_id) {
     using namespace vectorized;
 
-    for (size_t i = 0; i < batch_size && !state->is_cancelled(); ++i) {
-        if (_chunk_token == nullptr && (_chunk_token = _chunk_buffer.limiter()->pin(1)) == nullptr) {
-            return Status::OK();
-        }
-
-        ChunkPtr chunk;
-        _status = _read_chunk(state, &chunk);
-        if (!_status.ok()) {
-            // end of file is normal case, need process chunk
-            if (_status.is_end_of_file()) {
-                _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
-            }
-            break;
-        }
-
-        _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
-    }
-
-    return _status;
-}
-
-Status ChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t batch_size, RuntimeState* state,
-                                                                    size_t* num_read_chunks, int worker_id,
-                                                                    workgroup::WorkGroupPtr running_wg) {
     if (!_status.ok()) {
-        return _status;
+        return std::make_pair(_status, 0);
     }
 
-    using namespace vectorized;
     int64_t time_spent = 0;
+    size_t num_read_chunks = 0;
     for (size_t i = 0; i < batch_size && !state->is_cancelled(); ++i) {
         {
             SCOPED_RAW_TIMER(&time_spent);
 
             if (_chunk_token == nullptr && (_chunk_token = _chunk_buffer.limiter()->pin(1)) == nullptr) {
-                return Status::OK();
+                return std::make_pair(_status, num_read_chunks);
             }
 
             ChunkPtr chunk;
@@ -90,28 +66,30 @@ Status ChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t batch
             if (!_status.ok()) {
                 // end of file is normal case, need process chunk
                 if (_status.is_end_of_file()) {
-                    ++(*num_read_chunks);
+                    ++num_read_chunks;
                     _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
                 }
                 break;
             }
 
-            ++(*num_read_chunks);
+            ++num_read_chunks;
             _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
         }
 
-        if (time_spent >= YIELD_MAX_TIME_SPENT) {
-            break;
-        }
+        if (running_wg != nullptr) {
+            if (time_spent >= YIELD_MAX_TIME_SPENT) {
+                break;
+            }
 
-        if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
-            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(workgroup::TypeOlapScanExecutor,
-                                                                               worker_id, running_wg)) {
-            break;
+            if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+                workgroup::WorkGroupManager::instance()->should_yield_scan_worker(_executor_type, worker_id,
+                                                                                  running_wg)) {
+                break;
+            }
         }
     }
 
-    return _status;
+    return std::make_pair(_status, num_read_chunks);
 }
 
 using namespace vectorized;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -136,7 +136,8 @@ connector::ConnectorType ConnectorScanOperator::connector_type() {
 ConnectorChunkSource::ConnectorChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile,
                                            MorselPtr&& morsel, ScanOperator* op,
                                            vectorized::ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer)
-        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel), chunk_buffer),
+        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel), chunk_buffer,
+                      workgroup::TypeConnectorScanExecutor),
           _scan_node(scan_node),
           _limit(scan_node->limit()),
           _runtime_in_filters(op->runtime_in_filters()),

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -26,7 +26,8 @@ using namespace vectorized;
 
 OlapChunkSource::OlapChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
                                  vectorized::OlapScanNode* scan_node, OlapScanContext* scan_ctx)
-        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel), scan_ctx->get_chunk_buffer()),
+        : ChunkSource(scan_operator_id, runtime_profile, std::move(morsel), scan_ctx->get_chunk_buffer(),
+                      workgroup::TypeOlapScanExecutor),
           _scan_node(scan_node),
           _scan_ctx(scan_ctx),
           _limit(scan_node->limit()),

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -45,6 +45,8 @@ ScanOperator::~ScanOperator() {
 }
 
 Status ScanOperator::prepare(RuntimeState* state) {
+    DCHECK(_scan_executor != nullptr);
+
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     _unique_metrics->add_info_string("MorselQueueType", _morsel_queue->name());
@@ -54,27 +56,12 @@ Status ScanOperator::prepare(RuntimeState* state) {
     _buffer_unplug_counter = ADD_COUNTER(_unique_metrics, "BufferUnplugCount", TUnit::UNIT);
     _submit_task_counter = ADD_COUNTER(_unique_metrics, "SubmitTaskCount", TUnit::UNIT);
 
-    if (_workgroup == nullptr) {
-        DCHECK(_io_threads != nullptr);
-        auto num_scan_operators = 1 + state->exec_env()->increment_num_scan_operators(1);
-        if (num_scan_operators > _io_threads->get_queue_capacity()) {
-            state->exec_env()->decrement_num_scan_operators(1);
-            return Status::TooManyTasks(
-                    strings::Substitute("num_scan_operators exceeds queue capacity($0) of pipeline_pool_thread",
-                                        _io_threads->get_queue_capacity()));
-        }
-    }
-
     RETURN_IF_ERROR(do_prepare(state));
 
     return Status::OK();
 }
 
 void ScanOperator::close(RuntimeState* state) {
-    if (_workgroup == nullptr) {
-        state->exec_env()->decrement_num_scan_operators(1);
-    }
-
     set_buffer_finished();
     // For the running io task, we close its chunk sources in ~ScanOperator not in ScanOperator::close.
     for (size_t i = 0; i < _chunk_sources.size(); i++) {
@@ -306,7 +293,6 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     _num_running_io_tasks++;
     _is_io_task_running[chunk_source_index] = true;
 
-    bool offer_task_success = false;
     // to avoid holding mutex in bthread, we choose to initialize lazily here instead of in prepare
     if (is_uninitialized(_query_ctx)) {
         _query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
@@ -314,82 +300,50 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     starrocks::debug::QueryTraceContext query_trace_ctx = starrocks::debug::tls_trace_ctx;
     query_trace_ctx.id = reinterpret_cast<int64_t>(_chunk_sources[chunk_source_index].get());
     int32_t driver_id = CurrentThread::current().get_driver_id();
-    if (_workgroup != nullptr) {
-        workgroup::ScanTask task = workgroup::ScanTask(_workgroup, [wp = _query_ctx, this, state, chunk_source_index,
-                                                                    query_trace_ctx, driver_id](int worker_id) {
-            if (auto sp = wp.lock()) {
-                // Set driver_id here to share some driver-local contents.
-                // Current it's used by ExprContext's driver-local state
-                CurrentThread::current().set_pipeline_driver_id(driver_id);
-                DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-                [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);
-                QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);
-                auto& chunk_source = _chunk_sources[chunk_source_index];
-                size_t num_read_chunks = 0;
-                int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
-                int64_t prev_scan_rows = chunk_source->get_scan_rows();
-                int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
 
-                // Read chunk
-                Status status = chunk_source->buffer_next_batch_chunks_blocking_for_workgroup(
-                        kIOTaskBatchSize, state, &num_read_chunks, worker_id, _workgroup);
-                if (!status.ok() && !status.is_end_of_file()) {
-                    _set_scan_status(status);
-                }
+    workgroup::ScanTask task;
+    task.workgroup = _workgroup;
+    // TODO(by satanson): set a proper priority
+    task.priority = 20;
+    task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id](int worker_id) {
+        if (auto sp = wp.lock()) {
+            // Set driver_id here to share some driver-local contents.
+            // Current it's used by ExprContext's driver-local state
+            CurrentThread::current().set_pipeline_driver_id(driver_id);
+            DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
 
-                int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+
+            [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);
+            QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);
+
+            auto& chunk_source = _chunk_sources[chunk_source_index];
+            int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
+            int64_t prev_scan_rows = chunk_source->get_scan_rows();
+            int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
+
+            // Read chunk
+            auto [status, num_read_chunks] =
+                    chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup, worker_id);
+            if (!status.ok() && !status.is_end_of_file()) {
+                _set_scan_status(status);
+            }
+
+            int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
+            if (_workgroup != nullptr) {
                 _workgroup->increment_real_runtime_ns(delta_cpu_time);
                 _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
-
-                _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
-                                          chunk_source->get_scan_rows() - prev_scan_rows,
-                                          chunk_source->get_scan_bytes() - prev_scan_bytes);
-                QUERY_TRACE_ASYNC_FINISH("io_task", category, query_trace_ctx);
             }
-        });
-        if (dynamic_cast<ConnectorScanOperator*>(this) != nullptr) {
-            offer_task_success = ExecEnv::GetInstance()->connector_scan_executor()->submit(std::move(task));
-        } else {
-            offer_task_success = ExecEnv::GetInstance()->scan_executor()->submit(std::move(task));
+
+            _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
+                                      chunk_source->get_scan_rows() - prev_scan_rows,
+                                      chunk_source->get_scan_bytes() - prev_scan_bytes);
+
+            QUERY_TRACE_ASYNC_FINISH("io_task", category, query_trace_ctx);
         }
-    } else {
-        PriorityThreadPool::Task task;
-        task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id]() {
-            if (auto sp = wp.lock()) {
-                // Set driver_id here to share some driver-local contents.
-                // Current it's used by ExprContext's driver-local state
-                CurrentThread::current().set_pipeline_driver_id(driver_id);
-                DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
+    };
 
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-                [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);
-                QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);
-                auto& chunk_source = _chunk_sources[chunk_source_index];
-                int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
-                int64_t prev_scan_rows = chunk_source->get_scan_rows();
-                int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
-
-                Status status =
-                        _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(kIOTaskBatchSize, state);
-                if (!status.ok() && !status.is_end_of_file()) {
-                    _set_scan_status(status);
-                }
-                int64_t delta_cpu_time = chunk_source->get_cpu_time_spent() - prev_cpu_time;
-
-                _finish_chunk_source_task(state, chunk_source_index, delta_cpu_time,
-                                          chunk_source->get_scan_rows() - prev_scan_rows,
-                                          chunk_source->get_scan_bytes() - prev_scan_bytes);
-                QUERY_TRACE_ASYNC_FINISH("io_task", category, query_trace_ctx);
-            }
-        };
-        // TODO(by satanson): set a proper priority
-        task.priority = 20;
-
-        offer_task_success = _io_threads->try_offer(task);
-    }
-
-    if (offer_task_success) {
+    if (_scan_executor->submit(std::move(task))) {
         _io_task_retry_cnt = 0;
     } else {
         _chunk_sources[chunk_source_index]->unpin_chunk_token();

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -42,7 +42,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
+    void set_scan_executor(workgroup::ScanExecutor* scan_executor) { _scan_executor = scan_executor; }
 
     void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
 
@@ -113,7 +113,7 @@ protected:
 
 private:
     int32_t _io_task_retry_cnt = 0;
-    PriorityThreadPool* _io_threads = nullptr;
+    workgroup::ScanExecutor* _scan_executor = nullptr;
     std::atomic<int> _num_running_io_tasks = 0;
 
     mutable std::shared_mutex _task_mutex; // Protects the chunk-source from concurrent close and read

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -7,8 +7,8 @@
 
 namespace starrocks::workgroup {
 
-ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, ScanExecutorType type)
-        : _task_queue(std::make_unique<ScanTaskQueueWithWorkGroup>(type)), _thread_pool(std::move(thread_pool)) {}
+ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue)
+        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {}
 
 ScanExecutor::~ScanExecutor() {
     _task_queue->close();

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -8,12 +8,12 @@ namespace workgroup {
 
 class ScanExecutor;
 class WorkGroupManager;
-class ScanTask;
+struct ScanTask;
 class ScanTaskQueue;
 
 class ScanExecutor {
 public:
-    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, ScanExecutorType type);
+    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue);
     virtual ~ScanExecutor();
 
     void initialize(int32_t num_threads);

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -7,6 +7,7 @@
 
 namespace starrocks::workgroup {
 
+/// FifoScanTaskQueue.
 StatusOr<ScanTask> FifoScanTaskQueue::take(int worker_id) {
     auto task = std::move(_queue.front());
     _queue.pop();
@@ -18,6 +19,20 @@ bool FifoScanTaskQueue::try_offer(ScanTask task) {
     return true;
 }
 
+/// PriorityScanTaskQueue.
+PriorityScanTaskQueue::PriorityScanTaskQueue(size_t max_elements) : _queue(max_elements) {}
+
+StatusOr<ScanTask> PriorityScanTaskQueue::take(int worker_id) {
+    ScanTask task;
+    _queue.blocking_get(&task);
+    return task;
+}
+
+bool PriorityScanTaskQueue::try_offer(ScanTask task) {
+    return _queue.blocking_put(std::move(task));
+}
+
+/// ScanTaskQueueWithWorkGroup.
 void ScanTaskQueueWithWorkGroup::close() {
     std::lock_guard<std::mutex> lock(_global_mutex);
 

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -24,8 +24,11 @@ PriorityScanTaskQueue::PriorityScanTaskQueue(size_t max_elements) : _queue(max_e
 
 StatusOr<ScanTask> PriorityScanTaskQueue::take(int worker_id) {
     ScanTask task;
-    _queue.blocking_get(&task);
-    return task;
+    if (_queue.blocking_get(&task)) {
+        return task;
+    }
+
+    return Status::Cancelled("Shutdown");
 }
 
 bool PriorityScanTaskQueue::try_offer(ScanTask task) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -502,8 +502,8 @@ std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_driver_worker(i
     return _driver_worker_owner_manager->get_owners(worker_id);
 }
 
-bool WorkGroupManager::should_yield_driver_worker(int worker_id, WorkGroupPtr running_wg) {
-    return _driver_worker_owner_manager->should_yield(worker_id, std::move(running_wg));
+bool WorkGroupManager::should_yield_driver_worker(int worker_id, const WorkGroupPtr& running_wg) {
+    return _driver_worker_owner_manager->should_yield(worker_id, running_wg);
 }
 
 std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_scan_worker(ScanExecutorType type, int worker_id) {
@@ -511,10 +511,9 @@ std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_scan_worker(Sca
                                         : _connector_scan_worker_owner_manager->get_owners(worker_id);
 }
 
-bool WorkGroupManager::get_owners_of_scan_worker(ScanExecutorType type, int worker_id, WorkGroupPtr running_wg) {
-    return type == TypeOlapScanExecutor
-                   ? _scan_worker_owner_manager->should_yield(worker_id, std::move(running_wg))
-                   : _connector_scan_worker_owner_manager->should_yield(worker_id, std::move(running_wg));
+bool WorkGroupManager::should_yield_scan_worker(ScanExecutorType type, int worker_id, const WorkGroupPtr& running_wg) {
+    return type == TypeOlapScanExecutor ? _scan_worker_owner_manager->should_yield(worker_id, running_wg)
+                                        : _connector_scan_worker_owner_manager->should_yield(worker_id, running_wg);
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -262,10 +262,10 @@ public:
     std::vector<TWorkGroup> list_all_workgroups();
 
     std::shared_ptr<WorkGroupPtrSet> get_owners_of_driver_worker(int worker_id);
-    bool should_yield_driver_worker(int worker_id, WorkGroupPtr running_wg);
+    bool should_yield_driver_worker(int worker_id, const WorkGroupPtr& running_wg);
 
     std::shared_ptr<WorkGroupPtrSet> get_owners_of_scan_worker(ScanExecutorType type, int worker_id);
-    bool get_owners_of_scan_worker(ScanExecutorType type, int worker_id, WorkGroupPtr running_wg);
+    bool should_yield_scan_worker(ScanExecutorType type, int worker_id, const WorkGroupPtr& running_wg);
 
     int num_total_driver_workers() const { return _driver_worker_owner_manager->num_total_workers(); }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -146,23 +146,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
             new PriorityThreadPool("table_scan_io", // olap/external table scan thread pool
                                    config::scanner_thread_pool_thread_num, config::scanner_thread_pool_queue_size);
 
-    int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
-    CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
-
-    _pipeline_connector_scan_io_thread_pool = new PriorityThreadPool("pip_connector_scan_io", connector_num_io_threads,
-                                                                     config::pipeline_scan_thread_pool_queue_size);
-
-    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool;
-    RETURN_IF_ERROR(ThreadPoolBuilder("connector_scan_executor")
-                            .set_min_threads(0)
-                            .set_max_threads(connector_num_io_threads)
-                            .set_max_queue_size(1000)
-                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                            .build(&connector_scan_worker_thread_pool));
-    _connector_scan_executor = new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool),
-                                                           workgroup::TypeConnectorScanExecutor);
-    _connector_scan_executor->initialize(connector_num_io_threads);
-
     _udf_call_pool = new PriorityThreadPool("udf", config::udf_thread_pool_size, config::udf_thread_pool_size);
     _fragment_mgr = new FragmentMgr(this);
 
@@ -229,19 +212,56 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                      ? std::thread::hardware_concurrency()
                                      : config::pipeline_scan_thread_pool_thread_num;
 
-        _pipeline_scan_io_thread_pool =
-                new PriorityThreadPool("pip_scan_io", // pipeline scan io
-                                       num_io_threads, config::pipeline_scan_thread_pool_queue_size);
-        std::unique_ptr<ThreadPool> scan_worker_thread_pool;
-        RETURN_IF_ERROR(ThreadPoolBuilder("scan_executor") // scan io task executor
+        std::unique_ptr<ThreadPool> scan_worker_thread_pool_without_workgroup;
+        RETURN_IF_ERROR(ThreadPoolBuilder("pip_scan_io")
                                 .set_min_threads(0)
                                 .set_max_threads(num_io_threads)
                                 .set_max_queue_size(1000)
                                 .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                                .build(&scan_worker_thread_pool));
-        _scan_executor =
-                new workgroup::ScanExecutor(std::move(scan_worker_thread_pool), workgroup::TypeOlapScanExecutor);
-        _scan_executor->initialize(num_io_threads);
+                                .build(&scan_worker_thread_pool_without_workgroup));
+        _scan_executor_without_workgroup = new workgroup::ScanExecutor(
+                std::move(scan_worker_thread_pool_without_workgroup),
+                std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+        _scan_executor_without_workgroup->initialize(num_io_threads);
+
+        std::unique_ptr<ThreadPool> scan_worker_thread_pool_with_workgroup;
+        RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_scan_io")
+                                .set_min_threads(0)
+                                .set_max_threads(num_io_threads)
+                                .set_max_queue_size(1000)
+                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                                .build(&scan_worker_thread_pool_with_workgroup));
+        _scan_executor_with_workgroup = new workgroup::ScanExecutor(
+                std::move(scan_worker_thread_pool_with_workgroup),
+                std::make_unique<workgroup::ScanTaskQueueWithWorkGroup>(workgroup::TypeOlapScanExecutor));
+        _scan_executor_with_workgroup->initialize(num_io_threads);
+
+        int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
+        CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
+
+        std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;
+        RETURN_IF_ERROR(ThreadPoolBuilder("con_scan_io")
+                                .set_min_threads(0)
+                                .set_max_threads(connector_num_io_threads)
+                                .set_max_queue_size(1000)
+                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                                .build(&connector_scan_worker_thread_pool_without_workgroup));
+        _connector_scan_executor_without_workgroup = new workgroup::ScanExecutor(
+                std::move(connector_scan_worker_thread_pool_without_workgroup),
+                std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+        _connector_scan_executor_without_workgroup->initialize(connector_num_io_threads);
+
+        std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
+        RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
+                                .set_min_threads(0)
+                                .set_max_threads(connector_num_io_threads)
+                                .set_max_queue_size(1000)
+                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                                .build(&connector_scan_worker_thread_pool_with_workgroup));
+        _connector_scan_executor_with_workgroup = new workgroup::ScanExecutor(
+                std::move(connector_scan_worker_thread_pool_with_workgroup),
+                std::make_unique<workgroup::ScanTaskQueueWithWorkGroup>(workgroup::TypeConnectorScanExecutor));
+        _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
 
         Status status = _load_path_mgr->init();
         if (!status.ok()) {
@@ -441,21 +461,21 @@ void ExecEnv::_destroy() {
         delete _pipeline_prepare_pool;
         _pipeline_prepare_pool = nullptr;
     }
-    if (_pipeline_scan_io_thread_pool) {
-        delete _pipeline_scan_io_thread_pool;
-        _pipeline_scan_io_thread_pool = nullptr;
+    if (_scan_executor_without_workgroup) {
+        delete _scan_executor_without_workgroup;
+        _scan_executor_without_workgroup = nullptr;
     }
-    if (_pipeline_connector_scan_io_thread_pool) {
-        delete _pipeline_connector_scan_io_thread_pool;
-        _pipeline_connector_scan_io_thread_pool = nullptr;
+    if (_scan_executor_with_workgroup) {
+        delete _scan_executor_with_workgroup;
+        _scan_executor_with_workgroup = nullptr;
     }
-    if (_scan_executor) {
-        delete _scan_executor;
-        _scan_executor = nullptr;
+    if (_connector_scan_executor_without_workgroup) {
+        delete _connector_scan_executor_without_workgroup;
+        _connector_scan_executor_without_workgroup = nullptr;
     }
-    if (_connector_scan_executor) {
-        delete _connector_scan_executor;
-        _connector_scan_executor = nullptr;
+    if (_connector_scan_executor_with_workgroup) {
+        delete _connector_scan_executor_with_workgroup;
+        _connector_scan_executor_with_workgroup = nullptr;
     }
     if (_runtime_filter_cache) {
         delete _runtime_filter_cache;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -137,11 +137,15 @@ public:
 
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
-    PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
-    PriorityThreadPool* pipeline_connector_scan_io_thread_pool() { return _pipeline_connector_scan_io_thread_pool; }
+    workgroup::ScanExecutor* scan_executor_without_workgroup() { return _scan_executor_without_workgroup; }
+    workgroup::ScanExecutor* scan_executor_with_workgroup() { return _scan_executor_with_workgroup; }
+    workgroup::ScanExecutor* connector_scan_executor_without_workgroup() {
+        return _connector_scan_executor_without_workgroup;
+    }
+    workgroup::ScanExecutor* connector_scan_executor_with_workgroup() {
+        return _connector_scan_executor_with_workgroup;
+    }
 
-    size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
-    size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
     PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
@@ -156,9 +160,6 @@ public:
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
     StreamContextMgr* stream_context_mgr() { return _stream_context_mgr; }
     TransactionMgr* transaction_mgr() { return _transaction_mgr; }
-
-    starrocks::workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
-    starrocks::workgroup::ScanExecutor* connector_scan_executor() { return _connector_scan_executor; }
 
     const std::vector<StorePath>& store_paths() const { return _store_paths; }
     void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
@@ -240,22 +241,22 @@ private:
 
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_connector_scan_io_thread_pool = nullptr;
-    std::atomic<size_t> _num_scan_operators{0};
+
+    workgroup::ScanExecutor* _scan_executor_without_workgroup = nullptr;
+    workgroup::ScanExecutor* _scan_executor_with_workgroup = nullptr;
+    workgroup::ScanExecutor* _connector_scan_executor_without_workgroup = nullptr;
+    workgroup::ScanExecutor* _connector_scan_executor_with_workgroup = nullptr;
+
     PriorityThreadPool* _udf_call_pool = nullptr;
     PriorityThreadPool* _pipeline_prepare_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
-    starrocks::pipeline::QueryContextManager* _query_context_mgr = nullptr;
-    starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;
+    pipeline::QueryContextManager* _query_context_mgr = nullptr;
+    pipeline::DriverExecutor* _driver_executor = nullptr;
     pipeline::DriverExecutor* _wg_driver_executor = nullptr;
     pipeline::DriverLimiter* _driver_limiter;
     int64_t _max_executor_threads; // Max thread number of executor
 
     LoadPathMgr* _load_path_mgr = nullptr;
-
-    starrocks::workgroup::ScanExecutor* _scan_executor = nullptr;
-    starrocks::workgroup::ScanExecutor* _connector_scan_executor = nullptr;
 
     BfdParser* _bfd_parser = nullptr;
     BrokerMgr* _broker_mgr = nullptr;

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -238,9 +238,9 @@ void PipeLineFileScanNodeTest::prepare_pipeline() {
                 driver->set_morsel_queue(morsel_queue_factory->create(i));
                 if (auto* scan_operator = driver->source_scan_operator()) {
                     if (dynamic_cast<starrocks::pipeline::ConnectorScanOperator*>(scan_operator) != nullptr) {
-                        scan_operator->set_io_threads(_exec_env->pipeline_connector_scan_io_thread_pool());
+                        scan_operator->set_scan_executor(exec_env->connector_scan_executor_without_workgroup());
                     } else {
-                        scan_operator->set_io_threads(_exec_env->pipeline_scan_io_thread_pool());
+                        scan_operator->set_scan_executor(exec_env->scan_executor_without_workgroup());
                     }
                 }
 

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -238,9 +238,9 @@ void PipeLineFileScanNodeTest::prepare_pipeline() {
                 driver->set_morsel_queue(morsel_queue_factory->create(i));
                 if (auto* scan_operator = driver->source_scan_operator()) {
                     if (dynamic_cast<starrocks::pipeline::ConnectorScanOperator*>(scan_operator) != nullptr) {
-                        scan_operator->set_scan_executor(exec_env->connector_scan_executor_without_workgroup());
+                        scan_operator->set_scan_executor(_exec_env->connector_scan_executor_without_workgroup());
                     } else {
-                        scan_operator->set_scan_executor(exec_env->scan_executor_without_workgroup());
+                        scan_operator->set_scan_executor(_exec_env->scan_executor_without_workgroup());
                     }
                 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Workgroup and none-workgroup uses different versions of i/o task as follows:
- `buffer_next_batch_chunks_blocking` and `buffer_next_batch_chunks_blocking_for_workgroup` in `ChunkSource`.
- Two different i/o task functions in `ScanOperator:: _trigger_next_scan`.
- Commit i/o tasks to `io_thread_pool` or `scan_executor`.

These two versions are the same, except setting some information to workgroup after finishing the i/o task. When we modify the logic of i/o task, we must write the same codes two times carefully.

We could unify them by the following way:
- Use different `ScanExecutor`s instead of `io_thread_pool` regardless with or without workgroup.
- Use the same `ScanTask` and i/o task function.
- Set the information to workgroup after finishing the i/o task, if it is with workgroup.


