### PR TITLE
[Refactor] Removed not used log upon start and unified drop_tablet_unlock interface

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1097,7 +1097,6 @@ void* TaskWorkerPool::_report_task_worker_thread_callback(void* arg_this) {
         if (master_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
-            LOG(INFO) << "Waiting to receive first heartbeat from frontend";
             sleep(1);
             continue;
         }
@@ -1137,7 +1136,6 @@ void* TaskWorkerPool::_report_disk_state_worker_thread_callback(void* arg_this) 
         if (master_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
-            LOG(INFO) << "Waiting to receive first heartbeat from frontend";
             sleep(config::sleep_one_second);
             continue;
         }
@@ -1196,7 +1194,6 @@ void* TaskWorkerPool::_report_tablet_worker_thread_callback(void* arg_this) {
         if (master_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
-            LOG(INFO) << "Waiting to receive first heartbeat from frontend";
             sleep(config::sleep_one_second);
             continue;
         }
@@ -1243,7 +1240,6 @@ void* TaskWorkerPool::_report_workgroup_thread_callback(void* arg_this) {
         if (master_address.port == 0) {
             // port == 0 means not received heartbeat yet
             // sleep a short time and try again
-            LOG(INFO) << "Waiting to receive first heartbeat from frontend";
             sleep(config::sleep_one_second);
             continue;
         }

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -99,7 +99,6 @@ Status EvHttpServer::start() {
     RETURN_IF_ERROR(_bind());
     for (int i = 0; i < _num_workers; ++i) {
         auto worker = [this, i]() {
-            LOG(INFO) << "EvHttpServer worker start, id=" << i;
             struct event_base* base = event_base_new();
             if (base == nullptr) {
                 LOG(WARNING) << "Couldn't create an event_base.";

--- a/be/src/service/backend_base.cpp
+++ b/be/src/service/backend_base.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<ThriftServer> BackendServiceBase::create(ExecEnv* exec_env, int 
     auto thread_factory = std::make_shared<ThreadFactory>();
     auto processor = std::make_shared<BackendServiceProcessor>(handler);
 
-    LOG(INFO) << "StarRocksInternalService listening on " << port;
+    LOG(INFO) << "StarRocksInternalService has started listening port on " << port;
     // TODO: May be rename be_service_threads to thrift_service_threads ?
     return std::make_unique<ThriftServer>("BackendService", processor, port, exec_env->metrics(),
                                           config::be_service_threads);

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -74,7 +74,7 @@ bool BackendOptions::init() {
         LOG(INFO) << "fail to find one valid non-loopback address, use loopback address.";
         _s_localhost = loopback;
     }
-    LOG(INFO) << "local host ip=" << _s_localhost;
+    LOG(INFO) << "local host" << _s_localhost;
     return true;
 }
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -265,8 +265,6 @@ int main(int argc, char** argv) {
         LOG(ERROR) << "StarRocks BE HeartBeat Service did not start correctly. Error=" << status.to_string();
         starrocks::shutdown_logging();
         exit(1);
-    } else {
-        LOG(INFO) << "StarRocks BE HeartBeat Service started correctly.";
     }
 
 #ifdef USE_STAROS

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -511,8 +511,6 @@ Status DataDir::update_capacity() {
     ASSIGN_OR_RETURN(auto space_info, FileSystem::Default()->space(_path));
     _available_bytes = space_info.available;
     _disk_capacity_bytes = space_info.capacity;
-    LOG(INFO) << "path: " << _path << " total capacity: " << _disk_capacity_bytes
-              << ", available capacity: " << _available_bytes;
     return Status::OK();
 }
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -79,13 +79,7 @@ public:
     template <class U>
     TraceAlloc(TraceAlloc<U> const&) noexcept {}
 
-    value_type* allocate(std::size_t n) {
-        if (n >= large_mem_alloc_threhold / phmap_hash_table_shard / sizeof(value_type)) {
-            LOG(INFO) << "primary_index large alloc " << n << "*" << sizeof(value_type) << "="
-                      << n * sizeof(value_type);
-        }
-        return static_cast<value_type*>(::operator new(n * sizeof(value_type)));
-    }
+    value_type* allocate(std::size_t n) { return static_cast<value_type*>(::operator new(n * sizeof(value_type))); }
 
     void deallocate(value_type* p, std::size_t) noexcept { ::operator delete(p); }
 };

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -73,11 +73,9 @@ static Status _validate_options(const EngineOptions& options) {
 
 Status StorageEngine::open(const EngineOptions& options, StorageEngine** engine_ptr) {
     RETURN_IF_ERROR(_validate_options(options));
-    LOG(INFO) << "Opening storage engine using uid=" << options.backend_uid.to_string();
     std::unique_ptr<StorageEngine> engine = std::make_unique<StorageEngine>(options);
     RETURN_IF_ERROR_WITH_WARN(engine->_open(), "open engine failed");
     *engine_ptr = engine.release();
-    LOG(INFO) << "Opened storage engine";
     return Status::OK();
 }
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -191,8 +191,6 @@ private:
 
     static Status _create_inital_rowset_unlocked(const TCreateTabletReq& request, Tablet* tablet);
 
-    Status _drop_tablet_directly_unlocked(TTabletId tablet_id, TabletDropFlag flag);
-
     Status _drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag);
 
     TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id);

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -372,7 +372,7 @@ Status ThriftServer::start() {
 
     RETURN_IF_ERROR(event_processor->start_and_wait_for_server());
 
-    LOG(INFO) << "ThriftServer '" << _name << "' started on port: " << _port;
+    LOG(INFO) << _name << " has started listening port on " << _port;
 
     DCHECK(_started);
     return Status::OK();


### PR DESCRIPTION
Many logs upon start are non-sense, and the pull request removes these logs.
The AlterTask is already not used, and drop_tablet_unlocked can be unified.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
