### PR TITLE
[BugFix] Fix the mv of a single partition is always refreshed

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -250,6 +250,33 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         }
     }
 
+    @Test
+    public void testMvWithoutPartitionRefreshTwice() {
+        final AtomicInteger taskRunCounter = new AtomicInteger();
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                taskRunCounter.incrementAndGet();
+            }
+        };
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_without_partition"));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
+        try {
+            for (int i = 0; i < 2; i++) {
+                taskRun.executeTaskRun();
+            }
+            Assert.assertEquals(1, taskRunCounter.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("refresh failed");
+        }
+    }
+
     private void testBaseTablePartitionInsertData(Database testDb, MaterializedView materializedView, TaskRun taskRun)
             throws Exception {
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10068

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The mv of a single partition is always refreshed. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
