### PR TITLE
[Refactor] Change starlet fs URI format

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -67,13 +67,6 @@ inline bool is_posix_uri(std::string_view uri) {
     return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
 }
 
-inline bool is_staros_uri(std::string_view uri) {
-#ifdef USE_STAROS
-    return parse_starlet_uri(uri).ok();
-#endif
-    return false;
-}
-
 StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::string_view uri) {
     if (is_posix_uri(uri)) {
         return new_fs_posix();
@@ -85,7 +78,7 @@ StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::st
         return new_fs_s3();
     }
 #ifdef USE_STAROS
-    if (is_staros_uri(uri)) {
+    if (is_starlet_uri(uri)) {
         return new_fs_starlet();
     }
 #endif
@@ -103,7 +96,7 @@ StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::st
         return get_tls_fs_s3();
     }
 #ifdef USE_STAROS
-    if (is_staros_uri(uri)) {
+    if (is_starlet_uri(uri)) {
         return get_tls_fs_starlet();
     }
 #endif

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -69,7 +69,7 @@ inline bool is_posix_uri(std::string_view uri) {
 
 inline bool is_staros_uri(std::string_view uri) {
 #ifdef USE_STAROS
-    return starts_with(uri, kStarletPrefix);
+    return parse_starlet_uri(uri).ok();
 #endif
     return false;
 }

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -34,10 +34,6 @@ using FileSystemPtr = std::unique_ptr<staros::starlet::fslib::FileSystem>;
 using ReadOnlyFilePtr = std::unique_ptr<staros::starlet::fslib::ReadOnlyFile>;
 using WritableFilePtr = std::unique_ptr<staros::starlet::fslib::WritableFile>;
 using Anchor = staros::starlet::fslib::Stream::Anchor;
-using staros::starlet::fslib::kS3AccessKeyId;
-using staros::starlet::fslib::kS3AccessKeySecret;
-using staros::starlet::fslib::kS3OverrideEndpoint;
-using staros::starlet::fslib::kSysRoot;
 
 bool is_starlet_uri(std::string_view uri) {
     return HasPrefixString(uri, "staros://");

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -22,6 +22,7 @@
 #include "io/output_stream.h"
 #include "io/seekable_input_stream.h"
 #include "service/staros_worker.h"
+#include "util/string_parser.hpp"
 
 namespace starrocks {
 
@@ -38,23 +39,32 @@ using staros::starlet::fslib::kS3AccessKeySecret;
 using staros::starlet::fslib::kS3OverrideEndpoint;
 using staros::starlet::fslib::kSysRoot;
 
-StatusOr<std::pair<std::string, int64_t>> parse_starlet_path(const std::string& path) {
-    static size_t prefix_len = std::strlen(kStarletPrefix);
-    const static std::string shard_qs("?ShardId=");
+std::string build_starlet_uri(int64_t shard_id, std::string_view path) {
+    while (!path.empty() && path.front() == '/') {
+        path.remove_prefix(1);
+    }
+    return path.empty() ? fmt::format("staros://{}", shard_id) : fmt::format("staros://{}/{}", shard_id, path);
+}
 
-    // check starlet filesystem prefix
-    if (!HasPrefixString(path, kStarletPrefix)) {
-        return Status::InvalidArgument(fmt::format("Starlet Fs need {} prefix, {}", kStarletPrefix, path));
+// Expected format of uri: staros://ShardID/path/to/file
+StatusOr<std::pair<std::string_view, int64_t>> parse_starlet_uri(std::string_view uri) {
+    std::string_view path = uri;
+    if (!HasPrefixString(path, "staros://")) {
+        return Status::InvalidArgument(fmt::format("Invalid starlet URI: {}", uri));
+    }
+    path.remove_prefix(sizeof("staros://") - 1);
+    auto end_shard_id = path.find('/');
+    if (end_shard_id == std::string::npos) {
+        end_shard_id = path.size();
     }
 
-    // check ?ShardId= info
-    auto pos = path.find(shard_qs);
-    if (pos == std::string::npos) {
-        return Status::InvalidArgument(fmt::format("Starlet Fs need a ShardId, {}", path));
+    StringParser::ParseResult result;
+    auto shard_id = StringParser::string_to_int<int64_t>(path.data(), end_shard_id, &result);
+    if (result != StringParser::PARSE_SUCCESS) {
+        return Status::InvalidArgument(fmt::format("Invalid starlet URI: {}", uri));
     }
-
-    int64_t shardid = std::stol(path.substr(pos + shard_qs.size()));
-    return std::make_pair(path.substr(prefix_len, pos - prefix_len), shardid);
+    path.remove_prefix(std::min<size_t>(path.size(), end_shard_id + 1));
+    return std::make_pair(path, shard_id);
 };
 
 class StarletInputStream : public starrocks::io::SeekableInputStream {
@@ -176,7 +186,7 @@ public:
 
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
                                                                        const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
@@ -192,7 +202,7 @@ public:
     }
 
     StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
 
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
@@ -213,7 +223,7 @@ public:
 
     StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const WritableFileOptions& opts,
                                                               const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         if (!pair.first.empty() && pair.first.back() == '/') {
             return Status::NotSupported(fmt::format("Starlet: cannot create file with name ended with '/': {}", path));
         }
@@ -234,7 +244,7 @@ public:
     }
 
     Status delete_file(const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
@@ -244,10 +254,7 @@ public:
     }
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(dir));
-        if (!pair.first.empty() && pair.first.back() != '/') {
-            pair.first.push_back('/');
-        }
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(dir));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
@@ -261,11 +268,7 @@ public:
         if (st.ok() && st.value()) {
             return Status::AlreadyExist(dirname);
         }
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(dirname));
-        if (pair.first.back() != '/') {
-            pair.first.push_back('/');
-        }
-
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(dirname));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
@@ -289,10 +292,7 @@ public:
     Status create_dir_recursive(const std::string& dirname) override { return create_dir_if_missing(dirname, nullptr); }
 
     Status delete_dir(const std::string& dirname) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(dirname));
-        if (!pair.first.empty() && pair.first.back() != '/') {
-            pair.first.push_back('/');
-        }
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(dirname));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
@@ -316,14 +316,10 @@ public:
     }
 
     Status delete_dir_recursive(const std::string& dirname) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(dirname));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(dirname));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
