### PR TITLE
[Enhancement] Refine profile merge mechanism

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1030,7 +1030,11 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
                 continue;
             }
 
-            std::vector<std::tuple<Counter*, Counter*, Counter*>> counters;
+            std::vector<Counter*> counters;
+
+            int64_t min_value = std::numeric_limits<int64_t>::max();
+            int64_t max_value = std::numeric_limits<int64_t>::min();
+            bool already_merged = false;
             for (auto j = 0; j < profiles.size(); j++) {
                 auto* profile = profiles[j];
                 auto* counter = profile->get_counter(name);
@@ -1049,13 +1053,24 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
                 }
 
                 auto* min_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name));
+                if (min_counter != nullptr && min_counter->value() < min_value) {
+                    min_value = min_counter->value();
+                    already_merged = true;
+                }
                 auto* max_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name));
-                counters.push_back(std::make_tuple(counter, min_counter, max_counter));
+                if (max_counter != nullptr && max_counter->value() > max_value) {
+                    max_value = max_counter->value();
+                    already_merged = true;
+                }
+                counters.push_back(counter);
             }
+
             const auto merged_info = merge_isomorphic_counters(type, counters);
             const auto merged_value = std::get<0>(merged_info);
-            const auto min_value = std::get<1>(merged_info);
-            const auto max_value = std::get<2>(merged_info);
+            if (!already_merged) {
+                min_value = std::get<1>(merged_info);
+                max_value = std::get<2>(merged_info);
+            }
 
             auto* counter0 = profile0->get_counter(name);
             // As memtioned before, some counters may only attach to one of the isomorphic profiles
@@ -1065,19 +1080,27 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             }
             counter0->set(merged_value);
 
-            // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-            const auto diff = max_value - min_value;
-            if (is_average_type(counter0->type())) {
-                if ((diff > 5'000'000L && diff > merged_value / 5)) {
-                    auto* min_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name),
-                                                              type, name);
-                    auto* max_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name),
-                                                              type, name);
-                    min_counter->set(min_value);
-                    max_counter->set(max_value);
-                }
+            if (already_merged) {
+                auto* min_counter =
+                        profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
+                auto* max_counter =
+                        profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
+                min_counter->set(min_value);
+                max_counter->set(max_value);
             } else {
-                if (diff > min_value) {
+                // If the values vary greatly, we need to save extra info (min value and max value) of this counter
+                const auto diff = max_value - min_value;
+                if (is_average_type(counter0->type())) {
+                    if ((diff > 5'000'000L && diff > merged_value / 5.0)) {
+                        auto* min_counter = profile0->add_counter(
+                                strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
+                        auto* max_counter = profile0->add_counter(
+                                strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
+                        min_counter->set(min_value);
+                        max_counter->set(max_value);
+                    }
+                } else {
+                    // All sum type counters will have extra info (min value and max value)
                     auto* min_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name),
                                                               type, name);
                     auto* max_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name),
@@ -1113,28 +1136,18 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
     }
 }
 
-RuntimeProfile::MergedInfo RuntimeProfile::merge_isomorphic_counters(
-        TUnit::type type, std::vector<std::tuple<Counter*, Counter*, Counter*>>& counters) {
+RuntimeProfile::MergedInfo RuntimeProfile::merge_isomorphic_counters(TUnit::type type,
+                                                                     std::vector<Counter*>& counters) {
     DCHECK_GE(counters.size(), 0);
     int64_t merged_value = 0;
     int64_t min_value = std::numeric_limits<int64_t>::max();
     int64_t max_value = std::numeric_limits<int64_t>::min();
 
-    for (auto& triple : counters) {
-        Counter* counter = std::get<0>(triple);
-        Counter* min_counter = std::get<1>(triple);
-        Counter* max_counter = std::get<2>(triple);
-
-        if (min_counter != nullptr && min_counter->value() < min_value) {
-            min_value = min_counter->value();
-        }
+    for (auto& counter : counters) {
         if (counter->value() < min_value) {
             min_value = counter->value();
         }
 
-        if (max_counter != nullptr && max_counter->value() > max_value) {
-            max_value = max_counter->value();
-        }
         if (counter->value() > max_value) {
             max_value = counter->value();
         }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1053,14 +1053,18 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
                 }
 
                 auto* min_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name));
-                if (min_counter != nullptr && min_counter->value() < min_value) {
-                    min_value = min_counter->value();
+                if (min_counter != nullptr) {
                     already_merged = true;
+                    if (min_counter->value() < min_value) {
+                        min_value = min_counter->value();
+                    }
                 }
                 auto* max_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name));
