### PR TITLE
[Enhancement] Update CTENoOp/Anchor required parent property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpRequestException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpRequestException.java
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
 package com.starrocks.http;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -118,7 +118,7 @@ public class CTEContext {
     }
 
     public boolean needOptimizeCTE() {
-        return consumeNums.values().stream().reduce(Integer::max).orElse(0) > 0 || produces.size() > 0;
+        return consumeNums.values().stream().reduce(Integer::max).orElse(0) > 0 || !produces.isEmpty();
     }
 
     public boolean needPushPredicate() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -260,7 +260,7 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
 
     @Override
     public Void visitPhysicalNoCTE(PhysicalNoCTEOperator node, ExpressionContext context) {
-        requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
+        requiredProperties.add(Lists.newArrayList(requirementsFromParent));
         return null;
     }
 
@@ -290,9 +290,12 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
 
             CTEProperty thisCTE = new CTEProperty(node.getCteId());
             thisCTE.merge(requiredRight.getCteProperty());
-            PhysicalPropertySet copy = requiredRight.copy();
 
+            DistributionProperty requiredDistributionProp = requiredRight.getDistributionProperty();
+
+            PhysicalPropertySet copy = requiredRight.copy();
             copy.setCteProperty(thisCTE);
+            copy.setDistributionProperty(new DistributionProperty(requiredDistributionProp.getSpec(), true));
             requiredProperties.get(0).set(1, copy);
             return null;
         }
