### PR TITLE
[Enhancement] Improve the performance of extract conjuncts/disjuncts

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -57,47 +57,51 @@ public class Utils {
     private static final Logger LOG = LogManager.getLogger(Utils.class);
 
     public static List<ScalarOperator> extractConjuncts(ScalarOperator root) {
-        if (null == root) {
-            return Lists.newArrayList();
-        }
-
         LinkedList<ScalarOperator> list = new LinkedList<>();
-        if (!OperatorType.COMPOUND.equals(root.getOpType())) {
-            list.add(root);
+        if (null == root) {
             return list;
+        }
+        extractConjunctsImpl(root, list);
+        return list;
+    }
+
+    public static void extractConjunctsImpl(ScalarOperator root, List<ScalarOperator> result) {
+        if (!OperatorType.COMPOUND.equals(root.getOpType())) {
+            result.add(root);
+            return;
         }
 
         CompoundPredicateOperator cpo = (CompoundPredicateOperator) root;
         if (!cpo.isAnd()) {
-            list.add(root);
-            return list;
+            result.add(root);
+            return;
         }
-
-        list.addAll(extractConjuncts(cpo.getChild(0)));
-        list.addAll(extractConjuncts(cpo.getChild(1)));
-        return list;
+        extractConjunctsImpl(cpo.getChild(0), result);
+        extractConjunctsImpl(cpo.getChild(1), result);
     }
 
     public static List<ScalarOperator> extractDisjunctive(ScalarOperator root) {
-        if (null == root) {
-            return Lists.newArrayList();
-        }
-
         LinkedList<ScalarOperator> list = new LinkedList<>();
-        if (!OperatorType.COMPOUND.equals(root.getOpType())) {
-            list.add(root);
+        if (null == root) {
             return list;
+        }
+        extractDisjunctiveImpl(root, list);
+        return list;
+    }
+
+    public static void extractDisjunctiveImpl(ScalarOperator root, List<ScalarOperator> result) {
+        if (!OperatorType.COMPOUND.equals(root.getOpType())) {
+            result.add(root);
+            return;
         }
 
         CompoundPredicateOperator cpo = (CompoundPredicateOperator) root;
-
-        if (cpo.isOr()) {
-            list.addAll(extractDisjunctive(cpo.getChild(0)));
-            list.addAll(extractDisjunctive(cpo.getChild(1)));
-        } else {
-            list.add(root);
+        if (!cpo.isOr()) {
+            result.add(root);
+            return;
         }
-        return list;
+        extractDisjunctiveImpl(cpo.getChild(0), result);
+        extractDisjunctiveImpl(cpo.getChild(1), result);
     }
 
     public static List<ColumnRefOperator> extractColumnRef(ScalarOperator root) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The function  extractConjuncts/extractDisjunctive will create a new List evrey time, When query has more than 1000+ OR, AND predicate,  This function will call 1000+ recursively , it cost a lot of time.
The time cost of query from 50s to 4s+  after optimize.