### PR TITLE
[Enhancement] add more error info to s3 sdk

### DIFF
--- a/be/src/io/s3_input_stream.cpp
+++ b/be/src/io/s3_input_stream.cpp
@@ -30,7 +30,9 @@ StatusOr<int64_t> S3InputStream::read(void* out, int64_t count) {
         _offset += body.gcount();
         return body.gcount();
     } else {
-        return Status::IOError(outcome.GetError().GetMessage());
+        const auto& error = outcome.GetError();
+        return Status::IOError(fmt::format("code={}(SdkErrorType:{}), message={}", error.GetResponseCode(),
+                                           error.GetErrorType(), error.GetMessage()));
     }
 }
 
@@ -53,7 +55,9 @@ StatusOr<int64_t> S3InputStream::get_size() {
         if (outcome.IsSuccess()) {
             _size = outcome.GetResult().GetContentLength();
         } else {
-            return Status::IOError(outcome.GetError().GetMessage());
+            const auto& error = outcome.GetError();
+            return Status::IOError(fmt::format("code={}(SdkErrorType:{}), message={}", error.GetResponseCode(),
+                                               error.GetErrorType(), error.GetMessage()));
         }
     }
     return _size;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Try to expose more error info of accessing s3. The possible used field are

1. [x] http code (403)
2. [x] message: no response body
3. exception: null
4. response headers:
    1. connection / keepalive
    2. content-length: 324
    3. content-type: application/xml
    4. date: Sat, 06 Aug 2022 04:46:56 GMT
    5. server: AliyunOSS
    6. x-amz-request-id: 62EDF240825092313227F4B8
    7. x-oss-server-time: 22
5. [x] errortype: Aws::S3::S3Errors::ACCESS_DENIED



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
