### PR TITLE
[BugFix] Fix multi nest cte inline error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -221,7 +221,7 @@ public class QueryAnalyzer {
                         // eg: with w as (select * from t0) select v1,sum(v2) from w group by v1 " +
                         //                "having v1 in (select v3 from w where v2 = 2)
                         // cte used in outer query and subquery can't use same relation-id and field
-                        CTERelation newCteRelation = new CTERelation(cteRelation.getCteId(), tableName.getTbl(),
+                        CTERelation newCteRelation = new CTERelation(cteRelation.getCteMouldId(), tableName.getTbl(),
                                 cteRelation.getColumnOutputNames(),
                                 cteRelation.getCteQueryStatement());
                         newCteRelation.setAlias(tableRelation.getAlias());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -7,30 +7,25 @@ import com.starrocks.analysis.TableName;
 import java.util.List;
 
 public class CTERelation extends Relation {
-    // @Note: don't join hash method, maybe multi-change
-    private int cteId;
+    private final int cteMouldId;
     private final String name;
     private List<String> columnOutputNames;
     private final QueryStatement cteQueryStatement;
     private boolean resolvedInFromClause;
 
-    public CTERelation(int cteId, String name, List<String> columnOutputNames, QueryStatement cteQueryStatement) {
-        this.cteId = cteId;
+    public CTERelation(int cteMouldId, String name, List<String> columnOutputNames, QueryStatement cteQueryStatement) {
+        this.cteMouldId = cteMouldId;
         this.name = name;
         this.columnOutputNames = columnOutputNames;
         this.cteQueryStatement = cteQueryStatement;
     }
 
-    public void setCteId(int cteId) {
-        this.cteId = cteId;
+    public int getCteMouldId() {
+        return cteMouldId;
     }
 
     public QueryStatement getCteQueryStatement() {
         return cteQueryStatement;
-    }
-
-    public int getCteId() {
-        return cteId;
     }
 
     public String getName() {
@@ -55,7 +50,7 @@ public class CTERelation extends Relation {
 
     @Override
     public String toString() {
-        return name == null ? String.valueOf(cteId) : name;
+        return name == null ? String.valueOf(cteMouldId) : name;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -7,7 +7,8 @@ import com.starrocks.analysis.TableName;
 import java.util.List;
 
 public class CTERelation extends Relation {
-    private final int cteId;
+    // @Note: don't join hash method, maybe multi-change
+    private int cteId;
     private final String name;
     private List<String> columnOutputNames;
     private final QueryStatement cteQueryStatement;
@@ -18,6 +19,10 @@ public class CTERelation extends Relation {
         this.name = name;
         this.columnOutputNames = columnOutputNames;
         this.cteQueryStatement = cteQueryStatement;
+    }
+
+    public void setCteId(int cteId) {
+        this.cteId = cteId;
     }
 
     public QueryStatement getCteQueryStatement() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -203,7 +203,9 @@ public class CTEContext {
         }
 
         Preconditions.checkState(produceCosts.containsKey(cteId));
-        Preconditions.checkState(consumeInlineCosts.containsKey(cteId));
+        if (!consumeInlineCosts.containsKey(cteId)) {
+            return false;
+        }
 
         if (inlineCTERatio <= 0) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -157,8 +157,11 @@ public class CTEUtils {
                                               boolean collectCosts) {
         GroupExpression expression = root.getFirstLogicalExpression();
 
-        if (OperatorType.LOGICAL_CTE_CONSUME.equals(expression.getOp().getOpType()) &&
-                ((LogicalCTEConsumeOperator) expression.getOp()).getCteId() == cteId) {
+        if (OperatorType.LOGICAL_CTE_CONSUME.equals(expression.getOp().getOpType())) {
+            if (((LogicalCTEConsumeOperator) expression.getOp()).getCteId() != cteId) {
+                // not ask children
+                return;
+            }
             // consumer
             LogicalCTEConsumeOperator consume = (LogicalCTEConsumeOperator) expression.getOp();
             context.getCteContext().addCTEConsume(consume.getCteId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -2,15 +2,19 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -104,6 +108,10 @@ public class CTEUtils {
     private static void collectCteProduce(Group root, OptimizerContext context, boolean collectCosts) {
         GroupExpression expression = root.getFirstLogicalExpression();
 
+        for (Group group : expression.getInputs()) {
+            collectCteProduce(group, context, collectCosts);
+        }
+
         if (OperatorType.LOGICAL_CTE_PRODUCE.equals(expression.getOp().getOpType())) {
             // produce
             LogicalCTEProduceOperator produce = (LogicalCTEProduceOperator) expression.getOp();
@@ -118,16 +126,39 @@ public class CTEUtils {
                 context.getCteContext().addCTEProduceCost(produce.getCteId(), statistics.getComputeSize());
             }
         }
-
-        for (Group group : expression.getInputs()) {
-            collectCteProduce(group, context, collectCosts);
-        }
     }
 
     private static void collectCteConsume(Group root, OptimizerContext context, boolean collectCosts) {
+        for (Integer cteId : context.getCteContext().getAllCTEProduce().keySet()) {
+            Group anchor = findCteAnchor(root, cteId);
+            Preconditions.checkNotNull(anchor);
+            collectCteConsumeImpl(anchor, cteId, context, collectCosts);
+        }
+    }
+
+    private static Group findCteAnchor(Group root, Integer cteId) {
+        LinkedList<Group> queue = Lists.newLinkedList();
+        queue.addLast(root);
+
+        while (!queue.isEmpty()) {
+            Group group = queue.pollFirst();
+            GroupExpression expression = group.getFirstLogicalExpression();
+            if (OperatorType.LOGICAL_CTE_ANCHOR.equals(expression.getOp().getOpType()) &&
+                    ((LogicalCTEAnchorOperator) expression.getOp()).getCteId() == cteId) {
+                return group.getFirstLogicalExpression().inputAt(1);
+            }
+
+            expression.getInputs().forEach(queue::addLast);
+        }
+        return null;
+    }
+
+    private static void collectCteConsumeImpl(Group root, Integer cteId, OptimizerContext context,
+                                              boolean collectCosts) {
         GroupExpression expression = root.getFirstLogicalExpression();
 
-        if (OperatorType.LOGICAL_CTE_CONSUME.equals(expression.getOp().getOpType())) {
+        if (OperatorType.LOGICAL_CTE_CONSUME.equals(expression.getOp().getOpType()) &&
+                ((LogicalCTEConsumeOperator) expression.getOp()).getCteId() == cteId) {
             // consumer
             LogicalCTEConsumeOperator consume = (LogicalCTEConsumeOperator) expression.getOp();
             context.getCteContext().addCTEConsume(consume.getCteId());
@@ -149,7 +180,7 @@ public class CTEUtils {
         }
 
         for (Group group : expression.getInputs()) {
-            collectCteConsume(group, context, collectCosts);
+            collectCteConsumeImpl(group, cteId, context, collectCosts);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -12,12 +12,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CTETransformerContext {
     private final Map<Integer, ExpressionMapping> cteExpressions;
 
-    private final Map<Integer, Integer> cteRefId;
+    // cteMould -> current cte ref
+    private final Map<Integer, Integer> cteRefIdMapping;
     private final AtomicInteger uniqueId;
 
     public CTETransformerContext() {
         this.cteExpressions = new HashMap<>();
-        this.cteRefId = new HashMap<>();
+        this.cteRefIdMapping = new HashMap<>();
         this.uniqueId = new AtomicInteger();
     }
 
@@ -26,7 +27,7 @@ public class CTETransformerContext {
         // and the internal cte with the same name will overwrite the original mapping
         this.cteExpressions = Maps.newHashMap(other.cteExpressions);
         // must use one instance
-        this.cteRefId = other.cteRefId;
+        this.cteRefIdMapping = other.cteRefIdMapping;
         this.uniqueId = other.uniqueId;
     }
 
@@ -70,12 +71,13 @@ public class CTETransformerContext {
      *  CTEAnchor2 and CTEAnchor2-1 is from same CTE (with x2), but has different cteID
      *  So, modify the cteID everytime on one CTE instance.
      */
-    public void registerCteRef(int cteId) {
-        cteRefId.put(cteId, uniqueId.incrementAndGet());
+    public int registerCteRef(int cteMouldId) {
+        cteRefIdMapping.put(cteMouldId, uniqueId.incrementAndGet());
+        return cteRefIdMapping.get(cteMouldId);
     }
 
-    public int getCteRefId(int cteId) {
-        Preconditions.checkState(cteRefId.containsKey(cteId));
-        return cteRefId.get(cteId);
+    public int getCurrentCteRefId(int cteMouldId) {
+        Preconditions.checkState(cteRefIdMapping.containsKey(cteMouldId));
+        return cteRefIdMapping.get(cteMouldId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -36,7 +36,7 @@ public class CTETransformerContext {
     }
 
     /*
-     * Regenerate cteID, we do inline CTE in transform phase, needs
+     * Regenerate cteId, we do inline CTE in transform phase, needs
      * to be promised that the cteId generated each time is different
      *
      * e.g.
@@ -68,8 +68,8 @@ public class CTETransformerContext {
      *               /             \               /             \
      *          Scan(t0)        Scan(t0)      Scan(t0)           Scan(t0)
      *
-     *  CTEAnchor2 and CTEAnchor2-1 is from same CTE (with x2), but has different cteID
-     *  So, modify the cteID everytime on one CTE instance.
+     *  CTEAnchor2 and CTEAnchor2-1 are from same CTE (with x2), but have different cteID
+     *  So, generate the cteID everytime on one CTE instance.
      */
     public int registerCteRef(int cteMouldId) {
         cteRefIdMapping.put(cteMouldId, uniqueId.incrementAndGet());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -76,7 +76,7 @@ public class CTETransformerContext {
         return cteRefIdMapping.get(cteMouldId);
     }
 
-    public int getCurrentCteRefId(int cteMouldId) {
+    public int getCurrentCteRef(int cteMouldId) {
         Preconditions.checkState(cteRefIdMapping.containsKey(cteMouldId));
         return cteRefIdMapping.get(cteMouldId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -1,0 +1,81 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer.transformer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CTETransformerContext {
+    private final Map<Integer, ExpressionMapping> cteExpressions;
+
+    private final Map<Integer, Integer> cteRefId;
+    private final AtomicInteger uniqueId;
+
+    public CTETransformerContext() {
+        this.cteExpressions = new HashMap<>();
+        this.cteRefId = new HashMap<>();
+        this.uniqueId = new AtomicInteger();
+    }
+
+    public CTETransformerContext(CTETransformerContext other) {
+        // This must be a copy of the context, because the new Relation may contain cte with the same name,
+        // and the internal cte with the same name will overwrite the original mapping
+        this.cteExpressions = Maps.newHashMap(other.cteExpressions);
+        // must use one instance
+        this.cteRefId = other.cteRefId;
+        this.uniqueId = other.uniqueId;
+    }
+
+    public Map<Integer, ExpressionMapping> getCteExpressions() {
+        return cteExpressions;
+    }
+
+    /*
+     * Regenerate cteID, we do inline CTE in transform phase, needs
+     * to be promised that the cteId generated each time is different
+     *
+     * e.g.
+     *   with x1 (
+     *       with x2 (select * from t0) select * from x2
+     *   )
+     *   select * from x1;
+     *
+     * Transform result without inline cte:
+     *
+     *                             CTEAnchor1
+     *                          /             \
+     *                    CTEProduce1         CTEConsume1
+     *                       /
+     *                CTEAnchor2
+     *                 /       \
+     *         CTEProduce2    CTEConsume2
+     *               /
+     *          Scan(t0)
+     *
+     * But we do inline cte in transform phase now, the result will be:
+     *                             CTEAnchor1
+     *                          /             \
+     *                    CTEProduce1         CTEConsume1
+     *                       /                        \
+     *                CTEAnchor2                    CTEAnchor2-1
+     *                 /       \                     /       \
+     *         CTEProduce2    CTEConsume2    CTEProduce2-1    CTEConsume2-1
+     *               /             \               /             \
+     *          Scan(t0)        Scan(t0)      Scan(t0)           Scan(t0)
+     *
+     *  CTEAnchor2 and CTEAnchor2-1 is from same CTE (with x2), but has different cteID
+     *  So, modify the cteID everytime on one CTE instance.
+     */
+    public void registerCteRef(int cteId) {
+        cteRefId.put(cteId, uniqueId.incrementAndGet());
+    }
+
+    public int getCteRefId(int cteId) {
+        Preconditions.checkState(cteRefId.containsKey(cteId));
+        return cteRefId.get(cteId);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -48,10 +48,10 @@ class QueryTransformer {
     private final ColumnRefFactory columnRefFactory;
     private final ConnectContext session;
     private final List<ColumnRefOperator> correlation = new ArrayList<>();
-    private final Map<Integer, ExpressionMapping> cteContext;
+    private final CTETransformerContext cteContext;
 
     public QueryTransformer(ColumnRefFactory columnRefFactory, ConnectContext session,
-                            Map<Integer, ExpressionMapping> cteContext) {
+                            CTETransformerContext cteContext) {
         this.columnRefFactory = columnRefFactory;
         this.session = session;
         this.cteContext = cteContext;
@@ -109,12 +109,12 @@ class QueryTransformer {
         return outputs;
     }
 
-    private OptExprBuilder planFrom(Relation node, Map<Integer, ExpressionMapping> cteContext) {
+    private OptExprBuilder planFrom(Relation node, CTETransformerContext cteContext) {
         // This must be a copy of the context, because the new Relation may contain cte with the same name,
         // and the internal cte with the same name will overwrite the original mapping
-        Map<Integer, ExpressionMapping> newCTEContext = Maps.newHashMap(cteContext);
+        CTETransformerContext newCteContext = new CTETransformerContext(cteContext);
         return new RelationTransformer(columnRefFactory, session,
-                new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())), newCTEContext).visit(
+                new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())), newCteContext).visit(
                 node).getRootBuilder();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -479,7 +479,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitCTE(CTERelation node, ExpressionMapping context) {
-        int cteId = cteContext.getCurrentCteRefId(node.getCteMouldId());
+        int cteId = cteContext.getCurrentCteRef(node.getCteMouldId());
         ExpressionMapping expressionMapping = cteContext.getCteExpressions().get(cteId);
         Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = new HashMap<>();
         LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -104,18 +104,18 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
     private final ConnectContext session;
 
     private final ExpressionMapping outer;
-    private final Map<Integer, ExpressionMapping> cteContext;
+    private final CTETransformerContext cteContext;
     private final List<ColumnRefOperator> correlation = new ArrayList<>();
 
     public RelationTransformer(ColumnRefFactory columnRefFactory, ConnectContext session) {
         this.columnRefFactory = columnRefFactory;
         this.session = session;
         this.outer = new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
-        this.cteContext = new HashMap<>();
+        this.cteContext = new CTETransformerContext();
     }
 
     public RelationTransformer(ColumnRefFactory columnRefFactory, ConnectContext session, ExpressionMapping outer,
-                               Map<Integer, ExpressionMapping> cteContext) {
+                               CTETransformerContext cteContext) {
         this.columnRefFactory = columnRefFactory;
         this.session = session;
         this.cteContext = cteContext;
@@ -157,8 +157,10 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         OptExprBuilder root = null;
         OptExprBuilder anchorOptBuilder = null;
         for (CTERelation cteRelation : node.getCteRelations()) {
-            LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteRelation.getCteId());
-            LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteRelation.getCteId());
+            cteContext.registerCteRef(cteRelation.getCteId());
+            int cteId = cteContext.getCteRefId(cteRelation.getCteId());
+            LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteId);
+            LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteId);
             LogicalPlan producerPlan =
                     new RelationTransformer(columnRefFactory, session,
                             new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
@@ -177,7 +179,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             }
             anchorOptBuilder = newAnchorOptBuilder;
 
-            cteContext.put(cteRelation.getCteId(), new ExpressionMapping(
+            cteContext.getCteExpressions().put(cteId, new ExpressionMapping(
                     new Scope(RelationId.of(
                             cteRelation.getCteQueryStatement().getQueryRelation()),
                             cteRelation.getRelationFields()),
@@ -478,9 +480,10 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitCTE(CTERelation node, ExpressionMapping context) {
-        LogicalPlan childPlan = visit(node.getCteQueryStatement());
-        ExpressionMapping expressionMapping = cteContext.get(node.getCteId());
+        int cteId = cteContext.getCteRefId(node.getCteId());
+        ExpressionMapping expressionMapping = cteContext.getCteExpressions().get(cteId);
         Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = new HashMap<>();
+        LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());
 
         Preconditions.checkState(childPlan.getOutputColumn().size() == expressionMapping.getFieldMappings().size());
 
@@ -494,7 +497,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             cteOutputColumnRefMap.put(childColumn, produceColumn);
         }
 
-        LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(node.getCteId(), cteOutputColumnRefMap);
+        LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(cteId, cteOutputColumnRefMap);
         OptExprBuilder consumeBuilder = new OptExprBuilder(consume, Lists.newArrayList(childPlan.getRootBuilder()),
                 new ExpressionMapping(node.getScope(), childPlan.getOutputColumn()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -157,8 +157,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         OptExprBuilder root = null;
         OptExprBuilder anchorOptBuilder = null;
         for (CTERelation cteRelation : node.getCteRelations()) {
-            cteContext.registerCteRef(cteRelation.getCteId());
-            int cteId = cteContext.getCteRefId(cteRelation.getCteId());
+            int cteId = cteContext.registerCteRef(cteRelation.getCteMouldId());
             LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteId);
             LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteId);
             LogicalPlan producerPlan =
@@ -480,7 +479,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitCTE(CTERelation node, ExpressionMapping context) {
-        int cteId = cteContext.getCteRefId(node.getCteId());
+        int cteId = cteContext.getCurrentCteRefId(node.getCteMouldId());
         ExpressionMapping expressionMapping = cteContext.getCteExpressions().get(cteId);
         Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = new HashMap<>();
         LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SubqueryTransformer {
@@ -46,7 +45,7 @@ public class SubqueryTransformer {
     }
 
     public OptExprBuilder handleSubqueries(ColumnRefFactory columnRefFactory, OptExprBuilder subOpt, Expr expression,
-                                           Map<Integer, ExpressionMapping> cteContext) {
+                                           CTETransformerContext cteContext) {
         if (subOpt.getExpressionMapping().hasExpression(expression)) {
             return subOpt;
         }
@@ -59,7 +58,7 @@ public class SubqueryTransformer {
 
     // Only support scalar-subquery in `SELECT` clause
     public OptExprBuilder handleScalarSubqueries(ColumnRefFactory columnRefFactory, OptExprBuilder subOpt,
-                                                 Expr expression, Map<Integer, ExpressionMapping> cteContext) {
+                                                 Expr expression, CTETransformerContext cteContext) {
         if (subOpt.getExpressionMapping().hasExpression(expression)) {
             return subOpt;
         }
@@ -108,11 +107,11 @@ public class SubqueryTransformer {
     private static class SubqueryContext {
         public OptExprBuilder builder;
         public boolean useSemiAnti;
-        public Map<Integer, ExpressionMapping> cteContext;
+        public CTETransformerContext cteContext;
         public List<Expr> outerExprs;
 
         public SubqueryContext(OptExprBuilder builder, boolean useSemiAnti,
-                               Map<Integer, ExpressionMapping> cteContext) {
+                               CTETransformerContext cteContext) {
             this.builder = builder;
             this.useSemiAnti = useSemiAnti;
             this.cteContext = cteContext;
@@ -120,7 +119,7 @@ public class SubqueryTransformer {
         }
 
         public SubqueryContext(OptExprBuilder builder, boolean useSemiAnti,
-                               Map<Integer, ExpressionMapping> cteContext, List<Expr> outerExprs) {
+                               CTETransformerContext cteContext, List<Expr> outerExprs) {
             this.builder = builder;
             this.useSemiAnti = useSemiAnti;
             this.cteContext = cteContext;
@@ -138,7 +137,7 @@ public class SubqueryTransformer {
         }
 
         private LogicalPlan getLogicalPlan(QueryRelation relation, ConnectContext session, ExpressionMapping outer,
-                                           Map<Integer, ExpressionMapping> cteContext) {
+                                           CTETransformerContext cteContext) {
             if (!(relation instanceof SelectRelation)) {
                 throw new SemanticException("Currently only subquery of the Select type are supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1780,6 +1780,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
 
         QueryRelation queryRelation = (QueryRelation) visit(context.queryBody());
+        // Regenerate cteID when generating plan
         return new CTERelation(
                 RelationId.of(queryRelation).hashCode(),
                 ((Identifier) visit(context.name)).getValue(),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -7,6 +7,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.EmptyStatisticStorage;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -415,5 +416,154 @@ public class CTEPlanTest extends PlanTestBase {
         assertContains(thrift, "TMultiCastDataStreamSink");
         assertContains(thrift, "dest_dop:0, output_columns:[1]");
         assertContains(thrift, "dest_dop:0, output_columns:[2]");
+    }
+
+    @Test
+    public void testMultiNestCTE() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000);
+        String sql = "WITH x1 as (" +
+                "   WITH x2 as (SELECT * FROM t0)" +
+                "   SELECT * from x2 " +
+                "   UNION ALL " +
+                "   SELECT * from x2 " +
+                ") \n" +
+                "SELECT * from x1 " +
+                "UNION ALL " +
+                "SELECT * from x1 ";
+        defaultCTEReuse();
+        String plan = getFragmentPlan(sql);
+        Assert.assertEquals(4, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(0, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+
+        alwaysCTEReuse();
+        plan = getFragmentPlan(sql);
+        Assert.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(2, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+    }
+
+    @Test
+    public void testMultiNestCTE2() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000);
+        String sql = "WITH x1 as (" +
+                "   WITH x2 as (" +
+                "       WITH x3 as (SELECT * FROM t0)" +
+                "       SELECT * FROM x3 " +
+                "       UNION ALL " +
+                "       SELECT * FROM x3 " +
+                "   )" +
+                "   SELECT * from x2 " +
+                "   UNION ALL " +
+                "   SELECT * from x2 " +
+                ") \n" +
+                "SELECT * from x1 " +
+                "UNION ALL " +
+                "SELECT * from x1 ";
+        defaultCTEReuse();
+        String plan = getFragmentPlan(sql);
+        Assert.assertEquals(8, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(0, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+
+        alwaysCTEReuse();
+        plan = getFragmentPlan(sql);
+        Assert.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(3, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+    }
+
+    @Test
+    public void testMultiNestCTE3() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000000);
+        String sql = "WITH x1 as (" +
+                "   WITH x2 as (SELECT * FROM t0)" +
+                "   SELECT * from x2 " +
+                "   UNION ALL " +
+                "   SELECT * from x2 " +
+                ") \n" +
+                "SELECT * from (" +
+                "   with x3 as (" +
+                "       SELECT * from x1 " +
+                "       UNION ALL " +
+                "       SELECT * from x1 " +
+                "   )" +
+                "   select * from x3" +
+                "   union all " +
+                "   select * from x3" +
+                ") x4 ";
+        String plan = getFragmentPlan(sql);
+        defaultCTEReuse();
+        System.out.println(plan);
+        Assert.assertEquals(8, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(0, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+
+        alwaysCTEReuse();
+        plan = getFragmentPlan(sql);
+        Assert.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(3, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+    }
+
+    @Test
+    public void testMultiNestCTE4() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(Double.MAX_VALUE);
+        String sql = "WITH x1 as (" +
+                "   WITH x2 as (SELECT * FROM t0)" +
+                "   SELECT * from x2 " +
+                "   UNION ALL " +
+                "   SELECT * from x2 " +
+                ") \n" +
+                "SELECT * from (" +
+                "   with x3 as (" +
+                "       SELECT * from x1 " +
+                "       UNION ALL " +
+                "       SELECT * from x1 " +
+                "   )" +
+                "   select * from x3" +
+                "   union all " +
+                "   select * from x3" +
+                ") x4 join (" +
+                "   with x5 as (" +
+                "       SELECT * from x1 " +
+                "       UNION ALL " +
+                "       SELECT * from x1 " +
+                "   )" +
+                "   select * from x5" +
+                "   union all " +
+                "   select * from x5" +
+                ") x7";
+        String plan = getFragmentPlan(sql);
+        defaultCTEReuse();
+        Assert.assertEquals(16, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(0, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+
+        alwaysCTEReuse();
+        plan = getFragmentPlan(sql);
+        Assert.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        Assert.assertEquals(4, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+    }
+
+    @Test
+    public void testMultiRefCTE() throws Exception {
+        String sql = "WITH x1 as (" +
+                " select * from t0" +
+                "), " +
+                " x2 as (" +
+                " select * from x1" +
+                " union all" +
+                " select * from x1" +
+                ")" +
+                "SELECT * from x1 " +
+                "UNION ALL " +
+                "SELECT * from x2 ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  MultiCastDataSinks\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 02\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 06\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 09\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  0:OlapScanNode");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -246,9 +246,6 @@ public class ReplayFromDumpTest {
     public void testTPCDS23_1() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/tpcds23_1"), null, TExplainLevel.NORMAL);
-        System.out.println(replayPair.first.getOriginStmt());
-
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains(" MultiCastDataSinks\n" +
                 "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 51\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -246,6 +246,9 @@ public class ReplayFromDumpTest {
     public void testTPCDS23_1() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/tpcds23_1"), null, TExplainLevel.NORMAL);
+        System.out.println(replayPair.first.getOriginStmt());
+
+        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains(" MultiCastDataSinks\n" +
                 "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 51\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9347

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

e.g.
```
  with x1 (
      with x2 (select * from t0) select * from x2
  )
  select * from x1;
```
Transform result without inline cte:
```
                            CTEAnchor1
                         /             \
                   CTEProduce1         CTEConsume1
                      /
               CTEAnchor2
                /       \
        CTEProduce2    CTEConsume2
              /
         Scan(t0)
```
But we do inline cte in transform phase now, the expect result is:
```
                            CTEAnchor1
                         /             \
                   CTEProduce1         CTEConsume1
                      /                        \
               CTEAnchor2                    CTEAnchor2-1
                /       \                     /       \
        CTEProduce2    CTEConsume2    CTEProduce2-1    CTEConsume2-1
              /             \               /             \
         Scan(t0)        Scan(t0)      Scan(t0)           Scan(t0)

```
 CTEAnchor2 and CTEAnchor2-1 is from same CTE (with x2), but has different cteID.

But now result is:
```
                            CTEAnchor1
                         /             \
                   CTEProduce1         CTEConsume1
                      /                        \
               CTEAnchor2                    CTEAnchor2
                /       \                     /       \
        CTEProduce2    CTEConsume2    CTEProduce2   CTEConsume2
              /             \               /             \
         Scan(t0)        Scan(t0)      Scan(t0)           Scan(t0)
```

It's will cause find CTEAnchor/Produce error

so we need generate a new cteID when inline child plan

