### PR TITLE
[BugFix] Remove colocated index from memory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -373,10 +373,8 @@ public class CatalogRecycleBin extends LeaderDaemon implements Writable {
                 Runnable runnable = null;
                 Table table = tableInfo.getTable();
                 nameToTableInfo.remove(dbId, table.getName());
-                if (!isCheckpointThread()) {
-                    runnable = table.delete(true);
-                }
-                if (runnable != null) {
+                runnable = table.delete(true);
+                if (!isCheckpointThread() && runnable != null) {
                     runnable.run();
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -114,7 +114,7 @@ public class ColocateTableIndex implements Writable {
     }
 
     // group_name -> group_id
-    private Map<String, GroupId> groupName2Id = Maps.newHashMap();
+    protected Map<String, GroupId> groupName2Id = Maps.newHashMap();
     // group_id -> table_ids
     private Multimap<GroupId, Long> group2Tables = ArrayListMultimap.create();
     // table_id -> group_id
@@ -742,6 +742,8 @@ public class ColocateTableIndex implements Writable {
         if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_46) {
             GlobalStateMgr.getCurrentColocateIndex().readFields(dis);
         }
+        // clean up if dbId or tableId not found, this is actually a bug
+        cleanupInvalidDbOrTable(GlobalStateMgr.getCurrentState());
         LOG.info("finished replay colocateTableIndex from image");
         return checksum;
     }
@@ -847,6 +849,36 @@ public class ColocateTableIndex implements Writable {
             LOG.warn("failed to replay modify table colocate", e);
         } finally {
             db.writeUnlock();
+        }
+    }
+
+    /**
+     * for legacy reason, all the colocate group index cannot be properly removed
+     * we have to add a cleanup function on start when loading image
+     */
+    protected void cleanupInvalidDbOrTable(GlobalStateMgr globalStateMgr) {
+        List<Long> badTableIds = new ArrayList<>();
+        for (Map.Entry<Long, GroupId> entry : table2Group.entrySet()) {
+            long dbId = entry.getValue().dbId;
+            long tableId = entry.getKey();
+            Database database = globalStateMgr.getDbIncludeRecycleBin(dbId);
+            if (database == null) {
+                LOG.warn("cannot find db {}, will remove invalid table {} from group {}",
+                        dbId, tableId, entry.getValue());
+            } else {
+                Table table = globalStateMgr.getTableIncludeRecycleBin(database, tableId);
+                if (table != null) {
+                    // this is a valid table/database, do nothing
+                    continue;
+                }
+                LOG.warn("cannot find table {} in db {}, will remove invalid table {} from group {}",
+                        tableId, dbId, tableId, entry.getValue());
+            }
+            badTableIds.add(tableId);
+        }
+        LOG.warn("remove {} invalid tableid: {}", badTableIds.size(), badTableIds);
+        for (Long tableId : badTableIds) {
+            removeTable(tableId);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -114,7 +114,7 @@ public class ColocateTableIndex implements Writable {
     }
 
     // group_name -> group_id
-    protected Map<String, GroupId> groupName2Id = Maps.newHashMap();
+    private Map<String, GroupId> groupName2Id = Maps.newHashMap();
     // group_id -> table_ids
     private Multimap<GroupId, Long> group2Tables = ArrayListMultimap.create();
     // table_id -> group_id


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5681

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is a legacy bug that will keep colocated groups in memory FOREVER.
The root cause is probably that we intended to skip change `TabletInvertedIndex` when making a checkpoint. Since `table.delete()` will call `invertedIndex.deleteTablet()` function that will eventually change `TabletInvertedIndex`, we won't call `table.delete()` in checkpointer. Unfortunately, this function is also responsible for removing colocated groups from memory. As a result, when making a checkpoint, the colocate group index will stay in the final image and never be removed.

1. Call `table.delete()` when replaying a journal of erasing table.
2. Add an extra function `cleanupInvalidDbOrTable` to clean all the invalid colocated groups of which table or database is not found. We should clean up every time an image is loaded so that all legacy colocated groups can clean up at once.