### PR TITLE
[Enhancement]support creating multiple single connections between BE

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -49,6 +49,10 @@ CONF_Int32(brpc_port, "8060");
 // The number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores.
 CONF_Int32(brpc_num_threads, "-1");
 
+// The max number of single connections maintained by the brpc client and each server.
+// Theses connections are created during the first few access and will be used thereafter
+CONF_Int32(brpc_max_connections_per_server, "1");
+
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.
 // this is a list in semicolon-delimited format, in CIDR notation, e.g. 10.10.10.0/24

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -36,6 +36,7 @@
 
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
@@ -66,23 +67,13 @@ public:
 
     doris::PBackendService_Stub* get_stub(const butil::EndPoint& endpoint) {
         std::lock_guard<SpinLock> l(_lock);
-        auto stub_ptr = _stub_map.seek(endpoint);
-        if (stub_ptr != nullptr) {
-            return *stub_ptr;
+        auto stub_pool = _stub_map.seek(endpoint);
+        if (stub_pool == nullptr) {
+            StubPool* pool = new StubPool();
+            _stub_map.insert(endpoint, pool);
+            return pool->get_or_create(endpoint);
         }
-        // new one stub and insert into map
-        brpc::ChannelOptions options;
-        options.connect_timeout_ms = 3000;
-        // Explicitly set the max_retry
-        // TODO(meegoo): The retry strategy can be customized in the future
-        options.max_retry = 3;
-        std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
-        if (channel->Init(endpoint, &options)) {
-            return nullptr;
-        }
-        auto stub = new doris::PBackendService_Stub(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
-        _stub_map.insert(endpoint, stub);
-        return stub;
+        return (*stub_pool)->get_or_create(endpoint);
     }
 
     // rarely used, so create as needed
@@ -136,8 +127,50 @@ public:
     }
 
 private:
+    // StubPool is used to store all stubs with a single endpoint, and the client in the same BE process maintains up to
+    // brpc_max_connections_per_server single connections with each server.
+    // These connections will be created during the first few accesses and will be reused later.
+    struct StubPool {
+        StubPool() { _stubs.reserve(config::brpc_max_connections_per_server); }
+
+        ~StubPool() {
+            for (auto& stub : _stubs) {
+                delete stub;
+            }
+        }
+
+        doris::PBackendService_Stub* get_or_create(const butil::EndPoint& endpoint) {
+            if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
+                brpc::ChannelOptions options;
+                options.connect_timeout_ms = 3000;
+                // Explicitly set the max_retry
+                // TODO(meegoo): The retry strategy can be customized in the future
+                options.max_retry = 3;
+                // the single connection of brpc will only maintain one connection with the same server by default,
+                // all requests are sent on this connection and the throughput will be limited by this.
+                // we use `connection_group` to create multiple single connections to remove this bottleneck.
+                options.connection_group = std::to_string(_stubs.size());
+                std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
+                if (channel->Init(endpoint, &options)) {
+                    return nullptr;
+                }
+                auto stub = new doris::PBackendService_Stub(channel.release(),
+                                                            google::protobuf::Service::STUB_OWNS_CHANNEL);
+                _stubs.push_back(stub);
+                return stub;
+            }
+            if (++_idx >= config::brpc_max_connections_per_server) {
+                _idx = 0;
+            }
+            return _stubs[_idx];
+        }
+
+        std::vector<doris::PBackendService_Stub*> _stubs;
+        int64_t _idx = -1;
+    };
+
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, doris::PBackendService_Stub*> _stub_map;
+    butil::FlatMap<butil::EndPoint, StubPool*> _stub_map;
 };
 
 } // namespace starrocks


### PR DESCRIPTION

Currently, our brpc client uses single connection mode, each client only establishes one connection with the server, and all requests are on this connection, which may limit the throughput of transmit_chunk.
In this PR, I added a configuration so that the brpc client can maintain multiple single connections with the server to eliminate the above bottleneck.

I tested with the following query, the test dataset is tpcds-1TB, the test env contains 1FE and 3 BE, BE has 64cores, the network bandwidth of each BE is 32Gbit/s.

This is a network-heavy query, in my env, the exchange operator will transfer 7.16GB of data through tramsmit_chunk rpc.

```sql
set new_planner_agg_stage =1;
select  count(*) c, sum(cs_item_sk) from catalog_sales group by cs_order_number order by c limit 10;
```
under the default configuration, this query takes about 2.7s. when I change the brpc_max_connections_per_server to 3, the query latency can be reduced to 2.1s.

TODO:
1. maybe we need a strategy to dynamically adjust the number of single connections.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
