### PR TITLE
[Bugfix] Sync cpu cores of BEs when replaying master FE info to other FEs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -350,6 +350,14 @@ public class ComputeNode implements IComputable, Writable {
         return DecommissionBackendJob.DecommissionType.SystemDecommission;
     }
 
+    public int getCpuCores() {
+        return cpuCores;
+    }
+
+    public void setCpuCores(int cpuCores) {
+        this.cpuCores = cpuCores;
+    }
+
     /**
      * handle Compute node's heartbeat response.
      * return true if any port changed, or alive state is changed.

--- a/fe/fe-core/src/main/java/com/starrocks/system/FrontendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/FrontendHbResponse.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.system;
 
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -29,6 +30,7 @@ import com.starrocks.common.util.TimeUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Frontend heartbeat response contains Frontend's query port, rpc port and current replayed journal id.
@@ -49,8 +51,20 @@ public class FrontendHbResponse extends HeartbeatResponse implements Writable {
     @SerializedName(value = "feVersion")
     private String feVersion;
 
+    // Synchronize cpu cores of backends when synchronizing master info to other Frontends.
+    // It is non-empty, only when replaying a 'mocked' master Frontend heartbeat response to other Frontends.
+    @SerializedName(value = "backendId2cpuCores")
+    private Map<Long, Integer> backendId2cpuCores = Maps.newHashMap();
+
     public FrontendHbResponse() {
         super(HeartbeatResponse.Type.FRONTEND);
+    }
+
+    public FrontendHbResponse(String name, int queryPort, int rpcPort,
+                              long replayedJournalId, long hbTime, long feStartTime, String feVersion,
+                              Map<Long, Integer> backendId2cpuCores) {
+        this(name, queryPort, rpcPort, replayedJournalId, hbTime, feStartTime, feVersion);
+        this.backendId2cpuCores = backendId2cpuCores;
     }
 
     public FrontendHbResponse(String name, int queryPort, int rpcPort,
@@ -95,6 +109,10 @@ public class FrontendHbResponse extends HeartbeatResponse implements Writable {
 
     public String getFeVersion() {
         return feVersion;
+    }
+
+    public Map<Long, Integer> getBackendId2cpuCores() {
+        return backendId2cpuCores;
     }
 
     public static FrontendHbResponse read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -158,11 +158,14 @@ public class HeartbeatMgr extends LeaderDaemon {
             }
         } // end for all results
 
-        // we also add a 'mocked' master Frontends heartbeat response to synchronize master info to other Frontends.
+        // we also add a 'mocked' master Frontend heartbeat response to synchronize master info to other Frontends.
+        Map<Long, Integer> backendId2cpuCores = Maps.newHashMap();
+        nodeMgr.getIdToBackend().values().forEach(
+                backend -> backendId2cpuCores.put(backend.getId(), BackendCoreStat.getCoresOfBe(backend.getId())));
         hbPackage.addHbResponse(new FrontendHbResponse(masterFeNodeName, Config.query_port, Config.rpc_port,
                 GlobalStateMgr.getCurrentState().getMaxJournalId(),
                 System.currentTimeMillis(), GlobalStateMgr.getCurrentState().getFeStartTime(),
-                Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH));
+                Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH, backendId2cpuCores));
 
         // write edit log
         GlobalStateMgr.getCurrentState().getEditLog().logHeartbeat(hbPackage);
@@ -172,6 +175,17 @@ public class HeartbeatMgr extends LeaderDaemon {
         switch (response.getType()) {
             case FRONTEND: {
                 FrontendHbResponse hbResponse = (FrontendHbResponse) response;
+
+                // Synchronize cpu cores of backends when synchronizing master info to other Frontends.
+                // It is non-empty, only when replaying a 'mocked' master Frontend heartbeat response to other Frontends.
+                hbResponse.getBackendId2cpuCores().forEach((backendId, cpuCores) -> {
+                    Backend be = nodeMgr.getBackend(backendId);
+                    if (be != null && be.getCpuCores() != cpuCores) {
+                        be.setCpuCores(cpuCores);
+                        BackendCoreStat.setNumOfHardwareCoresOfBe(backendId, cpuCores);
+                    }
+                });
+
                 Frontend fe = GlobalStateMgr.getCurrentState().getFeByName(hbResponse.getName());
                 if (fe != null) {
                     return fe.handleHbResponse(hbResponse, isReplay);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9581.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, The follower FE could get the BE cpuCores from the master FE by replaying `BEHeartbeatResponse` log from the master FE.
However, if the following two conditions are established, `BEHeartbeatResponse` would never be replaying to the new follower FEs.
1. The master FE already saves a new checkpoint image after replaying `BEHeartbeatResponse` log.
2. The information about BE doesn't change, so there wouldn't replaying a new `BEHeartbeatResponse` log.

Therefore, synchronize cpu cores of backends when synchronizing master info to other Frontends.

In addition, there is another way to solve this. We could persistent cpuCores of each backend to the catalog image. However, we should solve this problem both in the branch-2.3 and main branch, and the catalog image format has already been significantly different between the branch-2.3 and main branch, which causes we can't guarantee the compatibility of catalog image format in the branch-2.3 and main branch at the same time.



