### PR TITLE
[Refactor] Move some codes in SchemaChangeHandler to AlterJobV2Builder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -1,0 +1,87 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Index;
+import com.starrocks.common.UserException;
+import com.starrocks.thrift.TStorageFormat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+public abstract class AlterJobV2Builder {
+    protected long jobId = 0;
+    protected long dbId = 0;
+    protected long startTime = 0;
+    protected long timeoutMs = 0;
+    protected boolean bloomFilterColumnsChanged = false;
+    protected Set<String> bloomFilterColumns;
+    protected double bloomFilterFpp;
+    protected boolean hasIndexChanged = false;
+    protected List<Index> indexes;
+    protected TStorageFormat newStorageFormat;
+    protected Map<Long, List<Column>> newIndexSchema = new HashMap<>();
+    protected Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+
+    public AlterJobV2Builder() {
+    }
+
+    public AlterJobV2Builder withJobId(long jobId) {
+        this.jobId = jobId;
+        return this;
+    }
+
+    public AlterJobV2Builder withDbId(long dbId) {
+        this.dbId = dbId;
+        return this;
+    }
+
+    public AlterJobV2Builder withTimeoutSeconds(long timeout) {
+        this.timeoutMs = timeout * 1000;
+        return this;
+    }
+
+    public AlterJobV2Builder withStartTime(long startTime) {
+        this.startTime = startTime;
+        return this;
+    }
+
+    public AlterJobV2Builder withBloomFilterColumnsChanged(boolean changed) {
+        this.bloomFilterColumnsChanged = changed;
+        return this;
+    }
+
+    public AlterJobV2Builder withBloomFilterColumns(@Nullable Set<String> bfColumns, double bfFpp) {
+        this.bloomFilterColumns = bfColumns;
+        this.bloomFilterFpp = bfFpp;
+        return this;
+    }
+
+    public AlterJobV2Builder withAlterIndexInfo(boolean hasIndexChanged, @NotNull List<Index> indexes) {
+        this.hasIndexChanged = hasIndexChanged;
+        this.indexes = indexes;
+        return this;
+    }
+
+    public AlterJobV2Builder withNewStorageFormat(TStorageFormat storageFormat) {
+        this.newStorageFormat = storageFormat;
+        return this;
+    }
+
+    public AlterJobV2Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount) {
+        this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+        return this;
+    }
+
+    public AlterJobV2Builder withNewIndexSchema(long indexId, @NotNull List<Column> indexSchema) {
+        newIndexSchema.put(indexId, indexSchema);
+        return this;
+    }
+
+    public abstract AlterJobV2 build() throws UserException;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -1,0 +1,13 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.alter;
+
+import com.starrocks.common.NotImplementedException;
+import com.starrocks.common.UserException;
+
+public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
+    @Override
+    public AlterJobV2 build() throws UserException {
+        throw new NotImplementedException("does not support alter lake table yet");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -1,0 +1,141 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.alter;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.Util;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStorageMedium;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
+    private static final Logger LOG = LogManager.getLogger(OlapTableAlterJobV2Builder.class);
+
+    private final OlapTable table;
+
+    public OlapTableAlterJobV2Builder(OlapTable table) {
+        this.table = table;
+    }
+
+    @Override
+    public AlterJobV2 build() throws UserException {
+        if (newIndexSchema.isEmpty() && !hasIndexChanged) {
+            throw new DdlException("Nothing is changed. please check your alter stmt.");
+        }
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        long tableId = table.getId();
+        SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(jobId, dbId, tableId, table.getName(), timeoutMs);
+        schemaChangeJob.setBloomFilterInfo(bloomFilterColumnsChanged, bloomFilterColumns, bloomFilterFpp);
+        schemaChangeJob.setAlterIndexInfo(hasIndexChanged, indexes);
+        schemaChangeJob.setStartTime(startTime);
+        schemaChangeJob.setStorageFormat(newStorageFormat);
+        /*
+         * Create schema change job
+         * 1. For each index which has been changed, create a SHADOW index, and save the mapping of origin index to SHADOW index.
+         * 2. Create all tablets and replicas of all SHADOW index, add them to tablet inverted index.
+         * 3. Change table's state as SCHEMA_CHANGE
+         */
+        for (Map.Entry<Long, List<Column>> entry : newIndexSchema.entrySet()) {
+            long originIndexId = entry.getKey();
+            MaterializedIndexMeta currentIndexMeta = table.getIndexMetaByIndexId(originIndexId);
+            // 1. get new schema version/schema version hash, short key column count
+            int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
+            int newSchemaVersion = currentSchemaVersion + 1;
+            // generate schema hash for new index has to generate a new schema hash not equal to current schema hash
+            int currentSchemaHash = currentIndexMeta.getSchemaHash();
+            int newSchemaHash = Util.generateSchemaHash();
+            while (currentSchemaHash == newSchemaHash) {
+                newSchemaHash = Util.generateSchemaHash();
+            }
+            String newIndexName = SchemaChangeHandler.SHADOW_NAME_PRFIX + table.getIndexNameById(originIndexId);
+            short newShortKeyColumnCount = newIndexShortKeyCount.get(originIndexId);
+            long shadowIndexId = globalStateMgr.getNextId();
+
+            // create SHADOW index for each partition
+            List<Tablet> addedTablets = Lists.newArrayList();
+            for (Partition partition : table.getPartitions()) {
+                long partitionId = partition.getId();
+                TStorageMedium medium = table.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
+                // index state is SHADOW
+                MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW);
+                MaterializedIndex originIndex = partition.getIndex(originIndexId);
+                TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId, newSchemaHash, medium);
+                short replicationNum = table.getPartitionInfo().getReplicationNum(partitionId);
+                for (Tablet originTablet : originIndex.getTablets()) {
+                    long originTabletId = originTablet.getId();
+                    long shadowTabletId = globalStateMgr.getNextId();
+
+                    LocalTablet shadowTablet = new LocalTablet(shadowTabletId);
+                    shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
+                    addedTablets.add(shadowTablet);
+
+                    schemaChangeJob.addTabletIdMap(partitionId, shadowIndexId, shadowTabletId, originTabletId);
+                    List<Replica> originReplicas = ((LocalTablet) originTablet).getImmutableReplicas();
+
+                    int healthyReplicaNum = 0;
+                    for (Replica originReplica : originReplicas) {
+                        long shadowReplicaId = globalStateMgr.getNextId();
+                        long backendId = originReplica.getBackendId();
+
+                        if (originReplica.getState() == Replica.ReplicaState.CLONE
+                                || originReplica.getState() == Replica.ReplicaState.DECOMMISSION
+                                || originReplica.getLastFailedVersion() > 0) {
+                            LOG.info(
+                                    "origin replica {} of tablet {} state is {}, and last failed version is {}, " +
+                                            "skip creating shadow replica",
+                                    originReplica.getId(), originReplica, originReplica.getState(),
+                                    originReplica.getLastFailedVersion());
+                            continue;
+                        }
+                        Preconditions
+                                .checkState(originReplica.getState() == Replica.ReplicaState.NORMAL, originReplica.getState());
+                        // replica's init state is ALTER, so that tablet report process will ignore its report
+                        Replica shadowReplica = new Replica(shadowReplicaId, backendId, Replica.ReplicaState.ALTER,
+                                Partition.PARTITION_INIT_VERSION,
+                                newSchemaHash);
+                        shadowTablet.addReplica(shadowReplica);
+                        healthyReplicaNum++;
+                    }
+
+                    if (healthyReplicaNum < replicationNum / 2 + 1) {
+                        /*
+                         * TODO(cmy): This is a bad design.
+                         * Because in the schema change job, we will only send tasks to the shadow replicas that
+                         * have been created, without checking whether the quorum of replica number are satisfied.
+                         * This will cause the job to fail until we find that the quorum of replica number
+                         * is not satisfied until the entire job is done.
+                         * So here we check the replica number strictly and do not allow to submit the job
+                         * if the quorum of replica number is not satisfied.
+                         */
+                        for (Tablet tablet : addedTablets) {
+                            GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tablet.getId());
+                        }
+                        throw new DdlException(
+                                "tablet " + originTabletId + " has few healthy replica: " + healthyReplicaNum);
+                    }
+                }
+
+                schemaChangeJob.addPartitionShadowIndex(partitionId, shadowIndexId, shadowIndex);
+            } // end for partition
+            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaVersion, newSchemaHash,
+                    newShortKeyColumnCount, entry.getValue());
+        } // end for index
+        return schemaChangeJob;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -27,7 +27,9 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.AlterJobV2Builder;
 import com.starrocks.alter.MaterializedViewHandler;