-                if (max_counter != nullptr && max_counter->value() > max_value) {
-                    max_value = max_counter->value();
+                if (max_counter != nullptr) {
                     already_merged = true;
+                    if (max_counter->value() > max_value) {
+                        max_value = max_counter->value();
+                    }
                 }
                 counters.push_back(counter);
             }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1080,34 +1080,28 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             }
             counter0->set(merged_value);
 
+            bool update_min_max = false;
             if (already_merged) {
+                update_min_max = true;
+            } else {
+                // If the values vary greatly, we need to save extra info (min value and max value) of this counter
+                const auto diff = max_value - min_value;
+                if (is_average_type(counter0->type())) {
+                    if ((diff > 5'000'000L && diff > merged_value / 5.0)) {
+                        update_min_max = true;
+                    }
+                } else {
+                    // All sum type counters will have extra info (min value and max value)
+                    update_min_max = true;
+                }
+            }
+            if (update_min_max) {
                 auto* min_counter =
                         profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
                 auto* max_counter =
                         profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
                 min_counter->set(min_value);
                 max_counter->set(max_value);
-            } else {
-                // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-                const auto diff = max_value - min_value;
-                if (is_average_type(counter0->type())) {
-                    if ((diff > 5'000'000L && diff > merged_value / 5.0)) {
-                        auto* min_counter = profile0->add_counter(
-                                strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
-                        auto* max_counter = profile0->add_counter(
-                                strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
-                        min_counter->set(min_value);
-                        max_counter->set(max_value);
-                    }
-                } else {
-                    // All sum type counters will have extra info (min value and max value)
-                    auto* min_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name),
-                                                              type, name);
-                    auto* max_counter = profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name),
-                                                              type, name);
-                    min_counter->set(min_value);
-                    max_counter->set(max_value);
-                }
             }
         }
     }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -622,7 +622,7 @@ private:
                                      std::ostream* s);
 
 public:
-    // Merge all the isomorphic sub profiles and the caller must known for sure
+    // Merge all the isomorphic sub profiles and the caller must know for sure
     // that all the children are isomorphic, otherwise, the behavior is undefined
     // The merged result will be stored in the first profile
     static void merge_isomorphic_profiles(std::vector<RuntimeProfile*>& profiles);
@@ -631,8 +631,6 @@ private:
     static const std::unordered_set<std::string> NON_MERGE_COUNTER_NAMES;
     // Merge all the isomorphic counters
     // The exact semantics of merge depends on TUnit::type
-    // TODO(hcf) is the classification right?
-    // TODO(hcf) merge bucket counters
     // sum:
     //     UNIT / UNIT_PER_SECOND
     //     BYTES / BYTES_PER_SECOND
@@ -640,8 +638,7 @@ private:
     // average:
     //     CPU_TICKS / TIME_NS / TIME_MS / TIME_S
     typedef std::tuple<int64_t, int64_t, int64_t> MergedInfo;
