### PR TITLE
[Enhancement] Refine profile mechanism

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -69,8 +69,9 @@ RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
           _name(std::move(name)),
           _metadata(-1),
           _is_averaged_profile(is_averaged_profile),
+          _counter_total_time(TUnit::TIME_NS, 0),
           _local_time_percent(0) {
-    _counter_total_time = add_counter("TotalTime", TUnit::TIME_NS);
+    _counter_map["TotalTime"] = std::make_pair(&_counter_total_time, ROOT_COUNTER);
 }
 
 RuntimeProfile::~RuntimeProfile() {

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -69,9 +69,8 @@ RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
           _name(std::move(name)),
           _metadata(-1),
           _is_averaged_profile(is_averaged_profile),
-          _counter_total_time(TUnit::TIME_NS, 0),
           _local_time_percent(0) {
-    _counter_map["TotalTime"] = std::make_pair(&_counter_total_time, ROOT_COUNTER);
+    _counter_total_time = add_counter("TotalTime", TUnit::TIME_NS);
 }
 
 RuntimeProfile::~RuntimeProfile() {
@@ -328,15 +327,15 @@ void RuntimeProfile::add_child_unlock(RuntimeProfile* child, bool indent, ChildV
 }
 
 RuntimeProfile::Counter* RuntimeProfile::add_counter_unlock(const std::string& name, TUnit::type type,
-                                                            const std::string& parent_counter_name) {
+                                                            const std::string& parent_name) {
     if (auto iter = _counter_map.find(name); iter != _counter_map.end()) {
         return iter->second.first;
     }
 
-    DCHECK(parent_counter_name == ROOT_COUNTER || _counter_map.find(parent_counter_name) != _counter_map.end());
+    DCHECK(parent_name == ROOT_COUNTER || _counter_map.find(parent_name) != _counter_map.end());
     Counter* counter = _pool->add(new Counter(type, 0));
-    _counter_map[name] = std::make_pair(counter, parent_counter_name);
-    _child_counter_map[parent_counter_name].insert(name);
+    _counter_map[name] = std::make_pair(counter, parent_name);
+    _child_counter_map[parent_name].insert(name);
     return counter;
 }
 
@@ -424,20 +423,20 @@ void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
     }
 }
 
