### PR TITLE
[Actions] change to download artifact until the workflow completed

### DIFF
--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -22,11 +22,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
 
-      - run: sleep 10 # wait the pr review upload artifact finished
+#      - run: sleep 5 # wait the pr review upload artifact finished
 
       - uses: dawidd6/action-download-artifact@v2
         with:
           workflow: review-pr-trigger.yml
+          workflow_conclusion: completed
           run_id: ${{ github.event.workflow_run.id }}
           path: ${{ github.workspace }}
 #           pr: ${{ steps.source-run-info.outputs.pullRequestNumber }} # pr number, commit, run_id, branch cannot use together

--- a/.github/workflows/add-approve-label.yml
+++ b/.github/workflows/add-approve-label.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
 
-      - run: sleep 5 # wait the pr review upload artifact finished
+      - run: sleep 10 # wait the pr review upload artifact finished
 
       - uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
sleep to 10 seconds

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # use the workflow status of completed to ganrantee the process

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) --> we use sleep to wait the previous workflow, which is uncertain in some case
