### PR TITLE
[Enhancement] rename `currentKey` to `nextKey` in `BDBJournalCursor`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -111,7 +111,7 @@ public class BDBJournalCursor implements JournalCursor {
      *
      * there are two cases:
      * 1. if this is the first time, we're actually looking for the db of nextKey
-     * 2. otherwise, we're already open a db for previous key, we're looking for the next db of the previous key
+     * 2. otherwise, we've already opened a db for previous key. Now we're looking for the next db of the previous key
      **/
     protected void calculateNextDbIndex() throws JournalException {
         if (!localDBNames.isEmpty() && nextKey < localDBNames.get(0)) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
A long long time ago in a galaxy far far away, there was a litter variable called `currentKey`  that always referred to the key of the journal to be replay instead of the current one, unless when inside the `next()` function. This name has successfully confused some aliens that arrive ten years later, and will be changed to `nextKey` which they all agreed is much more accurate.