### PR TITLE
[Feature] Support ON Clause subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -779,29 +779,6 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     /**
-     * Gather conjuncts from this expr and return them in a list.
-     * A conjunct is an expr that returns a boolean, e.g., Predicates, function calls,
-     * SlotRefs, etc. Hence, this method is placed here and not in Predicate.
-     */
-    public List<Expr> getConjuncts() {
-        List<Expr> list = Lists.newArrayList();
-        if (this instanceof CompoundPredicate && ((CompoundPredicate) this).getOp() ==
-                CompoundPredicate.Operator.AND) {
-            // TODO: we have to convert CompoundPredicate.AND to two expr trees for
-            // conjuncts because NULLs are handled differently for CompoundPredicate.AND
-            // and conjunct evaluation.  This is not optimal for jitted exprs because it
-            // will result in two functions instead of one. Create a new CompoundPredicate
-            // Operator (i.e. CONJUNCT_AND) with the right NULL semantics and use that
-            // instead
-            list.addAll((getChild(0)).getConjuncts());
-            list.addAll((getChild(1)).getConjuncts());
-        } else {
-            list.add(this);
-        }
-        return list;
-    }
-
-    /**
      * Create a deep copy of 'this'. If sMap is non-null,
      * use it to substitute 'this' or its subnodes.
      * <p/>

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -261,6 +261,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     public boolean isFilter() {
         return isFilter;
     }
+
     public boolean isAuxExpr() {
         return isAuxExpr;
     }
@@ -618,6 +619,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     public String toJDBCSQL(boolean isMySQL) {
         return toSql();
     }
+
     /**
      * Return a column label for the expression
      */

--- a/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
@@ -32,6 +32,7 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,7 @@ public abstract class LoadScanNode extends ScanNode {
         if (!whereExpr.getType().isBoolean()) {
             throw new UserException("where statement is not a valid statement return bool");
         }
-        addConjuncts(whereExpr.getConjuncts());
+        addConjuncts(AnalyzerUtils.extractConjuncts(whereExpr));
     }
 
     protected void checkBitmapCompatibility(Analyzer analyzer, SlotDescriptor slotDesc, Expr expr)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -6,6 +6,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.AnalyticExpr;
