### PR TITLE
[Enhancement] more control on cbo

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -53,7 +53,7 @@ public class TransactionLoadAction extends RestBaseAction {
 
     private Map<String, Long> txnBackendMap = new LinkedHashMap<String, Long>(512, 0.75f, true) {
         protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
-            return size() > GlobalStateMgr.getCurrentSystemInfo().backendSize() * 512;
+            return size() > GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber() * 512;
         }
     };
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -173,16 +173,7 @@ public class ConnectContext {
     }
 
     public ConnectContext() {
-        state = new QueryState();
-        returnRows = 0;
-        serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
-        isKilled = false;
-        serializer = MysqlSerializer.newInstance();
-        sessionVariable = VariableMgr.newSessionVariable();
-        command = MysqlCommand.COM_SLEEP;
-        dumpInfo = new QueryDumpInfo(sessionVariable);
-        plannerProfile = new PlannerProfile();
-        plannerProfile.init(this);
+        this(null);
     }
 
     public ConnectContext(SocketChannel channel) {
@@ -190,17 +181,18 @@ public class ConnectContext {
         returnRows = 0;
         serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
         isKilled = false;
-        mysqlChannel = new MysqlChannel(channel);
         serializer = MysqlSerializer.newInstance();
         sessionVariable = VariableMgr.newSessionVariable();
         command = MysqlCommand.COM_SLEEP;
-        if (channel != null) {
-            remoteIP = mysqlChannel.getRemoteIp();
-        }
         queryDetail = null;
         dumpInfo = new QueryDumpInfo(sessionVariable);
         plannerProfile = new PlannerProfile();
         plannerProfile.init(this);
+
+        mysqlChannel = new MysqlChannel(channel);
+        if (channel != null) {
+            remoteIP = mysqlChannel.getRemoteIp();
+        }
     }
 
     public long getStmtId() {
@@ -559,6 +551,18 @@ public class ConnectContext {
             threadInfo = new ThreadInfo();
         }
         return threadInfo;
+    }
+
+    public int getAliveBackendNumber() {
+        int v = sessionVariable.getCboDebugAliveBackendNumber();
+        if (v > 0) {
+            return v;
+        }
+        return globalStateMgr.getClusterInfo().getAliveBackendNumber();
+    }
+
+    public int getTotalBackendNumber() {
+        return globalStateMgr.getClusterInfo().getTotalBackendNumber();
     }
 
     public class ThreadInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -192,6 +192,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // --------  New planner session variables start --------
     public static final String NEW_PLANER_AGG_STAGE = "new_planner_agg_stage";
     public static final String BROADCAST_ROW_LIMIT = "broadcast_row_limit";
+    public static final String BROADCAST_RIGHT_TABLE_SCALE_FACTOR =
+            "broadcast_right_table_scale_factor";
     public static final String NEW_PLANNER_OPTIMIZER_TIMEOUT = "new_planner_optimize_timeout";
     public static final String ENABLE_GROUPBY_USE_OUTPUT_ALIAS = "enable_groupby_use_output_alias";
     public static final String ENABLE_QUERY_DUMP = "enable_query_dump";
@@ -209,6 +211,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
+    public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
+
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -496,6 +500,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CBO_ENABLE_GREEDY_JOIN_REORDER, flag = VariableMgr.INVISIBLE)
     private boolean cboEnableGreedyJoinReorder = true;
 
+    @VariableMgr.VarAttr(name = CBO_DEBUG_ALIVE_BACKEND_NUMBER, flag = VariableMgr.INVISIBLE)
+    private int cboDebugAliveBackendNumber = 0;
+
     @VariableMgr.VarAttr(name = TRANSACTION_VISIBLE_WAIT_TIMEOUT)
     private long transactionVisibleWaitTimeout = 10;
 
@@ -504,6 +511,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = BROADCAST_ROW_LIMIT)
     private long broadcastRowCountLimit = 15000000;
+
+    @VariableMgr.VarAttr(name = BROADCAST_RIGHT_TABLE_SCALE_FACTOR, flag = VariableMgr.INVISIBLE)
+    private double broadcastRightTableScaleFactor = 10.0;
 
     @VariableMgr.VarAttr(name = NEW_PLANNER_OPTIMIZER_TIMEOUT)
     private long optimizerExecuteTimeout = 3000;
@@ -824,6 +834,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboMaxReorderNode;
     }
 
+    public int getCboDebugAliveBackendNumber() {
+        return cboDebugAliveBackendNumber;
+    }
+
     public long getTransactionVisibleWaitTimeout() {
         return transactionVisibleWaitTimeout;
     }
