### PR TITLE
[Enhancement] Wait the BE process to exit (#9175)

### DIFF
--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -38,20 +38,14 @@ if [ -f $pidfile ]; then
         exit 1
     fi
 
-    if kill -0 $pid; then
-        if kill -9 $pid > /dev/null 2>&1; then
-            echo "stop $pidcomm, and remove pid file. "
-            rm $pidfile
-            exit 0
-        else
+    if kill -0 $pid >/dev/null 2>&1; then
+        kill -${sig} $pid > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
             exit 1
         fi
-    else
-        echo "Backend already exit, remove pid file. "
-        rm $pidfile
+        while kill -0 $pid >/dev/null 2>&1; do
+            sleep 1
+        done
     fi
-else
-    echo "$pidfile does not exist"
-    exit 1
+    rm $pidfile
 fi
-


### PR DESCRIPTION
`kill -SIGKILL $pid` does not guarantee the process exit immediately.
If the process is doing I/O operations, the exit will last for a while.
You can simulate with 500 threads and read a large file in one thread.
Because the rocksdb use fcntl to set F_WRLCK, so the restart will encounter error.
```
Store load failed, status=IO error: IO error: While lock file
Fail to open rocksdb, reason:IO error: While lock file
Fail to init meta store: IO error: IO error: While lock file
```

The pull request solves the problem by checking the process to exist using `kill -0 $pid`
