### PR TITLE
[Cherry-pick 2.3][BugFix] Fix collect query detail bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -21,7 +21,6 @@
 
 package com.starrocks.qe;
 
-import com.amazonaws.services.inspector.model.ResourceGroup;
 import com.google.common.base.Strings;
 import com.starrocks.analysis.KillStmt;
 import com.starrocks.analysis.QueryStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.qe;
 
+import com.amazonaws.services.inspector.model.ResourceGroup;
 import com.google.common.base.Strings;
 import com.starrocks.analysis.KillStmt;
 import com.starrocks.analysis.QueryStmt;
@@ -29,6 +30,7 @@ import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.WorkGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -49,6 +51,7 @@ import com.starrocks.plugin.AuditEvent.EventType;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.common.SqlDigestBuilder;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.thrift.TMasterOpRequest;
@@ -65,6 +68,7 @@ import java.nio.channels.AsynchronousCloseException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Process one mysql connection, receive one pakcet, process, send one packet.
@@ -229,6 +233,34 @@ public class ConnectProcessor {
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail);
     }
 
+    private void addRunningQueryDetail(StatementBase parsedStmt) {
+        if (!Config.enable_collect_query_detail_info) {
+            return;
+        }
+        String sql;
+        if (parsedStmt.needAuditEncryption()) {
+            sql = parsedStmt.toSql();
+        } else {
+            sql = parsedStmt.getOrigStmt().originStmt;
+        }
+        boolean isQuery = parsedStmt instanceof QueryStmt || parsedStmt instanceof QueryStatement;
+        QueryDetail queryDetail = new QueryDetail(
+                DebugUtil.printId(ctx.getQueryId()),
+                isQuery,
+                ctx.connectionId,
+                ctx.getMysqlChannel() != null ?
+                        ctx.getMysqlChannel().getRemoteIp() : "System",
+                ctx.getStartTime(), -1, -1,
+                QueryDetail.QueryMemState.RUNNING,
+                ctx.getDatabase(),
+                sql,
+                ctx.getQualifiedUser(),
+                Optional.ofNullable(ctx.getWorkGroup()).map(WorkGroup::getName).orElse(""));
+        ctx.setQueryDetail(queryDetail);
+        //copy queryDetail, cause some properties can be changed in future
+        QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail.copy());
+    }
+
     // process COM_QUERY statement,
     private void handleQuery() {
         MetricRepo.COUNTER_REQUEST_ALL.increase(1L);
@@ -274,6 +306,12 @@ public class ConnectProcessor {
                 }
                 parsedStmt = stmts.get(i);
                 parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
+
+                // Only add the last running stmt for multi statement,
+                // because the audit log will only show the last stmt.
+                if (i == stmts.size() - 1) {
+                    addRunningQueryDetail(parsedStmt);
+                }
 
                 executor = new StmtExecutor(ctx, parsedStmt);
                 ctx.setExecutor(executor);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -125,7 +125,6 @@ import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -369,13 +369,6 @@ public class StmtExecutor {
                 LOG.debug("no need to transfer to Master. stmt: {}", context.getStmtId());
             }
 
-            // Only add the last running stmt for multi statement,
-            // because the audit log will only show the last stmt and
-            // the ConnectProcessor only add the last finished stmt
-            if (context.getIsLastStmt()) {
-                addRunningQueryDetail();
-            }
-
             if (parsedStmt instanceof QueryStmt || parsedStmt instanceof QueryStatement) {
                 context.getState().setIsQuery(true);
 
@@ -1002,34 +995,6 @@ public class StmtExecutor {
         ExportStmt exportStmt = (ExportStmt) parsedStmt;
         exportStmt.setExportStartTime(context.getStartTime());
         context.getGlobalStateMgr().getExportMgr().addExportJob(queryId, exportStmt);
-    }
-
-    private void addRunningQueryDetail() {
-        if (!Config.enable_collect_query_detail_info) {
-            return;
-        }
-        String sql;
-        if (parsedStmt.needAuditEncryption()) {
-            sql = parsedStmt.toSql();
-        } else {
-            sql = originStmt.originStmt;
-        }
-        boolean isQuery = parsedStmt instanceof QueryStmt || parsedStmt instanceof QueryStatement;
-        QueryDetail queryDetail = new QueryDetail(
-                DebugUtil.printId(context.getQueryId()),
-                isQuery,
-                context.connectionId,
-                context.getMysqlChannel() != null ?
-                        context.getMysqlChannel().getRemoteIp() : "System",
-                context.getStartTime(), -1, -1,
-                QueryDetail.QueryMemState.RUNNING,
-                context.getDatabase(),
-                sql,
-                context.getQualifiedUser(),
-                Optional.ofNullable(context.getWorkGroup()).map(WorkGroup::getName).orElse(""));
-        context.setQueryDetail(queryDetail);
-        //copy queryDetail, cause some properties can be changed in future
-        QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail.copy());
     }
 
     public PQueryStatistics getQueryStatisticsForAuditLog() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9185

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
QueryDetail is added as a RUNNING event in the StmtExecutor.execute, and is added as a FINISH/FAIL event at the end of ConnectProcessor.handleQuery. But if the query is forward to leader, the query is only added as a Running event, because the process of forward stmt if another function in the ConnectProcessor. This will cause some statements (`show frontends` `show load`) to keep showing running on the Starrocks manager. To fix this bug, we should add the RUNNING event at the begin of ConnectProcessor.handleQuery. In this scenario, the QueryDetail will be recorded in the fe who received the query, and this is same to the record of audit log.