### PR TITLE
[BugFix] Fix streamLoad import large number of columns failed with error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -468,6 +468,15 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_backlog_num = 1024;
 
+    @ConfField
+    public static int http_max_initial_line_length = 4096;
+
+    @ConfField
+    public static int http_max_header_size = 8192;
+
+    @ConfField
+    public static int http_max_chunk_size = 8192;
+
     /**
      * Cluster name will be shown as the title of web page
      */

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpRequestException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpRequestException.java
@@ -1,0 +1,13 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.http;
+
+public class HttpRequestException extends RuntimeException {
+    public HttpRequestException(String message) {
+        super(message);
+    }
+
+    public HttpRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -192,7 +192,10 @@ public class HttpServer {
     protected class StarrocksHttpServerInitializer extends ChannelInitializer<SocketChannel> {
         @Override
         protected void initChannel(SocketChannel ch) throws Exception {
-            ch.pipeline().addLast(new HttpServerCodec())
+            ch.pipeline().addLast(new HttpServerCodec(
+                            Config.http_max_initial_line_length,
+                            Config.http_max_header_size,
+                            Config.http_max_chunk_size))
                     .addLast(new StarRocksHttpPostObjectAggregator(100 * 65536))
                     .addLast(new ChunkedWriteHandler())
                     // add content compressor

--- a/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
@@ -1,0 +1,84 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.http;
+
+import com.starrocks.common.Config;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class BadHttpRequestTest extends StarRocksHttpTestCase {
+    private static final String STREAM_LOAD_URI_FORMAT = "/api/%s/%s/_stream_load";
+
+    private static String STREAM_LOAD_URL_FORMAT;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        STREAM_LOAD_URL_FORMAT = "http://localhost:" + HTTP_PORT + STREAM_LOAD_URI_FORMAT;
+    }
+
+    /**
+     * netty http server default http_header_max_length=8192
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testStreamLoadWithBadRequest() throws IOException {
+        Request request = createRequest(Config.http_max_header_size);
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertEquals(400, response.code());
+        String respStr = Objects.requireNonNull(response.body()).string();
+        Assert.assertTrue(respStr.startsWith("Bad Request"));
+    }
+
+    @Test
+    public void testStreamLoadWithNormalRequest() throws IOException {
+        Request request = createRequest(Config.http_max_header_size / 2);
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertEquals(200, response.code());
+    }
+
+    @NotNull
+    private Request createRequest(int columnTotalLength) {
+        RequestBody body = RequestBody.create(JSON, "{}");
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(String.format(STREAM_LOAD_URL_FORMAT, DB_NAME, TABLE_NAME))
+                .put(body)
+                .addHeader("Authorization", rootAuth)
+                .addHeader("columns", genColumnNameList(columnTotalLength))
+                .addHeader("label", UUID.randomUUID().toString())
+                .addHeader("Expect", "100-continue");
+        return requestBuilder.build();
+    }
+
+    private static String genColumnNameList(int max) {
+        List<String> columnList = new ArrayList<>();
+        String delimited = ",";
+        int delimitedLength = delimited.length();
+        int length = 0;
+        int columnIndex = 1;
+        while (length < max) {
+            StringBuilder sb = new StringBuilder("column_").append(columnIndex++).append("_");
+            String uuid = UUID.randomUUID().toString().replace("-", "");
+            do {
+                sb.append(uuid);
+            } while (sb.length() < 64);
+            String c = sb.substring(0, 64);
+            length += c.length() + delimitedLength;
+            columnList.add(c.substring(0, 64));
+        }
+        return String.join(delimited, columnList);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9865

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fe's HTTP service is implemented by netty, netty HttpServerCodec has default properties：
http_max_initial_line_length=4096
http_max_header_size=8192
http_max_chunk_size=8192

when use streamLoad import large number of columns, http header properties "columns" will be more than http_max_header_size,but netty decode not throw exception and return an empty header request. Next, the auth information will not be found in the Request execution phase. So we need to validate the request before executing it and return a true error message.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
