### PR TITLE
[Enhancement] Complete the error message when selecting an Iceberg table created by spark2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/hive/HiveTableOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/hive/HiveTableOperations.java
@@ -4,6 +4,7 @@ package com.starrocks.external.iceberg.hive;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -78,7 +79,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             validateTableIsIceberg(table, fullName);
 
             metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
-            if (null == metadataLocation || metadataLocation.length() == 0) {
+            if (Strings.isNullOrEmpty(metadataLocation)) {
                 throw new NotFoundException("Property 'metadata_location' can not be found in table %s.%s. " +
                         "Probably this table is created by Spark2, which is not supported.", database, tableName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/hive/HiveTableOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/hive/HiveTableOperations.java
@@ -13,6 +13,7 @@ import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.thrift.TException;
 
@@ -77,6 +78,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             validateTableIsIceberg(table, fullName);
 
             metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
+            if (null == metadataLocation || metadataLocation.length() == 0) {
+                throw new NotFoundException("Property 'metadata_location' can not be found in table %s.%s. " +
+                        "Probably this table is created by Spark2, which is not supported.", database, tableName);
+            }
 
         } catch (NoSuchObjectException e) {
             if (currentMetadataLocation() != null) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Iceberg tables created with spark2 by default configurations don't have the property 'metadata_location', which is necessary when selected using Hive catalog. Trino can neither select such table, so I suppose it reasonable and just throw an exception with reasons in detail.

MySQL client will crash when executing `show tables` after using a database with such tables. I'll try to solve it later in a separated PR.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
