### PR TITLE
[Bugfix] fix select subquery with order by throw exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -70,13 +70,14 @@ class QueryTransformer {
         if (queryBlock.hasOrderByClause()) {
             if (!queryBlock.hasAggregation()) {
                 //requires both output and source fields to be visible if there are no aggregations
-                builder = projectForOrderWithoutAggregation(
-                        builder, queryBlock.getOutputExpr(), builder.getFieldMappings(), queryBlock.getOrderScope());
+                builder = projectForOrder(builder, queryBlock.getOutputExpr(), builder.getFieldMappings(),
+                        queryBlock.getOrderScope(), false);
             } else {
                 //requires output fields, groups and translated aggregations to be visible for queries with aggregation
-                builder = projectForOrderWithAggregation(builder,
+                builder = projectForOrder(builder,
                         Iterables.concat(queryBlock.getOutputExpr(), queryBlock.getOrderSourceExpressions()),
-                        queryBlock.getOrderScope());
+                        builder.getFieldMappings(),
+                        queryBlock.getOrderScope(), true);
             }
 
             builder = window(builder, queryBlock.getOrderByAnalytic());
@@ -118,41 +119,28 @@ class QueryTransformer {
                 node).getRootBuilder();
     }
 
-    private OptExprBuilder projectForOrderWithoutAggregation(OptExprBuilder subOpt, Iterable<Expr> outputExpression,
-                                                             List<ColumnRefOperator> sourceExpression, Scope scope) {
+    private OptExprBuilder projectForOrder(OptExprBuilder subOpt, Iterable<Expr> expressions,
+                                           List<ColumnRefOperator> sourceExpression, Scope scope,
+                                           boolean withAggregation) {
         ExpressionMapping outputTranslations = new ExpressionMapping(scope);
 
         List<ColumnRefOperator> fieldMappings = new ArrayList<>();
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        SubqueryTransformer subqueryTransformer = new SubqueryTransformer(session);
 
-        for (Expr expression : outputExpression) {
-            ColumnRefOperator columnRef = findOrCreateColumnRefForExpr(expression,
-                    subOpt.getExpressionMapping(), projections, columnRefFactory);
-            fieldMappings.add(columnRef);
-            outputTranslations.put(expression, columnRef);
-        }
-
-        for (ColumnRefOperator expression : sourceExpression) {
-            projections.put(expression, expression);
-            fieldMappings.add(expression);
-        }
-
-        LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections);
-        outputTranslations.setFieldMappings(fieldMappings);
-        return new OptExprBuilder(projectOperator, Lists.newArrayList(subOpt), outputTranslations);
-    }
-
-    private OptExprBuilder projectForOrderWithAggregation(OptExprBuilder subOpt, Iterable<Expr> expressions,
-                                                          Scope scope) {
-        ExpressionMapping outputTranslations = new ExpressionMapping(scope);
-
-        List<ColumnRefOperator> fieldMappings = new ArrayList<>();
-        Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
         for (Expr expression : expressions) {
+            subOpt = subqueryTransformer.handleScalarSubqueries(columnRefFactory, subOpt, expression, cteContext);
             ColumnRefOperator columnRef = findOrCreateColumnRefForExpr(expression,
                     subOpt.getExpressionMapping(), projections, columnRefFactory);
             fieldMappings.add(columnRef);
             outputTranslations.put(expression, columnRef);
+        }
+
+        if (!withAggregation) {
+            for (ColumnRefOperator expression : sourceExpression) {
+                projections.put(expression, expression);
+                fieldMappings.add(expression);
+            }
         }
 
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -137,4 +137,43 @@ public class OrderByTest extends PlanTestBase {
                 "  |  limit: 10");
         connectContext.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
     }
+
+    @Test
+    public void testOrderByWithSubquery() throws Exception {
+        String sql = "select t0.*, " +
+                "(select sum(v5) from t1) as x1, " +
+                "(select sum(v7) from t2) as x2 from t0 order by t0.v3";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  11:SORT\n" +
+                "  |  order by: <slot 3> 3: v3 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  10:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 8> : 8: expr\n" +
+                "  |  <slot 13> : 12: sum\n" +
+                "  |  \n" +
+                "  9:NESTLOOP JOIN");
+    }
+
+    @Test
+    public void testOrderByGroupByWithSubquery() throws Exception {
+        String sql = "select t0.v2, sum(v3) as x3, " +
+                "(select sum(v5) from t1) as x1, " +
+                "(select sum(v7) from t2) as x2 from t0 group by v2 order by x3";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  12:SORT\n" +
+                "  |  order by: <slot 4> 4: sum ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  11:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 4: sum\n" +
+                "  |  <slot 9> : 9: expr\n" +
+                "  |  <slot 14> : 13: sum\n" +
+                "  |  \n" +
+                "  10:NESTLOOP JOIN");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
MySQL td> select
    a.*,
    (select sum(t1.v1) from t1) initial_balance,
    ( select sum(t2.v2) from t2) ending_balance
from t3 a
order by a.v3
(1064, 'complex subquery on (SELECT sum(v1) FROM td.t1)')
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