-        }
-
-        if (pair.first.back() != '/') {
-            pair.first.push_back('/');
         }
         auto st = (*fs_st)->delete_dir(pair.first, true);
         return to_status(st);
@@ -335,7 +331,7 @@ public:
     //  * false - exists but is not a directory
     //  * error status: not exist or other errors
     StatusOr<bool> is_directory(const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         auto fs_st = get_shard_filesystem(pair.second);
 
         if (!fs_st.ok()) {
@@ -353,17 +349,6 @@ public:
                 return to_status(fst.status());
             }
             return S_ISDIR((*fst).mode);
-        }
-        if (!pair.first.empty() && pair.first.back() != '/') {
-            // force a directory naming convention
-            pair.first.push_back('/');
-            auto st2 = (*fs_st)->exists(pair.first);
-            if (!st2.ok()) {
-                return to_status(st2.status());
-            }
-            if (*st2) {
-                return true;
-            }
         }
         return Status::NotFound(path);
     }
@@ -401,7 +386,7 @@ public:
     }
 
     StatusOr<uint64_t> get_file_modified_time(const std::string& path) override {
-        ASSIGN_OR_RETURN(auto pair, parse_starlet_path(path));
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         auto fs_st = get_shard_filesystem(pair.second);
 
         if (!fs_st.ok()) {

--- a/be/src/fs/fs_starlet.h
+++ b/be/src/fs/fs_starlet.h
@@ -4,11 +4,15 @@
 
 #pragma once
 
-#include <fs/fs.h>
+#include "common/statusor.h"
+#include "fs/fs.h"
 
 namespace starrocks {
 
-static const char* const kStarletPrefix = "staros://";
+std::string build_starlet_uri(int64_t shard_id, std::string_view path);
+
+// The first element of pair is path, the second element of pair is shard id.
+StatusOr<std::pair<std::string_view, int64_t>> parse_starlet_uri(std::string_view uri);
 
 std::unique_ptr<FileSystem> new_fs_starlet();
 

--- a/be/src/fs/fs_starlet.h
+++ b/be/src/fs/fs_starlet.h
@@ -9,10 +9,16 @@
 
 namespace starrocks {
 
+// is_starlet_uri() performs less strict validation than parse_starlet_uri(), which means
+// if is_starlet_uri() returns false parse_starlet_uri() must fail and if is_starlet_uri()
+// returns true parse_starlet_uri() may also fail.
+bool is_starlet_uri(std::string_view uri);
+
 std::string build_starlet_uri(int64_t shard_id, std::string_view path);
 
 // The first element of pair is path, the second element of pair is shard id.
-StatusOr<std::pair<std::string_view, int64_t>> parse_starlet_uri(std::string_view uri);
+// If parse_starlet_uri() succeeded, is_starlet_uri() must be true.
+StatusOr<std::pair<std::string, int64_t>> parse_starlet_uri(std::string_view uri);
 
 std::unique_ptr<FileSystem> new_fs_starlet();
 

--- a/be/src/fs/fs_starlet.h
+++ b/be/src/fs/fs_starlet.h
@@ -9,7 +9,7 @@
 
 namespace starrocks {
 
-// is_starlet_uri() performs less strict validation than parse_starlet_uri(), which means
+// is_starlet_uri() performs less strict verification than parse_starlet_uri(), which means
 // if is_starlet_uri() returns false parse_starlet_uri() must fail and if is_starlet_uri()
 // returns true parse_starlet_uri() may also fail.
 bool is_starlet_uri(std::string_view uri);
@@ -17,6 +17,11 @@ bool is_starlet_uri(std::string_view uri);
 std::string build_starlet_uri(int64_t shard_id, std::string_view path);
 
 // The first element of pair is path, the second element of pair is shard id.
+//      staros://shardid/over/there
+//      \__/    \_____/ \_______/
+//       |         |        |
+//     scheme   shard_id   path
+//
 // If parse_starlet_uri() succeeded, is_starlet_uri() must be true.
 StatusOr<std::pair<std::string, int64_t>> parse_starlet_uri(std::string_view uri);
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -1,8 +1,8 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
-#include "service/staros_worker.h"
-
 #ifdef USE_STAROS
+
+#include "service/staros_worker.h"
 
 #include <starlet.h>
 #include <worker.h>

--- a/be/src/storage/lake/fixed_location_provider.cpp
+++ b/be/src/storage/lake/fixed_location_provider.cpp
@@ -26,10 +26,6 @@ std::string FixedLocationProvider::segment_location(int64_t /*tablet_id*/, std::
     return fmt::format("{}/{}", _root, segment_name);
 }
 
-std::string FixedLocationProvider::join_path(std::string_view parent, std::string_view child) const {
-    return fmt::format("{}/{}", parent, child);
-}
-
 Status FixedLocationProvider::list_root_locations(std::set<std::string>* roots) const {
     roots->insert(_root);
     return Status::OK();

--- a/be/src/storage/lake/fixed_location_provider.h
+++ b/be/src/storage/lake/fixed_location_provider.h
@@ -24,8 +24,6 @@ public:
 
     std::string segment_location(int64_t tablet_id, std::string_view segment_name) const override;
 
-    std::string join_path(std::string_view parent, std::string_view child) const override;
-
     Status list_root_locations(std::set<std::string>* roots) const override;
 
 private:

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -9,6 +9,7 @@
 #include "common/config.h"
 #include "fs/fs.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
@@ -108,7 +109,7 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
     };
 
     for (const auto& filename : tablet_metadatas) {
-        auto location = tablet_mgr->location_provider()->join_path(root_location, filename);
+        auto location = join_path(root_location, filename);
         auto res = tablet_mgr->get_tablet_metadata(location, false);
         if (res.status().is_not_found()) {
             continue;
@@ -123,7 +124,7 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
     }
 
     for (const auto& filename : txn_logs) {
-        auto location = tablet_mgr->location_provider()->join_path(root_location, filename);
+        auto location = join_path(root_location, filename);
         auto res = tablet_mgr->get_txn_log(location, false);
         if (res.status().is_not_found()) {
             continue;
@@ -147,7 +148,7 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
     }
 
     for (auto& seg : segments) {
-        auto location = tablet_mgr->location_provider()->join_path(root_location, seg);
+        auto location = join_path(root_location, seg);
         auto res = fs->get_file_modified_time(location);
         if (!res.ok() && !res.status().is_not_found()) {
             LOG(WARNING) << "Fail to get modified time of " << location << ": " << res.status();

--- a/be/src/storage/lake/join_path.h
+++ b/be/src/storage/lake/join_path.h
@@ -1,0 +1,22 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <assert.h> // NOLINT(modernize-deprecated-headers)
+#include <fmt/format.h>
+
+#include <string_view>
+
+namespace starrocks::lake {
+
+inline std::string join_path(std::string_view parent, std::string_view child) {
+    assert(!parent.empty());
+    assert(!child.empty());
+    assert(child.back() != '/');
+    if (parent.back() != '/') {
+        return fmt::format("{}/{}", parent, child);
+    }
+    return fmt::format("{}{}", parent, child);
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -23,9 +23,6 @@ public:
 
     virtual std::string segment_location(int64_t tablet_id, std::string_view segment_name) const = 0;
 
-    // TODO: remove this method after we removed the ShardId suffix from StarletFileSystem.
-    virtual std::string join_path(std::string_view parent, std::string_view child) const = 0;
-
     virtual Status list_root_locations(std::set<std::string>* groups) const = 0;
 };
 

--- a/be/src/storage/lake/starlet_location_provider.cpp
+++ b/be/src/storage/lake/starlet_location_provider.cpp
@@ -17,28 +17,19 @@
 namespace starrocks::lake {
 
 std::string StarletLocationProvider::root_location(int64_t tablet_id) const {
-    return fmt::format("{}?ShardId={}", kStarletPrefix, tablet_id);
+    return build_starlet_uri(tablet_id, "");
 }
 
 std::string StarletLocationProvider::tablet_metadata_location(int64_t tablet_id, int64_t version) const {
-    return fmt::format("{}{}?ShardId={}", kStarletPrefix, tablet_metadata_filename(tablet_id, version), tablet_id);
+    return build_starlet_uri(tablet_id, tablet_metadata_filename(tablet_id, version));
 }
 
 std::string StarletLocationProvider::txn_log_location(int64_t tablet_id, int64_t txn_id) const {
-    return fmt::format("{}{}?ShardId={}", kStarletPrefix, txn_log_filename(tablet_id, txn_id), tablet_id);
+    return build_starlet_uri(tablet_id, txn_log_filename(tablet_id, txn_id));
 }
 
 std::string StarletLocationProvider::segment_location(int64_t tablet_id, std::string_view segment_name) const {
-    return fmt::format("{}{}?ShardId={}", kStarletPrefix, segment_name, tablet_id);
-}
-
-std::string StarletLocationProvider::join_path(std::string_view parent, std::string_view child) const {
-    auto pos = parent.find("?ShardId=");
-    CHECK(pos != std::string::npos);
-    auto prefix = parent.substr(0, pos);
-    auto suffix = parent.substr(pos);
-    return prefix.back() == '/' ? fmt::format("{}{}{}", prefix, child, suffix)
-                                : fmt::format("{}/{}{}", prefix, child, suffix);
+    return build_starlet_uri(tablet_id, segment_name);
 }
 
 Status StarletLocationProvider::list_root_locations(std::set<std::string>* roots) const {

--- a/be/src/storage/lake/starlet_location_provider.h
+++ b/be/src/storage/lake/starlet_location_provider.h
@@ -27,8 +27,6 @@ public:
 
     std::string segment_location(int64_t tablet_id, std::string_view segment_name) const override;
 
-    std::string join_path(std::string_view parent, std::string_view child) const override;
-
     Status list_root_locations(std::set<std::string>* roots) const override;
 };
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -21,6 +21,7 @@ DIAGNOSTIC_POP
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/gc.h"
 #include "storage/lake/horizontal_compaction_task.h"
+#include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
@@ -181,7 +182,7 @@ Status TabletManager::drop_tablet(int64_t tablet_id) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
     auto scan_cb = [&](std::string_view name) {
         if (HasPrefixString(name, tablet_metadata_prefix) || HasPrefixString(name, txnlog_prefix)) {
-            objects.emplace_back(_location_provider->join_path(root_path, name));
+            objects.emplace_back(join_path(root_path, name));
         }
         return true;
     };
@@ -269,7 +270,7 @@ StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root));
     auto scan_cb = [&](std::string_view name) {
         if (HasPrefixString(name, prefix)) {
-            objects.emplace_back(_location_provider->join_path(root, name));
+            objects.emplace_back(join_path(root, name));
         }
         return true;
     };
@@ -357,7 +358,7 @@ StatusOr<TxnLogIter> TabletManager::list_txn_log(int64_t tablet_id, bool filter_
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root));
     auto scan_cb = [&](std::string_view name) {
         if (HasPrefixString(name, prefix)) {
-            objects.emplace_back(_location_provider->join_path(root, name));
+            objects.emplace_back(join_path(root, name));
         }
         return true;
     };

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -64,7 +64,7 @@ public:
     void CheckIsDirectory(FileSystem* fs, const std::string& dir_name, bool expected_success,
                           bool expected_is_dir = true) {
         const StatusOr<bool> status_or = fs->is_directory(dir_name);
-        EXPECT_EQ(expected_success, status_or.ok()) << dir_name;
+        EXPECT_EQ(expected_success, status_or.ok()) << status_or.status() << ": " << dir_name;
         if (status_or.ok()) {
             EXPECT_EQ(expected_is_dir, status_or.value());
         }

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -45,7 +45,7 @@ public:
         (void)g_worker->add_shard(shard_info);
 
         // Expect a clean root directory before testing
-        auto fs = new_fs_starlet();
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(StarletPath("/")));
         fs->delete_dir_recursive(StarletPath("/"));
     }
     void TearDown() override {
@@ -101,7 +101,7 @@ TEST_P(StarletFileSystemTest, test_build_and_parse_uri) {
 
 TEST_P(StarletFileSystemTest, test_write_and_read) {
     auto uri = StarletPath("test1");
-    auto fs = new_fs_starlet();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(uri));
     ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(uri));
     EXPECT_OK(wf->append("hello"));
     EXPECT_OK(wf->append(" world!"));
@@ -122,7 +122,7 @@ TEST_P(StarletFileSystemTest, test_write_and_read) {
 }
 
 TEST_P(StarletFileSystemTest, test_directory) {
-    auto fs = new_fs_starlet();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(StarletPath("/")));
     bool created = false;
 
     //
@@ -242,7 +242,7 @@ TEST_P(StarletFileSystemTest, test_directory) {
 }
 
 TEST_P(StarletFileSystemTest, test_delete_dir_recursive) {
-    auto fs = new_fs_starlet();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(StarletPath("/")));
 
     std::vector<std::string> entries;
     auto cb = [&](std::string_view name) -> bool {
@@ -285,7 +285,7 @@ TEST_P(StarletFileSystemTest, test_delete_dir_recursive) {
 }
 
 TEST_P(StarletFileSystemTest, test_delete_nonexist_file) {
-    auto fs = new_fs_starlet();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(StarletPath("/")));
     ASSERT_OK(fs->delete_file(StarletPath("/nonexist.dat")));
 }
 

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -45,7 +45,7 @@ public:
         (void)g_worker->add_shard(shard_info);
 
         // Expect a clean root directory before testing
-        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(kStarletPrefix));
+        auto fs = new_fs_starlet();
         fs->delete_dir_recursive(StarletPath("/"));
     }
     void TearDown() override {
@@ -59,13 +59,7 @@ public:
         }
     }
 
-    std::string StarletPath(std::string_view path) {
-        if (path.front() == '/') {
-            return fmt::format("{}{}?ShardId={}", kStarletPrefix, path.substr(1), 10086);
-        } else {
-            return fmt::format("{}{}?ShardId={}", kStarletPrefix, path, 10086);
-        }
-    }
+    std::string StarletPath(std::string_view path) { return build_starlet_uri(10086, path); }
 
     void CheckIsDirectory(FileSystem* fs, const std::string& dir_name, bool expected_success,
                           bool expected_is_dir = true) {
@@ -77,9 +71,37 @@ public:
     }
 };
 
+TEST_P(StarletFileSystemTest, test_build_and_parse_uri) {
+    ASSERT_EQ("staros://10", build_starlet_uri(10, ""));
+    ASSERT_EQ("staros://10", build_starlet_uri(10, "/"));
+    ASSERT_EQ("staros://10", build_starlet_uri(10, "///"));
+    ASSERT_EQ("staros://10/abc", build_starlet_uri(10, "abc"));
+    ASSERT_EQ("staros://10/abc", build_starlet_uri(10, "/abc"));
+    ASSERT_EQ("staros://10/abc", build_starlet_uri(10, "////abc"));
+    ASSERT_EQ("staros://10/abc/xyz", build_starlet_uri(10, "////abc/xyz"));
+
+    ASSERT_FALSE(parse_starlet_uri("posix://x/y").ok());
+    ASSERT_FALSE(parse_starlet_uri("staros:/10").ok());
+    ASSERT_FALSE(parse_starlet_uri("staros://x/y").ok());
+    ASSERT_FALSE(parse_starlet_uri("Staros://x/y").ok());
+    ASSERT_FALSE(parse_starlet_uri("SATROS://x/y").ok());
+
+    ASSIGN_OR_ABORT(auto path_and_id, parse_starlet_uri("staros://10/abc"));
+    ASSERT_EQ("abc", path_and_id.first);
+    ASSERT_EQ(10, path_and_id.second);
+
+    ASSIGN_OR_ABORT(path_and_id, parse_starlet_uri("staros://10"));
+    ASSERT_EQ("", path_and_id.first);
+    ASSERT_EQ(10, path_and_id.second);
+
+    ASSIGN_OR_ABORT(path_and_id, parse_starlet_uri("staros://10/usr/bin"));
+    ASSERT_EQ("usr/bin", path_and_id.first);
+    ASSERT_EQ(10, path_and_id.second);
+}
+
 TEST_P(StarletFileSystemTest, test_write_and_read) {
     auto uri = StarletPath("test1");
-    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(kStarletPrefix));
+    auto fs = new_fs_starlet();
     ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(uri));
     EXPECT_OK(wf->append("hello"));
     EXPECT_OK(wf->append(" world!"));
@@ -100,7 +122,7 @@ TEST_P(StarletFileSystemTest, test_write_and_read) {
 }
 
 TEST_P(StarletFileSystemTest, test_directory) {
-    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(kStarletPrefix));
+    auto fs = new_fs_starlet();
     bool created = false;
 
     //
@@ -220,7 +242,7 @@ TEST_P(StarletFileSystemTest, test_directory) {
 }
 
 TEST_P(StarletFileSystemTest, test_delete_dir_recursive) {
-    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(kStarletPrefix));
+    auto fs = new_fs_starlet();
 
     std::vector<std::string> entries;
     auto cb = [&](std::string_view name) -> bool {
@@ -260,7 +282,7 @@ TEST_P(StarletFileSystemTest, test_delete_dir_recursive) {
 }
 
 TEST_P(StarletFileSystemTest, test_delete_nonexist_file) {
-    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(kStarletPrefix));
+    auto fs = new_fs_starlet();
     ASSERT_OK(fs->delete_file(StarletPath("/nonexist.dat")));
 }
 

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -278,7 +278,10 @@ TEST_P(StarletFileSystemTest, test_delete_dir_recursive) {
     ASSERT_EQ(1, entries.size());
     ASSERT_EQ("dirname0x/", entries[0]);
     ASSERT_OK(fs->delete_dir(StarletPath("/dirname0x")));
-    ASSERT_ERROR(fs->delete_dir_recursive(StarletPath("/")));
+    ASSERT_OK(fs->delete_dir_recursive(StarletPath("/")));
+    entries.clear();
+    // NOTE: this is incompatible with other file systems.
+    EXPECT_TRUE(fs->iterate_dir(StarletPath("/"), cb).is_not_found());
 }
 
 TEST_P(StarletFileSystemTest, test_delete_nonexist_file) {

--- a/be/test/storage/lake/location_provider_test.cpp
+++ b/be/test/storage/lake/location_provider_test.cpp
@@ -6,11 +6,13 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "fs/fs_starlet.h"
 #include "service/staros_worker.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/starlet_location_provider.h"
 #include "testutil/assert.h"
 
-namespace starrocks {
+namespace starrocks::lake {
 
 extern std::shared_ptr<StarOSWorker> g_worker;
 
@@ -32,16 +34,16 @@ public:
 
 TEST_F(StarletLocationProviderTest, test_location) {
     auto location = _provider->root_location(12345);
-    EXPECT_EQ("staros://?ShardId=12345", location);
+    EXPECT_EQ(build_starlet_uri(12345, "/"), location);
 
     location = _provider->tablet_metadata_location(12345, 1);
-    EXPECT_EQ(fmt::format("staros://tbl_{:016X}_{:016X}?ShardId=12345", 12345, 1), location);
+    EXPECT_EQ(build_starlet_uri(12345, tablet_metadata_filename(12345, 1)), location);
 
     location = _provider->txn_log_location(12345, 45678);
-    EXPECT_EQ(fmt::format("staros://txn_{:016X}_{:016X}?ShardId=12345", 12345, 45678), location);
+    EXPECT_EQ(build_starlet_uri(12345, txn_log_filename(12345, 45678)), location);
 
     location = _provider->segment_location(12345, "c805dab9-4048-4909-8239-6d5431989044.dat");
-    EXPECT_EQ("staros://c805dab9-4048-4909-8239-6d5431989044.dat?ShardId=12345", location);
+    EXPECT_EQ(build_starlet_uri(12345, "c805dab9-4048-4909-8239-6d5431989044.dat"), location);
 
     std::set<std::string> roots;
     auto st = _provider->list_root_locations(&roots);
@@ -50,5 +52,5 @@ TEST_F(StarletLocationProviderTest, test_location) {
     EXPECT_TRUE(roots.empty());
 }
 
-} // namespace starrocks
+} // namespace starrocks::lake
 #endif // USE_STAROS

--- a/be/test/storage/lake/location_provider_test.cpp
+++ b/be/test/storage/lake/location_provider_test.cpp
@@ -12,9 +12,11 @@
 #include "storage/lake/starlet_location_provider.h"
 #include "testutil/assert.h"
 
-namespace starrocks::lake {
-
+namespace starrocks {
 extern std::shared_ptr<StarOSWorker> g_worker;
+} // namespace starrocks
+
+namespace starrocks::lake {
 
 class StarletLocationProviderTest : public testing::Test {
 public:


### PR DESCRIPTION
Old URI format: staros://path/to/object?ShardId=shard_id
New URI format: staros://shard_id/path/to/object

The new format make it easier to join paths, e.g, `auto new_string = fmt::format("{}/{}", parent, child)`

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others


