### PR TITLE
[Enhancement] Optimize close phase in aggregator

### DIFF
--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "column/column.h"
 
 namespace starrocks_udf {
@@ -79,6 +81,7 @@ public:
     // State management methods:
     virtual size_t size() const = 0;
     virtual size_t alignof_size() const = 0;
+    virtual bool is_pod_state() const { return false; }
     virtual void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const = 0;
     virtual void destroy(FunctionContext* ctx, AggDataPtr __restrict ptr) const = 0;
 
@@ -154,6 +157,8 @@ public:
     size_t size() const final { return sizeof(State); }
 
     size_t alignof_size() const final { return alignof(State); }
+
+    bool is_pod_state() const { return std::is_trivially_destructible_v<State>; }
 };
 
 template <typename State, typename Derived>


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
#9118

DATASET SSB100G
```
mysql> set pipeline_dop=1;
Query OK, 0 rows affected (0.00 sec)

mysql> set profile_timeout=20;
Query OK, 0 rows affected (0.00 sec)

mysql> set profile_timeout=200;
Query OK, 0 rows affected (0.00 sec)

mysql> select level, count(*) uv from ( select lo_orderkey, window_funnel(3600000, lo_orderdate, 0, [lo_linenumber=1, lo_linenumber=2]) as level from lineorder group by lo_orderkey ) AS x group by level
    -> ;
+-------+-----------+
| level | uv        |
+-------+-----------+
|     1 |  21421685 |
|     2 | 128578315 |
+-------+-----------+
2 rows in set (47.73 sec)

mysql> select level, count(*) uv from ( select lo_orderkey, window_funnel(3600000, lo_orderdate, 0, [lo_linenumber=1, lo_linenumber=2]) as level from lineorder group by lo_orderkey ) AS x group by level;
+-------+-----------+
| level | uv        |
+-------+-----------+
|     2 | 128578315 |
|     1 |  21421685 |
+-------+-----------+
2 rows in set (44.20 sec)

mysql> set profile_timeout=2;
Query OK, 0 rows affected (0.00 sec)

mysql> select level, count(*) uv from ( select lo_orderkey, window_funnel(3600000, lo_orderdate, 0, [lo_linenumber=1, lo_linenumber=2]) as level from lineorder group by lo_orderkey ) AS x group by level;
+-------+-----------+
| level | uv        |
+-------+-----------+
|     2 | 128578315 |
|     1 |  21421685 |
+-------+-----------+
2 rows in set (23.41 sec)


patched:

mysql> set profile_timeout=200;
mysql> select level, count(*) uv from ( select lo_orderkey, window_funnel(3600000, lo_orderdate, 0, [lo_linenumber=1, lo_linenumber=2]) as level from lineorder group by lo_orderkey ) AS x group by level;
+-------+-----------+
| level | uv        |
+-------+-----------+
|     1 |  21421685 |
|     2 | 128578315 |
+-------+-----------+
2 rows in set (23.09 sec)
```

## Problem Summary(Required) ：
If all function states are of POD type, then we don't have to traverse the hash table to call destroy method.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
