### PR TITLE
[BugFix] Fix unknown error of profile merge mechanism

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -32,6 +32,7 @@ import com.starrocks.thrift.TRuntimeProfileNode;
 import com.starrocks.thrift.TRuntimeProfileTree;
 import com.starrocks.thrift.TUnit;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -544,35 +545,72 @@ public class RuntimeProfile {
 
         RuntimeProfile profile0 = profiles.get(0);
 
-        // merge counters
-        Map<String, Pair<TUnit, String>> counterTypes = Maps.newTreeMap();
+        // Find all counters, although these profiles are expected to be isomorphic,
+        // some counters are only attached to one of them
+        List<Map<String, Pair<TUnit, String>>> allLevelCounters = Lists.newArrayList();
         for (RuntimeProfile profile : profiles) {
-            for (Map.Entry<String, Pair<Counter, String>> entry : profile.counterMap.entrySet()) {
-                String name = entry.getKey();
-                Pair<Counter, String> pair = entry.getValue();
+            // Level order traverse starts with root
+            Queue<String> nameQueue = Lists.newLinkedList();
+            nameQueue.offer(ROOT_COUNTER);
+            int levelIdx = -1;
+            while (!nameQueue.isEmpty()) {
+                levelIdx++;
+                List<String> currentNames = Lists.newArrayList(nameQueue);
+                nameQueue.clear();
+                for (String name : currentNames) {
+                    if (NON_MERGE_COUNTER_NAMES.contains(name)) {
+                        continue;
+                    }
 
-                if (NON_MERGE_COUNTER_NAMES.contains(name)) {
-                    continue;
-                }
+                    TreeSet<String> childNames = profile.childCounterMap.get(name);
+                    if (childNames != null) {
+                        for (String childName : childNames) {
+                            nameQueue.offer(childName);
+                        }
+                    }
 
-                if (!counterTypes.containsKey(name)) {
-                    counterTypes.put(name, Pair.create(pair.first.getType(), pair.second));
-                    continue;
-                }
-                TUnit existType = counterTypes.get(name).first;
-                if (!existType.equals(pair.first.getType())) {
-                    LOG.warn(
-                            "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
-                            profile0.name, name, existType.name(), pair.first.getType().name());
-                    return;
+                    if (Objects.equals(ROOT_COUNTER, name)) {
+                        continue;
+                    }
+                    Pair<Counter, String> pair = profile.counterMap.get(name);
+                    Preconditions.checkNotNull(pair);
+                    Counter counter = pair.first;
+                    String parentName = pair.second;
+
+                    while (allLevelCounters.size() <= levelIdx) {
+                        allLevelCounters.add(Maps.newHashMap());
+                    }
+
+                    Map<String, Pair<TUnit, String>> levelCounters = allLevelCounters.get(levelIdx);
+                    if (!levelCounters.containsKey(name)) {
+                        levelCounters.put(name, Pair.create(counter.getType(), parentName));
+                        continue;
+                    }
+                    TUnit existType = levelCounters.get(name).first;
+                    if (!existType.equals(counter.getType())) {
+                        LOG.warn(
+                                "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
+                                profile0.name, name, existType.name(), counter.getType().name());
+                        return;
+                    }
                 }
             }
         }
 
-        for (Map.Entry<String, Pair<TUnit, String>> entry : counterTypes.entrySet()) {
-            String name = entry.getKey();
-            TUnit type = entry.getValue().first;
-            String parentName = entry.getValue().second;
+        List<Triple<TUnit, String, String>> levelOrderedCounters = Lists.newArrayList();
+        for (Map<String, Pair<TUnit, String>> levelCounters : allLevelCounters) {
+            for (Map.Entry<String, Pair<TUnit, String>> entry : levelCounters.entrySet()) {
+                String name = entry.getKey();
+                TUnit type = entry.getValue().first;
+                String parentName = entry.getValue().second;
+                levelOrderedCounters.add(Triple.of(type, name, parentName));
+            }
+        }
+
+        for (Triple<TUnit, String, String> triple : levelOrderedCounters) {
+            TUnit type = triple.getLeft();
+            String name = triple.getMiddle();
+            String parentName = triple.getRight();
 
             // We don't need to calculate sum or average of counter's extra info (min value and max value) created by be
             if (name.startsWith(MERGED_INFO_PREFIX_MIN) || name.startsWith(MERGED_INFO_PREFIX_MAX)) {
@@ -586,7 +624,7 @@ public class RuntimeProfile {
             for (RuntimeProfile profile : profiles) {
                 Counter counter = profile.getCounter(name);
 
-                // Allow some of the counters only attach to one of the isomorphic profiles
+                // Allow some counters which only attach to one of the isomorphic profiles
                 // E.g. A bunch of ExchangeSinkOperators may share one SinkBuffer, so the metrics
                 // of SinkBuffer only attach to the first ExchangeSinkOperator's profile
                 if (counter == null) {
@@ -623,10 +661,18 @@ public class RuntimeProfile {
             }
 
             Counter counter0 = profile0.getCounter(name);
-            // As memtioned before, some counters may only attach to one of the isomorphic profiles
+            // As stated before, some counters may only attach to one of the isomorphic profiles
             // and the first profile may not have this counter, so we create a counter here
             if (counter0 == null) {
-                counter0 = profile0.addCounter(name, type, parentName);
+                if (!Objects.equals(ROOT_COUNTER, parentName) && profile0.getCounter(parentName) != null) {
+                    counter0 = profile0.addCounter(name, type, parentName);
+                } else {
+                    if (!Objects.equals(ROOT_COUNTER, parentName)) {
+                        LOG.warn("missing parent counter, profileName={}, counterName={}, parentCounterName={}",
+                                profile0.name, name, parentName);
+                    }
+                    counter0 = profile0.addCounter(name, type);
+                }
             }
             counter0.setValue(mergedValue);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9553

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Traverse counter in level ordered way, i.e. visit counters through its hierarchy, starting from root counter. In order to avoid missing parent counter when add child counters.

Consider the following 2 profiles. Noticing that profile1 has one counter while profile2 has two counters, and `subCnt1` is a child counter of `cnt1`. These two profiles will be merged into one profile. But if we visit count in the order `subCnt1 -> cnt1`, we may come across an assertion failure if we add `subCnt1` before `cnt1`.

```
# profile1
- cnt1
```

```
# profile2
- cnt1
    - subCnt1
```

So, the solution is straightforward, we need to traverse the counters by its hierarchy. For the above case, we must first visit `cnt1` then `subCnt1`