### PR TITLE
[WIP][Others] Support rollback from version 2.4 to version 2.3 for PrimaryKey table with persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1252,14 +1252,39 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
         // so we can load persistent index according to PersistentIndexMetaPB
         EditVersion version = index_meta.version();
         if (version == lastest_applied_version) {
-            status = load(index_meta);
-            LOG(INFO) << "load persistent index tablet:" << tablet->tablet_id() << " version:" << version.to_string()
-                      << " size: " << _size << " l0_size: " << (_l0 ? _l0->size() : 0)
-                      << " l0_capacity:" << (_l0 ? _l0->capacity() : 0)
-                      << " #shard: " << (_l1 ? _l1->_shards.size() : 0) << " l1_size:" << (_l1 ? _l1->_size : 0)
-                      << " memory: " << memory_usage() << " status: " << status.to_string()
-                      << " time:" << timer.elapsed_time() / 1000000 << "ms";
-            return status;
+            MutableIndexMetaPB l0_meta = index_meta.l0_meta();
+            if (l0_meta.format_version() != PERSISTENT_INDEX_VERSION_1) {
+                LOG(WARNING) << "different format version, we need to rebuild persistent index";
+                status = Status::InternalError("different format version");
+            } else {
+                status = load(index_meta);
+                LOG(INFO) << "load persistent index tablet:" << tablet->tablet_id()
+                          << " version:" << version.to_string() << " size: " << _size
+                          << " l0_size: " << (_l0 ? _l0->size() : 0) << " l0_capacity:" << (_l0 ? _l0->capacity() : 0)
+                          << " #shard: " << (_l1 ? _l1->_shards.size() : 0) << " l1_size:" << (_l1 ? _l1->_size : 0)
+                          << " memory: " << memory_usage() << " status: " << status.to_string()
+                          << " time:" << timer.elapsed_time() / 1000000 << "ms";
+            }
+            if (status.ok()) {
+                return status;
+            } else {
+                LOG(WARNING) << "load persistent index failed, tablet: " << tablet->tablet_id()
+                             << ", status: " << status;
+                if (index_meta.has_l0_meta()) {
+                    EditVersion l0_version = index_meta.l0_meta().snapshot().version();
+                    std::string l0_file_name =
+                            strings::Substitute("index.l0.$0.$1", l0_version.major(), l0_version.minor());
+                    Status st = FileSystem::Default()->delete_file(l0_file_name);
+                    LOG(WARNING) << "delete error l0 index file: " << l0_file_name << ", status: " << st;
+                }
+                if (index_meta.has_l1_version()) {
+                    EditVersion l1_version = index_meta.l1_version();
+                    std::string l1_file_name =
+                            strings::Substitute("index.l1.$0.$1", l1_version.major(), l1_version.minor());
+                    Status st = FileSystem::Default()->delete_file(l1_file_name);
+                    LOG(WARNING) << "delete error l1 index file: " << l1_file_name << ", status: " << st;
+                }
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -683,7 +683,7 @@ public class RuntimeProfile {
                 updateMinMax = true;
             } else {
                 // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-                double diff = maxValue - minValue;
+                double diff = (double) (maxValue - minValue);
                 if (Counter.isAverageType(counter0.getType())) {
                     if (diff > 5000000L && diff > mergedValue / 5.0) {
                         updateMinMax = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -683,7 +683,7 @@ public class RuntimeProfile {
                 updateMinMax = true;
             } else {
                 // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-                double diff = (double) (maxValue - minValue);
+                double diff = maxValue - minValue;
                 if (Counter.isAverageType(counter0.getType())) {
                     if (diff > 5000000L && diff > mergedValue / 5.0) {
                         updateMinMax = true;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We will support varlen key for PrimaryKey table with persistent index from version 2.4. However, if we create a PrimaryKey table with persistent index which key length is less than 64 Bytes in version 2.4, we can't rollback to version 2.3 directly. Because the meta structure is changed in version 2.4.

This pr support rollback from version 2.4 to version 2.3 for PrimaryKey table with persistent index.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
