### PR TITLE
[BugFix] BE blocked in starrocks::KafkaDataConsumer::get_partition_offset

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -789,4 +789,6 @@ CONF_String(dependency_librdkafka_debug, "all");
 // max loop count when be waiting its fragments finish
 CONF_Int64(loop_count_wait_fragments_finish, "0");
 
+CONF_Int32(internal_service_async_thread_num, "2");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -789,6 +789,8 @@ CONF_String(dependency_librdkafka_debug, "all");
 // max loop count when be waiting its fragments finish
 CONF_Int64(loop_count_wait_fragments_finish, "0");
 
-CONF_Int32(internal_service_async_thread_num, "2");
+// Now, only get_info is processed by _async_thread_pool, and only needs a small number of threads.
+// The default value is set as the THREAD_POOL_SIZE of RoutineLoadTaskScheduler of FE.
+CONF_Int32(internal_service_async_thread_num, "10");
 
 } // namespace starrocks::config

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -315,8 +315,7 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
 
     // get topic metadata
     RdKafka::Metadata* metadata = nullptr;
-    RdKafka::ErrorCode err = _k_consumer->metadata(true /* for this topic */, topic, &metadata,
-                                                   timeout);
+    RdKafka::ErrorCode err = _k_consumer->metadata(true /* for this topic */, topic, &metadata, timeout);
     if (err != RdKafka::ERR_NO_ERROR) {
         std::stringstream ss;
         ss << "failed to get partition meta: " << RdKafka::err2str(err);

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -273,15 +273,15 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
 
 Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_ids,
                                                std::vector<int64_t>* beginning_offsets,
-                                               std::vector<int64_t>* latest_offsets) {
+                                               std::vector<int64_t>* latest_offsets, int timeout) {
     _last_visit_time = time(nullptr);
     beginning_offsets->reserve(partition_ids->size());
     latest_offsets->reserve(partition_ids->size());
     for (auto p_id : *partition_ids) {
         int64_t beginning_offset;
         int64_t latest_offset;
-        RdKafka::ErrorCode err = _k_consumer->query_watermark_offsets(_topic, p_id, &beginning_offset, &latest_offset,
-                                                                      config::routine_load_kafka_timeout_second * 1000);
+        RdKafka::ErrorCode err =
+                _k_consumer->query_watermark_offsets(_topic, p_id, &beginning_offset, &latest_offset, timeout);
         if (err != RdKafka::ERR_NO_ERROR) {
             LOG(WARNING) << "failed to query watermark offset of topic: " << _topic << " partition: " << p_id
                          << ", err: " << RdKafka::err2str(err);
@@ -294,7 +294,7 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
     return Status::OK();
 }
 
-Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids) {
+Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids, int timeout) {
     _last_visit_time = time(nullptr);
     // create topic conf
     RdKafka::Conf* tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
@@ -316,7 +316,7 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
     // get topic metadata
     RdKafka::Metadata* metadata = nullptr;
     RdKafka::ErrorCode err = _k_consumer->metadata(true /* for this topic */, topic, &metadata,
-                                                   config::routine_load_kafka_timeout_second * 1000);
+                                                   timeout);
     if (err != RdKafka::ERR_NO_ERROR) {
         std::stringstream ss;
         ss << "failed to get partition meta: " << RdKafka::err2str(err);

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -135,11 +135,11 @@ public:
     Status group_consume(TimedBlockingQueue<RdKafka::Message*>* queue, int64_t max_running_time_ms);
 
     // get the partitions ids of the topic
-    Status get_partition_meta(std::vector<int32_t>* partition_ids);
+    Status get_partition_meta(std::vector<int32_t>* partition_ids, int timeout);
 
     // get beginning or latest offset of partitions
     Status get_partition_offset(std::vector<int32_t>* partition_ids, std::vector<int64_t>* beginning_offsets,
-                                std::vector<int64_t>* latest_offsets);
+                                std::vector<int64_t>* latest_offsets, int timeout);
 
 private:
     std::string _brokers;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -40,7 +40,7 @@
 namespace starrocks {
 
 Status RoutineLoadTaskExecutor::get_kafka_partition_meta(const PKafkaMetaProxyRequest& request,
-                                                         std::vector<int32_t>* partition_ids) {
+                                                         std::vector<int32_t>* partition_ids, int timeout) {
     DCHECK(request.has_kafka_info());
 
     // This context is meaningless, just for unifing the interface
@@ -66,7 +66,7 @@ Status RoutineLoadTaskExecutor::get_kafka_partition_meta(const PKafkaMetaProxyRe
     std::shared_ptr<DataConsumer> consumer;
     RETURN_IF_ERROR(_data_consumer_pool.get_consumer(&ctx, &consumer));
 
-    Status st = std::static_pointer_cast<KafkaDataConsumer>(consumer)->get_partition_meta(partition_ids);
+    Status st = std::static_pointer_cast<KafkaDataConsumer>(consumer)->get_partition_meta(partition_ids, timeout);
     if (st.ok()) {
         _data_consumer_pool.return_consumer(consumer);
     }
@@ -75,7 +75,7 @@ Status RoutineLoadTaskExecutor::get_kafka_partition_meta(const PKafkaMetaProxyRe
 
 Status RoutineLoadTaskExecutor::get_kafka_partition_offset(const PKafkaOffsetProxyRequest& request,
                                                            std::vector<int64_t>* beginning_offsets,
-                                                           std::vector<int64_t>* latest_offsets) {
+                                                           std::vector<int64_t>* latest_offsets, int timeout) {
     DCHECK(request.has_kafka_info());
 
     // This context is meaningless, just for unifing the interface
@@ -109,7 +109,7 @@ Status RoutineLoadTaskExecutor::get_kafka_partition_offset(const PKafkaOffsetPro
     RETURN_IF_ERROR(_data_consumer_pool.get_consumer(&ctx, &consumer));
 
     Status st = std::static_pointer_cast<KafkaDataConsumer>(consumer)->get_partition_offset(
-            &partition_ids, beginning_offsets, latest_offsets);
+            &partition_ids, beginning_offsets, latest_offsets, timeout);
     if (st.ok()) {
         _data_consumer_pool.return_consumer(consumer);
     }

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -75,7 +75,8 @@ public:
     // submit a routine load task
     Status submit_task(const TRoutineLoadTask& task);
 
-    Status get_kafka_partition_meta(const PKafkaMetaProxyRequest& request, std::vector<int32_t>* partition_ids, int timeout);
+    Status get_kafka_partition_meta(const PKafkaMetaProxyRequest& request, std::vector<int32_t>* partition_ids,
+                                    int timeout);
 
     Status get_kafka_partition_offset(const PKafkaOffsetProxyRequest& request, std::vector<int64_t>* beginning_offsets,
                                       std::vector<int64_t>* latest_offsets, int timeout);

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -75,10 +75,10 @@ public:
     // submit a routine load task
     Status submit_task(const TRoutineLoadTask& task);
 
-    Status get_kafka_partition_meta(const PKafkaMetaProxyRequest& request, std::vector<int32_t>* partition_ids);
+    Status get_kafka_partition_meta(const PKafkaMetaProxyRequest& request, std::vector<int32_t>* partition_ids, int timeout);
 
     Status get_kafka_partition_offset(const PKafkaOffsetProxyRequest& request, std::vector<int64_t>* beginning_offsets,
-                                      std::vector<int64_t>* latest_offsets);
+                                      std::vector<int64_t>* latest_offsets, int timeout);
 
 private:
     // execute the task

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -52,7 +52,7 @@ using PromiseStatusSharedPtr = std::shared_ptr<PromiseStatus>;
 template <typename T>
 PInternalServiceImplBase<T>::PInternalServiceImplBase(ExecEnv* exec_env)
         : _exec_env(exec_env),
-        // Now, only get_info is processed by _async_thread_pool, and only needs a small number of threads.
+          // Now, only get_info is processed by _async_thread_pool, and only needs a small number of threads.
           _async_thread_pool("async_thread_pool", config::internal_service_async_thread_num,
                              config::internal_service_async_thread_num * 4) {}
 
@@ -390,7 +390,9 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
     GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable> latch(1);
 
     if (!_async_thread_pool.try_offer([&]() { _get_info_impl(request, response, &latch); })) {
-        Status::ServiceUnavailable("too busy to get kafka info, please check the kafka broker status, or set internal_service_async_thread_num bigger")
+        Status::ServiceUnavailable(
+                "too busy to get kafka info, please check the kafka broker status, or set "
+                "internal_service_async_thread_num bigger")
                 .to_protobuf(response->mutable_status());
         return;
     }
@@ -399,8 +401,9 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
 }
 
 template <typename T>
-void PInternalServiceImplBase<T>::_get_info_impl(const PProxyRequest* request, PProxyResult* response,
-                                                 GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch) {
+void PInternalServiceImplBase<T>::_get_info_impl(
+        const PProxyRequest* request, PProxyResult* response,
+        GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch) {
     DeferOp defer([latch] { latch->count_down(); });
 
     if (request->has_kafka_meta_request()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -39,6 +39,7 @@
 #include "runtime/routine_load/routine_load_task_executor.h"
 #include "runtime/runtime_filter_worker.h"
 #include "service/brpc.h"
+#include "util/stopwatch.hpp"
 #include "util/thrift_util.h"
 #include "util/uid_util.h"
 
@@ -52,9 +53,8 @@ using PromiseStatusSharedPtr = std::shared_ptr<PromiseStatus>;
 template <typename T>
 PInternalServiceImplBase<T>::PInternalServiceImplBase(ExecEnv* exec_env)
         : _exec_env(exec_env),
-          // Now, only get_info is processed by _async_thread_pool, and only needs a small number of threads.
           _async_thread_pool("async_thread_pool", config::internal_service_async_thread_num,
-                             config::internal_service_async_thread_num * 4) {}
+                             config::internal_service_async_thread_num) {}
 
 template <typename T>
 PInternalServiceImplBase<T>::~PInternalServiceImplBase() = default;
@@ -389,7 +389,17 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
 
     GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable> latch(1);
 
-    if (!_async_thread_pool.try_offer([&]() { _get_info_impl(request, response, &latch); })) {
+    int timeout = request->has_timeout() ? request->timeout : config::routine_load_kafka_timeout_second;
+
+    // watch estimates the interval before the task is actually executed.
+    MonotonicStopWatch watch;
+    watch.start();
+
+    if (!_async_thread_pool.try_offer([&]() {
+            watch.stop();
+            timeout -= watch.elapsed_time() / 1000 / 1000;
+            _get_info_impl(request, response, &latch, timeout);
+        })) {
         Status::ServiceUnavailable(
                 "too busy to get kafka info, please check the kafka broker status, or set "
                 "internal_service_async_thread_num bigger")
@@ -403,13 +413,13 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
 template <typename T>
 void PInternalServiceImplBase<T>::_get_info_impl(
         const PProxyRequest* request, PProxyResult* response,
-        GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch) {
+        GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch, int timeout) {
     DeferOp defer([latch] { latch->count_down(); });
 
     if (request->has_kafka_meta_request()) {
         std::vector<int32_t> partition_ids;
         Status st = _exec_env->routine_load_task_executor()->get_kafka_partition_meta(request->kafka_meta_request(),
-                                                                                      &partition_ids);
+                                                                                      &partition_ids, timeout);
         if (st.ok()) {
             PKafkaMetaProxyResult* kafka_result = response->mutable_kafka_meta_result();
             for (int32_t id : partition_ids) {
@@ -423,7 +433,7 @@ void PInternalServiceImplBase<T>::_get_info_impl(
         std::vector<int64_t> beginning_offsets;
         std::vector<int64_t> latest_offsets;
         Status st = _exec_env->routine_load_task_executor()->get_kafka_partition_offset(
-                request->kafka_offset_request(), &beginning_offsets, &latest_offsets);
+                request->kafka_offset_request(), &beginning_offsets, &latest_offsets, timeout);
         if (st.ok()) {
             auto result = response->mutable_kafka_offset_result();
             for (int i = 0; i < beginning_offsets.size(); i++) {
@@ -436,11 +446,13 @@ void PInternalServiceImplBase<T>::_get_info_impl(
         return;
     }
     if (request->has_kafka_offset_batch_request()) {
+        MonotonicStopWatch watch;
+        watch.start();
         for (auto offset_req : request->kafka_offset_batch_request().requests()) {
             std::vector<int64_t> beginning_offsets;
             std::vector<int64_t> latest_offsets;
             Status st = _exec_env->routine_load_task_executor()->get_kafka_partition_offset(
-                    offset_req, &beginning_offsets, &latest_offsets);
+                    offset_req, &beginning_offsets, &latest_offsets, timeout - watch.elapsed_time() / 1000 / 1000);
             auto offset_result = response->mutable_kafka_offset_batch_result()->add_results();
             if (st.ok()) {
                 for (int i = 0; i < beginning_offsets.size(); i++) {
@@ -454,6 +466,7 @@ void PInternalServiceImplBase<T>::_get_info_impl(
                 return;
             }
         }
+        watch.stop();
     }
     Status::OK().to_protobuf(response->mutable_status());
 }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -389,7 +389,7 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
 
     GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable> latch(1);
 
-    int timeout = request->has_timeout() ? request->timeout : config::routine_load_kafka_timeout_second;
+    int timeout = request->has_timeout() ? request->timeout() : config::routine_load_kafka_timeout_second;
 
     // watch estimates the interval before the task is actually executed.
     MonotonicStopWatch watch;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -390,7 +390,7 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
     GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable> latch(1);
 
     if (!_async_thread_pool.try_offer([&]() { _get_info_impl(request, response, &latch); })) {
-        Status::ServiceUnavailable("too busy to get kafka info, you could set internal_service_async_thread_num bigger")
+        Status::ServiceUnavailable("too busy to get kafka info, please check the kafka broker status, or set internal_service_async_thread_num bigger")
                 .to_protobuf(response->mutable_status());
         return;
     }

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -97,7 +97,7 @@ public:
 
 private:
     void _get_info_impl(const PProxyRequest* request, PProxyResult* response,
-                        GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch);
+                        GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch, int timeout);
 
     Status _exec_plan_fragment(brpc::Controller* cntl);
     Status _exec_batch_plan_fragments(brpc::Controller* cntl);

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -93,6 +93,11 @@ public:
         return _work_queue.blocking_put(std::move(task));
     }
 
+    bool try_offer(WorkFunction func) {
+        PriorityThreadPool::Task task = {0, std::move(func)};
+        return _work_queue.try_put(std::move(task));
+    }
+
     // Shuts the thread pool down, causing the work queue to cease accepting offered work
     // and the worker threads to terminate once they have processed their current work item.
     // Returns once the shutdown flag has been set, does not wait for the threads to

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -173,6 +173,7 @@ public class KafkaUtil {
                 address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
                 // get info
+                request.timeout = Config.routine_load_kafka_timeout_second;
                 Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
                 PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                 TStatusCode code = TStatusCode.findByValue(result.status.statusCode);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -66,11 +66,12 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
 
     private static final long BACKEND_SLOT_UPDATE_INTERVAL_MS = 10000; // 10s
     private static final long SLOT_FULL_SLEEP_MS = 10000; // 10s
+    private static final int THREAD_POOL_SIZE = 10;
 
     private final RoutineLoadManager routineLoadManager;
     private final LinkedBlockingQueue<RoutineLoadTaskInfo> needScheduleTasksQueue = Queues.newLinkedBlockingQueue();
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    private final ExecutorService threadPool = Executors.newFixedThreadPool(10);
+    private final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
 
     private long lastBackendSlotUpdateTime = -1;
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -288,6 +288,7 @@ message PProxyRequest {
     optional PKafkaMetaProxyRequest kafka_meta_request = 1;
     optional PKafkaOffsetProxyRequest kafka_offset_request = 101;
     optional PKafkaOffsetBatchProxyRequest kafka_offset_batch_request = 102;
+    optional int64 timeout = 103;
 };
 
 message PKafkaMetaProxyResult {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/8947

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The FE gets Kafka partition offset by calling RPC of BE.`starrocks::KafkaDataConsumer::get_partition_offset` on BE queries the partition offset from kafka.
The previous implementation would block many bthreads in `starrocks::KafkaDataConsumer::get_partition_offset` when all brokers of Kafka are down, which is led by the pthread lock in librdkafka. The blocked bthread cannot be scheduled, and the other operation like query would be influenced.
This PR makes the `get_info` an asynchronised call, which is executed in the specific thread pool. In this way, the pthread lock in librdkafka would not block the bthread, and other operations would not be influenced.