### PR TITLE
[BugFix] remove null value from in clause when extract range info(#10053)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -234,7 +234,8 @@ public class ScalarRangePredicateExtractor {
 
         public static ValueDescriptor in(ScalarOperator operator) {
             MultiValuesDescriptor d = new MultiValuesDescriptor(operator.getChild(0));
-            operator.getChildren().stream().skip(1).map(c -> (ConstantOperator) c).forEach(d.values::add);
+            operator.getChildren().stream().skip(1).map(c -> (ConstantOperator) c)
+                    .filter(c -> !c.isNull()).forEach(d.values::add);
             return d;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -95,4 +95,26 @@ public class PartitionPruneTest extends PlanTestBase {
                 "     partitions=1/4\n" +
                 "     rollup: ptest"));
     }
+
+    @Test
+    public void testInClauseCombineOr_1() throws Exception {
+        String plan = getFragmentPlan("select * from ptest where (d2 > '1000-01-01') or (d2 in (null, '2020-01-01'));");
+        assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: ptest\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: (2: d2 > '1000-01-01') OR (2: d2 IN (NULL, '2020-01-01')), 2: d2 > '1000-01-01'\n" +
+                "     partitions=4/4\n" +
+                "     rollup: ptest"));
+    }
+
+    @Test
+    public void testInClauseCombineOr_2() throws Exception {
+        String plan = getFragmentPlan("select * from ptest where (d2 > '1000-01-01') or (d2 in (null, null));");
+        assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: ptest\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: (2: d2 > '1000-01-01') OR (2: d2 IN (NULL, NULL)), 2: d2 > '1000-01-01'\n" +
+                "     partitions=4/4\n" +
+                "     rollup: ptest"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  [#10053](https://github.com/StarRocks/starrocks/issues/10053) 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Any value comparing null is unknown. Filter null value from in clause to avoid generating expr like 'key >= null' which lead to extract exception in further process.

