### PR TITLE
[Enhancement] assign tablets to driver sequence only if num_buckets>1

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -24,8 +24,7 @@ void LogicalSplitScanMorsel::init_tablet_reader_params(vectorized::TabletReaderP
     params->short_key_ranges = _short_key_ranges;
 }
 
-/// MorselQueueFactory
-
+/// MorselQueueFactory.
 size_t SharedMorselQueueFactory::num_original_morsels() const {
     return _queue->num_original_morsels();
 }
@@ -38,7 +37,9 @@ size_t IndividualMorselQueueFactory::num_original_morsels() const {
     return total;
 }
 
-IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq) {
+IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
+                                                           bool need_local_shuffle)
+        : _need_local_shuffle(need_local_shuffle) {
     if (queue_per_driver_seq.empty()) {
         _queue_per_driver_seq.emplace_back(pipeline::create_empty_morsel_queue());
         return;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -111,7 +111,9 @@ public:
     virtual MorselQueue* create(int driver_sequence) = 0;
     virtual size_t size() const = 0;
     virtual size_t num_original_morsels() const = 0;
+
     virtual bool is_shared() const = 0;
+    virtual bool need_local_shuffle() const = 0;
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
@@ -122,7 +124,9 @@ public:
     MorselQueue* create(int driver_sequence) override { return _queue.get(); }
     size_t size() const override { return _size; }
     size_t num_original_morsels() const override;
+
     bool is_shared() const override { return true; }
+    bool need_local_shuffle() const override { return true; }
 
 private:
     MorselQueuePtr _queue;
@@ -131,7 +135,7 @@ private:
 
 class IndividualMorselQueueFactory final : public MorselQueueFactory {
 public:
-    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq);
+    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq, bool need_local_shuffle);
     ~IndividualMorselQueueFactory() override = default;
 
     MorselQueue* create(int driver_sequence) override {
@@ -144,9 +148,11 @@ public:
     size_t num_original_morsels() const override;
 
     bool is_shared() const override { return false; }
+    bool need_local_shuffle() const override { return _need_local_shuffle; }
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
+    const bool _need_local_shuffle;
 };
 
 /// MorselQueue.

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -436,7 +436,7 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
 
     const auto* morsel_queue_factory = context->morsel_queue_factory_of_source_operator(scan_operator.get());
     scan_operator->set_degree_of_parallelism(morsel_queue_factory->size());
-    scan_operator->set_need_local_shuffle(morsel_queue_factory->is_shared());
+    scan_operator->set_need_local_shuffle(morsel_queue_factory->need_local_shuffle());
 
     ops.emplace_back(std::move(scan_operator));
 

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -87,7 +87,8 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         if (scan_dop > 1 && dynamic_cast<pipeline::FixedMorselQueue*>(morsel_queue.get()) &&
             morsel_queue->num_original_morsels() <= io_parallelism) {
             auto morsel_queue_map = uniform_distribute_morsels(std::move(morsel_queue), scan_dop);
-            return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map));
+            return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map),
+                                                                            /*need_local_shuffle*/ true);
         } else {
             return std::make_unique<pipeline::SharedMorselQueueFactory>(std::move(morsel_queue), scan_dop);
         }
@@ -105,7 +106,8 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
             queue_per_driver_seq.emplace(dop, std::move(queue));
         }
 
