### PR TITLE
[BugFix] max_continuous_version may not update after base compaction

### DIFF
--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -251,10 +251,10 @@ void VersionGraph::add_version_to_graph(const Version& version) {
         // e.g.
         // 1. Tablet A is doing schema change
         // 2. We create a new tablet B releated A, and we will create a initial rowset and _max_continuous_version
-        //    will be updated to 0
-        // 3. Tablet A has a version [0, m], [m+1, n]
-        // 4. Schema change will try convert rowsets with version [0, m]
-        // 5. The input_version's first(0) is not equal to _max_continuous_version + 1, and the _max_continuous_version
+        //    will be updated to 1
+        // 3. Tablet A has a rowset R with version (0, m)
+        // 4. Schema change will try convert R
+        // 5. The start version of R (0) is not equal to `_max_continuous_version + 1`, and the _max_continuous_version
         //    will not update
         _max_continuous_version = _get_max_continuous_version_from(0);
     }

--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -246,6 +246,17 @@ void VersionGraph::add_version_to_graph(const Version& version) {
     _add_version_to_graph(version);
     if (version.first == _max_continuous_version + 1) {
         _max_continuous_version = _get_max_continuous_version_from(_max_continuous_version + 1);
+    } else if (version.first == 0) {
+        // We need to reconstruct max_continuous_version from zero if input version is starting from zero
+        // e.g.
+        // 1. Tablet A is doing schema change
+        // 2. We create a new tablet B releated A, and we will create a initial rowset and _max_continuous_version
+        //    will be updated to 0
+        // 3. Tablet A has a version [0, m], [m+1, n]
+        // 4. Schema change will try convert rowsets with version [0, m]
+        // 5. The input_version's first(0) is not equal to _max_continuous_version + 1, and the _max_continuous_version
+        //    will not update
+        _max_continuous_version = _get_max_continuous_version_from(0);
     }
 }
 

--- a/be/test/storage/version_graph_test.cpp
+++ b/be/test/storage/version_graph_test.cpp
@@ -302,6 +302,18 @@ TEST(VersionGraphTest, max_continuous_version) {
     EXPECT_EQ(graph.max_continuous_version(), 6);
     graph.add_version_to_graph(Version(7, 7));
     EXPECT_EQ(graph.max_continuous_version(), 7);
+    
+    // The following case may be happened in schema change
+    // 1. Schema change first remove the existing rowset
+    // 2. Add new version rowset into new tablet
+    graph.delete_version_from_graph(Version(0, 1));
+    for (int i = 2; i <= 7; i++) {
+        graph.delete_version_from_graph(Version(i, i));
+    }
+    EXPECT_EQ(graph.max_continuous_version(), 7);
+    graph.add_version_to_graph(Version(0, 10));
+    EXPECT_EQ(graph.max_continuous_version(), 10);
+
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/9984

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

max_continuous_version of tablet may not be updated after base compaction. So we need to reconstruct max_continuous_version from zero if input version is starting from zero.

e.g.
```
1. tablet A is doing schema change, and has a rowset R with version (0, m)
2. create a new tablet B releated tablet A
3. create a initial rowset of tablet B, and the `max_continuous_version` will be set to 1
4. convert rowset R, the version.first(0) is not equal to `max_continuous_version + 1`, so we don't update the max_continuous_version
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
