### PR TITLE
[BugFix] Replayer quit on exception if environment is invalid

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -24,6 +24,7 @@ package com.starrocks.journal.bdbje;
 import com.sleepycat.bind.tuple.TupleBinding;
 import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.DatabaseException;
+import com.sleepycat.je.EnvironmentFailureException;
 import com.sleepycat.je.LockMode;
 import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.rep.InsufficientLogException;
@@ -61,7 +62,7 @@ public class BDBJournalCursor implements JournalCursor {
      *
      * 1. wrap as JournalException and return if it's a normal DatabaseException.
      * 2. RestartRequiredException is a fatal error since we're replaying as a follower, we must exit by raising an
-     * JournalInconsistentException.
+     * JournalInconsistentException. Same with EnvironmentFailureException when replicated environment is invalid.
      * 3. If it is an InsufficientLogException, we should call refreshLog() to restore the data as much as possible.
      */
     protected JournalException wrapDatabaseException(DatabaseException originException, String errMsg)
@@ -74,6 +75,13 @@ public class BDBJournalCursor implements JournalCursor {
                 // then exit the process because we may have read dirty data.
                 environment.refreshLog((InsufficientLogException) originException);
             }
+            JournalInconsistentException journalInconsistentException = new JournalInconsistentException(errMsg);
+            journalInconsistentException.initCause(originException);
+            throw journalInconsistentException;
+        } else if (originException instanceof EnvironmentFailureException
+                && ! environment.getReplicatedEnvironment().isValid()) {
+            errMsg += "Got EnvironmentFailureException and the current ReplicatedEnvironment is invalid, will exit.";
+            LOG.warn(errMsg, originException);
             JournalInconsistentException journalInconsistentException = new JournalInconsistentException(errMsg);
             journalInconsistentException.initCause(originException);
             throw journalInconsistentException;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10137 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When the disk is full, or the permission of the BDB directory has been mistakenly changed, the replayer will catch the exception and retry in vain.
This PR will handle EnvironmentFailureException with great care, and will raise a JournalInconsistentException to replayer when the current replicated environment is invalid so that the whole process will quit.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
