### PR TITLE
[Feature] Inject errors for execute engine

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -802,10 +802,10 @@ CONF_Int16(jdbc_connection_pool_size, "8");
 CONF_Int32(internal_service_async_thread_num, "10");
 
 /*
- * When compile with ENABLE_STATUS_FAILED, every use of RETURN_INJECT has probability of 1/probability_of_inject
+ * When compile with ENABLE_STATUS_FAILED, every use of RETURN_INJECT has probability of 1/cardinality_of_inject
  * to inject error through return random status(except ok).
  */
-CONF_Int32(probability_of_inject, "100");
+CONF_Int32(cardinality_of_inject, "100");
 
 /*
  * Config range for inject erros,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -801,4 +801,16 @@ CONF_Int16(jdbc_connection_pool_size, "8");
 // The default value is set as the THREAD_POOL_SIZE of RoutineLoadTaskScheduler of FE.
 CONF_Int32(internal_service_async_thread_num, "10");
 
+/*
+ * When compile with ENABLE_STATUS_FAILED, every use of RETURN_INJECT has probability of 1/probability_of_inject
+ * to inject error through return random status(except ok).
+ */
+CONF_Int32(probability_of_inject, "100");
+
+/*
+ * Config range for inject erros,
+ * Specify the source code directory,
+ * Split by "," strictly.
+ */
+CONF_String(directory_of_inject, "/src/exec,/src/exprs");
 } // namespace starrocks::config

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -103,7 +103,7 @@ bool Status::in_directory_of_inject(const std::string& direct_name) {
         std::stringstream ss;
         for (int i = 1; i < fields.size(); ++i) {
             ss << "/" << fields[i];
-            if (dircetory_enable.find(ss.tr()) != dircetory_enable.end()) {
+            if (dircetory_enable.find(ss.str()) != dircetory_enable.end()) {
                 return true;
             }
         }

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -87,7 +87,12 @@ Status::Status(TStatusCode::type code, Slice msg, Slice ctx) : _state(assemble_s
 
 #if defined(ENABLE_STATUS_FAILED)
 int32_t Status::get_cardinality_of_inject() {
-    return starrocks::config::cardinality_of_inject;
+    const auto& cardinality_of_inject = starrocks::config::cardinality_of_inject;
+    if (cardinality_of_inject < 1) {
+        return 1;
+    } else {
+        return cardinality_of_inject;
+    }
 }
 
 void Status::access_directory_of_inject() {

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include "common/config.h"
 #include "gen_cpp/Status_types.h"  // for TStatus
 #include "gen_cpp/status.pb.h"     // for StatusPB
 #include "gutil/strings/fastmem.h" // for memcpy_inlined
@@ -84,6 +85,11 @@ Status::Status(const StatusPB& s) : _state(nullptr) {
 
 Status::Status(TStatusCode::type code, Slice msg, Slice ctx) : _state(assemble_state(code, msg, ctx)) {}
 
+#if defined(ENABLE_STATUS_FAILED)
+int32_t Status::get_cardinality_of_inject() {
+    return starrocks::config::cardinality_of_inject;
+}
+
 void Status::access_directory_of_inject() {
     std::string directs = starrocks::config::directory_of_inject;
     vector<string> fields = strings::Split(directs, ",");
@@ -114,6 +120,7 @@ bool Status::in_directory_of_inject(const std::string& direct_name) {
         return false;
     }
 }
+#endif
 
 void Status::to_thrift(TStatus* s) const {
     s->error_msgs.clear();

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -114,7 +114,8 @@ bool Status::in_directory_of_inject(const std::string& direct_name) {
         std::stringstream ss;
         for (int i = 1; i < fields.size(); ++i) {
             ss << "/" << fields[i];
-            if (dircetory_enable.find(ss.str()) != dircetory_enable.end()) {
+            const auto& iter = dircetory_enable.find(ss.str());
+            if (iter != dircetory_enable.end() && iter->second) {
                 return true;
             }
         }

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -103,7 +103,7 @@ bool Status::in_directory_of_inject(const std::string& direct_name) {
         std::stringstream ss;
         for (int i = 1; i < fields.size(); ++i) {
             ss << "/" << fields[i];
-            if (dircetory_enable[ss.str()]) {
+            if (dircetory_enable.find(ss.tr()) != dircetory_enable.end()) {
                 return true;
             }
         }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "common/compiler_util.h"
-#include "common/config.h"
 #include "common/logging.h"
 #include "gen_cpp/StatusCode_types.h" // for TStatus
 #include "util/slice.h"               // for Slice
@@ -30,9 +29,12 @@ public:
         }
     }
 
+#if defined(ENABLE_STATUS_FAILED)
+    static int32_t get_cardinality_of_inject();
     static inline std::unordered_map<std::string, bool> dircetory_enable;
     static void access_directory_of_inject();
     static bool in_directory_of_inject(const std::string&);
+#endif
 
     // Copy c'tor makes copy of error detail so Status can be returned by value
     Status(const Status& s) : _state(s._state == nullptr ? nullptr : copy_state(s._state)) {}
@@ -365,7 +367,7 @@ struct StatusInstance {
     do {                                                                                                  \
         uint32_t seed = starrocks::GetCurrentTimeNanos();                                                 \
         seed = ::rand_r(&seed);                                                                           \
-        uint32_t boundary_value = RAND_MAX / (1.0 * starrocks::config::probability_of_inject);            \
+        uint32_t boundary_value = RAND_MAX / (1.0 * starrocks::Status::get_cardinality_of_inject());      \
         /* Pre-condition of inject errors: probability and File scope*/                                   \
         if (seed <= boundary_value && starrocks::Status::in_directory_of_inject(__FILE__)) {              \
             RETURN_INJECT(seed);                                                                          \

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -8,10 +8,11 @@
 #include <vector>
 
 #include "common/compiler_util.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "gen_cpp/StatusCode_types.h" // for TStatus
 #include "util/slice.h"               // for Slice
-
+#include "util/time.h"
 namespace starrocks {
 
 class StatusPB;
@@ -28,6 +29,10 @@ public:
             delete[] _state;
         }
     }
+
+    static inline std::unordered_map<std::string, bool> dircetory_enable;
+    static void access_directory_of_inject();
+    static bool in_directory_of_inject(const std::string&);
 
     // Copy c'tor makes copy of error detail so Status can be returned by value
     Status(const Status& s) : _state(s._state == nullptr ? nullptr : copy_state(s._state)) {}
@@ -287,14 +292,93 @@ inline const Status& to_status(const StatusOr<T>& st) {
 #define AS_STRING_INTERNAL(x) #x
 #endif
 
-// Some generally useful macros.
-#define RETURN_IF_ERROR(stmt)                                                                         \
+#define RETURN_IF_ERROR_INTERNAL(stmt)                                                                \
     do {                                                                                              \
         auto&& status__ = (stmt);                                                                     \
         if (UNLIKELY(!status__.ok())) {                                                               \
             return to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
         }                                                                                             \
     } while (false)
+
+#if defined(ENABLE_STATUS_FAILED)
+struct StatusInstance {
+    static constexpr Status (*random[])(const Slice& msg) = {&Status::Unknown,
+                                                             &Status::PublishTimeout,
+                                                             &Status::MemoryAllocFailed,
+                                                             &Status::BufferAllocFailed,
+                                                             &Status::InvalidArgument,
+                                                             &Status::MinimumReservationUnavailable,
+                                                             &Status::Corruption,
+                                                             &Status::IOError,
+                                                             &Status::NotFound,
+                                                             &Status::AlreadyExist,
+                                                             &Status::NotSupported,
+                                                             &Status::EndOfFile,
+                                                             &Status::ServiceUnavailable,
+                                                             &Status::Uninitialized,
+                                                             &Status::Aborted,
+                                                             &Status::DataQualityError,
+                                                             &Status::VersionAlreadyMerged,
+                                                             &Status::DuplicateRpcInvocation,
+                                                             &Status::JsonFormatError,
+                                                             &Status::GlobalDictError,
+                                                             &Status::TransactionInProcessing,
+                                                             &Status::TransactionNotExists,
+                                                             &Status::LabelAlreadyExists,
+                                                             &Status::ResourceBusy};
+
+    static constexpr TStatusCode::type codes[] = {TStatusCode::UNKNOWN,
+                                                  TStatusCode::PUBLISH_TIMEOUT,
+                                                  TStatusCode::MEM_ALLOC_FAILED,
+                                                  TStatusCode::BUFFER_ALLOCATION_FAILED,
+                                                  TStatusCode::INVALID_ARGUMENT,
+                                                  TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE,
+                                                  TStatusCode::CORRUPTION,
+                                                  TStatusCode::IO_ERROR,
+                                                  TStatusCode::NOT_FOUND,
+                                                  TStatusCode::ALREADY_EXIST,
+                                                  TStatusCode::NOT_IMPLEMENTED_ERROR,
+                                                  TStatusCode::END_OF_FILE,
+                                                  TStatusCode::SERVICE_UNAVAILABLE,
+                                                  TStatusCode::UNINITIALIZED,
+                                                  TStatusCode::ABORTED,
+                                                  TStatusCode::DATA_QUALITY_ERROR,
+                                                  TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED,
+                                                  TStatusCode::DUPLICATE_RPC_INVOCATION,
+                                                  TStatusCode::DATA_QUALITY_ERROR,
+                                                  TStatusCode::GLOBAL_DICT_ERROR,
+                                                  TStatusCode::TXN_IN_PROCESSING,
+                                                  TStatusCode::TXN_NOT_EXISTS,
+                                                  TStatusCode::LABEL_ALREADY_EXISTS,
+                                                  TStatusCode::RESOURCE_BUSY};
+
+    static constexpr int SIZE = sizeof(random) / sizeof(Status(*)(const Slice& msg));
+};
+
+#define RETURN_INJECT(index)                                                         \
+    std::stringstream ss;                                                            \
+    ss << "INJECT ERROR: " << __FILE__ << " " << __LINE__ << " "                     \
+       << starrocks::StatusInstance::codes[index % starrocks::StatusInstance::SIZE]; \
+    return starrocks::StatusInstance::random[index % starrocks::StatusInstance::SIZE](ss.str());
+
+#define RETURN_IF_ERROR(stmt)                                                                             \
+    do {                                                                                                  \
+        uint32_t seed = starrocks::GetCurrentTimeNanos();                                                 \
+        seed = ::rand_r(&seed);                                                                           \
+        uint32_t boundary_value = RAND_MAX / (1.0 * starrocks::config::probability_of_inject);            \
+        /* Pre-condition of inject errors: probability and File scope*/                                   \
+        if (seed <= boundary_value && starrocks::Status::in_directory_of_inject(__FILE__)) {              \
+            RETURN_INJECT(seed);                                                                          \
+        } else {                                                                                          \
+            auto&& status__ = (stmt);                                                                     \
+            if (UNLIKELY(!status__.ok())) {                                                               \
+                return to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+            }                                                                                             \
+        }                                                                                                 \
+    } while (false)
+#else
+#define RETURN_IF_ERROR(stmt) RETURN_IF_ERROR_INTERNAL(stmt)
+#endif
 
 #define EXIT_IF_ERROR(stmt)                        \
     do {                                           \

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -149,6 +149,11 @@ int main(int argc, char** argv) {
         return -1;
     }
 
+#if defined(ENABLE_STATUS_FAILED)
+    // read range of source code for inject errors.
+    starrocks::Status::access_directory_of_inject();
+#endif
+
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
     // Aggressive decommit is required so that unused pages in the TCMalloc page heap are
     // not backed by physical pages and do not contribute towards memory consumption.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- We can inject errors with RETURN_IF_ERROR through compile with **ENABLE_STATUS_FAILED**.
- Use RETURN_IF_ERROR_INTERNAL to ensure be startup successfully.
- When ENABLE_STATUS_FAILED, probability of injection specify by **probability_of_inject**(means:1/probability_of_inject).
- Considering too much scope, so we specify range of inject errors through **directory_of_inject**("/src/exec,/src/exprs" and so on).
- Client will be responsed with message of "Inject error" with inject position.
like:
```
mysql> select d_year, s_nation, p_category, sum(lo_revenue) - sum(lo_supplycost) as profit from lineorder join dates on lo_orderdate = d_datekey join customer on lo_custkey = c_custkey join supplier on lo_suppkey = s_suppkey join part on lo_partkey = p_partkey where c_region = 'AMERICA'and s_region = 'AMERICA' and (d_year = 1997 or d_year = 1998) and (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2') group by d_year, s_nation, p_category order by d_year, s_nation, p_category;
ERROR 1064 (HY000): INJECT ERROR: ../src/exec/pipeline/scan/scan_operator.cpp 192
```