### PR TITLE
[Enhancement] Avoid VERSION_INCOMPLETE repair task got blocked by REPLICA_MISSING

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -588,6 +588,20 @@ public class SystemInfoService {
         return backendIds;
     }
 
+    public List<Long> getAvailableBackendIds() {
+        ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
+        List<Long> backendIds = Lists.newArrayList(idToBackend.keySet());
+
+        Iterator<Long> iter = backendIds.iterator();
+        while (iter.hasNext()) {
+            Backend backend = this.getBackend(iter.next());
+            if (backend == null || !backend.isAvailable()) {
+                iter.remove();
+            }
+        }
+        return backendIds;
+    }
+
     public List<Backend> getBackends() {
         return idToBackendRef.values().asList();
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We should create a `REPLICA_MISSING` type task only when there exists enough available BEs which
we can choose to clone data. If not, we should check if we can create a `VERSION_INCOMPLETE` task
so that the repair of the replica with an incomplete version won't be blocked. Therefore the version publish process
of load task won't be blocked either.