### PR TITLE
[BugFix] Fix FileScanNode use not null column

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -345,6 +345,23 @@ std::string Chunk::debug_row(uint32_t index) const {
     return os.str();
 }
 
+std::string Chunk::debug_columns() const {
+    std::stringstream os;
+    os << "nullable[";
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->is_nullable();
+        os << ", ";
+    }
+    os << _columns[_columns.size() - 1]->is_nullable() << "]";
+    os << " const[";
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->is_constant();
+        os << ", ";
+    }
+    os << _columns[_columns.size() - 1]->is_constant() << "]";
+    return os.str();
+}
+
 void Chunk::merge(Chunk&& src) {
     DCHECK_EQ(src.num_rows(), num_rows());
     for (auto& it : src._slot_id_to_index) {

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -230,6 +230,8 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
+    std::string debug_columns() const;
+
     bool capacity_limit_reached(std::string* msg = nullptr) const {
         for (const auto& column : _columns) {
             if (column->capacity_limit_reached(msg)) {

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -110,6 +110,9 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
     _counter->num_rows_filtered += _chunk_start_idx - num_rows;
     ChunkPtr cast_chunk = std::make_shared<Chunk>();
     {
+        if (VLOG_ROW_IS_ON) {
+            VLOG_ROW << "before finalize chunk: " << (*chunk)->debug_columns();
+        }
         SCOPED_RAW_TIMER(&_counter->cast_chunk_ns);
         for (auto i = 0; i < _num_of_columns_from_file; ++i) {
             SlotDescriptor* slot_desc = _src_slot_descriptors[i];
@@ -125,6 +128,9 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
         if (range.__isset.num_of_columns_from_file) {
             fill_columns_from_path(cast_chunk, range.num_of_columns_from_file, range.columns_from_path,
                                    cast_chunk->num_rows());
+        }
+        if (VLOG_ROW_IS_ON) {
+            VLOG_ROW << "after finalize chunk: " << cast_chunk->debug_columns();
         }
     }
     ASSIGN_OR_RETURN(auto dest_chunk, materialize(*chunk, cast_chunk));

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -221,7 +221,7 @@ Status PlanFragmentExecutor::_open_internal_vectorized() {
 
         if (VLOG_ROW_IS_ON) {
             VLOG_ROW << "_open_internal_vectorized: #rows=" << chunk->num_rows()
-                     << " desc=" << row_desc().debug_string();
+                     << " desc=" << row_desc().debug_string() << " columns=" << chunk->debug_columns();
             // TODO(kks): support chunk debug log
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -395,7 +395,6 @@ public class Load {
                             slotDesc.setType(tblColumn.getType());
                             slotDesc.setColumn(new Column(columnName, tblColumn.getType()));
                         }
-                        slotDesc.setIsNullable(tblColumn.isAllowNull());
                         slotDesc.setIsMaterialized(true);
                     } else if (columnName.equals(Load.LOAD_OP_COLUMN)) {
                         // to support auto mapping, the new grammer for compatible with existing load tool.
@@ -404,15 +403,16 @@ public class Load {
                         // columns:__op,pk,col1,col2 equals to columns:srccol0,srccol1,srccol2,srccol3,__op=srccol0,pk=srccol1,col1=srccol2,col2=srccol3
                         slotDesc.setType(Type.TINYINT);
                         slotDesc.setColumn(new Column(columnName, Type.TINYINT));
-                        slotDesc.setIsNullable(false);
                         slotDesc.setIsMaterialized(true);
                     } else {
                         slotDesc.setType(Type.VARCHAR);
                         slotDesc.setColumn(new Column(columnName, Type.VARCHAR));
-                        slotDesc.setIsNullable(true);
                         // Will check mapping expr has this slot or not later
                         slotDesc.setIsMaterialized(false);
                     }
+                    // FileScanNode will set all slot nullable, it check null in OlapTableSink if
+                    // dest table column is not null
+                    slotDesc.setIsNullable(true);
                 } else {
                     slotDesc.setType(Type.VARCHAR);
                     slotDesc.setColumn(new Column(columnName, Type.VARCHAR));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9552

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
FileScanNode use dest table's column type, it may be not nullable. But after data scan, it may be convert to nullable column.
It will make schema different between each chunk, which will make exchange node crash since it cache the chunk schema.