### PR TITLE
[Bugfix] Avoid local shuffle for blocking agg with bucket shuffle join

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -50,7 +50,11 @@ public:
                                                                  _aggregator_factory->get_or_create(driver_sequence));
     }
 
+    bool need_local_shuffle() const override { return _need_local_shuffle; }
+    void set_need_local_shuffle(bool need_local_shuffle) { _need_local_shuffle = need_local_shuffle; }
+
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
+    bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -55,6 +55,8 @@ public:
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
+    // This flag will be inherited from the source operator of AggregateBlockingSinkOperator,
+    // by calling `set_need_local_shuffle` when decomposing to pipeline.
     bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -56,6 +56,8 @@ public:
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
+    // This flag will be inherited from the source operator of AggregateDistinctBlockingSinkOperator,
+    // by calling `set_need_local_shuffle` when decomposing to pipeline.
     bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -51,7 +51,11 @@ public:
                 this, _id, _plan_node_id, driver_sequence, _aggregator_factory->get_or_create(driver_sequence));
     }
 
+    bool need_local_shuffle() const override { return _need_local_shuffle; }
+    void set_need_local_shuffle(bool need_local_shuffle) { _need_local_shuffle = need_local_shuffle; }
+
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
+    bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -210,6 +210,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     // Aggregator must be used by a pair of sink and source operators,
     // so ops_with_source's degree of parallelism must be equal with operators_with_sink's
     source_operator->set_degree_of_parallelism(degree_of_parallelism);
+    source_operator->set_need_local_shuffle(
+            down_cast<pipeline::SourceOperatorFactory*>(ops_with_sink[0].get())->need_local_shuffle());
     ops_with_source.push_back(std::move(source_operator));
 
     if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -165,6 +165,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // so ops_with_source's degree of parallelism must be equal with operators_with_sink's
     auto degree_of_parallelism = ((SourceOperatorFactory*)(ops_with_sink[0].get()))->degree_of_parallelism();
     source_operator->set_degree_of_parallelism(degree_of_parallelism);
+    source_operator->set_need_local_shuffle(
+            down_cast<pipeline::SourceOperatorFactory*>(ops_with_sink[0].get())->need_local_shuffle());
     ops_with_source.push_back(std::move(source_operator));
 
     if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9271 and fixes #9342.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The original local bucket shuffle in pipeline needs to insert a local shuffle between the scan operator and the hash join probe operator, because it is uncertain that a tablet is read by which scan operator.
In the meanwhile, local exchange and exchange need apply **rehash** operations to avoid data skew.
<img width="474" alt="image" src="https://user-images.githubusercontent.com/13313784/181510763-91d13e5c-dc6d-49c8-8881-c27bafb121d0.png">

Then, we eliminate this local shuffle by assign each tablet to the specific scan operator according to the data distribution.
Because data distribution isn't applied **rehash** operations, so the exchange also cannot apply it.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/13313784/181511145-2092a521-4bc8-4848-b7fe-a9c3e9c537e5.png">

Unfortunately, when it is not scan⇨localBucketShuffleJoin，scan⇨onePhaseAgg⇨localBucketShuffleJoin, there is inserting a local shuffle incorrectly.
As a result, the right table shuffle isn't applied rehash, but the left table shuffle is applied rehash.
<img width="724" alt="image" src="https://user-images.githubusercontent.com/13313784/181511336-db975c90-f8ce-4b1f-83e8-ddfcb95bc42c.png">

### Modification
Set the property `need_local_shuffle` to `AggregateBlockingSourceOperator`, according to the source operator of the fragment.




