### PR TITLE
[BugFix] Fix calculate next db index after refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -114,7 +114,7 @@ public class BDBJournalCursor implements JournalCursor {
      * 2. otherwise, we're already open a db for previous key, we're looking for the next db of the previous key
      **/
     protected void calculateNextDbIndex() throws JournalException {
-        if (localDBNames.size() > 0 && currentKey < localDBNames.get(0)) {
+        if (!localDBNames.isEmpty() && currentKey < localDBNames.get(0)) {
             throw new JournalException(String.format(
                     "Can not find the key[%d] in %s: key too small", currentKey, localDBNames));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -106,23 +106,32 @@ public class BDBJournalCursor implements JournalCursor {
         return cursor;
     }
 
+    /**
+     * calculate the index of next db to be opened
+     *
+     * there are two cases:
+     * 1. if this is the first time, we're actually looking for the db of currentKey
+     * 2. otherwise, we're already open a db for previous key, we're looking for the next db of the previous key
+     **/
     protected void calculateNextDbIndex() throws JournalException {
-        int dbIndex = 0;
-        // find the db which may contain the fromKey
-        String dbName = null;
+        if (localDBNames.size() > 0 && currentKey < localDBNames.get(0)) {
+            throw new JournalException(String.format(
+                    "Can not find the key[%d] in %s: key too small", currentKey, localDBNames));
+        }
+        long objectKey = (database == null) ? currentKey : currentKey - 1;
+        // find the db index which may contain objectKey
+        int dbIndex = -1;
         for (long db : localDBNames) {
-            if (currentKey >= db) {
-                dbName = Long.toString(db);
+            if (objectKey >= db) {
                 dbIndex++;
             } else {
                 break;
             }
         }
-        if (dbName == null) {
-            throw new JournalException(String.format("Can not find the key:%d, fail to get journal cursor!", currentKey));
+        if (database != null) {
+            dbIndex += 1;
         }
-        // will open current db in next()
-        nextDbPositionIndex = dbIndex - 1;
+        nextDbPositionIndex = dbIndex;
         LOG.info("currentKey {}, currentDatabase {}, index of next opened db is {}",
                 currentKey, database, nextDbPositionIndex);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
@@ -101,9 +101,14 @@ public class BDBJournalCursorTest {
         //
         // >>> write 1->6
         //
-        // db1: 1-2
+        // db1: 1
         journal.batchWriteBegin();
         journal.batchWriteAppend(1, makeBuffer(1));
+        journal.batchWriteCommit();
+
+        // db2: 2
+        journal.rollJournal(2);
+        journal.batchWriteBegin();
         journal.batchWriteAppend(2, makeBuffer(2));
         journal.batchWriteCommit();
 
@@ -121,19 +126,23 @@ public class BDBJournalCursorTest {
         journal.batchWriteAppend(6, makeBuffer(6));
         journal.batchWriteCommit();
 
+        for (int i = 1; i <= 5; ++ i) {
+            // <<< read from i to 6
+            LOG.info("pretend I'm reading from {} to 6", i);
+            BDBJournalCursor bdbJournalCursor = BDBJournalCursor.getJournalCursor(environment, i, -1);
+            for (int j = i; j <= 6; ++ j) {
+                JournalEntity entity = bdbJournalCursor.next();
+                Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
+                Assert.assertEquals(String.valueOf(j), entity.getData().toString());
+            }
+            bdbJournalCursor.close();
+        }
+
         //
-        // <<< read 4->6
+        // <<< read 6->6
         //
-        BDBJournalCursor bdbJournalCursor = BDBJournalCursor.getJournalCursor(environment, 4, -1);
+        BDBJournalCursor bdbJournalCursor = BDBJournalCursor.getJournalCursor(environment, 6, -1);
         JournalEntity entity = bdbJournalCursor.next();
-        Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
-        Assert.assertEquals("4", entity.getData().toString());
-
-        entity = bdbJournalCursor.next();
-        Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
-        Assert.assertEquals("5", entity.getData().toString());
-
-        entity = bdbJournalCursor.next();
         Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
         Assert.assertEquals("6", entity.getData().toString());
 
@@ -150,7 +159,6 @@ public class BDBJournalCursorTest {
         // <<< read 7
         //
         bdbJournalCursor.refresh();
-
         entity = bdbJournalCursor.next();
         Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
         Assert.assertEquals("7", entity.getData().toString());
@@ -167,12 +175,12 @@ public class BDBJournalCursorTest {
         journal.batchWriteAppend(9, makeBuffer(9));
         journal.batchWriteCommit();
 
-        // drop db1, db3, now we only have  5, 8
+        // drop db1, db2, db3 now we only have 5, 8
+        // [1, 2, 3, 5] -> [5, 8]
         journal.deleteJournals(5);
-        journal.close();
 
         //
-        // <<< read 8-9
+        // <<< read 8
         //
         bdbJournalCursor.refresh();
 
@@ -180,12 +188,34 @@ public class BDBJournalCursorTest {
         Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
         Assert.assertEquals("8", entity.getData().toString());
 
+        //
+        // >>> write 10
+        //
+        // db10: 10
+        journal.rollJournal(10);
+        journal.batchWriteBegin();
+        journal.batchWriteAppend(10, makeBuffer(10));
+        journal.batchWriteCommit();
+
+        // drop db 5, now we only have db8, db10
+        // [5, 8] -> [8, 10]
+        journal.deleteJournals(8);
+
+        //
+        // <<< read 9-10
+        //
+        bdbJournalCursor.refresh();
+
         entity = bdbJournalCursor.next();
         Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
         Assert.assertEquals("9", entity.getData().toString());
 
+        entity = bdbJournalCursor.next();
+        Assert.assertEquals(OperationType.OP_SAVE_NEXTID, entity.getOpCode());
+        Assert.assertEquals("10", entity.getData().toString());
         Assert.assertNull(bdbJournalCursor.next());
 
+        journal.close();
         bdbJournalCursor.close();
     }
 
@@ -397,24 +427,6 @@ public class BDBJournalCursorTest {
         BDBJournalCursor.getJournalCursor(environment, 9, 9);
         Assert.fail();
     }
-
-    @Test
-    public void testCalculateNextDbIndex(
-            @Mocked BDBEnvironment environment, @Mocked CloseSafeDatabase database) throws Exception {
-        BDBJournalCursor cursor = new BDBJournalCursor(environment, "", 11, 13);
-
-        cursor.localDBNames = Arrays.asList(10L, 14L);
-        cursor.calculateNextDbIndex();
-        Assert.assertEquals(0, cursor.nextDbPositionIndex);
-
-        cursor.localDBNames = Arrays.asList(10L, 11L, 14L);
-        cursor.calculateNextDbIndex();
-        Assert.assertEquals(1, cursor.nextDbPositionIndex);
-
-        cursor.localDBNames = Arrays.asList(10L);
-        cursor.calculateNextDbIndex();
-        Assert.assertEquals(0, cursor.nextDbPositionIndex);
-   }
 
     @Ignore
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
@@ -179,6 +179,16 @@ public class BDBJournalCursorTest {
         // [1, 2, 3, 5] -> [5, 8]
         journal.deleteJournals(5);
 
+        // refresh will fail if try to read old value
+        boolean expected = false;
+        try {
+            BDBJournalCursor.getJournalCursor(environment, 4, -1);
+        } catch (JournalException e) {
+            LOG.info("got an expected exception, ", e);
+            expected = true;
+        }
+        Assert.assertTrue(expected);
+
         //
         // <<< read 8
         //


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9327 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we calculate the `nextDbIndex` after local databases changed, there are actually two cases
1. if this is the first time, we're actually looking for the db of currentKey
2. otherwise, we're already open a db for previous key, we're looking for the next db of the previous key