### PR TITLE
[Enhancement] Unable to filter NULL data by WHERE to build NOT NULL column

### DIFF
--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -191,25 +191,6 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPt
                     _state->append_error_msg_to_file(src->debug_row(i), error_msg.str());
                 }
             }
-
-            if (!slot->is_nullable()) {
-                for (int i = 0; i < col->size(); ++i) {
-                    if (!col->is_null(i) || !filter[i]) {
-                        continue;
-                    }
-
-                    filter[i] = 0;
-                    _error_counter++;
-
-                    // avoid print too many debug log
-                    if (_error_counter > 50) {
-                        continue;
-                    }
-                    _state->append_error_msg_to_file(
-                            src->debug_row(i),
-                            strings::Substitute("NULL value in non-nullable column '$0'", slot->col_name()));
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/8785

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The previous implementation checks whether the not-null column with null data before the predicate evaluation, which leads we cannot filter null record by setting WHERE KEY IS NOT NULL in load.
The new implementation removes the check before predicate evaluation.