### PR TITLE
[Lake] Support lake tablet statistic collection

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -277,6 +277,46 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
             response->add_failed_tablets(tablet_id);
         }
     }
+
+void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* controller,
+                                       const ::starrocks::lake::TabletStatRequest* request,
+                                       ::starrocks::lake::TabletStatResponse* response,
+                                       ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+    auto cntl = static_cast<brpc::Controller*>(controller);
+
+    if (request->tablet_infos_size() == 0) {
+        cntl->SetFailed("missing tablet_infos");
+        return;
+    }
+
+    for (const auto& tablet_info : request->tablet_infos()) {
+        int64_t tablet_id = tablet_info.tablet_id();
+        auto tablet = _env->lake_tablet_manager()->get_tablet(tablet_id);
+        if (!tablet.ok()) {
+            LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
+            continue;
+        }
+
+        int64_t version = tablet_info.version();
+        auto tablet_metadata = tablet->get_metadata(version);
+        if (!tablet_metadata.ok()) {
+            LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << tablet_id << ", version: " << version
+                         << ", error: " << tablet.status();
+            continue;
+        }
+
+        int64_t num_rows = 0;
+        int64_t data_size = 0;
+        for (const auto& rowset : (*tablet_metadata)->rowsets()) {
+            num_rows += rowset.num_rows();
+            data_size += rowset.data_size();
+        }
+        auto tablet_stat = response->add_tablet_stats();
+        tablet_stat->set_tablet_id(tablet_id);
+        tablet_stat->set_num_rows(num_rows);
+        tablet_stat->set_data_size(data_size);
+    }
 }
 
 } // namespace starrocks

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -277,6 +277,7 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
             response->add_failed_tablets(tablet_id);
         }
     }
+}
 
 void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* controller,
                                        const ::starrocks::lake::TabletStatRequest* request,

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -34,6 +34,10 @@ public:
     void delete_data(::google::protobuf::RpcController* controller, const ::starrocks::lake::DeleteDataRequest* request,
                      ::starrocks::lake::DeleteDataResponse* response, ::google::protobuf::Closure* done) override;
 
