### PR TITLE
[WIP][Enhancement] avoid maybe same table to join at first when in left deep reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -846,6 +846,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboDebugAliveBackendNumber;
     }
 
+    public void setCboDebugAliveBackendNumber(int v) {
+        cboDebugAliveBackendNumber = v;
+    }
+
     public long getTransactionVisibleWaitTimeout() {
         return transactionVisibleWaitTimeout;
     }
@@ -856,6 +860,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getCboMaxReorderNodeUseExhaustive() {
         return cboMaxReorderNodeUseExhaustive;
+    }
+
+    public void setCboMaxReorderNodeUseExhaustive(int v) {
+        cboMaxReorderNodeUseExhaustive = v;
     }
 
     public int getNewPlannerAggStage() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to extend heuristic method in left deep join reorder
- https://github.com/StarRocks/starrocks/pull/9031
- to avoid __maybe__ same table join at first(probably regression to cross join)

this is tpcds-1g query85 with following settings.

```
set cbo_debug_alive_backend_number = 30; // to emulate there are 30 backends
set parallel_fragment_exec_instance_num = 24;
```

![image](https://user-images.githubusercontent.com/1081215/184093579-b9cb902c-05e3-417d-99e6-199dc793aeb8.png)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
