### PR TITLE
[Lake][Delete 2/2] Support read and compact lake tablet with delete rowset

### DIFF
--- a/be/src/storage/delete_predicates.h
+++ b/be/src/storage/delete_predicates.h
@@ -10,6 +10,7 @@
 namespace starrocks::vectorized {
 
 // DeletePredicates is a set of delete predicates of different versions.
+// version is rowset index if tablet is lake tablet.
 class DeletePredicates {
 public:
     // Add a new version of delete predicates.

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -9,7 +9,7 @@
 namespace starrocks::lake {
 class Rowset {
 public:
-    explicit Rowset(Tablet* tablet, RowsetMetadataPtr rowset_metadata);
+    explicit Rowset(Tablet* tablet, RowsetMetadataPtr rowset_metadata, int index);
 
     ~Rowset();
 
@@ -33,6 +33,7 @@ private:
     // _tablet is owned by TabletReader
     Tablet* _tablet;
     RowsetMetadataPtr _rowset_metadata;
+    int _index;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -65,8 +65,9 @@ StatusOr<std::vector<RowsetPtr>> Tablet::get_rowsets(int64_t version) {
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     std::vector<RowsetPtr> rowsets;
     rowsets.reserve(tablet_metadata->rowsets_size());
-    for (const auto& rowset_metadata : tablet_metadata->rowsets()) {
-        auto rowset = std::make_shared<Rowset>(this, std::make_shared<const RowsetMetadata>(rowset_metadata));
+    for (int i = 0, size = tablet_metadata->rowsets_size(); i < size; ++i) {
+        const auto& rowset_metadata = tablet_metadata->rowsets(i);
+        auto rowset = std::make_shared<Rowset>(this, std::make_shared<const RowsetMetadata>(rowset_metadata), i);
         rowsets.emplace_back(std::move(rowset));
     }
     return rowsets;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -16,6 +16,7 @@ DIAGNOSTIC_POP
 #include "fs/fs_util.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/lake_types.pb.h"
+#include "gutil/strings/join.h"
 #include "gutil/strings/util.h"
 #include "runtime/exec_env.h"
 #include "storage/lake/compaction_policy.h"
@@ -394,11 +395,16 @@ Status TabletManager::publish_version(int64_t tablet_id, int64_t base_version, i
 }
 
 static Status apply_write_log(const TxnLogPB_OpWrite& op_write, TabletMetadata* metadata) {
-    if (op_write.has_rowset() && op_write.rowset().num_rows() > 0) {
+    if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
         auto rowset = metadata->add_rowsets();
         rowset->CopyFrom(op_write.rowset());
         rowset->set_id(metadata->next_rowset_id());
-        metadata->set_next_rowset_id(metadata->next_rowset_id() + rowset->segments_size());
+        if (op_write.rowset().num_rows() > 0) {
+            metadata->set_next_rowset_id(metadata->next_rowset_id() + rowset->segments_size());
+        } else {
+            // delete
+            metadata->set_next_rowset_id(metadata->next_rowset_id() + 1);
+        }
     }
     return Status::OK();
 }
@@ -457,7 +463,7 @@ static Status apply_compaction_log(const TxnLogPB_OpCompaction& op_compaction, T
         new_cumulative_point = first_idx;
     } else {
         // base compaction
-        new_cumulative_point = first_idx - op_compaction.input_rowsets_size();
+        new_cumulative_point = metadata->cumulative_point() - op_compaction.input_rowsets_size();
     }
     if (op_compaction.has_output_rowset() && op_compaction.output_rowset().num_rows() > 0) {
         ++new_cumulative_point;
@@ -467,6 +473,20 @@ static Status apply_compaction_log(const TxnLogPB_OpCompaction& op_compaction, T
                                                  new_cumulative_point, metadata->rowsets_size()));
     }
     metadata->set_cumulative_point(new_cumulative_point);
+
+    // Debug new tablet metadata
+    std::vector<uint32_t> rowset_ids;
+    std::vector<uint32_t> delete_rowset_ids;
+    for (const auto& rowset : metadata->rowsets()) {
+        rowset_ids.emplace_back(rowset.id());
+        if (rowset.has_delete_predicate()) {
+            delete_rowset_ids.emplace_back(rowset.id());
+        }
+    }
+    LOG(INFO) << "compaction finish. tablet: " << metadata->id() << ", version: " << metadata->version()
+              << ", cumulative point: " << metadata->cumulative_point() << ", rowsets: [" << JoinInts(rowset_ids, ",")
+              << "]"
+              << ", delete rowsets: [" << JoinInts(delete_rowset_ids, ",") + "]";
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -29,7 +29,14 @@ using PredicateParser = starrocks::vectorized::PredicateParser;
 using ZonemapPredicatesRewriter = starrocks::vectorized::ZonemapPredicatesRewriter;
 
 TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema)
-        : ChunkIterator(std::move(schema)), _tablet(std::move(tablet)), _version(version), _is_vertical_merge(false) {}
+        : ChunkIterator(std::move(schema)), _tablet(std::move(tablet)), _version(version) {}
+
+TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema, const std::vector<RowsetPtr>& rowsets)
+        : ChunkIterator(std::move(schema)),
+          _tablet(std::move(tablet)),
+          _version(version),
+          _rowsets_inited(true),
+          _rowsets(std::move(rowsets)) {}
 
 TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema, bool is_key, RowSourceMaskBuffer* mask_buffer)
         : ChunkIterator(std::move(schema)),
@@ -47,7 +54,10 @@ TabletReader::~TabletReader() {
 
 Status TabletReader::prepare() {
     ASSIGN_OR_RETURN(_tablet_schema, _tablet.get_schema());
-    ASSIGN_OR_RETURN(_rowsets, _tablet.get_rowsets(_version));
+    if (!_rowsets_inited) {
+        ASSIGN_OR_RETURN(_rowsets, _tablet.get_rowsets(_version));
+        _rowsets_inited = true;
+    }
     _stats.rowsets_read_count += _rowsets.size();
     return Status::OK();
 }
@@ -66,6 +76,7 @@ void TabletReader::close() {
         _collect_iter->close();
         _collect_iter.reset();
     }
+    STLDeleteElements(&_predicate_free_list);
     _rowsets.clear();
     _obj_pool.clear();
 }
@@ -83,13 +94,13 @@ Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* sourc
 }
 
 // TODO: support
-//  1. delete predicates
-//  2. primary key table
-//  3. rowid range and short key range
+//  1. primary key table
+//  2. rowid range and short key range
 Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters) {
     RowsetReadOptions rs_opts;
     KeysType keys_type = _tablet_schema->keys_type();
     RETURN_IF_ERROR(init_predicates(params));
+    RETURN_IF_ERROR(init_delete_predicates(params, &_delete_predicates));
     RETURN_IF_ERROR(parse_seek_range(*_tablet_schema, params.range, params.end_range, params.start_key, params.end_key,
                                      &rs_opts.ranges, &_mempool));
     rs_opts.predicates = _pushdown_predicates;
@@ -98,6 +109,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.sorted = (keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation;
     rs_opts.reader_type = params.reader_type;
     rs_opts.chunk_size = params.chunk_size;
+    rs_opts.delete_predicates = &_delete_predicates;
     rs_opts.stats = &_stats;
     rs_opts.runtime_state = params.runtime_state;
     rs_opts.profile = params.profile;
@@ -118,6 +130,78 @@ Status TabletReader::init_predicates(const TabletReaderParams& params) {
     for (const ColumnPredicate* pred : params.predicates) {
         _pushdown_predicates[pred->column_id()].emplace_back(pred);
     }
+    return Status::OK();
+}
+
+Status TabletReader::init_delete_predicates(const TabletReaderParams& params, DeletePredicates* dels) {
+    PredicateParser pred_parser(*_tablet_schema);
+    ASSIGN_OR_RETURN(auto tablet_metadata, _tablet.get_metadata(_version));
+
+    for (int index = 0, size = tablet_metadata->rowsets_size(); index < size; ++index) {
+        const auto& rowset_metadata = tablet_metadata->rowsets(index);
+        if (!rowset_metadata.has_delete_predicate()) {
+            continue;
+        }
+
+        const auto& pred_pb = rowset_metadata.delete_predicate();
+        std::vector<TCondition> conds;
+        for (int i = 0; i < pred_pb.binary_predicates_size(); ++i) {
+            const auto& binary_predicate = pred_pb.binary_predicates(i);
+            TCondition cond;
+            cond.__set_column_name(binary_predicate.column_name());
+            auto& op = binary_predicate.op();
+            if (op == "<") {
+                cond.__set_condition_op("<<");
+            } else if (op == ">") {
+                cond.__set_condition_op(">>");
+            } else {
+                cond.__set_condition_op(op);
+            }
+            cond.condition_values.emplace_back(binary_predicate.value());
+            conds.emplace_back(std::move(cond));
+        }
+
+        for (int i = 0; i < pred_pb.is_null_predicates_size(); ++i) {
+            const auto& is_null_predicate = pred_pb.is_null_predicates(i);
+            TCondition cond;
+            cond.__set_column_name(is_null_predicate.column_name());
+            cond.__set_condition_op("IS");
+            cond.condition_values.emplace_back(is_null_predicate.is_not_null() ? "NOT NULL" : "NULL");
+            conds.emplace_back(std::move(cond));
+        }
+
+        for (int i = 0; i < pred_pb.in_predicates_size(); ++i) {
+            TCondition cond;
+            const InPredicatePB& in_predicate = pred_pb.in_predicates(i);
+            cond.__set_column_name(in_predicate.column_name());
+            if (in_predicate.is_not_in()) {
+                cond.__set_condition_op("!*=");
+            } else {
+                cond.__set_condition_op("*=");
+            }
+            for (const auto& value : in_predicate.values()) {
+                cond.condition_values.push_back(value);
+            }
+            conds.emplace_back(std::move(cond));
+        }
+
+        ConjunctivePredicates conjunctions;
+        for (const auto& cond : conds) {
+            ColumnPredicate* pred = pred_parser.parse_thrift_cond(cond);
+            if (pred == nullptr) {
+                LOG(WARNING) << "failed to parse delete condition.column_name[" << cond.column_name
+                             << "], condition_op[" << cond.condition_op << "], condition_values["
+                             << cond.condition_values[0] << "].";
+                continue;
+            }
+            conjunctions.add(pred);
+            // save for memory release.
+            _predicate_free_list.emplace_back(pred);
+        }
+
+        dels->add(index, conjunctions);
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -4,6 +4,7 @@
 
 #include "runtime/mem_pool.h"
 #include "storage/chunk_iterator.h"
+#include "storage/delete_predicates.h"
 #include "storage/lake/tablet.h"
 #include "storage/tablet_reader_params.h"
 
@@ -28,6 +29,7 @@ class TabletReader final : public vectorized::ChunkIterator {
     using Chunk = starrocks::vectorized::Chunk;
     using ChunkIteratorPtr = starrocks::vectorized::ChunkIteratorPtr;
     using ColumnPredicate = starrocks::vectorized::ColumnPredicate;
+    using DeletePredicates = starrocks::vectorized::DeletePredicates;
     using RowsetPtr = std::shared_ptr<Rowset>;
     using RowSourceMask = starrocks::vectorized::RowSourceMask;
     using RowSourceMaskBuffer = starrocks::vectorized::RowSourceMaskBuffer;
@@ -38,6 +40,7 @@ class TabletReader final : public vectorized::ChunkIterator {
 
 public:
     TabletReader(Tablet tablet, int64_t version, Schema schema);
+    TabletReader(Tablet tablet, int64_t version, Schema schema, const std::vector<RowsetPtr>& rowsets);
     TabletReader(Tablet tablet, int64_t version, Schema schema, bool is_key, RowSourceMaskBuffer* mask_buffer);
     ~TabletReader() override;
 
@@ -66,6 +69,7 @@ private:
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
     Status init_predicates(const TabletReaderParams& read_params);
+    Status init_delete_predicates(const TabletReaderParams& read_params, DeletePredicates* dels);
 
     Status init_collector(const TabletReaderParams& read_params);
 
@@ -83,10 +87,14 @@ private:
     std::shared_ptr<const TabletSchema> _tablet_schema;
     int64_t _version;
 
+    // _rowsets is specified in the constructor when compaction
+    bool _rowsets_inited = false;
     std::vector<RowsetPtr> _rowsets;
     std::shared_ptr<ChunkIterator> _collect_iter;
 
     PredicateMap _pushdown_predicates;
+    DeletePredicates _delete_predicates;
+    PredicateList _predicate_free_list;
 
     OlapReaderStatistics _stats;
 

--- a/be/test/storage/lake/horizontal_compaction_task_test.cpp
+++ b/be/test/storage/lake/horizontal_compaction_task_test.cpp
@@ -341,4 +341,183 @@ TEST_F(UniqueKeyHorizontalCompactionTest, test1) {
     ASSERT_EQ(1, new_tablet_metadata->cumulative_point());
     ASSERT_EQ(1, new_tablet_metadata->rowsets_size());
 }
+
+class UniqueKeyHorizontalCompactionWithDeleteTest : public testing::Test {
+public:
+    UniqueKeyHorizontalCompactionWithDeleteTest() {
+        _tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+
+        _parent_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_tracker = std::make_unique<MemTracker>(-1, "", _parent_mem_tracker.get());
+        _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
+        _backup_location_provider = _tablet_manager->TEST_set_location_provider(_location_provider.get());
+
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_cumulative_point(0);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(UNIQUE_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        schema->set_compress_kind(COMPRESS_LZ4);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("REPLACE");
+        }
+
+        _tablet_schema = TabletSchema::create(_mem_tracker.get(), *schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_lake_hcompaction_task_unique_with_delete";
+    constexpr static const int kChunkSize = 12;
+
+    void SetUp() override {
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_location_provider.get());
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(kTestGroupPath));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        tablet.delete_txn_log(_txn_id);
+        _txn_id++;
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kTestGroupPath);
+    }
+
+    VChunk generate_data(int64_t chunk_size) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * 3;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        return VChunk({c0, c1}, _schema);
+    }
+
+    int64_t read(int64_t version) {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+        int64_t ret = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            ret += chunk->num_rows();
+            chunk->reset();
+        }
+        return ret;
+    }
+
+    TabletManager* _tablet_manager;
+    std::unique_ptr<MemTracker> _parent_mem_tracker;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<FixedLocationProvider> _location_provider;
+    LocationProvider* _backup_location_provider;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+    int64_t _partition_id = 4562;
+    int64_t _txn_id = 1002;
+};
+
+TEST_F(UniqueKeyHorizontalCompactionWithDeleteTest, test_base_compaction_with_delete) {
+    // Prepare data for writing
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1));
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read(version));
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
+    ASSIGN_OR_ABORT(auto t, _tablet_manager->get_tablet(tablet_id));
+    _txn_id++;
+
+    // add delete rowset version
+    {
+        ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+        auto new_delete_metadata = std::make_shared<TabletMetadata>(*tablet_metadata);
+        auto* rowset = new_delete_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(0);
+
+        auto* delete_predicate = rowset->mutable_delete_predicate();
+        // delete c0 < 4
+        auto* binary_predicate = delete_predicate->add_binary_predicates();
+        binary_predicate->set_column_name("c0");
+        binary_predicate->set_op("<");
+        binary_predicate->set_value("4");
+
+        new_delete_metadata->set_version(version + 1);
+        new_delete_metadata->set_cumulative_point(new_delete_metadata->rowsets_size());
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*new_delete_metadata));
+
+        version++;
+        _txn_id++;
+    }
+
+    ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
+    ASSERT_OK(task->execute());
+    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1));
+    version++;
+    ASSERT_EQ(kChunkSize - 4, read(version));
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    ASSERT_EQ(1, new_tablet_metadata->cumulative_point());
+    ASSERT_EQ(1, new_tablet_metadata->rowsets_size());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -11,6 +11,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/lake_delete.pb.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -336,6 +337,177 @@ TEST_F(AggregateTabletReaderTest, test_read_success) {
     for (int i = 0, sz = k1.size(); i < sz; i++) {
         EXPECT_EQ(k1[i], read_chunk_ptr->get(k0.size() + i)[0].get_int32());
         EXPECT_EQ(v1[i] * 3, read_chunk_ptr->get(k0.size() + i)[1].get_int32());
+    }
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+}
+
+class DuplicateTabletReaderWithDeleteTest : public testing::Test {
+public:
+    DuplicateTabletReaderWithDeleteTest() {
+        _mem_tracker = std::make_unique<MemTracker>(-1);
+        _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), 0);
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        schema->set_compress_kind(COMPRESS_LZ4);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(_mem_tracker.get(), *schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(kTestGroupPath));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { (void)fs::remove_all(kTestGroupPath); }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_duplicate_lake_tablet_reader_with_delete";
+
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<FixedLocationProvider> _location_provider;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+};
+
+TEST_F(DuplicateTabletReaderWithDeleteTest, test_read_success) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    VChunk chunk0({c0, c1}, _schema);
+    VChunk chunk1({c2, c3}, _schema);
+
+    const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+
+    {
+        // write rowset 1 with 2 segments
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer());
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        // segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        // segment #2
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(2, files.size());
+
+        // add rowset metadata
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file));
+        }
+
+        writer->close();
+    }
+
+    {
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(0);
+
+        auto* delete_predicate = rowset->mutable_delete_predicate();
+        // delete c0 (21, 22, 30)
+        auto* binary_predicate = delete_predicate->add_binary_predicates();
+        binary_predicate->set_column_name("c0");
+        binary_predicate->set_op("<=");
+        binary_predicate->set_value("30");
+        auto* in_predicate = delete_predicate->add_in_predicates();
+        in_predicate->set_column_name("c1");
+        in_predicate->set_is_not_in(false);
+        in_predicate->add_values("41");
+        in_predicate->add_values("44");
+        in_predicate->add_values("0");
+        in_predicate->add_values("1");
+    }
+
+    // write tablet metadata
+    _tablet_metadata->set_version(3);
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+
+    // test reader
+    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(3, *_schema));
+    ASSERT_OK(reader->prepare());
+    vectorized::TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    for (int j = 0; j < 2; ++j) {
+        read_chunk_ptr->reset();
+        ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+        ASSERT_EQ(segment_rows - 3, read_chunk_ptr->num_rows());
+        int chunk_index = 0;
+        int sz0 = k0.size() - 2;
+        for (int i = 0; i < sz0; i++) {
+            EXPECT_EQ(k0[i], read_chunk_ptr->get(chunk_index)[0].get_int32());
+            EXPECT_EQ(v0[i], read_chunk_ptr->get(chunk_index)[1].get_int32());
+            ++chunk_index;
+        }
+        int sz1 = k1.size() - 1;
+        for (int i = 0; i < sz1; i++) {
+            EXPECT_EQ(k1[i + 1], read_chunk_ptr->get(chunk_index)[0].get_int32());
+            EXPECT_EQ(v1[i + 1], read_chunk_ptr->get(chunk_index)[1].get_int32());
+            ++chunk_index;
+        }
     }
 
     read_chunk_ptr->reset();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Add delete predicate processing in lake tablet reader and compaction policy.
2. Fix update cumulative point bug in base compaction.