-    static MergedInfo merge_isomorphic_counters(TUnit::type type,
-                                                std::vector<std::tuple<Counter*, Counter*, Counter*>>& counters);
+    static MergedInfo merge_isomorphic_counters(TUnit::type type, std::vector<Counter*>& counters);
 
     static bool is_average_type(TUnit::type type) {
         return TUnit::type::CPU_TICKS == type || TUnit::type::TIME_NS == type || TUnit::type::TIME_MS == type ||

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -22,7 +22,6 @@
 package com.starrocks.common.util;
 
 import com.starrocks.thrift.TUnit;
-import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 
@@ -63,26 +62,16 @@ public class Counter {
      * Merge all the isomorphic counters
      * The exact semantics of merge depends on TUnit
      */
-    public static MergedInfo mergeIsomorphicCounters(TUnit type, List<Triple<Counter, Counter, Counter>> counters) {
+    public static MergedInfo mergeIsomorphicCounters(TUnit type, List<Counter> counters) {
         long mergedValue = 0;
         long minValue = Long.MAX_VALUE;
         long maxValue = Long.MIN_VALUE;
 
-        for (Triple<Counter, Counter, Counter> triple : counters) {
-            Counter counter = triple.getLeft();
-            Counter minCounter = triple.getMiddle();
-            Counter maxCounter = triple.getRight();
-
-            if (minCounter != null && minCounter.getValue() < minValue) {
-                minValue = minCounter.getValue();
-            }
+        for (Counter counter : counters) {
             if (counter.getValue() < minValue) {
                 minValue = counter.getValue();
             }
 
-            if (maxCounter != null && maxCounter.getValue() > maxValue) {
-                maxValue = maxCounter.getValue();
-            }
             if (counter.getValue() > maxValue) {
                 maxValue = counter.getValue();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -520,34 +520,26 @@ public class RuntimeProfile {
             }
             counter0.setValue(mergedValue);
 
+            boolean updateMinMax = false;
             if (alreadyMerged) {
-                Counter minCounter =
-                        profile0.addCounter(mergedInfoPrefixMin + name, type, name);
-                Counter maxCounter =
-                        profile0.addCounter(mergedInfoPrefixMax + name, type, name);
-                minCounter.setValue(minValue);
-                maxCounter.setValue(maxValue);
+                updateMinMax = true;
             } else {
                 // If the values vary greatly, we need to save extra info (min value and max value) of this counter
                 double diff = maxValue - minValue;
                 if (Counter.isAverageType(counter0.getType())) {
                     if (diff > 5000000L && diff > mergedValue / 5.0) {
-                        Counter minCounter =
-                                profile0.addCounter(mergedInfoPrefixMin + name, type, name);
-                        Counter maxCounter =
-                                profile0.addCounter(mergedInfoPrefixMax + name, type, name);
-                        minCounter.setValue(minValue);
-                        maxCounter.setValue(maxValue);
+                        updateMinMax = true;
                     }
                 } else {
                     // All sum type counters will have extra info (min value and max value)
-                    Counter minCounter =
-                            profile0.addCounter(mergedInfoPrefixMin + name, type, name);
-                    Counter maxCounter =
-                            profile0.addCounter(mergedInfoPrefixMax + name, type, name);
-                    minCounter.setValue(minValue);
-                    maxCounter.setValue(maxValue);
+                    updateMinMax = true;
                 }
+            }
+            if (updateMinMax) {
+                Counter minCounter = profile0.addCounter(mergedInfoPrefixMin + name, type, name);
+                Counter maxCounter = profile0.addCounter(mergedInfoPrefixMax + name, type, name);
+                minCounter.setValue(minValue);
+                maxCounter.setValue(maxValue);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -494,14 +494,18 @@ public class RuntimeProfile {
                 }
 
                 Counter minCounter = profile.getCounter(mergedInfoPrefixMin + name);
-                if (minCounter != null && minCounter.getValue() < minValue) {
-                    minValue = minCounter.getValue();
+                if (minCounter != null) {
                     alreadyMerged = true;
+                    if (minCounter.getValue() < minValue) {
+                        minValue = minCounter.getValue();
+                    }
                 }
                 Counter maxCounter = profile.getCounter(mergedInfoPrefixMax + name);
-                if (maxCounter != null && maxCounter.getValue() > maxValue) {
-                    maxValue = maxCounter.getValue();
+                if (maxCounter != null) {
                     alreadyMerged = true;
+                    if (maxCounter.getValue() > maxValue) {
+                        maxValue = maxCounter.getValue();
+                    }
                 }
                 counters.add(counter);
             }
@@ -542,52 +546,6 @@ public class RuntimeProfile {
                 maxCounter.setValue(maxValue);
             }
         }
-
-        // As for counter's extra info (min value and max value) created by be
-        // we only need to update it across over all isomorphic profiles
-        Map<String, Long> minValues = Maps.newHashMap();
-        Map<String, Long> maxValues = Maps.newHashMap();
-        profiles.forEach(profile ->
-                profile.counterMap.entrySet().forEach(entry -> {
-                    String name = entry.getKey();
-                    Counter counter = entry.getValue();
-                    if (name.startsWith(mergedInfoPrefixMin)) {
-                        if (!minValues.containsKey(name)) {
-                            minValues.put(name, counter.getValue());
-                        } else if (counter.getValue() < minValues.get(name)) {
-                            minValues.put(name, counter.getValue());
-                        }
-                    } else if (name.startsWith(mergedInfoPrefixMax)) {
-                        if (!maxValues.containsKey(name)) {
-                            maxValues.put(name, counter.getValue());
-                        } else if (counter.getValue() > maxValues.get(name)) {
-                            maxValues.put(name, counter.getValue());
-                        }
-                    }
-                })
-        );
-        minValues.entrySet().forEach(entry -> {
-            String name = entry.getKey();
-            long minValue = entry.getValue();
-            Counter counter = profile0.getCounter(name);
-            if (counter == null) {
-                String parentName = name.substring(mergedInfoPrefixMin.length());
-                Counter parentCounter = profile0.getCounter(parentName);
-                counter = profile0.addCounter(name, parentCounter.getType(), parentName);
-            }
-            counter.setValue(minValue);
-        });
-        maxValues.entrySet().forEach(entry -> {
-            String name = entry.getKey();
-            long maxValue = entry.getValue();
-            Counter counter = profile0.getCounter(name);
-            if (counter == null) {
-                String parentName = name.substring(mergedInfoPrefixMax.length());
-                Counter parentCounter = profile0.getCounter(parentName);
-                counter = profile0.addCounter(name, parentCounter.getType(), parentName);
-            }
-            counter.setValue(maxValue);
-        });
 
         // merge children
         for (int i = 0; i < profile0.childList.size(); i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -179,32 +179,125 @@ public class RuntimeProfileTest {
     }
 
     @Test
-    public void testMergeIsomorphicProfiles() {
+    public void testMergeIsomorphicProfiles1() {
         List<RuntimeProfile> profiles = Lists.newArrayList();
 
-        RuntimeProfile profile = new RuntimeProfile("profile1");
-        Counter counter = profile.addCounter("counter1", TUnit.TIME_NS);
-        counter.setValue(1000000000L);
-        Counter minCounter = profile.addCounter("__MIN_OF_counter1", TUnit.TIME_NS);
-        minCounter.setValue(100000000L);
-        Counter maxCounter = profile.addCounter("__MAX_OF_counter1", TUnit.TIME_NS);
-        maxCounter.setValue(2000000000L);
-        profiles.add(profile);
+        RuntimeProfile profile1 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS);
+            time1.setValue(2000000000L);
+            Counter time2 = profile1.addCounter("time2", TUnit.TIME_NS);
+            time2.setValue(0);
 
-        profile = new RuntimeProfile("profile2");
-        counter = profile.addCounter("counter1", TUnit.TIME_NS);
-        counter.setValue(3000000000L);
-        profiles.add(profile);
+            Counter count1 = profile1.addCounter("count1", TUnit.UNIT);
+            count1.setValue(1);
+
+            profiles.add(profile1);
+        }
+
+        RuntimeProfile profile2 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile2.addCounter("time1", TUnit.TIME_NS);
+            time1.setValue(2000000000L);
+            Counter time2 = profile2.addCounter("time2", TUnit.TIME_NS);
+            time2.setValue(2000000000L);
+
+            Counter count1 = profile2.addCounter("count1", TUnit.UNIT);
+            count1.setValue(1);
+
+            profiles.add(profile2);
+        }
 
         RuntimeProfile.mergeIsomorphicProfiles(profiles);
-        profile = profiles.get(0);
-        counter = profile.getCounter("counter1");
-        Assert.assertEquals(2000000000L, counter.getValue());
-        minCounter = profile.getCounter("__MIN_OF_counter1");
-        maxCounter = profile.getCounter("__MAX_OF_counter1");
-        Assert.assertNotNull(minCounter);
-        Assert.assertNotNull(maxCounter);
-        Assert.assertEquals(100000000L, minCounter.getValue());
-        Assert.assertEquals(3000000000L, maxCounter.getValue());
+
+        RuntimeProfile mergedProfile = profiles.get(0);
+        Counter mergedTime1 = mergedProfile.getCounter("time1");
+        Assert.assertEquals(2000000000L, mergedTime1.getValue());
+        Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
+        Counter mergedMaxOfTime1 = mergedProfile.getCounter("__MAX_OF_time1");
+        Assert.assertNull(mergedMinOfTime1);
+        Assert.assertNull(mergedMaxOfTime1);
+
+        Counter mergedTime2 = mergedProfile.getCounter("time2");
+        Assert.assertEquals(1000000000L, mergedTime2.getValue());
+        Counter mergedMinOfTime2 = mergedProfile.getCounter("__MIN_OF_time2");
+        Counter mergedMaxOfTime2 = mergedProfile.getCounter("__MAX_OF_time2");
+        Assert.assertNotNull(mergedMinOfTime2);
+        Assert.assertNotNull(mergedMaxOfTime2);
+        Assert.assertEquals(0, mergedMinOfTime2.getValue());
+        Assert.assertEquals(2000000000L, mergedMaxOfTime2.getValue());
+
+        Counter mergedCount1 = mergedProfile.getCounter("count1");
+        Assert.assertEquals(2, mergedCount1.getValue());
+        Counter mergedMinOfCount1 = mergedProfile.getCounter("__MIN_OF_count1");
+        Counter mergedMaxOfCount1 = mergedProfile.getCounter("__MAX_OF_count1");
+        Assert.assertNotNull(mergedMinOfCount1);
+        Assert.assertNotNull(mergedMaxOfCount1);
+        Assert.assertEquals(1, mergedMinOfCount1.getValue());
+        Assert.assertEquals(1, mergedMaxOfCount1.getValue());
+    }
+
+    @Test
+    public void testMergeIsomorphicProfiles2() {
+        List<RuntimeProfile> profiles = Lists.newArrayList();
+
+        RuntimeProfile profile1 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS);
+            time1.setValue(2000000000L);
+            Counter minOfTime1 = profile1.addCounter("__MIN_OF_time1", TUnit.TIME_NS);
+            minOfTime1.setValue(1500000000L);
+            Counter maxOfTime1 = profile1.addCounter("__MAX_OF_time1", TUnit.TIME_NS);
+            maxOfTime1.setValue(5000000000L);
+
+            Counter count1 = profile1.addCounter("count1", TUnit.UNIT);
+            count1.setValue(6);
+            Counter minOfCount1 = profile1.addCounter("__MIN_OF_count1", TUnit.UNIT);
+            minOfCount1.setValue(1);
+            Counter maxOfCount1 = profile1.addCounter("__MAX_OF_count1", TUnit.UNIT);
+            maxOfCount1.setValue(3);
+
+            profiles.add(profile1);
+        }
+
+        RuntimeProfile profile2 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile2.addCounter("time1", TUnit.TIME_NS);
+            time1.setValue(3000000000L);
+            Counter minOfTime1 = profile2.addCounter("__MIN_OF_time1", TUnit.TIME_NS);
+            minOfTime1.setValue(100000000L);
+            Counter maxOfTime1 = profile2.addCounter("__MAX_OF_time1", TUnit.TIME_NS);
+            maxOfTime1.setValue(4000000000L);
+
+            Counter count1 = profile2.addCounter("count1", TUnit.UNIT);
+            count1.setValue(15);
+            Counter minOfCount1 = profile2.addCounter("__MIN_OF_count1", TUnit.UNIT);
+            minOfCount1.setValue(4);
+            Counter maxOfCount1 = profile2.addCounter("__MAX_OF_count1", TUnit.UNIT);
+            maxOfCount1.setValue(6);
+
+            profiles.add(profile2);
+        }
+
+        RuntimeProfile.mergeIsomorphicProfiles(profiles);
+
+        RuntimeProfile mergedProfile = profiles.get(0);
+        Counter mergedTime1 = mergedProfile.getCounter("time1");
+        Assert.assertEquals(2500000000L, mergedTime1.getValue());
+        Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
+        Counter mergedMaxOfTime1 = mergedProfile.getCounter("__MAX_OF_time1");
+        Assert.assertNotNull(mergedMinOfTime1);
+        Assert.assertNotNull(mergedMaxOfTime1);
+        Assert.assertEquals(100000000L, mergedMinOfTime1.getValue());
+        Assert.assertEquals(5000000000L, mergedMaxOfTime1.getValue());
+
+        Counter mergedCount1 = mergedProfile.getCounter("count1");
+        Assert.assertEquals(21, mergedCount1.getValue());
+        Counter mergedMinOfCount1 = mergedProfile.getCounter("__MIN_OF_count1");
+        Counter mergedMaxOfCount1 = mergedProfile.getCounter("__MAX_OF_count1");
+        Assert.assertNotNull(mergedMinOfCount1);
+        Assert.assertNotNull(mergedMaxOfCount1);
+        Assert.assertEquals(1, mergedMinOfCount1.getValue());
+        Assert.assertEquals(6, mergedMaxOfCount1.getValue());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9356

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Refer to #9356 for background of the problem.

## Solution

For all non-time metrics, we calculate `__MIN_xxx`、`__MAX_xxx`, and DO NOT perform the second merge if current metric is already a merged one, just pick the minimum one among `__MIN_xxx` and the maximum one among `__MAX_xxx` as the new `__MIN_xxx`、`__MAX_xxx` of current metric.

For example

**Before**

```
# first merge
(1,2,3) -> 6[MIN=1, MAX=3]
(4,5,6) -> 15[MIN=4, MAX=6]
(7,8,9) -> 24[MIN=7, MAX=9]

# second merge
(6[MIN=1, MAX=3], 15[MIN=4, MAX=6)], 24[MIN=7, MAX=9]) -> 45[MIN=1, MAX=24]
```

**After**

```
# first merge
(1,2,3) -> 6[MIN=1, MAX=3]
(4,5,6) -> 15[MIN=4, MAX=6]
(7,8,9) -> 24[MIN=7, MAX=9]

# second merge
(6[MIN=1, MAX=3], 15[MIN=4, MAX=6)], 24[MIN=7, MAX=9]) -> 45[MIN=1, MAX=9]
```
