### PR TITLE
[BugFix] Fix Prune Distinct Global Aggregate lose projection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/PruneAggregateNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/PruneAggregateNodeRule.java
@@ -78,6 +78,7 @@ public class PruneAggregateNodeRule implements PhysicalOperatorTreeRewriteRule {
             if (parentOperator.getType().isDistinctGlobal() && childOperator instanceof PhysicalHashAggregateOperator) {
                 PhysicalHashAggregateOperator hashAggregateOperator = (PhysicalHashAggregateOperator) childOperator;
                 hashAggregateOperator.setUseStreamingPreAgg(false);
+                hashAggregateOperator.setProjection(parentOperator.getProjection());
                 return optExpression.inputAt(0);
             } else {
                 return visit(optExpression, context);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1512,6 +1512,57 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testGroupByConstantWithAggPrune() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(4);
+        FeConstants.runningUnitTest = true;
+        String sql = "select count(distinct L_ORDERKEY) from lineitem group by 1.0001";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, " 4:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  output: count(1: L_ORDERKEY)\n" +
+                "  |  group by: 18: expr\n" +
+                "  |  \n" +
+                "  3:Project\n" +
+                "  |  <slot 1> : 1: L_ORDERKEY\n" +
+                "  |  <slot 18> : 1.0001\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update serialize)\n" +
+                "  |  group by: 1: L_ORDERKEY");
+
+        sql = "select count(distinct L_ORDERKEY) from lineitem group by 1.0001, 2.0001";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "4:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  output: count(1: L_ORDERKEY)\n" +
+                "  |  group by: 18: expr\n" +
+                "  |  \n" +
+                "  3:Project\n" +
+                "  |  <slot 1> : 1: L_ORDERKEY\n" +
+                "  |  <slot 18> : 1.0001\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update serialize)\n" +
+                "  |  group by: 1: L_ORDERKEY");
+
+        sql = "select count(distinct L_ORDERKEY), count(L_PARTKEY) from lineitem group by 1.0001";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "4:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  output: count(1: L_ORDERKEY), count(20: count)\n" +
+                "  |  group by: 18: expr\n" +
+                "  |  \n" +
+                "  3:Project\n" +
+                "  |  <slot 1> : 1: L_ORDERKEY\n" +
+                "  |  <slot 18> : 1.0001\n" +
+                "  |  <slot 20> : 20: count\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update serialize)\n" +
+                "  |  output: count(2: L_PARTKEY)\n" +
+                "  |  group by: 1: L_ORDERKEY");
+        FeConstants.runningUnitTest = false;
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    @Test
     public void testAggregateDuplicatedExprs() throws Exception {
         String plan = getFragmentPlan("SELECT " +
                 "sum(arrays_overlap(v3, [1])) as q1, " +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9519

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In PruneAggregateNodeRule, StarRocks prune aggregate node which type is DISTINCT GLOBAL, this rule lose the aggregate node's projection, we should add the projection at its child.