### PR TITLE
[Enhancement] Limit the number of migration task sent to BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -191,7 +192,8 @@ public class TabletInvertedIndex {
                                             LOG.debug("available storage medium type count is less than 1, " +
                                                             "no need to send migrate task. tabletId={}, backendId={}.",
                                                     tabletId, backendId);
-                                        } else {
+                                        } else if (tabletMigrationMap.size() <=
+                                                Config.tablet_sched_max_migration_task_sent_once) {
                                             tabletMigrationMap.put(storageMedium, tabletId);
                                         }
                                     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1107,6 +1107,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int tablet_sched_checker_interval_seconds = 20;
 
+    @ConfField(mutable = true)
+    public static int tablet_sched_max_migration_task_sent_once = 1000;
+
     @Deprecated
     @ConfField(mutable = true)
     public static int report_queue_size = 100;


### PR DESCRIPTION
Add a new configuration `tablet_sched_max_migration_task_sent_once`
to control the number of migration task sent to BE on every tablet
report.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9954 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

 Add a new configuration `tablet_sched_max_migration_task_sent_once`
 to control the number of migration task sent to BE on every tablet
 report.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
