### PR TITLE
[Cherry-pick 2.3][BugFix] Discard expired backup/restore job (#9531)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -71,6 +71,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,7 +93,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // If the last job is finished, user can get the job info from repository. If the last job is cancelled,
     // user can get the error message before submitting the next one.
     // Use ConcurrentMap to get rid of locks.
-    private Map<Long, AbstractJob> dbIdToBackupOrRestoreJob = Maps.newConcurrentMap();
+    protected Map<Long, AbstractJob> dbIdToBackupOrRestoreJob = Maps.newConcurrentMap();
 
     // this lock is used for handling one backup or restore request at a time.
     private ReentrantLock seqlock = new ReentrantLock();
@@ -559,6 +560,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
             // for example: In restore job, PENDING will transfer to SNAPSHOTING, not DOWNLOAD.
             job.replayRun();
         }
+        if (isJobExpired(job, System.currentTimeMillis())) {
+            LOG.warn("skip expired job {}", job);
+            return;
+        }
         dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
     }
 
@@ -598,11 +603,17 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void readFields(DataInput in) throws IOException {
         repoMgr = RepositoryMgr.read(in);
 
+        long currentTimeMs = System.currentTimeMillis();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             AbstractJob job = AbstractJob.read(in);
+            if (isJobExpired(job, currentTimeMs)) {
+                LOG.warn("skip expired job {}", job);
+                continue;
+            }
             dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
         }
+        LOG.info("finished replay {} backup/store jobs from image", dbIdToBackupOrRestoreJob.size());
     }
 
     public long saveBackupHandler(DataOutputStream dos, long checksum) throws IOException {
@@ -617,6 +628,31 @@ public class BackupHandler extends MasterDaemon implements Writable {
         setGlobalStateMgr(globalStateMgr);
         LOG.info("finished replay backupHandler from image");
         return checksum;
+    }
+
+    /**
+     * will remove finished/cancelled job periodically
+     */
+    private boolean isJobExpired(AbstractJob job, long currentTimeMs) {
+        return (job.isDone() || job.isCancelled())
+                && (currentTimeMs - job.getFinishedTime()) / 1000 > Config.history_job_keep_max_second;
+    }
+
+    public void removeOldJobs() throws DdlException {
+        tryLock();
+        try {
+            long currentTimeMs = System.currentTimeMillis();
+            Iterator<Map.Entry<Long, AbstractJob>> iterator = dbIdToBackupOrRestoreJob.entrySet().iterator();
+            while (iterator.hasNext()) {
+                AbstractJob job = iterator.next().getValue();
+                if (isJobExpired(job, currentTimeMs)) {
+                    LOG.warn("discard expired job {}", job);
+                    iterator.remove();
+                }
+            }
+        } finally {
+            seqlock.unlock();
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -94,7 +94,7 @@ public class BackupJob extends AbstractJob {
     // all objects which need backup
     private List<TableRef> tableRefs = Lists.newArrayList();
 
-    private BackupJobState state;
+    protected BackupJobState state;
 
     private long snapshotFinishedTime = -1;
     private long snapshopUploadFinishedTime = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3145,6 +3145,11 @@ public class GlobalStateMgr {
         } catch (Throwable t) {
             LOG.warn("routine load manager clean old routine load jobs failed", t);
         }
+        try {
+            backupHandler.removeOldJobs();
+        } catch (Throwable t) {
+            LOG.warn("backup handler clean old jobs failed", t);
+        }
     }
 
     public void doTaskBackgroundJob() {


### PR DESCRIPTION
1. skip expired backup/restore job when loading image.
2. skip expired backup/restore job when replaying journal.
3. discard expired backup/restore job periodically.
4. add UT
Fixes #9517