### PR TITLE
[Enhancement] Make clone test more stable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -641,7 +641,7 @@ public class TransactionState implements Writable {
                 sb.append(", finish txn cost: ").append(finishTime - publishVersionFinishTime).append("ms");
             }
         }
-        if (finishTime > commitTime) {
+        if (finishTime > commitTime && commitTime > 0) {
             sb.append(", publish total cost: ").append(finishTime - commitTime).append("ms");
         }
         if (finishTime > prepareTime) {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/CloneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/CloneTest.java
@@ -14,6 +14,10 @@ import org.junit.Test;
 public class CloneTest {
     @BeforeClass
     public static void setUp() throws Exception {
+        // set timeout to a really long time so that ut can pass even when load of ut machine is very high
+        Config.bdbje_heartbeat_timeout_second = 60;
+        Config.bdbje_replica_ack_timeout_second = 60;
+        Config.bdbje_lock_timeout_second = 60;
         // set some parameters to speedup test
         Config.tablet_sched_checker_interval_seconds = 1;
         Config.tablet_sched_repair_delay_factor_second = 1;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Increase the timeout configurations of bdbje to avoid leader membership change which will cause the test fail.

```
globalStateMgr is not ready, wait for 1 second
globalStateMgr is not ready, wait for 1 second
globalStateMgr is not ready, wait for 1 second
globalStateMgr is not ready, wait for 1 second
globalStateMgr is not ready, wait for 1 second
[2022-08-18 17:16:38] notify new FE type transfer: LEADER
globalStateMgr is not ready, wait for 1 second
globalStateMgr is not ready, wait for 1 second
[2022-08-18 17:16:41] leaer finished to replay journal, can write now.
globalStateMgr is not ready, wait for 1 second
Fe process is started
clone tablet:10006 10002 -> 10001 version:2 #pending:0
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
