### PR TITLE
[Feature] Ignore fragment_instance_num when enabling pipeline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -181,45 +181,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      */
     private void setParallelExecNumIfExists() {
         if (ConnectContext.get() != null) {
-            int instanceNum = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
-
             if (ConnectContext.get().getSessionVariable().isEnablePipelineEngine()) {
-                // In pipeline engine, we prefer inter-pipeline parallelism to inter-fragment parallelism
-                // So in default case, instanceNum should be 1, and DOP should be cores/2
-                int pipelineDop = ConnectContext.get().getSessionVariable().getPipelineDop();
-                if (pipelineDop > 0) {
-                    this.parallelExecNum = instanceNum;
-                    this.pipelineDop = pipelineDop;
-                } else {
-                    this.parallelExecNum = 1;
-                    this.pipelineDop = BackendCoreStat.getDefaultDOP();
-                }
+                this.parallelExecNum = 1;
+                this.pipelineDop = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
             } else {
-                this.parallelExecNum = instanceNum;
+                this.parallelExecNum = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
                 this.pipelineDop = 1;
             }
         }
-    }
-
-    /**
-     * Several cases we could prefer the instance-parallel:
-     * 1. One-phase aggregation: avoid local exchange
-     * 2. Colocate join
-     * 3. Bucket join
-     */
-    public void preferInstanceParallel() {
-        this.parallelExecNum = BackendCoreStat.getDefaultDOP();
-        this.pipelineDop = 1;
-        this.dopEstimated = true;
-    }
-
-    /**
-     * In most cases we prefer the pipeline-parallel
-     */
-    public void preferPipelineParallel() {
-        this.parallelExecNum = 1;
-        this.pipelineDop = BackendCoreStat.getDefaultDOP();
-        this.dopEstimated = true;
     }
 
     public ExchangeNode getDestNode() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -32,7 +32,6 @@ import com.starrocks.common.TreeNode;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
-import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TGlobalDict;
 import com.starrocks.thrift.TNetworkAddress;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -730,7 +730,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getDegreeOfParallelism() {
         if (enablePipelineEngine) {
             if (pipelineDop > 0) {
-                return pipelineDop * parallelExecInstanceNum;
+                return pipelineDop;
             }
             return BackendCoreStat.getDefaultDOP();
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -227,7 +227,7 @@ public class AggregateTest extends PlanTestBase {
                         + "  0:OlapScanNode"));
 
                 PlanFragment aggPlan = plan.second.getFragments().get(0);
-                Assert.assertEquals(instanceNum, aggPlan.getParallelExecNum());
+                Assert.assertEquals(1, aggPlan.getParallelExecNum());
                 Assert.assertEquals(pipelineDop, aggPlan.getPipelineDop());
             }
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2085,10 +2085,48 @@ public class JoinTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
+    private void testParallelismHelper(int expectedParallelism) throws Exception {
+        // Case 1: local bucket shuffle join should use fragment instance parallel.
+        String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
+        ExecPlan plan = getExecPlan(sql);
+        PlanFragment fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 2: colocate join should use pipeline instance parallel.
+        sql = "select * from colocate1 left join colocate2 " +
+                "on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 3: broadcast join should use pipeline parallel.
+        sql = "select a.v1 from t0 a join [broadcast] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BROADCAST)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
+        sql = "select a.v1 from t0 a " +
+                "join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 " +
+                "join [broadcast] t0 c on a.v1 = c.v2";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);
+        assertContains(fragmentString, "join op: INNER JOIN (BROADCAST)");
+        assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+    }
+
     @Test
     public void testParallelism() throws Exception {
         int numCores = 8;
-        int expectedParallelism = numCores / 2;
         new MockUp<BackendCoreStat>() {
             @Mock
             public int getAvgNumOfHardwareCoresOfBe() {
@@ -2102,48 +2140,17 @@ public class JoinTest extends PlanTestBase {
         int parallelExecInstanceNum = sessionVariable.getParallelExecInstanceNum();
 
         try {
-            // Enable DopAutoEstimate.
+            FeConstants.runningUnitTest = true;
             sessionVariable.setEnablePipelineEngine(true);
+
             sessionVariable.setPipelineDop(0);
             sessionVariable.setParallelExecInstanceNum(1);
-            FeConstants.runningUnitTest = true;
+            testParallelismHelper(numCores / 2);
 
-            // Case 1: local bucket shuffle join should use fragment instance parallel.
-            String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
-            ExecPlan plan = getExecPlan(sql);
-            PlanFragment fragment = plan.getFragments().get(1);
-            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
-            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-            Assert.assertEquals(1, fragment.getParallelExecNum());
+            sessionVariable.setPipelineDop(4);
+            sessionVariable.setParallelExecInstanceNum(8);
+            testParallelismHelper(4);
 
-            // Case 2: colocate join should use fragment instance parallel.
-            sql = "select * from colocate1 left join colocate2 " +
-                    "on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
-            plan = getExecPlan(sql);
-            fragment = plan.getFragments().get(1);
-            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
-            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-            Assert.assertEquals(1, fragment.getParallelExecNum());
-
-            // Case 3: broadcast join should use pipeline parallel.
-            sql = "select a.v1 from t0 a join [broadcast] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
-            plan = getExecPlan(sql);
-            fragment = plan.getFragments().get(1);
-            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BROADCAST)");
-            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-            Assert.assertEquals(1, fragment.getParallelExecNum());
-
-            // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
-            sql = "select a.v1 from t0 a " +
-                    "join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 " +
-                    "join [broadcast] t0 c on a.v1 = c.v2";
-            plan = getExecPlan(sql);
-            fragment = plan.getFragments().get(1);
-            String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);
-            assertContains(fragmentString, "join op: INNER JOIN (BROADCAST)");
-            assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
-            Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-            Assert.assertEquals(1, fragment.getParallelExecNum());
         } finally {
             sessionVariable.setEnablePipelineEngine(enablePipeline);
             sessionVariable.setPipelineDop(pipelineDop);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
From branch-2.4 all the scenarios prefer pipeline parallel, so we could ignore fragment_instance_num when enabling pipeline, and always set it to 1.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
