### PR TITLE
[Bugfix] mv task info not exists after modify async to MANUAL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -276,12 +276,6 @@ public class Alter {
                 taskManager.dropTasks(Lists.newArrayList(refreshTask.getId()), false);
             }
 
-            if (newRefreshType == MaterializedView.RefreshType.MANUAL) {
-                Task task = TaskBuilder.buildMvTask(materializedView, dbName);
-                task.setType(Constants.TaskType.EVENT_TRIGGERED);
-                taskManager.createTask(task, false);
-                taskManager.executeTask(task.getName());
-            }
         }
 
         if (newRefreshType == MaterializedView.RefreshType.ASYNC) {
@@ -298,6 +292,13 @@ public class Alter {
             }
             taskManager.createTask(task, false);
             // run task
+            taskManager.executeTask(task.getName());
+        } else {
+            // newRefreshType = MaterializedView.RefreshType.MANUAL
+            // for now SYNC is not supported
+            Task task = TaskBuilder.buildMvTask(materializedView, dbName);
+            task.setType(Constants.TaskType.EVENT_TRIGGERED);
+            taskManager.createTask(task, false);
             taskManager.executeTask(task.getName());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -275,13 +275,13 @@ public class Alter {
             if (refreshTask != null) {
                 taskManager.dropTasks(Lists.newArrayList(refreshTask.getId()), false);
             }
-        }
 
-        if (newRefreshType == MaterializedView.RefreshType.MANUAL) {
-            Task task = TaskBuilder.buildMvTask(materializedView, dbName);
-            task.setType(Constants.TaskType.EVENT_TRIGGERED);
-            taskManager.createTask(task, false);
-            taskManager.executeTask(task.getName());
+            if (newRefreshType == MaterializedView.RefreshType.MANUAL) {
+                Task task = TaskBuilder.buildMvTask(materializedView, dbName);
+                task.setType(Constants.TaskType.EVENT_TRIGGERED);
+                taskManager.createTask(task, false);
+                taskManager.executeTask(task.getName());
+            }
         }
 
         if (newRefreshType == MaterializedView.RefreshType.ASYNC) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -275,7 +275,6 @@ public class Alter {
             if (refreshTask != null) {
                 taskManager.dropTasks(Lists.newArrayList(refreshTask.getId()), false);
             }
-
         }
 
         if (newRefreshType == MaterializedView.RefreshType.ASYNC) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -277,6 +277,13 @@ public class Alter {
             }
         }
 
+        if (newRefreshType == MaterializedView.RefreshType.MANUAL) {
+            Task task = TaskBuilder.buildMvTask(materializedView, dbName);
+            task.setType(Constants.TaskType.EVENT_TRIGGERED);
+            taskManager.createTask(task, false);
+            taskManager.executeTask(task.getName());
+        }
+
         if (newRefreshType == MaterializedView.RefreshType.ASYNC) {
             // create task
             Task task = TaskBuilder.buildMvTask(materializedView, dbName);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9577

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
CREATE TABLE t1
                    (a int,
                    b int,
                    c int)
                    DUPLICATE KEY(a)
                    DISTRIBUTED BY HASH(a) BUCKETS 10
                    PROPERTIES ("replication_num" = "3");
CREATE MATERIALIZED VIEW mv2
                             DISTRIBUTED BY HASH(a) BUCKETS 10
                             REFRESH ASYNC START('2050-07-01 10:00:00') EVERY (interval 1 day)
                             AS SELECT a,b FROM t1;
alter materialized view mv2 refresh MANUAL;
SELECT * FROM INFORMATION_SCHEMA.tasks order by create_time desc limit 1;
```
**problem**

The PERIODICAL task has been droped ,but  there is not a EVENT_TRIGGERED task

**resolved**

![image](https://user-images.githubusercontent.com/13373748/183031862-6bf5c59b-82ce-42b8-9d6d-07129f6a9789.png)
