### PR TITLE
[BugFix] db name for ShowRoutineLoadStmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
@@ -134,8 +134,8 @@ public class ShowRoutineLoadStmt extends ShowStmt {
     }
 
     private void checkLabelName(Analyzer analyzer) throws AnalysisException {
-        String dbName = labelName == null ? null : labelName.getDbName();
-        if (Strings.isNullOrEmpty(dbName)) {
+        dbFullName = labelName == null ? null : labelName.getDbName();
+        if (Strings.isNullOrEmpty(dbFullName)) {
             dbFullName = analyzer.getContext().getDatabase();
             if (Strings.isNullOrEmpty(dbFullName)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/849

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The origin implementation may left the db name of the `ShowRoutineLoadStmt` unset when the routine load is like following:
```
show routine load for {db_name}.{routine_load_name}
```
which leads the result including routine load not belong to the specified database. 
