### PR TITLE
[Bugfix] Fix GRF use a wrong partition method in no-pipeline engine

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -204,7 +204,7 @@ public:
         bool use_merged_selection;
         std::vector<uint32_t> hash_values;
         const std::vector<int32_t>* bucketseq_to_partition;
-        bool compatibility;
+        bool compatibility = true;
     };
 
     virtual void evaluate(Column* input_column, RunningContext* ctx) const = 0;

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -306,7 +306,7 @@ void RuntimeFilterProbeCollector::do_evaluate(vectorized::Chunk* chunk, RuntimeB
         auto& selection = eval_context.running_context.selection;
         eval_context.running_context.use_merged_selection = false;
         eval_context.running_context.compatibility =
-                _runtime_state->func_version() <= 3 && _runtime_state->enable_pipeline_engine();
+                _runtime_state->func_version() <= 3 || !_runtime_state->enable_pipeline_engine();
         for (auto& kv : eval_context.selectivity) {
             RuntimeFilterProbeDescriptor* rf_desc = kv.second;
             const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
@@ -372,7 +372,7 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
     auto& merged_selection = eval_context.running_context.merged_selection;
     auto& use_merged_selection = eval_context.running_context.use_merged_selection;
     eval_context.running_context.compatibility =
-            _runtime_state->func_version() <= 3 && _runtime_state->enable_pipeline_engine();
+            _runtime_state->func_version() <= 3 || !_runtime_state->enable_pipeline_engine();
     use_merged_selection = true;
     for (auto& it : _descriptors) {
         RuntimeFilterProbeDescriptor* rf_desc = it.second;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：

Fixes #9816 

## Problem Summary(Required) ：
Compatibility in RF means use "Modulo" rather than "Reduce" in
HashPartition

mini reproduce case:
```
mysql> select c_custkey from customer l join [shuffle] ssb.dates r on l.c_custkey = r.d_year;
```
expected result: 2556

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
