### PR TITLE
[BugFix] Fix correlated scalar non-aggregate subquery unknown error when correlated predicate has expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -102,6 +102,16 @@ public class ScalarApply2JoinRule extends TransformationRule {
         // t1.v1
         ColumnRefSet correlationPredicateInnerRefs = new ColumnRefSet(correlationPredicatePair.second.keySet());
 
+        OptExpression rightChild = input.inputAt(1);
+        if (correlationPredicatePair.second.values().stream().anyMatch(v -> !v.isColumnRef())) {
+            // There are expression, need project node
+            Map<ColumnRefOperator, ScalarOperator> rightChildProjectMap = Maps.newHashMap();
+            Arrays.stream(input.inputAt(1).getOutputColumns().getColumnIds()).
+                    mapToObj(context.getColumnRefFactory()::getColumnRef).forEach(i -> rightChildProjectMap.put(i, i));
+            rightChildProjectMap.putAll(correlationPredicatePair.second);
+            rightChild = OptExpression.create(new LogicalProjectOperator(rightChildProjectMap), rightChild);
+        }
+
         /*
          * Step1: build agg
          *      output: count(1) as countRows, any_value(t1.v2) as anyValue
@@ -130,7 +140,7 @@ public class ScalarApply2JoinRule extends TransformationRule {
 
         OptExpression newAggOpt = OptExpression.create(
                 new LogicalAggregationOperator(AggType.GLOBAL, countAggregateGroupBys, aggregates),
-                input.inputAt(1));
+                rightChild);
 
         /*
          * Step2: build left outer join

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -471,4 +471,60 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  group by: 5: v4");
         }
     }
+
+    @Test
+    public void testCorrelatedScalarNonAggSubqueryWithExpression() throws Exception {
+        String sql = "SELECT \n" +
+                "  subt0.v1 \n" +
+                "FROM \n" +
+                "  (\n" +
+                "    SELECT \n" +
+                "      t0.v1\n" +
+                "    FROM \n" +
+                "      t0 \n" +
+                "    WHERE \n" +
+                "      (\n" +
+                "          SELECT \n" +
+                "            t2.v7 \n" +
+                "          FROM \n" +
+                "            t2 \n" +
+                "          WHERE \n" +
+                "            t0.v2 = 284082749\n" +
+                "      ) >= 1\n" +
+                "  ) subt0;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, " 2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(1), any_value(4: v7)\n" +
+                "  |  group by: 8: expr\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 4> : 4: v7\n" +
+                "  |  <slot 8> : 284082749");
+        sql = "SELECT \n" +
+                "  subt0.v1 \n" +
+                "FROM \n" +
+                "  (\n" +
+                "    SELECT \n" +
+                "      t0.v1\n" +
+                "    FROM \n" +
+                "      t0 \n" +
+                "    WHERE \n" +
+                "      (\n" +
+                "          SELECT \n" +
+                "            t2.v7 \n" +
+                "          FROM \n" +
+                "            t2 \n" +
+                "          WHERE \n" +
+                "            t0.v2 = t2.v8 + 1\n" +
+                "      ) >= 1\n" +
+                "  ) subt0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 3:AGGREGATE (update finalize)\n" +
+                "  |  output: count(1), any_value(4: v7)\n" +
+                "  |  group by: 8: add\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 4> : 4: v7\n" +
+                "  |  <slot 8> : 5: v8 + 1");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9616 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
SELECT * FROM t0
WHERE t0.v2 > (
      SELECT t1.v2 FROM t1
      WHERE t0.v1 = t1.v1 +1 
);
```
correlated predicate has expression, we need add project node

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
