### PR TITLE
[BugFix] Fix exchange source operator has_output always false

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -11,8 +11,7 @@
 namespace starrocks::pipeline {
 Status ExchangeSourceOperator::prepare(RuntimeState* state) {
     SourceOperator::prepare(state);
-    _stream_recvr = std::move(
-            static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state, _unique_metrics));
+    _stream_recvr = static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state, _unique_metrics);
     return Status::OK();
 }
 

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -219,7 +219,7 @@ private:
     // key of second level is request sequence
     phmap::flat_hash_map<int, phmap::flat_hash_map<int64_t, ChunkList>> _buffered_chunk_queues;
 
-    std::unordered_set<int32_t> _short_circuit_driver_sequences;
+    std::vector<bool> _short_circuit_driver_sequences;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
when we call short_circuit, we will remove all of the chunk for the chunk list. but it was not protected by a mutex.
```
        auto& chunk_queue = _chunk_queues[driver_sequence];
        ChunkItem item;
        while (chunk_queue.size_approx() > 0) {
            if (chunk_queue.try_dequeue(item)) {
                if (item.closure != nullptr) {
                    _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
                    item.closure->Run();
                }
                --_total_chunks;
                _recvr->_num_buffered_bytes -= item.chunk_bytes;
            }
        }
```

but at this time, when we add a chunk to the queue. it will never pop from the queue.
```
        for (auto& chunk : chunks) {
            int index = _is_pipeline_level_shuffle ? chunk.driver_sequence : 0;
            size_t chunk_bytes = chunk.chunk_bytes;
            _chunk_queues[index].enqueue(std::move(chunk));
            _total_chunks++;
            _recvr->_num_buffered_bytes += chunk_bytes;
        }
```

thus, the _total_chunks will always greater than 0 and is_finished will always false
```
bool DataStreamRecvr::PipelineSenderQueue::is_finished() const {
    return _is_cancelled || (_num_remaining_senders == 0 && _total_chunks == 0);
}
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
