### PR TITLE
[Enhancement] Set cpu_limit of default workgroup to num_executor_threads

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -517,9 +517,12 @@ bool WorkGroupManager::should_yield_scan_worker(ScanExecutorType type, int worke
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
-    int64_t default_cpu_limit = ExecEnv::GetInstance()->max_executor_threads();
+    // The default workgroup can use all the resources of CPU and memory,
+    // so set cpu_limit to max_executor_threads and memory_limit to 100%.
+    int64_t cpu_limit = ExecEnv::GetInstance()->max_executor_threads();
+    double memory_limit = 1.0;
     auto default_wg = std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION,
-                                                  default_cpu_limit, 1.0, 0, WorkGroupType::WG_DEFAULT);
+                                                  cpu_limit, memory_limit, 0, WorkGroupType::WG_DEFAULT);
     WorkGroupManager::instance()->add_workgroup(default_wg);
 }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -517,8 +517,9 @@ bool WorkGroupManager::should_yield_scan_worker(ScanExecutorType type, int worke
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
-    auto default_wg = std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION, 1,
-                                                  1.0, 0, WorkGroupType::WG_DEFAULT);
+    int64_t default_cpu_limit = ExecEnv::GetInstance()->max_executor_threads();
+    auto default_wg = std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION,
+                                                  default_cpu_limit, 1.0, 0, WorkGroupType::WG_DEFAULT);
     WorkGroupManager::instance()->add_workgroup(default_wg);
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The previous `cpu_limit` of default workgroup is  1, but default workgroup shouldn't have the limit of CPU.
Therefore, set it as `num_executor_threads`.
