### PR TITLE
[Refactor] Replace waitTransactionVisible with VisibleStateWaiter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -351,8 +351,8 @@ public class DatabaseTransactionMgr {
      * 5. persistent transactionState
      * 6. update nextVersion because of the failure of persistent transaction resulting in error version
      */
-    public void commitTransaction(long transactionId, List<TabletCommitInfo> tabletCommitInfos,
-                                  TxnCommitAttachment txnCommitAttachment)
+    public VisibleStateWaiter commitTransaction(long transactionId, List<TabletCommitInfo> tabletCommitInfos,
+                                                TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         // 1. check status
         // the caller method already own db lock, we do not obtain db lock here
@@ -374,13 +374,14 @@ public class DatabaseTransactionMgr {
         if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
             throw new TransactionCommitFailedException(transactionState.getReason());
         }
+        VisibleStateWaiter waiter = new VisibleStateWaiter(transactionState);
         if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
             LOG.debug("transaction is already visible: {}", transactionId);
-            return;
+            return waiter;
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
             LOG.debug("transaction is already committed: {}", transactionId);
-            return;
+            return waiter;
         }
         // For compatible reason, the default behavior of empty load is still returning "all partitions have no load data" and abort transaction.
         if (Config.empty_load_as_error && (tabletCommitInfos == null || tabletCommitInfos.isEmpty())) {
@@ -463,6 +464,7 @@ public class DatabaseTransactionMgr {
             updateCatalogAfterCommittedSpan.end();
         }
         LOG.info("transaction:[{}] successfully committed", transactionState);
+        return waiter;
     }
 
     /**
@@ -575,7 +577,7 @@ public class DatabaseTransactionMgr {
         LOG.info("transaction:[{}] successfully prepare", transactionState);
     }
 
-    public void commitPreparedTransaction(long transactionId)
+    public VisibleStateWaiter commitPreparedTransaction(long transactionId)
             throws UserException {
         // 1. check status
         // the caller method already own db lock, we do not obtain db lock here
@@ -597,13 +599,14 @@ public class DatabaseTransactionMgr {
         if (transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
             throw new TransactionCommitFailedException(transactionState.getReason());
         }
+        VisibleStateWaiter waiter = new VisibleStateWaiter(transactionState);
         if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
             LOG.debug("transaction is already visible: {}", transactionId);
-            return;
+            return waiter;
         }
         if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
             LOG.debug("transaction is already committed: {}", transactionId);
-            return;
+            return waiter;
         }
 
         Span txnSpan = transactionState.getTxnSpan();
@@ -658,38 +661,7 @@ public class DatabaseTransactionMgr {
             updateCatalogAfterCommittedSpan.end();
         }
         LOG.info("transaction:[{}] successfully committed", transactionState);
-    }
-
-    public boolean waitTransactionVisible(Database db, long transactionId, long timeoutMillis)
-            throws TransactionCommitFailedException {
-        TransactionState transactionState = null;
-        readLock();
-        try {
-            transactionState = unprotectedGetTransactionState(transactionId);
-        } finally {
-            readUnlock();
-        }
-
-        switch (transactionState.getTransactionStatus()) {
-            case COMMITTED:
-            case VISIBLE:
-                break;
-            default:
-                LOG.warn("transaction commit failed, db={}, txn_id: {}", db.getOriginName(), transactionId);
-                throw new TransactionCommitFailedException("transaction commit failed");
-        }
-
-        long currentTimeMillis = System.currentTimeMillis();
-        long timeoutTimeMillis = currentTimeMillis + timeoutMillis;
-        while (currentTimeMillis < timeoutTimeMillis && transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
-            try {
-                transactionState.waitTransactionVisible(timeoutMillis);
-            } catch (InterruptedException e) {
-                LOG.info("thread interrupted while waiting for transaction {} to be visible", transactionId);
-            }
-            currentTimeMillis = System.currentTimeMillis();
-        }
-        return transactionState.getTransactionStatus() == TransactionStatus.VISIBLE;
+        return waiter;
     }
 
     public void deleteTransaction(TransactionState transactionState) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
 
 /**
  * Transaction Manager
@@ -321,14 +322,15 @@ public class GlobalTransactionMgr implements Writable {
     /**
      * @param transactionId
      * @param tabletCommitInfos
-     * @return
+     * @return a {@link VisibleStateWaiter} object used to wait for the transaction become visible.
      * @throws UserException
      * @throws TransactionCommitFailedException
      * @note it is necessary to optimize the `lock` mechanism and `lock` scope resulting from wait lock long time
      * @note callers should get db.write lock before call this api
      */
-    public void commitTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
-                                  TxnCommitAttachment txnCommitAttachment)
+    @NotNull
+    public VisibleStateWaiter commitTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
+                                                TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         if (Config.disable_load_job) {
             throw new TransactionCommitFailedException("disable_load_job is set to true, all load jobs are prevented");
@@ -336,7 +338,7 @@ public class GlobalTransactionMgr implements Writable {
 
         LOG.debug("try to commit transaction: {}", transactionId);
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, txnCommitAttachment);
+        return dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, txnCommitAttachment);
     }
 
     public void prepareTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
