### PR TITLE
Fix compatibility of Hudi table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -31,6 +31,7 @@ import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -260,6 +261,16 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         Option<String[]> hudiPartitionFields = hudiTableConfig.getPartitionFields();
         if (hudiPartitionFields.isPresent()) {
             for (String partField : hudiPartitionFields.get()) {
+                Column partColumn = this.nameToColumn.get(partField);
+                if (partColumn == null) {
+                    throw new DdlException("Partition column [" + partField + "] must exist in column list");
+                } else {
+                    this.partColumnNames.add(partField);
+                }
+            }
+        } else if (!metastoreTable.getPartitionKeys().isEmpty()) {
+            for (FieldSchema fieldSchema : metastoreTable.getPartitionKeys()) {
+                String partField = fieldSchema.getName();
                 Column partColumn = this.nameToColumn.get(partField);
                 if (partColumn == null) {
                     throw new DdlException("Partition column [" + partField + "] must exist in column list");


### PR DESCRIPTION
… doesn't contain partition column info

Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Get partition column from HMS because old version Hudi table metadata doesn't contain partition column info. 

Hudi partition info is added to hoodie.properties since 2021/4/2
<img width="1423" alt="image" src="https://user-images.githubusercontent.com/8065637/181281907-b1235433-43e1-4829-b1a4-bdc726a8edbb.png">
