### PR TITLE
[Enhancement] Load transanction state in image in commit order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -130,9 +130,7 @@ public class DatabaseTransactionMgr {
     // not realtime usedQuota value to make a fast check for database data quota
     private volatile long usedQuotaDataBytes = -1;
 
-    private long lastCommitTs = 0;
-
-    private long commitTsInc = 0;
+    private long maxCommitTs = 0;
 
     private final TransactionStateListenerFactory stateListenerFactory = new TransactionStateListenerFactory();
 
@@ -1046,18 +1044,8 @@ public class DatabaseTransactionMgr {
         if (transactionState.getTransactionStatus() != TransactionStatus.PREPARE) {
             return;
         }
-        // since we send publish order by commit timestamp
-        // so that we need handle timetamp fallback
-        // & same timestamp cause by granularity
-        // The probability of timestamp fallback after FE failover is small
-        // and it is not considered at present
-        long commitTs = System.currentTimeMillis();
-        if (commitTs <= lastCommitTs) {
-            commitTs = lastCommitTs + ++commitTsInc;
-        } else {
-            commitTsInc = 0;
-        }
-        lastCommitTs = commitTs;
+        // commit timestamps needs to be strictly monotonically increasing
+        long commitTs = Math.max(System.currentTimeMillis(), maxCommitTs + 1);
         transactionState.setCommitTime(commitTs);
         // update transaction state version
         transactionState.setTransactionStatus(TransactionStatus.COMMITTED);
@@ -1098,22 +1086,12 @@ public class DatabaseTransactionMgr {
     }
 
     protected void unprotectedCommitPreparedTransaction(TransactionState transactionState, Database db) {
-        // transaction state is modified during check if the transaction could committed
+        // transaction state is modified during check if the transaction could be committed
         if (transactionState.getTransactionStatus() != TransactionStatus.PREPARED) {
             return;
         }
-        // since we send publish order by commit timestamp
-        // so that we need handle timetamp fallback
-        // & same timestamp cause by granularity
-        // The probability of timestamp fallback after FE failover is small
-        // and it is not considered at present
-        long commitTs = System.currentTimeMillis();
-        if (commitTs <= lastCommitTs) {
-            commitTs = lastCommitTs + ++commitTsInc;
-        } else {
-            commitTsInc = 0;
-        }
-        lastCommitTs = commitTs;
+        // commit timestamps needs to be strictly monotonically increasing
+        long commitTs = Math.max(System.currentTimeMillis(), maxCommitTs + 1);
         transactionState.setCommitTime(commitTs);
         // update transaction state version
         transactionState.setTransactionStatus(TransactionStatus.COMMITTED);
@@ -1168,6 +1146,8 @@ public class DatabaseTransactionMgr {
                 editLog.logInsertTransactionState(transactionState);
             }
         }
+        // it's OK if getCommitTime() returns -1
+        maxCommitTs = Math.max(maxCommitTs, transactionState.getCommitTime());
         if (!transactionState.getTransactionStatus().isFinalStatus()) {
             if (idToRunningTransactionState.put(transactionState.getTransactionId(), transactionState) == null) {
                 if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9648

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR change the image loading logic, to load txn states in commit order (rather than record order in image), some logic(txngraph, finalStatusTransactionStateDeque) may depend on the txns' events being delivered the same as commit order. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
