### PR TITLE
[BugFix] The time interval is too short to compaction in TabletUpdatesTest.compaction_with_empty_rowset, need wait for its version.

### DIFF
--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1228,7 +1228,7 @@ void TabletUpdatesTest::test_compaction_with_empty_rowset(bool enable_persistent
             break;
         }
         std::cerr << "waiting for compaction applied\n";
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 }
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1213,7 +1213,11 @@ void TabletUpdatesTest::test_compaction_with_empty_rowset(bool enable_persistent
         keys5.push_back(i * 3 + 2);
     }
     ASSERT_TRUE(_tablet->rowset_commit(5, create_rowset(_tablet, keys5)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        // used for wait merely
+        std::vector<RowsetSharedPtr> dummy_rowsets;
+        ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(5, &dummy_rowsets).ok());
+    }
     ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1222,17 +1222,16 @@ void TabletUpdatesTest::test_compaction_with_empty_rowset(bool enable_persistent
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 }
 
-// Todo(qzc): fix this ut
-// TEST_F(TabletUpdatesTest, compaction_with_empty_rowset) {
-//     test_compaction_with_empty_rowset(false, true, false);
-//     test_compaction_with_empty_rowset(false, true, true);
-//     test_compaction_with_empty_rowset(false, false, false);
-//     test_compaction_with_empty_rowset(false, false, true);
-//     test_compaction_with_empty_rowset(true, true, false);
-//     test_compaction_with_empty_rowset(true, true, true);
-//     test_compaction_with_empty_rowset(true, false, false);
-//     test_compaction_with_empty_rowset(true, false, true);
-// }
+TEST_F(TabletUpdatesTest, compaction_with_empty_rowset) {
+    test_compaction_with_empty_rowset(false, true, false);
+    test_compaction_with_empty_rowset(false, true, true);
+    test_compaction_with_empty_rowset(false, false, false);
+    test_compaction_with_empty_rowset(false, false, true);
+    test_compaction_with_empty_rowset(true, true, false);
+    test_compaction_with_empty_rowset(true, true, true);
+    test_compaction_with_empty_rowset(true, false, false);
+    test_compaction_with_empty_rowset(true, false, true);
+}
 
 void TabletUpdatesTest::test_link_from(bool enable_persistent_index) {
     srand(GetCurrentTimeMicros());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9677

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When number of keys is large or machine is high load, this time interval too short to compaction, the inputs vector is empty, cause the _apply_compaction_rowset crash on this line
https://github.com/StarRocks/starrocks/blob/866275b05e89a5cb7e5cd778753798cbbed002f4/be/src/storage/tablet_updates.cpp#L1325
so wait for its version.