### PR TITLE
[BugFix] BE crash when base rowset is missing

### DIFF
--- a/be/src/storage/base_and_cumulative_compaction_policy.cpp
+++ b/be/src/storage/base_and_cumulative_compaction_policy.cpp
@@ -158,6 +158,9 @@ void BaseAndCumulativeCompactionPolicy::_pick_base_rowsets(std::vector<RowsetSha
     size_t rowsets_compaction_score = 0;
     // add the base rowset to input_rowsets
     Rowset* base_rowset = *_compaction_context->rowset_levels[2].begin();
+    if (base_rowset == nullptr) {
+        return;
+    }
     rowsets->push_back(base_rowset->shared_from_this());
     rowsets_compaction_score += base_rowset->rowset_meta()->get_compaction_score();
     input_rows_num += base_rowset->num_rows();
@@ -183,7 +186,7 @@ std::shared_ptr<CompactionTask> BaseAndCumulativeCompactionPolicy::_create_base_
     std::vector<RowsetSharedPtr> input_rowsets;
     _pick_base_rowsets(&input_rowsets);
     if (input_rowsets.size() <= 1) {
-        LOG(INFO) << "no suitable version for compaction. size:" << input_rowsets.size();
+        LOG(INFO) << "no suitable version for compaction. tablet_id: :" << _compaction_context->tablet->tablet_id();
         return nullptr;
     }
 

--- a/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
+++ b/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
@@ -245,4 +245,36 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
     ASSERT_EQ(base_task, nullptr);
 }
 
+TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_without_base_rowset) {
+    TabletSharedPtr tablet = std::make_shared<Tablet>();
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->set_tablet_id(100);
+    tablet->set_tablet_meta(tablet_meta);
+    std::unique_ptr<CompactionContext> compaction_context = std::make_unique<CompactionContext>();
+    compaction_context->tablet = tablet;
+
+    std::vector<RowsetSharedPtr> rowsets;
+    TabletSchema tablet_schema;
+    create_tablet_schema(&tablet_schema);
+    int64_t base_time = UnixSeconds() - 100 * 60;
+
+    {
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_start_version(10);
+        rowset_meta->set_end_version(19);
+        rowset_meta->set_creation_time(base_time +1);
+        rowset_meta->set_segments_overlap(NONOVERLAPPING);
+        rowset_meta->set_num_segments(1);
+        rowset_meta->set_total_disk_size(1024 * 1024);
+        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset1", rowset_meta);
+        compaction_context->rowset_levels[1].insert(rowset.get());
+        rowsets.emplace_back(std::move(rowset));
+    }
+
+    compaction_context->chosen_compaction_type = BASE_COMPACTION;
+    BaseAndCumulativeCompactionPolicy policy(compaction_context.get());
+    std::shared_ptr<CompactionTask> base_task = policy.create_compaction();
+    ASSERT_EQ(base_task, nullptr);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10008

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The base rowset (rowset whose start version is 0) may be missing for some tablets. This PR check the base rowset to avoid the crash in compaction.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