@@ -301,8 +304,9 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
         public Void visitPhysicalNoCTE(PhysicalNoCTEOperator node, Void context) {
             visitOperator(node, context);
             CTEProperty required = requiredProperties.get(0).get(0).getCteProperty();
+            Preconditions.checkState(!required.getCteIds().contains(node.getCteId()));
             PhysicalPropertySet copy = requiredProperties.get(0).get(0).copy();
-            copy.setCteProperty(required.removeCTE(node.getCteId()));
+            copy.setDistributionProperty(new DistributionProperty(copy.getDistributionProperty().getSpec(), true));
             requiredProperties.get(0).set(0, copy);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
@@ -9,15 +9,23 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperato
 
 public class DistributionProperty implements PhysicalProperty {
     private final DistributionSpec spec;
+    private final boolean isCTERequired;
 
     public static final DistributionProperty EMPTY = new DistributionProperty();
 
     public DistributionProperty() {
         this.spec = DistributionSpec.createAnyDistributionSpec();
+        this.isCTERequired = false;
     }
 
     public DistributionProperty(DistributionSpec spec) {
         this.spec = spec;
+        this.isCTERequired = false;
+    }
+
+    public DistributionProperty(DistributionSpec spec, boolean isCTERequired) {
+        this.spec = spec;
+        this.isCTERequired = isCTERequired;
     }
 
     public DistributionSpec getSpec() {
@@ -40,8 +48,18 @@ public class DistributionProperty implements PhysicalProperty {
         return spec.type == DistributionSpec.DistributionType.BROADCAST;
     }
 
+    public boolean isCTERequired() {
+        return isCTERequired;
+    }
+
     @Override
     public boolean isSatisfy(PhysicalProperty other) {
+        if (((DistributionProperty) other).isCTERequired()) {
+            // always satisfy if parent is CTENoOp/CTEAnchor.
+            // the plan will be adjusted in the father of CTENoOp/CTEAnchor, and
+            // the distribution of CTENoOp/CTEAnchor always keep same with children
+            return true;
+        }
         DistributionSpec otherSpec = ((DistributionProperty) other).getSpec();
         return spec.isSatisfy(otherSpec);
     }
@@ -65,6 +83,6 @@ public class DistributionProperty implements PhysicalProperty {
         }
 
         DistributionProperty rhs = (DistributionProperty) obj;
-        return spec.equals(rhs.getSpec());
+        return spec.equals(rhs.getSpec()) && isCTERequired == rhs.isCTERequired;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -101,6 +101,12 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         if (groupExpression.isUnused()) {
             return;
         }
+
+        if (!checkCTEPropertyValid(groupExpression, context.getRequiredProperty())) {
+            // prune CTE invalid plan
+            return;
+        }
+
         // Init costs and get required properties for children
         initRequiredProperties();
 
@@ -157,10 +163,6 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
 
             // Successfully optimize all child group
             if (curChildIndex == groupExpression.getInputs().size()) {
-                if (!checkCTEPropertyValid(groupExpression, context.getRequiredProperty())) {
-                    break;
-                }
-
                 // before we compute the property, here need to make sure that the plan is legal
                 ChildOutputPropertyGuarantor childOutputPropertyGuarantor = new ChildOutputPropertyGuarantor(context,
                         groupExpression,
@@ -399,8 +401,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
             // and shuffle join two types outputProperty.
             groupExpression.setOutputPropertySatisfyRequiredProperty(outputProperty, requiredProperty);
         }
-        this.groupExpression.getGroup().setBestExpression(groupExpression,
-                curTotalCost, requiredProperty);
+        this.groupExpression.getGroup().setBestExpression(groupExpression, curTotalCost, requiredProperty);
         if (ConnectContext.get().getSessionVariable().isSetUseNthExecPlan()) {
             // record the output/input properties when child group could satisfy this group expression required property
             groupExpression.addValidOutputInputProperties(requiredProperty, inputProperties);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1159,4 +1159,35 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0");
     }
+
+    @Test
+    public void testExpressionWithCTE() throws Exception {
+        String sql = "WITH x1 as (" +
+                "   select * from t0" +
+                ") " +
+                "select sum(k2) from (" +
+                "   SELECT * " +
+                "   from x1 join[bucket] " +
+                "   (SELECT v1 + 1 as k1, v2 + 2 as k2, v3 + 3 as k3 from x1) as y1 on x1.v1 = y1.k1" +
+                ") d group by v3, k3";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 4: v1 = 10: expr\n" +
+                "  |  \n" +
+                "  |----3:EXCHANGE\n" +
+                "  |    \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0");
+        assertContains(plan, "    BUCKET_SHUFFLE_HASH_PARTITIONED: 10: expr\n" +
+                "\n" +
+                "  2:Project\n" +
+                "  |  <slot 10> : 7: v1 + 1\n" +
+                "  |  <slot 11> : 8: v2 + 2\n" +
+                "  |  <slot 12> : 9: v3 + 3\n" +
+                "  |  \n" +
+                "  1:OlapScanNode\n" +
+                "     TABLE: t0");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For SQL:
```
WITH x1 as (
    select * from t0
)
SELECT * 
from x1 join[bucket]
(   
    SELECT v1 + 1 as k1, v2 + 2 as k2, v3 + 3 as k3 
    from x1
) as y1 on x1.v1 = y1.k1

```
When finish inline CTE, the memo plan will be:
```
         CTEAnchor                            CTENoOp          
        /         \                              |        
CTEProduce        Join                         Join          
     |         /        \                     /     \          
   Scan  CTEConsume   Project     ===>   CTENoOp   Project
            |            |                   |        |   
          Scan       CTEConsume            Scan    CTENoOp                   
                         |                            |        
                        Scan                         Scan          
```
Question 1. what property CTENoOp should support?
First, CTENoOp/CTEAnchor is logical node, not a execute node, just for mark CTE refs.
For developers, the distribution of CTENoOp/CTEAnchor is same with his children, it's easy to understand.

Question 2. what property CTENoOp should required?
* If CTENoOp required `ANY` property, CTENoOp will keep same distribution with his child, but it's will prune some better plan, such as: Bucket-Join, Colcate-Join
* If CTENoOp required parent property, CTENoOp will enforce his children, and the parent will enforce CTENoOp too, because CTENoOp maybe has a projection(parent required columns is from projection)

so, I update distribution property, add a flag to mark the property is from CTENoOp,  child can be modify himself by CTE's distribution property, and child's property always staisfy the CTE's property.

* Update CTEAnchor/CTENoOp required property: ANY -> parent property(cte = true)
* add flag in distribution property 
* move the position of the cte plan prune

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
