### PR TITLE
[Bugfix] Fix delete throw unknown error when enable query detail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1004,7 +1004,12 @@ public class StmtExecutor {
                 explainString += "RESOURCE GROUP: " + resourceGroupStr + "\n\n";
             }
         }
-        explainString += execPlan.getExplainString(parsedStmt.getExplainLevel());
+        // marked delete will get execPlan null
+        if (execPlan == null) {
+            explainString += "NOT AVAILABLE";
+        } else {
+            explainString += execPlan.getExplainString(parsedStmt.getExplainLevel());
+        }
         return explainString;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9596

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This because if FE config enable_collect_query_detail_info = true
in StmtExecutor context.getQueryDetail != null will apply and will call buildExplaianString
but marked delete does not have explainString so execPlan will be null cause of NPE.