@@ -850,6 +864,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getBroadcastRowCountLimit() {
         return broadcastRowCountLimit;
+    }
+
+    public double getBroadcastRightTableScaleFactor() {
+        return broadcastRightTableScaleFactor;
     }
 
     public long getOptimizerExecuteTimeout() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -17,6 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.external.hive.HiveColumnStats;
 import com.starrocks.external.iceberg.cost.IcebergTableStatisticCalculator;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -446,8 +447,9 @@ public class Utils {
     public static boolean canDoReplicatedJoin(OlapTable table, long selectedIndexId,
                                               Collection<Long> selectedPartitionId,
                                               Collection<Long> selectedTabletId) {
-        int backendSize = GlobalStateMgr.getCurrentSystemInfo().backendSize();
-        int aliveBackendSize = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendNumber();
+        ConnectContext ctx = ConnectContext.get();
+        int backendSize = ctx.getTotalBackendNumber();
+        int aliveBackendSize = ctx.getAliveBackendNumber();
         int schemaHash = table.getSchemaHashByIndexId(selectedIndexId);
         for (Long partitionId : selectedPartitionId) {
             Partition partition = table.getPartition(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
@@ -13,6 +13,7 @@ import com.starrocks.catalog.View;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Version;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +79,8 @@ public class QueryDumpSerializer implements JsonSerializer<QueryDumpInfo> {
         }
         dumpJson.add("column_statistics", tableColumnStatistics);
         // 7. BE number
-        long beNum = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendNumber();
+        ConnectContext ctx = ConnectContext.get();
+        long beNum = ctx.getAliveBackendNumber();
         dumpJson.addProperty("be_number", beNum);
         // 8. exception
         JsonArray exceptions = new JsonArray();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -5,7 +5,7 @@ package com.starrocks.sql.optimizer.task;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.ChildOutputPropertyGuarantor;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
@@ -243,10 +243,12 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         // Only when right table is not significantly smaller than left table, consider the
         // broadcastRowCountLimit, Otherwise, this limit is not considered, which can avoid
         // shuffling large left-hand table data
+        ConnectContext ctx = ConnectContext.get();
+        SessionVariable sv = ConnectContext.get().getSessionVariable();
         int parallelExecInstance = Math.max(1,
                 Math.min(groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum(),
-                        ConnectContext.get().getSessionVariable().getDegreeOfParallelism()));
-        int beNum = Math.max(1, GlobalStateMgr.getCurrentSystemInfo().getAliveBackendNumber());
+                        sv.getDegreeOfParallelism()));
+        int beNum = Math.max(1, ctx.getAliveBackendNumber());
         Statistics leftChildStats = groupExpression.getInputs().get(curChildIndex - 1).getStatistics();
         Statistics rightChildStats = groupExpression.getInputs().get(curChildIndex).getStatistics();
         if (leftChildStats == null || rightChildStats == null) {
@@ -255,9 +257,9 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         double leftOutputSize = leftChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex - 1));
         double rightOutputSize = rightChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex));
 
-        if (leftOutputSize < rightOutputSize * parallelExecInstance * beNum * 10
+        if (leftOutputSize < rightOutputSize * parallelExecInstance * beNum * sv.getBroadcastRightTableScaleFactor()
                 && rightChildStats.getOutputRowCount() >
-                ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit()) {
+                sv.getBroadcastRowCountLimit()) {
             return false;
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -527,7 +527,7 @@ public class SystemInfoService {
     }
 
     public int getTotalBackendNumber() {
-        return getBackendIds(false).size();
+        return idToBackendRef.size();
     }
 
     public ComputeNode getComputeNodeWithBePort(String host, int bePort) {
@@ -572,10 +572,6 @@ public class SystemInfoService {
             }
             return backendIds;
         }
-    }
-
-    public int backendSize() {
-        return idToBackendRef.size();
     }
 
     public List<Long> getDecommissionedBackendIds() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

summary
===
This PR is to have more control on CBO:
1. put `aliveBackendNumber` and `totalBackendNumebr` into ConnectContext.It's more modular.
2. refactor init of `ConnectContext`, to share a common init function.
3. add session variable `broadcast_right_table_scale_factor`
4. add session variable `cbo_debug_alive_backend_number` to fake alive backend number(which will affect final plan)
5. rename `backendSize` to `getTotalBackendNumber`

rationale
===

The variable `cbo_debug_alive_backend_number` can be very useful. You can emulate running a query on 50 machines, and spot plan bug as soon as possible without actually deploying our planner on 50 machines.



__following are deleted__
`cbo_enable_derived_predicate_when_column_stats_missing` is to avoid bad plan(tpch-100g q2) by this PR. https://github.com/StarRocks/starrocks/pull/8219/files. I suspect a lot of derived predicate will affect statistics and finally affect plan. Perhaps there is a better solution but I've tried my best. 

```
select
  s_acctbal,
  s_name,
  n_name,
  p_partkey,
  p_mfgr,
  s_address,
  s_phone,
  s_comment
from
  part,
  supplier,
  partsupp,
  nation,
  region
where
  p_partkey = ps_partkey
  and s_suppkey = ps_suppkey
  and p_size = 15
  and p_type like '%BRASS'
  and s_nationkey = n_nationkey
  and n_regionkey = r_regionkey
  and r_name = 'EUROPE'
  and ps_supplycost = ( 
    select
      min(ps_supplycost)
    from
      partsupp,
      supplier,
      nation,
      region
    where
      p_partkey = ps_partkey
      and s_suppkey = ps_suppkey
      and s_nationkey = n_nationkey
      and n_regionkey = r_regionkey
      and r_name = 'EUROPE'
  )
order by
  s_acctbal desc,
  n_name,
  s_name,
  p_partkey limit 100
```
