### PR TITLE
[Bugfix] Try catch runtime_error in TRY_CATCH_BAD_ALLOC

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -245,23 +245,15 @@ private:
         } else {                                                                                                       \
             return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");                                \
         }                                                                                                              \
+    }                                                                                                                  \
+    catch (std::runtime_error const& e) {                                                                              \
+        return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)                                                                  \
-    do {                                                                                           \
-        try {                                                                                      \
-            SCOPED_SET_CATCHED(true);                                                              \
-            { stmt; }                                                                              \
-        } catch (std::bad_alloc const&) {                                                          \
-            MemTracker* exceed_tracker = tls_exceed_mem_tracker;                                   \
-            tls_exceed_mem_tracker = nullptr;                                                      \
-            if (LIKELY(exceed_tracker != nullptr)) {                                               \
-                return Status::MemoryLimitExceeded(exceed_tracker->err_msg(                        \
-                        fmt::format("try consume:{}", tls_thread_status.try_consume_mem_size()))); \
-            } else {                                                                               \
-                return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");        \
-            }                                                                                      \
-        }                                                                                          \
+#define TRY_CATCH_BAD_ALLOC(stmt)               \
+    do {                                        \
+        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
+        TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10265.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Some third-party libraries throw `std::runtime_error` instead of `std::bad_alloc`, when it fails to allocate memory.

This will occur more frequently, when we use `TRY_CATCH_BAD_ALLOC`. The reason is that, 
- if we don't use `TRY_CATCH_BAD_ALLOC`, the system will try its best to allocate memory.
- If we use `TRY_CATCH_BAD_ALLOC`, we check whether it exceed `mem_limit` before really allocating memory, and  return `nullptr` to indicate failing to allocate memory.

Therefore, also try catch `runtime_error` in `TRY_CATCH_BAD_ALLOC`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
