### PR TITLE
[BugFix] read-after-free in CompactionManager::update_tablet_async

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -17,6 +17,10 @@ CompactionManager::CompactionManager() : _next_task_id(0) {
     DCHECK(st.ok());
 }
 
+CompactionManager::~CompactionManager() {
+    _update_candidate_pool->wait();
+}
+
 void CompactionManager::init_max_task_num() {
     if (config::base_compaction_num_threads_per_disk >= 0 && config::cumulative_compaction_num_threads_per_disk >= 0) {
         _max_task_num = static_cast<int32_t>(

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -27,7 +27,7 @@ class CompactionManager {
 public:
     CompactionManager();
 
-    ~CompactionManager() = default;
+    ~CompactionManager();
 
     void init_max_task_num();
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10057 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The event-based compaction framework use `update_tablet_async` to update compaction candidates of the tablet in the background. However, the background thread may access the freed memory.

This PR waits for the background job to be finished before the compaction manager is destructed to avoid the freed memory access.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
