### PR TITLE
[Enhancement] Create async delta writer thread pool for each DataDir

### DIFF
--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -43,6 +43,10 @@ class Tablet;
 class TabletManager;
 class TxnManager;
 
+namespace bthreads {
+class ThreadPoolExecutor;
+}
+
 // A DataDir used to manage data in same path.
 // Now, After DataDir was created, it will never be deleted for easy implementation.
 class DataDir {
@@ -54,7 +58,7 @@ public:
     DataDir(const DataDir&) = delete;
     void operator=(const DataDir&) = delete;
 
-    Status init(bool read_only = false);
+    Status init(bool read_only = false, int max_delta_writer_threads = 16);
     void stop_bg_worker();
 
     const std::string& path() const { return _path; }
@@ -120,6 +124,8 @@ public:
 
     Status update_capacity();
 
+    bthreads::ThreadPoolExecutor* async_delta_writer_executor() { return _async_delta_writer_executor.get(); }
+
 private:
     Status _init_data_dir();
     Status _init_tmp_dir();
@@ -159,6 +165,8 @@ private:
     std::condition_variable _cv;
     std::set<std::string> _all_check_paths;
     std::set<std::string> _all_tablet_schemahash_paths;
+
+    std::unique_ptr<bthreads::ThreadPoolExecutor> _async_delta_writer_executor;
 };
 
 } // namespace starrocks

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -49,10 +49,6 @@
 #include "storage/rowset/rowset_id_generator.h"
 #include "storage/tablet.h"
 
-namespace bthread {
-class Executor;
-}
-
 namespace starrocks {
 
 class DataDir;
@@ -156,8 +152,7 @@ public:
 
     CompactionManager* compaction_manager() { return _compaction_manager.get(); }
 
-    bthread::Executor* async_delta_writer_executor() { return _async_delta_writer_executor.get(); }
-
+    // TODO: maybe we should move this thread pool to `DataDir`.
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
 
     UpdateManager* update_manager() { return _update_manager.get(); }
@@ -337,8 +332,6 @@ private:
     std::unique_ptr<TxnManager> _txn_manager;
 
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
-
-    std::unique_ptr<bthread::Executor> _async_delta_writer_executor;
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
 

--- a/be/src/util/bthreads/executor.cpp
+++ b/be/src/util/bthreads/executor.cpp
@@ -22,4 +22,8 @@ int ThreadPoolExecutor::submit(void* (*fn)(void*), void* args) {
     return st.ok() ? 0 : -1;
 }
 
+int ThreadPoolExecutor::num_queued_tasks() const {
+    return _thread_pool->num_queued_tasks();
+}
+
 } // namespace starrocks::bthreads

--- a/be/src/util/bthreads/executor.h
+++ b/be/src/util/bthreads/executor.h
@@ -44,6 +44,8 @@ public:
         _thread_pool = thread_pool;
     }
 
+    int num_queued_tasks() const;
+
     void set_ownership(Ownership ownership) { _ownership = ownership; }
 
     void set_busy_sleep_ms(int64_t value) { _busy_sleep_ms = value; }

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1005,7 +1005,7 @@ PARALLEL_TEST(ArrayColumnTest, test_assign) {
     offsets->append(6);
 
     // assign
-    column->assign(4,0);
+    column->assign(4, 0);
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
     ASSERT_EQ("[1, 2, 3]", column->debug_item(1));

--- a/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
+++ b/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
@@ -262,7 +262,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_without_
         RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
         rowset_meta->set_start_version(10);
         rowset_meta->set_end_version(19);
-        rowset_meta->set_creation_time(base_time +1);
+        rowset_meta->set_creation_time(base_time + 1);
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);


### PR DESCRIPTION
1. Instead of creating a single thread pool in StorageEngine and share it among all
AsyncDeltaWriter's, create a thread pool in each DataDir and only share it among
AsyncDeltaWriter's that belongs to the same DataDir.
2. Fail faster: reject service directly if there are too many queued tasks in the thread pool.

Please note that the real IO tasks are processed in the thread pool
`_storage_engine->memtable_flush_executor()` which is shared
among all disks, so it's still possible that a slow disk blocks tasks
of other disks.

Please also note that the data ingestion speed may decreased if a user has configured
more than one storage paths, because the number of threads used by a single
storage path is decreased.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

