### PR TITLE
[Refactor][Enhancement] DataStreamRecvr::SenderQueue phase 3: introduce unplug mechanism

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -660,7 +660,7 @@ CONF_Int64(pipeline_prepare_thread_pool_queue_size, "102400");
 // The buffer size of SinkBuffer.
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // The degree of parallelism of brpc.
-CONF_Int64(pipeline_sink_brpc_dop, "8");
+CONF_Int64(pipeline_sink_brpc_dop, "64");
 // Used to reject coming fragment instances, when the number of running drivers
 // exceeds it*pipeline_exec_thread_pool_thread_num.
 CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -207,12 +207,13 @@ private:
     std::unique_ptr<ChunkQueue::producer_token_t> _producer_token;
 
     struct ChunkQueueState {
+        // Record the number of blocked closure in the queue
+        std::atomic_int32_t blocked_closure_num = 0;
         // Record whether the queue is in the unplug state.
         // In the unplug state, has_output will return true directly if there is a chunk in the queue.
         // Otherwise, it will try to batch enough chunks to reduce the scheduling overhead.
         bool unpluging = false;
-        // Record the number of blocked closure in the queue
-        std::atomic_int32_t blocked_closure_num = 0;
+        bool is_short_circuited = false;
     };
     std::vector<ChunkQueueState> _chunk_queue_states;
 
@@ -229,8 +230,6 @@ private:
     // key of first level is be_number
     // key of second level is request sequence
     phmap::flat_hash_map<int, phmap::flat_hash_map<int64_t, ChunkList>> _buffered_chunk_queues;
-
-    std::vector<bool> _short_circuit_driver_sequences;
 
     static constexpr size_t kUnplugBufferThreshold = 16;
 };


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

in this PR, I introduce an unplug mechanism similar to ScanOperator for PipelineSenderQueue to reduce the overhead caused by pipeline driver scheduling. In order to make the effect of unplug more significant, change the default value of pipeline_sink_brpc_dop from 8 to 64.

I tested with the following query, the test dataset is tpcds-1TB, the test env contains 1FE and 3 BE, BE has 64cores
```sql
select  count(*) c, sum(cs_item_sk) from catalog_sales group by cs_order_number order by c limit 10;
```

After this change, the scheduling count of the pipeline driver which contains ExchangeSourceOperator will be reduced by more than half (66k->23k) and the query time will be close to that before (2.767s->2.68s)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
