### PR TITLE
[Enhancement] assign morsels uniformly among ScanOperators to avoid skew (backport #9893)

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -382,7 +382,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
         _chunk_sources[chunk_source_index] = nullptr;
     }
 
-    ASSIGN_OR_RETURN(auto morsel, _morsel_queue->try_get());
+    ASSIGN_OR_RETURN(auto morsel, _morsel_queue->try_get(_driver_sequence));
     if (morsel != nullptr) {
         COUNTER_UPDATE(_morsels_counter, 1);
 

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -93,6 +93,8 @@ public:
     const std::string& name() const { return _name; }
 
 protected:
+    int _scan_dop(const std::vector<TScanRangeParams>& scan_ranges, const TExecPlanFragmentParams& request) const;
+
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
     RuntimeProfile::Counter* _rows_read_counter;


### PR DESCRIPTION
Implement the same functionality with #9893 but in different way.