### PR TITLE
[Enhancement] Disable adding fe with the same host

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -668,9 +668,8 @@ public class NodeMgr {
             throw new DdlException("Failed to acquire globalStateMgr lock. Try again");
         }
         try {
-            Frontend fe = checkFeExist(host, editLogPort);
-            if (fe != null) {
-                throw new DdlException("frontend already exists " + fe);
+            if (hasSameHostFe(host)) {
+                throw new DdlException("frontend use host [" + host + "] already exists ");
             }
 
             String nodeName = GlobalStateMgr.genFeNodeName(host, editLogPort, false /* new name style */);
@@ -679,7 +678,7 @@ public class NodeMgr {
                 throw new DdlException("frontend name already exists " + nodeName + ". Try again");
             }
 
-            fe = new Frontend(role, nodeName, host, editLogPort);
+            Frontend fe = new Frontend(role, nodeName, host, editLogPort);
             frontends.put(nodeName, fe);
             if (role == FrontendNodeType.FOLLOWER) {
                 helperNodes.add(Pair.create(host, editLogPort));
@@ -831,6 +830,15 @@ public class NodeMgr {
         } finally {
             unlock();
         }
+    }
+
+    public boolean hasSameHostFe(String host) {
+        for (Frontend fe : frontends.values()) {
+            if (fe.getHost().equals(host)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Frontend checkFeExist(String host, int port) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -668,7 +668,8 @@ public class NodeMgr {
             throw new DdlException("Failed to acquire globalStateMgr lock. Try again");
         }
         try {
-            if (hasSameHostFe(host)) {
+            Frontend fe = getFeByHost(host);
+            if (null != fe) {
                 throw new DdlException("frontend use host [" + host + "] already exists ");
             }
 
@@ -678,7 +679,7 @@ public class NodeMgr {
                 throw new DdlException("frontend name already exists " + nodeName + ". Try again");
             }
 
-            Frontend fe = new Frontend(role, nodeName, host, editLogPort);
+            fe = new Frontend(role, nodeName, host, editLogPort);
             frontends.put(nodeName, fe);
             if (role == FrontendNodeType.FOLLOWER) {
                 helperNodes.add(Pair.create(host, editLogPort));
@@ -830,15 +831,6 @@ public class NodeMgr {
         } finally {
             unlock();
         }
-    }
-
-    public boolean hasSameHostFe(String host) {
-        for (Frontend fe : frontends.values()) {
-            if (fe.getHost().equals(host)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public Frontend checkFeExist(String host, int port) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTest.java
@@ -313,4 +313,10 @@ public class GlobalStateMgrTest {
         // this case will occur [can not modify current master node] exception
         globalStateMgr.modifyFrontendHost(clause);
     }
+
+    @Test(expected = DdlException.class)
+    public void testAddRepeatedFe() throws Exception {
+        GlobalStateMgr globalStateMgr = mockGlobalStateMgr();
+        globalStateMgr.addFrontend(FrontendNodeType.FOLLOWER, "127.0.0.1", 1000);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9499 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If we add a FE to the cluster with the same IP and a different edit log port, the FE can be added to the cluster under the current logic, but this situation will result in a series of errors. 
This PR will fix this issue.
A new FE node will be blocked from joining the cluster as long as it has the same host as one of the existing nodes.
