### PR TITLE
[WIP] [Enhancement] Small opt for hash join ？

### DIFF
--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -106,6 +106,7 @@ struct JoinHashTableItems {
     bool left_to_nullable = false;
     bool right_to_nullable = false;
     bool has_large_column = false;
+    bool is_distinct = false;
 
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
 
@@ -470,80 +471,80 @@ private:
     void _search_ht(RuntimeState* state, ChunkPtr* probe_chunk);
     void _search_ht_remain(RuntimeState* state);
 
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _search_ht_impl(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& data);
 
     // for one key inner join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key left outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
 
     // for one key left semi join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                            const Buffer<CppType>& probe_data);
 
     // for one key left anti join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                            const Buffer<CppType>& probe_data);
 
     // for one key right outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                              const Buffer<CppType>& probe_data);
 
     // for one key right semi join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
 
     // for one key right anti join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
 
     // for one key full outer join
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_full_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
                                             const Buffer<CppType>& probe_data);
 
     // for left outer join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for left semi join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
     // for left anti join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_left_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
     // for one key right outer join with other conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                  const Buffer<CppType>& probe_data);
 
     // for one key right semi join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for one key right anti join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_right_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for one key full outer join with other join conjunct
-    template <bool first_probe>
+    template <bool first_probe, bool is_distinct>
     void _probe_from_ht_for_full_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -55,7 +55,6 @@ void JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableI
     }
     if (table_items->bucket_size / 2 > table_items->row_count) {
         size_t count = SIMD::count_nonzero(table_items->first);
-        std::cout<<"ROW:"<<count<<":"<<table_items->row_count<<":"<<table_items->bucket_size<<std::endl;
         if (count == table_items->row_count) {
             table_items->is_distinct = true;
         }

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -11,6 +11,14 @@
 
 namespace SIMD {
 
+inline size_t count_nonzero(const std::vector<uint32_t>& nums) {
+    size_t count = 0;
+    for (size_t num : nums) {
+        count += (num != 0);
+    }
+    return count;
+}
+
 // Count the number of zeros of 8-bit signed integers.
 inline size_t count_zero(const int8_t* data, size_t size) {
     size_t count = 0;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
mysql> select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+
1 row in set (5.78 sec)

mysql> select count(*) from part;
+----------+
| count(*) |
+----------+
|  1000000 |
+----------+
1 row in set (0.01 sec)
```

```
select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<100000;
before: 0.29
after: 0.28


select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<200000;
before: 0.59
after: 0.60

select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<300000;
before: 0.95
after:  0.94

select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<400000;
before: 1.30
after:  1.30

select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<500000;
before: 1.71
after:  1.48
bucket_size: 1048576

select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<600000;
before: 1.98
after:  1.99

select count(*) from lineorder join [broadcast] part on lineorder.lo_partkey=part.p_partkey where p_partkey<1000000;
before: 2.08
after:  1.83
bucket_size: 2097152
```

```

Further, if the loading rate is relatively high, do we manually check whether there are duplicates?

Or take advantage of the optimizer's statistics？

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
