### PR TITLE
[BugFix] Fix BE crashed on start when built with --use-staros

### DIFF
--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -31,7 +31,7 @@ public:
     using FileSystem = staros::starlet::fslib::FileSystem;
     using Configuration = staros::starlet::fslib::Configuration;
 
-    StarOSWorker() : _service_id(0), _worker_id(0) {}
+    StarOSWorker() : _service_id(), _worker_id(0) {}
 
     ~StarOSWorker() override = default;
 


### PR DESCRIPTION
The type of service id has changed from int to std::string thus
cannot initialize it with 0 now.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