+import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
@@ -39,8 +40,12 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class AnalyzerUtils {
     public static void verifyNoAggregateFunctions(Expr expression, String clause) {
@@ -300,7 +305,6 @@ public class AnalyzerUtils {
         return tableRelations;
     }
 
-
     public static Map<TableName, SubqueryRelation> collectAllSubQueryRelation(QueryStatement queryStatement) {
         Map<TableName, SubqueryRelation> subQueryRelations = Maps.newHashMap();
         new AnalyzerUtils.SubQueryRelationCollector(subQueryRelations).visit(queryStatement);
@@ -368,4 +372,93 @@ public class AnalyzerUtils {
         }
     }
 
+    public static List<Expr> extractConjuncts(Expr root) {
+        List<Expr> conjuncts = Lists.newArrayList();
+        if (null == root) {
+            return conjuncts;
+        }
+
+        extractConjunctsImpl(root, conjuncts);
+        return conjuncts;
+    }
+
+    private static void extractConjunctsImpl(Expr root, List<Expr> conjuncts) {
+        if (!(root instanceof CompoundPredicate)) {
+            conjuncts.add(root);
+            return;
+        }
+
+        CompoundPredicate cpe = (CompoundPredicate) root;
+        if (!CompoundPredicate.Operator.AND.equals(cpe.getOp())) {
+            conjuncts.add(root);
+            return;
+        }
+
+        extractConjunctsImpl(cpe.getChild(0), conjuncts);
+        extractConjunctsImpl(cpe.getChild(1), conjuncts);
+    }
+
+    public static Expr compoundAnd(Collection<Expr> conjuncts) {
+        return createCompound(CompoundPredicate.Operator.AND, conjuncts);
+    }
+
+    public static Expr compoundOr(Collection<Expr> conjuncts) {
+        return createCompound(CompoundPredicate.Operator.OR, conjuncts);
+    }
+
+    // Build a compound tree by bottom up
+    //
+    // Example: compoundType.OR
+    // Initial state:
+    //  a b c d e
+    //
+    // First iteration:
+    //  or    or
+    //  /\    /\   e
+    // a  b  c  d
+    //
+    // Second iteration:
+    //     or   e
+    //    / \
+    //  or   or
+    //  /\   /\
+    // a  b c  d
+    //
+    // Last iteration:
+    //       or
+    //      / \
+    //     or  e
+    //    / \
+    //  or   or
+    //  /\   /\
+    // a  b c  d
+    public static Expr createCompound(CompoundPredicate.Operator type, Collection<Expr> nodes) {
+        LinkedList<Expr> link =
+                nodes.stream().filter(Objects::nonNull).collect(Collectors.toCollection(Lists::newLinkedList));
+
+        if (link.size() < 1) {
+            return null;
+        }
+        if (link.size() == 1) {
+            return link.get(0);
+        }
+
+        while (link.size() > 1) {
+            LinkedList<Expr> buffer = Lists.newLinkedList();
+
+            // combine pairs of elements
+            while (link.size() >= 2) {
+                buffer.add(new CompoundPredicate(type, link.poll(), link.poll()));
+            }
+
+            // if there's and odd number of elements, just append the last one
+            if (!link.isEmpty()) {
+                buffer.add(link.remove());
+            }
+
+            link = buffer;
+        }
+
+        return link.remove();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -372,6 +372,11 @@ public class AnalyzerUtils {
         }
     }
 
+    /**
+     * Gather conjuncts from this expr and return them in a list.
+     * A conjunct is an expr that returns a boolean, e.g., Predicates, function calls,
+     * SlotRefs, etc. Hence, this method is placed here and not in Predicate.
+     */
     public static List<Expr> extractConjuncts(Expr root) {
         List<Expr> conjuncts = Lists.newArrayList();
         if (null == root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -15,7 +15,6 @@ import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StatementBase;
-import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -193,7 +192,8 @@ public class QueryAnalyzer {
                 return join;
             } else if (relation instanceof TableRelation) {
                 if (aliasSet.contains(relation.getResolveTableName().getTbl())) {
-                    ErrorReport.reportSemanticException(ErrorCode.ERR_NONUNIQ_TABLE, relation.getResolveTableName().getTbl());
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_NONUNIQ_TABLE,
+                            relation.getResolveTableName().getTbl());
                 } else {
                     aliasSet.add(relation.getResolveTableName().getTbl());
                 }
@@ -249,7 +249,8 @@ public class QueryAnalyzer {
             } else {
                 if (relation.getResolveTableName() != null) {
                     if (aliasSet.contains(relation.getResolveTableName().getTbl())) {
-                        ErrorReport.reportSemanticException(ErrorCode.ERR_NONUNIQ_TABLE, relation.getResolveTableName().getTbl());
+                        ErrorReport.reportSemanticException(ErrorCode.ERR_NONUNIQ_TABLE,
+                                relation.getResolveTableName().getTbl());
                     } else {
                         aliasSet.add(relation.getResolveTableName().getTbl());
                     }
@@ -340,10 +341,6 @@ public class QueryAnalyzer {
             }
 
             if (joinEqual != null) {
-                if (joinEqual.contains(Subquery.class)) {
-                    throw new SemanticException("Not support use subquery in ON clause");
-                }
-
                 /*
                  * sourceRelation.getRelationFields() is used to represent the column information of output.
                  * To ensure the OnPredicate in semi/anti is correct, the relation needs to be re-assembled here

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
@@ -104,6 +104,12 @@ public class ExpressionMapping {
         expressionToColumns.put(expression, variable);
     }
 
+    public void putAll(ExpressionMapping other) {
+        for (Map.Entry<Expr, ColumnRefOperator> entry : other.expressionToColumns.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
     public boolean hasExpression(Expr expr) {
         return expressionToColumns.containsKey(expr);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -114,8 +114,8 @@ class QueryTransformer {
         // and the internal cte with the same name will overwrite the original mapping
         CTETransformerContext newCteContext = new CTETransformerContext(cteContext);
         return new RelationTransformer(columnRefFactory, session,
-                new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())), newCteContext).visit(
-                node).getRootBuilder();
+                new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())), newCteContext)
+                .visit(node).getRootBuilder();
     }
 
     private OptExprBuilder projectForOrderWithoutAggregation(OptExprBuilder subOpt, Iterable<Expr> outputExpression,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -581,4 +581,356 @@ public class SubqueryTest extends PlanTestBase {
         Assert.assertThrows("Not support Non-EQ correlation predicate correlation scalar-subquery",
                 SemanticException.class, () -> getFragmentPlan(sql));
     }
+
+    @Test
+    public void testOnClauseCorrelatedScalarAggSubquery() throws Exception {
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason:");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5\n" +
+                    "  |  other predicates: 1: v1 = ifnull(10: count, 0)");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on (select count(*) from t0 where t0.v2 = t1.v5) = t1.v5";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  5:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 8: v2\n" +
+                    "  |  other predicates: ifnull(10: count, 0) = 5: v5");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5) + t1.v6";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  other predicates: 1: v1 = 11: expr + 6: v6");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v3 = (select count(*) from t1 where t0.v2 = t1.v5)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5\n" +
+                    "  |  other predicates: 3: v3 = ifnull(10: count, 0)");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on (select count(*) from t0 where t0.v2 = t1.v5) + t0.v3 = t1.v5";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  other predicates: 11: expr + 3: v3 = 5: v5");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 8: v2");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5 and t0.v3 = t1.v6)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5\n" +
+                    "  |  equal join conjunct: 3: v3 = 9: v6\n" +
+                    "  |  other predicates: 1: v1 = ifnull(10: count, 0)");
+        }
+    }
+
+    @Test
+    public void testOnClauseCorrelatedScalarNonAggSubquery() throws Exception {
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select v4 from t1 where t0.v2 = t1.v5)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  10:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v3 = (select v4 from t1 where t0.v2 = t1.v5)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  10:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select v4 from t1 where t0.v2 = t1.v5 and t1.v5 = 10 and t1.v6 != 3)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  11:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  5:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v5");
+            assertContains(plan, "  1:OlapScanNode\n" +
+                    "     TABLE: t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 8: v5 = 10, 9: v6 != 3\n");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on (select v1 from t0,t2 where t0.v2 = t1.v5 and t0.v2 = t2.v7) * 2 = t1.v4";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  15:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  10:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 8: v2");
+        }
+    }
+
+    @Test
+    public void testOnClauseNonCorrelatedScalarAggSubquery() throws Exception {
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t3 join t4)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  14:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  10:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 13: count");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on (select count(*) from t3) = t1.v5";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  5:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 10: count");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t1)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 10: count");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select count(*) from t0)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 10: count");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v3 = (select count(*) from t0)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "4:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 3: v3 = 10: count");
+        }
+    }
+
+    @Test
+    public void testOnClauseNonCorrelatedScalarNonAggSubquery() throws Exception {
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select t2.v8 from t2 where t2.v7 = 10)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  11:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  7:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 8: v8");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = (select t2.v7 + t3.v10 from t2 join t3)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  14:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: ");
+            assertContains(plan, "  10:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 13: expr");
+        }
+        {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v3 = (select t2.v8 from t2 where t2.v7 = 10)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  11:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  7:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 3: v3 = 8: v8");
+        }
+    }
+
+    @Test
+    public void testOnClauseExistentialSubquery() throws Exception {
+        {
+            // Uncorrelated
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v1 = (exists (select v7 from t2 where t2.v8 = 1))";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  11:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  7:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 12: cast");
+        }
+        {
+            // correlated
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v1 = (exists (select v7 from t2 where t2.v8 = t1.v5))";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 4: v4 = 1: v1\n" +
+                    "  |  equal join conjunct: 11: cast = 1: v1");
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 8: v8\n" +
+                    "  |  other predicates: CAST(8: v8 IS NOT NULL AS BIGINT) IS NOT NULL");
+        }
+    }
+
+    @Test
+    public void testOnClauseQuantifiedSubquery() throws Exception {
+        {
+            // Uncorrelated
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v1 in (select v7 from t2 where t2.v8 = 1)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  9:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  5:HASH JOIN\n" +
+                    "  |  join op: LEFT SEMI JOIN (PARTITIONED)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 7: v7");
+        }
+        {
+            // correlated
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 = t1.v4 " +
+                    "and t0.v1 in (select v7 from t2 where t2.v9 = t0.v3)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  7:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
+            assertContains(plan, "  3:HASH JOIN\n" +
+                    "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 1: v1 = 7: v7\n" +
+                    "  |  equal join conjunct: 3: v3 = 9: v9");
+        }
+    }
+
+    @Test
+    public void testOnClauseNotSupportedCases() {
+        try {
+            String sql = "select * from t0 " +
+                    "join t1 on (select v1 from t0 where t0.v2 = t1.v5) = (select v4 from t1 where t0.v2 = t1.v5)";
+            getFragmentPlan(sql);
+        } catch (Exception e) {
+            Assert.assertEquals(
+                    "only support one subquery in ((SELECT v1 FROM test.t0 WHERE v2 = v5)) = ((SELECT v4 FROM test.t1 WHERE v2 = v5))",
+                    e.getMessage());
+        }
+        try {
+            String sql = "select * from t0 " +
+                    "join t1 on t0.v1 + t1.v4 = (select count(*) from t0)";
+            getFragmentPlan(sql);
+        } catch (Exception e) {
+            Assert.assertEquals(
+                    "Not support ON Clause un-correlated subquery referencing columns of two or more tables",
+                    e.getMessage());
+        }
+        try {
+            String sql = "select * from t0 " +
+                    "join t1 on 1 = (select count(*) from t2 where t0.v1 = t2.v7 and t1.v4 = t2.v7)";
+            getFragmentPlan(sql);
+        } catch (Exception e) {
+            Assert.assertEquals("Not support ON Clause correlated subquery referencing columns of two or more tables",
+                    e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9875

## Enhancement

Since the exist sql parser supports the grammar of ON clause subquery, the only thing we need to do is removing the semantic checking and transforming ON Clause subquery into ApplyOperator

Below are the supported types of ON Clause subquery

-  ✅ orrelated scalar agg subquery
-  ✅ correlated scalar non-agg subquery
-  ✅ uncorrelated scalar agg subquery
-  ✅ uncorrelated scalar non-agg subquery
-  ✅ correlated exist subquery
-  ✅ correlated quantified subquery
-  ✅ uncorrelated exist subquery
-  ✅ uncorrelated quantified subquery

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
