### PR TITLE
[BugFix] Fix not enough hosts error when BE is decommissioned

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -843,7 +843,7 @@ public class RestoreJob extends AbstractJob {
                 List<Long> beIds =
                         GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(restoreReplicationNum, true,
                                 true);
-                if (beIds == null) {
+                if (beIds.isEmpty()) {
                     status = new Status(ErrCode.COMMON_ERROR,
                             "failed to get enough backends for creating replica of tablet "
                                     + newTabletId + ". need: " + restoreReplicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -78,6 +78,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTaskType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -843,7 +844,7 @@ public class RestoreJob extends AbstractJob {
                 List<Long> beIds =
                         GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(restoreReplicationNum, true,
                                 true);
-                if (beIds.isEmpty()) {
+                if (CollectionUtils.isEmpty(beIds)) {
                     status = new Status(ErrCode.COMMON_ERROR,
                             "failed to get enough backends for creating replica of tablet "
                                     + newTabletId + ". need: " + restoreReplicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -65,6 +65,7 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -547,7 +548,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                     List<Long> beIds = GlobalStateMgr.getCurrentSystemInfo()
                             .seqChooseBackendIds(partitionInfo.getReplicationNum(entry.getKey()),
                                     true, true);
-                    if (beIds.isEmpty()) {
+                    if (CollectionUtils.isEmpty(beIds)) {
                         return new Status(ErrCode.COMMON_ERROR, "failed to find "
                                 + partitionInfo.getReplicationNum(entry.getKey())
                                 + " different hosts to create table: " + name);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -547,7 +547,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                     List<Long> beIds = GlobalStateMgr.getCurrentSystemInfo()
                             .seqChooseBackendIds(partitionInfo.getReplicationNum(entry.getKey()),
                                     true, true);
-                    if (beIds == null) {
+                    if (beIds.isEmpty()) {
                         return new Status(ErrCode.COMMON_ERROR, "failed to find "
                                 + partitionInfo.getReplicationNum(entry.getKey())
                                 + " different hosts to create table: " + name);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -34,6 +34,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -77,7 +78,7 @@ public class LoadAction extends RestBaseAction {
 
         // Choose a backend sequentially.
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-        if (backendIds.isEmpty()) {
+        if (CollectionUtils.isEmpty(backendIds)) {
             throw new DdlException("No backend alive.");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -77,7 +77,7 @@ public class LoadAction extends RestBaseAction {
 
         // Choose a backend sequentially.
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-        if (backendIds == null) {
+        if (backendIds.isEmpty()) {
             throw new DdlException("No backend alive.");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -138,7 +138,7 @@ public class TransactionLoadAction extends RestBaseAction {
             // 2.1 save label->be map when begin transaction, so that subsequent operator can send to same BE
             if (op.equalsIgnoreCase(TXN_BEGIN)) {
                 List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-                if (backendIds == null) {
+                if (backendIds.isEmpty()) {
                     throw new DdlException("No backend alive.");
                 }
                 backendID = backendIds.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -34,6 +34,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.transaction.TransactionStatus;
 import io.netty.handler.codec.http.HttpMethod;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -138,7 +139,7 @@ public class TransactionLoadAction extends RestBaseAction {
             // 2.1 save label->be map when begin transaction, so that subsequent operator can send to same BE
             if (op.equalsIgnoreCase(TXN_BEGIN)) {
                 List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-                if (backendIds.isEmpty()) {
+                if (CollectionUtils.isEmpty(backendIds)) {
                     throw new DdlException("No backend alive.");
                 }
                 backendID = backendIds.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -9,6 +9,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -31,7 +32,7 @@ public class Utils {
             LOG.info("Ignored error {}", ex.getMessage());
         }
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-        if (backendIds == null || backendIds.isEmpty()) {
+        if (CollectionUtils.isEmpty(backendIds)) {
             return null;
         }
         return backendIds.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -197,6 +197,7 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.logging.log4j.LogManager;
@@ -2645,7 +2646,7 @@ public class LocalMetastore implements ConnectorMetadata {
             throws DdlException {
         List<Long> chosenBackendIds = systemInfoService.seqChooseBackendIdsByStorageMedium(replicationNum,
                 true, true, storageMedium);
-        if (chosenBackendIds.isEmpty()) {
+        if (CollectionUtils.isEmpty(chosenBackendIds)) {
             throw new DdlException(
                     "Failed to find enough hosts with storage medium " + storageMedium +
                             " at all backends, number of replicas needed: " +
@@ -2660,7 +2661,7 @@ public class LocalMetastore implements ConnectorMetadata {
     private List<Long> chosenBackendIdBySeq(int replicationNum) throws DdlException {
         List<Long> chosenBackendIds =
                 systemInfoService.seqChooseBackendIds(replicationNum, true, true);
-        if (chosenBackendIds.isEmpty()) {
+        if (CollectionUtils.isEmpty(chosenBackendIds)) {
             List<Long> backendIds = systemInfoService.getBackendIds(true);
             throw new DdlException("Failed to find enough host in all backends. need: " + replicationNum +
                     ", Current alive backend is [" + Joiner.on(",").join(backendIds) + "]");

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2645,7 +2645,7 @@ public class LocalMetastore implements ConnectorMetadata {
             throws DdlException {
         List<Long> chosenBackendIds = systemInfoService.seqChooseBackendIdsByStorageMedium(replicationNum,
                 true, true, storageMedium);
-        if (chosenBackendIds == null) {
+        if (chosenBackendIds.isEmpty()) {
             throw new DdlException(
                     "Failed to find enough hosts with storage medium " + storageMedium +
                             " at all backends, number of replicas needed: " +
@@ -2660,7 +2660,7 @@ public class LocalMetastore implements ConnectorMetadata {
     private List<Long> chosenBackendIdBySeq(int replicationNum) throws DdlException {
         List<Long> chosenBackendIds =
                 systemInfoService.seqChooseBackendIds(replicationNum, true, true);
-        if (chosenBackendIds == null) {
+        if (chosenBackendIds.isEmpty()) {
             List<Long> backendIds = systemInfoService.getBackendIds(true);
             throw new DdlException("Failed to find enough host in all backends. need: " + replicationNum +
                     ", Current alive backend is [" + Joiner.on(",").join(backendIds) + "]");

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -256,6 +256,10 @@ public class ComputeNode implements IComputable, Writable {
         return this.isDecommissioned.get();
     }
 
+    public void setIsDecommissioned(boolean isDecommissioned) {
+        this.isDecommissioned.set(isDecommissioned);
+    }
+
     public boolean isAvailable() {
         return this.isAlive.get() && !this.isDecommissioned.get();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -241,7 +241,7 @@ public class SystemInfoService {
         GlobalStateMgr.getCurrentState().getEditLog().logBackendStateChange(updateBackend);
 
         // Message
-        StringBuffer formatSb = new StringBuffer();
+        StringBuilder formatSb = new StringBuilder();
         String opMessage;
         formatSb.append("%s:%d's host has been modified to %s");
         if (candidateBackends.size() >= 2) {
@@ -293,7 +293,7 @@ public class SystemInfoService {
         if (null != cluster) {
             cluster.removeComputeNode(dropComputeNode.getId());
         } else {
-            LOG.error("Cluster " + dropComputeNode.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", dropComputeNode.getOwnerClusterName());
         }
         // log
         GlobalStateMgr.getCurrentState().getEditLog()
@@ -406,7 +406,7 @@ public class SystemInfoService {
 
             cluster.removeBackend(droppedBackend.getId());
         } else {
-            LOG.error("Cluster " + droppedBackend.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", droppedBackend.getOwnerClusterName());
         }
         // log
         GlobalStateMgr.getCurrentState().getEditLog().logDropBackend(droppedBackend);
@@ -696,10 +696,10 @@ public class SystemInfoService {
 
         // debug
         for (Backend backend : backends) {
-            LOG.debug("random select: {}", backend.toString());
+            LOG.debug("random select: {}", backend);
         }
 
-        return null;
+        return new ArrayList<>();
     }
 
     public ImmutableMap<Long, Backend> getIdToBackend() {
@@ -828,13 +828,11 @@ public class SystemInfoService {
         try {
             String s = Text.readString(dis);
             SystemInfoService.SerializeData data = GsonUtils.GSON.fromJson(s, SystemInfoService.SerializeData.class);
-            if (data != null) {
-                if (data.computeNodes != null) {
-                    for (ComputeNode computeNode : data.computeNodes) {
-                        replayAddComputeNode(computeNode);
-                    }
-                    computeNodeSize = data.computeNodes.size();
+            if (data != null && data.computeNodes != null) {
+                for (ComputeNode computeNode : data.computeNodes) {
+                    replayAddComputeNode(computeNode);
                 }
+                computeNodeSize = data.computeNodes.size();
             }
             checksum ^= computeNodeSize;
             LOG.info("finished replaying compute node from image");
@@ -984,7 +982,7 @@ public class SystemInfoService {
                 GlobalStateMgr.getCurrentState().getStarOSAgent().removeWorkerFromMap(workerId, workerAddr);
             }
         } else {
-            LOG.error("Cluster " + backend.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", backend.getOwnerClusterName());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -592,24 +592,24 @@ public class SystemInfoService {
         return idToBackendRef.values().asList();
     }
 
-    public List<Long> seqChooseBackendIdsByStorageMedium(int backendNum, boolean needAlive, boolean isCreate,
+    public List<Long> seqChooseBackendIdsByStorageMedium(int backendNum, boolean needAvailable, boolean isCreate,
                                                          TStorageMedium storageMedium) {
         final List<Backend> backends =
                 getBackends().stream().filter(v -> !v.diskExceedLimitByStorageMedium(storageMedium))
                         .collect(Collectors.toList());
-        return seqChooseBackendIds(backendNum, needAlive, isCreate, backends);
+        return seqChooseBackendIds(backendNum, needAvailable, isCreate, backends);
     }
 
-    public List<Long> seqChooseBackendIds(int backendNum, boolean needAlive, boolean isCreate) {
+    public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable, boolean isCreate) {
         final List<Backend> backends =
                 getBackends().stream().filter(v -> !v.diskExceedLimit()).collect(Collectors.toList());
-        return seqChooseBackendIds(backendNum, needAlive, isCreate, backends);
+        return seqChooseBackendIds(backendNum, needAvailable, isCreate, backends);
     }
 
     // choose backends by round-robin
     // return null if not enough backend
     // use synchronized to run serially
-    public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAlive, boolean isCreate,
+    public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable, boolean isCreate,
                                                        final List<Backend> srcBackends) {
         long lastBackendId;
 
@@ -622,6 +622,11 @@ public class SystemInfoService {
         // host -> BE list
         Map<String, List<Backend>> backendMaps = Maps.newHashMap();
         for (Backend backend : srcBackends) {
+            // If needAvailable is true, unavailable backend won't go into the pick list
+            if (needAvailable && !backend.isAvailable()) {
+                continue;
+            }
+
             if (backendMaps.containsKey(backend.getHost())) {
                 backendMaps.get(backend.getHost()).add(backend);
             } else {
@@ -664,12 +669,6 @@ public class SystemInfoService {
             if (index > maxIndex) {
                 failed = true;
                 break;
-            }
-
-            if (needAlive) {
-                if (!backend.isAlive() || backend.isDecommissioned()) {
-                    continue;
-                }
             }
 
             long backendId = backend.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -699,7 +699,7 @@ public class SystemInfoService {
             LOG.debug("random select: {}", backend);
         }
 
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     public ImmutableMap<Long, Backend> getIdToBackend() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -31,6 +31,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -43,6 +44,8 @@ public class CreateTableTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        Backend be = UtFrameUtils.addMockBackend(10002);
+        be.setIsDecommissioned(true);
         Config.enable_strict_storage_medium_check = true;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -280,7 +280,7 @@ public class UtFrameUtils {
         createMinStarRocksCluster(false);
     }
 
-    public static void addMockBackend(int backendId) throws Exception {
+    public static Backend addMockBackend(int backendId) throws Exception {
         // start be
         MockedBackend backend = new MockedBackend("127.0.0.1");
 
@@ -299,6 +299,8 @@ public class UtFrameUtils {
         be.setBrpcPort(backend.getBrpcPort());
         be.setHttpPort(backend.getHttpPort());
         GlobalStateMgr.getCurrentSystemInfo().addBackend(be);
+
+        return be;
     }
 
     public static void dropMockBackend(int backendId) throws DdlException {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6145 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. When multiple BEs reside on the same host, only one BE will be chosen when create table. But if some of them are decommissioned,  FE still might choose the decommissioned one, this will cause the problem described in the issue.
2. Also refine some codes based on sonar code smell.
