### PR TITLE
[Enhancement] Async fetch the offset lags of routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.metric;
 
+import com.starrocks.common.Config;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 
@@ -126,6 +127,10 @@ public class MetricCalculator extends TimerTask {
             MetricRepo.GAUGE_QUERY_LATENCY_P95.setValue(0.0);
             MetricRepo.GAUGE_QUERY_LATENCY_P99.setValue(0.0);
             MetricRepo.GAUGE_QUERY_LATENCY_P999.setValue(0.0);
+        }
+
+        if (Config.enable_routine_load_lag_metrics)  {
+            MetricRepo.updateRoutineLoadProcessMetrics();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 public final class MetricRepo {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -120,7 +120,6 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Long> GAUGE_STACKED_JOURNAL_NUM;
 
     public static List<GaugeMetricImpl<Long>> GAUGE_ROUTINE_LOAD_LAGS;
-    public static ReentrantReadWriteLock GAUGE_ROUTINE_LOAD_LAGS_LOCK;
 
     private static final ScheduledThreadPoolExecutor metricTimer =
             ThreadPoolManager.newDaemonScheduledThreadPool(1, "Metric-Timer-Pool", true);
@@ -132,7 +131,6 @@ public final class MetricRepo {
         }
 
         GAUGE_ROUTINE_LOAD_LAGS = new ArrayList<>();
-        GAUGE_ROUTINE_LOAD_LAGS_LOCK = new ReentrantReadWriteLock();
 
         // 1. gauge
         // load jobs
@@ -564,9 +562,7 @@ public final class MetricRepo {
             }
         }
 
-        GAUGE_ROUTINE_LOAD_LAGS_LOCK.writeLock().lock();
         GAUGE_ROUTINE_LOAD_LAGS = routineLoadLags;
-        GAUGE_ROUTINE_LOAD_LAGS_LOCK.writeLock().unlock();
     }
 
     public static synchronized String getMetric(MetricVisitor visitor, boolean collectTableMetrics,
@@ -646,13 +642,8 @@ public final class MetricRepo {
     }
 
     private static void collectRoutineLoadProcessMetrics(MetricVisitor visitor) {
-        GAUGE_ROUTINE_LOAD_LAGS_LOCK.readLock().lock();
-        try {
-            for (GaugeMetricImpl<Long> metric : GAUGE_ROUTINE_LOAD_LAGS) {
-                visitor.visit(metric);
-            }
-        } finally {
-            GAUGE_ROUTINE_LOAD_LAGS_LOCK.readLock().unlock();
+        for (GaugeMetricImpl<Long> metric : GAUGE_ROUTINE_LOAD_LAGS) {
+            visitor.visit(metric);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9772 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If we set `enable_routine_load_lag_metrics=true`, we will obtain the offset of Kafka synchronously. If a BE obtains the offset overtime, it will cause the API time out.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
