### PR TITLE
[Enhancement] ON Clause support mutiple subqueries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -52,10 +52,13 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Root of the expr node hierarchy.
@@ -370,6 +373,102 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         } catch (AnalysisException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * Gather conjuncts from this expr and return them in a list.
+     * A conjunct is an expr that returns a boolean, e.g., Predicates, function calls,
+     * SlotRefs, etc. Hence, this method is placed here and not in Predicate.
+     */
+    public static List<Expr> extractConjuncts(Expr root) {
+        List<Expr> conjuncts = Lists.newArrayList();
+        if (null == root) {
+            return conjuncts;
+        }
+
+        extractConjunctsImpl(root, conjuncts);
+        return conjuncts;
+    }
+
+    private static void extractConjunctsImpl(Expr root, List<Expr> conjuncts) {
+        if (!(root instanceof CompoundPredicate)) {
+            conjuncts.add(root);
+            return;
+        }
+
+        CompoundPredicate cpe = (CompoundPredicate) root;
+        if (!CompoundPredicate.Operator.AND.equals(cpe.getOp())) {
+            conjuncts.add(root);
+            return;
+        }
+
+        extractConjunctsImpl(cpe.getChild(0), conjuncts);
+        extractConjunctsImpl(cpe.getChild(1), conjuncts);
+    }
+
+    public static Expr compoundAnd(Collection<Expr> conjuncts) {
+        return createCompound(CompoundPredicate.Operator.AND, conjuncts);
+    }
+
+    public static Expr compoundOr(Collection<Expr> conjuncts) {
+        return createCompound(CompoundPredicate.Operator.OR, conjuncts);
+    }
+
+    // Build a compound tree by bottom up
+    //
+    // Example: compoundType.OR
+    // Initial state:
+    //  a b c d e
+    //
+    // First iteration:
+    //  or    or
+    //  /\    /\   e
+    // a  b  c  d
+    //
+    // Second iteration:
+    //     or   e
+    //    / \
+    //  or   or
+    //  /\   /\
+    // a  b c  d
+    //
+    // Last iteration:
+    //       or
+    //      / \
+    //     or  e
+    //    / \
+    //  or   or
+    //  /\   /\
+    // a  b c  d
+    public static Expr createCompound(CompoundPredicate.Operator type, Collection<Expr> nodes) {
+        LinkedList<Expr> link =
+                nodes.stream().filter(java.util.Objects::nonNull)
+                        .collect(Collectors.toCollection(Lists::newLinkedList));
+
+        if (link.size() < 1) {
+            return null;
+        }
+        if (link.size() == 1) {
+            return link.get(0);
+        }
+
+        while (link.size() > 1) {
+            LinkedList<Expr> buffer = Lists.newLinkedList();
+
+            // combine pairs of elements
+            while (link.size() >= 2) {
+                buffer.add(new CompoundPredicate(type, link.poll(), link.poll()));
+            }
+
+            // if there's and odd number of elements, just append the last one
+            if (!link.isEmpty()) {
+                buffer.add(link.remove());
+            }
+
+            link = buffer;
+        }
+
+        return link.remove();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
@@ -32,7 +32,6 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -74,7 +73,7 @@ public abstract class LoadScanNode extends ScanNode {
         if (!whereExpr.getType().isBoolean()) {
             throw new UserException("where statement is not a valid statement return bool");
         }
-        addConjuncts(AnalyzerUtils.extractConjuncts(whereExpr));
+        addConjuncts(Expr.extractConjuncts(whereExpr));
     }
 
     protected void checkBitmapCompatibility(Analyzer analyzer, SlotDescriptor slotDesc, Expr expr)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -6,7 +6,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.AnalyticExpr;
-import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
@@ -40,12 +39,8 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class AnalyzerUtils {
     public static void verifyNoAggregateFunctions(Expr expression, String clause) {
@@ -370,100 +365,5 @@ public class AnalyzerUtils {
         public Void visitTable(TableRelation node, Void context) {
             return null;
         }
-    }
-
-    /**
-     * Gather conjuncts from this expr and return them in a list.
-     * A conjunct is an expr that returns a boolean, e.g., Predicates, function calls,
-     * SlotRefs, etc. Hence, this method is placed here and not in Predicate.
-     */
-    public static List<Expr> extractConjuncts(Expr root) {
-        List<Expr> conjuncts = Lists.newArrayList();
-        if (null == root) {
-            return conjuncts;
-        }
-
-        extractConjunctsImpl(root, conjuncts);
-        return conjuncts;
-    }
-
-    private static void extractConjunctsImpl(Expr root, List<Expr> conjuncts) {
-        if (!(root instanceof CompoundPredicate)) {
-            conjuncts.add(root);
-            return;
-        }
-
-        CompoundPredicate cpe = (CompoundPredicate) root;
-        if (!CompoundPredicate.Operator.AND.equals(cpe.getOp())) {
-            conjuncts.add(root);
-            return;
-        }
-
-        extractConjunctsImpl(cpe.getChild(0), conjuncts);
-        extractConjunctsImpl(cpe.getChild(1), conjuncts);
-    }
-
-    public static Expr compoundAnd(Collection<Expr> conjuncts) {
-        return createCompound(CompoundPredicate.Operator.AND, conjuncts);
-    }
-
-    public static Expr compoundOr(Collection<Expr> conjuncts) {
-        return createCompound(CompoundPredicate.Operator.OR, conjuncts);
-    }
-
-    // Build a compound tree by bottom up
-    //
-    // Example: compoundType.OR
-    // Initial state:
-    //  a b c d e
-    //
-    // First iteration:
-    //  or    or
-    //  /\    /\   e
-    // a  b  c  d
-    //
-    // Second iteration:
-    //     or   e
-    //    / \
-    //  or   or
-    //  /\   /\
-    // a  b c  d
-    //
-    // Last iteration:
-    //       or
-    //      / \
-    //     or  e
-    //    / \
-    //  or   or
-    //  /\   /\
-    // a  b c  d
-    public static Expr createCompound(CompoundPredicate.Operator type, Collection<Expr> nodes) {
-        LinkedList<Expr> link =
-                nodes.stream().filter(Objects::nonNull).collect(Collectors.toCollection(Lists::newLinkedList));
-
-        if (link.size() < 1) {
-            return null;
-        }
-        if (link.size() == 1) {
-            return link.get(0);
-        }
-
-        while (link.size() > 1) {
-            LinkedList<Expr> buffer = Lists.newLinkedList();
-
-            // combine pairs of elements
-            while (link.size() >= 2) {
-                buffer.add(new CompoundPredicate(type, link.poll(), link.poll()));
-            }
-
-            // if there's and odd number of elements, just append the last one
-            if (!link.isEmpty()) {
-                buffer.add(link.remove());
-            }
-
-            link = buffer;
-        }
-
-        return link.remove();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SubqueryTransformer.java
@@ -14,7 +14,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.QueryRelation;
@@ -105,11 +104,7 @@ public class SubqueryTransformer {
     }
 
     public Expr rewriteJoinOnPredicate(Expr predicate) {
-        if (predicate.getSubquery() == null) {
-            return predicate;
-        }
-
-        List<Expr> conjuncts = AnalyzerUtils.extractConjuncts(predicate);
+        List<Expr> conjuncts = Expr.extractConjuncts(predicate);
         List<Expr> newConjuncts = Lists.newArrayListWithCapacity(conjuncts.size());
         for (Expr conjunct : conjuncts) {
             List<InPredicate> inPredicates = Lists.newArrayList();
@@ -138,7 +133,7 @@ public class SubqueryTransformer {
             }
         }
 
-        return AnalyzerUtils.compoundAnd(newConjuncts);
+        return Expr.compoundAnd(newConjuncts);
     }
 
     private static class SubqueryContext {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -462,7 +462,8 @@ public class SubqueryTest extends PlanTestBase {
                     "    where l.t1a = r.t1a\n" +
                     ");";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "args: DECIMAL64; result: DECIMAL64(10,2); args nullable: false; result nullable: true");
+            assertContains(plan,
+                    "args: DECIMAL64; result: DECIMAL64(10,2); args nullable: false; result nullable: true");
             assertContains(plan, "  7:Project\n" +
                     "  |  output columns:\n" +
                     "  |  10 <-> [10: id_decimal, DECIMAL64(10,2), true]\n" +
@@ -630,9 +631,9 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5) + t1.v6";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  8:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  other predicates: 1: v1 = 11: expr + 6: v6");
+                    "  |  other join predicates: 1: v1 = 11: expr + 6: v6");
             assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
@@ -658,9 +659,9 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on (select count(*) from t0 where t0.v2 = t1.v5) + t0.v3 = t1.v5";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  8:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  other predicates: 11: expr + 3: v3 = 5: v5");
+                    "  |  other join predicates: 11: expr + 3: v3 = 5: v5");
             assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9875

## Enhancement

Continuation of the previous work #9832, the main work of this pr is to remove the restriction that the on clause can only contain one subquery, then we can write join on predicate like the below example

```sql
select * from t0 join t1 on
t0.v1 = t1.v1
and t0.v2 in (select v2 from t2)
and t0.v3 = (select v3 from t2 where t2.v1 = t0.v1)
```

And the solution is simple and straightforward, since the `Expr` can only contains one subquery, I'm not going to remove this limitation, but turn to extract all the conjuncts of the join on predicate, and processing every single conjunct indenpendently, and each conjunct can only contains one subquery(conjunct is also a Expr, which should follow the same limitation).

## Other changes

* Move some utility methods from `AnalyzerUtils` to `Expr`

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
