### PR TITLE
[BugFix] Fix broker load parquet file has uppercase column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2478,12 +2478,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<String> colList = null;
         if (context.colList != null) {
             List<Identifier> identifiers = visit(context.colList.identifier(), Identifier.class);
-            colList = identifiers.stream().map(Identifier::getValue).map(String::toLowerCase).collect(toList());
+            colList = identifiers.stream().map(Identifier::getValue).collect(toList());
         }
         List<String> colFromPath = null;
         if (context.colFromPath != null) {
             List<Identifier> identifiers = visit(context.colFromPath.identifier(), Identifier.class);
-            colFromPath = identifiers.stream().map(Identifier::getValue).map(String::toLowerCase).collect(toList());
+            colFromPath = identifiers.stream().map(Identifier::getValue).collect(toList());
         }
         return new DataDescription(dstTableName, partitionNames, files, colList, colSep, null, format,
                 colFromPath, context.NEGATIVE() != null, colMappingList, whereExpr);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9858

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Parquet file create by spark sql will have uppercase column name, we can not direct covert to lowercase.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
