### PR TITLE
[WIP] [Enhancement] cache iceberg db & table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -2,11 +2,16 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.external.hive.HiveTableName;
 import com.starrocks.external.iceberg.IcebergCatalog;
 import com.starrocks.external.iceberg.IcebergCatalogType;
 import com.starrocks.external.iceberg.IcebergUtil;
@@ -19,6 +24,7 @@ import org.apache.thrift.TException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.IcebergTable.ICEBERG_CATALOG;
@@ -26,6 +32,7 @@ import static com.starrocks.catalog.IcebergTable.ICEBERG_IMPL;
 import static com.starrocks.catalog.IcebergTable.ICEBERG_METASTORE_URIS;
 import static com.starrocks.external.iceberg.IcebergUtil.getIcebergCustomCatalog;
 import static com.starrocks.external.iceberg.IcebergUtil.getIcebergHiveCatalog;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergMetadata implements ConnectorMetadata {
 
@@ -35,6 +42,9 @@ public class IcebergMetadata implements ConnectorMetadata {
     private String catalogImpl;
     private IcebergCatalog icebergCatalog;
     private Map<String, String> customProperties;
+    private LoadingCache<String, Database> dbCache;
+    private LoadingCache<HiveTableName, Table> tableCache;
+    private static final long MAX_TABLE_CACHE_SIZE = 1000L;
 
     public IcebergMetadata(Map<String, String> properties) {
         if (IcebergCatalogType.HIVE_CATALOG == IcebergCatalogType.fromString(properties.get(ICEBERG_CATALOG))) {
@@ -42,7 +52,8 @@ public class IcebergMetadata implements ConnectorMetadata {
             metastoreURI = properties.get(ICEBERG_METASTORE_URIS);
             icebergCatalog = getIcebergHiveCatalog(metastoreURI, properties);
             Util.validateMetastoreUris(metastoreURI);
-        } else if (IcebergCatalogType.CUSTOM_CATALOG == IcebergCatalogType.fromString(properties.get(ICEBERG_CATALOG))) {
+        } else if (IcebergCatalogType.CUSTOM_CATALOG ==
+                IcebergCatalogType.fromString(properties.get(ICEBERG_CATALOG))) {
             catalogType = properties.get(ICEBERG_CATALOG);
             catalogImpl = properties.get(ICEBERG_IMPL);
             icebergCatalog = getIcebergCustomCatalog(catalogImpl, properties);
@@ -52,6 +63,28 @@ public class IcebergMetadata implements ConnectorMetadata {
         } else {
             throw new RuntimeException(String.format("Property %s is missing or not supported now.", ICEBERG_CATALOG));
         }
+        tableCache = newCacheBuilder(MAX_TABLE_CACHE_SIZE).build(new CacheLoader<HiveTableName, Table>() {
+            @Override
+            public Table load(HiveTableName key) throws Exception {
+                return loadTable(key.getDatabaseName(), key.getTableName());
+            }
+        });
+        dbCache = newCacheBuilder(MAX_TABLE_CACHE_SIZE).build(new CacheLoader<String, Database>() {
+            @Override
+            public Database load(String key) throws Exception {
+                return loadDatabase(key);
+            }
+        });
+    }
+
+    /**
+     * Currently we only support either refreshAfterWrite or automatic refresh by events.
+     */
+    private static CacheBuilder<Object, Object> newCacheBuilder(long maximumSize) {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        cacheBuilder.expireAfterWrite(Config.hive_meta_cache_ttl_s, SECONDS);
+        cacheBuilder.maximumSize(maximumSize);
+        return cacheBuilder;
     }
 
     @Override
@@ -60,31 +93,41 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<String> listTableNames(String dbName) throws DdlException {
+        List<TableIdentifier> tableIdentifiers = icebergCatalog.listTables(Namespace.of(dbName));
+        return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public Table loadTable(String dbName, String tblName) throws DdlException {
+        org.apache.iceberg.Table icebergTable
+                = icebergCatalog.loadTable(IcebergUtil.getIcebergTableIdentifier(dbName, tblName));
+        if (IcebergCatalogType.fromString(catalogType).equals(IcebergCatalogType.CUSTOM_CATALOG)) {
+            return IcebergUtil.convertCustomCatalogToSRTable(icebergTable, catalogImpl, dbName, tblName,
+                    customProperties);
+        }
+        return IcebergUtil.convertHiveCatalogToSRTable(icebergTable, metastoreURI, dbName, tblName);
+    }
+
+    public Database loadDatabase(String dbName) throws TException, InterruptedException {
+        return icebergCatalog.getDB(dbName);
+    }
+
+    @Override
     public Database getDb(String dbName) {
         try {
-            return icebergCatalog.getDB(dbName);
-        } catch (InterruptedException | TException e) {
+            return dbCache.get(dbName);
+        } catch (ExecutionException e) {
             LOG.error("Failed to get iceberg database " + dbName, e);
             return null;
         }
     }
 
     @Override
-    public List<String> listTableNames(String dbName) throws DdlException {
-        List<TableIdentifier> tableIdentifiers = icebergCatalog.listTables(Namespace.of(dbName));
-        return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    @Override
     public Table getTable(String dbName, String tblName) {
         try {
-            org.apache.iceberg.Table icebergTable
-                    = icebergCatalog.loadTable(IcebergUtil.getIcebergTableIdentifier(dbName, tblName));
-            if (IcebergCatalogType.fromString(catalogType).equals(IcebergCatalogType.CUSTOM_CATALOG)) {
-                return IcebergUtil.convertCustomCatalogToSRTable(icebergTable, catalogImpl, dbName, tblName, customProperties);
-            }
-            return IcebergUtil.convertHiveCatalogToSRTable(icebergTable, metastoreURI, dbName, tblName);
-        } catch (DdlException e) {
+            HiveTableName key = new HiveTableName(dbName, tblName);
+            return tableCache.get(key);
+        } catch (ExecutionException e) {
             LOG.error("Failed to get iceberg table " + IcebergUtil.getIcebergTableIdentifier(dbName, tblName), e);
             return null;
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/10032

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The main purpose of this PR is to fix tpcds-1g query85.

We have a heuristic join reorder policy introduced in this PR: https://github.com/StarRocks/starrocks/pull/9031

But this heuristic policy is based on a assumption: same table has the same table id. But for iceberg table, that assumption is not hold. So we might have bad plan. 

To fix this problem, we have to make sure same tables have the same table id by cahcing.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
