### PR TITLE
[Feature] Iceberg table supports unknown types

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -274,7 +274,7 @@ public class IcebergTable extends Table {
             case LIST:
             case MAP:
             default:
-                return false;
+                return primitiveType == PrimitiveType.UNKNOWN_TYPE;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -242,7 +242,7 @@ public class IcebergUtil {
             case STRUCT:
             case MAP:
             default:
-                throw new RuntimeException("Unsupported type " + icebergType.typeId().toString());
+                primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }
         return ScalarType.createType(primitiveType);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.external.iceberg;
 
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.external.hive.HdfsFileFormat;
@@ -59,10 +60,11 @@ public class IcebergUtilTest {
         Assert.assertEquals(resType, stringType);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testUnsupported() {
         org.apache.iceberg.types.Type icebergType = Types.MapType.ofRequired(1, 2,
                 Types.StringType.get(), Types.StringType.get());
-        convertColumnType(icebergType);
+        Type resType = convertColumnType(icebergType);
+        Assert.assertEquals(resType, ScalarType.createType(PrimitiveType.UNKNOWN_TYPE));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Related to #8881 
When there are unsupported types in an Iceberg table, exception will not be thrown if users don't select columns with such types. Like the followings:
```sql
hive> select * from t.m;
OK
1	{"a":"b"}
MySQL [(none)]> select * from ice.t.m;
ERROR 1064 (HY000): External Table Column [m] convert failed, and column type is known!
MySQL [(none)]> select i from ice.t.m;
+------+
| i    |
+------+
|    1 |
+------+
1 row in set (0.08 sec)
```
