### PR TITLE
[Enhancement] Array type conversion with more friendly error msg 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -275,6 +275,10 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (type1.isJsonType() || type2.isJsonType()) {
             return Type.JSON;
         }
+        if (type1.isArrayType() || type2.isArrayType()) {
+            // We don't support array type for binary predicate.
+            return Type.INVALID;
+        }
         if (t1 == PrimitiveType.VARCHAR && t2 == PrimitiveType.VARCHAR) {
             return Type.VARCHAR;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -252,14 +252,13 @@ public class ExpressionAnalyzer {
             Type compatibleType =
                     TypeManager.getCompatibleTypeForBinary(node.getOp().isNotRangeComparison(), type1, type2);
             // check child type can be cast
+            final String ERROR_MSG = "Column type %s does not support binary predicate operation.";
             if (!Type.canCastTo(type1, compatibleType)) {
-                throw new SemanticException(
-                        "binary type " + type1.toSql() + " with type " + compatibleType.toSql() + " is invalid.");
+                throw new SemanticException(String.format(ERROR_MSG, type1.toSql()));
             }
 
             if (!Type.canCastTo(type2, compatibleType)) {
-                throw new SemanticException(
-                        "binary type " + type2.toSql() + " with type " + compatibleType.toSql() + " is invalid.");
+                throw new SemanticException(String.format(ERROR_MSG, type1.toSql()));
             }
 
             node.setType(Type.BOOLEAN);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MetricTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MetricTypeTest.java
@@ -35,7 +35,7 @@ public class MetricTypeTest extends PlanTestBase {
                 .analysisError(Type.OnlyMetricTypeErrorMsg);
 
         starRocksAssert.query("select count(*) from test.bitmap_table where id2 = 1;").analysisError(
-                "binary type bitmap with type double is invalid.");
+                "bitmap", "not support binary predicate");
     }
 
     @Test
@@ -66,19 +66,19 @@ public class MetricTypeTest extends PlanTestBase {
                 .analysisError(Type.OnlyMetricTypeErrorMsg);
 
         starRocksAssert.query("select count(*) from test.hll_table where id2 = 1").analysisError(
-                "binary type hll with type double is invalid.");
+                "hll", "not support binary predicate");
     }
 
     @Test
     public void TestJoinOnBitmapColumn() {
         String sql = "select * from test.bitmap_table a join test.bitmap_table b on a.id2 = b.id2";
-        starRocksAssert.query(sql).analysisError("binary type bitmap with type varchar(-1) is invalid.");
+        starRocksAssert.query(sql).analysisError("bitmap", "not support binary predicate");
 
         sql = "select * from test.bitmap_table a join test.bitmap_table b on a.id2 = b.id";
-        starRocksAssert.query(sql).analysisError("binary type bitmap with type double is invalid.");
+        starRocksAssert.query(sql).analysisError("bitmap", "not support binary predicate");
 
         sql = "select * from test.bitmap_table a join test.hll_table b on a.id2 = b.id2";
-        starRocksAssert.query(sql).analysisError("binary type bitmap with type varchar(-1) is invalid.");
+        starRocksAssert.query(sql).analysisError("bitmap", "not support binary predicate");
 
         sql = "select * from test.bitmap_table a join test.hll_table b where a.id2 in (1, 2, 3)";
         starRocksAssert.query(sql).analysisError("HLL, BITMAP, PERCENTILE and ARRAY type couldn't as Predicate");

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -282,7 +282,8 @@ public class StarRocksAssert {
             return UtFrameUtils.getFragmentPlan(connectContext, sql);
         }
 
-        public void analysisError(String keywords) {
+        // Assert true only if analysisException.getMessage() contains all keywords.
+        public void analysisError(String... keywords) {
             try {
                 explainQuery();
             } catch (AnalysisException | StarRocksPlannerException analysisException) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Origin behavior:

```sql
mysql> select [1,2]=[1,2];
ERROR 1064 (HY000): binary type ARRAY<tinyint(4)> with type double is invalid.
```
It's really wired for users to understand the error message.

Now behavior:

```sql
mysql> select [1,2]=[1,2];
ERROR 1064 (HY000): Column type ARRAY<tinyint(4)> does not support binary predicate operation.
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
