### PR TITLE
[cherry-pick] [branch-2.1] [BugFix] Fix the bug of replace_if_not_null for array (#10143)

### DIFF
--- a/be/src/storage/vectorized/column_aggregate_func.cpp
+++ b/be/src/storage/vectorized/column_aggregate_func.cpp
@@ -252,15 +252,8 @@ public:
     void reset() override { this->data().reset(); }
 
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        if (row == src->size() - 1) {
-            // copy the last row to prevent to be overwritten or reset by get_next in aggregate iterator.
-            this->data().column = src->clone_empty();
-            this->data().column->append(*src, row, 1);
-            this->data().row = 0;
-        } else {
-            this->data().column = src;
-            this->data().row = row;
-        }
+        this->data().column = src;
+        this->data().row = row;
     }
 
     void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override { aggregate_impl(end - 1, src); }
@@ -273,6 +266,8 @@ public:
             col->append_default();
         }
     }
+
+    bool need_deep_copy() const override { return true; }
 };
 
 class ReplaceNullableColumnAggregator final : public ValueColumnAggregatorBase {

--- a/be/src/storage/vectorized/column_aggregator.h
+++ b/be/src/storage/vectorized/column_aggregator.h
@@ -54,6 +54,8 @@ public:
 
     // |data| is readonly.
     virtual void aggregate_batch_impl(int start, int end, const ColumnPtr& data) = 0;
+
+    virtual bool need_deep_copy() const { return false; };
 };
 
 using ColumnAggregatorPtr = std::unique_ptr<ColumnAggregatorBase>;
@@ -87,8 +89,16 @@ public:
             reset();
         }
 
-        if (nums > 0) {
-            // last row just aggregate, not finalize
+        CHECK(nums > 0);
+        // last row just aggregate, not finalize
+        int end = start + aggregate_loops[nums - 1];
+        int size = end - start;
+        if (need_deep_copy() && end == _source_column->size()) {
+            // copy the last rows of same key to prevent to be overwritten or reset by get_next in aggregate iterator.
+            ColumnPtr column = _source_column->clone_empty();
+            column->append(*_source_column, start, size);
+            aggregate_batch_impl(0, size, column);
+        } else {
             aggregate_batch_impl(start, start + aggregate_loops[nums - 1], _source_column);
         }
     }
@@ -156,9 +166,8 @@ public:
                 reset();
             }
 
