### PR TITLE
[Enhancement] Add throw exception for cast when allow throw exception

### DIFF
--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -39,11 +39,6 @@ namespace starrocks::vectorized {
        << " to " << type_to_string(TOTYPE) << " failed";                  \
     throw std::runtime_error(ss.str())
 
-#define THROW_RUNTIME_ERROR_WITH_TYPE_AND_VALUE(TYPE, VALUE)           \
-    std::stringstream ss;                                              \
-    ss << VALUE << " conflict with range of " << type_to_string(TYPE); \
-    throw std::runtime_error(ss.str())
-
 template <PrimitiveType FromType, PrimitiveType ToType>
 ColumnPtr cast_fn(ColumnPtr& column);
 
@@ -317,7 +312,6 @@ DEFINE_UNARY_FN_WITH_IMPL(NumberCheck, value) {
     auto result = (value < (Type)std::numeric_limits<ResultType>::lowest()) |
                   (value > (Type)std::numeric_limits<ResultType>::max());
     if (result) {
-        //THROW_RUNTIME_ERROR_WITH_TYPE_AND_VALUE(ResultType, value);
         std::stringstream ss;
         if constexpr (std::is_same_v<Type, __int128_t>) {
             ss << LargeIntValue::to_string(value) << " conflict with range of "

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -152,7 +152,7 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
             if constexpr (AllowThrowException) {
                 THROW_RUNTIME_ERROR_WITH_TYPE(FromType);
             }
-            CHECK(false) << "not supported type " << FromType;
+            DCHECK(false) << "not supported type " << FromType;
         }
         if (overflow || value.is_null()) {
             if constexpr (AllowThrowException) {
@@ -205,7 +205,7 @@ static ColumnPtr cast_from_json_fn(ColumnPtr& column) {
                 if constexpr (AllowThrowException) {
                     THROW_RUNTIME_ERROR_WITH_TYPE(ToType);
                 }
-                CHECK(false) << "unreachable type " << ToType;
+                DCHECK(false) << "unreachable type " << ToType;
                 __builtin_unreachable();
             }
             if (ok) {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -342,9 +342,8 @@ static ColumnPtr cast_from_string_to_hll_fn(ColumnPtr& column) {
         if (!HyperLogLog::is_valid(value)) {
             if constexpr (AllowThrowException) {
                 THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(TYPE_VARCHAR, TYPE_HLL, value.to_string());
-            } else {
-                builder.append_null();
             }
+            builder.append_null();
         } else {
             HyperLogLog hll;
             hll.deserialize(value);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When insert data into tables with cast function, if cast failed it default use null instead, but maybe It's better to Prompt this, so we decide to configure this. 
**We should set allow_throw_exception from fe to decide whether print exception when cast failed.**
And if allow_throw_exception is true, we will get exception when cast failed with insert, like following:
```
mysql> insert into action333 values (cast("starrocks" as int), "sss", '2020-05-13 10:33:33');
ERROR 1064 (HY000): Expr evaluate meet error: cast from VARCHAR(starrocks) to INT failed
```