### PR TITLE
[Bugfix] Fix the redundant read request caused by mismatched buffer o…

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -90,7 +90,7 @@ public:
         } else {
             const uint8_t* ptr = nullptr;
             size_t nbytes = length;
-            status = _buffer_stream.get_bytes(&ptr, offset, &nbytes);
+            status = _buffer_stream.get_bytes(&ptr, offset, &nbytes, false);
             DCHECK_EQ(nbytes, length);
             if (status.ok()) {
                 ::memcpy(buf, ptr, length);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -31,7 +31,7 @@ Status PageReader::next_header() {
     size_t remaining = _finish_offset - _offset;
     do {
         nbytes = std::min(nbytes, remaining);
-        RETURN_IF_ERROR(_stream->get_bytes(&page_buf, _offset, &nbytes));
+        RETURN_IF_ERROR(_stream->get_bytes(&page_buf, _offset, &nbytes, true));
 
         header_length = nbytes;
         auto st = deserialize_thrift_msg(page_buf, &header_length, TProtocolType::COMPACT, &_cur_header);
@@ -47,6 +47,7 @@ Status PageReader::next_header() {
 
     _offset += header_length;
     _next_header_pos = _offset + _cur_header.compressed_page_size;
+    _stream->skip(header_length);
     return Status::OK();
 }
 
@@ -55,7 +56,7 @@ Status PageReader::read_bytes(const uint8_t** buffer, size_t size) {
         return Status::InternalError("Size to read exceed page size");
     }
     uint64_t nbytes = size;
-    RETURN_IF_ERROR(_stream->get_bytes(buffer, _offset, &nbytes));
+    RETURN_IF_ERROR(_stream->get_bytes(buffer, _offset, &nbytes, false));
     DCHECK_EQ(nbytes, size);
     _offset += nbytes;
     return Status::OK();

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -38,6 +38,7 @@ public:
 
     // seek to read position, this position must be a start of a page header.
     void seek_to_offset(uint64_t offset) {
+        _stream->seek_to(offset);
         _offset = offset;
         _next_header_pos = offset;
     }

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -66,9 +66,9 @@ Status DefaultBufferedInputStream::_read_data() {
     return Status::OK();
 }
 
-Status DefaultBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) {
+Status DefaultBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) {
     seek_to(offset);
-    return get_bytes(buffer, nbytes, false);
+    return get_bytes(buffer, nbytes, peek);
 }
 
 // ===================================================================================
@@ -137,7 +137,7 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     return Status::OK();
 }
 
-Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) {
+Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) {
     auto iter = _map.upper_bound(offset);
     if (iter == _map.end()) {
         return Status::RuntimeError("failed to find shared buffer based on offset");

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -14,7 +14,9 @@ class RandomAccessFile;
 
 class IBufferedInputStream {
 public:
-    virtual Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) = 0;
+    virtual Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) = 0;
+    virtual void seek_to(uint64_t offset) = 0;
+    virtual void skip(uint64_t nbytes) = 0;
     virtual ~IBufferedInputStream() {}
 };
 
@@ -24,7 +26,7 @@ public:
 
     ~DefaultBufferedInputStream() override = default;
 
-    void seek_to(uint64_t offset) {
+    void seek_to(uint64_t offset) override {
         uint64_t current_file_offset = tell();
         if (offset < current_file_offset) {
             // TODO(zc): To reuse already read data in some case, however it is not a common case
@@ -36,7 +38,7 @@ public:
         }
     }
 
-    void skip(uint64_t nbytes) {
+    void skip(uint64_t nbytes) override {
         if (_buf_position + nbytes < _buf_written) {
             _buf_position += nbytes;
         } else {
@@ -48,11 +50,11 @@ public:
 
     uint64_t tell() const { return _file_offset - num_remaining(); }
 
-    Status get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek = false);
+    Status get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek);
 
     void reserve(size_t nbytes);
 
-    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) override;
+    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) override;
 
 private:
     Status _read_data();
@@ -92,7 +94,9 @@ public:
     Status set_io_ranges(const std::vector<IORange>& ranges);
     void release_to_offset(int64_t offset);
 
-    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes) override;
+    void seek_to(uint64_t offset) override {}
+    void skip(uint64_t nbytes) override {}
+    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) override;
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
 

--- a/be/test/util/buffered_stream_test.cpp
+++ b/be/test/util/buffered_stream_test.cpp
@@ -66,14 +66,14 @@ TEST_F(BufferedStreamTest, Large) {
     {
         const uint8_t* buf;
         size_t nbytes = 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
     }
     // get 65K to enlarge the buffer
     {
         const uint8_t* buf;
         size_t nbytes = 65 * 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(65 * 1024, nbytes);
     }
@@ -81,7 +81,7 @@ TEST_F(BufferedStreamTest, Large) {
     {
         const uint8_t* buf;
         size_t nbytes = 1 * 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(0, nbytes);
     }
@@ -98,14 +98,14 @@ TEST_F(BufferedStreamTest, Large2) {
     {
         const uint8_t* buf;
         size_t nbytes = 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
     }
     // get 64K to move
     {
         const uint8_t* buf;
         size_t nbytes = 64 * 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(64 * 1024, nbytes);
     }
@@ -113,7 +113,7 @@ TEST_F(BufferedStreamTest, Large2) {
     {
         const uint8_t* buf;
         size_t nbytes = 1 * 1024;
-        auto st = stream.get_bytes(&buf, &nbytes);
+        auto st = stream.get_bytes(&buf, &nbytes, false);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(0, nbytes);
     }


### PR DESCRIPTION


## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When reading parquet pages, the page reader offset and stream buffer postion always should be moved forward in same steps.
While in the current code, page reader tries to read 1024 bytes and then deserializes the header from data buffer. As the page header size always less than 1024 bytes, which results in the offset  increase less than buffer position does. As a result, the data buffer will be reset when checking remain data and the data previously read will be discarded.
This triggers more remote read requests, resulting in reading performance degradation.
