### PR TITLE
[BugFix] Show routine load for non-existed job

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -136,7 +136,7 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
         return Status::InternalError("PAUSE: failed to create kafka consumer: " + errstr);
     }
 
-    LOG(INFO) << "finished to init kafka consumer. " << ctx->brief();
+    VLOG(3) << "finished to init kafka consumer. " << ctx->brief();
 
     _init = true;
     return Status::OK();

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -136,7 +136,7 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
         return Status::InternalError("PAUSE: failed to create kafka consumer: " + errstr);
     }
 
-    VLOG(3) << "finished to init kafka consumer. " << ctx->brief();
+    LOG(INFO) << "finished to init kafka consumer. " << ctx->brief();
 
     _init = true;
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
@@ -93,8 +93,6 @@ public class ShowRoutineLoadStmt extends ShowStmt {
                     .build();
 
     private final LabelName labelName;
-    private String dbFullName; // optional
-    private String name; // optional
     private boolean includeHistory = false;
     private RoutineLoadFunctionalExprProvider functionalExprProvider;
     private Expr whereClause;
@@ -115,11 +113,11 @@ public class ShowRoutineLoadStmt extends ShowStmt {
     }
 
     public String getDbFullName() {
-        return dbFullName;
+        return labelName.getDbName();
     }
 
     public String getName() {
-        return name;
+        return labelName.getLabelName();
     }
 
     public boolean isIncludeHistory() {
@@ -152,14 +150,13 @@ public class ShowRoutineLoadStmt extends ShowStmt {
 
     @Deprecated
     private void checkLabelName(Analyzer analyzer) throws AnalysisException {
-        dbFullName = labelName == null ? null : labelName.getDbName();
-        if (Strings.isNullOrEmpty(dbFullName)) {
-            dbFullName = analyzer.getContext().getDatabase();
-            if (Strings.isNullOrEmpty(dbFullName)) {
+        if (Strings.isNullOrEmpty(labelName.getDbName())) {
+            String dbName = analyzer.getContext().getDatabase();
+            if (Strings.isNullOrEmpty(dbName)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
             }
+            labelName.setDbName(dbName);
         }
-        name = labelName == null ? null : labelName.getLabelName();
     }
 
     public static List<String> getTitleNames() {
@@ -213,7 +210,7 @@ public class ShowRoutineLoadStmt extends ShowStmt {
     }
 
     public void setDb(String db) {
-        this.dbFullName = db;
+        this.labelName.setDbName(db);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -778,7 +778,7 @@ public class ShowExecutorTest {
     public void testShowRoutineLoadNonExisted() throws AnalysisException, DdlException {
         ShowRoutineLoadStmt stmt = new ShowRoutineLoadStmt(new LabelName("testDb", "non-existed-job-name"), false);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
-        // AnalysisException("There is no job named...") is  expected.
+        // AnalysisException("There is no job named...") is expected.
         Assert.assertThrows(AnalysisException.class, () -> executor.execute());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -22,25 +22,7 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.AccessTestUtil;
-import com.starrocks.analysis.Analyzer;
-import com.starrocks.analysis.DescribeStmt;
-import com.starrocks.analysis.HelpStmt;
-import com.starrocks.analysis.SetType;
-import com.starrocks.analysis.ShowAuthorStmt;
-import com.starrocks.analysis.ShowBackendsStmt;
-import com.starrocks.analysis.ShowColumnStmt;
-import com.starrocks.analysis.ShowCreateDbStmt;
-import com.starrocks.analysis.ShowCreateTableStmt;
-import com.starrocks.analysis.ShowDbStmt;
-import com.starrocks.analysis.ShowEnginesStmt;
-import com.starrocks.analysis.ShowMaterializedViewStmt;
-import com.starrocks.analysis.ShowPartitionsStmt;
-import com.starrocks.analysis.ShowProcedureStmt;
-import com.starrocks.analysis.ShowTableStmt;
-import com.starrocks.analysis.ShowUserStmt;
-import com.starrocks.analysis.ShowVariablesStmt;
-import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.*;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
@@ -789,6 +771,16 @@ public class ShowExecutorTest {
         Assert.assertEquals("testDb", resultSet.getString(2));
         Assert.assertEquals("create materialized view testMv select col1, col2 from table1", resultSet.getString(3));
         Assert.assertEquals("10", resultSet.getString(4));
+        Assert.assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testShowRoutineLoadNonExisted() throws AnalysisException, DdlException {
+        ShowRoutineLoadStmt stmt = new ShowRoutineLoadStmt(new LabelName("testDb", "non-existed-job-name"), false);
+        ShowExecutor executor = new ShowExecutor(ctx, stmt);
+        ShowResultSet resultSet = executor.execute();
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("1000", resultSet.getString(0));
         Assert.assertFalse(resultSet.next());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -778,9 +778,7 @@ public class ShowExecutorTest {
     public void testShowRoutineLoadNonExisted() throws AnalysisException, DdlException {
         ShowRoutineLoadStmt stmt = new ShowRoutineLoadStmt(new LabelName("testDb", "non-existed-job-name"), false);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
-        ShowResultSet resultSet = executor.execute();
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("1000", resultSet.getString(0));
-        Assert.assertFalse(resultSet.next());
+        // AnalysisException("There is no job named...") is  expected.
+        Assert.assertThrows(AnalysisException.class, () -> executor.execute());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/883

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The job name of `ShowRoutineLoadStmt` is unset with the new analyzer.
The label name contains db/job name, so it's no need to retain db/job name alone.
To fix this problem and simplify the code, this PR removes the db name and job name of the stmt, and replaces them with label name.