-#define ADD_COUNTER_IMPL(NAME, T)                                                                                    \
-    RuntimeProfile::T* RuntimeProfile::NAME(const std::string& name, TUnit::type unit,                               \
-                                            const std::string& parent_counter_name) {                                \
-        DCHECK_EQ(_is_averaged_profile, false);                                                                      \
-        std::lock_guard<std::mutex> l(_counter_lock);                                                                \
-        if (_counter_map.find(name) != _counter_map.end()) {                                                         \
-            return reinterpret_cast<T*>(_counter_map[name].first);                                                   \
-        }                                                                                                            \
-        DCHECK(parent_counter_name == ROOT_COUNTER || _counter_map.find(parent_counter_name) != _counter_map.end()); \
-        T* counter = _pool->add(new T(unit));                                                                        \
-        _counter_map[name] = std::make_pair(counter, parent_counter_name);                                           \
-        auto& child_counters = LookupOrInsert(&_child_counter_map, parent_counter_name, std::set<std::string>());    \
-        child_counters.insert(name);                                                                                 \
-        return counter;                                                                                              \
+#define ADD_COUNTER_IMPL(NAME, T)                                                                         \
+    RuntimeProfile::T* RuntimeProfile::NAME(const std::string& name, TUnit::type unit,                    \
+                                            const std::string& parent_name) {                             \
+        DCHECK_EQ(_is_averaged_profile, false);                                                           \
+        std::lock_guard<std::mutex> l(_counter_lock);                                                     \
+        if (_counter_map.find(name) != _counter_map.end()) {                                              \
+            return reinterpret_cast<T*>(_counter_map[name].first);                                        \
+        }                                                                                                 \
+        DCHECK(parent_name == ROOT_COUNTER || _counter_map.find(parent_name) != _counter_map.end());      \
+        T* counter = _pool->add(new T(unit));                                                             \
+        _counter_map[name] = std::make_pair(counter, parent_name);                                        \
+        auto& child_counters = LookupOrInsert(&_child_counter_map, parent_name, std::set<std::string>()); \
+        child_counters.insert(name);                                                                      \
+        return counter;                                                                                   \
     }
 
 //ADD_COUNTER_IMPL(AddCounter, Counter);
@@ -445,14 +444,14 @@ ADD_COUNTER_IMPL(AddHighWaterMarkCounter, HighWaterMarkCounter)
 //ADD_COUNTER_IMPL(AddConcurrentTimerCounter, ConcurrentTimerCounter);
 
 RuntimeProfile::Counter* RuntimeProfile::add_counter(const std::string& name, TUnit::type type,
-                                                     const std::string& parent_counter_name) {
+                                                     const std::string& parent_name) {
     std::lock_guard<std::mutex> l(_counter_lock);
-    return add_counter_unlock(name, type, parent_counter_name);
+    return add_counter_unlock(name, type, parent_name);
 }
 
 RuntimeProfile::DerivedCounter* RuntimeProfile::add_derived_counter(const std::string& name, TUnit::type type,
                                                                     const DerivedCounterFunction& counter_fn,
-                                                                    const std::string& parent_counter_name) {
+                                                                    const std::string& parent_name) {
     std::lock_guard<std::mutex> l(_counter_lock);
 
     if (_counter_map.find(name) != _counter_map.end()) {
@@ -460,8 +459,8 @@ RuntimeProfile::DerivedCounter* RuntimeProfile::add_derived_counter(const std::s
     }
 
     DerivedCounter* counter = _pool->add(new DerivedCounter(type, counter_fn));
-    _counter_map[name] = std::make_pair(counter, parent_counter_name);
-    auto& child_counters = LookupOrInsert(&_child_counter_map, parent_counter_name, std::set<std::string>());
+    _counter_map[name] = std::make_pair(counter, parent_name);
+    auto& child_counters = LookupOrInsert(&_child_counter_map, parent_name, std::set<std::string>());
     child_counters.insert(name);
     return counter;
 }
@@ -500,23 +499,23 @@ void RuntimeProfile::copy_all_counters_from(RuntimeProfile* src_profile) {
         auto top_pair = std::move(name_queue.front());
         name_queue.pop();
 
-        auto& counter_name = top_pair.first;
-        auto& parent_counter_name = top_pair.second;
+        auto& name = top_pair.first;
+        auto& parent_name = top_pair.second;
 
-        if (counter_name != ROOT_COUNTER) {
-            auto* src_counter = src_profile->_counter_map[counter_name].first;
+        if (name != ROOT_COUNTER) {
+            auto* src_counter = src_profile->_counter_map[name].first;
             DCHECK(src_counter != nullptr);
-            auto* new_counter = add_counter_unlock(counter_name, src_counter->type(), parent_counter_name);
+            auto* new_counter = add_counter_unlock(name, src_counter->type(), parent_name);
             new_counter->set(src_counter->value());
         }
 
-        auto names_it = src_profile->_child_counter_map.find(counter_name);
+        auto names_it = src_profile->_child_counter_map.find(name);
         if (names_it == src_profile->_child_counter_map.end()) {
             continue;
         }
 
-        for (auto& child_counter_name : names_it->second) {
-            name_queue.push(std::make_pair(child_counter_name, counter_name));
+        for (auto& child_name : names_it->second) {
+            name_queue.push(std::make_pair(child_name, name));
         }
     }
 }
@@ -529,8 +528,8 @@ void RuntimeProfile::remove_counter(const std::string& name) {
 
     // Remove from its parent sub sets
     auto pair = _counter_map[name];
-    auto& parent_counter_name = pair.second;
-    if (auto names_it = _child_counter_map.find(parent_counter_name); names_it != _child_counter_map.end()) {
+    auto& parent_name = pair.second;
+    if (auto names_it = _child_counter_map.find(parent_name); names_it != _child_counter_map.end()) {
         auto& child_names = names_it->second;
         child_names.erase(child_names.find(name));
     }
@@ -539,30 +538,31 @@ void RuntimeProfile::remove_counter(const std::string& name) {
     std::queue<std::string> name_queue;
     name_queue.push(name);
     while (!name_queue.empty()) {
-        std::string counter_name = std::move(name_queue.front());
+        std::string top_name = std::move(name_queue.front());
         name_queue.pop();
-        auto names_it = _child_counter_map.find(counter_name);
-        if (names_it == _child_counter_map.end()) {
-            continue;
+        auto names_it = _child_counter_map.find(top_name);
+        if (names_it != _child_counter_map.end()) {
+            for (auto& child_name : names_it->second) {
+                name_queue.push(child_name);
+            }
         }
-        for (auto& child_name : names_it->second) {
-            name_queue.push(child_name);
+        _counter_map.erase(_counter_map.find(top_name));
+        if (names_it != _child_counter_map.end()) {
+            _child_counter_map.erase(names_it);
         }
-        _counter_map.erase(_counter_map.find(counter_name));
-        _child_counter_map.erase(names_it);
     }
 }
 
-void RuntimeProfile::remove_counters(const std::set<std::string>& saved_counter_names) {
+void RuntimeProfile::remove_counters(const std::set<std::string>& saved_names) {
     std::lock_guard<std::mutex> l(_counter_lock);
 
     // Find all parent counter names
-    std::set<std::string> all_saved_counter_names;
-    all_saved_counter_names.insert(ROOT_COUNTER);
-    for (auto& saved_counter_name : saved_counter_names) {
-        std::string iterator_name = saved_counter_name;
+    std::set<std::string> all_saved_names;
+    all_saved_names.insert(ROOT_COUNTER);
+    for (auto& saved_name : saved_names) {
+        std::string iterator_name = saved_name;
         while (iterator_name != ROOT_COUNTER) {
-            all_saved_counter_names.insert(iterator_name);
+            all_saved_names.insert(iterator_name);
             if (auto it = _counter_map.find(iterator_name); it != _counter_map.end()) {
                 iterator_name = _counter_map[iterator_name].second;
             } else {
@@ -574,16 +574,16 @@ void RuntimeProfile::remove_counters(const std::set<std::string>& saved_counter_
     // Remove from _child_counter_map
     auto names_it = _child_counter_map.begin();
     while (names_it != _child_counter_map.end()) {
-        auto& child_counter_names = names_it->second;
-        std::vector<std::string> copy(child_counter_names.begin(), child_counter_names.end());
+        auto& child_names = names_it->second;
+        std::vector<std::string> copy(child_names.begin(), child_names.end());
         copy.erase(std::remove_if(copy.begin(), copy.end(),
                                   [&](const std::string& name) {
-                                      return all_saved_counter_names.find(name) == all_saved_counter_names.end();
+                                      return all_saved_names.find(name) == all_saved_names.end();
                                   }),
                    copy.end());
-        child_counter_names.clear();
-        child_counter_names.insert(copy.begin(), copy.end());
-        if (names_it->first != ROOT_COUNTER && child_counter_names.empty()) {
+        child_names.clear();
+        child_names.insert(copy.begin(), copy.end());
+        if (names_it->first != ROOT_COUNTER && child_names.empty()) {
             names_it = _child_counter_map.erase(names_it);
         } else {
             names_it++;
@@ -595,7 +595,7 @@ void RuntimeProfile::remove_counters(const std::set<std::string>& saved_counter_
         auto it = _counter_map.begin();
         while (it != _counter_map.end()) {
             const auto name = it->first;
-            if (all_saved_counter_names.find(name) == all_saved_counter_names.end()) {
+            if (all_saved_names.find(name) == all_saved_names.end()) {
                 it = _counter_map.erase(it);
             } else {
                 it++;
@@ -809,7 +809,7 @@ RuntimeProfile::Counter* RuntimeProfile::add_sampling_counter(const std::string&
     return dst_counter;
 }
 
-void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::string& parent_counter_name,
+void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::string& parent_name,
                                             Counter* src_counter, int num_buckets, std::vector<Counter*>* buckets) {
     {
         std::lock_guard<std::mutex> l(_counter_lock);
@@ -819,7 +819,7 @@ void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::
     for (int i = 0; i < num_buckets; ++i) {
         std::stringstream counter_name;
         counter_name << name << "=" << i;
-        buckets->push_back(add_counter(counter_name.str(), TUnit::DOUBLE_VALUE, parent_counter_name));
+        buckets->push_back(add_counter(counter_name.str(), TUnit::DOUBLE_VALUE, parent_name));
     }
 
     std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -361,7 +361,7 @@ public:
     void copy_all_info_strings_from(RuntimeProfile* src_profile);
 
     // Returns the counter for the total elapsed time.
-    Counter* total_time_counter() { return _counter_total_time; }
+    Counter* total_time_counter() { return &_counter_total_time; }
 
     // Prints the counters in a name: value format.
     // Does not hold locks when it makes any function calls.
@@ -530,7 +530,7 @@ private:
     EventSequenceMap _event_sequence_map;
     mutable std::mutex _event_sequences_lock;
 
-    Counter* _counter_total_time;
+    Counter _counter_total_time;
     // Time spent in just in this profile (i.e. not the children) as a fraction
     // of the total time in the entire profile tree.
     double _local_time_percent;

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -305,20 +305,19 @@ public:
 
     // Add a counter with 'name'/'type'.  Returns a counter object that the caller can
     // update.  The counter is owned by the RuntimeProfile object.
-    // If parent_counter_name is a non-empty string, the counter is added as a child of
-    // parent_counter_name.
+    // If parent_name is a non-empty string, the counter is added as a child of
+    // parent_name.
     // If the counter already exists, the existing counter object is returned.
-    Counter* add_counter(const std::string& name, TUnit::type type, const std::string& parent_counter_name);
+    Counter* add_counter(const std::string& name, TUnit::type type, const std::string& parent_name);
     Counter* add_counter(const std::string& name, TUnit::type type) { return add_counter(name, type, ROOT_COUNTER); }
 
     // Add a derived counter with 'name'/'type'. The counter is owned by the
     // RuntimeProfile object.
-    // If parent_counter_name is a non-empty string, the counter is added as a child of
-    // parent_counter_name.
+    // If parent_name is a non-empty string, the counter is added as a child of
+    // parent_name.
     // Returns NULL if the counter already exists.
     DerivedCounter* add_derived_counter(const std::string& name, TUnit::type type,
-                                        const DerivedCounterFunction& counter_fn,
-                                        const std::string& parent_counter_name);
+                                        const DerivedCounterFunction& counter_fn, const std::string& parent_name);
 
     // Add a set of thread counters prefixed with 'prefix'. Returns a ThreadCounters object
     // that the caller can update.  The counter is owned by the RuntimeProfile object.
@@ -338,8 +337,8 @@ public:
     // Remove the counter object with 'name', and it will remove all the child counters recursively
     void remove_counter(const std::string& name);
 
-    // Clean all the counters except saved_counter_names
-    void remove_counters(const std::set<std::string>& saved_counter_names);
+    // Clean all the counters except saved_names
+    void remove_counters(const std::set<std::string>& saved_names);
 
     // Helper to append to the "ExecOption" info string.
     void append_exec_option(const std::string& option) { add_info_string("ExecOption", option); }
@@ -362,7 +361,7 @@ public:
     void copy_all_info_strings_from(RuntimeProfile* src_profile);
 
     // Returns the counter for the total elapsed time.
-    Counter* total_time_counter() { return &_counter_total_time; }
+    Counter* total_time_counter() { return _counter_total_time; }
 
     // Prints the counters in a name: value format.
     // Does not hold locks when it makes any function calls.
@@ -433,13 +432,13 @@ public:
 
     // Add a bucket of counters to store the sampled value of src_counter.
     // The src_counter is sampled periodically and the buckets are updated.
-    void add_bucketing_counters(const std::string& name, const std::string& parent_counter_name, Counter* src_counter,
+    void add_bucketing_counters(const std::string& name, const std::string& parent_name, Counter* src_counter,
                                 int max_buckets, std::vector<Counter*>* buckets);
 
     /// Adds a high water mark counter to the runtime profile. Otherwise, same behavior
     /// as AddCounter().
     HighWaterMarkCounter* AddHighWaterMarkCounter(const std::string& name, TUnit::type unit,
-                                                  const std::string& parent_counter_name = "");
+                                                  const std::string& parent_name = "");
 
     // stops updating the value of 'rate_counter'. Rate counters are updated
     // periodically so should be removed as soon as the underlying counter is
@@ -471,7 +470,7 @@ private:
     typedef std::vector<std::pair<RuntimeProfile*, bool>> ChildVector;
 
     void add_child_unlock(RuntimeProfile* child, bool indent, ChildVector::iterator pos);
-    Counter* add_counter_unlock(const std::string& name, TUnit::type type, const std::string& parent_counter_name);
+    Counter* add_counter_unlock(const std::string& name, TUnit::type type, const std::string& parent_name);
 
     RuntimeProfile* _parent;
 
@@ -531,7 +530,7 @@ private:
     EventSequenceMap _event_sequence_map;
     mutable std::mutex _event_sequences_lock;
 
-    Counter _counter_total_time;
+    Counter* _counter_total_time;
     // Time spent in just in this profile (i.e. not the children) as a fraction
     // of the total time in the entire profile tree.
     double _local_time_percent;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -97,4 +97,12 @@ public class Counter {
             this.maxValue = maxValue;
         }
     }
+
+    @Override
+    public String toString() {
+        return "Counter{" +
+                "value=" + value +
+                ", type=" + type +
+                '}';
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -354,9 +354,19 @@ public class RuntimeProfile {
         if (childCounterMap.get(counterName) == null) {
             return;
         }
-        Set<String> childCounterSet = new TreeSet<>(childCounterMap.get(counterName));
+        List<String> childNames = Lists.newArrayList(childCounterMap.get(counterName));
 
-        for (String childName : childCounterSet) {
+        // Keep MIN/MAX metrics head of other child counters
+        List<String> reorderedChildNames = Lists.newArrayList();
+        for (String childName : childNames) {
+            if (childName.startsWith(MERGED_INFO_PREFIX_MIN) || childName.startsWith(MERGED_INFO_PREFIX_MAX)) {
+                reorderedChildNames.add(0, childName);
+            } else {
+                reorderedChildNames.add(childName);
+            }
+        }
+
+        for (String childName : reorderedChildNames) {
             Pair<Counter, String> pair = this.counterMap.get(childName);
             Preconditions.checkState(pair != null);
             builder.append(prefix).append("   - ").append(childName).append(": ")

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -40,6 +40,8 @@ import java.util.Comparator;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -55,6 +57,8 @@ public class RuntimeProfile {
     private static final Set<String> NON_MERGE_COUNTER_NAMES =
             Sets.newHashSet("DegreeOfParallelism", "RuntimeBloomFilterNum", "RuntimeInFilterNum", "PushdownPredicates",
                     "MemoryLimit");
+    private static final String MERGED_INFO_PREFIX_MIN = "__MIN_OF_";
+    private static final String MERGED_INFO_PREFIX_MAX = "__MAX_OF_";
 
     private final Counter counterTotalTime;
 
@@ -62,7 +66,7 @@ public class RuntimeProfile {
     private final List<String> infoStringsDisplayOrder = Lists.newArrayList();
 
     // These will be hold by other thread.
-    private final Map<String, Counter> counterMap = Maps.newConcurrentMap();
+    private final Map<String, Pair<Counter, String>> counterMap = Maps.newConcurrentMap();
     private final Map<String, RuntimeProfile> childMap = Maps.newConcurrentMap();
 
     private final Map<String, TreeSet<String>> childCounterMap = Maps.newConcurrentMap();
@@ -77,9 +81,8 @@ public class RuntimeProfile {
     }
 
     public RuntimeProfile() {
-        this.counterTotalTime = new Counter(TUnit.TIME_NS, 0);
+        this.counterTotalTime = addCounter("TotalTime", TUnit.TIME_NS);
         this.localTimePercent = 0;
-        this.counterMap.put("TotalTime", counterTotalTime);
     }
 
     public Counter getCounterTotalTime() {
@@ -87,7 +90,8 @@ public class RuntimeProfile {
     }
 
     public Map<String, Counter> getCounterMap() {
-        return counterMap;
+        return counterMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().first));
     }
 
     public List<Pair<RuntimeProfile, Boolean>> getChildList() {
@@ -107,25 +111,58 @@ public class RuntimeProfile {
         return addCounter(name, type, ROOT_COUNTER);
     }
 
-    public Counter addCounter(String name, TUnit type, String parentCounterName) {
-        Counter counter = this.counterMap.get(name);
-        if (counter != null) {
-            return counter;
+    public Counter addCounter(String name, TUnit type, String parentName) {
+        Pair<Counter, String> pair = this.counterMap.get(name);
+        if (pair != null) {
+            return pair.first;
         } else {
-            Preconditions.checkState(parentCounterName.equals(ROOT_COUNTER)
-                    || this.counterMap.containsKey(parentCounterName));
+            Preconditions.checkState(parentName.equals(ROOT_COUNTER)
+                    || this.counterMap.containsKey(parentName));
             Counter newCounter = new Counter(type, 0);
-            this.counterMap.put(name, newCounter);
+            this.counterMap.put(name, Pair.create(newCounter, parentName));
 
-            TreeSet<String> childCounters = childCounterMap.getOrDefault(parentCounterName, new TreeSet<>());
-            childCounters.add(name);
-            childCounterMap.put(parentCounterName, childCounters);
+            TreeSet<String> childNames = childCounterMap.getOrDefault(parentName, new TreeSet<>());
+            childNames.add(name);
+            childCounterMap.put(parentName, childNames);
             return newCounter;
         }
     }
 
+    public void removeCounter(String name) {
+        if (!counterMap.containsKey(name)) {
+            return;
+        }
+
+        // Remove from its parent sub sets
+        Pair<Counter, String> pair = counterMap.get(name);
+        String parentName = pair.second;
+        if (childCounterMap.containsKey(parentName)) {
+            TreeSet<String> childNames = childCounterMap.get(parentName);
+            childNames.remove(name);
+        }
+
+        // Remove child counter recursively
+        Queue<String> nameQueue = Lists.newLinkedList();
+        nameQueue.offer(name);
+        while (!nameQueue.isEmpty()) {
+            String topName = nameQueue.poll();
+            TreeSet<String> childNames = childCounterMap.get(topName);
+            if (childNames != null) {
+                for (String childName : childNames) {
+                    nameQueue.offer(childName);
+                }
+            }
+            counterMap.remove(topName);
+            childCounterMap.remove(topName);
+        }
+    }
+
     public Counter getCounter(String name) {
-        return counterMap.get(name);
+        Pair<Counter, String> pair = counterMap.get(name);
+        if (pair == null) {
+            return null;
+        }
+        return pair.first;
     }
 
     // Copy all the counters from src profile
@@ -134,14 +171,31 @@ public class RuntimeProfile {
             return;
         }
 
-        srcProfile.counterMap.forEach((name, counter) -> {
-            addCounter(name, counter.getType());
-            getCounter(name).setValue(counter.getValue());
-        });
+        Queue<Pair<String, String>> nameQueue = Lists.newLinkedList();
+        nameQueue.offer(Pair.create(ROOT_COUNTER, ROOT_COUNTER));
+        while (!nameQueue.isEmpty()) {
+            Pair<String, String> topPair = nameQueue.poll();
+
+            String name = topPair.first;
+            String parentName = topPair.second;
+
+            if (!Objects.equals(ROOT_COUNTER, name)) {
+                Counter srcCounter = srcProfile.counterMap.get(name).first;
+                Counter newCounter = addCounter(name, srcCounter.getType(), parentName);
+                newCounter.setValue(srcCounter.getValue());
+            }
+
+            TreeSet<String> childNames = srcProfile.childCounterMap.get(name);
+            if (childNames != null) {
+                for (String childName : childNames) {
+                    nameQueue.offer(Pair.create(childName, name));
+                }
+            }
+        }
     }
 
     public void update(final TRuntimeProfileTree thriftProfile) {
-        Reference<Integer> idx = new Reference<Integer>(0);
+        Reference<Integer> idx = new Reference<>(0);
         update(thriftProfile.nodes, idx);
         Preconditions.checkState(idx.getRef().equals(thriftProfile.nodes.size()));
     }
@@ -152,27 +206,67 @@ public class RuntimeProfile {
 
         // update this level's counters
         if (node.counters != null) {
-            for (TCounter tcounter : node.counters) {
-                Counter counter = counterMap.get(tcounter.name);
-                if (counter == null) {
-                    counterMap.put(tcounter.name, new Counter(tcounter.type, tcounter.value));
-                } else {
-                    if (counter.getType() != tcounter.type) {
-                        LOG.error("Cannot update counters with the same name but different types"
-                                + " type=" + tcounter.type);
-                    } else {
-                        counter.setValue(tcounter.value);
-                    }
-                }
-            }
-
+            // mapping from counterName to parentCounterName
+            Map<String, String> child2ParentMap = Maps.newHashMap();
             if (node.child_counters_map != null) {
                 // update childCounters
                 for (Map.Entry<String, Set<String>> entry : node.child_counters_map.entrySet()) {
-                    String parentCounterName = entry.getKey();
-                    TreeSet<String> childCounters = childCounterMap.getOrDefault(parentCounterName, new TreeSet<>());
-                    childCounters.addAll(entry.getValue());
-                    childCounterMap.put(parentCounterName, childCounters);
+                    String parentName = entry.getKey();
+                    for (String childName : entry.getValue()) {
+                        child2ParentMap.put(childName, parentName);
+                    }
+                }
+            }
+            // First processing counters by hierarchy
+            Map<String, TCounter> tCounterMap = node.counters.stream()
+                    .collect(Collectors.toMap(TCounter::getName, t -> t));
+            Queue<String> nameQueue = Lists.newLinkedList();
+            nameQueue.offer(ROOT_COUNTER);
+            while (!nameQueue.isEmpty()) {
+                String topName = nameQueue.poll();
+
+                if (!Objects.equals(ROOT_COUNTER, topName)) {
+                    Pair<Counter, String> pair = counterMap.get(topName);
+                    TCounter tcounter = tCounterMap.get(topName);
+                    String parentName = child2ParentMap.get(topName);
+                    if (pair == null && tcounter != null && parentName != null) {
+                        Counter counter =
+                                addCounter(topName, tcounter.type, parentName);
+                        counter.setValue(tcounter.value);
+                        tCounterMap.remove(topName);
+                    } else if (pair != null && tcounter != null) {
+                        if (pair.first.getType() != tcounter.type) {
+                            LOG.error("Cannot update counters with the same name but different types"
+                                    + " type=" + tcounter.type);
+                        } else {
+                            pair.first.setValue(tcounter.value);
+                        }
+                        tCounterMap.remove(topName);
+                    }
+                }
+
+                if (node.child_counters_map != null) {
+                    Set<String> childNames = node.child_counters_map.get(topName);
+                    if (childNames != null) {
+                        for (String childName : childNames) {
+                            nameQueue.offer(childName);
+                        }
+                    }
+                }
+            }
+            // Second, processing the remaining counters, set ROOT_COUNTER as it's parent
+            for (TCounter tcounter : tCounterMap.values()) {
+                Pair<Counter, String> pair = counterMap.get(tcounter.name);
+                if (pair == null) {
+                    Counter counter = addCounter(tcounter.name, tcounter.type);
+                    counter.setValue(tcounter.value);
+                } else {
+                    if (pair.first.getType() != tcounter.type) {
+                        LOG.error("Cannot update counters with the same name but different types"
+                                + " type=" + tcounter.type);
+                    } else {
+                        pair.first.setValue(tcounter.value);
+                    }
                 }
             }
         }
@@ -199,10 +293,8 @@ public class RuntimeProfile {
             String childName = tchild.name;
             RuntimeProfile childProfile = this.childMap.get(childName);
             if (childProfile == null) {
-                childMap.put(childName, new RuntimeProfile(childName));
-                childProfile = this.childMap.get(childName);
-                Pair<RuntimeProfile, Boolean> pair = Pair.create(childProfile, tchild.indent);
-                this.childList.add(pair);
+                childProfile = new RuntimeProfile(childName);
+                addChild(childProfile);
             }
             childProfile.update(nodes, idx);
         }
@@ -214,18 +306,18 @@ public class RuntimeProfile {
     //  3. Counters
     //  4. Children
     public void prettyPrint(StringBuilder builder, String prefix) {
-        Counter counter = this.counterMap.get("TotalTime");
-        Preconditions.checkState(counter != null);
+        Pair<Counter, String> pair = this.counterMap.get("TotalTime");
+        Preconditions.checkState(pair != null);
         // 1. profile name
         builder.append(prefix).append(name).append(":");
         // total time
-        if (counter.getValue() != 0) {
+        if (pair.first.getValue() != 0) {
             try (Formatter fmt = new Formatter()) {
                 builder.append("(Active: ")
-                        .append(this.printCounter(counter.getValue(), counter.getType()));
-                if (DebugUtil.THOUSAND < counter.getValue()) {
+                        .append(this.printCounter(pair.first.getValue(), pair.first.getType()));
+                if (DebugUtil.THOUSAND < pair.first.getValue()) {
                     // TotalTime in nanosecond concated if it's larger than 1000ns
-                    builder.append("[").append(counter.getValue()).append("ns]");
+                    builder.append("[").append(pair.first.getValue()).append("ns]");
                 }
                 builder.append(", % non-child: ").append(fmt.format("%.2f", localTimePercent))
                         .append("%)");
@@ -244,9 +336,9 @@ public class RuntimeProfile {
 
         // 4. children
         for (int i = 0; i < childList.size(); i++) {
-            Pair<RuntimeProfile, Boolean> pair = childList.get(i);
-            boolean indent = pair.second;
-            RuntimeProfile profile = pair.first;
+            Pair<RuntimeProfile, Boolean> childPair = childList.get(i);
+            boolean indent = childPair.second;
+            RuntimeProfile profile = childPair.first;
             profile.prettyPrint(builder, prefix + (indent ? "  " : ""));
         }
     }
@@ -263,12 +355,12 @@ public class RuntimeProfile {
         }
         Set<String> childCounterSet = new TreeSet<>(childCounterMap.get(counterName));
 
-        for (String childCounterName : childCounterSet) {
-            Counter counter = this.counterMap.get(childCounterName);
-            Preconditions.checkState(counter != null);
-            builder.append(prefix).append("   - ").append(childCounterName).append(": ")
-                    .append(printCounter(counter.getValue(), counter.getType())).append("\n");
-            this.printChildCounters(prefix + "  ", childCounterName, builder);
+        for (String childName : childCounterSet) {
+            Pair<Counter, String> pair = this.counterMap.get(childName);
+            Preconditions.checkState(pair != null);
+            builder.append(prefix).append("   - ").append(childName).append(": ")
+                    .append(printCounter(pair.first.getValue(), pair.first.getType())).append("\n");
+            this.printChildCounters(prefix + "  ", childName, builder);
         }
     }
 
@@ -436,40 +528,39 @@ public class RuntimeProfile {
         }
 
         RuntimeProfile profile0 = profiles.get(0);
-        final String mergedInfoPrefixMin = "__MIN_OF_";
-        final String mergedInfoPrefixMax = "__MAX_OF_";
 
         // merge counters
-        Map<String, TUnit> counterTypes = Maps.newTreeMap();
+        Map<String, Pair<TUnit, String>> counterTypes = Maps.newTreeMap();
         for (RuntimeProfile profile : profiles) {
-            for (Map.Entry<String, Counter> entry : profile.counterMap.entrySet()) {
+            for (Map.Entry<String, Pair<Counter, String>> entry : profile.counterMap.entrySet()) {
                 String name = entry.getKey();
-                Counter counter = entry.getValue();
+                Pair<Counter, String> pair = entry.getValue();
 
                 if (NON_MERGE_COUNTER_NAMES.contains(name)) {
                     continue;
                 }
 
                 if (!counterTypes.containsKey(name)) {
-                    counterTypes.put(name, counter.getType());
+                    counterTypes.put(name, Pair.create(pair.first.getType(), pair.second));
                     continue;
                 }
-                TUnit existType = counterTypes.get(name);
-                if (!existType.equals(counter.getType())) {
+                TUnit existType = counterTypes.get(name).first;
+                if (!existType.equals(pair.first.getType())) {
                     LOG.warn(
                             "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
-                            profile0.name, name, existType.name(), counter.getType().name());
+                            profile0.name, name, existType.name(), pair.first.getType().name());
                     return;
                 }
             }
         }
 
-        for (Map.Entry<String, TUnit> entry : counterTypes.entrySet()) {
+        for (Map.Entry<String, Pair<TUnit, String>> entry : counterTypes.entrySet()) {
             String name = entry.getKey();
-            TUnit type = entry.getValue();
+            TUnit type = entry.getValue().first;
+            String parentName = entry.getValue().second;
 
             // We don't need to calculate sum or average of counter's extra info (min value and max value) created by be
-            if (name.startsWith(mergedInfoPrefixMin) || name.startsWith(mergedInfoPrefixMax)) {
+            if (name.startsWith(MERGED_INFO_PREFIX_MIN) || name.startsWith(MERGED_INFO_PREFIX_MAX)) {
                 continue;
             }
 
@@ -493,14 +584,14 @@ public class RuntimeProfile {
                     return;
                 }
 
-                Counter minCounter = profile.getCounter(mergedInfoPrefixMin + name);
+                Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
                 if (minCounter != null) {
                     alreadyMerged = true;
                     if (minCounter.getValue() < minValue) {
                         minValue = minCounter.getValue();
                     }
                 }
-                Counter maxCounter = profile.getCounter(mergedInfoPrefixMax + name);
+                Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
                 if (maxCounter != null) {
                     alreadyMerged = true;
                     if (maxCounter.getValue() > maxValue) {
@@ -520,7 +611,7 @@ public class RuntimeProfile {
             // As memtioned before, some counters may only attach to one of the isomorphic profiles
             // and the first profile may not have this counter, so we create a counter here
             if (counter0 == null) {
-                counter0 = profile0.addCounter(name, type);
+                counter0 = profile0.addCounter(name, type, parentName);
             }
             counter0.setValue(mergedValue);
 
@@ -540,8 +631,8 @@ public class RuntimeProfile {
                 }
             }
             if (updateMinMax) {
-                Counter minCounter = profile0.addCounter(mergedInfoPrefixMin + name, type, name);
-                Counter maxCounter = profile0.addCounter(mergedInfoPrefixMax + name, type, name);
+                Counter minCounter = profile0.addCounter(MERGED_INFO_PREFIX_MIN + name, type, name);
+                Counter maxCounter = profile0.addCounter(MERGED_INFO_PREFIX_MAX + name, type, name);
                 minCounter.setValue(minValue);
                 maxCounter.setValue(maxValue);
             }
@@ -555,8 +646,8 @@ public class RuntimeProfile {
             for (int j = 1; j < profiles.size(); j++) {
                 RuntimeProfile profile = profiles.get(j);
                 if (i >= profile.childList.size()) {
-                    LOG.warn("find non-isomorphic children, profileName={}, childNames={}" +
-                                    ", another profileName={}, another childNames={}",
+                    LOG.warn("find non-isomorphic children, profileName={}, childCounterNames={}" +
+                                    ", another profileName={}, another childCounterNames={}",
                             profile0.name,
                             profile0.childList.stream().map(p -> p.first.getName()).collect(Collectors.toList()),
                             profile.name,
@@ -568,5 +659,22 @@ public class RuntimeProfile {
             }
             mergeIsomorphicProfiles(subProfiles);
         }
+    }
+
+    public static void removeRedundantMinMaxMetrics(RuntimeProfile profile) {
+        for (String name : profile.counterMap.keySet()) {
+            Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
+            Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
+            if (minCounter == null || maxCounter == null) {
+                continue;
+            }
+            // Remove MIN/MAX metrics if it's value is identical
+            if (Objects.equals(minCounter.getValue(), maxCounter.getValue())) {
+                profile.removeCounter(MERGED_INFO_PREFIX_MIN + name);
+                profile.removeCounter(MERGED_INFO_PREFIX_MAX + name);
+            }
+        }
+
+        profile.getChildList().forEach(pair -> removeRedundantMinMaxMetrics(pair.first));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -81,8 +81,9 @@ public class RuntimeProfile {
     }
 
     public RuntimeProfile() {
-        this.counterTotalTime = addCounter("TotalTime", TUnit.TIME_NS);
+        this.counterTotalTime = new Counter(TUnit.TIME_NS, 0);
         this.localTimePercent = 0;
+        this.counterMap.put("TotalTime", Pair.create(counterTotalTime, ROOT_COUNTER));
     }
 
     public Counter getCounterTotalTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -647,8 +647,8 @@ public class RuntimeProfile {
             for (int j = 1; j < profiles.size(); j++) {
                 RuntimeProfile profile = profiles.get(j);
                 if (i >= profile.childList.size()) {
-                    LOG.warn("find non-isomorphic children, profileName={}, childCounterNames={}" +
-                                    ", another profileName={}, another childCounterNames={}",
+                    LOG.warn("find non-isomorphic children, profileName={}, childProfileNames={}" +
+                                    ", another profileName={}, another childProfileNames={}",
                             profile0.name,
                             profile0.childList.stream().map(p -> p.first.getName()).collect(Collectors.toList()),
                             profile.name,

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -357,14 +357,18 @@ public class RuntimeProfile {
         List<String> childNames = Lists.newArrayList(childCounterMap.get(counterName));
 
         // Keep MIN/MAX metrics head of other child counters
-        List<String> reorderedChildNames = Lists.newArrayList();
+        List<String> minMaxChildNames = Lists.newArrayListWithCapacity(2);
+        List<String> otherChildNames = Lists.newArrayListWithCapacity(childNames.size());
         for (String childName : childNames) {
             if (childName.startsWith(MERGED_INFO_PREFIX_MIN) || childName.startsWith(MERGED_INFO_PREFIX_MAX)) {
-                reorderedChildNames.add(0, childName);
+                minMaxChildNames.add(childName);
             } else {
-                reorderedChildNames.add(childName);
+                otherChildNames.add(childName);
             }
         }
+        List<String> reorderedChildNames = Lists.newArrayListWithCapacity(childNames.size());
+        reorderedChildNames.addAll(minMaxChildNames);
+        reorderedChildNames.addAll(otherChildNames);
 
         for (String childName : reorderedChildNames) {
             Pair<Counter, String> pair = this.counterMap.get(childName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2272,6 +2272,11 @@ public class Coordinator {
             });
         }
 
+        // Remove redundant MIN/MAX metrics if MIN and MAX are identical
+        for (RuntimeProfile fragmentProfile : fragmentProfiles) {
+            RuntimeProfile.removeRedundantMinMaxMetrics(fragmentProfile);
+        }
+
         // Set backend number
         for (int i = 0; i < fragments.size(); i++) {
             PlanFragment fragment = fragments.get(i);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -245,16 +245,16 @@ public class RuntimeProfileTest {
         {
             Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS);
             time1.setValue(2000000000L);
-            Counter minOfTime1 = profile1.addCounter("__MIN_OF_time1", TUnit.TIME_NS);
+            Counter minOfTime1 = profile1.addCounter("__MIN_OF_time1", TUnit.TIME_NS, "time1");
             minOfTime1.setValue(1500000000L);
-            Counter maxOfTime1 = profile1.addCounter("__MAX_OF_time1", TUnit.TIME_NS);
+            Counter maxOfTime1 = profile1.addCounter("__MAX_OF_time1", TUnit.TIME_NS, "time1");
             maxOfTime1.setValue(5000000000L);
 
             Counter count1 = profile1.addCounter("count1", TUnit.UNIT);
             count1.setValue(6);
-            Counter minOfCount1 = profile1.addCounter("__MIN_OF_count1", TUnit.UNIT);
+            Counter minOfCount1 = profile1.addCounter("__MIN_OF_count1", TUnit.UNIT, "count1");
             minOfCount1.setValue(1);
-            Counter maxOfCount1 = profile1.addCounter("__MAX_OF_count1", TUnit.UNIT);
+            Counter maxOfCount1 = profile1.addCounter("__MAX_OF_count1", TUnit.UNIT, "count1");
             maxOfCount1.setValue(3);
 
             profiles.add(profile1);
@@ -264,16 +264,16 @@ public class RuntimeProfileTest {
         {
             Counter time1 = profile2.addCounter("time1", TUnit.TIME_NS);
             time1.setValue(3000000000L);
-            Counter minOfTime1 = profile2.addCounter("__MIN_OF_time1", TUnit.TIME_NS);
+            Counter minOfTime1 = profile2.addCounter("__MIN_OF_time1", TUnit.TIME_NS, "time1");
             minOfTime1.setValue(100000000L);
-            Counter maxOfTime1 = profile2.addCounter("__MAX_OF_time1", TUnit.TIME_NS);
+            Counter maxOfTime1 = profile2.addCounter("__MAX_OF_time1", TUnit.TIME_NS, "time1");
             maxOfTime1.setValue(4000000000L);
 
             Counter count1 = profile2.addCounter("count1", TUnit.UNIT);
             count1.setValue(15);
-            Counter minOfCount1 = profile2.addCounter("__MIN_OF_count1", TUnit.UNIT);
+            Counter minOfCount1 = profile2.addCounter("__MIN_OF_count1", TUnit.UNIT, "count1");
             minOfCount1.setValue(4);
-            Counter maxOfCount1 = profile2.addCounter("__MAX_OF_count1", TUnit.UNIT);
+            Counter maxOfCount1 = profile2.addCounter("__MAX_OF_count1", TUnit.UNIT, "count1");
             maxOfCount1.setValue(6);
 
             profiles.add(profile2);
@@ -299,5 +299,51 @@ public class RuntimeProfileTest {
         Assert.assertNotNull(mergedMaxOfCount1);
         Assert.assertEquals(1, mergedMinOfCount1.getValue());
         Assert.assertEquals(6, mergedMaxOfCount1.getValue());
+    }
+
+    @Test
+    public void testRemoveRedundantMinMaxMetrics() {
+        RuntimeProfile profile0 = new RuntimeProfile("profile0");
+        RuntimeProfile profile1 = new RuntimeProfile("profile1");
+        profile0.addChild(profile1);
+
+        Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS);
+        time1.setValue(1500000000L);
+        Counter minOfTime1 = profile1.addCounter("__MIN_OF_time1", TUnit.TIME_NS, "time1");
+        minOfTime1.setValue(1500000000L);
+        Counter maxOfTime1 = profile1.addCounter("__MAX_OF_time1", TUnit.TIME_NS, "time1");
+        maxOfTime1.setValue(1500000000L);
+
+        Counter time2 = profile1.addCounter("time2", TUnit.TIME_NS);
+        time2.setValue(2000000000L);
+        Counter minOfTime2 = profile1.addCounter("__MIN_OF_time2", TUnit.TIME_NS, "time2");
+        minOfTime2.setValue(1500000000L);
+        Counter maxOfTime2 = profile1.addCounter("__MAX_OF_time2", TUnit.TIME_NS, "time2");
+        maxOfTime2.setValue(3000000000L);
+
+        Counter count1 = profile1.addCounter("count1", TUnit.UNIT);
+        count1.setValue(6);
+        Counter minOfCount1 = profile1.addCounter("__MIN_OF_count1", TUnit.UNIT, "count1");
+        minOfCount1.setValue(1);
+        Counter maxOfCount1 = profile1.addCounter("__MAX_OF_count1", TUnit.UNIT, "count1");
+        maxOfCount1.setValue(1);
+
+        Counter count2 = profile1.addCounter("count2", TUnit.UNIT);
+        count2.setValue(6);
+        Counter minOfCount2 = profile1.addCounter("__MIN_OF_count2", TUnit.UNIT, "count2");
+        minOfCount2.setValue(1);
+        Counter maxOfCount2 = profile1.addCounter("__MAX_OF_count2", TUnit.UNIT, "count2");
+        maxOfCount2.setValue(3);
+
+        RuntimeProfile.removeRedundantMinMaxMetrics(profile0);
+
+        Assert.assertNull(profile1.getCounter("__MIN_OF_time1"));
+        Assert.assertNull(profile1.getCounter("__MAX_OF_time1"));
+        Assert.assertNotNull(profile1.getCounter("__MIN_OF_time2"));
+        Assert.assertNotNull(profile1.getCounter("__MAX_OF_time2"));
+        Assert.assertNull(profile1.getCounter("__MIN_OF_count1"));
+        Assert.assertNull(profile1.getCounter("__MAX_OF_count1"));
+        Assert.assertNotNull(profile1.getCounter("__MIN_OF_count2"));
+        Assert.assertNotNull(profile1.getCounter("__MAX_OF_count2"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Enhancement

1. Add `RuntimeProfile::removeRedundantMinMaxMetrics` and `RuntimeProfile::removeCounter`to support removing redundant `__MIN_OF_xxx`/`__MAX_OF_xxx` metrics if their values are identical.
2. Refine `RuntimeProfile::update`, using `addChild` and `addCounter` instead of manipulating fields directly.
3. Refine `RuntimeProfile::printChildCounters`, put `MIN/MAX` metrics head of other child counters.
4. Unify naming style