### PR TITLE
[BugFix] Followers could not update statistics immediately after the statistics rebuild

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -53,6 +53,7 @@ import com.starrocks.thrift.TPriority;
 import com.starrocks.thrift.TPushType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -364,6 +365,7 @@ public class OlapDeleteJob extends DeleteJob {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
         }
-        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, tabletCommitInfos, timeoutMs);
+        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, tabletCommitInfos, timeoutMs,
+                new InsertTxnCommitAttachment());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -798,6 +798,9 @@ public class EditLog {
                 case OperationType.OP_ADD_BASIC_STATS_META: {
                     BasicStatsMeta basicStatsMeta = (BasicStatsMeta) journal.getData();
                     globalStateMgr.getAnalyzeManager().replayAddBasicStatsMeta(basicStatsMeta);
+                    // The follower replays the stats meta log, indicating that the master has re-completed
+                    // statistic, and the follower's should expire cache here.
+                    globalStateMgr.getAnalyzeManager().expireBasicStatisticsCache(basicStatsMeta);
                     break;
                 }
                 case OperationType.OP_REMOVE_BASIC_STATS_META: {
@@ -808,6 +811,9 @@ public class EditLog {
                 case OperationType.OP_ADD_HISTOGRAM_STATS_META: {
                     HistogramStatsMeta histogramStatsMeta = (HistogramStatsMeta) journal.getData();
                     globalStateMgr.getAnalyzeManager().replayAddHistogramStatsMeta(histogramStatsMeta);
+                    // The follower replays the stats meta log, indicating that the master has re-completed
+                    // statistic, and the follower's should expire cache here.
+                    globalStateMgr.getAnalyzeManager().expireHistogramStatisticsCache(histogramStatsMeta);
                     break;
                 }
                 case OperationType.OP_REMOVE_HISTOGRAM_STATS_META: {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -59,8 +59,7 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
 
         long totalCollectColumnsSize = table.getBaseSchema().stream().filter(column -> !column.isAggregated()).count();
 
-        if (null != columns && !columns.isEmpty()
-                && (columns.size() != totalCollectColumnsSize)) {
+        if (null != columns && !columns.isEmpty() && (columns.size() != totalCollectColumnsSize)) {
             String str = String.join(",", columns);
             row.set(3, str);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -26,6 +26,7 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
             ShowResultSetMetaData.builder()
                     .addColumn(new Column("Database", ScalarType.createVarchar(60)))
                     .addColumn(new Column("Table", ScalarType.createVarchar(60)))
+                    .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
                     .addColumn(new Column("Type", ScalarType.createVarchar(20)))
                     .addColumn(new Column("UpdateTime", ScalarType.createVarchar(60)))
                     .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
@@ -33,9 +34,10 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
                     .build();
 
     public static List<String> showBasicStatsMeta(BasicStatsMeta basicStatsMeta) throws MetaNotFoundException {
-        List<String> row = Lists.newArrayList("", "", "", "", "", "");
+        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "");
         long dbId = basicStatsMeta.getDbId();
         long tableId = basicStatsMeta.getTableId();
+        List<String> columns = basicStatsMeta.getColumns();
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
         if (db == null) {
@@ -47,10 +49,16 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
             throw new MetaNotFoundException("No found table: " + tableId);
         }
         row.set(1, table.getName());
-        row.set(2, basicStatsMeta.getType().name());
-        row.set(3, basicStatsMeta.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        row.set(4, basicStatsMeta.getProperties() == null ? "{}" : basicStatsMeta.getProperties().toString());
-        row.set(5, (int) (basicStatsMeta.getHealthy() * 100) + "%");
+
+        long totalCollectColumnsSize = table.getBaseSchema().stream().filter(column -> !column.isAggregated()).count();
+        if (null != columns && !columns.isEmpty() && (columns.size() != totalCollectColumnsSize)) {
+            row.set(2, String.join(",", columns));
+        }
+
+        row.set(3, basicStatsMeta.getType().name());
+        row.set(4, basicStatsMeta.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        row.set(5, basicStatsMeta.getProperties() == null ? "{}" : basicStatsMeta.getProperties().toString());
+        row.set(6, (int) (basicStatsMeta.getHealthy() * 100) + "%");
 
         return row;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -113,6 +113,9 @@ public class CachedStatisticStorage implements StatisticStorage {
 
     @Override
     public void expireColumnStatistics(Table table, List<String> columns) {
+        if (columns == null) {
+            return;
+        }
         List<ColumnStatsCacheKey> allKeys = Lists.newArrayList();
         for (String column : columns) {
             ColumnStatsCacheKey key = new ColumnStatsCacheKey(table.getId(), column);
@@ -160,6 +163,10 @@ public class CachedStatisticStorage implements StatisticStorage {
 
     @Override
     public void expireHistogramStatistics(Long tableId, List<String> columns) {
+        if (columns == null) {
+            return;
+        }
+
         List<ColumnStatsCacheKey> allKeys = Lists.newArrayList();
         for (String column : columns) {
             ColumnStatsCacheKey key = new ColumnStatsCacheKey(tableId, column);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -163,9 +163,7 @@ public class CachedStatisticStorage implements StatisticStorage {
 
     @Override
     public void expireHistogramStatistics(Long tableId, List<String> columns) {
-        if (columns == null) {
-            return;
-        }
+        Preconditions.checkNotNull(columns);
 
         List<ColumnStatsCacheKey> allKeys = Lists.newArrayList();
         for (String column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -5,12 +5,11 @@ package com.starrocks.statistic;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
-import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
@@ -37,8 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
 
 public class AnalyzeManager implements Writable {
     private static final Logger LOG = LogManager.getLogger(AnalyzeManager.class);
@@ -47,9 +44,6 @@ public class AnalyzeManager implements Writable {
     private final Map<Long, AnalyzeStatus> analyzeStatusMap;
     private final Map<Long, BasicStatsMeta> basicStatsMetaMap;
     private final Map<Pair<Long, String>, HistogramStatsMeta> histogramStatsMetaMap;
-
-    private static final ExecutorService executor =
-            ThreadPoolManager.newDaemonFixedThreadPool(1, 16, "analyze-replay-pool", true);
 
     public AnalyzeManager() {
         analyzeJobMap = Maps.newConcurrentMap();
@@ -85,7 +79,6 @@ public class AnalyzeManager implements Writable {
     }
 
     public void replayAddAnalyzeJob(AnalyzeJob job) {
-        executor.submit(new AnalyzeReplayTask(job));
         analyzeJobMap.put(job.getId(), job);
     }
 
@@ -146,6 +139,18 @@ public class AnalyzeManager implements Writable {
         basicStatsMetaMap.put(basicStatsMeta.getTableId(), basicStatsMeta);
     }
 
+    public void expireBasicStatisticsCache(BasicStatsMeta basicStatsMeta) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(basicStatsMeta.getDbId());
+        if (null == db) {
+            return;
+        }
+        Table table = db.getTable(basicStatsMeta.getTableId());
+        if (null == table) {
+            return;
+        }
+        GlobalStateMgr.getCurrentStatisticStorage().expireColumnStatistics(table, basicStatsMeta.getColumns());
+    }
+
     public void replayRemoveBasicStatsMeta(BasicStatsMeta basicStatsMeta) {
         basicStatsMetaMap.remove(basicStatsMeta.getTableId());
     }
@@ -163,6 +168,19 @@ public class AnalyzeManager implements Writable {
     public void replayAddHistogramStatsMeta(HistogramStatsMeta histogramStatsMeta) {
         histogramStatsMetaMap.put(
                 new Pair<>(histogramStatsMeta.getTableId(), histogramStatsMeta.getColumn()), histogramStatsMeta);
+    }
+
+    public void expireHistogramStatisticsCache(HistogramStatsMeta histogramStatsMeta) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(histogramStatsMeta.getDbId());
+        if (null == db) {
+            return;
+        }
+        Table table = db.getTable(histogramStatsMeta.getTableId());
+        if (null == table) {
+            return;
+        }
+        GlobalStateMgr.getCurrentStatisticStorage().expireHistogramStatistics(table.getId(),
+                Lists.newArrayList(histogramStatsMeta.getColumn()));
     }
 
     public void replayRemoveHistogramStatsMeta(HistogramStatsMeta histogramStatsMeta) {
@@ -279,7 +297,13 @@ public class AnalyzeManager implements Writable {
             BasicStatsMeta basicStatsMeta =
                     GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(transactionState.getTableIdList().get(0));
             if (basicStatsMeta != null) {
-                basicStatsMeta.increaseUpdateRows(((InsertTxnCommitAttachment) attachment).getLoadedRows());
+                long loadRows = ((InsertTxnCommitAttachment) attachment).getLoadedRows();
+                if (loadRows == 0) {
+                    OlapTable table = (OlapTable) db.getTable(basicStatsMeta.getTableId());
+                    basicStatsMeta.increaseUpdateRows(table.getRowCount());
+                } else {
+                    basicStatsMeta.increaseUpdateRows(((InsertTxnCommitAttachment) attachment).getLoadedRows());
+                }
             }
         }
     }
@@ -356,79 +380,5 @@ public class AnalyzeManager implements Writable {
 
         @SerializedName("histogramStatsMeta")
         public List<HistogramStatsMeta> histogramStatsMeta;
-    }
-
-    // This task is used to expire cached statistics
-    public class AnalyzeReplayTask implements Runnable {
-        private AnalyzeJob analyzeJob;
-
-        public AnalyzeReplayTask(AnalyzeJob job) {
-            this.analyzeJob = job;
-        }
-
-        public void checkAndExpireCachedStatistics(Table table, AnalyzeJob job) {
-            if (null == table || !table.isNativeTable()) {
-                return;
-            }
-
-            // check table has update
-            // use job last work time compare table update time to determine whether to expire cached statistics
-            LocalDateTime updateTime = StatisticUtils.getTableLastUpdateTime(table);
-            LocalDateTime jobLastWorkTime = LocalDateTime.MIN;
-            if (analyzeJobMap.containsKey(job.getId())) {
-                jobLastWorkTime = analyzeJobMap.get(job.getId()).getWorkTime();
-            }
-            if (jobLastWorkTime.isBefore(updateTime)) {
-                List<String> columns = (job.getColumns() == null || job.getColumns().isEmpty()) ?
-                        table.getFullSchema().stream().filter(d -> !d.isAggregated()).map(Column::getName)
-                                .collect(Collectors.toList()) : job.getColumns();
-                GlobalStateMgr.getCurrentStatisticStorage().expireColumnStatistics(table, columns);
-            }
-        }
-
-        public void expireCachedStatistics(AnalyzeJob job) {
-            if (job.getScheduleType().equals(StatsConstants.ScheduleType.ONCE)) {
-                Database db = GlobalStateMgr.getCurrentState().getDb(job.getDbId());
-                if (null == db) {
-                    return;
-                }
-                GlobalStateMgr.getCurrentStatisticStorage()
-                        .expireColumnStatistics(db.getTable(job.getTableId()), job.getColumns());
-            } else {
-                List<Table> tableNeedCheck = new ArrayList<>();
-                if (job.getDbId() == StatsConstants.DEFAULT_ALL_ID) {
-                    List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIds();
-                    for (Long dbId : dbIds) {
-                        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-                        if (null == db || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
-                            continue;
-                        }
-                        tableNeedCheck.addAll(db.getTables());
-                    }
-                } else if (job.getDbId() != StatsConstants.DEFAULT_ALL_ID &&
-                        job.getTableId() == StatsConstants.DEFAULT_ALL_ID) {
-                    Database db = GlobalStateMgr.getCurrentState().getDb(job.getDbId());
-                    if (null == db) {
-                        return;
-                    }
-                    tableNeedCheck.addAll(db.getTables());
-                } else {
-                    Database db = GlobalStateMgr.getCurrentState().getDb(job.getDbId());
-                    if (null == db) {
-                        return;
-                    }
-                    tableNeedCheck.add(db.getTable(job.getTableId()));
-                }
-
-                for (Table table : tableNeedCheck) {
-                    checkAndExpireCachedStatistics(table, job);
-                }
-            }
-        }
-
-        @Override
-        public void run() {
-            expireCachedStatistics(analyzeJob);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -15,6 +15,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 public class BasicStatsMeta implements Writable {
@@ -23,6 +24,9 @@ public class BasicStatsMeta implements Writable {
 
     @SerializedName("tableId")
     private long tableId;
+
+    @SerializedName("columns")
+    private List<String> columns;
 
     @SerializedName("type")
     private StatsConstants.AnalyzeType type;
@@ -36,12 +40,13 @@ public class BasicStatsMeta implements Writable {
     @SerializedName("updateRows")
     private long updateRows;
 
-    public BasicStatsMeta(long dbId, long tableId,
+    public BasicStatsMeta(long dbId, long tableId, List<String> columns,
                           StatsConstants.AnalyzeType type,
                           LocalDateTime updateTime,
                           Map<String, String> properties) {
         this.dbId = dbId;
         this.tableId = tableId;
+        this.columns = columns;
         this.type = type;
         this.updateTime = updateTime;
         this.properties = properties;
@@ -65,6 +70,10 @@ public class BasicStatsMeta implements Writable {
 
     public long getTableId() {
         return tableId;
+    }
+
+    public List<String> getColumns() {
+        return columns;
     }
 
     public StatsConstants.AnalyzeType getType() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -284,7 +284,7 @@ public class StatisticExecutor {
             }
         } else {
             GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(db.getId(), table.getId(),
-                    statsJob.getType(), analyzeStatus.getEndTime(), statsJob.getProperties()));
+                    statsJob.getColumns(), statsJob.getType(), analyzeStatus.getEndTime(), statsJob.getProperties()));
         }
         return analyzeStatus;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -69,7 +69,7 @@ public class StatisticsCollectJobFactory {
                                                                  StatsConstants.AnalyzeType analyzeType,
                                                                  StatsConstants.ScheduleType scheduleType,
                                                                  Map<String, String> properties) {
-        if (columns == null) {
+        if (columns == null || columns.isEmpty()) {
             columns = table.getBaseSchema().stream().filter(d -> !d.isAggregated()).map(Column::getName)
                     .collect(Collectors.toList());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -209,7 +209,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().entrySet()) {
             BasicStatsMeta basicStatsMeta = entry.getValue();
             GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(
-                    basicStatsMeta.getDbId(), basicStatsMeta.getTableId(),
+                    basicStatsMeta.getDbId(), basicStatsMeta.getTableId(), basicStatsMeta.getColumns(),
                     basicStatsMeta.getType(), LocalDateTime.MIN, basicStatsMeta.getProperties()));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -120,9 +120,9 @@ public class AnalyzeStmtTest {
         sql = "show stats meta";
         ShowBasicStatsMetaStmt showAnalyzeMetaStmt = (ShowBasicStatsMetaStmt) analyzeSuccess(sql);
 
-        BasicStatsMeta basicStatsMeta = new BasicStatsMeta(10002, 10004, StatsConstants.AnalyzeType.FULL,
+        BasicStatsMeta basicStatsMeta = new BasicStatsMeta(10002, 10004, null, StatsConstants.AnalyzeType.FULL,
                 LocalDateTime.of(2020, 1, 1, 1, 1), Maps.newHashMap());
-        Assert.assertEquals("[test, t0, FULL, 2020-01-01 01:01:00, {}, 100%]",
+        Assert.assertEquals("[test, t0, ALL, FULL, 2020-01-01 01:01:00, {}, 100%]",
                 ShowBasicStatsMetaStmt.showBasicStatsMeta(basicStatsMeta).toString());
 
         sql = "show histogram meta";

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -19,7 +19,7 @@ public class StatisticExecutorTest extends PlanTestBase {
         Database db = GlobalStateMgr.getCurrentState().getDb(10002);
         OlapTable olapTable = (OlapTable) db.getTable("t0");
 
-        GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(10002, olapTable.getId(),
+        GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(10002, olapTable.getId(),null,
                 StatsConstants.AnalyzeType.FULL,
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -145,7 +145,8 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         Database db = GlobalStateMgr.getCurrentState().getDb(10002);
         OlapTable olapTable = (OlapTable) db.getTable("t0_stats");
 
-        BasicStatsMeta basicStatsMeta = new BasicStatsMeta(10002, olapTable.getId(), StatsConstants.AnalyzeType.SAMPLE,
+        BasicStatsMeta basicStatsMeta = new BasicStatsMeta(10002, olapTable.getId(), null,
+                StatsConstants.AnalyzeType.SAMPLE,
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1), Maps.newHashMap());
         basicStatsMeta.increaseUpdateRows(10000000L);
         GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
@@ -166,7 +167,8 @@ public class StatisticsCollectJobTest extends PlanTestBase {
                         LocalDateTime.MIN));
         Assert.assertEquals(1, jobs.size());
 
-        BasicStatsMeta basicStatsMeta2 = new BasicStatsMeta(10002, olapTable.getId(), StatsConstants.AnalyzeType.SAMPLE,
+        BasicStatsMeta basicStatsMeta2 = new BasicStatsMeta(10002, olapTable.getId(), null,
+                StatsConstants.AnalyzeType.SAMPLE,
                 LocalDateTime.of(2022, 1, 1, 1, 1, 1), Maps.newHashMap());
         GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(basicStatsMeta2);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9840 #10047

## Problem Summary(Required) ：
specific reproduction conditions
1. Run the analyze statement on the follower, the command will be forwarded to the master
2. Collect statistical information on the master, and delete the local cache after the master collects successfully
3. The follower runs the query statement of the related table, because the local cache is not cleared, continue to use the local cache

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
