### PR TITLE
[Refactor] Change keys parameter type to Slice

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -925,8 +925,8 @@ PrimaryIndex::PrimaryIndex(const vectorized::Schema& pk_schema) {
 void PrimaryIndex::_set_schema(const vectorized::Schema& pk_schema) {
     _pk_schema = pk_schema;
     _enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(_pk_schema);
-    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
-    _pkey_to_rssid_rowid = std::move(create_hash_index(_enc_pk_type, fix_size));
+    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
+    _pkey_to_rssid_rowid = std::move(create_hash_index(_enc_pk_type, _key_size));
 }
 
 Status PrimaryIndex::load(Tablet* tablet) {
@@ -1132,7 +1132,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
 }
 
 Status PrimaryIndex::_build_persistent_values(uint32_t rssid, uint32_t rowid_start, uint32_t idx_begin,
-                                              uint32_t idx_end, std::vector<uint64_t>* values) {
+                                              uint32_t idx_end, std::vector<uint64_t>* values) const {
     uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
     for (uint32_t i = idx_begin; i < idx_end; i++) {
         values->emplace_back(base + i);
@@ -1141,7 +1141,7 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, uint32_t rowid_sta
 }
 
 Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint32_t>& rowids, uint32_t idx_begin,
-                                              uint32_t idx_end, std::vector<uint64_t>* values) {
+                                              uint32_t idx_end, std::vector<uint64_t>* values) const {
     DCHECK(idx_end <= rowids.size());
     uint64_t base = ((uint64_t)rssid) << 32;
     for (uint32_t i = idx_begin; i < idx_end; i++) {
@@ -1150,23 +1150,39 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint3
     return Status::OK();
 }
 
+const Slice* PrimaryIndex::_build_persistent_keys(const vectorized::Column& pks, std::vector<Slice>* key_slices) const {
+    if (pks.is_binary()) {
+        return reinterpret_cast<const Slice*>(pks.raw_data());
+    } else {
+        const uint8_t* keys = pks.raw_data();
+        for (size_t i = 0; i < pks.size(); i++) {
+            key_slices->emplace_back(keys, _key_size);
+            keys += _key_size;
+        }
+        return reinterpret_cast<const Slice*>(key_slices->data());
+    }
+}
+
 Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids,
                                                    const vectorized::Column& pks) {
+    std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowids, 0, pks.size(), &values);
-    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), pks.continuous_data(),
-                                              reinterpret_cast<IndexValue*>(values.data()), true));
+    const Slice* vkeys = _build_persistent_keys(pks, &keys);
+    RETURN_IF_ERROR(_persistent_index->insert(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), true));
     return Status::OK();
 }
 
 void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
                                                  DeletesMap* deletes) {
+    std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
+    const Slice* vkeys = _build_persistent_keys(pks, &keys);
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    _persistent_index->upsert(pks.size(), pks.continuous_data(), reinterpret_cast<IndexValue*>(values.data()),
+    _persistent_index->upsert(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()),
                               reinterpret_cast<IndexValue*>(old_values.data()));
     for (uint32_t i = 0; i < old_values.size(); ++i) {
         uint64_t old = old_values[i];
@@ -1180,9 +1196,10 @@ void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_
 }
 
 void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
+    std::vector<Slice> keys;
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    Status st = _persistent_index->erase(key_col.size(), key_col.continuous_data(),
-                                         reinterpret_cast<IndexValue*>(old_values.data()));
+    const Slice* vkeys = _build_persistent_keys(key_col, &keys);
+    Status st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1195,8 +1212,9 @@ void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, De
 }
 
 void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
-    Status st = _persistent_index->get(key_col.size(), key_col.continuous_data(),
-                                       reinterpret_cast<IndexValue*>(rowids->data()));
+    std::vector<Slice> keys;
+    const Slice* vkeys = _build_persistent_keys(key_col, &keys);
+    Status st = _persistent_index->get(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
@@ -1206,10 +1224,11 @@ void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col,
                                                               const vectorized::Column& pks,
                                                               const vector<uint32_t>& src_rssid,
                                                               vector<uint32_t>* deletes) {
+    std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
+    Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
@@ -1218,10 +1237,11 @@ void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col,
 
 void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
                                              const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+    std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
-    Status st = _persistent_index->try_replace(pks.size(), pks.continuous_data(),
+    Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -115,16 +115,20 @@ public:
 
     bool enable_persistent_index() { return _persistent_index != nullptr; }
 
+    size_t key_size() { return _key_size; }
+
 private:
     void _set_schema(const vectorized::Schema& pk_schema);
 
     Status _do_load(Tablet* tablet);
 
     Status _build_persistent_values(uint32_t rssid, uint32_t rowid_start, uint32_t idx_begin, uint32_t idx_end,
-                                    std::vector<uint64_t>* values);
+                                    std::vector<uint64_t>* values) const;
 
     Status _build_persistent_values(uint32_t rssid, const vector<uint32_t>& rowids, uint32_t idx_begin,
-                                    uint32_t idx_end, std::vector<uint64_t>* values);
+                                    uint32_t idx_end, std::vector<uint64_t>* values) const;
+
+    const Slice* _build_persistent_keys(const vectorized::Column& pks, std::vector<Slice>* key_slices) const;
 
     Status _insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const vectorized::Column& pks);
 
