### PR TITLE
[BugFix] Shouldn't close file system when broker encounters exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -797,7 +797,6 @@ public class HdfsFsManager {
             throw new UserException("file not found: " + e.getMessage());
         } catch (Exception e) {
             LOG.error("errors while get file status ", e);
-            fileSystem.closeFileSystem();
             throw new UserException("unknown error when get file status: " + e.getMessage());
         }
         return resultFileStatus;
@@ -811,7 +810,6 @@ public class HdfsFsManager {
             fileSystem.getDFSFileSystem().delete(filePath, true);
         } catch (IOException e) {
             LOG.error("errors while delete path " + path);
-            fileSystem.closeFileSystem();
             throw new UserException("delete path " + path + "error");
         }
     }
@@ -833,7 +831,6 @@ public class HdfsFsManager {
             }
         } catch (IOException e) {
             LOG.error("errors while rename path from " + srcPath + " to " + destPath);
-            fileSystem.closeFileSystem();
             throw new UserException("errors while rename " + srcPath + "to " +  destPath);
         }
     }
@@ -847,7 +844,6 @@ public class HdfsFsManager {
             return isPathExist;
         } catch (IOException e) {
             LOG.error("errors while check path exist: " + path);
-            fileSystem.closeFileSystem();
             throw new UserException("errors while check if path " + path + " exist");
         }
     }
@@ -865,7 +861,6 @@ public class HdfsFsManager {
             return fd;
         } catch (IOException e) {
             LOG.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new UserException("could not open file " + path);
         }
     }
@@ -952,7 +947,6 @@ public class HdfsFsManager {
             return fd;
         } catch (IOException e) {
             LOG.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new UserException("could not open file " + path);
         }
     }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -735,7 +735,6 @@ public class FileSystemManager {
                     e, "file not found");
         } catch (Exception e) {
             logger.error("errors while get file status ", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "unknown error when get file status");
         }
@@ -750,7 +749,6 @@ public class FileSystemManager {
             fileSystem.getDFSFileSystem().delete(filePath, true);
         } catch (IOException e) {
             logger.error("errors while delete path " + path);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "delete path {} error", path);
         }
@@ -774,7 +772,6 @@ public class FileSystemManager {
             }
         } catch (IOException e) {
             logger.error("errors while rename path from " + srcPath + " to " + destPath);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "errors while rename {} to {}", srcPath, destPath);
         }
@@ -789,7 +786,6 @@ public class FileSystemManager {
             return isPathExist;
         } catch (IOException e) {
             logger.error("errors while check path exist: " + path);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "errors while check if path {} exist", path);
         }
@@ -808,7 +804,6 @@ public class FileSystemManager {
             return fd;
         } catch (IOException e) {
             logger.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "could not open file {}", path);
         }
@@ -895,7 +890,6 @@ public class FileSystemManager {
             return fd;
         } catch (IOException e) {
             logger.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "could not open file {}", path);
         }


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9506

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the current implementation, the broker will close the file system when it encounters an exception.
Suppose there are two threads, threads A is in the middle of the reading process, and thread B
is opening the file, and it finds the file doesn't exist, then the broker will throw an exception
and close the file system. However, thread A is still using the file system to read files,
close the file system will also lead to a thread A abort reading.