### PR TITLE
[Cherry-pick 2.0][BugFix] Remove colocated index from memory (#9578)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -731,4 +731,34 @@ public class ColocateTableIndex implements Writable {
             writeUnlock();
         }
     }
+
+    /**
+     * for legacy reason, all the colocate group index cannot be properly removed
+     * we have to add a cleanup function on start when loading image
+     */
+    protected void cleanupInvalidDbOrTable(Catalog catalog) {
+        List<Long> badTableIds = new ArrayList<>();
+        for (Map.Entry<Long, GroupId> entry : table2Group.entrySet()) {
+            long dbId = entry.getValue().dbId;
+            long tableId = entry.getKey();
+            Database database = catalog.getDbIncludeRecycleBin(dbId);
+            if (database == null) {
+                LOG.warn("cannot find db {}, will remove invalid table {} from group {}",
+                        dbId, tableId, entry.getValue());
+            } else {
+                Table table = catalog.getTableIncludeRecycleBin(database, tableId);
+                if (table != null) {
+                    // this is a valid table/database, do nothing
+                    continue;
+                }
+                LOG.warn("cannot find table {} in db {}, will remove invalid table {} from group {}",
+                        tableId, dbId, tableId, entry.getValue());
+            }
+            badTableIds.add(tableId);
+        }
+        LOG.warn("remove {} invalid tableid: {}", badTableIds.size(), badTableIds);
+        for (Long tableId : badTableIds) {
+            removeTable(tableId);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -668,6 +668,8 @@ public class ColocateTableIndex implements Writable {
                 unstableGroups.add(GroupId.read(in));
             }
         }
+        // clean up if dbId or tableId not found, this is actually a bug
+        cleanupInvalidDbOrTable(Catalog.getCurrentCatalog());
     }
 
     private void convertedToNewMembers(Multimap<Long, Long> tmpGroup2Tables, Map<Long, Long> tmpTable2Group,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -143,7 +143,7 @@ public class ColocateTableIndexTest {
         Database goodDb = Catalog.getCurrentCatalog().getDb("default_cluster:goodDb");
         // create goodtable
         String sql = "CREATE TABLE " +
-                "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
+                "goodDb.goodTable (k1 int NOT NULL, k2 int, k3 varchar(32))\n" +
                 "PRIMARY KEY(k1)\n" +
                 "DISTRIBUTED BY HASH(k1)\n" +
                 "BUCKETS 4\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -11,6 +11,7 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -18,11 +19,13 @@ import java.util.UUID;
 
 public class ColocateTableIndexTest {
     private static final Logger LOG = LogManager.getLogger(ColocateTableIndexTest.class);
-    private static final String runningDir = "fe/mocked/ColocateTableIndexTest/" + UUID.randomUUID().toString() + "/";
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster("fe/mocked/ColocateTableIndexTest/" + UUID.randomUUID().toString() + "/");
+    }
 
     @Test
     public void testDropTable() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster(runningDir);
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
 
         // create db1
@@ -126,5 +129,48 @@ public class ColocateTableIndexTest {
         Assert.assertTrue(infos.get(1).get(1).contains("group2"));
         Assert.assertEquals(String.format("%d*", table2_1.getId()), infos.get(1).get(2));
         LOG.info("after drop db2: {}", infos);
-      }
+    }
+
+    @Test
+    public void testCleanUp() throws Exception {
+        ColocateTableIndex colocateTableIndex = Catalog.getCurrentColocateIndex();
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        int n = colocateTableIndex.getAllGroupIds().size();
+
+        // create goodDb
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt("create database goodDb;", connectContext);
+        Catalog.getCurrentCatalog().createDb(createDbStmt);
+        Database goodDb = Catalog.getCurrentCatalog().getDb("default_cluster:goodDb");
+        // create goodtable
+        String sql = "CREATE TABLE " +
+                "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        Catalog.getCurrentCatalog().createTable(createTableStmt);
+        OlapTable table = (OlapTable)goodDb.getTable("goodTable");
+        ColocateTableIndex.GroupId goodGroup = Catalog.getCurrentColocateIndex().getGroup(table.getId());
+        Assert.assertEquals(n + 1, colocateTableIndex.getAllGroupIds().size());
+
+        // create a bad db
+        long badDbId = 100;
+        table.id = 101;
+        table.name = "goodTableOfBadDb";
+        colocateTableIndex.addTableToGroup(
+                badDbId, table, "badGroupOfBadDb", new ColocateTableIndex.GroupId(badDbId, 102));
+        // create a bad table in good db
+        table.id = 200;
+        table.name = "badTable";
+        colocateTableIndex.addTableToGroup(
+                goodDb.getId(), table, "badGroupOfBadTable", new ColocateTableIndex.GroupId(goodDb.getId(), 201));
+
+        Assert.assertEquals(n + 3, colocateTableIndex.getAllGroupIds().size());
+
+        colocateTableIndex.cleanupInvalidDbOrTable(Catalog.getCurrentCatalog());
+
+        Assert.assertEquals(n + 1, colocateTableIndex.getAllGroupIds().size());
+    }
+
 }


### PR DESCRIPTION
This is a legacy bug that will keep colocated groups in memory FOREVER.
The root cause is probably that we intended to skip change TabletInvertedIndex when making a checkpoint. Since table.delete() will call invertedIndex.deleteTablet() function that will eventually change TabletInvertedIndex, we won't call table.delete() in checkpointer. Unfortunately, this function is also responsible for removing colocated groups from memory. As a result, when making a checkpoint, the colocate group index will stay in the final image and never be removed.

Call table.delete() when replaying a journal of erasing table.
Add an extra function cleanupInvalidDbOrTable to clean all the invalid colocated groups of which table or database is not found. We should clean up every time an image is loaded so that all legacy colocated groups can clean up at once.

Fixes #5681