### PR TITLE
[BugFix] Shared fs shouldn't set individual FSOptions

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -20,9 +20,9 @@ static thread_local std::shared_ptr<FileSystem> tls_fs_hdfs;
 static thread_local std::shared_ptr<FileSystem> tls_fs_starlet;
 #endif
 
-inline std::shared_ptr<FileSystem> get_tls_fs_hdfs(FSOptions& options) {
+inline std::shared_ptr<FileSystem> get_tls_fs_hdfs() {
     if (tls_fs_hdfs == nullptr) {
-        tls_fs_hdfs.reset(new_fs_hdfs(options).release());
+        tls_fs_hdfs.reset(new_fs_hdfs(FSOptions()).release());
     }
     return tls_fs_hdfs;
 }
@@ -34,9 +34,9 @@ inline std::shared_ptr<FileSystem> get_tls_fs_posix() {
     return tls_fs_posix;
 }
 
-inline std::shared_ptr<FileSystem> get_tls_fs_s3(FSOptions& options) {
+inline std::shared_ptr<FileSystem> get_tls_fs_s3() {
     if (tls_fs_s3 == nullptr) {
-        tls_fs_s3.reset(new_fs_s3(options).release());
+        tls_fs_s3.reset(new_fs_s3(FSOptions()).release());
     }
     return tls_fs_s3;
 }
@@ -93,15 +93,15 @@ StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::st
     return Status::NotSupported(fmt::format("No FileSystem associated with {}", uri));
 }
 
-StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::string_view uri, FSOptions options) {
+StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::string_view uri) {
     if (is_posix_uri(uri)) {
         return get_tls_fs_posix();
     }
     if (is_hdfs_uri(uri)) {
-        return get_tls_fs_hdfs(options);
+        return get_tls_fs_hdfs();
     }
     if (is_s3_uri(uri)) {
-        return get_tls_fs_s3(options);
+        return get_tls_fs_s3();
     }
 #ifdef USE_STAROS
     if (is_starlet_uri(uri)) {

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -61,8 +61,7 @@ public:
     static StatusOr<std::unique_ptr<FileSystem>> CreateUniqueFromString(std::string_view uri,
                                                                         FSOptions options = FSOptions());
 
-    static StatusOr<std::shared_ptr<FileSystem>> CreateSharedFromString(std::string_view uri,
-                                                                        FSOptions options = FSOptions());
+    static StatusOr<std::shared_ptr<FileSystem>> CreateSharedFromString(std::string_view uri);
 
     // Return a default environment suitable for the current operating
     // system.  Sophisticated users may wish to provide their own FileSystem


### PR DESCRIPTION
Shared fs is shared by many users, we shouldn't pass in FSOptions each time we call CreateSharedFromString,
it doesn't make sense.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9409

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
