### PR TITLE
[Enhancement] Set priority of i/o task in pipeline by submitted times

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -76,16 +76,13 @@ std::pair<Status, size_t> ChunkSource::buffer_next_batch_chunks_blocking(Runtime
             _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
         }
 
-        if (running_wg != nullptr) {
-            if (time_spent >= YIELD_MAX_TIME_SPENT) {
-                break;
-            }
+        if (time_spent >= YIELD_MAX_TIME_SPENT) {
+            break;
+        }
 
-            if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
-                workgroup::WorkGroupManager::instance()->should_yield_scan_worker(_executor_type, worker_id,
-                                                                                  running_wg)) {
-                break;
-            }
+        if (running_wg != nullptr && time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+            workgroup::WorkGroupManager::instance()->should_yield_scan_worker(_executor_type, worker_id, running_wg)) {
+            break;
         }
     }
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -303,8 +303,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
 
     workgroup::ScanTask task;
     task.workgroup = _workgroup;
-    // TODO(by satanson): set a proper priority
-    task.priority = 20;
+    // TODO: consider more factors, such as scan bytes and i/o time.
+    task.priority = vectorized::OlapScanNode::compute_priority(_submit_task_counter->value());
     task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id](int worker_id) {
         if (auto sp = wp.lock()) {
             // Set driver_id here to share some driver-local contents.

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -501,7 +501,7 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
 }
 
 // The more tasks you submit, the less priority you get.
-int OlapScanNode::_compute_priority(int32_t num_submitted_tasks) {
+int OlapScanNode::compute_priority(int32_t num_submitted_tasks) {
     // int nice = 20;
     // while (nice > 0 && num_submitted_tasks > (22 - nice) * (20 - nice) * 6) {
     //     --nice;
@@ -536,7 +536,7 @@ bool OlapScanNode::_submit_scanner(TabletScanner* scanner, bool blockable) {
     int32_t num_submit = _scanner_submit_count.fetch_add(delta, std::memory_order_relaxed);
     PriorityThreadPool::Task task;
     task.work_function = [this, scanner] { _scanner_thread(scanner); };
-    task.priority = _compute_priority(num_submit);
+    task.priority = compute_priority(num_submit);
     _running_threads.fetch_add(1, std::memory_order_release);
     if (LIKELY(thread_pool->try_offer(task))) {
         return true;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -74,9 +74,10 @@ public:
 
     const TOlapScanNode& thrift_olap_scan_node() const { return _olap_scan_node; }
 
-    static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
-
     int estimated_max_concurrent_chunks() const;
+
+    static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
+    static int compute_priority(int32_t num_submitted_tasks);
 
 private:
     friend class TabletScanner;
@@ -126,7 +127,6 @@ private:
     void _fill_chunk_pool(int count, bool force_column_pool);
     bool _submit_scanner(TabletScanner* scanner, bool blockable);
     void _close_pending_scanners();
-    int _compute_priority(int32_t num_submitted_tasks);
 
     // Reference the row sets into _tablet_rowsets in the preparation phase to avoid
     // the row sets being deleted. Should be called after set_scan_ranges.

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -91,7 +91,7 @@ void WorkGroup::init() {
     _mem_tracker = std::make_shared<starrocks::MemTracker>(_memory_limit_bytes, _name,
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
     _driver_queue = std::make_unique<pipeline::QuerySharedDriverQueueWithoutLock>();
-    _scan_task_queue = std::make_unique<FifoScanTaskQueue>();
+    _scan_task_queue = std::make_unique<PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size);
 }
 
 std::string WorkGroup::to_string() const {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Set priority of an i/o task in pipeline according to the number of submitted tasks by the scan operator.

For the inner scan i/o task queue in a workgroup, also replace `FifoScanTaskQueue` with `PriorityScanTaskQueue`.



Besides, make a scan i/o task yield, when it already costs 100ms.

