### PR TITLE
[Bugfix] Async reload hive meta causes that the hive metastore couldn…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -5,6 +5,7 @@ package com.starrocks.external.hive;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.HiveMetaStoreTableInfo;
 import com.starrocks.catalog.HiveResource;
 import com.starrocks.catalog.HudiResource;
@@ -27,10 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -47,8 +46,8 @@ public class HiveRepository {
 
     HiveExternalTableCounter counter = new HiveExternalTableCounter();
 
-    Executor executor = new ThreadPoolExecutor(Config.hive_meta_cache_refresh_min_threads,
-            Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+    Executor executor = Executors.newFixedThreadPool(100,
+            new ThreadFactoryBuilder().setNameFormat("hive-metastore-refresh-%d").build());
 
     private static final Logger LOG = LogManager.getLogger(HiveRepository.class);
     private final ExecutorService partitionDaemonExecutor =


### PR DESCRIPTION

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10103

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
FE uses guava loading cache as the hive meta cache structure. our async refresh interval is two hours. we use an unbounded   thread pool as reload executor.  fe will automatically and asynchronously reload hive meta cache when we trigger the cache refreshing when we send the query again in two hours.

The following figure takes asynchronous reload 3000 partitions as an example. and the thread pool size is 1000 in hive-site.xml of hive metastore.

![image](https://user-images.githubusercontent.com/91597003/185054717-25f27867-16f1-4e60-8a64-763f6e3e7f14.png)
1.  1000 threads that have established connections wait for acquiring object lock to close connection. https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java#L137
2.  2000 threads wait to connect from hive metastore. one of them have acquired the object lock. https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java#L157.  but the thread pool sizes of hive metastore is 1000. it will block the [establishment of the connection](https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java#L163). In current version of fe, fe will retry 3 times and the interval is 10 seconds.
3.  Hive metastore wait for fe to close the connection.

So, this is a fake dead lock, because the tasks in the queue digest and retry very slowly.

In issue [#5836](https://github.com/StarRocks/starrocks/issues/5836),  Through verification, the conclusion at that time was wrong, and the previous scenario could not be reproduced when using extreme case, so we first revert to the previous version, and we will thoroughly solve these problems in the next version.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
