### PR TITLE
[Bugfix] ignore partition and columns name case when create mv.#9386

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -30,6 +30,8 @@ import com.starrocks.catalog.RefreshType;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
@@ -51,7 +53,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class MaterializedViewAnalyzer {
 
@@ -206,7 +207,7 @@ public class MaterializedViewAnalyzer {
                         + slotRef.toSql() + " must related to column");
             }
             for (Column column : columns) {
-                if (slotRef.getColumnName().equals(column.getName())) {
+                if (slotRef.getColumnName().equalsIgnoreCase(column.getName())) {
                     statement.setPartitionColumn(column);
                     break;
                 }
@@ -288,7 +289,7 @@ public class MaterializedViewAnalyzer {
                 }
                 boolean isInPartitionColumns = false;
                 for (Column basePartitionColumn : partitionColumns) {
-                    if (basePartitionColumn.getName().equals(slotRef.getColumnName())) {
+                    if (basePartitionColumn.getName().equalsIgnoreCase(slotRef.getColumnName())) {
                         isInPartitionColumns = true;
                         break;
                     }
@@ -356,8 +357,13 @@ public class MaterializedViewAnalyzer {
                     throw new SemanticException("Materialized view should contain distribution desc");
                 }
             }
-            distributionDesc.analyze(
-                    mvColumnItems.stream().map(Column::getName).collect(Collectors.toSet()));
+            Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+            for (Column columnDef : mvColumnItems) {
+                if (!columnSet.add(columnDef.getName())) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, columnDef.getName());
+                }
+            }
+            distributionDesc.analyze(columnSet);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1408,5 +1408,39 @@ public class CreateMaterializedViewTest {
             Assert.assertEquals("Can not find database:default_cluster:db1", e.getMessage());
         }
     }
+
+    @Test
+    public void testPartitionAndDistributionByColumnNameIgnoreCase() {
+        String sql = "create materialized view mv1 " +
+                "partition by K1 " +
+                "distributed by hash(K2) " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select k1, tbl1.k2 from tbl1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateColumn() {
+        String sql = "create materialized view mv1 " +
+                "partition by K1 " +
+                "distributed by hash(K2) " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select k1, K1 from tbl1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.assertEquals("Duplicate column name 'K1'", e.getMessage());
+        }
+    }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#9386
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
CREATE TABLE t1 (
                  col1 int,
                  col2 double,
                  col3 varchar(20)
                ) ENGINE=OLAP
                DUPLICATE KEY(col1)
                COMMENT "OLAP"
                PARTITION BY RANGE(`col1`)
                (
                    PARTITION p1 VALUES LESS THAN ("100")
                )
                DISTRIBUTED BY HASH(col1) BUCKETS 3
                PROPERTIES (
                "replication_num" = "3"
                );

CREATE MATERIALIZED VIEW mv1
PARTITION BY COL1
DISTRIBUTED BY HASH(col1) BUCKETS 10
REFRESH ASYNC
AS SELECT col1, col2
FROM t1;


CREATE MATERIALIZED VIEW mv2
PARTITION BY COL1
DISTRIBUTED BY HASH(col1) BUCKETS 10
REFRESH ASYNC
AS SELECT COL1, col2
FROM t1;
```

![image](https://user-images.githubusercontent.com/70745826/182087285-f799b7d6-044a-4f34-8e04-13d376da2c48.png)

If there are two identical fields ignore case in select , it will report error "Duplicate column name ".For example:

```
CREATE MATERIALIZED VIEW mv5
PARTITION BY COL1
DISTRIBUTED BY HASH(col1) BUCKETS 10
REFRESH ASYNC
AS SELECT COL1, col2 ,Col1 
FROM t1;

ERROR 1064 (HY000): Duplicate column name 'col1'
```

