### PR TITLE
[BugFix] build script supports Python3 and fix file path typos (#9563)

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -40,12 +40,18 @@ if [[ -z ${STARROCKS_THIRDPARTY} ]]; then
 fi
 
 # check python
-export PYTHON=python
+if [[ -z ${PYTHON} ]]; then
+    export PYTHON=python
+fi
+
 if ! ${PYTHON} --version; then
     export PYTHON=python2.7
     if ! ${PYTHON} --version; then
-        echo "Error: python is not found"
-        exit 1
+        export PYTHON=python3
+        if ! ${PYTHON} --version; then
+            echo "Error: python is not found"
+            exit 1
+        fi
     fi
 fi
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -39,6 +39,7 @@ under the License.
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.5</jacoco.version>
         <iceberg.version>0.12.1</iceberg.version>
+        <python>python</python>
     </properties>
 
     <profiles>
@@ -79,7 +80,17 @@ under the License.
                 <starrocks.thrift>thrift.exe</starrocks.thrift>
             </properties>
         </profile>
-
+        <profile>
+            <id>python</id>
+            <activation>
+                <property>
+                    <name>env.PYTHON</name>
+                </property>
+            </activation>
+            <properties>
+                <python>${env.PYTHON}</python>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -809,6 +820,7 @@ under the License.
                         <phase>generate-sources</phase>
                         <configuration>
                             <tasks>
+                                <property name="ant.python" value="${python}"/>
                                 <mkdir dir="${basedir}/target/generated-sources/proto"/>
                                 <exec executable="${java.home}/bin/java">
                                     <arg value="-jar"/>
@@ -828,7 +840,7 @@ under the License.
                                     <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
                                     <arg value="${starrocks.home}/gensrc/proto/lake_service.proto"/>
                                 </exec>
-                                <exec executable="${PYTHON}">
+                                <exec executable="${ant.python}">
                                     <arg value="${starrocks.home}/build-support/gen_build_version.py"/>
                                     <arg value="--cpp"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
@@ -836,7 +848,7 @@ under the License.
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>
                                 <mkdir dir="${starrocks.home}/gensrc/build/python/vectorized"/>
-                                <exec executable="${PYTHON}" dir="${starrocks.home}/gensrc/build/python/vectorized">
+                                <exec executable="${ant.python}" dir="${starrocks.home}/gensrc/build/python/vectorized">
                                     <arg value="${starrocks.home}/gensrc/script/vectorized/gen_vectorized_functions.py"/>
                                 </exec>
                             </tasks>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -828,15 +828,15 @@ under the License.
                                     <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
                                     <arg value="${starrocks.home}/gensrc/proto/lake_service.proto"/>
                                 </exec>
-                                <exec executable="python">
+                                <exec executable="${PYTHON}">
                                     <arg value="${starrocks.home}/build-support/gen_build_version.py"/>
                                     <arg value="--cpp"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                     <arg value="--java"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>
-                                <mkdir dir="${starrocks.home}gensrc/build/python/vectorized"/>
-                                <exec executable="python" dir="${starrocks.home}gensrc/build/python/vectorized">
+                                <mkdir dir="${starrocks.home}/gensrc/build/python/vectorized"/>
+                                <exec executable="${PYTHON}" dir="${starrocks.home}/gensrc/build/python/vectorized">
                                     <arg value="${starrocks.home}/gensrc/script/vectorized/gen_vectorized_functions.py"/>
                                 </exec>
                             </tasks>


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9563

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. add python3 support in env.sh.
2. Add a default python execute command property and update it when user set a PYTHON environment variable. Use this property in antrun-plugin to ensure build successfully in platform with Python2.x installed or PYTHON environment variable had been set. This won't help user who only installed Python3 and without setting PYTHON environment variable.