### PR TITLE
[Enhancement] modify start and stop scripts for cn gracefully exit

### DIFF
--- a/bin/start_cn.sh
+++ b/bin/start_cn.sh
@@ -125,5 +125,5 @@ fi
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup ${STARROCKS_HOME}/lib/starrocks_be --cn "$@" >> $LOG_DIR/cn.out 2>&1 </dev/null &
 else
-    ${STARROCKS_HOME}/lib/starrocks_be --cn "$@" >> $LOG_DIR/cn.out 2>&1 </dev/null
+    exec ${STARROCKS_HOME}/lib/starrocks_be --cn "$@" >> $LOG_DIR/cn.out 2>&1 </dev/null
 fi

--- a/bin/stop_cn.sh
+++ b/bin/stop_cn.sh
@@ -16,6 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+#############################################################################
+# This script is used to stop CN process
+# Usage:
+#     sh stop_cn.sh [option]
+#
+# Options:
+#     -h, --help              display this usage only
+#     -g, --graceful          send SIGTERM to CN process instead of SIGKILL
+#
+#############################################################################
+
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
@@ -30,6 +41,33 @@ export_env_from_conf $STARROCKS_HOME/conf/cn.conf
 
 pidfile=$PID_DIR/cn.pid
 
+sig=9
+
+usage() {
+    echo "
+This script is used to stop CN process
+Usage:
+    sh stop_cn.sh [option]
+
+Options:
+    -h, --help              display this usage only
+    -g, --graceful          send SIGTERM to CN process instead of SIGKILL
+"
+    exit 0
+}
+
+for arg in "$@"
+do
+    case $arg in
+        --help|-h)
+            usage
+        ;;
+        --graceful|-g)
+            sig=15
+        ;;
+    esac
+done
+
 if [ -f $pidfile ]; then
     pid=`cat $pidfile`
     pidcomm=`ps -p $pid -o comm=`
@@ -39,8 +77,8 @@ if [ -f $pidfile ]; then
     fi
 
     if kill -0 $pid; then
-        if kill -9 $pid > /dev/null 2>&1; then
-            echo "stop $pidcomm, and remove pid file. "
+        if kill -${sig} $pid > /dev/null 2>&1; then
+            echo "stop $pidcomm using signal $sig, and remove pid file. "
             rm $pidfile
             exit 0
         else
@@ -54,4 +92,3 @@ else
     echo "$pidfile does not exist"
     exit 1
 fi
-


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Add graceful option for `stop_cn.sh`
2. Make starrocks run as pid 1 in container, let CN handle signal from container manager.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
