### PR TITLE
[Enhancement] Enable tablet internal parallel by default

### DIFF
--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -95,8 +95,8 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
 /// OlapScanContextFactory.
 OlapScanContextPtr OlapScanContextFactory::get_or_create(int32_t driver_sequence) {
     DCHECK_LT(driver_sequence, _dop);
-    // ScanOperators sharing one morsel and chunk buffer use the same context.
-    int32_t idx = _shared_scan ? 0 : driver_sequence;
+    // ScanOperators sharing one morsel use the same context.
+    int32_t idx = _shared_morsel_queue ? 0 : driver_sequence;
     DCHECK_LT(idx, _contexts.size());
 
     if (_contexts[idx] == nullptr) {

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -84,21 +84,23 @@ private:
 // Otherwise, it outputs the same context for each scan operator.
 class OlapScanContextFactory {
 public:
-    OlapScanContextFactory(vectorized::OlapScanNode* const scan_node, int32_t dop, bool shared_scan,
-                           ChunkBufferLimiterPtr chunk_buffer_limiter)
+    OlapScanContextFactory(vectorized::OlapScanNode* const scan_node, int32_t dop, bool shared_morsel_queue,
+                           bool shared_scan, ChunkBufferLimiterPtr chunk_buffer_limiter)
             : _scan_node(scan_node),
               _dop(dop),
+              _shared_morsel_queue(shared_morsel_queue),
               _shared_scan(shared_scan),
               _chunk_buffer(shared_scan ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect, dop,
                             std::move(chunk_buffer_limiter)),
-              _contexts(shared_scan ? 1 : dop) {}
+              _contexts(shared_morsel_queue ? 1 : dop) {}
 
     OlapScanContextPtr get_or_create(int32_t driver_sequence);
 
 private:
     vectorized::OlapScanNode* const _scan_node;
     const int32_t _dop;
-    const bool _shared_scan;           // Whether the scan operators share one morsel and chunk buffer.
+    const bool _shared_morsel_queue;   // Whether the scan operators share a morsel queue.
+    const bool _shared_scan;           // Whether the scan operators share a chunk buffer.
     BalancedChunkBuffer _chunk_buffer; // Shared Chunk buffer for all the scan operators.
 
     std::vector<OlapScanContextPtr> _contexts;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -156,6 +156,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_RESOURCE_GROUP = "enable_resource_group";
 
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL = "enable_tablet_internal_parallel";
+    public static final String ENABLE_TABLET_INTERNAL_PARALLEL_V2 = "enable_tablet_internal_parallel_v2";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
@@ -295,8 +296,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_RESOURCE_GROUP)
     private boolean enableResourceGroup = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_TABLET_INTERNAL_PARALLEL)
-    private boolean enableTabletInternalParallel = false;
+    @VariableMgr.VarAttr(name = ENABLE_TABLET_INTERNAL_PARALLEL_V2,
+            alias = ENABLE_TABLET_INTERNAL_PARALLEL, show = ENABLE_TABLET_INTERNAL_PARALLEL)
+    private boolean enableTabletInternalParallel = true;
 
     @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
     private boolean enableSharedScan = false;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Enable tablet internal parallel in session variables by default.

In addition, distinguish `shared_morsel_queue` and `shared_chunk_buffer`.
- `shared_morsel_queue`: whether scan operators share a morsel queue. 
- `shared_chunk_buffer`: whether scan operators share a chunk buffer.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
