### PR TITLE
[BugFix] Fix the crash caused by DictMappingExpr rewrite

### DIFF
--- a/be/src/exprs/vectorized/dictmapping_expr.h
+++ b/be/src/exprs/vectorized/dictmapping_expr.h
@@ -37,7 +37,7 @@ public:
             _rewrite_status = rewrite_result.status();
             if (_rewrite_status.ok()) {
                 dict_func_expr = rewrite_result.value();
-                add_child(dict_func_expr);
+                DCHECK(dict_func_expr != nullptr);
             }
         });
         return _rewrite_status;

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -243,9 +243,9 @@ Status DictOptimizeParser::rewrite_expr(ExprContext* ctx, Expr* expr, SlotId slo
     // call rewrite for each DictMappingExpr
     if (auto f = dynamic_cast<DictMappingExpr*>(expr)) {
         f->rewrite([&]() -> StatusOr<Expr*> {
-            auto* dict_ctx_handle = _free_pool.add(new DictOptimizeContext());
+            auto* dict_ctx_handle = _runtime_state->obj_pool()->add(new DictOptimizeContext());
             RETURN_IF_ERROR(_eval_and_rewrite(ctx, f, dict_ctx_handle, slot_id));
-            return _free_pool.add(new DictFuncExpr(*f, dict_ctx_handle));
+            return _runtime_state->obj_pool()->add(new DictFuncExpr(*f, dict_ctx_handle));
         });
         return Status::OK();
     }


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksBenchmark/issues/200




## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

fix 2 bugs in https://github.com/StarRocks/starrocks/pull/8950
add child in DictMappingExpr::rewrite may cause read-write conflicts; 
DictOptimizeParser::rewrite_expr should create expression objects with longer lifespan than itself.

test:
manual tests: run the sql more than 100+ times on the issue env and results are ok.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