-            if (nums - 1 >= 0) {
-                _row_is_null &= 1u;
-            }
+            CHECK(nums >= 1);
+            _row_is_null &= 1u;
         } else if (zeros == row_nums) {
             // all not null
             for (int i = 0; i < nums - 1; ++i) {
@@ -170,10 +179,18 @@ public:
                 reset();
             }
 
-            if (nums - 1 >= 0) {
-                _row_is_null &= 0u;
-                _child->aggregate_batch_impl(start, start + implicit_cast<int>(aggregate_loops[nums - 1]),
-                                             _child->_source_column);
+            CHECK(nums >= 1);
+
+            _row_is_null &= 0u;
+            int end = start + implicit_cast<int>(aggregate_loops[nums - 1]);
+            int size = end - start;
+            if (_child->need_deep_copy() && end == _child->_source_column->size()) {
+                // copy the last rows of same key to prevent to be overwritten or reset by get_next in aggregate iterator.
+                ColumnPtr column = _child->_source_column->clone_empty();
+                column->append(*_child->_source_column, start, size);
+                _child->aggregate_batch_impl(0, size, column);
+            } else {
+                _child->aggregate_batch_impl(start, end, _child->_source_column);
             }
         } else {
             for (int i = 0; i < nums - 1; ++i) {
@@ -189,8 +206,22 @@ public:
                 reset();
             }
 
-            if (nums - 1 >= 0) {
-                for (int j = start; j < start + aggregate_loops[nums - 1]; ++j) {
+            CHECK(nums >= 1);
+            int end = start + aggregate_loops[nums - 1];
+            int size = end - start;
+
+            if (_child->need_deep_copy() && end == _child->_source_column->size()) {
+                // copy the last rows of same key to prevent to be overwritten or reset by get_next in aggregate iterator.
+                ColumnPtr column = _child->_source_column->clone_empty();
+                column->append(*_child->_source_column, start, size);
+                for (int j = 0; j < size; ++j) {
+                    if (_source_nulls_data[start + j] != 1) {
+                        _row_is_null &= 0u;
+                        _child->aggregate_impl(j, column);
+                    }
+                }
+            } else {
+                for (int j = start; j < end; ++j) {
                     if (_source_nulls_data[j] != 1) {
                         _row_is_null &= 0u;
                         _child->aggregate_impl(j, _child->_source_column);

--- a/be/test/storage/vectorized/column_aggregator_test.cpp
+++ b/be/test/storage/vectorized/column_aggregator_test.cpp
@@ -671,7 +671,7 @@ TEST(ColumnAggregator, testArrayReplace) {
 
 // NOLINTNEXTLINE
 TEST(ColumnAggregator, testNullArrayReplaceIfNotNull2) {
-    auto array_type_info = get_array_type_info(get_type_info(FieldType::OLAP_FIELD_TYPE_INT));
+    auto array_type_info = std::make_shared<ArrayTypeInfo>(get_type_info(FieldType::OLAP_FIELD_TYPE_INT));
     FieldPtr field =
             std::make_shared<Field>(1, "test_array", array_type_info,
                                     FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL, 1, false, true);

--- a/be/test/storage/vectorized/column_aggregator_test.cpp
+++ b/be/test/storage/vectorized/column_aggregator_test.cpp
@@ -669,6 +669,83 @@ TEST(ColumnAggregator, testArrayReplace) {
     EXPECT_EQ("['20', '21', '22', '23', '24', '25', '26', '27', '28', '29']", agg->debug_item(4));
 }
 
+// NOLINTNEXTLINE
+TEST(ColumnAggregator, testNullArrayReplaceIfNotNull2) {
+    auto array_type_info = get_array_type_info(get_type_info(FieldType::OLAP_FIELD_TYPE_INT));
+    FieldPtr field =
+            std::make_shared<Field>(1, "test_array", array_type_info,
+                                    FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL, 1, false, true);
+    auto agg = NullableColumn::create(
+            ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                UInt32Column::create()),
+            NullColumn::create());
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    aggregator->update_aggregate(agg.get());
+
+    // first chunk column
+    auto src = NullableColumn::create(
+            ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                UInt32Column::create()),
+            NullColumn::create());
+    DatumArray array_3{Datum((int32_t)(3))};
+    DatumArray array_4{Datum((int32_t)(4))};
+    DatumArray array_8{Datum((int32_t)(8))};
+    DatumArray array_11{Datum((int32_t)(11))};
+    DatumArray array_13{Datum((int32_t)(13))};
+    DatumArray array_14{Datum((int32_t)(14))};
+    DatumArray array_15{Datum((int32_t)(15))};
+
+    src->append_nulls(1);
+    src->append_datum(Datum(array_3));
+    src->append_datum(Datum(array_4));
+    src->append_datum(Datum(array_8));
+    src->append_nulls(1);
+
+    aggregator->update_source(src);
+
+    std::vector<uint32_t> loops{1, 1, 1, 2};
+
+    aggregator->aggregate_values(0, 4, loops.data(), false);
+
+    src->reset_column();
+
+    src->append_nulls(1);
+    src->append_datum(Datum(array_11));
+    src->append_datum(Datum(array_13));
+    src->append_datum(Datum(array_14));
+    src->append_datum(Datum(array_15));
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+    loops.emplace_back(1);
+    loops.emplace_back(1);
+    loops.emplace_back(1);
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 1, loops.data(), false);
+    aggregator->finalize();
+
+    ASSERT_EQ(agg->size(), 4);
+    ASSERT_TRUE(agg->get(0).is_null());
+    ASSERT_EQ(agg->get(1).get_array()[0].get_int32(), 3);
+    ASSERT_EQ(agg->get(2).get_array()[0].get_int32(), 4);
+    ASSERT_EQ(agg->get(3).get_array()[0].get_int32(), 8);
+
+    agg->reset_column();
+    aggregator->update_aggregate(agg.get());
+
+    aggregator->aggregate_values(1, 4, loops.data(), false);
+    aggregator->finalize();
+
+    ASSERT_EQ(agg->size(), 4);
+    ASSERT_EQ(agg->get(0).get_array()[0].get_int32(), 11);
+    ASSERT_EQ(agg->get(1).get_array()[0].get_int32(), 13);
+    ASSERT_EQ(agg->get(2).get_array()[0].get_int32(), 14);
+    ASSERT_EQ(agg->get(3).get_array()[0].get_int32(), 15);
+}
+
 // insert into tbl values (key, null);
 TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
     auto array_type_info = std::make_shared<ArrayTypeInfo>(get_type_info(FieldType::OLAP_FIELD_TYPE_VARCHAR));


### PR DESCRIPTION
the ref column of the array is already reset in the next iterator
one example: three rowset, chunk_size=5
c1 is key, c2 is value (array replace_if_not_null)
rowset (version 1): (1, null), (8, [8]), (13, [13])
rowset (version 2): (3, [3]), (4, [4]), (8, null)
rowset (version 3): (8, null), (11, [11]), (14, [14]), (15, [15])

the first chunk getted from iterator is (1, null), (3, [3]), (4, [4]), (8, [8]), (8, null).
the second chunk getter from iterator is (8, null), (11, [11]), (13, [13]), (14, [14]), (15, [15])

array replace don't copy the (8, [8]) because it's not the last element of src_column。In the next iterator, the ref chunk is already reset so that it will return the wrong result.