### PR TITLE
[BugFix] updateScanRangeLocations always set hasBroker to be true

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -667,7 +667,7 @@ public class FileScanNode extends LoadScanNode {
             TScanRangeLocations newLocations = null;
             try {
                 // Get new alive be and broker here, and params is not used, so set null
-                newLocations = newLocations(null, brokerDesc.getName(), true);
+                newLocations = newLocations(null, brokerDesc.getName(), brokerDesc.hasBroker());
             } catch (UserException e) {
                 LOG.warn("new locations failed.", e);
                 // Just return, retry by LoadTask


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

When broker loader fail for the first time, it will update the broker through updateScanRangeLocations,
here we always assume that updateScanRangeLocations has broker, which may lead to an error.
We should use brokerDesc.hasBroker() to determine if we has broker