### PR TITLE
[BugFix] fix intialization of empty global runtime filter

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -384,9 +384,6 @@ void OlapScanConjunctsManager::normalize_join_runtime_filter(const SlotDescripto
         if (!desc->is_probe_slot_ref(&slot_id) || slot_id != slot.id()) continue;
 
         const RuntimeBloomFilter<SlotType>* filter = down_cast<const RuntimeBloomFilter<SlotType>*>(rf);
-        // For some cases such as in bucket shuffle, some hash join node may not have any input chunk from right table.
-        // Runtime filter does not have any min/max values in this case.
-        if (!filter->has_min_max()) continue;
         // If this column doesn't have other filter, we use join runtime filter
         // to fast comput row range in storage engine
         if (range->is_init_state()) {

--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -256,7 +256,7 @@ public:
 
     RuntimeBloomFilter* create_empty(ObjectPool* pool) override {
         auto* p = pool->add(new RuntimeBloomFilter());
-        p->init(0);
+        p->init_min_max();
         return p;
     };
 

--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -254,7 +254,11 @@ public:
     RuntimeBloomFilter() = default;
     ~RuntimeBloomFilter() override = default;
 
-    RuntimeBloomFilter* create_empty(ObjectPool* pool) override { return pool->add(new RuntimeBloomFilter()); };
+    RuntimeBloomFilter* create_empty(ObjectPool* pool) override {
+        auto* p = pool->add(new RuntimeBloomFilter());
+        p->init(0);
+        return p;
+    };
 
     void init_min_max() {
         _has_min_max = false;

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1833,7 +1833,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_BOOLEAN_TYPE(type)                                      \
     case type: {                                                       \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf); \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;       \
+        if (xrf == nullptr) return false;                              \
         auto lower = orc::Literal(bool(xrf->min_value()));             \
         auto upper = orc::Literal(bool(xrf->max_value()));             \
         ADD_RF_TO_BUILDER                                              \
@@ -1842,7 +1842,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_INT_TYPE(type)                                          \
     case type: {                                                       \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf); \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;       \
+        if (xrf == nullptr) return false;                              \
         auto lower = orc::Literal(int64_t(xrf->min_value()));          \
         auto upper = orc::Literal(int64_t(xrf->max_value()));          \
         ADD_RF_TO_BUILDER                                              \
@@ -1851,7 +1851,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_DOUBLE_TYPE(type)                                       \
     case type: {                                                       \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf); \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;       \
+        if (xrf == nullptr) return false;                              \
         auto lower = orc::Literal(double(xrf->min_value()));           \
         auto upper = orc::Literal(double(xrf->max_value()));           \
         ADD_RF_TO_BUILDER                                              \
@@ -1860,7 +1860,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_STRING_TYPE(type)                                                 \
     case type: {                                                                 \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf);           \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;                 \
+        if (xrf == nullptr) return false;                                        \
         auto lower = orc::Literal(xrf->min_value().data, xrf->min_value().size); \
         auto upper = orc::Literal(xrf->max_value().data, xrf->max_value().size); \
         ADD_RF_TO_BUILDER                                                        \
@@ -1869,7 +1869,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_DATE_TYPE(type)                                                                              \
     case type: {                                                                                            \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf);                                      \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;                                            \
+        if (xrf == nullptr) return false;                                                                   \
         auto lower = orc::Literal(orc::PredicateDataType::DATE, native_date_to_orc_date(xrf->min_value())); \
         auto upper = orc::Literal(orc::PredicateDataType::DATE, native_date_to_orc_date(xrf->max_value())); \
         ADD_RF_TO_BUILDER                                                                                   \
@@ -1878,7 +1878,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_DECIMALV2_TYPE(type)                                                                                    \
     case type: {                                                                                                       \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<type>*>(rf);                                                 \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;                                                       \
+        if (xrf == nullptr) return false;                                                                              \
         auto lower =                                                                                                   \
                 orc::Literal(to_orc128(xrf->min_value().value()), xrf->min_value().PRECISION, xrf->min_value().SCALE); \
         auto upper =                                                                                                   \
@@ -1889,7 +1889,7 @@ void OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::Se
 #define ADD_RF_DECIMALV3_TYPE(xtype)                                                                          \
     case xtype: {                                                                                             \
         auto* xrf = dynamic_cast<const RuntimeBloomFilter<xtype>*>(rf);                                       \
-        if (xrf == nullptr || !xrf->has_min_max()) return false;                                              \
+        if (xrf == nullptr) return false;                                                                     \
         auto lower = orc::Literal(orc::Int128(xrf->min_value()), slot->type().precision, slot->type().scale); \
         auto upper = orc::Literal(orc::Int128(xrf->max_value()), slot->type().precision, slot->type().scale); \
         ADD_RF_TO_BUILDER                                                                                     \

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -269,7 +269,6 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int32_t filter_id, RuntimeF
     for (auto it : status->filters) {
         out->concat(it.second);
     }
-
     // if well enough, then we send it out.
 
     PTransmitRuntimeFilterParams request;
@@ -300,9 +299,9 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int32_t filter_id, RuntimeF
 
     VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter. target_nodes[0] = " << target_nodes->at(0)
               << ", target_nodes_size = " << target_nodes->size() << ", filter_id = " << request.filter_id()
-              << ", filter_size = " << out->size()
               << ", latency(last-first = " << status->recv_last_filter_ts - status->recv_first_filter_ts
-              << ", send-first = " << status->broadcast_filter_ts - status->recv_first_filter_ts << ")";
+              << ", send-first = " << status->broadcast_filter_ts - status->recv_first_filter_ts << ")"
+              << ", filter = " << out->debug_string();
     request.set_broadcast_timestamp(now);
 
     std::map<TNetworkAddress, std::vector<TUniqueId>> nodes_to_frag_insts;

--- a/be/test/exprs/vectorized/runtime_filter_test.cpp
+++ b/be/test/exprs/vectorized/runtime_filter_test.cpp
@@ -589,7 +589,6 @@ TEST_F(RuntimeFilterTest, TestGlobalRuntimeFilterMinMax) {
         }
         global->concat(&local);
     }
-    EXPECT_TRUE(global->has_min_max());
     EXPECT_EQ(global->min_value(), 10);
     EXPECT_EQ(global->max_value(), 33);
 }

--- a/be/test/exprs/vectorized/runtime_filter_test.cpp
+++ b/be/test/exprs/vectorized/runtime_filter_test.cpp
@@ -575,5 +575,24 @@ TEST_F(RuntimeFilterTest, TestLocalHashBucketRuntimeFilterWithBucketAbsent2) {
     test_bucket_shuffle_grf_helper(3, 3, 4, {0, 1, 2, 0});
 }
 
+TEST_F(RuntimeFilterTest, TestGlobalRuntimeFilterMinMax) {
+    RuntimeBloomFilter<TYPE_INT> prototype;
+    ObjectPool pool;
+
+    RuntimeBloomFilter<TYPE_INT>* global = prototype.create_empty(&pool);
+    for (int i = 0; i < 3; i++) {
+        RuntimeBloomFilter<TYPE_INT> local;
+        local.init(10);
+        for (int j = 0; j < 4; j++) {
+            int value = (i + 1) * 10 + j;
+            local.insert(&value);
+        }
+        global->concat(&local);
+    }
+    EXPECT_TRUE(global->has_min_max());
+    EXPECT_EQ(global->min_value(), 10);
+    EXPECT_EQ(global->max_value(), 33);
+}
+
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9816

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If we don't call `p->init(0)`, the min/max values are not initialized. 

And for runtime filter who has no min/max value, we can not use generate min/max preidcate from it.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
