### PR TITLE
[BugFix] Add lock to save meta

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1186,9 +1186,8 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
             // See comments above
             std::unique_lock l(dropped_tablet->get_header_lock());
             dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+            dropped_tablet->save_meta();
         }
-
-        dropped_tablet->save_meta();
 
         std::unique_lock l(_shutdown_tablets_lock);
         _shutdown_tablets.emplace(tablet_id, std::move(drop_info));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10325
The drop_tablet operation does not hold the lock to save meta. The data race results in a crash.
The lock has been locked in the GC thread.
```
#0  0x00007fa996f0139e in pthread_rwlock_wrlock () from /lib64/libpthread.so.0
#1  0x0000000001d68d43 in std::__glibcxx_rwlock_wrlock (__rwlock=0x480a4b00) at /usr/include/c++/10.3.0/shared_mutex:75
#2  std::__shared_mutex_pthread::lock (this=0x480a4b00) at /usr/include/c++/10.3.0/shared_mutex:188
#3  std::shared_mutex::lock (this=0x480a4b00) at /usr/include/c++/10.3.0/shared_mutex:415
#4  std::unique_lock<std::shared_mutex>::lock (this=<synthetic pointer>) at /usr/include/c++/10.3.0/bits/unique_lock.h:138
#5  std::unique_lock<std::shared_mutex>::unique_lock (__m=..., this=<synthetic pointer>) at /usr/include/c++/10.3.0/bits/unique_lock.h:68
#6  starrocks::TabletMeta::save_meta (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x480a4a20, data_dir=0xa0b1520) at /root/starrocks/be/src/storage/tablet_meta.cpp:135
#7  0x0000000001d412ab in starrocks::Tablet::save_meta (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=<optimized out>) at /root/starrocks/be/src/storage/tablet.cpp:122
#8  0x0000000001d4acd8 in starrocks::Tablet::delete_expired_inc_rowsets (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x84670a380) at /root/starrocks/be/src/storage/tablet.cpp:406
#9  0x0000000001d5d4a8 in starrocks::TabletManager::start_trash_sweep (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0xa1ba000) at /root/starrocks/be/src/storage/tablet_manager.cpp:789
#10 0x0000000001d2ae87 in starrocks::StorageEngine::_start_trash_sweep (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=this@entry=0xa203c00, Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
usage=usage@entry=0x7fa8921f2640) at /root/starrocks/be/src/storage/storage_engine.cpp:779
#11 0x0000000001eef259 in starrocks::StorageEngine::_garbage_sweeper_thread_callback (this=0xa203c00, arg=<optimized out>) at /root/starrocks/be/src/storage/olap_server.cpp:381
#12 0x00000000060774e0 in std::execute_native_thread_routine (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
__p=0x1202e870) at ../../../.././libstdc++-v3/src/c++11/thread.cc:80
#13 0x00007fa996efdea5 in start_thread () from /lib64/libpthread.so.0
Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
#14 0x00007fa996518b0d in clone () from /lib64/libc.so.6
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
