### PR TITLE
[BugFix] Fix split topN merge memo bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
@@ -25,7 +25,7 @@ public class LogicalTopNOperator extends LogicalOperator {
     private final long offset;
     private final SortPhase sortPhase;
     private final TopNType topNType;
-    private boolean isSplit = false;
+    private final boolean isSplit;
 
     public LogicalTopNOperator(List<Ordering> orderByElements) {
         this(DEFAULT_LIMIT, null, null, null, DEFAULT_LIMIT, orderByElements, DEFAULT_OFFSET, SortPhase.FINAL,
@@ -75,10 +75,6 @@ public class LogicalTopNOperator extends LogicalOperator {
 
     public boolean isSplit() {
         return isSplit;
-    }
-
-    public void setSplit() {
-        isSplit = true;
     }
 
     public ColumnRefSet getRequiredChildInputColumns() {
@@ -142,13 +138,20 @@ public class LogicalTopNOperator extends LogicalOperator {
             return false;
         }
         LogicalTopNOperator that = (LogicalTopNOperator) o;
-        return offset == that.offset && Objects.equals(orderByElements, that.orderByElements) &&
-                sortPhase == that.sortPhase;
+        return partitionLimit == that.partitionLimit && offset == that.offset && isSplit == that.isSplit &&
+                Objects.equals(partitionByColumns, that.partitionByColumns) &&
+                Objects.equals(orderByElements, that.orderByElements) &&
+                sortPhase == that.sortPhase && topNType == that.topNType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sortPhase, orderByElements, offset);
+        return Objects.hash(super.hashCode(), partitionByColumns, partitionLimit, orderByElements, offset,
+                sortPhase, topNType, isSplit);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     public static class Builder

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -36,14 +36,14 @@ public class SplitTopNRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalTopNOperator src = (LogicalTopNOperator) input.getOp();
-        src.setSplit();
 
         long limit = src.getLimit() + src.getOffset();
         LogicalTopNOperator partialSort = new LogicalTopNOperator(
                 src.getOrderByElements(), limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);
 
+        LogicalTopNOperator finalSort = LogicalTopNOperator.builder().withOperator(src).setIsSplit(true).build();
         OptExpression partialSortExpression = OptExpression.create(partialSort, input.getInputs());
-        OptExpression finalSortExpression = OptExpression.create(src, partialSortExpression);
+        OptExpression finalSortExpression = OptExpression.create(finalSort, partialSortExpression);
         return Lists.newArrayList(finalSortExpression);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we run SplitTopNRule first, then enforce one-phase TopN, the plan can't pruned, because splitTopNRule is modify TopN node not create new TopN node, the check of enforce task will fail.

BTW, ut can't cover the case, because we always enforce TopN first, not run splitTopNRule first now

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
