### PR TITLE
[Bugfix] fix mv partition refresh all the time if partition roll up

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -32,6 +32,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -358,10 +359,6 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
         basePartitionInfoMap.put(basePartitionName, basePartitionInfo);
     }
 
-    public void removeBasePartition(long baseTableId, String baseTablePartitionName) {
-        removeBasePartition(baseTableId, baseTablePartitionName, false);
-    }
-
     public void removeBasePartition(long baseTableId, String baseTablePartitionName, boolean isReplay) {
         Map<String, BasePartitionInfo> basePartitionInfoMap = this.getRefreshScheme().getAsyncRefreshContext()
                 .getBaseTableVisibleVersionMap()
@@ -373,19 +370,22 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
         }
     }
 
-    public void cleanBasePartition(OlapTable base) {
+    public int cleanBasePartition(OlapTable base) {
+        int cleanedBasePartitionCounter = 0;
         Map<String, BasePartitionInfo> basePartitionInfoMap = this.getRefreshScheme().getAsyncRefreshContext()
                 .getBaseTableVisibleVersionMap()
                 .computeIfAbsent(base.getId(), k -> Maps.newHashMap());
-        Set<String> deletedBasePartitionNames = Sets.newHashSet();
-        for (String basePartitionName : basePartitionInfoMap.keySet()) {
+        Iterator<String> basePartitionNameIterator = basePartitionInfoMap.keySet().iterator();
+        while (basePartitionNameIterator.hasNext()) {
+            String basePartitionName = basePartitionNameIterator.next();
             if (base.getPartition(basePartitionName) == null) {
-                deletedBasePartitionNames.add(basePartitionName);
+                basePartitionNameIterator.remove();
+                GlobalStateMgr.getCurrentState().getEditLog().logRemoveMvVersionMapInfo(
+                        new MaterializedViewPartitionVersionInfo(this.dbId, this.id, base.getId(), basePartitionName, -1, -1));
+                cleanedBasePartitionCounter++;
             }
         }
-        for (String deletedBasePartitionName : deletedBasePartitionNames) {
-            removeBasePartition(base.getId(), deletedBasePartitionName, false);
-        }
+        return cleanedBasePartitionCounter;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -377,10 +377,14 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
         Map<String, BasePartitionInfo> basePartitionInfoMap = this.getRefreshScheme().getAsyncRefreshContext()
                 .getBaseTableVisibleVersionMap()
                 .computeIfAbsent(base.getId(), k -> Maps.newHashMap());
+        Set<String> deletedBasePartitionNames = Sets.newHashSet();
         for (String basePartitionName : basePartitionInfoMap.keySet()) {
             if (base.getPartition(basePartitionName) == null) {
-                removeBasePartition(base.getId(), basePartitionName, false);
+                deletedBasePartitionNames.add(basePartitionName);
             }
+        }
+        for (String deletedBasePartitionName : deletedBasePartitionNames) {
+            removeBasePartition(base.getId(), deletedBasePartitionName, false);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -224,7 +224,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             String mvPartitionName = deleteEntry.getKey();
             dropPartition(db, mv, mvPartitionName);
         }
-        LOG.info("The process of synchronizing partitions delete range {}", deletes);
+        LOG.info("The process of synchronizing materialized view [{}] partitions delete range [{}]", mv.getName(), deletes);
 
         for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
             String mvPartitionName = addEntry.getKey();
@@ -234,7 +234,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             // The newly added partition must be the partition that needs to be refreshed
             needRefreshMvPartitionNames.add(mvPartitionName);
         }
-        LOG.info("The process of synchronizing partitions add range {} ", adds);
+        LOG.info("The process of synchronizing materialized view [{}] partitions add range [{}]", mv.getName(), adds);
 
         Map<String, Set<String>> baseToMvNameRef = SyncPartitionUtils
                 .generatePartitionRefMap(basePartitionMap, mvPartitionMap);
@@ -270,7 +270,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             mv.cleanBasePartition(base);
         }
 
-        LOG.info("Calculate the partitions that need to be refreshed:[{}]", needRefreshMvPartitionNames);
+        LOG.info("Calculate the materialized view [{}] partitions that need to be refreshed [{}]", mv.getName(), needRefreshMvPartitionNames);
 
         return needRefreshMvPartitionNames;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -270,7 +270,8 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             mv.cleanBasePartition(base);
         }
 
-        LOG.info("Calculate the materialized view [{}] partitions that need to be refreshed [{}]", mv.getName(), needRefreshMvPartitionNames);
+        LOG.info("Calculate the materialized view [{}] partitions that need to be refreshed [{}]",
+                mv.getName(), needRefreshMvPartitionNames);
 
         return needRefreshMvPartitionNames;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunProcessor.java
@@ -266,7 +266,7 @@ public class MvTaskRunProcessor extends BaseTaskRunProcessor {
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
         }
-        if (!deletes.isEmpty()) {
+        if (!deletes.isEmpty() || !needRefreshMvPartitionNames.isEmpty()) {
             mv.cleanBasePartition(base);
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Create table and mv
```
CREATE TABLE tbl1
(
k1 date,
k2 int,
v1 int sum
)
PARTITION BY RANGE(k1)
(
    PARTITION p1 values less than('2022-02-01'),
    PARTITION p2 values less than('2022-03-01'),
    PARTITION p3 values less than('2022-04-01')
)
DISTRIBUTED BY HASH(k2) BUCKETS 3
PROPERTIES('replication_num' = '1');

CREATE TABLE tbl2
(
k1 date,
k2 int,
v1 int
)
DISTRIBUTED BY HASH(k2) BUCKETS 3
PROPERTIES('replication_num' = '1');

CREATE MATERIALIZED VIEW mv1_multi_tables_partition_by_function_year
PARTITION BY date_trunc('month',s1)
distributed by hash(s2)
refresh async EVERY(INTERVAL 10 SECOND)
PROPERTIES('replication_num' = '1')
AS select t1.k1 s1, t2.k2 s2 from tbl1 t1 join tbl2 t2 on t1.k1 = t2.k1;
```
2. Drop exist base table partition
```
ALTER TABLE tbl1 DROP PARTITION p3;
```
3.  Fe.log like this:
```
2022-07-28 11:14:13,369 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-28 11:14:13,389 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-28 11:14:13,390 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():273] Calculate the partitions that need to be refreshed:[[p2022_2023, p0001_2022]]
……
2022-07-28 11:14:23,366 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-28 11:14:23,386 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-28 11:14:23,386 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():273] Calculate the partitions that need to be refreshed:[[p2022_2023, p0001_2022]]
……
2022-07-28 11:14:33,363 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():227] The process of synchronizing partitions delete range {}
2022-07-28 11:14:33,384 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():237] The process of synchronizing partitions add range {} 
2022-07-28 11:14:33,385 INFO (pool-21-thread-3|418) [MvTaskRunProcessor.processSyncBasePartition():273] Calculate the partitions that need to be refreshed:[[p2022_2023, p0001_2022]]
……
```
