### PR TITLE
[Cherry-pick branch-2.3] Fix join precedence error (#9063)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2558,8 +2558,8 @@ public class JoinTest extends PlanTestBase {
                 "test_all_type1.t1c as right_int from (select * from test_all_type limit 0) " +
                 "test_all_type cross join (select * from test_all_type limit 0) test_all_type1 cross join (select * from test_all_type limit 0) test_all_type6) t;";
         String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:EMPTYSET");
         assertContains(plan, "1:EMPTYSET");
-        assertContains(plan, "2:EMPTYSET");
     }
 
     @Test


### PR DESCRIPTION
The precedence of the comma operator is less than that of INNER JOIN, CROSS JOIN, LEFT JOIN, and so on
In consecutive joins without on conditions, a left-deep tree should be generated, and if there is an on predicate in the last join, it should correspond to the join formed by all preceding tables and the join generated by the last table.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
