### PR TITLE
[Enhancement] Support pipeline level shuffle for CTE

### DIFF
--- a/be/src/runtime/data_stream_sender.h
+++ b/be/src/runtime/data_stream_sender.h
@@ -101,19 +101,19 @@ public:
 
     TPartitionType::type get_partition_type() const { return _part_type; }
 
-    std::vector<ExprContext*>& get_partition_exprs() { return _partition_expr_ctxs; }
+    const std::vector<ExprContext*>& get_partition_exprs() const { return _partition_expr_ctxs; }
 
     int32_t get_destinations_size() const { return _channels.size(); }
 
     PlanNodeId get_dest_node_id() const { return _dest_node_id; }
 
-    const std::vector<TPlanFragmentDestination>& destinations() { return _destinations; }
+    const std::vector<TPlanFragmentDestination>& destinations() const { return _destinations; }
 
     int sender_id() const { return _sender_id; }
 
     const bool get_enable_exchange_pass_through() const { return _enable_exchange_pass_through; }
 
-    const std::vector<int32_t>& output_columns() { return _output_columns; }
+    const std::vector<int32_t>& output_columns() const { return _output_columns; }
 
 private:
     class Channel;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -39,6 +39,10 @@ public class MultiCastPlanFragment extends PlanFragment {
         return destNodeList.stream().map(PlanNode::getFragment).collect(Collectors.toList());
     }
 
+    public ExchangeNode getDestNode(int index) {
+        return destNodeList.get(index);
+    }
+
     @Override
     public void finalize(Analyzer analyzer, boolean validateFileFormats) {
         if (sink != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1398,7 +1398,7 @@ public class Coordinator {
             // hash-partitioned
             // output at the moment
 
-            // set params for pipeline level shuffle
+            // Set params for pipeline level shuffle.
             params.fragment.getDestNode().setPartitionType(params.fragment.getOutputPartition().getType());
             if (sink instanceof DataStreamSink) {
                 DataStreamSink dataStreamSink = (DataStreamSink) sink;
@@ -1470,12 +1470,16 @@ public class Coordinator {
 
             for (int i = 0; i < multi.getDestFragmentList().size(); i++) {
                 PlanFragment destFragment = multi.getDestFragmentList().get(i);
-                DataSink sink = multiSink.getDataStreamSinks().get(i);
+                DataStreamSink sink = multiSink.getDataStreamSinks().get(i);
 
                 if (destFragment == null) {
                     continue;
                 }
                 FragmentExecParams destParams = fragmentExecParamsMap.get(destFragment.getFragmentId());
+
+                // Set params for pipeline level shuffle.
+                multi.getDestNode(i).setPartitionType(params.fragment.getOutputPartition().getType());
+                sink.setExchDop(destFragment.getPipelineDop());
 
                 PlanNodeId exchId = sink.getExchNodeId();
                 // MultiCastSink only send to itself, destination exchange only one senders


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9419.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`ExchangeSourceOperatorFactory::need_local_shuffle` invokes ` DCHECK(_texchange_node.__isset.partition_type)`, which means it expects that `exchange_source_node.partition_type` always be set.

However, when the sender of the `exchange_source_node` is `MultiCastDataSink` from CTE, `partition_type` isn't set.

Therefore, this PR make CTE also support pipeline level shuffle and set `partition_type` by setting two fields:
- `PartitionType` of `ExchangeSource`.
- `ExchDop` of `ExchangeSink`.