@@ -359,6 +361,7 @@ public class GlobalTransactionMgr implements Writable {
 
         LOG.debug("try to commit prepared transaction: {}", transactionId);
 
+        VisibleStateWaiter waiter;
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
         if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
@@ -366,8 +369,7 @@ public class GlobalTransactionMgr implements Writable {
                     + db.getFullName() + ", timeoutMillis=" + timeoutMillis);
         }
         try {
-            DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
-            dbTransactionMgr.commitPreparedTransaction(transactionId);
+            waiter = getDatabaseTransactionMgr(db.getId()).commitPreparedTransaction(transactionId);
         } finally {
             db.writeUnlock();
         }
@@ -379,8 +381,7 @@ public class GlobalTransactionMgr implements Writable {
             // so we just return false to indicate publish timeout
             throw new UserException("publish timeout: " + timeoutMillis);
         }
-        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
-        dbTransactionMgr.waitTransactionVisible(db, transactionId, publishTimeoutMillis);
+        waiter.await(publishTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public boolean commitAndPublishTransaction(Database db, long transactionId,
@@ -399,8 +400,9 @@ public class GlobalTransactionMgr implements Writable {
             throw new UserException("get database write lock timeout, database="
                     + db.getOriginName() + ", timeoutMillis=" + timeoutMillis);
         }
+        VisibleStateWaiter waiter;
         try {
-            commitTransaction(db.getId(), transactionId, tabletCommitInfos, txnCommitAttachment);
+            waiter = commitTransaction(db.getId(), transactionId, tabletCommitInfos, txnCommitAttachment);
         } finally {
             db.writeUnlock();
         }
@@ -411,8 +413,7 @@ public class GlobalTransactionMgr implements Writable {
             // so we just return false to indicate publish timeout
             return false;
         }
-        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
-        return dbTransactionMgr.waitTransactionVisible(db, transactionId, publishTimeoutMillis);
+        return waiter.await(publishTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason) throws UserException {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
 
 public class TransactionState implements Writable {
     private static final Logger LOG = LogManager.getLogger(TransactionState.class);
@@ -222,7 +223,6 @@ public class TransactionState implements Writable {
     private boolean hasSendTask;
     private long publishVersionTime = -1;
     private long publishVersionFinishTime = -1;
-    private TransactionStatus preStatus = null;
 
     private long callbackId = -1;
     private long timeoutMs = Config.stream_load_default_timeout_second * 1000;
@@ -305,8 +305,7 @@ public class TransactionState implements Writable {
     }
 
     public boolean isRunning() {
-        return transactionStatus == TransactionStatus.PREPARE
-                || transactionStatus == TransactionStatus.COMMITTED;
+        return transactionStatus == TransactionStatus.PREPARE || transactionStatus == TransactionStatus.COMMITTED;
     }
 
     // Only for OlapTable
@@ -371,10 +370,6 @@ public class TransactionState implements Writable {
         return reason;
     }
 
-    public TransactionStatus getPreStatus() {
-        return this.preStatus;
-    }
-
     public TxnCommitAttachment getTxnCommitAttachment() {
         return txnCommitAttachment;
     }
@@ -397,7 +392,6 @@ public class TransactionState implements Writable {
 
     public void setTransactionStatus(TransactionStatus transactionStatus) {
         // status changed
-        this.preStatus = this.transactionStatus;
         this.transactionStatus = transactionStatus;
 
         // after status changed
@@ -510,8 +504,12 @@ public class TransactionState implements Writable {
         }
     }
 
-    public void waitTransactionVisible(long timeoutMillis) throws InterruptedException {
-        this.latch.await(timeoutMillis, TimeUnit.MILLISECONDS);
+    public void waitTransactionVisible() throws InterruptedException {
+        this.latch.await();
+    }
+
+    public boolean waitTransactionVisible(long timeout, @NotNull TimeUnit unit) throws InterruptedException {
+        return this.latch.await(timeout, unit);
     }
 
     public void setPrepareTime(long prepareTime) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/VisibleStateWaiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/VisibleStateWaiter.java
@@ -1,0 +1,51 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.transaction;
+
+import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Waits for a transaction becomes visible.
+ */
+public final class VisibleStateWaiter {
+    private final TransactionState txnState;
+
+    VisibleStateWaiter(@NotNull TransactionState txnState) {
+        this.txnState = txnState;
+    }
+
+    /**
+     * Causes the current thread to wait until the transaction state changed to {@code TransactionState.VISIBLE}.
+     * If the current state is VISIBLE then this method returns immediately.
+     */
+    public void await() {
+        while (true) {
+            try {
+                txnState.waitTransactionVisible();
+                break;
+            } catch (InterruptedException e) {
+                // ignore InterruptedException
+            }
+        }
+    }
+
+    /**
+     * Causes the current thread to wait until the transaction state changed to {@code TransactionState.VISIBLE}, unless the
+     * specified waiting time elapses.
+     * <p>
+     * If the current state is VISIBLE then this method returns immediately with the value true.
+     *
+     * @param timeout – the maximum time to wait
+     * @param unit    – the time unit of the timeout argument
+     * @return true if the transaction state becomes VISIBLE and false if InterruptedException threw or, the waiting time
+     * elapsed before the state becomes VISIBLE
+     */
+    public boolean await(long timeout, @NotNull TimeUnit unit) {
+        try {
+            return txnState.waitTransactionVisible(timeout, unit);
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Compared with `VisibleStateWaiter`, function `waitTransactionVisible()` has some unnecessary checks and locks.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

