### PR TITLE
[Enhancement] Validate replica number by BE count in CREATE/ALTER TABLE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -216,8 +216,8 @@ public class PropertyAnalyzer {
         }
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().getAvailableBackendIds();
         if (replicationNum > backendIds.size()) {
-            throw new AnalysisException("Replication num should less than current alive be node count" + 
-            ", current alive be node count is [" + backendIds.size() + "]");
+            throw new AnalysisException("Replication num should be less than the number of available BE nodes. " 
+            + "Replication num is " + replicationNum + " available BE nodes is " + backendIds.size());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -191,7 +191,7 @@ public class PropertyAnalyzer {
             } catch (Exception e) {
                 throw new AnalysisException(e.getMessage());
             }
-            checkTheRangeOfReplicationNum(replicationNum);
+            checkAvailableBackendsIsEnough(replicationNum);
             properties.remove(PROPERTIES_REPLICATION_NUM);
         }
         return replicationNum;
@@ -206,15 +206,15 @@ public class PropertyAnalyzer {
             key = PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
         }
         short replicationNum = Short.parseShort(properties.get(key));
-        checkTheRangeOfReplicationNum(replicationNum);
+        checkAvailableBackendsIsEnough(replicationNum);
         return replicationNum;
     }
 
-    private static void checkTheRangeOfReplicationNum(short replicationNum) throws AnalysisException {
+    private static void checkAvailableBackendsIsEnough(short replicationNum) throws AnalysisException {
         if (replicationNum <= 0) {
             throw new AnalysisException("Replication num should larger than 0. (suggested 3)");
         }
-        List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
+        List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().getAvailableBackendIds();
         if (replicationNum > backendIds.size()) {
             throw new AnalysisException("Replication num should less than current alive be node count" + 
             ", current alive be node count is [" + backendIds.size() + "]");

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -591,7 +591,7 @@ public class SystemInfoService {
     public List<Long> getAvailableBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
-        
+
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -577,6 +577,7 @@ public class SystemInfoService {
     public List<Long> getDecommissionedBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
+        
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -574,27 +574,27 @@ public class SystemInfoService {
         }
     }
 
-    public List<Long> getAvailableBackendIds() {
+    public List<Long> getDecommissionedBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());
-            if (backend == null || !backend.isAvailable()) {
+            if (backend == null || !backend.isDecommissioned()) {
                 iter.remove();
             }
         }
         return backendIds;
     }
 
-    public List<Long> getDecommissionedBackendIds() {
+    public List<Long> getAvailableBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
 
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());
-            if (backend == null || !backend.isDecommissioned()) {
+            if (backend == null || !backend.isAvailable()) {
                 iter.remove();
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -601,20 +601,6 @@ public class SystemInfoService {
         return backendIds;
     }
 
-    public List<Long> getAvailableBackendIds() {
-        ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
-        List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
-
-        Iterator<Long> iter = backendIds.iterator();
-        while (iter.hasNext()) {
-            Backend backend = this.getBackend(iter.next());
-            if (backend == null || !backend.isAvailable()) {
-                iter.remove();
-            }
-        }
-        return backendIds;
-    }
-
     public List<Backend> getBackends() {
         return idToBackendRef.values().asList();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -577,7 +577,7 @@ public class SystemInfoService {
     public List<Long> getDecommissionedBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
-        
+
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());
@@ -591,7 +591,7 @@ public class SystemInfoService {
     public List<Long> getAvailableBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
-
+        
         Iterator<Long> iter = backendIds.iterator();
         while (iter.hasNext()) {
             Backend backend = this.getBackend(iter.next());

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -574,6 +574,19 @@ public class SystemInfoService {
         }
     }
 
+    public List<Long> getAvailableBackendIds() {
+        ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
+        List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
+        Iterator<Long> iter = backendIds.iterator();
+        while (iter.hasNext()) {
+            Backend backend = this.getBackend(iter.next());
+            if (backend == null || !backend.isAvailable()) {
+                iter.remove();
+            }
+        }
+        return backendIds;
+    }
+
     public List<Long> getDecommissionedBackendIds() {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -95,7 +95,8 @@ public class AlterTest {
         Config.dynamic_partition_check_interval_seconds = 1;
         Config.enable_strict_storage_medium_check = false;
         UtFrameUtils.createMinStarRocksCluster();
-
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -57,6 +57,8 @@ public class ColocateTableTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -30,6 +30,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+
+import mockit.Expectations;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +61,6 @@ public class ColocateTableTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
     }
@@ -229,6 +231,7 @@ public class ColocateTableTest {
 
     @Test
     public void testReplicationNum() throws Exception {
+        
         createTable("create table " + dbName + "." + tableName1 + " (\n" +
                 " `k1` int NULL COMMENT \"\",\n" +
                 " `k2` varchar(10) NULL COMMENT \"\"\n" +
@@ -243,6 +246,16 @@ public class ColocateTableTest {
 
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("Colocate tables must have same replication num: 1");
+
+        GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
+        new Expectations(globalStateMgr) {
+            {
+                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
+                minTimes = 0;
+                result = Arrays.asList(10001, 10002, 10003);
+            }
+        };
+        
         createTable("create table " + dbName + "." + tableName2 + " (\n" +
                 " `k1` int NULL COMMENT \"\",\n" +
                 " `k2` varchar(10) NULL COMMENT \"\"\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -250,7 +250,7 @@ public class ColocateTableTest {
         GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
+                GlobalStateMgr.getCurrentSystemInfo().getAvailableBackendIds();
                 minTimes = 0;
                 result = Arrays.asList(10001, 10002, 10003);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -46,6 +46,8 @@ public class CreateTableTest {
         UtFrameUtils.createMinStarRocksCluster();
         Backend be = UtFrameUtils.addMockBackend(10002);
         be.setIsDecommissioned(true);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
         Config.enable_strict_storage_medium_check = true;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
@@ -8,7 +8,10 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.utframe.UtFrameUtils;
+
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.text.DateFormat;
@@ -20,6 +23,14 @@ import java.util.Map;
 
 public class ListPartitionDescTest {
 
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+    }
+    
     private List<ColumnDef> findColumnDefList() {
         ColumnDef id = new ColumnDef("id", TypeDef.create(PrimitiveType.BIGINT));
         id.setAggregateType(AggregateType.NONE);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -9,10 +9,13 @@ import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.utframe.UtFrameUtils;
+
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.DataInputStream;
@@ -32,6 +35,13 @@ public class ListPartitionInfoTest {
 
     private ListPartitionInfo listPartitionInfo;
     private ListPartitionInfo listPartitionInfoForMulti;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+    }
 
     @Before
     public void setUp() throws DdlException, AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MultiListPartitionDescTest.java
@@ -9,7 +9,10 @@ import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.utframe.UtFrameUtils;
+
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.text.DateFormat;
@@ -21,6 +24,13 @@ import java.util.Map;
 
 public class MultiListPartitionDescTest {
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+    }
+    
     @Test
     public void testToSQL() {
         String partitionName = "p1";

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SingleListPartitionDescTest.java
@@ -9,7 +9,10 @@ import com.starrocks.analysis.TypeDef;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.utframe.UtFrameUtils;
+
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.text.DateFormat;
@@ -21,6 +24,13 @@ import java.util.Map;
 
 public class SingleListPartitionDescTest {
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+    }
+    
     @Test
     public void testToSQL() {
         String partitionName = "p1";

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -49,7 +49,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageType;
-import com.starrocks.utframe.UtFrameUtils;
 
 import mockit.Expectations;
 import mockit.Mock;
@@ -59,7 +58,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,6 +65,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 
 public class ShowExecutorTest {
@@ -79,13 +78,6 @@ public class ShowExecutorTest {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
-    }
-    
     @Before
     public void setUp() throws Exception {
         ctx = new ConnectContext(null);
@@ -318,6 +310,15 @@ public class ShowExecutorTest {
 
     @Test
     public void testShowPartitions(@Mocked Analyzer analyzer) throws UserException {
+
+        globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
+        new Expectations(globalStateMgr) {
+            {
+                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
+                minTimes = 0;
+                result = Arrays.asList(10001, 10002, 10003);
+            }
+        };
         // Prepare to Test
         ListPartitionInfoTest listPartitionInfoTest = new ListPartitionInfoTest();
         listPartitionInfoTest.setUp();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -314,7 +314,7 @@ public class ShowExecutorTest {
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
+                GlobalStateMgr.getCurrentSystemInfo().getAvailableBackendIds();
                 minTimes = 0;
                 result = Arrays.asList(10001, 10002, 10003);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -49,6 +49,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.utframe.UtFrameUtils;
+
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -57,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,6 +79,13 @@ public class ShowExecutorTest {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+    }
+    
     @Before
     public void setUp() throws Exception {
         ctx = new ConnectContext(null);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -29,6 +29,8 @@ public class AnalyzeAlterTableStatementTest {
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         AnalyzeTestUtil.init();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
         connectContext = AnalyzeTestUtil.getConnectContext();
         clauseAnalyzerVisitor = new AlterTableStatementAnalyzer.AlterTableClauseAnalyzerVisitor();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -36,7 +36,8 @@ public class CTASAnalyzerTest {
         Config.dynamic_partition_enable = true;
         Config.dynamic_partition_check_interval_seconds = 1;
         UtFrameUtils.createMinStarRocksCluster();
-
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -46,6 +46,8 @@ public class PrivilegeCheckerTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
         starRocksAssert = new StarRocksAssert();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6619

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Validate replica number by BE count in CREATE/ALTER TABLE
Currently, we have the following two rules
1. replication_num needs larger than 0
2. replication_num need less than current alive be node count