### PR TITLE
[Feature] Introduce a JNI connector

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -78,6 +78,7 @@ set(EXEC_FILES
     vectorized/except_node.cpp
     vectorized/file_scanner.cpp
     vectorized/orc_scanner.cpp
+    vectorized/jni_scanner.cpp
     vectorized/arrow_to_starrocks_converter.cpp
     vectorized/arrow_to_json_converter.cpp
     vectorized/parquet_scanner.cpp

--- a/be/src/exec/vectorized/jni_scanner.cpp
+++ b/be/src/exec/vectorized/jni_scanner.cpp
@@ -1,0 +1,340 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "jni_scanner.h"
+
+#include "column/type_traits.h"
+#include "fmt/core.h"
+#include "udf/java/java_udf.h"
+#include "util/defer_op.h"
+
+namespace starrocks::vectorized {
+
+Status JniScanner::_check_jni_exception(JNIEnv* _jni_env, const std::string& message) {
+    if (_jni_env->ExceptionCheck()) {
+        _jni_env->ExceptionDescribe();
+        _jni_env->ExceptionClear();
+        return Status::InternalError(message);
+    }
+    return Status::OK();
+}
+
+Status JniScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    SCOPED_RAW_TIMER(&_stats.reader_init_ns);
+    _init_profile(scanner_params);
+    JNIEnv* _jni_env = JVMFunctionHelper::getInstance().getEnv();
+    if (_jni_env->EnsureLocalCapacity(_jni_scanner_params.size() * 2 + 6) < 0) {
+        RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to ensure the local capacity."));
+    }
+    RETURN_IF_ERROR(_init_jni_table_scanner(_jni_env, runtime_state));
+    RETURN_IF_ERROR(_init_jni_method(_jni_env));
+    return Status::OK();
+}
+
+Status JniScanner::do_open(RuntimeState* state) {
+    JNIEnv* _jni_env = JVMFunctionHelper::getInstance().getEnv();
+    SCOPED_TIMER(_profile.open_timer);
+    _jni_env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_open);
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to open the off-heap table scanner."));
+    return Status::OK();
+}
+
+void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
+    JNIEnv* _jni_env = JVMFunctionHelper::getInstance().getEnv();
+    _jni_env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
+    _check_jni_exception(_jni_env, "Failed to close the off-heap table scanner.");
+    _jni_env->DeleteLocalRef(_jni_scanner_obj);
+    _jni_env->DeleteLocalRef(_jni_scanner_cls);
+}
+
+void JniScanner::_init_profile(const HdfsScannerParams& scanner_params) {
+    auto _runtime_profile = scanner_params.profile->runtime_profile;
+    _profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "JniScannerRowsRead", TUnit::UNIT);
+    _profile.io_timer = ADD_TIMER(_runtime_profile, "JniScannerIOTime");
+    _profile.io_counter = ADD_COUNTER(_runtime_profile, "JniScannerIOCounter", TUnit::UNIT);
+    _profile.fill_chunk_timer = ADD_TIMER(_runtime_profile, "JniScannerFillChunkTime");
+    _profile.open_timer = ADD_TIMER(_runtime_profile, "JniScannerOpenTime");
+}
+
+Status JniScanner::_init_jni_method(JNIEnv* _jni_env) {
+    // init jmethod
+    _jni_scanner_open = _jni_env->GetMethodID(_jni_scanner_cls, "open", "()V");
+    DCHECK(_jni_scanner_open != nullptr);
+    _jni_scanner_get_next_chunk = _jni_env->GetMethodID(_jni_scanner_cls, "getNextOffHeapChunk", "()J");
+    DCHECK(_jni_scanner_get_next_chunk != nullptr);
+    _jni_scanner_close = _jni_env->GetMethodID(_jni_scanner_cls, "close", "()V");
+    DCHECK(_jni_scanner_close != nullptr);
+    _jni_scanner_release_column = _jni_env->GetMethodID(_jni_scanner_cls, "releaseOffHeapColumnVector", "(I)V");
+    DCHECK(_jni_scanner_release_column != nullptr);
+    _jni_scanner_release_table = _jni_env->GetMethodID(_jni_scanner_cls, "releaseOffHeapTable", "()V");
+    DCHECK(_jni_scanner_release_table != nullptr);
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to init off-heap table jni methods."));
+
+    return Status::OK();
+}
+
+Status JniScanner::_init_jni_table_scanner(JNIEnv* _jni_env, RuntimeState* runtime_state) {
+    jclass scanner_factory_class = _jni_env->FindClass(_jni_scanner_factory_class.c_str());
+    jmethodID scanner_factory_constructor = _jni_env->GetMethodID(scanner_factory_class, "<init>", "()V");
+    jobject scanner_factory_obj = _jni_env->NewObject(scanner_factory_class, scanner_factory_constructor);
+    jmethodID get_scanner_method =
+            _jni_env->GetMethodID(scanner_factory_class, "getScannerClass", "()Ljava/lang/Class;");
+    _jni_scanner_cls = (jclass)_jni_env->CallObjectMethod(scanner_factory_obj, get_scanner_method);
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to init the scanner class."));
+    _jni_env->DeleteLocalRef(scanner_factory_class);
+    _jni_env->DeleteLocalRef(scanner_factory_obj);
+
+    jmethodID scanner_constructor = _jni_env->GetMethodID(_jni_scanner_cls, "<init>", "(ILjava/util/Map;)V");
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to get a scanner class constructor."));
+
+    jclass hashmap_class = _jni_env->FindClass("java/util/HashMap");
+    jmethodID hashmap_constructor = _jni_env->GetMethodID(hashmap_class, "<init>", "(I)V");
+    jobject hashmap_object = _jni_env->NewObject(hashmap_class, hashmap_constructor, _jni_scanner_params.size());
+    jmethodID hashmap_put =
+            _jni_env->GetMethodID(hashmap_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to get the HashMap methods."));
+
+    string message = "Initialize a scanner with parameters: ";
+    for (auto it : _jni_scanner_params) {
+        jstring key = _jni_env->NewStringUTF(it.first.c_str());
+        jstring value = _jni_env->NewStringUTF(it.second.c_str());
+        message.append(it.first);
+        message.append("->");
+        message.append(it.second);
+        message.append(", ");
+
+        _jni_env->CallObjectMethod(hashmap_object, hashmap_put, key, value);
+        _jni_env->DeleteLocalRef(key);
+        _jni_env->DeleteLocalRef(value);
+    }
+    _jni_env->DeleteLocalRef(hashmap_class);
+    LOG(INFO) << message;
+
+    int fetch_size = runtime_state->chunk_size();
+    _jni_scanner_obj = _jni_env->NewObject(_jni_scanner_cls, scanner_constructor, fetch_size, hashmap_object);
+    _jni_env->DeleteLocalRef(hashmap_object);
+
+    DCHECK(_jni_scanner_obj != nullptr);
+    RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to initialize a scanner instance."));
+
+    return Status::OK();
+}
+
+Status JniScanner::_get_next_chunk(JNIEnv* _jni_env, long* chunk_meta) {
+    SCOPED_TIMER(_profile.io_timer);
+    COUNTER_UPDATE(_profile.io_counter, 1);
+    *chunk_meta = _jni_env->CallLongMethod(_jni_scanner_obj, _jni_scanner_get_next_chunk);
+    RETURN_IF_ERROR(
+            _check_jni_exception(_jni_env, "Failed to call the nextChunkOffHeap method of off-heap table scanner."));
+    return Status::OK();
+}
+
+template <PrimitiveType type, typename CppType>
+void JniScanner::_append_data(Column* column, CppType& value) {
+    auto appender = [](auto* column, CppType& value) {
+        using ColumnType = typename vectorized::RunTimeColumnType<type>;
+        ColumnType* runtime_column = down_cast<ColumnType*>(column);
+        runtime_column->append(value);
+    };
+
+    if (column->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(column);
+        auto* data_column = nullable_column->data_column().get();
+        NullData& null_data = nullable_column->null_column_data();
+        null_data.push_back(0);
+        appender(data_column, value);
+    } else {
+        appender(column, value);
+    }
+}
+
+template <PrimitiveType type, typename CppType>
+Status JniScanner::_append_primitive_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index,
+                                          ColumnPtr& column) {
+    bool* null_column_ptr = reinterpret_cast<bool*>(chunk_meta_ptr[chunk_meta_index++]);
+    CppType* column_ptr = reinterpret_cast<CppType*>(chunk_meta_ptr[chunk_meta_index++]);
+
+    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+    nullable_column->resize(num_rows);
+
+    NullData& null_data = nullable_column->null_column_data();
+    memcpy(null_data.data(), null_column_ptr, num_rows);
+
+    auto* data_column = nullable_column->data_column().get();
+    using ColumnType = typename vectorized::RunTimeColumnType<type>;
+    ColumnType* runtime_column = down_cast<ColumnType*>(data_column);
+    memcpy(runtime_column->get_data().data(), column_ptr, num_rows * sizeof(CppType));
+
+    nullable_column->update_has_null();
+    return Status::OK();
+}
+
+template <PrimitiveType type, typename CppType>
+Status JniScanner::_append_decimal_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index, ColumnPtr& column,
+                                        SlotDescriptor* slot_desc) {
+    bool* null_column_ptr = reinterpret_cast<bool*>(chunk_meta_ptr[chunk_meta_index++]);
+    int* offset_ptr = reinterpret_cast<int*>(chunk_meta_ptr[chunk_meta_index++]);
+    char* column_ptr = reinterpret_cast<char*>(chunk_meta_ptr[chunk_meta_index++]);
+
+    int precision = slot_desc->type().precision;
+    int scale = slot_desc->type().scale;
+    for (int i = 0; i < num_rows; i++) {
+        if (null_column_ptr[i]) {
+            column->append_nulls(1);
+        } else {
+            std::string decimal_str(column_ptr + offset_ptr[i], column_ptr + offset_ptr[i + 1]);
+            CppType cpp_val;
+            if (DecimalV3Cast::from_string<CppType>(&cpp_val, precision, scale, decimal_str.data(),
+                                                    decimal_str.size())) {
+                return Status::DataQualityError(fmt::format("Invalid value occurs in column[{}], value is [{}]",
+                                                            slot_desc->col_name(), decimal_str));
+            }
+            _append_data<type, CppType>(column.get(), cpp_val);
+        }
+    }
+    return Status::OK();
+}
+
+template <PrimitiveType type>
+Status JniScanner::_append_string_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index, ColumnPtr& column) {
+    bool* null_column_ptr = reinterpret_cast<bool*>(chunk_meta_ptr[chunk_meta_index++]);
+    int* offset_ptr = reinterpret_cast<int*>(chunk_meta_ptr[chunk_meta_index++]);
+    char* column_ptr = reinterpret_cast<char*>(chunk_meta_ptr[chunk_meta_index++]);
+
+    auto* nullable_column = down_cast<NullableColumn*>(column.get());
+    nullable_column->resize(num_rows);
+
+    NullData& null_data = nullable_column->null_column_data();
+    memcpy(null_data.data(), null_column_ptr, num_rows);
+
+    auto* data_column = nullable_column->data_column().get();
+    using ColumnType = typename vectorized::RunTimeColumnType<type>;
+    ColumnType* runtime_column = down_cast<ColumnType*>(data_column);
+
+    int total_length = offset_ptr[num_rows];
+    runtime_column->get_bytes().resize(total_length);
+
+    memcpy(runtime_column->get_offset().data(), offset_ptr, (num_rows + 1) * sizeof(uint32_t));
+    memcpy(runtime_column->get_bytes().data(), column_ptr, total_length);
+
+    nullable_column->update_has_null();
+    return Status::OK();
+}
+
+Status JniScanner::_fill_chunk(JNIEnv* _jni_env, long chunk_meta, ChunkPtr* chunk) {
+    SCOPED_TIMER(_profile.fill_chunk_timer);
+
+    long* chunk_meta_ptr = reinterpret_cast<long*>(chunk_meta);
+    int chunk_meta_index = 0;
+    long num_rows = chunk_meta_ptr[chunk_meta_index++];
+    if (num_rows == 0) {
+        return Status::EndOfFile("");
+    }
+    COUNTER_UPDATE(_profile.rows_read_counter, num_rows);
+    auto slot_desc_list = _scanner_params.tuple_desc->slots();
+    for (size_t col_idx = 0; col_idx < slot_desc_list.size(); col_idx++) {
+        SlotDescriptor* slot_desc = slot_desc_list[col_idx];
+        ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_desc->id());
+        PrimitiveType column_type = slot_desc->type().type;
+        if (!column->is_nullable()) {
+            return Status::DataQualityError(
+                    fmt::format("NOT NULL column[{}] is not supported.", slot_desc->col_name()));
+        }
+        if (column_type == PrimitiveType::TYPE_BOOLEAN) {
+            RETURN_IF_ERROR((
+                    _append_primitive_data<TYPE_BOOLEAN, uint8_t>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_SMALLINT) {
+            RETURN_IF_ERROR((_append_primitive_data<TYPE_SMALLINT, int16_t>(num_rows, chunk_meta_ptr, chunk_meta_index,
+                                                                            column)));
+        } else if (column_type == PrimitiveType::TYPE_INT) {
+            RETURN_IF_ERROR(
+                    (_append_primitive_data<TYPE_INT, int32_t>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_FLOAT) {
+            RETURN_IF_ERROR(
+                    (_append_primitive_data<TYPE_FLOAT, float>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_BIGINT) {
+            RETURN_IF_ERROR(
+                    (_append_primitive_data<TYPE_BIGINT, int64_t>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_DOUBLE) {
+            RETURN_IF_ERROR(
+                    (_append_primitive_data<TYPE_DOUBLE, double>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_VARCHAR) {
+            RETURN_IF_ERROR((_append_string_data<TYPE_VARCHAR>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_CHAR) {
+            RETURN_IF_ERROR((_append_string_data<TYPE_CHAR>(num_rows, chunk_meta_ptr, chunk_meta_index, column)));
+        } else if (column_type == PrimitiveType::TYPE_DATE) {
+            bool* null_column_ptr = reinterpret_cast<bool*>(chunk_meta_ptr[chunk_meta_index++]);
+            int* offset_ptr = reinterpret_cast<int*>(chunk_meta_ptr[chunk_meta_index++]);
+            char* column_ptr = reinterpret_cast<char*>(chunk_meta_ptr[chunk_meta_index++]);
+            for (int i = 0; i < num_rows; i++) {
+                if (null_column_ptr[i]) {
+                    column->append_nulls(1);
+                } else {
+                    std::string date_str(column_ptr + offset_ptr[i], column_ptr + offset_ptr[i + 1]);
+                    DateValue dv;
+                    if (!dv.from_string(date_str.c_str(), date_str.size())) {
+                        return Status::DataQualityError(
+                                fmt::format("Invalid date value occurs on column[{}], value is [{}]",
+                                            slot_desc->col_name(), date_str));
+                    }
+                    _append_data<TYPE_DATE, DateValue>(column.get(), dv);
+                }
+            }
+        } else if (column_type == PrimitiveType::TYPE_DATETIME) {
+            bool* null_column_ptr = reinterpret_cast<bool*>(chunk_meta_ptr[chunk_meta_index++]);
+            int* offset_ptr = reinterpret_cast<int*>(chunk_meta_ptr[chunk_meta_index++]);
+            char* column_ptr = reinterpret_cast<char*>(chunk_meta_ptr[chunk_meta_index++]);
+            for (int i = 0; i < num_rows; i++) {
+                if (null_column_ptr[i]) {
+                    column->append_nulls(1);
+                } else {
+                    std::string origin_str(column_ptr + offset_ptr[i], column_ptr + offset_ptr[i + 1]);
+                    std::string datetime_str = origin_str.substr(0, origin_str.find('.'));
+                    TimestampValue tsv;
+                    if (!tsv.from_datetime_format_str(datetime_str.c_str(), datetime_str.size(), "%Y-%m-%d %H:%i:%s")) {
+                        return Status::DataQualityError(
+                                fmt::format("Invalid datetime value occurs on column[{}], value is [{}]",
+                                            slot_desc->col_name(), origin_str));
+                    }
+                    _append_data<TYPE_DATETIME, TimestampValue>(column.get(), tsv);
+                }
+            }
+        } else if (column_type == PrimitiveType::TYPE_DECIMAL32) {
+            RETURN_IF_ERROR((_append_decimal_data<TYPE_DECIMAL32, int32_t>(num_rows, chunk_meta_ptr, chunk_meta_index,
+                                                                           column, slot_desc)));
+        } else if (column_type == PrimitiveType::TYPE_DECIMAL64) {
+            RETURN_IF_ERROR((_append_decimal_data<TYPE_DECIMAL64, int64_t>(num_rows, chunk_meta_ptr, chunk_meta_index,
+                                                                           column, slot_desc)));
+        } else if (column_type == PrimitiveType::TYPE_DECIMAL128) {
+            RETURN_IF_ERROR((_append_decimal_data<TYPE_DECIMAL128, int128_t>(num_rows, chunk_meta_ptr, chunk_meta_index,
+                                                                             column, slot_desc)));
+        } else {
+            return Status::InternalError(
+                    fmt::format("Type {} is not supported for off-heap table scanner", column_type));
+        }
+        _jni_env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_column, col_idx);
+        RETURN_IF_ERROR(_check_jni_exception(
+                _jni_env, "Failed to call the releaseOffHeapColumnVector method of off-heap table scanner."));
+    }
+    if (num_rows < _runtime_state->chunk_size()) {
+        return Status::EndOfFile("");
+    }
+    return Status::OK();
+}
+
+Status JniScanner::_release_off_heap_table(JNIEnv* _jni_env) {
+    _jni_env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);
+    RETURN_IF_ERROR(
+            _check_jni_exception(_jni_env, "Failed to call the releaseOffHeapTable method of off-heap table scanner."));
+    return Status::OK();
+}
+
+Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
+    JNIEnv* _jni_env = JVMFunctionHelper::getInstance().getEnv();
+    long chunk_meta;
+    RETURN_IF_ERROR(_get_next_chunk(_jni_env, &chunk_meta));
+    Status status = _fill_chunk(_jni_env, chunk_meta, chunk);
+    RETURN_IF_ERROR(_release_off_heap_table(_jni_env));
+    return status;
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/jni_scanner.h
+++ b/be/src/exec/vectorized/jni_scanner.h
@@ -1,0 +1,75 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "common/logging.h"
+#include "common/status.h"
+#include "hdfs_scanner.h"
+#include "jni.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::vectorized {
+
+struct JniScannerProfile {
+    RuntimeProfile::Counter* rows_read_counter = nullptr;
+    RuntimeProfile::Counter* io_timer = nullptr;
+    RuntimeProfile::Counter* io_counter = nullptr;
+    RuntimeProfile::Counter* fill_chunk_timer = nullptr;
+    RuntimeProfile::Counter* open_timer = nullptr;
+};
+
+class JniScanner : public HdfsScanner {
+public:
+    JniScanner(std::string factory_class, std::map<std::string, std::string> params)
+            : _jni_scanner_params(std::move(params)), _jni_scanner_factory_class(std::move(factory_class)) {}
+
+    ~JniScanner() override { finalize(); }
+
+    Status do_open(RuntimeState* runtime_state) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
+    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
+    Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+
+private:
+    static Status _check_jni_exception(JNIEnv* _jni_env, const std::string& message);
+
+    Status _init_jni_table_scanner(JNIEnv* _jni_env, RuntimeState* runtime_state);
+
+    void _init_profile(const HdfsScannerParams& scanner_params);
+
+    Status _init_jni_method(JNIEnv* _jni_env);
+
+    Status _get_next_chunk(JNIEnv* _jni_env, long* chunk_meta);
+
+    template <PrimitiveType type, typename CppType>
+    Status _append_primitive_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index, ColumnPtr& column);
+
+    template <PrimitiveType type, typename CppType>
+    Status _append_decimal_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index, ColumnPtr& column,
+                                SlotDescriptor* slot_desc);
+
+    template <PrimitiveType type>
+    Status _append_string_data(long num_rows, long* chunk_meta_ptr, int& chunk_meta_index, ColumnPtr& column);
+
+    Status _fill_chunk(JNIEnv* _jni_env, long chunk_meta, ChunkPtr* chunk);
+
+    template <PrimitiveType type, typename CppType>
+    void _append_data(Column* column, CppType& value);
+
+    Status _release_off_heap_table(JNIEnv* _jni_env);
+
+    JniScannerProfile _profile;
+
+    jclass _jni_scanner_cls;
+    jobject _jni_scanner_obj;
+    jmethodID _jni_scanner_open;
+    jmethodID _jni_scanner_get_next_chunk;
+    jmethodID _jni_scanner_close;
+    jmethodID _jni_scanner_release_column;
+    jmethodID _jni_scanner_release_table;
+
+    std::map<std::string, std::string> _jni_scanner_params;
+    std::string _jni_scanner_factory_class;
+};
+} // namespace starrocks::vectorized

--- a/java-extensions/jni-connector/pom.xml
+++ b/java-extensions/jni-connector/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>java-extensions</artifactId>
+        <groupId>com.starrocks</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jni-connector</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <java-extensions.home>${basedir}/../</java-extensions.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>java-utils</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>starrocks-jni-connector</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <!-- copy all dependency libs to target lib dir -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jni-connector</outputDirectory>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
@@ -1,0 +1,109 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.jni.connector;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * The parent class of JNI scanner, developers need to inherit this class and implement the following methods:
+ * 1. {@link ConnectorScanner#open()}
+ * 2. {@link ConnectorScanner#close()}
+ * 3. {@link ConnectorScanner#getNext()}
+ *
+ * The constructor of inherited subclasses need to accept the following parameters in order:
+ * 1. int: the chunk size, this parameter need to be initialized using the parent constructor
+ * 2. Map<String, String>: the custom parameters
+ *
+ * BE will call the methods as follows (described in pseudocode):
+ * open();
+ * do {
+ *     int rows = getNext();
+ *     if (rows < fetchSize) {
+ *         break;
+ *     }
+ * } while (true);
+ * close();
+ *
+ */
+public abstract class ConnectorScanner {
+    private OffHeapTable offHeapTable;
+    private OffHeapColumnVector.OffHeapColumnType[] types;
+    private int tableSize;
+
+    /**
+     * Initialize the reader with parameters passed by the class constructor and allocate necessary resources.
+     * Developers can call {@link ConnectorScanner#initOffHeapTableWriter(String[], int, Map)} method here
+     * to allocate memory spaces.
+     */
+    public abstract void open() throws IOException;
+
+    /**
+     * Close the reader and release resources.
+     */
+    public abstract void close() throws IOException;
+
+    /**
+     * Scan original data and save it to off-heap table.
+     * @return The number of rows scanned.
+     * The specific implementation needs to call the {@link ConnectorScanner#scanData(int, Object)} method
+     * to save data to off-heap table.
+     * The number of rows scanned must less than or equal to {@link ConnectorScanner#tableSize}
+     */
+    public abstract int getNext() throws IOException;
+
+    /**
+     * This method need be called before {@link ConnectorScanner#getNext()}
+     * @param requiredTypes column types
+     * @param fetchSize number of rows
+     * @param typeMappings mappings of requiredTypes from {@link String}
+     *                     to {@link com.starrocks.jni.connector.OffHeapColumnVector.OffHeapColumnType}
+     */
+    protected void initOffHeapTableWriter(String[] requiredTypes, int fetchSize,
+                                          Map<String, OffHeapColumnVector.OffHeapColumnType> typeMappings) {
+        this.tableSize = fetchSize;
+        this.types = new OffHeapColumnVector.OffHeapColumnType[requiredTypes.length];
+        for (int i = 0; i < requiredTypes.length; i++) {
+            types[i] = typeMappings.get(requiredTypes[i]);
+        }
+    }
+
+    protected void scanData(int index, Object value) {
+        offHeapTable.appendData(index, value);
+    }
+
+    public int getTableSize() {
+        return tableSize;
+    }
+
+    protected long getNextOffHeapChunk() throws IOException {
+        initOffHeapTable();
+        int numRows = 0;
+        try {
+            numRows = getNext();
+        } catch (IOException e) {
+            releaseOffHeapTable();
+            throw e;
+        }
+        return finishOffHeapTable(numRows);
+    }
+
+    private void initOffHeapTable() {
+        offHeapTable = new OffHeapTable(types, tableSize);
+    }
+
+    private long finishOffHeapTable(int numRows) {
+        offHeapTable.setNumRows(numRows);
+        return offHeapTable.getMetaNativeAddress();
+    }
+
+    protected void releaseOffHeapColumnVector(int fieldId) {
+        offHeapTable.releaseOffHeapColumnVector(fieldId);
+    }
+
+    protected void releaseOffHeapTable() {
+        if (offHeapTable != null) {
+            offHeapTable.close();
+        }
+    }
+}

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -1,0 +1,337 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.jni.connector;
+
+import com.starrocks.utils.Platform;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Reference to Apache Spark with some customization
+ */
+public class OffHeapColumnVector {
+    public enum OffHeapColumnType {
+        BYTE,
+        BOOLEAN,
+        SHORT,
+        INT,
+        FLOAT,
+        LONG,
+        DOUBLE,
+        STRING,
+        DATE,
+        DECIMAL
+    }
+    private long nulls;
+    private long data;
+
+    // Only set if type is Array or Map.
+    private long offsetData;
+
+    private int capacity;
+
+    private OffHeapColumnType type;
+
+    /**
+     * Upper limit for the maximum capacity for this column.
+     */
+    // Some JVMs can't allocate arrays of length Integer.MAX_VALUE; actual max is somewhat smaller.
+    // Be conservative and lower the cap a little.
+    // Refer to "http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/util/ArrayList.java#l229"
+    // This value is word rounded. Use this value if the allocated byte arrays are used to store other
+    // types rather than bytes.
+    private static final int MAX_CAPACITY = Integer.MAX_VALUE - 15;
+
+    /**
+     * Number of nulls in this column. This is an optimization for the reader, to skip NULL checks.
+     */
+    private int numNulls;
+
+    /**
+     * Default size of each array length value. This grows as necessary.
+     */
+    private static final int DEFAULT_ARRAY_LENGTH = 4;
+
+    /**
+     * Current write cursor (row index) when appending data.
+     */
+    protected int elementsAppended;
+
+    private OffHeapColumnVector[] childColumns;
+
+    public OffHeapColumnVector(int capacity, OffHeapColumnType type) {
+        this.capacity = capacity;
+        this.type = type;
+        this.nulls = 0;
+        this.data = 0;
+        this.offsetData = 0;
+
+        reserveInternal(capacity);
+        reserveChildColumn();
+        reset();
+    }
+
+    public long nullsNativeAddress() {
+        return nulls;
+    }
+
+    public long valuesNativeAddress() {
+        return data;
+    }
+
+    public long arrayOffsetNativeAddress() {
+        return offsetData;
+    }
+
+    public long arrayDataNativeAddress() {
+        return arrayData().valuesNativeAddress();
+    }
+
+    public void close() {
+        if (childColumns != null) {
+            for (int i = 0; i < childColumns.length; i++) {
+                childColumns[i].close();
+                childColumns[i] = null;
+            }
+            childColumns = null;
+        }
+        Platform.freeMemory(nulls);
+        Platform.freeMemory(data);
+        Platform.freeMemory(offsetData);
+        nulls = 0;
+        data = 0;
+        offsetData = 0;
+    }
+
+    private void throwUnsupportedException(int requiredCapacity, Throwable cause) {
+        String message = "Cannot reserve additional contiguous bytes in the vectorized vector (" +
+                (requiredCapacity >= 0 ? "requested " + requiredCapacity + " bytes" : "integer overflow).");
+        throw new RuntimeException(message, cause);
+    }
+
+    private void reserve(int requiredCapacity) {
+        if (requiredCapacity < 0) {
+            throwUnsupportedException(requiredCapacity, null);
+        } else if (requiredCapacity > capacity) {
+            int newCapacity = (int) Math.min(MAX_CAPACITY, requiredCapacity * 2L);
+            if (requiredCapacity <= newCapacity) {
+                try {
+                    reserveInternal(newCapacity);
+                } catch (OutOfMemoryError outOfMemoryError) {
+                    throwUnsupportedException(requiredCapacity, outOfMemoryError);
+                }
+            } else {
+                throwUnsupportedException(requiredCapacity, null);
+            }
+        }
+    }
+
+    private void reserveInternal(int newCapacity) {
+        int oldCapacity = (nulls == 0L) ? 0 : capacity;
+        if (type == OffHeapColumnType.BOOLEAN || type == OffHeapColumnType.BYTE) {
+            this.data = Platform.reallocateMemory(data, oldCapacity, newCapacity);
+        } else if (type == OffHeapColumnType.SHORT) {
+            this.data = Platform.reallocateMemory(data, oldCapacity * 2L, newCapacity * 2L);
+        } else if (type == OffHeapColumnType.INT || type == OffHeapColumnType.FLOAT) {
+            this.data = Platform.reallocateMemory(data, oldCapacity * 4L, newCapacity * 4L);
+        } else if (type == OffHeapColumnType.LONG || type == OffHeapColumnType.DOUBLE) {
+            this.data = Platform.reallocateMemory(data, oldCapacity * 8L, newCapacity * 8L);
+        } else if (type == OffHeapColumnType.STRING || type == OffHeapColumnType.DATE || type == OffHeapColumnType.DECIMAL) {
+            this.offsetData =
+                    Platform.reallocateMemory(offsetData, oldCapacity * 4L, (newCapacity + 1) * 4L);
+        } else {
+            throw new RuntimeException("Unhandled " + type);
+        }
+        this.nulls = Platform.reallocateMemory(nulls, oldCapacity, newCapacity);
+        Platform.setMemory(nulls + oldCapacity, (byte) 0, newCapacity - oldCapacity);
+        capacity = newCapacity;
+    }
+
+    private void reserveChildColumn() {
+        if (type == OffHeapColumnType.STRING || type == OffHeapColumnType.DATE || type == OffHeapColumnType.DECIMAL) {
+            int childCapacity = capacity;
+            childCapacity *= DEFAULT_ARRAY_LENGTH;
+            this.childColumns = new OffHeapColumnVector[1];
+            this.childColumns[0] = new OffHeapColumnVector(childCapacity, OffHeapColumnType.BYTE);
+        }
+    }
+
+    private void reset() {
+        if (childColumns != null) {
+            for (OffHeapColumnVector c : childColumns) {
+                c.reset();
+            }
+        }
+        elementsAppended = 0;
+        if (numNulls > 0) {
+            putNotNulls(0, capacity);
+            numNulls = 0;
+        }
+    }
+
+    private OffHeapColumnVector arrayData() {
+        return childColumns[0];
+    }
+
+    public boolean isNullAt(int rowId) {
+        return Platform.getByte(null, nulls + rowId) == 1;
+    }
+
+    public boolean hasNull() {
+        return numNulls > 0;
+    }
+
+    private void putNotNulls(int rowId, int count) {
+        if (!hasNull()) {
+            return;
+        }
+        long offset = nulls + rowId;
+        for (int i = 0; i < count; ++i, ++offset) {
+            Platform.putByte(null, offset, (byte) 0);
+        }
+    }
+
+    public int appendNull() {
+        reserve(elementsAppended + 1);
+        putNull(elementsAppended);
+        return elementsAppended++;
+    }
+
+    private void putNull(int rowId) {
+        Platform.putByte(null, nulls + rowId, (byte) 1);
+        ++numNulls;
+    }
+
+    public int appendBoolean(boolean v) {
+        reserve(elementsAppended + 1);
+        putBoolean(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putBoolean(int rowId, boolean value) {
+        Platform.putByte(null, data + rowId, (byte) ((value) ? 1 : 0));
+    }
+
+    public boolean getBoolean(int rowId) {
+        return Platform.getByte(null, data + rowId) == 1;
+    }
+
+    public int appendShort(short v) {
+        reserve(elementsAppended + 1);
+        putShort(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putShort(int rowId, short value) {
+        Platform.putShort(null, data + 2L * rowId, value);
+    }
+
+    public short getShort(int rowId) {
+        return Platform.getShort(null, data + 2L * rowId);
+    }
+
+    public int appendInt(int v) {
+        reserve(elementsAppended + 1);
+        putInt(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putInt(int rowId, int value) {
+        Platform.putInt(null, data + 4L * rowId, value);
+    }
+
+    public int getInt(int rowId) {
+        return Platform.getInt(null, data + 4L * rowId);
+    }
+
+    public int appendFloat(float v) {
+        reserve(elementsAppended + 1);
+        putFloat(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putFloat(int rowId, float value) {
+        Platform.putFloat(null, data + rowId * 4L, value);
+    }
+
+    public float getFloat(int rowId) {
+        return Platform.getFloat(null, data + rowId * 4L);
+    }
+
+    public int appendLong(long v) {
+        reserve(elementsAppended + 1);
+        putLong(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putLong(int rowId, long value) {
+        Platform.putLong(null, data + 8L * rowId, value);
+    }
+
+    public long getLong(int rowId) {
+        return Platform.getLong(null, data + 8L * rowId);
+    }
+
+    public int appendDouble(double v) {
+        reserve(elementsAppended + 1);
+        putDouble(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putDouble(int rowId, double value) {
+        Platform.putDouble(null, data + rowId * 8L, value);
+    }
+
+    public double getDouble(int rowId) {
+        return Platform.getDouble(null, data + rowId * 8L);
+    }
+
+    private void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+        Platform.copyMemory(src, Platform.BYTE_ARRAY_OFFSET + srcIndex, null, data + rowId, count);
+    }
+
+    private byte[] getBytes(int rowId, int count) {
+        byte[] array = new byte[count];
+        Platform.copyMemory(null, data + rowId, array, Platform.BYTE_ARRAY_OFFSET, count);
+        return array;
+    }
+
+    private int appendBytes(int length, byte[] src, int offset) {
+        reserve(elementsAppended + length);
+        int result = elementsAppended;
+        putBytes(elementsAppended, length, src, offset);
+        elementsAppended += length;
+        return result;
+    }
+
+    public int appendString(String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        return appendByteArray(bytes, 0, str.length());
+    }
+
+    private int appendByteArray(byte[] value, int offset, int length) {
+        int copiedOffset = arrayData().appendBytes(length, value, offset);
+        reserve(elementsAppended + 1);
+        putArray(elementsAppended, copiedOffset, length);
+        return elementsAppended++;
+    }
+
+    private void putArray(int rowId, int offset, int length) {
+        Platform.putInt(null, offsetData + 4L * rowId, offset);
+        Platform.putInt(null, offsetData + 4L * (rowId + 1), offset + length);
+    }
+
+    public String getUTF8String(int rowId) {
+        if (isNullAt(rowId)) {
+            return null;
+        }
+        int start = getArrayOffset(rowId);
+        int end = getArrayOffset(rowId + 1);
+        byte[] bytes = arrayData().getBytes(start, end - start);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private int getArrayOffset(int rowId) {
+        return Platform.getInt(null, offsetData + 4L * rowId);
+    }
+}

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapTable.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapTable.java
@@ -1,0 +1,204 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.jni.connector;
+
+/**
+ * We use off-heap memory to save the off-heap table data
+ * and a custom memory layout to be parsed by Starrocks BE written in C++.
+ *
+ * Off-heap table memory layout details:
+ * 1. A single data column is stored continuously in off-heap memory.
+ * 2. Different data columns are stored in different locations in off-heap memory.
+ * 3. Introduce null indicator columns to determine if a field is empty or not.
+ * 4. Introduce a meta column to save the memory addresses of different data columns,
+ *    the memory addresses of null indicator columns and number of rows.
+ *
+ * Meta column layout:
+ * Meta column start address: | number of rows |
+ *                            | null indicator start address of fixed length column-A |
+ *                            | data column start address of the fixed length column-A  |
+ *                            | ... |
+ *                            | null indicator start address of variable length column-B |
+ *                            | offset column start address of the variable length column-B |
+ *                            | data column start address of the variable length column-B |
+ *                            | ... |
+ *
+ * Null indicator column layout:
+ * Null column start address: | 1-byte boolean | 1-byte boolean | 1-byte boolean | ... |
+ *                 Row index: -------row 0-------------row 1------------row 2----- ... -
+ *
+ * Data column layout:
+ * Data columns are divided into two storage types: fixed length column and variable length column.
+ *
+ * For fixed length column like BOOLEAN/INT/LONG, we use first-level index addressing method.
+ * (1) Get data column start address from meta column.
+ * (2) Use column start address to read the data of fixed length.
+ * Fixed length column memory layout:
+ * Data column start address of fixed length column: | X-bytes | X-bytes | X-bytes | ... |
+ * INT column of 4 bytes for example:
+ * Fixed length column start address: | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
+ *                         Row index:  ----row 0---------row 1---------row 2----- ... -
+ *
+ *
+ * For variable length column like STRING/DECIMAL, we use secondary-level index addressing method.
+ * (1) Get data column start address from meta column.
+ * (2) Get the field start memory address from offset column at a row index.
+ * (2) Get the field start memory address from offset column at the next row index to compute the filed length.
+ * (4) Use the data start address and the field length to read the data of variable length.
+ * Variable length column memory layout:
+ * Offset column start address of variable length column: : | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
+ * Data column start address of variable length column: | X-bytes | Y-bytes | Z-bytes | ... |
+ * STRING column for example:
+ * Offset column start address: | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
+ *                   Row index:  ----row 0---------row 1---------row 2----- ... -
+ * Variable length column start address: |    (length of row 0)-bytes    | (length of row 1)-bytes | ... |
+ *                                       |                               |
+ *                 column start address + offset of row 0    column start address + length of row 1
+ */
+public class OffHeapTable {
+    public OffHeapColumnVector[] vectors;
+    public OffHeapColumnVector.OffHeapColumnType[] types;
+    public OffHeapColumnVector meta;
+    public int numRows;
+    public boolean[] released;
+
+    public OffHeapTable(OffHeapColumnVector.OffHeapColumnType[] types, int capacity) {
+        this.types = types;
+        this.vectors = new OffHeapColumnVector[types.length];
+        this.released = new boolean[types.length];
+        int metaSize = 0;
+        for (int i = 0; i < types.length; i++) {
+            vectors[i] = new OffHeapColumnVector(capacity, types[i]);
+            if (types[i] == OffHeapColumnVector.OffHeapColumnType.STRING
+                    || types[i] == OffHeapColumnVector.OffHeapColumnType.DATE) {
+                metaSize += 3;
+            } else {
+                metaSize += 2;
+            }
+            released[i] = false;
+        }
+        this.meta = new OffHeapColumnVector(metaSize, OffHeapColumnVector.OffHeapColumnType.LONG);
+        this.numRows = 0;
+    }
+
+    public void appendData(int fieldId, Object o) {
+        OffHeapColumnVector column = vectors[fieldId];
+        if (o == null) {
+            column.appendNull();
+            return;
+        }
+
+        OffHeapColumnVector.OffHeapColumnType type = types[fieldId];
+        switch (type) {
+            case BOOLEAN:
+                column.appendBoolean((boolean) o);
+                break;
+            case SHORT:
+                column.appendShort((short) o);
+                break;
+            case INT:
+                column.appendInt((int) o);
+                break;
+            case FLOAT:
+                column.appendFloat((float) o);
+                break;
+            case LONG:
+                column.appendLong((long) o);
+                break;
+            case DOUBLE:
+                column.appendDouble((double) o);
+                break;
+            case STRING:
+            case DATE:
+            case DECIMAL:
+                column.appendString(o.toString());
+                break;
+            default:
+                throw new RuntimeException("Unsupported type: " + type);
+        }
+    }
+
+    public void releaseOffHeapColumnVector(int fieldId) {
+        if (!released[fieldId]) {
+            vectors[fieldId].close();
+            released[fieldId] = true;
+        }
+    }
+
+    public void setNumRows(int numRows) {
+        this.numRows = numRows;
+    }
+
+    public long getMetaNativeAddress() {
+        meta.appendLong(numRows);
+        for (int i = 0; i < types.length; i++) {
+            OffHeapColumnVector.OffHeapColumnType type = types[i];
+            OffHeapColumnVector column = vectors[i];
+            if (type == OffHeapColumnVector.OffHeapColumnType.STRING ||
+                    type == OffHeapColumnVector.OffHeapColumnType.DATE ||
+                    type == OffHeapColumnVector.OffHeapColumnType.DECIMAL) {
+                meta.appendLong(column.nullsNativeAddress());
+                meta.appendLong(column.arrayOffsetNativeAddress());
+                meta.appendLong(column.arrayDataNativeAddress());
+            } else {
+                meta.appendLong(column.nullsNativeAddress());
+                meta.appendLong(column.valuesNativeAddress());
+            }
+        }
+        return meta.valuesNativeAddress();
+    }
+
+    /**
+     * For test only
+     */
+    public void show(int limit) {
+        StringBuilder sb = new StringBuilder();
+        System.out.println("numRows = " + numRows);
+        for (int i = 0; i < limit && i < numRows; i++) {
+            for (int fieldId = 0; fieldId < types.length; fieldId++) {
+                OffHeapColumnVector column = vectors[fieldId];
+                if (column.isNullAt(i)) {
+                    sb.append("NULL").append(", ");
+                    continue;
+                }
+                OffHeapColumnVector.OffHeapColumnType type = types[fieldId];
+                switch (type) {
+                    case BOOLEAN:
+                        sb.append(column.getBoolean(i)).append(", ");
+                        break;
+                    case SHORT:
+                        sb.append(column.getShort(i)).append(", ");
+                        break;
+                    case INT:
+                        sb.append(column.getInt(i)).append(", ");
+                        break;
+                    case FLOAT:
+                        sb.append(column.getFloat(i)).append(", ");
+                        break;
+                    case LONG:
+                        sb.append(column.getLong(i)).append(", ");
+                        break;
+                    case DOUBLE:
+                        sb.append(column.getDouble(i)).append(", ");
+                        break;
+                    case STRING:
+                    case DATE:
+                    case DECIMAL:
+                        sb.append(column.getUTF8String(i)).append(", ");
+                        break;
+                    default:
+                        throw new RuntimeException("Unhandled " + type);
+                }
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public void close() {
+        for (int i = 0; i < vectors.length; i++) {
+            releaseOffHeapColumnVector(i);
+        }
+        meta.close();
+    }
+}

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerFactory.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerFactory.java
@@ -1,0 +1,7 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.jni.connector;
+
+public interface ScannerFactory {
+    Class getScannerClass() throws ClassNotFoundException;
+}

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/TypeMapping.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/TypeMapping.java
@@ -1,0 +1,22 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.jni.connector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TypeMapping {
+    public static Map<String, OffHeapColumnVector.OffHeapColumnType> hiveTypeMappings = new HashMap<>();
+    static {
+        hiveTypeMappings.put("byte", OffHeapColumnVector.OffHeapColumnType.BYTE);
+        hiveTypeMappings.put("bool", OffHeapColumnVector.OffHeapColumnType.BOOLEAN);
+        hiveTypeMappings.put("short", OffHeapColumnVector.OffHeapColumnType.SHORT);
+        hiveTypeMappings.put("int", OffHeapColumnVector.OffHeapColumnType.INT);
+        hiveTypeMappings.put("float", OffHeapColumnVector.OffHeapColumnType.FLOAT);
+        hiveTypeMappings.put("bigint", OffHeapColumnVector.OffHeapColumnType.LONG);
+        hiveTypeMappings.put("double", OffHeapColumnVector.OffHeapColumnType.DOUBLE);
+        hiveTypeMappings.put("string", OffHeapColumnVector.OffHeapColumnType.STRING);
+        hiveTypeMappings.put("date", OffHeapColumnVector.OffHeapColumnType.DATE);
+        hiveTypeMappings.put("decimal", OffHeapColumnVector.OffHeapColumnType.DECIMAL);
+    }
+}

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -12,6 +12,7 @@
         <module>jdbc-bridge</module>
         <module>udf-extensions</module>
         <module>java-utils</module>
+        <module>jni-connector</module>
     </modules>
     <name>starrocks-java-extensions</name>
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

 introduce a JNI connector In order to quickly access the data source of the java ecosystem.

This feature provides an interface to help developers mainly focus on their own java reader, no need to care about annoying JNI and just need to write a little cpp wrapper code.


Notes for review: 
Reviewer should read comments in OffHeapTable.java to understand the memory layout design used to interact with C++ in BE.

```java
/**
 * We use off-heap memory to save the off-heap table data
 * and a custom memory layout to be parsed by Starrocks BE written in C++.
 *
 * Off-heap table memory layout details:
 * 1. A single data column is stored continuously in off-heap memory.
 * 2. Different data columns are stored in different locations in off-heap memory.
 * 3. Introduce null indicator columns to determine if a field is empty or not.
 * 4. Introduce a meta column to save the memory addresses of different data columns,
 *    the memory addresses of null indicator columns and number of rows.
 *
 * Meta column layout:
 * Meta column start address: | number of rows |
 *                            | null indicator start address of fixed length column-A |
 *                            | data column start address of the fixed length column-A  |
 *                            | ... |
 *                            | null indicator start address of variable length column-B |
 *                            | offset column start address of the variable length column-B |
 *                            | data column start address of the variable length column-B |
 *                            | ... |
 *
 * Null indicator column layout:
 * Null column start address: | 1-byte boolean | 1-byte boolean | 1-byte boolean | ... |
 *                 Row index: -------row 0-------------row 1------------row 2----- ... -
 *
 * Data column layout:
 * Data columns are divided into two storage types: fixed length column and variable length column.
 *
 * For fixed length column like BOOLEAN/INT/LONG, we use first-level index addressing method.
 * (1) Get data column start address from meta column.
 * (2) Use column start address to read the data of fixed length.
 * Fixed length column memory layout:
 * Data column start address of fixed length column: | X-bytes | X-bytes | X-bytes | ... |
 * INT column of 4 bytes for example:
 * Fixed length column start address: | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
 *                         Row index:  ----row 0---------row 1---------row 2----- ... -
 *
 *
 * For variable length column like STRING/DECIMAL, we use secondary-level index addressing method.
 * (1) Get data column start address from meta column.
 * (2) Get the field start memory address from offset column at a row index.
 * (2) Get the field start memory address from offset column at the next row index to compute the filed length.
 * (4) Use the data start address and the field length to read the data of variable length.
 * Variable length column memory layout:
 * Offset column start address of variable length column: : | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
 * Data column start address of variable length column: | X-bytes | Y-bytes | Z-bytes | ... |
 * STRING column for example:
 * Offset column start address: | 4-bytes INT | 4-bytes INT | 4-bytes INT | ... |
 *                   Row index:  ----row 0---------row 1---------row 2----- ... -
 * Variable length column start address: |    (length of row 0)-bytes    | (length of row 1)-bytes | ... |
 *                                       |                               |
 *                 column start address + offset of row 0    column start address + length of row 1
 */
```
