### PR TITLE
[BugFix] Fix BrokerLoad FailMsg serialization throws NPE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/FailMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/FailMsg.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.load;
 
+import com.google.common.base.Strings;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 
@@ -75,7 +76,11 @@ public class FailMsg implements Writable {
 
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, cancelType.name());
-        Text.writeString(out, msg);
+        if (Strings.isNullOrEmpty(msg)) {
+            Text.writeString(out, "");
+        } else {
+            Text.writeString(out, msg);
+        }
     }
 
     public void readFields(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/load/FailMsgTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/FailMsgTest.java
@@ -17,9 +17,11 @@
 
 package com.starrocks.load;
 
+import com.starrocks.common.io.DataOutputBuffer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -30,26 +32,33 @@ public class FailMsgTest {
 
     @Test
     public void testSerialization() throws Exception {
-        File file = new File("./failMsgTest");
-        file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+        DataOutputBuffer dof = new DataOutputBuffer();
 
         FailMsg failMsg = new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED, "Job failed");
-        failMsg.write(dos);
-        dos.flush();
-        dos.close();
+        failMsg.write(dof);
 
-        DataInputStream dis = new DataInputStream(new FileInputStream(file));
+        DataInputStream dif = new DataInputStream(new ByteArrayInputStream(dof.getData()));
         FailMsg failMsg1 = new FailMsg();
-        failMsg1.readFields(dis);
+        failMsg1.readFields(dif);
 
         Assert.assertEquals(failMsg1.getMsg(), "Job failed");
         Assert.assertEquals(failMsg1.getCancelType(), FailMsg.CancelType.ETL_QUALITY_UNSATISFIED);
 
-        Assert.assertTrue(failMsg1.equals(failMsg));
-
-        dis.close();
-        file.delete();
+        Assert.assertEquals(failMsg1, failMsg);
     }
 
+    @Test
+    public void testSerialization2() throws Exception {
+        DataOutputBuffer dof = new DataOutputBuffer();
+
+        FailMsg failMsg = new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED, null);
+        failMsg.write(dof);
+
+        DataInputStream dif = new DataInputStream(new ByteArrayInputStream(dof.getData()));
+        FailMsg failMsg1 = new FailMsg();
+        failMsg1.readFields(dif);
+
+        Assert.assertEquals(failMsg1.getMsg(), "");
+        Assert.assertEquals(failMsg1.getCancelType(), FailMsg.CancelType.ETL_QUALITY_UNSATISFIED);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9726

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This bug appears in a customer's environment that has an internal version based on 2.1.2. But there are too many callers of FailMsg(CancelType cancelType, String msg); we should write some protectable code to prevent the NPE.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
