### PR TITLE
[BugFix] Fix the bug of not lock the shard of base tablet when creating tablet

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -150,7 +150,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
         int base_shard_idx = _get_tablets_shard_idx(request.base_tablet_id);
 
         if (shard_idx == base_shard_idx) {
-            // do nothing
+            wlock.lock();
         } else {
             std::unique_lock tmp_wlock(_get_tablets_shard_lock(request.base_tablet_id), std::defer_lock);
             base_wlock = std::move(tmp_wlock);

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -145,6 +145,9 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     std::unique_lock wlock(_get_tablets_shard_lock(tablet_id), std::defer_lock);
     std::unique_lock<std::shared_mutex> base_wlock;
 
+    // If do schema change, both the shard where the source tablet is located and
+    // the shard where the target tablet is located need to be locked.
+    // In order to prevent deadlock, the order of locking needs to be fixed.
     if (request.__isset.base_tablet_id && request.base_tablet_id > 0) {
         int shard_idx = _get_tablets_shard_idx(tablet_id);
         int base_shard_idx = _get_tablets_shard_idx(request.base_tablet_id);

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -219,9 +219,11 @@ private:
 
     TabletsShard& _get_tablets_shard(TTabletId tabletId);
 
-    Status _remove_tablet_meta(const TabletSharedPtr& tablet);
-    Status _remove_tablet_directories(const TabletSharedPtr& tablet);
-    Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
+    int32_t _get_tablets_shard_idx(TTabletId tabletId) const { return tabletId & _tablets_shards_mask; }
+
+    static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
+    static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
+    static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
 
     MemTracker* _mem_tracker = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9258 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The shard bucket of base tablet is not locked
