### PR TITLE
[BugFix] fix mv refresh all the time if base table dropped partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -373,6 +373,17 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
         }
     }
 
+    public void cleanBasePartition(OlapTable base) {
+        Map<String, BasePartitionInfo> basePartitionInfoMap = this.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableVisibleVersionMap()
+                .computeIfAbsent(base.getId(), k -> Maps.newHashMap());
+        for (String basePartitionName : basePartitionInfoMap.keySet()) {
+            if (base.getPartition(basePartitionName) == null) {
+                removeBasePartition(base.getId(), basePartitionName, false);
+            }
+        }
+    }
+
     @Override
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.MATERIALIZED_VIEW,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -247,9 +247,6 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             Set<String> baseChangedPartitionNames = mv.getNeedRefreshPartitionNames(base);
             needRefreshMvPartitionNames.addAll(baseChangedPartitionNames);
             // The partition of base and mv is 1 to 1 relationship
-            for (String mvPartitionName : deletes.keySet()) {
-                mv.removeBasePartition(baseTableId, mvPartitionName);
-            }
             for (String mvPartitionName : adds.keySet()) {
                 mv.addBasePartition(baseTableId, base.getPartition(mvPartitionName));
             }
@@ -268,9 +265,9 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             }
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
-            if (!deletes.isEmpty()) {
-                mv.cleanBasePartition(base);
-            }
+        }
+        if (!deletes.isEmpty()) {
+            mv.cleanBasePartition(base);
         }
 
         LOG.info("Calculate the partitions that need to be refreshed:[{}]", needRefreshMvPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -246,22 +246,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         if (partitionExpr instanceof SlotRef) {
             Set<String> baseChangedPartitionNames = mv.getNeedRefreshPartitionNames(base);
             needRefreshMvPartitionNames.addAll(baseChangedPartitionNames);
-            // The partition of base and mv is 1 to 1 relationship
-            for (String mvPartitionName : deletes.keySet()) {
-                mv.removeBasePartition(baseTableId, mvPartitionName);
-            }
-            for (String mvPartitionName : adds.keySet()) {
-                mv.addBasePartition(baseTableId, base.getPartition(mvPartitionName));
-            }
         }  else if (partitionExpr instanceof FunctionCallExpr) {
-            Set<String> deleteBasePartitionNames = Sets.newHashSet();
-            for (String mvPartitionName : deletes.keySet()) {
-                deleteBasePartitionNames.addAll(mvToBaseNameRef.get(mvPartitionName));
-            }
-            for (String basePartitionName : deleteBasePartitionNames) {
-                mv.removeBasePartition(baseTableId, basePartitionName);
-            }
-
             Set<String> addBasePartitionNames = Sets.newHashSet();
             for (String mvPartitionName : adds.keySet()) {
                 addBasePartitionNames.addAll(mvToBaseNameRef.get(mvPartitionName));
@@ -276,6 +261,9 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             }
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
+        }
+        if (!deletes.isEmpty()) {
+            mv.cleanBasePartition(base);
         }
 
         LOG.info("Calculate the partitions that need to be refreshed:[{}]", needRefreshMvPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -246,6 +246,10 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         if (partitionExpr instanceof SlotRef) {
             Set<String> baseChangedPartitionNames = mv.getNeedRefreshPartitionNames(base);
             needRefreshMvPartitionNames.addAll(baseChangedPartitionNames);
+            // The partition of base and mv is 1 to 1 relationship
+            for (String mvPartitionName : deletes.keySet()) {
+                mv.removeBasePartition(baseTableId, mvPartitionName);
+            }
             for (String mvPartitionName : adds.keySet()) {
                 mv.addBasePartition(baseTableId, base.getPartition(mvPartitionName));
             }
@@ -264,9 +268,9 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             }
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
-        }
-        if (!deletes.isEmpty()) {
-            mv.cleanBasePartition(base);
+            if (!deletes.isEmpty()) {
+                mv.cleanBasePartition(base);
+            }
         }
 
         LOG.info("Calculate the partitions that need to be refreshed:[{}]", needRefreshMvPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -246,6 +246,9 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
         if (partitionExpr instanceof SlotRef) {
             Set<String> baseChangedPartitionNames = mv.getNeedRefreshPartitionNames(base);
             needRefreshMvPartitionNames.addAll(baseChangedPartitionNames);
+            for (String mvPartitionName : adds.keySet()) {
+                mv.addBasePartition(baseTableId, base.getPartition(mvPartitionName));
+            }
         }  else if (partitionExpr instanceof FunctionCallExpr) {
             Set<String> addBasePartitionNames = Sets.newHashSet();
             for (String mvPartitionName : adds.keySet()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Create mv
```
CREATE MATERIALIZED VIEW mv1_multi_tables_partition_by_function_month
PARTITION BY date_trunc('month',s1)
distributed by hash(s2)
refresh async EVERY(INTERVAL 10 SECOND)
PROPERTIES('replication_num' = '1')
AS select t1.k1 s1, t2.k2 s2 from tbl1 t1 join tbl2 t2 on t1.k1 = t2.k1;
```
2. Drop exist base table partition
```
ALTER TABLE tbl1 DROP PARTITION p3;
```
3.  Fe.log like this:
```

2022-07-27 16:40:41,485 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-27 16:40:41,505 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-27 16:40:41,505 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():281] Calculate the partitions that need to be refreshed:[[p000101_202202, p202202_202203]]
……
……
……
2022-07-27 16:40:45,485 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-27 16:40:45,506 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-27 16:40:45,506 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():281] Calculate the partitions that need to be refreshed:[[p000101_202202, p202202_202203]]
……
……
……
2022-07-27 16:40:51,485 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-27 16:40:51,506 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-27 16:40:51,506 INFO (pool-21-thread-1|134) [MvTaskRunProcessor.processSyncBasePartition():281] Calculate the partitions that need to be refreshed:[[p000101_202202, p202202_202203]]
```