+import com.starrocks.alter.OlapTableAlterJobV2Builder;
 import com.starrocks.analysis.CreateTableStmt;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.backup.Status;
@@ -155,7 +157,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
     @SerializedName(value = "colocateMv")
     protected Set<String> colocateMaterializedViewNames = Sets.newHashSet();
     @SerializedName(value = "isInColocateMvGroup")
-    protected  boolean isInColocateMvGroup = false;
+    protected boolean isInColocateMvGroup = false;
 
     @SerializedName(value = "indexes")
     protected TableIndexes indexes;
@@ -1878,6 +1880,10 @@ public class OlapTable extends Table implements GsonPostProcessable {
     @Override
     public boolean isSupported() {
         return true;
+    }
+
+    public AlterJobV2Builder alterTable() {
+        return new OlapTableAlterJobV2Builder(this);
     }
 
     private static class DeleteOlapTableTask implements Runnable {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -4,6 +4,8 @@ package com.starrocks.lake;
 
 import com.staros.proto.ObjectStorageInfo;
 import com.staros.proto.ShardStorageInfo;
+import com.starrocks.alter.AlterJobV2Builder;
+import com.starrocks.alter.LakeTableAlterJobV2Builder;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -123,5 +125,10 @@ public class LakeTable extends OlapTable {
     public Runnable delete(boolean replay) {
         GlobalStateMgr.getCurrentState().getLocalMetastore().onEraseTable(this);
         return replay ? null : new DeleteLakeTableTask(this);
+    }
+
+    @Override
+    public AlterJobV2Builder alterTable() {
+        return new LakeTableAlterJobV2Builder();
     }
 }


### PR DESCRIPTION
I'm working on supporting schema change operations on our
lake tables now, before doing that I need to refactor some parts
of our codebase and here is the first one. This PR aims to move
the codes of creating AlterJobV2 instances to AlterJobV2Builder
so that we can add new implementation of AlterJobV2 without
modifying SchemaChangeHandler.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