+    void get_tablet_stats(::google::protobuf::RpcController* controller,
+                          const ::starrocks::lake::TabletStatRequest* request,
+                          ::starrocks::lake::TabletStatResponse* response, ::google::protobuf::Closure* done) override;
+
 private:
     ExecEnv* _env;
 };

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
@@ -24,7 +24,6 @@ package com.starrocks.analysis;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.CompoundPredicate.Operator;
-import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -22,12 +22,24 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.ClientPool;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.Utils;
+import com.starrocks.lake.proto.TabletStatRequest;
+import com.starrocks.lake.proto.TabletStatRequest.TabletInfo;
+import com.starrocks.lake.proto.TabletStatResponse;
+import com.starrocks.lake.proto.TabletStatResponse.TabletStat;
+import com.starrocks.rpc.LakeServiceClient;
+import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.BackendService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TTabletStat;
@@ -37,6 +49,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 /*
  * TabletStatMgr is for collecting tablet(replica) statistics from backends.
@@ -45,43 +59,21 @@ import java.util.Map;
 public class TabletStatMgr extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletStatMgr.class);
 
+    // for lake table
+    private Map<Long, Long> partitionToUpdatedVersion;
+
     public TabletStatMgr() {
         super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000L);
+        partitionToUpdatedVersion = Maps.newHashMap();
     }
 
     @Override
     protected void runAfterCatalogReady() {
-        ImmutableMap<Long, Backend> backends = GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
-
-        long start = System.currentTimeMillis();
-        for (Backend backend : backends.values()) {
-            BackendService.Client client = null;
-            TNetworkAddress address = null;
-            boolean ok = false;
-            try {
-                address = new TNetworkAddress(backend.getHost(), backend.getBePort());
-                client = ClientPool.backendPool.borrowObject(address);
-                TTabletStatResult result = client.get_tablet_stat();
-
-                LOG.debug("get tablet stat from backend: {}, num: {}", backend.getId(), result.getTablets_statsSize());
-                updateTabletStat(backend.getId(), result);
-
-                ok = true;
-            } catch (Exception e) {
-                LOG.warn("task exec error. backend[{}]", backend.getId(), e);
-            } finally {
-                if (ok) {
-                    ClientPool.backendPool.returnObject(address, client);
-                } else {
-                    ClientPool.backendPool.invalidateObject(address, client);
-                }
-            }
-        }
-        LOG.info("finished to get tablet stat of all backends. cost: {} ms",
-                (System.currentTimeMillis() - start));
+        updateLocalTabletStat();
+        updateLakeTabletStat();
 
         // after update replica in all backends, update index row num
-        start = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIds();
         for (Long dbId : dbIds) {
             Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
@@ -117,7 +109,38 @@ public class TabletStatMgr extends LeaderDaemon {
                 (System.currentTimeMillis() - start));
     }
 
-    private void updateTabletStat(Long beId, TTabletStatResult result) {
+    private void updateLocalTabletStat() {
+        ImmutableMap<Long, Backend> backends = GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
+
+        long start = System.currentTimeMillis();
+        for (Backend backend : backends.values()) {
+            BackendService.Client client = null;
+            TNetworkAddress address = null;
+            boolean ok = false;
+            try {
+                address = new TNetworkAddress(backend.getHost(), backend.getBePort());
+                client = ClientPool.backendPool.borrowObject(address);
+                TTabletStatResult result = client.get_tablet_stat();
+
+                LOG.debug("get tablet stat from backend: {}, num: {}", backend.getId(), result.getTablets_statsSize());
+                updateLocalTabletStat(backend.getId(), result);
+
+                ok = true;
+            } catch (Exception e) {
+                LOG.warn("task exec error. backend[{}]", backend.getId(), e);
+            } finally {
+                if (ok) {
+                    ClientPool.backendPool.returnObject(address, client);
+                } else {
+                    ClientPool.backendPool.invalidateObject(address, client);
+                }
+            }
+        }
+        LOG.info("finished to get local tablet stat of all backends. cost: {} ms",
+                (System.currentTimeMillis() - start));
+    }
+
+    private void updateLocalTabletStat(Long beId, TTabletStatResult result) {
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
         for (Map.Entry<Long, TTabletStat> entry : result.getTablets_stats().entrySet()) {
             if (invertedIndex.getTabletMeta(entry.getKey()) == null) {
@@ -137,6 +160,148 @@ public class TabletStatMgr extends LeaderDaemon {
                     entry.getValue().getRow_num(),
                     entry.getValue().getVersion_count()
             );
+        }
+    }
+
+    private void updateLakeTabletStat() {
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+
+            List<LakeTable> tables = Lists.newArrayList();
+            db.readLock();
+            try {
+                for (Table table : db.getTables()) {
+                    if (table.isLakeTable()) {
+                        tables.add((LakeTable) table);
+                    }
+                }
+            } finally {
+                db.readUnlock();
+            }
+
+            for (LakeTable table : tables) {
+                updateLakeTableTabletStat(db, table);
+            }
+        }
+    }
+
+    @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
+    private void updateLakeTableTabletStat(Database db, LakeTable table) {
+        // prepare tablet infos
+        Map<Long, List<TabletInfo>> beToTabletInfos = Maps.newHashMap();
+        Map<Long, Long> partitionToVersion = Maps.newHashMap();
+        db.readLock();
+        try {
+            for (Partition partition : table.getPartitions()) {
+                long partitionId = partition.getId();
+                long version = partition.getVisibleVersion();
+                // partition init version is 1
+                if (version <= partitionToUpdatedVersion.getOrDefault(partitionId, 1L)) {
+                    continue;
+                }
+
+                partitionToVersion.put(partitionId, version);
+                for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    for (Tablet tablet : index.getTablets()) {
+                        Long beId = Utils.chooseBackend((LakeTablet) tablet);
+                        if (beId == null) {
+                            continue;
+                        }
+                        TabletInfo tabletInfo = new TabletInfo();
+                        tabletInfo.tabletId = tablet.getId();
+                        tabletInfo.version = version;
+                        beToTabletInfos.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tabletInfo);
+                    }
+                }
+            }
+        } finally {
+            db.readUnlock();
+        }
+
+        if (beToTabletInfos.isEmpty()) {
+            return;
+        }
+
+        // get tablet stats from be
+        List<Future<TabletStatResponse>> responseList = Lists.newArrayListWithCapacity(beToTabletInfos.size());
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
+        Map<Long, TabletStat> idToStat = Maps.newHashMap();
+        long start = System.currentTimeMillis();
+        try {
+            for (Map.Entry<Long, List<TabletInfo>> entry : beToTabletInfos.entrySet()) {
+                Backend backend = systemInfoService.getBackend(entry.getKey());
+                if (backend == null) {
+                    continue;
+                }
+                TNetworkAddress address = new TNetworkAddress();
+                address.setHostname(backend.getHost());
+                address.setPort(backend.getBrpcPort());
+
+                LakeServiceClient client = new LakeServiceClient(address);
+                TabletStatRequest request = new TabletStatRequest();
+                request.tabletInfos = entry.getValue();
+
+                Future<TabletStatResponse> responseFuture = client.getTabletStats(request);
+                responseList.add(responseFuture);
+            }
+
+            for (Future<TabletStatResponse> responseFuture : responseList) {
+                TabletStatResponse response = responseFuture.get();
+                if (response != null && response.tabletStats != null) {
+                    for (TabletStat tabletStat : response.tabletStats) {
+                        idToStat.put(tabletStat.tabletId, tabletStat);
+                    }
+                }
+            }
+        } catch (RpcException | ExecutionException | InterruptedException e) {
+            LOG.warn("failed to get lake tablet stats. table id: {}", table.getId(), e);
+            return;
+        }
+        LOG.info("finished to get lake tablet stats. db id: {}, table id: {}, cost: {} ms", db.getId(), table.getId(),
+                (System.currentTimeMillis() - start));
+
+        if (idToStat.isEmpty()) {
+            return;
+        }
+
+        // update tablet stats
+        db.writeLock();
+        try {
+            for (Partition partition : table.getPartitions()) {
+                long partitionId = partition.getId();
+                if (!partitionToVersion.containsKey(partitionId)) {
+                    continue;
+                }
+
+                boolean allTabletsUpdated = true;
+                for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    for (Tablet tablet : index.getTablets()) {
+                        TabletStat stat = idToStat.get(tablet.getId());
+                        if (stat == null) {
+                            allTabletsUpdated = false;
+                            continue;
+                        }
+
+                        LakeTablet lakeTablet = (LakeTablet) tablet;
+                        lakeTablet.setRowCount(stat.numRows);
+                        lakeTablet.setDataSize(stat.dataSize);
+                        LOG.debug("update lake tablet info. tablet id: {}, num rows: {}, data size: {}", stat.tabletId,
+                                stat.numRows, stat.dataSize);
+                    }
+                }
+                if (allTabletsUpdated) {
+                    long version = partitionToVersion.get(partitionId);
+                    partitionToUpdatedVersion.put(partitionId, version);
+                    LOG.info("update lake tablet stats. db id: {}, table id: {}, partition id: {}, version: {}",
+                            db.getId(), table.getId(), partitionId, version);
+                }
+            }
+        } finally {
+            db.writeUnlock();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -31,7 +31,7 @@ public class Utils {
             LOG.info("Ignored error {}", ex.getMessage());
         }
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-        if (backendIds.isEmpty()) {
+        if (backendIds == null || backendIds.isEmpty()) {
             return null;
         }
         return backendIds.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -13,6 +13,8 @@ import com.starrocks.lake.proto.DropTabletRequest;
 import com.starrocks.lake.proto.DropTabletResponse;
 import com.starrocks.lake.proto.PublishVersionRequest;
 import com.starrocks.lake.proto.PublishVersionResponse;
+import com.starrocks.lake.proto.TabletStatRequest;
+import com.starrocks.lake.proto.TabletStatResponse;
 
 public interface LakeService {
     @BrpcMeta(serviceName = "LakeService", methodName = "publish_version")
@@ -29,5 +31,8 @@ public interface LakeService {
 
     @BrpcMeta(serviceName = "LakeService", methodName = "delete_data")
     DeleteDataResponse deleteData(DeleteDataRequest request);
+
+    @BrpcMeta(serviceName = "LakeService", methodName = "get_tablet_stats")
+    TabletStatResponse getTabletStats(TabletStatRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceAsync.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceAsync.java
@@ -13,6 +13,8 @@ import com.starrocks.lake.proto.DropTabletRequest;
 import com.starrocks.lake.proto.DropTabletResponse;
 import com.starrocks.lake.proto.PublishVersionRequest;
 import com.starrocks.lake.proto.PublishVersionResponse;
+import com.starrocks.lake.proto.TabletStatRequest;
+import com.starrocks.lake.proto.TabletStatResponse;
 
 import java.util.concurrent.Future;
 
@@ -27,4 +29,6 @@ public interface LakeServiceAsync extends LakeService  {
     Future<CompactResponse> compact(CompactRequest request, RpcCallback<CompactResponse> callback);
 
     Future<DeleteDataResponse> deleteData(DeleteDataRequest request, RpcCallback<DeleteDataResponse> callback);
+
+    Future<TabletStatResponse> getTabletStats(TabletStatRequest request, RpcCallback<TabletStatResponse> callback);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceClient.java
@@ -14,6 +14,8 @@ import com.starrocks.lake.proto.DropTabletRequest;
 import com.starrocks.lake.proto.DropTabletResponse;
 import com.starrocks.lake.proto.PublishVersionRequest;
 import com.starrocks.lake.proto.PublishVersionResponse;
+import com.starrocks.lake.proto.TabletStatRequest;
+import com.starrocks.lake.proto.TabletStatResponse;
 import com.starrocks.thrift.TNetworkAddress;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,6 +66,13 @@ public class LakeServiceClient {
     public Future<DeleteDataResponse> deleteData(DeleteDataRequest request) throws RpcException {
         RpcCallback<DeleteDataResponse> callback = new EmptyRpcCallback<DeleteDataResponse>();
         return run(() -> BrpcProxy.getInstance().getLakeService(serverAddress).deleteData(request, callback));
+    }
+
+    public Future<TabletStatResponse> getTabletStats(TabletStatRequest request) throws RpcException {
+        RpcCallback<TabletStatResponse> callback = new EmptyRpcCallback<>();
+        RpcContext rpcContext = RpcContext.getContext();
+        rpcContext.setReadTimeoutMillis(600000);
+        return run(() -> BrpcProxy.getInstance().getLakeService(serverAddress).getTabletStats(request, callback));
     }
 
     private <T> T run(Supplier<T> function) throws RpcException {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -69,6 +69,25 @@ message DeleteDataResponse {
     repeated int64 failed_tablets = 1;
 }
 
+message TabletStatRequest {
+    message TabletInfo {
+        optional int64 tablet_id = 1;
+        optional int64 version = 2;
+    }
+
+    repeated TabletInfo tablet_infos = 1;
+}
+
+message TabletStatResponse {
+    message TabletStat {
+        optional int64 tablet_id = 1;
+        optional int64 num_rows = 2;
+        optional int64 data_size = 3;
+    }
+
+    repeated TabletStat tablet_stats = 1;
+}
+
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc abort_txn(AbortTxnRequest) returns (AbortTxnResponse);
@@ -77,5 +96,6 @@ service LakeService {
     rpc drop_tablet(DropTabletRequest) returns (DropTabletResponse);
     rpc drop_table(DropTableRequest) returns (DropTableResponse);
     rpc delete_data(DeleteDataRequest) returns (DeleteDataResponse);
+    rpc get_tablet_stats(TabletStatRequest) returns (TabletStatResponse);
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

FE periodically collect lake tablet statistic, such as num rows and data size.
Num rows statistic is used in CBO optimizer.