### PR TITLE
[Bugfixi] not support create mv by mv #9543

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -115,6 +115,11 @@ public class MaterializedViewAnalyzer {
                             "Materialized view only supports olap table, but the type of table: " +
                                     table.getName() + " is: " + table.getType().name());
                 }
+                if (table instanceof MaterializedView) {
+                    throw new SemanticException(
+                            "Creating a materialized view from materialized view is not supported now. The type of table: " +
+                                    table.getName() + " is: Materialized View");
+                }
                 baseTableIds.add(table.getId());
             });
             statement.setBaseTableIds(baseTableIds);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1189,6 +1189,39 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
+    public void testAsTableOnMV() {
+        String sql1 = "create materialized view mv1 " +
+                "partition by k1 " +
+                "distributed by hash(k2) " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select k1, k2 from tbl1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql1, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        String sql2 = "create materialized view mv2 " +
+                "partition by k1 " +
+                "distributed by hash(k2) " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select k1, k2 from mv1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql2, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        } catch (Exception e) {
+            Assert.assertEquals("Creating a materialized view from materialized view is not supported now." +
+                    " The type of table: mv1 is: Materialized View", e.getMessage());
+        }
+    }
+
+    @Test
     public void testAsHasStar() {
         String sql = "create materialized view mv1 " +
                 "partition by ss " +


### PR DESCRIPTION
[Bugfix] not support create mv by mv #9543

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9543 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
CREATE TABLE t1
(a BIGINT,
b BIGINT,
c BIGINT,
d BIGINT,
e BIGINT,
f BIGINT)
DUPLICATE KEY(a)
DISTRIBUTED BY HASH(a) BUCKETS 10
PROPERTIES ("replication_num" = "1");

CREATE MATERIALIZED VIEW mv1
DISTRIBUTED BY HASH(a) BUCKETS 10
REFRESH ASYNC
AS SELECT a, b, c
FROM t1;

CREATE MATERIALIZED VIEW mv2
DISTRIBUTED BY HASH(a) BUCKETS 10
REFRESH ASYNC
AS SELECT a, b, c
FROM mv1;
```

Result:
```
MySQL [n1]> CREATE MATERIALIZED VIEW mv2
    -> DISTRIBUTED BY HASH(a) BUCKETS 10
    -> REFRESH ASYNC
    -> AS SELECT a, b, c
    -> FROM mv1;
ERROR 1064 (HY000): Materialized view not supports base on Materialized view so far, but the type of table: mv1 is: MATERIALIZED_VIEW
```

![image](https://user-images.githubusercontent.com/70745826/182819439-d2def87e-b710-48d8-af51-645db0fa1c12.png)
