### PR TITLE
[Bugfix] Fix Unstable UT SchemaChangeJobV2Test.testSchemaChange1

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -46,6 +46,9 @@ import com.starrocks.common.SchemaVersionAndHash;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.meta.MetaContext;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.TaskManagerTest;
+import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.task.AgentTask;
@@ -53,6 +56,9 @@ import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TStorageFormat;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -70,6 +76,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -80,6 +88,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase  {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
+    private static final Logger LOG = LogManager.getLogger(SchemaChangeJobV2Test.class);
     @Before
     public void setUp() throws Exception {
         super.setUp();
@@ -141,31 +150,18 @@ public class SchemaChangeJobV2Test extends DDLTestBase  {
         schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
 
-        // runWaitingTxnJob, task not finished
-        schemaChangeHandler.runAfterCatalogReady();
-        Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
-
-        // runRunningJob
-        schemaChangeHandler.runAfterCatalogReady();
-        // task not finished, still running
-        Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
+        int retryCount = 0, maxRetry = 5;
+        while (retryCount < maxRetry) {
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(2000L);
+            schemaChangeHandler.runAfterCatalogReady();
+            if(schemaChangeJob.getJobState() == JobState.FINISHED) {
+                break;
+            }
+            retryCount++;
+            LOG.info("testSchemaChange1 is waiting for JobState retryCount:" + retryCount);
+        }
 
         // finish alter tasks
-        List<AgentTask> tasks = AgentTaskQueue.getTask(TTaskType.ALTER);
-        Assert.assertEquals(3, tasks.size());
-        for (AgentTask agentTask : tasks) {
-            agentTask.setFinished(true);
-        }
-        MaterializedIndex shadowIndex = testPartition.getMaterializedIndices(IndexExtState.SHADOW).get(0);
-        for (Tablet shadowTablet : shadowIndex.getTablets()) {
-            for (Replica shadowReplica : ((LocalTablet) shadowTablet).getImmutableReplicas()) {
-                shadowReplica
-                        .updateRowCount(testPartition.getVisibleVersion(),
-                                shadowReplica.getDataSize(), shadowReplica.getRowCount());
-            }
-        }
-
-        schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.FINISHED, schemaChangeJob.getJobState());
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10071

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This test is actually a schemachange process test, but it relies on the operation of executing the Alter Task in the background. This operation may be executed in advance and cause a task error. And the logic of writing UT before is actually a FINISH operation implemented by itself, which is actually not good. Here it is changed to just wait for FINISH to complete the operation naturally.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
