### PR TITLE
[Bugfix] Catch exception in handleFieldList when showing tables with an unselectable Iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -400,7 +400,7 @@ public class ConnectProcessor {
             }
 
         } catch (StarRocksIcebergException e) {
-            LOG.warn("errors happened when getting Iceberg table " + tableName, e);
+            LOG.warn("errors happened when getting Iceberg table {}", tableName, e);
         } finally {
             db.readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -38,6 +38,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.external.iceberg.StarRocksIcebergException;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.mysql.MysqlChannel;
@@ -398,6 +399,8 @@ public class ConnectProcessor {
                 channel.sendOnePacket(serializer.toByteBuffer());
             }
 
+        } catch (StarRocksIcebergException e) {
+            LOG.warn("errors happened when getting Iceberg table " + tableName, e);
         } finally {
             db.readUnlock();
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, FE will do handleFieldList() in every request if `use database` command is executed. However, some kinds of Iceberg table maybe fail to load, see #9936, after which MySQL client will report "ERROR 2006 (HY000): MySQL server has gone away" whatever SQL user sends. User has to restart a MySQL client to do normal queries, which does not meet expectations.

Now that we can't determine what MySQL client sends, I catch all StarRocksIcebergException and print warning in handleFieldList() to make the client work fine with, say, `show tables` command in this case.

Should be merged after #9936.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
