### PR TITLE
[BugFix] Fix correlated scalar non-agg subquery loss non-correlated predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -150,6 +150,7 @@ public class ScalarApply2JoinRule extends TransformationRule {
         LogicalJoinOperator joinOp = new LogicalJoinOperator.Builder()
                 .setJoinType(JoinOperator.LEFT_OUTER_JOIN)
                 .setOnPredicate(Utils.compoundAnd(correlationPredicatePair.first))
+                .setPredicate(apply.getPredicate())
                 .build();
         OptExpression newLeftOuterJoinOpt = OptExpression.create(joinOp, input.inputAt(0), newAggOpt);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -416,7 +416,7 @@ public class SubqueryTest extends PlanTestBase {
             String sql = "SELECT * FROM t0\n" +
                     "WHERE t0.v2 > (\n" +
                     "      SELECT t1.v5 FROM t1\n" +
-                    "      WHERE t0.v1 = t1.v4 and t1.v4 = 10\n" +
+                    "      WHERE t0.v1 = t1.v4 and t1.v4 = 10 and t1.v5 < 2\n" +
                     ");";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  7:Project\n" +
@@ -437,11 +437,22 @@ public class SubqueryTest extends PlanTestBase {
                     "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  equal join conjunct: 1: v1 = 4: v4\n" +
-                    "  |  other predicates: 4: v4 = 10");
+                    "  |  equal join conjunct: 1: v1 = 4: v4");
             assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                     "  |  output: count(1), any_value(5: v5)\n" +
-                    "  |  group by: 4: v4");
+                    "  |  group by: 4: v4\n" +
+                    "  |  \n" +
+                    "  1:OlapScanNode\n" +
+                    "     TABLE: t1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: v4 = 10, 5: v5 < 2\n" +
+                    "     partitions=0/1\n" +
+                    "     rollup: t1\n" +
+                    "     tabletRatio=0/0\n" +
+                    "     tabletList=\n" +
+                    "     cardinality=0\n" +
+                    "     avgRowSize=2.0\n" +
+                    "     numNodes=0");
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9870

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The non-correlated predicates is lossed when transforming ApplyOperator to Left Outer Join.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
