### PR TITLE
[BugFix] Null date and datetime value for spark load is not consistent

### DIFF
--- a/be/src/exec/vectorized/sorting/compare_column.cpp
+++ b/be/src/exec/vectorized/sorting/compare_column.cpp
@@ -235,7 +235,7 @@ public:
             null_data = &_nullable_column->get_data();
         }
         for (size_t i = 1; i < column.size(); i++) {
-            if ((null_data == nullptr) || ((*null_data)[i-1] != 1 && (*null_data)[i] != 1)) {
+            if ((null_data == nullptr) || ((*null_data)[i - 1] != 1 && (*null_data)[i] != 1)) {
                 (*_tie)[i] &= SorterComparator<Slice>::compare(data[i - 1], data[i]) == 0;
             }
         }
@@ -250,7 +250,7 @@ public:
             null_data = &_nullable_column->get_data();
         }
         for (size_t i = 1; i < column.size(); i++) {
-            if ((null_data == nullptr) || ((*null_data)[i-1] != 1 && (*null_data)[i] != 1)) {
+            if ((null_data == nullptr) || ((*null_data)[i - 1] != 1 && (*null_data)[i] != 1)) {
                 (*_tie)[i] &= SorterComparator<T>::compare(data[i - 1], data[i]) == 0;
             }
         }

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -4,6 +4,7 @@
 
 #include "column/chunk.h"
 #include "column/datum.h"
+#include "column/nullable_column.h"
 #include "common/status.h"
 #include "exec/vectorized/sorting/sort_permute.h"
 #include "runtime/chunk_cursor.h"
@@ -51,7 +52,7 @@ void compare_columns(const Columns columns, std::vector<int8_t>& cmp_result, con
 
 // Build tie by comparison of adjacent rows in column.
 // Tie(i) is set to 1 only if row(i-1) is equal to row(i), otherwise is set to 0.
-void build_tie_for_column(const ColumnPtr column, Tie* tie);
+void build_tie_for_column(const ColumnPtr column, Tie* tie, const NullColumnPtr null_column = nullptr);
 
 // Append rows from permutation
 void append_by_permutation(Column* dst, const Columns& columns, const Permutation& perm);


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9496

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For broker/stream load, null value for date and datetime is DefaultValueGenerator<DateValue/TimestampValue>, however, for spark load, it is not so.

So when we create a aggregate table, we first perform broker load, and then perform spark load on the same data
(here assuming the data has null value), and query by select count(*) from table, the result will contain two null value.

In this pr, we let the null date and datetime value for spark load to be consistent with broker/stream load