### PR TITLE
[BugFix] Fix recovery for bad replica

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -216,7 +216,16 @@ public class TabletChecker extends LeaderDaemon {
      * to the queue again in the next `TabletChecker` round.
      */
     private boolean tryChooseSrcBeforeSchedule(TabletSchedCtx tabletCtx) {
-        return !(tabletCtx.needCloneFromSource() && tabletCtx.getHealthyReplicas().size() == 0);
+        if (tabletCtx.needCloneFromSource()) {
+            if (tabletCtx.getReplicas().size() == 1 && Config.recover_with_empty_tablet) {
+                // in this case, we need to forcefully create an empty replica to recover
+                return true;
+            } else {
+                return tabletCtx.getHealthyReplicas().size() != 0;
+            }
+        } else {
+            return true;
+        }
     }
 
     private void doCheck(boolean checkInPrios) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes SR-8301

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The precheck of source chosen logic didn't consider the situation
that tablet with single replica need to forcefully recover with an
empty replica.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

I will add test case using pseduo cluster (#8854) in another pr, because there are some functionalities about tablet schedule needed to add in pseudo cluster first.
