### PR TITLE
[BugFix] Disable txngraph in nonnewpublish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1176,7 +1176,7 @@ public class DatabaseTransactionMgr {
                     runningTxnNums++;
                 }
             }
-            if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
+            if (Config.enable_new_publish_mechanism && transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
                 transactionGraph.add(transactionState.getTransactionId(), transactionState.getTableIdList());
             }
         } else {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is temporary patch to fix the testing environment failure of load image&wal in FE.  For some reason, 2 txn of the same table, their visible order are not same as commit order, which needs further investigation, 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
