### PR TITLE
[BugFix] Fix error of ScanTime

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -324,8 +324,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             auto& chunk_source = _chunk_sources[chunk_source_index];
 
             DeferOp timer_defer([chunk_source]() {
-                COUNTER_UPDATE(chunk_source->scan_timer(), chunk_source->io_task_wait_timer()->value() +
-                                                                   chunk_source->io_task_exec_timer()->value());
+                COUNTER_SET(chunk_source->scan_timer(),
+                            chunk_source->io_task_wait_timer()->value() + chunk_source->io_task_exec_timer()->value());
             });
             COUNTER_UPDATE(chunk_source->io_task_wait_timer(), MonotonicNanos() - io_task_start_nano);
             SCOPED_TIMER(chunk_source->io_task_exec_timer());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Introduced by #9412

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`IOTaskExecTime` and `IOTaskIOWaitTime` are updated cumulatively, while `ScanTime` should always equals to `IOTaskExecTime + IOTaskIOWaitTime`