### PR TITLE
[BugFix] Fix `SHOW PROC /colocation_group' after erase db with same name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -498,6 +498,14 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    protected boolean validDbIdAndTableId(long dbId, long tableId) {
+        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (database == null) {
+            return false;
+        }
+        return database.getTable(tableId) != null;
+    }
+
     /**
      * After the user executes `DROP TABLE`, we only throw tables into the recycle bin instead of deleting them
      * immediately. As a side effect, the table that stores in ColocateTableIndex may not be visible to users. We need
@@ -505,18 +513,6 @@ public class ColocateTableIndex implements Writable {
      */
     public List<List<String>> getInfos() {
         List<List<String>> infos = Lists.newArrayList();
-
-        // mark for table that has just moved
-        Set<Long> tableIdsToBeRemoved = new HashSet<>();
-        CatalogRecycleBin catalogRecycleBin = GlobalStateMgr.getCurrentRecycleBin();
-        // loop for current dbs + removed dbs
-        List<Long> allDBIds = GlobalStateMgr.getCurrentState().getDbIds();
-        allDBIds.addAll(catalogRecycleBin.getAllDbIds());
-        for (long dbId : allDBIds) {
-            for (Table table : catalogRecycleBin.getTables(dbId)) {
-                tableIdsToBeRemoved.add(table.getId());
-            }
-        }
 
         readLock();
         try {
@@ -531,7 +527,7 @@ public class ColocateTableIndex implements Writable {
                         sb.append(", ");
                     }
                     sb.append(tableId);
-                    if (tableIdsToBeRemoved.contains(tableId)) {
+                    if (!validDbIdAndTableId(groupId.dbId, tableId)) {
                         sb.append("*");
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -9,15 +9,37 @@ import com.starrocks.analysis.DropTableStmt;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 public class ColocateTableIndexTest {
     private static final Logger LOG = LogManager.getLogger(ColocateTableIndexTest.class);
+
+    /**
+     * [
+     *   [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
+     *   [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
+     *  ]
+     * ->
+     * {
+     *   'group1': [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
+     *   'group2': [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
+     * }
+     */
+    private Map<String, List<String>> groupByName(List<List<String>> lists) {
+        Map<String, List<String>> ret = new HashedMap();
+        for (List<String> list : lists) {
+            ret.put(list.get(1).split("_")[1], list);
+        }
+        return ret;
+    }
 
     @Test
     public void testDropTable() throws Exception {
@@ -40,9 +62,9 @@ public class ColocateTableIndexTest {
         List<List<String>> infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
         // group1->table1_1
         Assert.assertEquals(1, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Map<String, List<String>> map = groupByName(infos);
         Table table1_1 = GlobalStateMgr.getCurrentState().getDb("default_cluster:db1").getTable("table1_1");
-        Assert.assertEquals(String.format("%d", table1_1.getId()), infos.get(0).get(2));
+        Assert.assertEquals(String.format("%d", table1_1.getId()), map.get("group1").get(2));
         LOG.info("after create db1.table1_1: {}", infos);
 
         // create table1_2->group1
@@ -56,9 +78,9 @@ public class ColocateTableIndexTest {
         // group1 -> table1_1, table1_2
         infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
         Assert.assertEquals(1, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        map = groupByName(infos);
         Table table1_2 = GlobalStateMgr.getCurrentState().getDb("default_cluster:db1").getTable("table1_2");
-        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
         LOG.info("after create db1.table1_2: {}", infos);
 
         // create db2
@@ -77,11 +99,10 @@ public class ColocateTableIndexTest {
         // group2 -> table2_l
         infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
         Assert.assertEquals(2, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
-        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        map = groupByName(infos);
+        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
         Table table2_1 = GlobalStateMgr.getCurrentState().getDb("default_cluster:db2").getTable("table2_1");
-        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
-        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), map.get("group2").get(2));
         LOG.info("after create db2.table2_1: {}", infos);
 
         // drop db1.table1_1
@@ -91,11 +112,10 @@ public class ColocateTableIndexTest {
         // group1 -> table1_1*, table1_2
         // group2 -> table2_l
         infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
+        map = groupByName(infos);
         Assert.assertEquals(2, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
-        Assert.assertEquals(String.format("%d*, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
-        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
-        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        Assert.assertEquals(String.format("%d*, %d", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), map.get("group2").get(2));
         LOG.info("after drop db1.table1_1: {}", infos);
 
         // drop db1.table1_2
@@ -105,11 +125,10 @@ public class ColocateTableIndexTest {
         // group1 -> table1_1*, table1_2*
         // group2 -> table2_l
         infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
+        map = groupByName(infos);
         Assert.assertEquals(2, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
-        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
-        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
-        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), map.get("group2").get(2));
         LOG.info("after drop db1.table1_2: {}", infos);
 
         // drop db2
@@ -119,11 +138,34 @@ public class ColocateTableIndexTest {
         // group1 -> table1_1*, table1_2*
         // group2 -> table2_l*
         infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
+        map = groupByName(infos);
         Assert.assertEquals(2, infos.size());
-        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
-        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
-        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
-        Assert.assertEquals(String.format("%d*", table2_1.getId()), infos.get(1).get(2));
+        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
+        Assert.assertEquals(String.format("%d*", table2_1.getId()), map.get("group2").get(2));
         LOG.info("after drop db2: {}", infos);
+
+        // create & drop db2 again
+        createDbStmtStr = "create database db2;";
+        createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+        // create table2_1 -> group2
+        sql = "CREATE TABLE db2.table2_3 (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group3\", \"replication_num\" = \"1\");\n";
+        createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Table table2_3 = GlobalStateMgr.getCurrentState().getDb("default_cluster:db2").getTable("table2_3");
+        sql = "DROP DATABASE db2;";
+        dropDbStmt = (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+        infos = GlobalStateMgr.getCurrentColocateIndex().getInfos();
+        map = groupByName(infos);
+        LOG.info("after create & drop db2: {}", infos);
+        Assert.assertEquals(3, infos.size());
+        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), map.get("group1").get(2));
+        Assert.assertEquals(String.format("%d*", table2_1.getId()), map.get("group2").get(2));
+        Assert.assertEquals(String.format("%d*", table2_3.getId()), map.get("group3").get(2));
       }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9535

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In my previous implementation, when executing `SHOW PROC /colocation_group`, there will be a star next to the table id if the ID of the database / table is in CatalogRecyleBin. 
If we create & drop databases with the same name twice, the first database will lose its Database ID from CatalogRecycleBin. As a result, it will look like a normal table in the output.
To fix this, now we only validate if the ID of the database or table in GlobalStateMgr.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
No new feature/function.
