### PR TITLE
[Bugfix] Use re2 when hyperscan report errors

### DIFF
--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -30,8 +30,6 @@ static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))", re2
 static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
 static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
 static const char* PROMPT_INFO = " so we switch to use re2.";
-// pattern's max length used in hyperscan.
-static const size_t MAX_PATTERN_OF_HYPERSCAN = 16000;
 
 bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
                                                  starrocks_udf::FunctionContext* context, const Slice& slice) {

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -30,6 +30,9 @@ static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))", re2
 static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
 static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
 
+// pattern's max length used in hyperscan.
+static const size_t MAX_PATTERN_OF_HYPERSCAN = 16000;
+
 Status LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
                                                    starrocks_udf::FunctionContext* context, const Slice& slice) {
     if (hs_compile(pattern.c_str(), HS_FLAG_ALLOWEMPTY | HS_FLAG_DOTALL | HS_FLAG_UTF8 | HS_FLAG_SINGLEMATCH,

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -418,7 +418,7 @@ ColumnPtr LikePredicate::_predicate_const_regex(FunctionContext* context, Column
 
         bool v = false;
         auto value_size = value_viewer.value(row).size;
-        auto status = hs_scan(
+        [[maybe_unused]] auto status = hs_scan(
                 // Use &_DUMMY_STRING_FOR_EMPTY_PATTERN instead of nullptr to avoid crash.
                 state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_FOR_EMPTY_PATTERN,
                 value_size, 0, scratch,

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -232,7 +232,7 @@ ColumnPtr LikePredicate::regex_fn_with_long_constant_pattern(FunctionContext* co
     return match_fn_with_long_constant_pattern<false>(context, columns);
 }
 
-template <bool like>
+template <bool full_match>
 ColumnPtr LikePredicate::match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns) {
     auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
 
@@ -249,7 +249,7 @@ ColumnPtr LikePredicate::match_fn_with_long_constant_pattern(FunctionContext* co
         }
 
         bool v = false;
-        if constexpr (like) {
+        if constexpr (full_match) {
             v = RE2::FullMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
                                *(state->re2));
         } else {

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -248,15 +248,15 @@ ColumnPtr LikePredicate::match_fn_with_long_constant_pattern(FunctionContext* co
             continue;
         }
 
+        bool v = false;
         if constexpr (like) {
-            auto v = RE2::FullMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
-                                    *(state->re2));
-            result.append(v);
+            v = RE2::FullMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
+                               *(state->re2));
         } else {
-            auto v = RE2::PartialMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
-                                       *(state->re2));
-            result.append(v);
+            v = RE2::PartialMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
+                                  *(state->re2));
         }
+        result.append(v);
     }
 
     return result.build(all_const);

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -136,7 +136,7 @@ private:
 
     static ColumnPtr regex_match_partial(FunctionContext* context, const Columns& columns);
 
-    template <bool like>
+    template <bool full_match>
     static ColumnPtr match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns);
 
     /// Convert a LIKE pattern (with embedded % and _) into the corresponding

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -72,6 +72,8 @@ private:
      */
     DEFINE_VECTORIZED_FN(regex_fn);
 
+    DEFINE_VECTORIZED_FN(regex_fn_with_long_constant_pattern);
+    DEFINE_VECTORIZED_FN(like_fn_with_long_constant_pattern);
     /**
      * use for:
      *  a like "xxxx%"
@@ -134,6 +136,10 @@ private:
 
     static ColumnPtr regex_match_partial(FunctionContext* context, const Columns& columns);
 
+    static const size_t MAX_PATTERN_OF_HYPERSCAN = 16000;
+    template <bool like>
+    static ColumnPtr match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns);
+
     /// Convert a LIKE pattern (with embedded % and _) into the corresponding
     /// regular expression pattern. Escaped chars are copied verbatim.
     template <bool fullMatch>
@@ -157,6 +163,7 @@ private:
     struct LikePredicateState {
         char escape_char{'\\'};
 
+        std::shared_ptr<re2::RE2> re2 = nullptr;
         /// This is the function, set in the prepare function, that will be used to determine
         /// the value of the predicate. It will be set depending on whether the expression is
         /// a LIKE, RLIKE or REGEXP predicate, whether the pattern is a constant argument

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -155,7 +155,7 @@ private:
     // to avoid crash with hs_scan.
     static inline char _DUMMY_STRING_FOR_EMPTY_PATTERN = 'A';
 
-    class LikePredicateState;
+    struct LikePredicateState;
     static Status hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
                                                const Slice& slice);
 

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -156,9 +156,11 @@ private:
     static inline char _DUMMY_STRING_FOR_EMPTY_PATTERN = 'A';
 
     struct LikePredicateState;
-    static Status hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
-                                               const Slice& slice);
-
+    static bool hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
+                                             const Slice& slice);
+    template <bool full_match>
+    static Status compile_with_hyperscan_or_re2(const std::string& pattern, LikePredicateState* state,
+                                                starrocks_udf::FunctionContext* context, const Slice& slice);
     struct LikePredicateState {
         char escape_char{'\\'};
 

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -136,7 +136,6 @@ private:
 
     static ColumnPtr regex_match_partial(FunctionContext* context, const Columns& columns);
 
-    static const size_t MAX_PATTERN_OF_HYPERSCAN = 16000;
     template <bool like>
     static ColumnPtr match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns);
 

--- a/be/test/exprs/vectorized/like_test.cpp
+++ b/be/test/exprs/vectorized/like_test.cpp
@@ -614,5 +614,38 @@ TEST_F(LikeTest, constValueRegexpLargerThanHyperscan) {
                         .ok());
 }
 
+TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto haystack = ColumnHelper::create_const_column<TYPE_VARCHAR>("CHINA", 1);
+
+    std::string large_pattern =
+            "(肉|便|便|胃|补钙|不喝奶|心|胖|服|食|不.{0,3}(想|要|愿|喜欢|爱|肯|好好|怎么).{0,3}(吃|喝)|擦鼻涕|肠梗阻|("
+            "肠|胃).{0,2}(敏感|弱|好|适应|舒服|难受|差|问题|炎)|吃不下饭|吃撑了|吃(的|得).{0,2}(少|多|饱|吐)|吃奶|打嗝|"
+            "低血糖|肚子饿|肚子疼|断奶|断食|饿肚子|饿坏了|发胖|发腮|肥胖|疯狂吃|腹泻|感冒|干呕|过敏|咳嗽|没吃饱|(好|很|"
+            "太|有点|有些)胖|(好|很|太|有点|有些)瘦|怀孕|换口味|减肥|焦虑|戒奶|拉肚子|拉稀|精神不好|拒绝吃|口臭|口炎|"
+            "狂吃|拉屎|cccccccccc|细小|毛囊炎|没精神|磨牙|奶.{0,2}不(够|足)|没有奶|奶癣|呕吐|胖不起来|皮肤病|偏瘦|缺钙|"
+            "缺维耐|便|火|好|竭|生|振|了|病|吃|病|(吃|喝)奶|不(好|了|良)|牙.{0,2}不好|牙(疼|痛)|腺|抑|(好|够|足|良)|越|"
+            "增|毛|胖|牙|奶|肉|毒|暑|总).{0,5}(永)";
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
+
+    columns.push_back(haystack);
+    columns.push_back(pattern);
+
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::regex(context, columns);
+
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
+
+    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixed https://github.com/StarRocks/starrocks/issues/10364

We use re2 instead of hyperscan when hyperscan report errors.
