### PR TITLE
[cherry-pick][branch-2.2][BugFix] shouldn't close file system when broker encounters excecption(backport #9507) 

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -729,7 +729,6 @@ public class FileSystemManager {
                     e, "file not found");
         } catch (Exception e) {
             logger.error("errors while get file status ", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "unknown error when get file status");
         }
@@ -744,7 +743,6 @@ public class FileSystemManager {
             fileSystem.getDFSFileSystem().delete(filePath, true);
         } catch (IOException e) {
             logger.error("errors while delete path " + path);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "delete path {} error", path);
         }
@@ -768,7 +766,6 @@ public class FileSystemManager {
             }
         } catch (IOException e) {
             logger.error("errors while rename path from " + srcPath + " to " + destPath);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "errors while rename {} to {}", srcPath, destPath);
         }
@@ -783,7 +780,6 @@ public class FileSystemManager {
             return isPathExist;
         } catch (IOException e) {
             logger.error("errors while check path exist: " + path);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "errors while check if path {} exist", path);
         }
@@ -802,7 +798,6 @@ public class FileSystemManager {
             return fd;
         } catch (IOException e) {
             logger.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "could not open file {}", path);
         }
@@ -889,7 +884,6 @@ public class FileSystemManager {
             return fd;
         } catch (IOException e) {
             logger.error("errors while open path", e);
-            fileSystem.closeFileSystem();
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
                     e, "could not open file {}", path);
         }


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9506

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In current implementation, broker will close file system when it encounters exception.
Suppose there are two threads, threads A is in the middle of reading process, thread B
is opening the file and it finds the file doesn't exist, then broker will throw an exception
and close the file system. However, thread A is still using the file system to read files,
close the file system will also lead to thread A abort reading.