### PR TITLE
[BugFix] Manual compaction request timeout

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -21,19 +21,8 @@ CompactionManager::~CompactionManager() {
     _update_candidate_pool->wait();
 }
 
-void CompactionManager::init_max_task_num() {
-    if (config::base_compaction_num_threads_per_disk >= 0 && config::cumulative_compaction_num_threads_per_disk >= 0) {
-        _max_task_num = static_cast<int32_t>(
-                StorageEngine::instance()->get_store_num() *
-                (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
-    } else {
-        // When cumulative_compaction_num_threads_per_disk or config::base_compaction_num_threads_per_disk is less than 0,
-        // there is no limit to _max_task_num if max_compaction_concurrency is also less than 0, and here we set maximum value to be 20.
-        _max_task_num = std::min(20, static_cast<int32_t>(StorageEngine::instance()->get_store_num() * 5));
-    }
-    if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
-        _max_task_num = config::max_compaction_concurrency;
-    }
+void CompactionManager::init_max_task_num(int32_t num) {
+    _max_task_num = num;
 }
 
 void CompactionManager::update_candidates(std::vector<CompactionCandidate> candidates) {

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -29,7 +29,7 @@ public:
 
     ~CompactionManager();
 
-    void init_max_task_num();
+    void init_max_task_num(int32_t num);
 
     size_t candidates_size() {
         std::lock_guard lg(_candidates_mutex);

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -118,8 +118,8 @@ Status StorageEngine::start_bg_threads() {
         if (config::base_compaction_num_threads_per_disk >= 0 &&
             config::cumulative_compaction_num_threads_per_disk >= 0) {
             max_task_num = static_cast<int32_t>(StorageEngine::instance()->get_store_num() *
-                                                 (config::cumulative_compaction_num_threads_per_disk +
-                                                  config::base_compaction_num_threads_per_disk));
+                                                (config::cumulative_compaction_num_threads_per_disk +
+                                                 config::base_compaction_num_threads_per_disk));
         } else {
             // When cumulative_compaction_num_threads_per_disk or config::base_compaction_num_threads_per_disk is less than 0,
             // there is no limit to _max_task_num if max_compaction_concurrency is also less than 0, and here we set maximum value to be 20.

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -113,10 +113,26 @@ Status StorageEngine::start_bg_threads() {
             Thread::set_thread_name(_cumulative_compaction_threads.back(), "cumulat_compact");
         }
     } else {
+        int32_t max_task_num = 0;
         // new compaction framework
+        if (config::base_compaction_num_threads_per_disk >= 0 &&
+            config::cumulative_compaction_num_threads_per_disk >= 0) {
+            max_task_num = static_cast<int32_t>(StorageEngine::instance()->get_store_num() *
+                                                 (config::cumulative_compaction_num_threads_per_disk +
+                                                  config::base_compaction_num_threads_per_disk));
+        } else {
+            // When cumulative_compaction_num_threads_per_disk or config::base_compaction_num_threads_per_disk is less than 0,
+            // there is no limit to _max_task_num if max_compaction_concurrency is also less than 0, and here we set maximum value to be 20.
+            max_task_num = std::min(20, static_cast<int32_t>(StorageEngine::instance()->get_store_num() * 5));
+        }
+        if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < max_task_num) {
+            max_task_num = config::max_compaction_concurrency;
+        }
+
+        vectorized::Compaction::init(max_task_num);
 
         // compaction_manager must init_max_task_num() before any comapction_scheduler starts
-        _compaction_manager->init_max_task_num();
+        _compaction_manager->init_max_task_num(max_task_num);
         _compaction_scheduler = std::thread([] {
             CompactionScheduler compaction_scheduler;
             compaction_scheduler.schedule();

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -107,7 +107,7 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
         tasks.emplace_back(std::move(task));
     }
 
-    StorageEngine::instance()->compaction_manager()->init_max_task_num();
+    StorageEngine::instance()->compaction_manager()->init_max_task_num(config::max_compaction_concurrency);
 
     for (int i = 0; i < config::max_compaction_concurrency; i++) {
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/941

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The `_concurrency_sem` is not inited when the new compaction framework is enabled, resulting that the manual compaction is blocked.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
