### PR TITLE
[Enhancement] Simplify the use of classpath of JNI

### DIFF
--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -82,14 +82,6 @@ std::pair<JNIEnv*, JVMFunctionHelper&> JVMFunctionHelper::getInstanceWithEnv() {
 }
 
 void JVMFunctionHelper::_init() {
-    std::string home = getenv("STARROCKS_HOME");
-    std::vector<std::string> class_paths = {home + "/lib/jni-packages/starrocks-java-utils-jar-with-dependencies.jar",
-                                            home + "/lib/jni-packages/udf-extensions-jar-with-dependencies.jar",
-                                            home + "/lib/jni-packages/starrocks-jdbc-bridge-jar-with-dependencies.jar"};
-    for (auto path : class_paths) {
-        _add_class_path(path);
-    }
-
     _object_class = JNI_FIND_CLASS("java/lang/Object");
     _object_array_class = JNI_FIND_CLASS("[Ljava/lang/Object;");
     _string_class = JNI_FIND_CLASS("java/lang/String");
@@ -172,38 +164,6 @@ void JVMFunctionHelper::_init() {
     name = JVMFunctionHelper::to_jni_class_name(UDAFStateList::clazz_name);
     jclass loaded_clazz = JNI_FIND_CLASS(name.c_str());
     _function_states_clazz = new JVMClass(std::move(loaded_clazz));
-}
-
-// https://stackoverflow.com/questions/45232522/how-to-set-classpath-of-a-running-jvm-in-cjni
-void JVMFunctionHelper::_add_class_path(const std::string& path) {
-    const std::string urlPath = "file://" + path;
-    LOG(INFO) << "add class path:" << urlPath;
-    jclass classLoaderCls = _env->FindClass("java/lang/ClassLoader");
-    auto env = _env;
-    LOCAL_REF_GUARD_ENV(env, classLoaderCls);
-    jmethodID getSystemClassLoaderMethod =
-            _env->GetStaticMethodID(classLoaderCls, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-    jobject classLoaderInstance = _env->CallStaticObjectMethod(classLoaderCls, getSystemClassLoaderMethod);
-    LOCAL_REF_GUARD_ENV(env, classLoaderInstance);
-
-    jclass urlClassLoaderCls = _env->FindClass("java/net/URLClassLoader");
-    LOCAL_REF_GUARD_ENV(env, urlClassLoaderCls);
-
-    jmethodID addUrlMethod = _env->GetMethodID(urlClassLoaderCls, "addURL", "(Ljava/net/URL;)V");
-    jclass urlCls = _env->FindClass("java/net/URL");
-    LOCAL_REF_GUARD_ENV(env, urlCls);
-
-    jmethodID urlConstructor = _env->GetMethodID(urlCls, "<init>", "(Ljava/lang/String;)V");
-    jobject urlInstance = _env->NewObject(urlCls, urlConstructor, _env->NewStringUTF(urlPath.c_str()));
-    LOCAL_REF_GUARD_ENV(env, urlInstance);
-
-    _env->CallVoidMethod(classLoaderInstance, addUrlMethod, urlInstance);
-    if (auto e = _env->ExceptionOccurred()) {
-        LOCAL_REF_GUARD_ENV(env, e);
-        std::string msg = JVMFunctionHelper::getInstance().dumpExceptionString(e);
-        LOG(WARNING) << "Exception: " << msg;
-        _env->ExceptionClear();
-    }
 }
 
 jobjectArray JVMFunctionHelper::_build_object_array(jclass clazz, jobject* arr, int sz) {

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -123,7 +123,6 @@ public:
 private:
     JVMFunctionHelper() { _init(); };
     void _init();
-    void _add_class_path(const std::string& path);
     // pack input array to java object array
     jobjectArray _build_object_array(jclass clazz, jobject* arr, int sz);
 

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -106,7 +106,7 @@ export LIBHDFS_OPTS=$final_java_opt
 
 # HADOOP_CLASSPATH defined in $STARROCKS_HOME/conf/hadoop_env.sh
 # put $STARROCKS_HOME/conf ahead of $HADOOP_CLASSPATH so that custom config can replace the config in $HADOOP_CLASSPATH
-export CLASSPATH=$STARROCKS_HOME/conf:$HADOOP_CLASSPATH:$CLASSPATH
+export CLASSPATH=$STARROCKS_HOME/conf:$STARROCKS_HOME/lib/jni-packages/*:$HADOOP_CLASSPATH:$CLASSPATH
 
 if [ ! -d $LOG_DIR ]; then
     mkdir -p $LOG_DIR


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

libhdfs will read environment CLASSPATH, resolve the wild card and set the java.class.path, so we can directly use the feature to avoid hardcoding of java package path


details in jni_helper.c
```
/**
 * Gets the classpath. Wild card entries are resolved only if the entry ends
 * with "/\*" (backslash to escape commenting) to match against .jar and .JAR.
 * All other wild card entries (eg /path/to/dir/\*foo*) are not resolved,
 * following JAVA default behavior, see:
 * https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html
 */
static char* getClassPath()
{
    //...
    classpath = getenv("CLASSPATH");
    //...
}
```
