### PR TITLE
[Cherry-pick 2.3][BugFix] Remove colocated index from memory (#9578)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -375,7 +375,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (tableInfo != null) {
                 Table table = tableInfo.getTable();
                 nameToTableInfo.remove(dbId, table.getName());
-                if (table.getType() == TableType.OLAP && !isCheckpointThread()) {
+                if (table.getType() == TableType.OLAP) {
                     GlobalStateMgr.getCurrentState().onEraseOlapTable((OlapTable) table, true);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -742,6 +742,8 @@ public class ColocateTableIndex implements Writable {
         if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_46) {
             GlobalStateMgr.getCurrentColocateIndex().readFields(dis);
         }
+        // clean up if dbId or tableId not found, this is actually a bug
+        cleanupInvalidDbOrTable(GlobalStateMgr.getCurrentState());
         LOG.info("finished replay colocateTableIndex from image");
         return checksum;
     }
@@ -847,6 +849,36 @@ public class ColocateTableIndex implements Writable {
             LOG.warn("failed to replay modify table colocate", e);
         } finally {
             db.writeUnlock();
+        }
+    }
+
+    /**
+     * for legacy reason, all the colocate group index cannot be properly removed
+     * we have to add a cleanup function on start when loading image
+     */
+    protected void cleanupInvalidDbOrTable(GlobalStateMgr globalStateMgr) {
+        List<Long> badTableIds = new ArrayList<>();
+        for (Map.Entry<Long, GroupId> entry : table2Group.entrySet()) {
+            long dbId = entry.getValue().dbId;
+            long tableId = entry.getKey();
+            Database database = globalStateMgr.getDbIncludeRecycleBin(dbId);
+            if (database == null) {
+                LOG.warn("cannot find db {}, will remove invalid table {} from group {}",
+                        dbId, tableId, entry.getValue());
+            } else {
+                Table table = globalStateMgr.getTableIncludeRecycleBin(database, tableId);
+                if (table != null) {
+                    // this is a valid table/database, do nothing
+                    continue;
+                }
+                LOG.warn("cannot find table {} in db {}, will remove invalid table {} from group {}",
+                        tableId, dbId, tableId, entry.getValue());
+            }
+            badTableIds.add(tableId);
+        }
+        LOG.warn("remove {} invalid tableid: {}", badTableIds.size(), badTableIds);
+        for (Long tableId : badTableIds) {
+            removeTable(tableId);
         }
     }
 }


### PR DESCRIPTION
This is a legacy bug that will keep colocated groups in memory FOREVER.
The root cause is probably that we intended to skip change TabletInvertedIndex when making a checkpoint. Since table.delete() will call invertedIndex.deleteTablet() function that will eventually change TabletInvertedIndex, we won't call table.delete() in checkpointer. Unfortunately, this function is also responsible for removing colocated groups from memory. As a result, when making a checkpoint, the colocate group index will stay in the final image and never be removed.

Call table.delete() when replaying a journal of erasing table.
Add an extra function cleanupInvalidDbOrTable to clean all the invalid colocated groups of which table or database is not found. We should clean up every time an image is loaded so that all legacy colocated groups can clean up at once.

Fixes #5681