### PR TITLE
[BugFix]Fix catalogs dirty read bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -41,7 +41,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class CatalogMgr {
     private static final Logger LOG = LogManager.getLogger(CatalogMgr.class);
-    private final ConcurrentHashMap<String, Catalog> catalogs = new ConcurrentHashMap<>();
+    private final Map<String, Catalog> catalogs = new HashMap<>();
     private final ConnectorMgr connectorMgr;
     private final ReadWriteLock catalogLock = new ReentrantReadWriteLock();
 
@@ -247,12 +247,17 @@ public class CatalogMgr {
         public ProcResult fetchResult() {
             BaseProcResult result = new BaseProcResult();
             result.setNames(CATALOG_PROC_NODE_TITLE_NAMES);
-            for (Map.Entry<String, Catalog> entry : catalogs.entrySet()) {
-                Catalog catalog = entry.getValue();
-                if (catalog == null) {
-                    continue;
+            readLock();
+            try {
+                for (Map.Entry<String, Catalog> entry : catalogs.entrySet()) {
+                    Catalog catalog = entry.getValue();
+                    if (catalog == null) {
+                        continue;
+                    }
+                    catalog.getProcNodeData(result);
                 }
-                catalog.getProcNodeData(result);
+            } finally {
+                readUnlock();
             }
             result.addRow(Lists.newArrayList(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, "Internal", "Internal Catalog"));
             return result;

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -191,7 +190,7 @@ public class CatalogMgr {
 
     public long saveCatalogs(DataOutputStream dos, long checksum) throws IOException {
         SerializeData data = new SerializeData();
-        data.catalogs = new HashMap<>(catalogs);
+        data.catalogs = catalogs;
         checksum ^= data.catalogs.size();
         String s = GsonUtils.GSON.toJson(data);
         Text.writeString(dos, s);
@@ -201,7 +200,6 @@ public class CatalogMgr {
     private static class SerializeData {
         @SerializedName("catalogs")
         public Map<String, Catalog> catalogs;
-
     }
 
     public List<List<String>> getCatalogsInfo() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8997

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
PR #8998 only add the write lock for create/drop catalogs, but the read operation is not in the lock. This PR put the read operation into the read lock. Since all ops of catalogs is in the catalogLock, change the ConcurrentHashMap to HashMap.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
