### PR TITLE
[Enhancement] Compatible with msql use 'truncate' to delete partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -386,7 +386,7 @@ public class Alter {
         String tableName = dbTableName.getTbl();
 
         // this logic is use to adapt mysql syntax, and cannot be executed after adding a write lock
-        // ALTER TABLE test TRUNCATE PARTITION pA;
+        // ALTER TABLE test TRUNCATE PARTITION p1;
         if (currentAlterOps.hasTruncatePartitionOp()) {
             TruncatePartitionClause clause = (TruncatePartitionClause) alterClauses.get(0);
             TableRef tableRef = new TableRef(stmt.getTbl(), null, clause.getPartitionNames());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
@@ -30,6 +30,7 @@ public enum AlterOpType {
     // partition
     ADD_PARTITION,
     DROP_PARTITION,
+    TRUNCATE_PARTITION,
     REPLACE_PARTITION,
     MODIFY_PARTITION,
     // rename

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterOperations.java
@@ -84,6 +84,10 @@ public class AlterOperations {
         return currentOps.contains(AlterOpType.SWAP);
     }
 
+    public boolean hasTruncatePartitionOp() {
+        return currentOps.contains(AlterOpType.TRUNCATE_PARTITION);
+    }
+
     public boolean contains(AlterOpType op) {
         return currentOps.contains(op);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TruncatePartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TruncatePartitionClause.java
@@ -1,0 +1,33 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import com.starrocks.alter.AlterOpType;
+import com.starrocks.sql.ast.AstVisitor;
+
+public class TruncatePartitionClause extends AlterTableClause {
+
+    private PartitionNames partitionNames;
+    public TruncatePartitionClause(AlterOpType opType) {
+        super(opType);
+    }
+
+    public TruncatePartitionClause(PartitionNames partitionNames) {
+        super(AlterOpType.TRUNCATE_PARTITION);
+        this.partitionNames = partitionNames;
+    }
+
+    public PartitionNames getPartitionNames() {
+        return partitionNames;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitTruncatePartitionClause(this, context);
+    }
+
+    @Override
+    public boolean isSupportNewPlanner() {
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -116,6 +116,7 @@ import com.starrocks.analysis.SwapTableClause;
 import com.starrocks.analysis.SysVariableDesc;
 import com.starrocks.analysis.TableRenameClause;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.TruncatePartitionClause;
 import com.starrocks.analysis.TruncateTableStmt;
 import com.starrocks.analysis.UpdateStmt;
 
@@ -560,6 +561,10 @@ public abstract class AstVisitor<R, C> {
     }
 
     public R visitDropPartitionClause(DropPartitionClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
+    public R visitTruncatePartitionClause(TruncatePartitionClause clause, C context) {
         return visitNode(clause, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -177,6 +177,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TableRenameClause;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.TruncatePartitionClause;
 import com.starrocks.analysis.TruncateTableStmt;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.analysis.UpdateStmt;
@@ -894,6 +895,15 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         boolean force = context.FORCE() != null;
         boolean exists = context.EXISTS() != null;
         return new DropPartitionClause(exists, partitionName, temp, force);
+    }
+
+    @Override
+    public ParseNode visitTruncatePartitionClause(StarRocksParser.TruncatePartitionClauseContext context) {
+        PartitionNames partitionNames = null;
+        if (context.partitionNames() != null) {
+            partitionNames = (PartitionNames) visit(context.partitionNames());
+        }
+        return new TruncatePartitionClause(partitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -466,6 +466,7 @@ alterClause
     | dropComputeNodeClause
     | swapTableClause
     | dropPartitionClause
+    | truncatePartitionClause
     | modifyTablePropertiesClause
     | addPartitionClause
     | modifyPartitionClause
@@ -492,6 +493,10 @@ dropIndexClause
 
 dropPartitionClause
     : DROP TEMPORARY? PARTITION (IF EXISTS)? identifier FORCE?
+    ;
+
+truncatePartitionClause
+    : TRUNCATE partitionNames
     ;
 
 tableRenameClause

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -27,6 +27,7 @@ import com.staros.proto.ObjectStorageInfo;
 import com.staros.proto.ShardStorageInfo;
 import com.starrocks.analysis.AddColumnsClause;
 import com.starrocks.analysis.AddPartitionClause;
+import com.starrocks.analysis.AlterClause;
 import com.starrocks.analysis.AlterDatabaseRename;
 import com.starrocks.analysis.AlterSystemStmt;
 import com.starrocks.analysis.AlterTableStmt;
@@ -41,8 +42,12 @@ import com.starrocks.analysis.GrantStmt;
 import com.starrocks.analysis.ModifyColumnClause;
 import com.starrocks.analysis.MultiItemListPartitionDesc;
 import com.starrocks.analysis.PartitionDesc;
+import com.starrocks.analysis.PartitionNames;
 import com.starrocks.analysis.ReorderColumnsClause;
 import com.starrocks.analysis.SingleItemListPartitionDesc;
+import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TruncatePartitionClause;
+import com.starrocks.analysis.TruncateTableStmt;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
@@ -58,6 +63,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.StarOSAgent;
@@ -78,6 +84,10 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+
+import mockit.Mock;
+import mockit.MockUp;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -89,6 +99,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -2171,5 +2182,31 @@ public class AlterTest {
         clause = (ReorderColumnsClause) alterTableStmt.getOps().get(0);
         Assert.assertEquals(clause.getRollupName(), "testRollup");
         Assert.assertEquals("ORDER BY `k1`, `k2` IN `testRollup`", clause.toString());
+    }
+
+
+    @Test(expected = DdlException.class)
+    public void testFindTruncatePartitionEntrance() throws Exception {
+
+        Database db = new Database();
+        
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Database getDb(String name) {
+                return db;
+            }
+            @Mock
+            public void truncateTable(TruncateTableStmt truncateTableStmt) throws DdlException {
+                throw new DdlException("test DdlException");
+            }
+        };
+        List<AlterClause> cList = new ArrayList<>();
+        PartitionNames partitionNames = new PartitionNames(true, Arrays.asList("p1"));
+        TruncatePartitionClause clause = new TruncatePartitionClause(partitionNames);
+        cList.add(clause);
+        Alter alter = new Alter();
+        TableName tableName = new TableName("test_db", "test_table");
+        AlterTableStmt stmt = new AlterTableStmt(tableName, cList);
+        alter.processAlterTable(stmt);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -59,6 +59,8 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.OlapTable.OlapTableState;
+import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -2189,7 +2191,8 @@ public class AlterTest {
     public void testFindTruncatePartitionEntrance() throws Exception {
 
         Database db = new Database();
-        
+        OlapTable table = new OlapTable(TableType.OLAP);
+        table.setState(OlapTableState.NORMAL);
         new MockUp<GlobalStateMgr>() {
             @Mock
             public Database getDb(String name) {
@@ -2198,6 +2201,12 @@ public class AlterTest {
             @Mock
             public void truncateTable(TruncateTableStmt truncateTableStmt) throws DdlException {
                 throw new DdlException("test DdlException");
+            }
+        };
+        new MockUp<Database>() {
+            @Mock
+            public Table getTable(String tableName) {
+                return table;
             }
         };
         List<AlterClause> cList = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/TruncatePartitionClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/TruncatePartitionClauseTest.java
@@ -1,0 +1,26 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.starrocks.alter.AlterOpType;
+
+public class TruncatePartitionClauseTest {
+    
+    @Test
+    public void testInitTruncatePartitionClause() {
+
+        TruncatePartitionClause clause1 = new TruncatePartitionClause(AlterOpType.TRUNCATE_PARTITION);
+        Assert.assertEquals(AlterOpType.TRUNCATE_PARTITION, clause1.getOpType()); 
+
+        PartitionNames partitionNames = new PartitionNames(true, Arrays.asList("p1"));
+        TruncatePartitionClause clause2 = new TruncatePartitionClause(partitionNames);
+        Assert.assertEquals("p1", clause2.getPartitionNames().getPartitionNames().get(0));
+
+        Assert.assertTrue(clause2.isSupportNewPlanner());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstBuilderTest.java
@@ -3,24 +3,47 @@
 package com.starrocks.sql.analyzer;
 
 
+import com.starrocks.analysis.AlterClause;
+import com.starrocks.analysis.AlterTableStmt;
 import com.starrocks.analysis.ModifyBackendAddressClause;
 import com.starrocks.analysis.ModifyFrontendAddressClause;
 import com.starrocks.analysis.StatementBase;
-
+import com.starrocks.analysis.TruncatePartitionClause;
+import com.starrocks.analysis.TruncateTableStmt;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.CaseInsensitiveStream;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.parser.StarRocksLexer;
 import com.starrocks.sql.parser.StarRocksParser;
+
+import com.starrocks.utframe.UtFrameUtils;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 public class AstBuilderTest {
     
+    private static ConnectContext connectContext;
+
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+    }
+
     @Test
     public void testModifyBackendHost() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
         String sql = "alter system modify backend host '127.0.0.1' to 'testHost'";
@@ -49,5 +72,15 @@ public class AstBuilderTest {
         field.setAccessible(true);
         ModifyFrontendAddressClause clause = (ModifyFrontendAddressClause) field.get(statement);
         Assert.assertTrue(clause.getSrcHost().equals("127.0.0.1") && clause.getDestHost().equals("testHost"));
+    }
+
+    @Test
+    public void testTruncatePartition() throws Exception {
+        String sql = "alter table db.test truncate partition p1";
+        StatementBase statement = SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+        AlterTableStmt aStmt = (AlterTableStmt) statement;
+        List<AlterClause> alterClauses = aStmt.getOps();
+        TruncatePartitionClause c = (TruncatePartitionClause)alterClauses.get(0);
+        Assert.assertTrue(c.getPartitionNames().getPartitionNames().get(0).equals("p1"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9528 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`// ALTER TABLE test TRUNCATE PARTITION p1;`
The current behavior of mysql with the above statement is to clear the partition data and keep the partition structure, StarRocks does not implement this statement
This PR will enable StarRocks to perform the same functions as mysql
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
