### PR TITLE
[Enhancement] Use the native scanner to read hudi MOR table without log files for read optimized queries

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -259,7 +259,13 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;
-    if (dynamic_cast<const HudiTableDescriptor*>(_tuple_desc->table_desc()) && scan_range.hudi_mor_table) {
+
+    bool use_hudi_jni_reader = false;
+    if (scan_range.__isset.use_hudi_jni_reader) {
+        use_hudi_jni_reader = scan_range.use_hudi_jni_reader;
+    }
+
+    if (use_hudi_jni_reader) {
         const auto* hudi_table = dynamic_cast<const HudiTableDescriptor*>(_hive_table);
         auto* partition_desc = hudi_table->get_partition(scan_range.partition_id);
         std::string partition_full_path = partition_desc->location();

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -148,11 +148,16 @@ HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
         auto* partition = pool->add(new HdfsPartitionDescriptor(tdesc.hudiTable, entry.second));
         _partition_id_to_desc_map[entry.first] = partition;
     }
+    _is_mor_table = tdesc.hudiTable.is_mor_table;
     _hudi_instant_time = tdesc.hudiTable.instant_time;
     _hive_column_names = tdesc.hudiTable.hive_column_names;
     _hive_column_types = tdesc.hudiTable.hive_column_types;
     _input_format = tdesc.hudiTable.input_format;
     _serde_lib = tdesc.hudiTable.serde_lib;
+}
+
+const bool& HudiTableDescriptor::is_mor_table() const {
+    return _is_mor_table;
 }
 
 const std::string& HudiTableDescriptor::get_base_path() const {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -230,6 +230,7 @@ public:
     HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     ~HudiTableDescriptor() override = default;
     bool has_partition() const override { return true; }
+    const bool& is_mor_table() const;
     const std::string& get_base_path() const;
     const std::string& get_instant_time() const;
     const std::string& get_hive_column_names() const;
@@ -238,6 +239,7 @@ public:
     const std::string& get_serde_lib() const;
 
 private:
+    bool _is_mor_table;
     std::string _hudi_instant_time;
     std::string _hive_column_names;
     std::string _hive_column_types;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hudi.avro.HoodieAvroUtils;
-import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.external.HiveMetaStoreTableUtils.isInternalCatalog;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfoFromTypeString;
-import static org.apache.hudi.common.table.HoodieTableConfig.CREATE_SCHEMA;
 
 /**
  * Currently, we depend on Hive metastore to obtain table/partition path and statistics.
@@ -76,11 +75,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
     private static final String JSON_KEY_HUDI_PROPERTIES = "hudiProperties";
 
     public static final String HUDI_TABLE_TYPE = "hudi.table.type";
-    public static final String HUDI_TABLE_PRIMARY_KEY = "hudi.table.primaryKey";
-    public static final String HUDI_TABLE_PRE_COMBINE_FIELD = "hudi.table.preCombineField";
     public static final String HUDI_BASE_PATH = "hudi.table.base.path";
-    public static final String HUDI_TABLE_BASE_FILE_FORMAT = "hudi.table.base.file.format";
-    public static final String HUDI_TABLE_AVRO_RECORD_SCHEMA = "hudi.table.avro.record.schema";
     public static final String HUDI_TABLE_SERDE_LIB = "hudi.table.serde.lib";
     public static final String HUDI_TABLE_INPUT_FOAMT = "hudi.table.input.format";
     public static final String HUDI_TABLE_COLUMN_NAMES = "hudi.table.column.names";
@@ -89,7 +84,14 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
     public static final String HUDI_TABLE = "table";
     public static final String HUDI_RESOURCE = "resource";
 
-    public enum HoodieTableType {
+    public static final String COW_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieParquetInputFormat";
+    public static final String COW_INPUT_FORMAT_LEGACY = "com.uber.hoodie.hadoop.HoodieInputFormat";
+    public static final String MOR_RO_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieParquetInputFormat";
+    public static final String MOR_RO_INPUT_FORMAT_LEGACY = "com.uber.hoodie.hadoop.HoodieInputFormat";
+    public static final String MOR_RT_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat";
+    public static final String MOR_RT_INPUT_FORMAT_LEGACY = "com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat";
+
+    public enum HudiTableType {
         COW, MOR, UNKNOWN
     }
 
@@ -128,16 +130,16 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         return resourceName;
     }
 
-    public org.apache.hudi.common.model.HoodieTableType getTableType() {
-        return org.apache.hudi.common.model.HoodieTableType.valueOf(hudiProperties.get(HUDI_TABLE_TYPE));
+    public HoodieTableType getTableType() {
+        return HoodieTableType.valueOf(hudiProperties.get(HUDI_TABLE_TYPE));
     }
 
     public String getHudiBasePath() {
         return hudiProperties.get(HUDI_BASE_PATH);
     }
 
-    public String getTableCreateSchema() {
-        return hudiProperties.get(HUDI_TABLE_AVRO_RECORD_SCHEMA);
+    public String getHudiInputFormat() {
+        return hudiProperties.get(HUDI_TABLE_INPUT_FOAMT);
     }
 
     @Override
@@ -163,16 +165,16 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         return dataColumnNames;
     }
 
-    public static HoodieTableType fromInputFormat(String inputFormat) {
+    public static HudiTableType fromInputFormat(String inputFormat) {
         switch (inputFormat) {
-            case "org.apache.hudi.hadoop.HoodieParquetInputFormat":
-            case "com.uber.hoodie.hadoop.HoodieInputFormat":
-                return HoodieTableType.COW;
-            case "org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat":
-            case "com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat":
-                return HoodieTableType.MOR;
+            case COW_INPUT_FORMAT:
+            case COW_INPUT_FORMAT_LEGACY:
+                return HudiTableType.COW;
+            case MOR_RT_INPUT_FORMAT:
+            case MOR_RT_INPUT_FORMAT_LEGACY:
+                return HudiTableType.MOR;
             default:
-                return HoodieTableType.UNKNOWN;
+                return HudiTableType.UNKNOWN;
         }
     }
 
@@ -314,34 +316,19 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
                 HoodieTableMetaClient.builder().setConf(conf).setBasePath(hudiBasePath).build();
         HoodieTableConfig hudiTableConfig = metaClient.getTableConfig();
 
-        org.apache.hudi.common.model.HoodieTableType hudiTableType = hudiTableConfig.getTableType();
+        HoodieTableType hudiTableType = metaClient.getTableType();
         hudiProperties.put(HUDI_TABLE_TYPE, hudiTableType.name());
-
-        Option<String[]> hudiTablePrimaryKey = hudiTableConfig.getRecordKeyFields();
-        if (hudiTablePrimaryKey.isPresent()) {
-            hudiProperties.put(HUDI_TABLE_PRIMARY_KEY, hudiTableConfig.getRecordKeyFieldProp());
-        }
-
-        String hudiTablePreCombineField = hudiTableConfig.getPreCombineField();
-        if (!Strings.isNullOrEmpty(hudiTablePreCombineField)) {
-            hudiProperties.put(HUDI_TABLE_PRE_COMBINE_FIELD, hudiTablePreCombineField);
-        }
-
-        HoodieFileFormat hudiBaseFileFormat = hudiTableConfig.getBaseFileFormat();
-        hudiProperties.put(HUDI_TABLE_BASE_FILE_FORMAT, hudiBaseFileFormat.name());
 
         StringBuilder columnNamesBuilder = new StringBuilder();
         StringBuilder columnTypesBuilder = new StringBuilder();
         List<FieldSchema> allFields = metastoreTable.getSd().getCols();
         allFields.addAll(metastoreTable.getPartitionKeys());
 
-        hudiProperties.put(HUDI_TABLE_AVRO_RECORD_SCHEMA, metaClient.getTableConfig().getString(CREATE_SCHEMA));
-
         boolean isFirst = true;
         for (Schema.Field hudiField : tableSchema.getFields()) {
             if (!isFirst) {
                 columnNamesBuilder.append(",");
-                columnTypesBuilder.append(",");
+                columnTypesBuilder.append(":");
             }
             Optional<FieldSchema> field = allFields.stream()
                     .filter(f -> f.getName().equals(hudiField.name().toLowerCase(Locale.ROOT))).findFirst();
@@ -567,6 +554,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         tHudiTable.setHive_column_types(hudiProperties.get(HUDI_TABLE_COLUMN_TYPES));
         tHudiTable.setInput_format(hudiProperties.get(HUDI_TABLE_INPUT_FOAMT));
         tHudiTable.setSerde_lib(hudiProperties.get(HUDI_TABLE_SERDE_LIB));
+        tHudiTable.setIs_mor_table(getTableType() == HoodieTableType.MERGE_ON_READ);
 
         TTableDescriptor tTableDescriptor =
                 new TTableDescriptor(id, TTableType.HUDI_TABLE, fullSchema.size(), 0, table, db);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
@@ -8,16 +8,17 @@ import com.starrocks.external.hive.text.TextFileFormatDesc;
 public class HdfsFileDesc {
     private String fileName;
     private String compression;
+    // length == -1 and fileName == "" when the table type is hudi MOR table
+    // and the base file is not exists (log files only).
     private long length;
     private ImmutableList<HdfsFileBlockDesc> blockDescs;
     private boolean splittable;
     private TextFileFormatDesc textFileFormatDesc;
     private ImmutableList<String> hudiDeltaLogs;
-    private boolean isHudiMORTable;
 
     public HdfsFileDesc(String fileName, String compression, long length,
                         ImmutableList<HdfsFileBlockDesc> blockDescs, ImmutableList<String> hudiDeltaLogs,
-                        boolean splittable, TextFileFormatDesc textFileFormatDesc, boolean isHudiMORTable) {
+                        boolean splittable, TextFileFormatDesc textFileFormatDesc) {
         this.fileName = fileName;
         this.compression = compression;
         this.length = length;
@@ -25,7 +26,6 @@ public class HdfsFileDesc {
         this.hudiDeltaLogs = hudiDeltaLogs;
         this.splittable = splittable;
         this.textFileFormatDesc = textFileFormatDesc;
-        this.isHudiMORTable = isHudiMORTable;
     }
 
     public String getFileName() {
@@ -54,10 +54,6 @@ public class HdfsFileDesc {
 
     public ImmutableList<String> getHudiDeltaLogs() {
         return hudiDeltaLogs;
-    }
-
-    public boolean isHudiMORTable() {
-        return isHudiMORTable;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -323,7 +323,7 @@ public class HiveMetaCache {
     private Table loadTable(HiveTableName hiveTableName) throws TException, DdlException {
         org.apache.hadoop.hive.metastore.api.Table hiveTable = client.getTable(hiveTableName);
         Table table = null;
-        if (HudiTable.fromInputFormat(hiveTable.getSd().getInputFormat()) != HudiTable.HoodieTableType.UNKNOWN) {
+        if (HudiTable.fromInputFormat(hiveTable.getSd().getInputFormat()) != HudiTable.HudiTableType.UNKNOWN) {
             table = HiveMetaStoreTableUtils.convertHudiConnTableToSRTable(hiveTable, resourceName);
         } else {
             table = HiveMetaStoreTableUtils.convertHiveConnTableToSRTable(hiveTable, resourceName);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -44,7 +44,6 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieLogFile;
-import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -335,7 +334,7 @@ public class HiveMetaClient {
             List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
             fileDescs.add(new HdfsFileDesc(fileName, "", fileLength,
                     ImmutableList.of(), ImmutableList.copyOf(logs), HdfsFileFormat.isSplittable(sd.getInputFormat()),
-                    getTextFileFormatDesc(sd), metaClient.getTableType() == HoodieTableType.MERGE_ON_READ));
+                    getTextFileFormatDesc(sd)));
         }
         return fileDescs;
     }
@@ -685,7 +684,7 @@ public class HiveMetaClient {
                 List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations);
                 fileDescs.add(new HdfsFileDesc(fileName, "", locatedFileStatus.getLen(),
                         ImmutableList.copyOf(fileBlockDescs), ImmutableList.of(),
-                        isSplittable, getTextFileFormatDesc(sd), false));
+                        isSplittable, getTextFileFormatDesc(sd)));
             }
         } catch (FileNotFoundException ignored) {
             // hive empty partition may not create directory

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -184,15 +184,15 @@ public class HudiTableTest {
 
     @Test
     public void testInputFormat() {
-        Assert.assertEquals(HudiTable.HoodieTableType.COW,
+        Assert.assertEquals(HudiTable.HudiTableType.COW,
                 HudiTable.fromInputFormat("org.apache.hudi.hadoop.HoodieParquetInputFormat"));
-        Assert.assertEquals(HudiTable.HoodieTableType.COW,
+        Assert.assertEquals(HudiTable.HudiTableType.COW,
                 HudiTable.fromInputFormat("com.uber.hoodie.hadoop.HoodieInputFormat"));
-        Assert.assertEquals(HudiTable.HoodieTableType.MOR,
+        Assert.assertEquals(HudiTable.HudiTableType.MOR,
                 HudiTable.fromInputFormat("org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat"));
-        Assert.assertEquals(HudiTable.HoodieTableType.MOR,
+        Assert.assertEquals(HudiTable.HudiTableType.MOR,
                 HudiTable.fromInputFormat("com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat"));
-        Assert.assertEquals(HudiTable.HoodieTableType.UNKNOWN,
+        Assert.assertEquals(HudiTable.HudiTableType.UNKNOWN,
                 HudiTable.fromInputFormat("org.apache.hadoop.hive.ql.io.HiveInputFormat"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -294,8 +294,7 @@ public class HiveMetaCacheTest {
                             ImmutableList.of(),
                             ImmutableList.of(),
                             false,
-                            null,
-                            false)),
+                            null)),
                     partitionPath);
         }
 

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -345,6 +345,9 @@ struct THudiTable {
 
     // hudi table serde_lib
     10: optional string serde_lib
+
+    // hudi table type: copy on write or merge on read
+    11: optional bool is_mor_table
 }
 
 struct TJDBCTable {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -266,8 +266,8 @@ struct THdfsScanRange {
     // delta logs of hudi MOR table
     9: optional list<string> hudi_logs
 
-    // hudi table type
-    10: optional bool hudi_mor_table
+    // whether to use JNI scanner to read data of hudi MOR table for snapshot queries
+    10: optional bool use_hudi_jni_reader;
 }
 
 // Specification of an individual data range which is held in its entirety

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
@@ -57,7 +57,7 @@ public class HudiSliceScanner extends ConnectorScanner {
         this.fetchSize = fetchSize;
         this.basePath = params.get("base_path");
         this.hiveColumnNames = params.get("hive_column_names");
-        this.hiveColumnTypes = params.get("hive_column_types").split(",");
+        this.hiveColumnTypes = params.get("hive_column_types").split(":");
         this.requiredFields = params.get("required_fields").split(",");
         this.instantTime = params.get("instant_time");
         if (params.get("delta_file_paths").length() == 0) {
@@ -98,7 +98,12 @@ public class HudiSliceScanner extends ConnectorScanner {
                     columnIdBuilder.append(",");
                 }
                 columnIdBuilder.append(hiveColumnNameToIndex.get(requiredFields[i]));
-                requiredTypes[i] = hiveColumnNameToType.get(requiredFields[i]);
+                String typeStr = hiveColumnNameToType.get(requiredFields[i]);
+                // convert decimal(x,y) to decimal
+                if (typeStr.startsWith("decimal")) {
+                    typeStr = "decimal";
+                }
+                requiredTypes[i] = typeStr;
                 isFirst = false;
             }
             initOffHeapTableWriter(requiredTypes, fetchSize, TypeMapping.hiveTypeMappings);

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
@@ -12,10 +12,14 @@ import java.util.Map;
  * 3. {@link ConnectorScanner#getNext()}
  *
  * The constructor of inherited subclasses need to accept the following parameters in order:
- * 1. int: the chunk size, this parameter need to be initialized using the parent constructor
+ * 1. int: the chunk size
  * 2. Map<String, String>: the custom parameters
  *
- * BE will call the methods as follows (described in pseudocode):
+ * {@link ConnectorScanner#initOffHeapTableWriter(String[], int, Map)} need be called to initialize
+ * {@link ConnectorScanner#tableSize} and {@link ConnectorScanner#types}
+ * before calling {@link ConnectorScanner#getNext()} (maybe in constructor or {@link ConnectorScanner#open()})
+ *
+ * BE will call these methods as follows (described in pseudocode):
  * open();
  * do {
  *     int rows = getNext();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others


1. use the native reader to read hudi MOR table without log files for read optimized queries instead of the jni reader
2. jni reader will only be used in this case: hudi MOR table, snapshot queries and log files exist
3. some code refinement and bugfix