-        return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(queue_per_driver_seq));
+        return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(queue_per_driver_seq),
+                                                                        /*need_local_shuffle*/ false);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1994,7 +1994,7 @@ public class Coordinator {
         for (Map.Entry<Integer, Map<Integer, List<TScanRangeParams>>> bucketSeqAndScanRanges : bucketSeqToScanRange.entrySet()) {
             TNetworkAddress address = bucketSeqToAddress.get(bucketSeqAndScanRanges.getKey());
             addressToScanRanges
-                    .computeIfAbsent(address, (k) -> Lists.newArrayList())
+                    .computeIfAbsent(address, k -> Lists.newArrayList())
                     .add(bucketSeqAndScanRanges);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -123,7 +123,7 @@ public class CoordinatorTest {
                 Assert.assertEquals(expectedDriverSeq, bucketSeqToDriverSeq.get(expectedBucketSeq));
             });
 
-            if (enablePipeline) {
+            if (enablePipeline && expectedPipelineDops.get(i) != -1) {
                 Assert.assertTrue(param.getPerNodeScanRanges().isEmpty());
 
                 Map<Integer, Integer> expectedDriverSeq2NumScanRanges = expectedDriverSeq2NumScanRangesList.get(i);
@@ -150,14 +150,14 @@ public class CoordinatorTest {
         // Bucket distribution:
         // - addr1: 11, 12, 13, 14, 15.
         // - addr2: 21, 22, 23.
-        // - addr3: 31
+        // - addr3: 31, 32
         TNetworkAddress addr1 = new TNetworkAddress("host1", 8000);
         TNetworkAddress addr2 = new TNetworkAddress("host2", 8000);
         TNetworkAddress addr3 = new TNetworkAddress("host3", 8000);
         Map<Integer, TNetworkAddress> bucketSeqToAddress = ImmutableMap.<Integer, TNetworkAddress>builder()
                 .put(11, addr1).put(12, addr1).put(13, addr1).put(14, addr1).put(15, addr1)
                 .put(21, addr2).put(22, addr2).put(23, addr2)
-                .put(31, addr3)
+                .put(32, addr3).put(31, addr3)
                 .build();
 
         // Test case 1: numInstance=1, pipelineDop=3, enablePipeline.
@@ -173,20 +173,21 @@ public class CoordinatorTest {
         //          - DriverSequence#2: 23.
         // - addr3
         //      - Instance#0
-        //          - DriverSequence#0: 31.
+        //          - DriverSequence#0: 32.
+        //          - DriverSequence#1: 31.
         int expectedInstances = 3;
         List<TNetworkAddress> expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
         List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs = ImmutableList.of(
                 ImmutableMap.of(11, 0, 12, 1, 13, 2, 14, 0, 15, 1),
                 ImmutableMap.of(21, 0, 22, 1, 23, 2),
-                ImmutableMap.of(31, 0)
+                ImmutableMap.of(32, 0, 31, 1)
         );
-        List<Integer> expectedPipelineDops = ImmutableList.of(3, 3, 1);
+        List<Integer> expectedPipelineDops = ImmutableList.of(3, 3, 2);
         List<Integer> expectedNumScanRangesList = null;
         List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList = ImmutableList.of(
                 ImmutableMap.of(0, 2, 1, 2, 2, 1),
                 ImmutableMap.of(0, 1, 1, 1, 2, 1),
-                ImmutableMap.of(0, 1)
+                ImmutableMap.of(0, 1, 1, 1)
         );
         testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
@@ -211,10 +212,12 @@ public class CoordinatorTest {
         //          - DriverSequence#0: 23.
         // - addr3
         //      - Instance#0
+        //          - DriverSequence#0: 32.
+        //      - Instance#1
         //          - DriverSequence#0: 31.
-        expectedInstances = 7;
+        expectedInstances = 8;
         expectedParamAddresses = ImmutableList.of(addr1, addr1, addr1, addr2, addr2, addr2, addr3, addr3);
-        expectedPipelineDops = ImmutableList.of(2, 2, 1, 1, 1, 1, 1);
+        expectedPipelineDops = ImmutableList.of(2, 2, 1, 1, 1, 1, 1, 1);
         expectedBucketSeqToDriverSeqs = ImmutableList.of(
                 ImmutableMap.of(11, 0, 14, 1),
                 ImmutableMap.of(12, 0, 15, 1),
@@ -222,11 +225,13 @@ public class CoordinatorTest {
                 ImmutableMap.of(21, 0),
                 ImmutableMap.of(22, 0),
                 ImmutableMap.of(23, 0),
+                ImmutableMap.of(32, 0),
                 ImmutableMap.of(31, 0)
         );
         expectedDriverSeq2NumScanRangesList = ImmutableList.of(
                 ImmutableMap.of(0, 1, 1, 1),
                 ImmutableMap.of(0, 1, 1, 1),
+                ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
@@ -254,8 +259,9 @@ public class CoordinatorTest {
         //          - DriverSequence#0: 23.
         // - addr3
         //      - Instance#0
+        //          - DriverSequence#0: 32.
+        //      - Instance#1
         //          - DriverSequence#0: 31.
-        expectedInstances = 7;
         expectedParamAddresses = ImmutableList.of(addr1, addr1, addr1, addr2, addr2, addr2, addr3, addr3);
         expectedPipelineDops = Collections.nCopies(expectedInstances, 1);
         expectedBucketSeqToDriverSeqs = ImmutableList.of(
@@ -265,11 +271,13 @@ public class CoordinatorTest {
                 ImmutableMap.of(21, 0),
                 ImmutableMap.of(22, 0),
                 ImmutableMap.of(23, 0),
+                ImmutableMap.of(32, 0),
                 ImmutableMap.of(31, 0)
         );
         expectedDriverSeq2NumScanRangesList = ImmutableList.of(
                 ImmutableMap.of(0, 2),
                 ImmutableMap.of(0, 2),
+                ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1),
@@ -290,8 +298,20 @@ public class CoordinatorTest {
         //      - Instance#1: 22.
         //      - Instance#2: 23.
         // - addr3
-        //      - Instance#0: 31.
-        expectedNumScanRangesList = ImmutableList.of(2, 2, 1, 1, 1, 1, 1);
+        //      - Instance#0: 32.
+        //      - Instance#1: 31.
+        expectedNumScanRangesList = ImmutableList.of(2, 2, 1, 1, 1, 1, 1, 1);
+        expectedPipelineDops = Collections.nCopies(expectedInstances, -1);
+        expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, -1, 14, -1),
+                ImmutableMap.of(12, -1, 15, -1),
+                ImmutableMap.of(13, -1),
+                ImmutableMap.of(21, -1),
+                ImmutableMap.of(22, -1),
+                ImmutableMap.of(23, -1),
+                ImmutableMap.of(32, -1),
+                ImmutableMap.of(31, -1)
+        );
         expectedDriverSeq2NumScanRangesList = null;
         testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 1, false,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
@@ -311,21 +331,53 @@ public class CoordinatorTest {
         // - addr3
         //      - Instance#0
         //          - DriverSequence#0: 31.
+        //          - DriverSequence#1: empty.
         coordinator.addReplicateScanId(scanId);
         expectedInstances = 3;
         expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
         expectedBucketSeqToDriverSeqs = ImmutableList.of(
                 ImmutableMap.of(11, 0, 12, 1, 13, 2, 14, 0, 15, 1),
                 ImmutableMap.of(21, 0, 22, 1, 23, 2),
-                ImmutableMap.of(31, 0)
+                ImmutableMap.of(32, 0, 31, 1)
         );
-        expectedPipelineDops = ImmutableList.of(3, 3, 1);
+        expectedPipelineDops = ImmutableList.of(3, 3, 2);
         expectedNumScanRangesList = null;
         expectedDriverSeq2NumScanRangesList = ImmutableList.of(
                 ImmutableMap.of(0, 1, 1, 0, 2, 0),
                 ImmutableMap.of(0, 1, 1, 0, 2, 0),
-                ImmutableMap.of(0, 1)
+                ImmutableMap.of(0, 1, 1, 0)
         );
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+                expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
+                expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
+
+        // Test case 6: numInstance=1, pipelineDop=3, enablePipeline, addr3 is assigned only one bucket.
+        // Bucket distribution:
+        // - addr1: 11, 12, 13, 14, 15.
+        // - addr2: 21, 22, 23.
+        // - addr3: 31
+        scanId = 1;
+        bucketSeqToAddress = ImmutableMap.<Integer, TNetworkAddress>builder()
+                .put(11, addr1).put(12, addr1).put(13, addr1).put(14, addr1).put(15, addr1)
+                .put(21, addr2).put(22, addr2).put(23, addr2)
+                .put(31, addr3)
+                .build();
+        // Test case 1: numInstance=1, pipelineDop=3, enablePipeline.
+        // - addr1
+        //      - Instance#0: 11, 12, 13, 14, 15.
+        // - addr2
+        //      - Instance#0: 21, 22, 23.
+        // - addr3
+        //      - Instance#0: 31
+        expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
+        expectedBucketSeqToDriverSeqs = ImmutableList.of(
+                ImmutableMap.of(11, -1, 12, -1, 13, -1, 14, -1, 15, -1),
+                ImmutableMap.of(21, -1, 22, -1, 23, -1),
+                ImmutableMap.of(31, -1)
+        );
+        expectedPipelineDops = ImmutableList.of(-1, -1, -1);
+        expectedNumScanRangesList = ImmutableList.of(5, 3, 1);
+        expectedDriverSeq2NumScanRangesList = null;
         testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for a local bucket shuffle join, we assign tablets to each driver sequence, and set `DOP` to the number of buckets a BE is assigned, in order to avoid local shuffle.

When enabling tablet internal parallel, we prefer setting `numBuckets` to `numBEs`, that is , each BE has **one** bucket.
Therefore, `DOP` of local bucket shuffle join in this scenario is only **one**.

In this case, we should insert local shuffle to improve the degree of parallelism of JoinOperator. Therefore, apply the strategy about assign tablets to each driver sequence, only if `num_buckets_of_one_BE` > 1. 



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
