### PR TITLE
[BugFix] Fix LocalTablet Inconsistent bug after deserialization from json string

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -31,6 +31,7 @@ import com.starrocks.clone.TabletSchedCtx;
 import com.starrocks.clone.TabletSchedCtx.Priority;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -52,7 +53,7 @@ import java.util.stream.Collectors;
  * This class represents the local olap tablet related metadata.
  * LocalTablet is based on local disk storage and replicas are managed by StarRocks.
  */
-public class LocalTablet extends Tablet {
+public class LocalTablet extends Tablet implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(LocalTablet.class);
 
     public enum TabletStatus {
@@ -368,6 +369,7 @@ public class LocalTablet extends Tablet {
         for (int i = 0; i < replicaCount; ++i) {
             Replica replica = Replica.read(in);
             if (deleteRedundantReplica(replica.getBackendId(), replica.getVersion())) {
+                // do not need to update immutableReplicas, because it is a view of replicas
                 replicas.add(replica);
             }
         }
@@ -383,6 +385,13 @@ public class LocalTablet extends Tablet {
         LocalTablet tablet = new LocalTablet();
         tablet.readFields(in);
         return tablet;
+    }
+
+    @Override
+    public void gsonPostProcess() {
+        // we need to update immutableReplicas, because replicas after deserialization from a json string
+        // will be different from the replicas initiated in the constructor
+        immutableReplicas = Collections.unmodifiableList(replicas);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -24,6 +24,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.FeConstants;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import mockit.Expectations;
@@ -125,7 +126,7 @@ public class LocalTabletTest {
         dos.flush();
         dos.close();
 
-        // 2. Read a object from file
+        // Read an object from file
         DataInputStream dis = new DataInputStream(new FileInputStream(file));
         LocalTablet rTablet1 = LocalTablet.read(dis);
         Assert.assertEquals(1, rTablet1.getId());
@@ -154,6 +155,13 @@ public class LocalTabletTest {
 
         dis.close();
         file.delete();
+
+        // Read an object from json
+        String jsonStr = GsonUtils.GSON.toJson(tablet);
+        LocalTablet jTablet = GsonUtils.GSON.fromJson(jsonStr, LocalTablet.class);
+        Assert.assertEquals(1, jTablet.getId());
+        Assert.assertEquals(3, jTablet.getImmutableReplicas().size());
+        Assert.assertEquals(jTablet.getImmutableReplicas().get(0).getVersion(), jTablet.getImmutableReplicas().get(1).getVersion());
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9439

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
PR #7665 added the immutableReplicas into the LocalTablet. But it will be empty if the LocalTablet is deserialize from a json string. It will cause some inconsistent bug such as #9439.
To fix this bug, just add a post hook for the deserialization.