### PR TITLE
[Enhancement] Use shuffle bucket join to reduce data shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -55,7 +55,8 @@ public class HashDistributionDesc {
 
         if (this.sourceType == SourceType.SHUFFLE_AGG && item.sourceType == SourceType.SHUFFLE_JOIN) {
             return this.columns.size() == item.columns.size() && this.columns.equals(item.columns);
-        } else if (this.sourceType == SourceType.SHUFFLE_JOIN && item.sourceType == SourceType.SHUFFLE_AGG) {
+        } else if (this.sourceType == SourceType.SHUFFLE_JOIN && (item.sourceType == SourceType.SHUFFLE_AGG ||
+                item.sourceType == SourceType.SHUFFLE_JOIN)) {
             return item.columns.containsAll(this.columns);
         } else if (!this.sourceType.equals(item.sourceType) &&
                 this.sourceType != HashDistributionDesc.SourceType.LOCAL) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -1,7 +1,6 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
-import com.starrocks.utframe.UtFrameUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
@@ -236,43 +236,18 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                 SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
                         EXCHANGE SHUFFLE[19]
                             INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                                EXCHANGE SHUFFLE[20]
-                                    INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
+                                INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
+                                    EXCHANGE SHUFFLE[21]
                                         INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
                                             SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
                                             EXCHANGE BROADCAST
                                                 SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                                        EXCHANGE BROADCAST
-                                            SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
-                                EXCHANGE SHUFFLE[36]
+                                    EXCHANGE SHUFFLE[11]
+                                        SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
+                                EXCHANGE SHUFFLE[37]
                                     SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
 [plan-10]
-TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
-    TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
-            EXCHANGE SHUFFLE[53, 57]
-                AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
-                    INNER JOIN (join-predicate [42: O_ORDERKEY = 19: L_ORDERKEY AND 52: N_NATIONKEY = 14: S_NATIONKEY] post-join-predicate [null])
-                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                            SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
-                        EXCHANGE SHUFFLE[19]
-                            INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
-                                EXCHANGE SHUFFLE[20]
-                                    INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
-                                        EXCHANGE SHUFFLE[21]
-                                            INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
-                                                SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
-                                                EXCHANGE BROADCAST
-                                                    SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                                        EXCHANGE SHUFFLE[11]
-                                            SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
-                                EXCHANGE SHUFFLE[36]
-                                    SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
-[end]
-[plan-11]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -295,7 +270,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE BROADCAST
                             SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
 [end]
-[plan-12]
+[plan-11]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -318,7 +293,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                 EXCHANGE SHUFFLE[42]
                                     SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
 [end]
-[plan-13]
+[plan-12]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -342,7 +317,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
-[plan-14]
+[plan-13]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -367,7 +342,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
-[plan-15]
+[plan-14]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -391,7 +366,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE BROADCAST
                             SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
 [end]
-[plan-16]
+[plan-15]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -415,7 +390,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                 EXCHANGE BROADCAST
                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
 [end]
-[plan-17]
+[plan-16]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -440,7 +415,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                 EXCHANGE SHUFFLE[52]
                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
 [end]
-[plan-18]
+[plan-17]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -464,7 +439,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE SHUFFLE[36]
                             SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
 [end]
-[plan-19]
+[plan-18]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9790 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Main change:
1.  Satisty requirement for SHFFLE_JOIN property, hash by column A can satisfy hash by A,B columns
2. check plan is legal for shuffle join in ChildOutputPropertyGuarantor. if not, add or modify the enforcer to be legal
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
