### PR TITLE
[Bugfix] fix miss string function in MAX/MIN function when enable dictionary optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDecodeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDecodeOperator.java
@@ -3,7 +3,6 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.OptExpression;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/AddDecodeNodeForDictStringRule.java
@@ -644,6 +644,9 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                         if (fnName.equals(FunctionSet.MAX) || fnName.equals(FunctionSet.MIN)) {
                             ColumnRefOperator outputStringColumn = kv.getKey();
                             final ColumnRefOperator newDictColumn = createNewDictColumn(context, dictColumn);
+                            if (context.stringFunctions.containsKey(dictColumn)) {
+                                context.stringFunctions.put(newDictColumn, context.stringFunctions.get(dictColumn));
+                            }
                             newStringToDicts.put(outputStringColumn.getId(), newDictColumn.getId());
 
                             for (Pair<Integer, ColumnDict> globalDict : context.globalDicts) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -482,8 +482,10 @@ public class LowCardinalityTest extends PlanTestBase {
 
         sql = "select max(upper(S_ADDRESS)) from supplier";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("Decode"));
-        Assert.assertTrue(plan.contains(" <function id 12>"));
+        Assert.assertTrue(plan.contains("  3:Decode\n" +
+                "  |  <dict id 13> : <string id 10>\n" +
+                "  |  string functions:\n" +
+                "  |  <function id 13> : DictExpr(11: S_ADDRESS,[upper(<place-holder>)])"));
 
         sql = "select max(\"CONST\") from supplier";
         plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1050,6 +1050,26 @@ public class LowCardinalityTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  4:Decode\n" +
                 "  |  <dict id 14> : <string id 9>\n" +
                 "  |  <dict id 15> : <string id 10>"));
+
+        sql = "select max(upper(S_ADDRESS)) from supplier_nullable";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  5:Decode\n" +
+                "  |  <dict id 14> : <string id 10>\n" +
+                "  |  string functions:\n" +
+                "  |  <function id 14> : DictExpr(11: S_ADDRESS,[upper(<place-holder>)])\n" +
+                "  |  "));
+
+        sql = "select max(if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT)), " +
+                "min(upper(S_COMMENT)) from supplier_nullable " +
+                "group by upper(S_COMMENT)";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  5:Decode\n" +
+                "  |  <dict id 17> : <string id 12>\n" +
+                "  |  <dict id 15> : <string id 9>\n" +
+                "  |  string functions:\n" +
+                "  |  <function id 17> : DictExpr(14: S_COMMENT,[upper(<place-holder>)])\n" +
+                "  |  <function id 15> : DictExpr(14: S_COMMENT,[upper(<place-holder>)])"));
+
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
 
     }


### PR DESCRIPTION
we will add a new dictionary column for MAX/MIN aggregate function in dictionary optimization.
so when we have a string function for a old dictionary column, we also need apply it to the new dictionary column.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #9619 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