@@ -144,6 +148,7 @@ private:
     std::mutex _lock;
     std::atomic<bool> _loaded{false};
     Status _status;
+    size_t _key_size = 0;
     int64_t _table_id = 0;
     int64_t _tablet_id = 0;
     vectorized::Schema _pk_schema;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -42,10 +42,8 @@ private:
     HdfsScannerContext* _create_context_for_skip_group();
 
     HdfsScannerContext* _create_file3_base_context();
-    HdfsScannerContext* _create_context_for_multi_filter(
-            HdfsScannerContext* base_ctx);
-    HdfsScannerContext* _create_context_for_multi_page(
-            HdfsScannerContext* base_ctx);
+    HdfsScannerContext* _create_context_for_multi_filter(HdfsScannerContext* base_ctx);
+    HdfsScannerContext* _create_context_for_multi_page(HdfsScannerContext* base_ctx);
 
     static vectorized::ChunkPtr _create_chunk();
     static vectorized::ChunkPtr _create_chunk_for_partition();
@@ -627,8 +625,7 @@ HdfsScannerContext* FileReaderTest::_create_file3_base_context() {
     return ctx;
 }
 
-HdfsScannerContext* FileReaderTest::_create_context_for_multi_filter(
-        HdfsScannerContext* base_ctx) {
+HdfsScannerContext* FileReaderTest::_create_context_for_multi_filter(HdfsScannerContext* base_ctx) {
     SlotDesc slot_descs[] = {
             {"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
             {"c2", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_BIGINT)},
@@ -651,8 +648,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_multi_filter(
     return base_ctx;
 }
 
-HdfsScannerContext* FileReaderTest::_create_context_for_multi_page(
-        HdfsScannerContext* base_ctx) {
+HdfsScannerContext* FileReaderTest::_create_context_for_multi_page(HdfsScannerContext* base_ctx) {
     SlotDesc slot_descs[] = {
             {"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
             {"c2", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_BIGINT)},
@@ -671,7 +667,6 @@ HdfsScannerContext* FileReaderTest::_create_context_for_multi_page(
 
     return base_ctx;
 }
-
 
 THdfsScanRange* FileReaderTest::_create_scan_range() {
     auto* scan_range = _pool.add(new THdfsScanRange());

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -25,51 +25,65 @@
 namespace starrocks {
 PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
     using Key = uint64_t;
-    vector<Key> keys;
-    vector<IndexValue> values;
     int N = 1000;
+    vector<Key> keys;
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    keys.reserve(N);
+    key_slices.reserve(N);
     for (int i = 0; i < N; i++) {
         keys.emplace_back(i);
         values.emplace_back(i * 2);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
     ASSIGN_OR_ABORT(auto idx, MutableIndex::create(sizeof(Key), "./PersistentIndexTest_test_mutable_index"));
 
     // test insert
-    ASSERT_OK(idx->insert(keys.size(), keys.data(), values.data()));
+    ASSERT_OK(idx->insert(keys.size(), key_slices.data(), values.data()));
     // insert duplicate should return error
-    ASSERT_FALSE(idx->insert(keys.size(), keys.data(), values.data()).ok());
+    ASSERT_FALSE(idx->insert(keys.size(), key_slices.data(), values.data()).ok());
 
     // test get
     vector<IndexValue> get_values(keys.size());
     KeysInfo get_not_found;
     size_t get_num_found = 0;
-    ASSERT_TRUE(idx->get(keys.size(), keys.data(), get_values.data(), &get_not_found, &get_num_found).ok());
+    ASSERT_TRUE(idx->get(keys.size(), key_slices.data(), get_values.data(), &get_not_found, &get_num_found).ok());
     ASSERT_EQ(keys.size(), get_num_found);
     ASSERT_EQ(get_not_found.key_idxes.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
     vector<Key> get2_keys;
+    vector<Slice> get2_key_slices;
+    get2_keys.reserve(N);
+    get2_key_slices.reserve(N);
     for (int i = 0; i < N; i++) {
         get2_keys.emplace_back(i * 2);
+        get2_key_slices.emplace_back((uint8_t*)(&get2_keys[i]), sizeof(Key));
     }
     vector<IndexValue> get2_values(get2_keys.size());
     KeysInfo get2_not_found;
     size_t get2_num_found = 0;
     // should only find 0,2,..N-2, not found: N,N+2, .. N*2-2
-    ASSERT_TRUE(
-            idx->get(get2_keys.size(), get2_keys.data(), get2_values.data(), &get2_not_found, &get2_num_found).ok());
+    ASSERT_TRUE(idx->get(get2_keys.size(), get2_key_slices.data(), get2_values.data(), &get2_not_found, &get2_num_found)
+                        .ok());
     ASSERT_EQ(N / 2, get2_num_found);
 
     // test erase
     vector<Key> erase_keys;
+    vector<Slice> erase_key_slices;
+    erase_keys.reserve(N);
+    erase_key_slices.reserve(N);
+    size_t num = 0;
     for (int i = 0; i < N + 3; i += 3) {
         erase_keys.emplace_back(i);
+        erase_key_slices.emplace_back((uint8_t*)(&erase_keys[num]), sizeof(Key));
+        num++;
     }
     vector<IndexValue> erase_old_values(erase_keys.size());
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
-    ASSERT_TRUE(idx->erase(erase_keys.size(), erase_keys.data(), erase_old_values.data(), &erase_not_found,
+    ASSERT_TRUE(idx->erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data(), &erase_not_found,
                            &erase_num_found)
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
@@ -78,7 +92,9 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
 
     // test upsert
     vector<Key> upsert_keys(N, 0);
+    vector<Slice> upsert_key_slices;
     vector<IndexValue> upsert_values(upsert_keys.size());
+    upsert_key_slices.reserve(N);
     size_t expect_exists = 0;
     size_t expect_not_found = 0;
     for (int i = 0; i < N; i++) {
@@ -86,6 +102,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
         if (i % 3 != 0 && i * 2 < N) {
             expect_exists++;
         }
+        upsert_key_slices.emplace_back((uint8_t*)(&upsert_keys[i]), sizeof(Key));
         if (i * 2 >= N && i * 2 != N + 2) {
             expect_not_found++;
         }
@@ -94,8 +111,8 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
     vector<IndexValue> upsert_old_values(upsert_keys.size());
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
-    ASSERT_TRUE(idx->upsert(upsert_keys.size(), upsert_keys.data(), upsert_values.data(), upsert_old_values.data(),
-                            &upsert_not_found, &upsert_num_found)
+    ASSERT_TRUE(idx->upsert(upsert_keys.size(), upsert_key_slices.data(), upsert_values.data(),
+                            upsert_old_values.data(), &upsert_not_found, &upsert_num_found)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
     ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
@@ -110,25 +127,37 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
 
     using Key = uint64_t;
     PersistentIndexMetaPB index_meta;
+    int N = 1000000;
     // insert
     vector<Key> keys;
+    vector<Slice> key_slices;
     vector<IndexValue> values;
-    int N = 1000000;
+    keys.reserve(N);
+    key_slices.reserve(N);
     for (int i = 0; i < N; i++) {
         keys.emplace_back(i);
         values.emplace_back(i * 2);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
     // erase
     vector<Key> erase_keys;
+    vector<Slice> erase_key_slices;
+    erase_keys.reserve(N / 2);
+    erase_key_slices.reserve(N / 2);
     for (int i = 0; i < N / 2; i++) {
         erase_keys.emplace_back(i);
+        erase_key_slices.emplace_back((uint8_t*)(&erase_keys[i]), sizeof(Key));
     }
     // append invalid wal
     std::vector<Key> invalid_keys;
+    std::vector<Slice> invalid_key_slices;
     std::vector<IndexValue> invalid_values;
+    invalid_keys.reserve(N / 2);
+    invalid_key_slices.reserve(N / 2);
     for (int i = 0; i < N / 2; i++) {
         invalid_keys.emplace_back(i);
         invalid_values.emplace_back(i * 2);
+        invalid_key_slices.emplace_back((uint8_t*)(&invalid_keys[i]), sizeof(Key));
     }
 
     {
@@ -150,25 +179,25 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
 
         ASSERT_OK(index.load(index_meta));
         ASSERT_OK(index.prepare(EditVersion(1, 0)));
-        ASSERT_OK(index.insert(N, keys.data(), values.data(), false));
+        ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
         std::vector<IndexValue> old_values(keys.size());
         ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
-        ASSERT_TRUE(index.upsert(keys.size(), keys.data(), values.data(), old_values.data()).ok());
+        ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
         vector<IndexValue> erase_old_values(erase_keys.size());
         ASSERT_TRUE(index.prepare(EditVersion(3, 0)).ok());
-        ASSERT_TRUE(index.erase(erase_keys.size(), erase_keys.data(), erase_old_values.data()).ok());
+        ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
         std::vector<IndexValue> get_values(keys.size());
-        ASSERT_TRUE(index.get(keys.size(), keys.data(), get_values.data()).ok());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
@@ -185,7 +214,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(new_index.load(index_meta).ok());
         std::vector<IndexValue> get_values(keys.size());
 
-        ASSERT_TRUE(new_index.get(keys.size(), keys.data(), get_values.data()).ok());
+        ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < N / 2; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
@@ -197,7 +226,9 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         // upsert key/value to new_index
         vector<IndexValue> old_values(invalid_keys.size());
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0)).ok());
-        ASSERT_TRUE(new_index.upsert(invalid_keys.size(), invalid_keys.data(), invalid_values.data(), old_values.data())
+        ASSERT_TRUE(new_index
+                            .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
+                                    old_values.data())
                             .ok());
         ASSERT_TRUE(new_index.commit(&index_meta).ok());
         ASSERT_TRUE(new_index.on_commited().ok());
@@ -209,7 +240,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(index.load(index_meta).ok());
         std::vector<IndexValue> get_values(keys.size());
 
-        ASSERT_TRUE(index.get(keys.size(), keys.data(), get_values.data()).ok());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
         for (int i = 0; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
@@ -223,16 +254,19 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {
     int N = 200000;
     vector<Key> keys(N);
     vector<IndexValue> values(N);
+    vector<Slice> key_slices;
+    key_slices.reserve(N);
     for (int i = 0; i < N; i++) {
         keys[i] = i;
         values[i] = i * 2;
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
     auto rs = MutableIndex::create(sizeof(Key), "./PersistentIndexTest_test_mutable_flush_to_immutable");
     ASSERT_TRUE(rs.ok());
     std::unique_ptr<MutableIndex> idx = std::move(rs).value();
 
     // test insert
-    ASSERT_TRUE(idx->insert(keys.size(), keys.data(), values.data()).ok());
+    ASSERT_TRUE(idx->insert(keys.size(), key_slices.data(), values.data()).ok());
 
     ASSERT_TRUE(idx->flush_to_immutable_index(".", EditVersion(1, 1)).ok());
 
@@ -252,7 +286,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {
     }
     vector<IndexValue> get_values(N);
     size_t num_found = 0;
-    auto st_get = idx_loaded->get(N, keys.data(), keys_info, get_values.data(), &num_found);
+    auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &num_found);
     if (!st_get.ok()) {
         LOG(WARNING) << st_get;
     }
@@ -261,13 +295,15 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
-    ASSERT_TRUE(idx_loaded->check_not_exist(N, keys.data()).is_already_exist());
+    ASSERT_TRUE(idx_loaded->check_not_exist(N, key_slices.data()).is_already_exist());
 
     vector<Key> check_not_exist_keys(10);
+    vector<Slice> check_not_exist_key_slices(10);
     for (int i = 0; i < 10; i++) {
         check_not_exist_keys[i] = N + i;
+        check_not_exist_key_slices[i] = Slice((uint8_t*)(&check_not_exist_keys[i]), sizeof(Key));
     }
-    ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_keys.data()).ok());
+    ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_key_slices.data()).ok());
 }
 
 TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
@@ -346,8 +382,11 @@ void build_persistent_index_from_tablet(size_t N) {
     TabletSharedPtr tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
     std::vector<int64_t> keys(N);
+    std::vector<Slice> key_slices;
+    key_slices.reserve(N);
     for (int64_t i = 0; i < N; ++i) {
         keys[i] = i;
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(uint64_t));
     }
 
     RowsetSharedPtr rowset = create_rowset(tablet, keys);
@@ -395,7 +434,20 @@ void build_persistent_index_from_tablet(size_t N) {
         primary_results.resize(pks.size());
         persistent_results.resize(pks.size());
         primary_index.get(pks, &primary_results);
-        persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
+        if (pks.is_binary()) {
+            persistent_index.get(pks.size(), reinterpret_cast<const Slice*>(pks.raw_data()),
+                                 reinterpret_cast<IndexValue*>(persistent_results.data()));
+        } else {
+            size_t key_size = primary_index.key_size();
+            ASSERT_TRUE(key_size == sizeof(uint64_t));
+            std::vector<Slice> col_key_slices;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                col_key_slices.emplace_back(pks.raw_data() + i * key_size, key_size);
+            }
+            persistent_index.get(pks.size(), col_key_slices.data(),
+                                 reinterpret_cast<IndexValue*>(persistent_results.data()));
+        }
+
         ASSERT_EQ(primary_results.size(), persistent_results.size());
         for (size_t j = 0; j < primary_results.size(); ++j) {
             ASSERT_EQ(primary_results[i], persistent_results[i]);
@@ -419,7 +471,18 @@ void build_persistent_index_from_tablet(size_t N) {
             primary_results.resize(pks.size());
             persistent_results.resize(pks.size());
             primary_index.get(pks, &primary_results);
-            persistent_index.get(pks.size(), pks.raw_data(), reinterpret_cast<IndexValue*>(persistent_results.data()));
+            if (pks.is_binary()) {
+                persistent_index.get(pks.size(), reinterpret_cast<const Slice*>(pks.raw_data()),
+                                     reinterpret_cast<IndexValue*>(persistent_results.data()));
+            } else {
+                size_t key_size = primary_index.key_size();
+                std::vector<Slice> col_key_slices;
+                for (size_t i = 0; i < pks.size(); ++i) {
+                    col_key_slices.emplace_back(pks.raw_data() + i * key_size, key_size);
+                }
+                persistent_index.get(pks.size(), col_key_slices.data(),
+                                     reinterpret_cast<IndexValue*>(persistent_results.data()));
+            }
             ASSERT_EQ(primary_results.size(), persistent_results.size());
             for (size_t j = 0; j < primary_results.size(); ++j) {
                 ASSERT_EQ(primary_results[i], persistent_results[i]);
@@ -453,12 +516,16 @@ PARALLEL_TEST(PersistentIndexTest, test_replace) {
     PersistentIndexMetaPB index_meta;
     // insert
     vector<Key> keys;
+    vector<Slice> key_slices;
     vector<IndexValue> values;
     vector<uint32_t> src_rssid;
     vector<IndexValue> replace_values;
     int N = 1000000;
+    keys.reserve(N);
+    key_slices.reserve(N);
     for (int i = 0; i < N; i++) {
         keys.emplace_back(i);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
         values.emplace_back(i * 2);
         replace_values.emplace_back(i * 3);
     }
@@ -484,12 +551,12 @@ PARALLEL_TEST(PersistentIndexTest, test_replace) {
 
     ASSERT_TRUE(index.load(index_meta).ok());
     ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
-    ASSERT_TRUE(index.insert(N, keys.data(), values.data(), false).ok());
+    ASSERT_TRUE(index.insert(N, key_slices.data(), values.data(), false).ok());
     ASSERT_TRUE(index.commit(&index_meta).ok());
     ASSERT_TRUE(index.on_commited().ok());
 
     std::vector<IndexValue> get_values(keys.size());
-    ASSERT_TRUE(index.get(keys.size(), keys.data(), get_values.data()).ok());
+    ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
     ASSERT_EQ(keys.size(), get_values.size());
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
@@ -497,10 +564,10 @@ PARALLEL_TEST(PersistentIndexTest, test_replace) {
 
     //replace
     std::vector<uint32_t> failed(keys.size());
-    Status st = index.try_replace(N, keys.data(), replace_values.data(), src_rssid, &failed);
+    Status st = index.try_replace(N, key_slices.data(), replace_values.data(), src_rssid, &failed);
     ASSERT_TRUE(st.ok());
     std::vector<IndexValue> new_get_values(keys.size());
-    ASSERT_TRUE(index.get(keys.size(), keys.data(), new_get_values.data()).ok());
+    ASSERT_TRUE(index.get(keys.size(), key_slices.data(), new_get_values.data()).ok());
     ASSERT_EQ(keys.size(), new_get_values.size());
     for (int i = 0; i < N / 2; i++) {
         ASSERT_EQ(replace_values[i], new_get_values[i]);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Change keys parameter type of `PersistentIndex` to Slice. This pr for the subsequent simplification of the interface to support varlen key implementation
