### PR TITLE
[Enhancement] make coalesce options configurable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -715,6 +715,9 @@ CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");
 CONF_mBool(parquet_coalesce_read_enable, "true");
 CONF_mInt32(parquet_header_max_size, "16384");
 
+CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
+CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 
 // default: 16MB

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -17,7 +17,12 @@ class ORCHdfsFileStream : public orc::InputStream {
 public:
     // |file| must outlive ORCHdfsFileStream
     ORCHdfsFileStream(RandomAccessFile* file, uint64_t length)
-            : _file(std::move(file)), _length(length), _cache_buffer(0), _cache_offset(0), _buffer_stream(_file) {}
+            : _file(std::move(file)), _length(length), _cache_buffer(0), _cache_offset(0), _buffer_stream(_file) {
+        SharedBufferedInputStream::CoalesceOptions options = {
+                .max_dist_size = config::io_coalesce_read_max_distance_size,
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
+        _buffer_stream.set_coalesce_options(options);
+    }
 
     ~ORCHdfsFileStream() override = default;
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -400,6 +400,11 @@ Status FileReader::_init_group_readers() {
     // 3. set io ranges to the stream.
     if (config::parquet_coalesce_read_enable) {
         _sb_stream = std::make_shared<SharedBufferedInputStream>(_file);
+        SharedBufferedInputStream::CoalesceOptions options = {
+                .max_dist_size = config::io_coalesce_read_max_distance_size,
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
+        _sb_stream->set_coalesce_options(options);
+
         std::vector<SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -124,7 +124,7 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
             const auto& now = small_ranges[i];
             size_t now_end = now.offset + now.size;
             size_t prev_end = prev.offset + prev.size;
-            if (((now_end - small_ranges[unmerge].offset) <= _options.max_read_size) &&
+            if (((now_end - small_ranges[unmerge].offset) <= _options.max_buffer_size) &&
                 (now.offset - prev_end) <= _options.max_dist_size) {
                 continue;
             } else {

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -81,7 +81,6 @@ public:
     };
     struct CoalesceOptions {
         static constexpr int64_t MB = 1024 * 1024;
-        int64_t max_read_size = 16 * MB;
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
     };
@@ -95,6 +94,7 @@ public:
 
     Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) override;
     void release();
+    void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
 
 private:
     struct SharedBuffer {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to:
1. make `coalesce options` configurable
2. remove `max_read_size` from coalesce options to align with trino/presto.

