### PR TITLE
[Enhancement] Optimze colocate balance with BE temporarily restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -564,7 +564,7 @@ public class LocalTablet extends Tablet {
      * tablet replicas:    1,2,3,4
      * <p>
      * No need to check if backend is available. We consider all backends in 'backendsSet' are available,
-     * If not, unavailable backends will be relocated by CalocateTableBalancer first.
+     * If not, unavailable backends will be relocated by ColocateTableBalancer first.
      */
     public TabletStatus getColocateHealthStatus(long visibleVersion,
                                                 int replicationNum, Set<Long> backendsSet) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -162,7 +162,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
                 ColocatePersistInfo info =
                         ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, balancedBackendsPerBucketSeq);
                 globalStateMgr.getEditLog().logColocateBackendsPerBucketSeq(info);
-                LOG.info("balance group {}. now backends per bucket sequence is: {}", groupId,
+                LOG.info("balance colocate group {}. now backends per bucket sequence is: {}", groupId,
                         balancedBackendsPerBucketSeq);
             }
         }
@@ -177,6 +177,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         ColocateTableIndex colocateIndex = globalStateMgr.getColocateTableIndex();
         TabletScheduler tabletScheduler = globalStateMgr.getTabletScheduler();
+        long checkStartTime = System.currentTimeMillis();
 
         // check each group
         Set<GroupId> groupIds = colocateIndex.getAllGroupIds();
@@ -217,33 +218,47 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                     backendBucketsSeq.size() + " vs. " + index.getTablets().size());
                             int idx = 0;
                             for (Long tabletId : index.getTabletIdsInOrder()) {
-                                Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
-                                Preconditions.checkState(bucketsSeq.size() == replicationNum,
-                                        bucketsSeq.size() + " vs. " + replicationNum);
                                 LocalTablet tablet = (LocalTablet) index.getTablet(tabletId);
-                                TabletStatus st = tablet.getColocateHealthStatus(visibleVersion,
-                                        replicationNum, bucketsSeq);
-                                if (st != TabletStatus.HEALTHY) {
-                                    isGroupStable = false;
-                                    LOG.debug("get unhealthy tablet {} in colocate table. status: {}", tablet.getId(),
-                                            st);
+                                // Tablet has already been scheduled, no need to schedule again
+                                if (!tabletScheduler.containsTablet(tablet.getId())) {
+                                    Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
+                                    Preconditions.checkState(bucketsSeq.size() == replicationNum,
+                                            bucketsSeq.size() + " vs. " + replicationNum);
+                                    TabletStatus st = tablet.getColocateHealthStatus(visibleVersion,
+                                            replicationNum, bucketsSeq);
+                                    if (st != TabletStatus.HEALTHY) {
+                                        isGroupStable = false;
+                                        Priority colocateUnhealthyPrio = Priority.HIGH;
+                                        // We should also check if the tablet is ready to be repaired like
+                                        // `TabletChecker` did. Slightly delay the repair action can avoid unnecessary
+                                        // clone in situation like temporarily restart BE Nodes.
+                                        if (tablet.readyToBeRepaired(colocateUnhealthyPrio)) {
+                                            LOG.debug("get unhealthy tablet {} in colocate table. status: {}",
+                                                    tablet.getId(),
+                                                    st);
 
-                                    TabletSchedCtx tabletCtx = new TabletSchedCtx(
-                                            TabletSchedCtx.Type.REPAIR,
-                                            db.getId(), tableId, partition.getId(), index.getId(), tablet.getId(),
-                                            System.currentTimeMillis());
-                                    // the tablet status will be set again when being scheduled
-                                    tabletCtx.setTabletStatus(st);
-                                    // using HIGH priority, cause we want to stabilize the colocate group as soon as possible
-                                    tabletCtx.setOrigPriority(Priority.HIGH);
-                                    tabletCtx.setTabletOrderIdx(idx);
+                                            TabletSchedCtx tabletCtx = new TabletSchedCtx(
+                                                    TabletSchedCtx.Type.REPAIR,
+                                                    db.getId(), tableId, partition.getId(), index.getId(),
+                                                    tablet.getId(),
+                                                    System.currentTimeMillis());
+                                            // the tablet status will be set again when being scheduled
+                                            tabletCtx.setTabletStatus(st);
+                                            // using HIGH priority, because we want to stabilize the colocate group
+                                            // as soon as possible
+                                            tabletCtx.setOrigPriority(colocateUnhealthyPrio);
+                                            tabletCtx.setTabletOrderIdx(idx);
 
-                                    AddResult res = tabletScheduler.addTablet(tabletCtx, false /* not force */);
-                                    if (res == AddResult.LIMIT_EXCEED) {
-                                        // tablet in scheduler exceed limit, skip this group and check next one.
-                                        LOG.info("number of scheduling tablets in tablet scheduler"
-                                                + " exceed to limit. stop colocate table check");
-                                        break OUT;
+                                            AddResult res = tabletScheduler.addTablet(tabletCtx, false /* not force */);
+                                            if (res == AddResult.LIMIT_EXCEED) {
+                                                // tablet in scheduler exceed limit, skip this group and check next one.
+                                                LOG.info("number of scheduling tablets in tablet scheduler"
+                                                        + " exceed to limit. stop colocate table check");
+                                                break OUT;
+                                            }
+                                        }
+                                    } else {
+                                        tablet.setLastStatusCheckTime(checkStartTime);
                                     }
                                 }
                                 idx++;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -963,7 +963,7 @@ public class Config extends ConfigBase {
     /**
      * 'storage_high_watermark_usage_percent' limit the max capacity usage percent of a Backend storage path.
      * 'storage_min_left_capacity_bytes' limit the minimum left capacity of a Backend storage path.
-     * If both limitations are reached, this storage path can not be chose as tablet balance destination.
+     * If both limitations are reached, this storage path can not be chosen as tablet balance destination.
      * But for tablet recovery, we may exceed these limit for keeping data integrity as much as possible.
      */
     @ConfField(mutable = true)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9235 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Delay colocate group repair as needed.
    We should also check if the tablet is ready to be repaired as `TabletChecker` did.
    Slightly delaying the repair action can avoid unnecessary clones in situations like temporarily restarting BE Nodes.

2. Avoid meaningless checks of the colocating tablets when the tablet is already being scheduled.


