### PR TITLE
[Enhancement] Make the be reboot time display more accurate

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -47,6 +47,8 @@ using apache::thrift::transport::TProcessor;
 namespace starrocks {
 extern std::atomic<bool> k_starrocks_exit;
 
+static bool first_heartbeat = true;
+
 HeartbeatServer::HeartbeatServer() : _olap_engine(StorageEngine::instance()) {}
 
 void HeartbeatServer::init_cluster_id_or_die() {
@@ -104,6 +106,10 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
 #endif
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_num_hardware_cores(num_hardware_cores);
+        heartbeat_result.backend_info.__set_is_first_heartbeat(first_heartbeat);
+        if (first_heartbeat) {
+            first_heartbeat = false;
+        }
     }
 }
 

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -47,7 +47,7 @@ using apache::thrift::transport::TProcessor;
 namespace starrocks {
 extern std::atomic<bool> k_starrocks_exit;
 
-static bool first_heartbeat = true;
+static int64_t reboot_time = 0;
 
 HeartbeatServer::HeartbeatServer() : _olap_engine(StorageEngine::instance()) {}
 
@@ -106,10 +106,11 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
 #endif
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_num_hardware_cores(num_hardware_cores);
-        heartbeat_result.backend_info.__set_is_first_heartbeat(first_heartbeat);
-        if (first_heartbeat) {
-            first_heartbeat = false;
+        if (reboot_time == 0) {
+            std::time_t currTime = std::time(0);
+            reboot_time = static_cast<int64_t>(currTime);
         }
+        heartbeat_result.backend_info.__set_reboot_time(reboot_time);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -47,10 +47,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private String version = "";
     @SerializedName(value = "cpuCores")
     private int cpuCores;
-    @SerializedName(value = "firstHeartbeat")
-    private boolean firstHeartbeat;
-    @SerializedName(value = "isSetFirstHeartbeat")
-    private boolean isSetFirstHeartbeat;
+    @SerializedName(value = "rebootTime")
+    private long rebootTime = -1L;   
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -77,20 +75,12 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.msg = errMsg;
     }
 
-    public void setFirstHeartbeat(boolean firstHeartbeat) {
-        this.firstHeartbeat = firstHeartbeat;
+    public long getRebootTime() {
+        return rebootTime;
     }
 
-    public void setIsSetFirstHeartbeat(boolean isFirstHeartbeatSet) {
-        this.isSetFirstHeartbeat = isFirstHeartbeatSet;
-    }
-
-    public boolean isFirstHeartbeat() {
-        return firstHeartbeat;
-    }
-
-    public boolean isSetFirstHeartbeat() {
-        return isSetFirstHeartbeat;
+    public void setRebootTime(long rebootTime) {
+        this.rebootTime = rebootTime * 1000;
     }
 
     public long getBeId() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -47,6 +47,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private String version = "";
     @SerializedName(value = "cpuCores")
     private int cpuCores;
+    @SerializedName(value = "firstHeartbeat")
+    private boolean firstHeartbeat;
+    @SerializedName(value = "isSetFirstHeartbeat")
+    private boolean isSetFirstHeartbeat;
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -71,6 +75,22 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.status = HbStatus.BAD;
         this.beId = beId;
         this.msg = errMsg;
+    }
+
+    public void setFirstHeartbeat(boolean firstHeartbeat) {
+        this.firstHeartbeat = firstHeartbeat;
+    }
+
+    public void setIsSetFirstHeartbeat(boolean isFirstHeartbeatSet) {
+        this.isSetFirstHeartbeat = isFirstHeartbeatSet;
+    }
+
+    public boolean isFirstHeartbeat() {
+        return firstHeartbeat;
+    }
+
+    public boolean isSetFirstHeartbeat() {
+        return isSetFirstHeartbeat;
     }
 
     public long getBeId() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -397,11 +397,18 @@ public class ComputeNode implements IComputable, Writable {
             this.lastUpdateMs = hbResponse.getHbTime();
             if (!isAlive.get()) {
                 isChanged = true;
-                this.lastStartTime = hbResponse.getHbTime();
+                // From version 2.5 we not use isAlive to determine whether to update the lastStartTime 
+                // This line to set 'lastStartTime' will be removed in due time
+                this.lastStartTime = hbResponse.getHbTime(); 
                 LOG.info("{} is alive, last start time: {}", this.toString(), hbResponse.getHbTime());
                 this.isAlive.set(true);
             } else if (this.lastStartTime <= 0) {
                 this.lastStartTime = hbResponse.getHbTime();
+            }
+
+            if (hbResponse.isSetFirstHeartbeat() && hbResponse.isFirstHeartbeat()) {
+                this.lastStartTime = hbResponse.getHbTime();
+                isChanged = true;
             }
 
             if (this.cpuCores != hbResponse.getCpuCores()) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -406,8 +406,8 @@ public class ComputeNode implements IComputable, Writable {
                 this.lastStartTime = hbResponse.getHbTime();
             }
 
-            if (hbResponse.isSetFirstHeartbeat() && hbResponse.isFirstHeartbeat()) {
-                this.lastStartTime = hbResponse.getHbTime();
+            if (hbResponse.getRebootTime() > this.lastStartTime) {
+                this.lastStartTime = hbResponse.getRebootTime();
                 isChanged = true;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -293,10 +293,9 @@ public class HeartbeatMgr extends LeaderDaemon {
                     BackendHbResponse backendHbResponse = new BackendHbResponse(
                             computeNodeId, bePort, httpPort, brpcPort, starletPort,
                             System.currentTimeMillis(), version, cpuCores);
-                    
-                    backendHbResponse.setIsSetFirstHeartbeat(tBackendInfo.isSetIs_first_heartbeat());
-                    backendHbResponse.setFirstHeartbeat(tBackendInfo.is_first_heartbeat);
-                    
+                    if (tBackendInfo.isSetReboot_time()) {
+                        backendHbResponse.setRebootTime(tBackendInfo.getReboot_time());
+                    }
                     return backendHbResponse;
                 } else {
                     return new BackendHbResponse(computeNodeId,

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -290,8 +290,14 @@ public class HeartbeatMgr extends LeaderDaemon {
                     }
 
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
-                    return new BackendHbResponse(computeNodeId, bePort, httpPort, brpcPort, starletPort,
+                    BackendHbResponse backendHbResponse = new BackendHbResponse(
+                            computeNodeId, bePort, httpPort, brpcPort, starletPort,
                             System.currentTimeMillis(), version, cpuCores);
+                    
+                    backendHbResponse.setIsSetFirstHeartbeat(tBackendInfo.isSetIs_first_heartbeat());
+                    backendHbResponse.setFirstHeartbeat(tBackendInfo.is_first_heartbeat);
+                    
+                    return backendHbResponse;
                 } else {
                     return new BackendHbResponse(computeNodeId,
                             result.getStatus().getError_msgs().isEmpty() ? "Unknown error"

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -17,4 +17,18 @@ public class ComputeNodeTest {
         boolean needSync = node.handleHbResponse(hbResponse);
         Assert.assertTrue(needSync);
     }
+
+    @Test
+    public void testUpdateStartTime() {
+
+        BackendHbResponse hbResponse = new BackendHbResponse();
+        hbResponse.status = HbStatus.OK;
+        hbResponse.setFirstHeartbeat(true);
+        hbResponse.setIsSetFirstHeartbeat(true);
+        hbResponse.hbTime = 1001L;
+        ComputeNode node = new ComputeNode();
+        boolean needSync = node.handleHbResponse(hbResponse);
+        Assert.assertTrue(node.getLastStartTime() == 1001L);    
+        Assert.assertTrue(needSync);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -23,12 +23,10 @@ public class ComputeNodeTest {
 
         BackendHbResponse hbResponse = new BackendHbResponse();
         hbResponse.status = HbStatus.OK;
-        hbResponse.setFirstHeartbeat(true);
-        hbResponse.setIsSetFirstHeartbeat(true);
-        hbResponse.hbTime = 1001L;
+        hbResponse.setRebootTime(1000L);
         ComputeNode node = new ComputeNode();
         boolean needSync = node.handleHbResponse(hbResponse);
-        Assert.assertTrue(node.getLastStartTime() == 1001L);    
+        Assert.assertTrue(node.getLastStartTime() == 1000000L);    
         Assert.assertTrue(needSync);
     }
 }

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -39,7 +39,7 @@ struct TBackendInfo {
     5: optional string version
     6: optional i32 num_hardware_cores
     7: optional Types.TPort starlet_port
-    8: optional bool is_first_heartbeat
+    8: optional i64 reboot_time
 }
 
 struct THeartbeatResult {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -39,6 +39,7 @@ struct TBackendInfo {
     5: optional string version
     6: optional i32 num_hardware_cores
     7: optional Types.TPort starlet_port
+    8: optional bool is_first_heartbeat
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7561

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The previous be's restart time is not accurate enough. 
Before that, whether fe updates the lastStartTime of be depends on the alive state of be recorded by fe itself.
When the alive state of be is false and the be heartbeat is received again, fe updates the lastStartTime of be. 
If fe dose not receive be's heartbeat 3 times, fe will set the alive stale of be to false. So if  be reboot quickly, the alive state of be will not be set to false, and the lastStartTime of will not be updated
This PR adds a field reboot time in be,  when be reports a heartbeat, reboot time will be sent to fe to determine if lastStartTime of be needs to be updated. 
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
