### PR TITLE
[Cherry-pick 2.1][Bugfix] show CG with star mark after table dropped (#6832)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -14,13 +14,15 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 public class ColocateTableIndexTest {
     private static final Logger LOG = LogManager.getLogger(ColocateTableIndexTest.class);
+    private static final String runningDir = "fe/mocked/ColocateTableIndexTest/" + UUID.randomUUID().toString() + "/";
 
     @Test
     public void testDropTable() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.createMinStarRocksCluster(runningDir);
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
 
         // create db1

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -1,51 +1,128 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/ColocateTableIndexTest.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 package com.starrocks.catalog;
 
-import com.google.common.collect.Maps;
-import com.starrocks.catalog.ColocateTableIndex.GroupId;
+import com.starrocks.analysis.CreateDbStmt;
+import com.starrocks.analysis.CreateTableStmt;
+import com.starrocks.analysis.DropDbStmt;
+import com.starrocks.analysis.DropTableStmt;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.List;
 
 public class ColocateTableIndexTest {
+    private static final Logger LOG = LogManager.getLogger(ColocateTableIndexTest.class);
 
     @Test
-    public void testGroupId() {
-        GroupId groupId1 = new GroupId(1000, 2000);
-        GroupId groupId2 = new GroupId(1000, 2000);
-        Map<GroupId, Long> map = Maps.newHashMap();
-        Assert.assertTrue(groupId1.equals(groupId2));
-        Assert.assertTrue(groupId1.hashCode() == groupId2.hashCode());
-        map.put(groupId1, 1000L);
-        Assert.assertTrue(map.containsKey(groupId2));
+    public void testDropTable() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
 
-        Set<GroupId> balancingGroups = new CopyOnWriteArraySet<GroupId>();
-        balancingGroups.add(groupId1);
-        Assert.assertTrue(balancingGroups.size() == 1);
-        balancingGroups.remove(groupId2);
-        Assert.assertTrue(balancingGroups.isEmpty());
-    }
+        // create db1
+        String createDbStmtStr = "create database db1;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+
+        // create table1_1->group1
+        String sql = "CREATE TABLE db1.table1_1 (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+        List<List<String>> infos = Catalog.getCurrentColocateIndex().getInfos();
+        // group1->table1_1
+        Assert.assertEquals(1, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Table table1_1 = Catalog.getCurrentCatalog().getDb("default_cluster:db1").getTable("table1_1");
+        Assert.assertEquals(String.format("%d", table1_1.getId()), infos.get(0).get(2));
+        LOG.info("after create db1.table1_1: {}", infos);
+
+        // create table1_2->group1
+        sql = "CREATE TABLE db1.table1_2 (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+        createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+        // group1 -> table1_1, table1_2
+        infos = Catalog.getCurrentColocateIndex().getInfos();
+        Assert.assertEquals(1, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Table table1_2 = Catalog.getCurrentCatalog().getDb("default_cluster:db1").getTable("table1_2");
+        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        LOG.info("after create db1.table1_2: {}", infos);
+
+        // create db2
+        createDbStmtStr = "create database db2;";
+        createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+        // create table2_1 -> group2
+        sql = "CREATE TABLE db2.table2_1 (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group2\", \"replication_num\" = \"1\");\n";
+        createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+        // group1 -> table1_1, table1_2
+        // group2 -> table2_l
+        infos = Catalog.getCurrentColocateIndex().getInfos();
+        Assert.assertEquals(2, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Assert.assertEquals(String.format("%d, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        Table table2_1 = Catalog.getCurrentCatalog().getDb("default_cluster:db2").getTable("table2_1");
+        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        LOG.info("after create db2.table2_1: {}", infos);
+
+        // drop db1.table1_1
+        sql = "DROP TABLE db1.table1_1;";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().dropTable(dropTableStmt);
+        // group1 -> table1_1*, table1_2
+        // group2 -> table2_l
+        infos = Catalog.getCurrentColocateIndex().getInfos();
+        Assert.assertEquals(2, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Assert.assertEquals(String.format("%d*, %d", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        LOG.info("after drop db1.table1_1: {}", infos);
+
+        // drop db1.table1_2
+        sql = "DROP TABLE db1.table1_2;";
+        dropTableStmt = (DropTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().dropTable(dropTableStmt);
+        // group1 -> table1_1*, table1_2*
+        // group2 -> table2_l
+        infos = Catalog.getCurrentColocateIndex().getInfos();
+        Assert.assertEquals(2, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
+        Assert.assertEquals(String.format("%d", table2_1.getId()), infos.get(1).get(2));
+        LOG.info("after drop db1.table1_2: {}", infos);
+
+        // drop db2
+        sql = "DROP DATABASE db2;";
+        DropDbStmt dropDbStmt = (DropDbStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().dropDb(dropDbStmt);
+        // group1 -> table1_1*, table1_2*
+        // group2 -> table2_l*
+        infos = Catalog.getCurrentColocateIndex().getInfos();
+        Assert.assertEquals(2, infos.size());
+        Assert.assertTrue(infos.get(0).get(1).contains("group1"));
+        Assert.assertEquals(String.format("%d*, %d*", table1_1.getId(), table1_2.getId()), infos.get(0).get(2));
+        Assert.assertTrue(infos.get(1).get(1).contains("group2"));
+        Assert.assertEquals(String.format("%d*", table2_1.getId()), infos.get(1).get(2));
+        LOG.info("after drop db2: {}", infos);
+      }
 }


### PR DESCRIPTION
Add a marker at the table that has just dropped when executing SHOW PROC '/colocation_group'
Fixes #1539