### PR TITLE
[Refactor][Lake] Extract common method for future use

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -8,7 +8,17 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.UserException;
+import com.starrocks.lake.proto.PublishLogVersionRequest;
+import com.starrocks.lake.proto.PublishLogVersionResponse;
+import com.starrocks.lake.proto.PublishVersionRequest;
+import com.starrocks.lake.proto.PublishVersionResponse;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.EmptyRpcCallback;
+import com.starrocks.rpc.LakeServiceAsync;
+import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +27,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
+import javax.validation.constraints.NotNull;
 
 public class Utils {
     private static final Logger LOG = LogManager.getLogger(Utils.class);
@@ -60,5 +72,101 @@ public class Utils {
             }
         }
         return groupMap;
+    }
+
+    @NotNull
+    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion)
+            throws NoAliveBackendException, RpcException {
+        Map<Long, List<Long>> beToTablets = new HashMap<>();
+        for (Tablet tablet : tablets) {
+            Long beId = Utils.chooseBackend((LakeTablet) tablet);
+            if (beId == null) {
+                throw new NoAliveBackendException("No alive backend for handle publish version request");
+            }
+            beToTablets.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tablet.getId());
+        }
+        List<Long> txnIds = Lists.newArrayList(txnId);
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
+        List<Future<PublishVersionResponse>> responseList = Lists.newArrayListWithCapacity(beToTablets.size());
+        List<Backend> backendList = Lists.newArrayListWithCapacity(beToTablets.size());
+        for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
+            Backend backend = systemInfoService.getBackend(entry.getKey());
+            if (backend == null) {
+                throw new NoAliveBackendException("Backend been dropped while building publish version request");
+            }
+            PublishVersionRequest request = new PublishVersionRequest();
+            request.baseVersion = baseVersion;
+            request.newVersion = newVersion;
+            request.tabletIds = entry.getValue();
+            request.txnIds = txnIds;
+
+            try {
+                LakeServiceAsync lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
+                Future<PublishVersionResponse> future = lakeService.publishVersion(request, new EmptyRpcCallback<>());
+                responseList.add(future);
+                backendList.add(backend);
+            } catch (Throwable e) {
+                throw new RpcException(backend.getHost(), e.getMessage());
+            }
+        }
+
+        for (int i = 0; i < responseList.size(); i++) {
+            try {
+                PublishVersionResponse response = responseList.get(i).get();
+                if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                    throw new RpcException(backendList.get(i).getHost(),
+                            "Fail to publish version for tablets {}" + response.failedTablets);
+                }
+            } catch (Exception e) {
+                throw new RpcException(backendList.get(i).getHost(), e.getMessage());
+            }
+        }
+    }
+
+    @NotNull
+    public static void publishLogVersion(@NotNull List<Tablet> tablets, long txnId, long version)
+            throws NoAliveBackendException, RpcException {
+        Map<Long, List<Long>> beToTablets = new HashMap<>();
+        for (Tablet tablet : tablets) {
+            Long beId = Utils.chooseBackend((LakeTablet) tablet);
+            if (beId == null) {
+                throw new NoAliveBackendException("No alive backend for handle publish version request");
+            }
+            beToTablets.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tablet.getId());
+        }
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
+        List<Future<PublishLogVersionResponse>> responseList = Lists.newArrayListWithCapacity(beToTablets.size());
+        List<Backend> backendList = Lists.newArrayListWithCapacity(beToTablets.size());
+        for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
+            Backend backend = systemInfoService.getBackend(entry.getKey());
+            if (backend == null) {
+                throw new NoAliveBackendException("Backend been dropped while building publish version request");
+            }
+            PublishLogVersionRequest request = new PublishLogVersionRequest();
+            request.tabletIds = entry.getValue();
+            request.txnId = txnId;
+            request.version = version;
+
+            try {
+                LakeServiceAsync lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
+                Future<PublishLogVersionResponse> future = lakeService.publishLogVersion(request, new EmptyRpcCallback<>());
+                responseList.add(future);
+                backendList.add(backend);
+            } catch (Throwable e) {
+                throw new RpcException(backend.getHost(), e.getMessage());
+            }
+        }
+
+        for (int i = 0; i < responseList.size(); i++) {
+            try {
+                PublishLogVersionResponse response = responseList.get(i).get();
+                if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                    throw new RpcException(backendList.get(i).getHost(),
+                            "Fail to publish log version for tablets {}" + response.failedTablets);
+                }
+            } catch (Exception e) {
+                throw new RpcException(backendList.get(i).getHost(), e.getMessage());
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -75,6 +75,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Transaction Manager in database level, as a component in GlobalTransactionMgr
@@ -187,6 +188,7 @@ public class DatabaseTransactionMgr {
     }
 
     @VisibleForTesting
+    @Nullable
     protected Set<Long> unprotectedGetTxnIdsByLabel(String label) {
         return labelToTxnIds.get(label);
     }
@@ -1151,11 +1153,7 @@ public class DatabaseTransactionMgr {
     }
 
     private void updateTxnLabels(TransactionState transactionState) {
-        Set<Long> txnIds = labelToTxnIds.get(transactionState.getLabel());
-        if (txnIds == null) {
-            txnIds = Sets.newHashSet();
-            labelToTxnIds.put(transactionState.getLabel(), txnIds);
-        }
+        Set<Long> txnIds = labelToTxnIds.computeIfAbsent(transactionState.getLabel(), k -> Sets.newHashSet());
         txnIds.add(transactionState.getTransactionId());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -33,22 +33,14 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.lake.LakeTable;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
-import com.starrocks.lake.proto.PublishLogVersionRequest;
-import com.starrocks.lake.proto.PublishLogVersionResponse;
-import com.starrocks.lake.proto.PublishVersionRequest;
-import com.starrocks.lake.proto.PublishVersionResponse;
-import com.starrocks.rpc.BrpcProxy;
-import com.starrocks.rpc.EmptyRpcCallback;
-import com.starrocks.rpc.LakeServiceAsync;
+import com.starrocks.rpc.RpcException;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
@@ -58,12 +50,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
@@ -294,7 +283,8 @@ public class PublishVersionDaemon extends LeaderDaemon {
 
     private boolean publishPartition(@NotNull Database db, @NotNull TableCommitInfo tableCommitInfo,
                                      @NotNull PartitionCommitInfo partitionCommitInfo,
-                                     @NotNull TransactionState txnState) throws ExecutionException, InterruptedException {
+                                     @NotNull TransactionState txnState)
+            throws RpcException, NoAliveBackendException {
         long tableId = tableCommitInfo.getTableId();
         long txnVersion = partitionCommitInfo.getVersion();
         long txnId = txnState.getTransactionId();
@@ -351,104 +341,20 @@ public class PublishVersionDaemon extends LeaderDaemon {
     }
 
     private boolean publishNormalTablets(@Nullable List<Tablet> tablets, long txnId, long version)
-            throws ExecutionException, InterruptedException {
+            throws RpcException, NoAliveBackendException {
         if (tablets == null || tablets.isEmpty()) {
             return true;
         }
-        Map<Long, List<Long>> beToTablets = new HashMap<>();
-        for (Tablet tablet : tablets) {
-            Long beId = Utils.chooseBackend((LakeTablet) tablet);
-            if (beId == null) {
-                LOG.warn("No available backend can execute publish version task");
-                return false;
-            }
-            beToTablets.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tablet.getId());
-        }
-
-        List<Long> txnIds = Lists.newArrayList(txnId);
-        List<Future<PublishVersionResponse>> responseList = Lists.newArrayListWithCapacity(beToTablets.size());
-        List<Backend> backendList = Lists.newArrayListWithCapacity(beToTablets.size());
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
-            Backend backend = systemInfoService.getBackend(entry.getKey());
-            if (backend == null) {
-                LOG.warn("Backend {} has been dropped", entry.getKey());
-                return false;
-            }
-            if (!backend.isAlive()) {
-                LOG.warn("Backend {} not alive", backend.getHost());
-                return false;
-            }
-
-            PublishVersionRequest request = new PublishVersionRequest();
-            request.baseVersion = version - 1;
-            request.newVersion = version;
-            request.tabletIds = entry.getValue();
-            request.txnIds = txnIds;
-
-            LakeServiceAsync lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
-            Future<PublishVersionResponse> future = lakeService.publishVersion(request, new EmptyRpcCallback<>());
-            responseList.add(future);
-            backendList.add(backend);
-        }
-
-        for (int i = 0; i < responseList.size(); i++) {
-            PublishVersionResponse response = responseList.get(i).get();
-            if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                LOG.warn("Fail to publish tablet {} on BE {}", response.failedTablets, backendList.get(i).getHost());
-                return false;
-            }
-        }
+        Utils.publishVersion(tablets, txnId, version - 1, version);
         return true;
     }
 
     private boolean publishShadowTablets(@Nullable List<Tablet> tablets, long txnId, long version)
-            throws ExecutionException, InterruptedException {
+            throws RpcException, NoAliveBackendException {
         if (tablets == null || tablets.isEmpty()) {
             return true;
         }
-        Map<Long, List<Long>> beToTablets = new HashMap<>();
-        for (Tablet tablet : tablets) {
-            Long beId = Utils.chooseBackend((LakeTablet) tablet);
-            if (beId == null) {
-                LOG.warn("No available backend can execute publish version task");
-                return false;
-            }
-            beToTablets.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tablet.getId());
-        }
-        List<Future<PublishLogVersionResponse>> responseList = Lists.newArrayListWithCapacity(beToTablets.size());
-        List<Backend> backendList = Lists.newArrayListWithCapacity(beToTablets.size());
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
-            Backend backend = systemInfoService.getBackend(entry.getKey());
-            if (backend == null) {
-                LOG.warn("Backend {} has been dropped", entry.getKey());
-                return false;
-            }
-            if (!backend.isAlive()) {
-                LOG.warn("Backend {} not alive", backend.getHost());
-                return false;
-            }
-
-            PublishLogVersionRequest request = new PublishLogVersionRequest();
-            request.tabletIds = entry.getValue();
-            request.txnId = txnId;
-            request.version = version;
-
-            LakeServiceAsync lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
-            Future<PublishLogVersionResponse> future = lakeService.publishLogVersion(request, new EmptyRpcCallback<>());
-            responseList.add(future);
-            backendList.add(backend);
-        }
-
-        for (int i = 0; i < responseList.size(); i++) {
-            PublishLogVersionResponse response = responseList.get(i).get();
-            if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                LOG.warn("Fail to publish log of shadow tablet {} on BE {}", response.failedTablets,
-                        backendList.get(i).getHost());
-                return false;
-            }
-        }
+        Utils.publishLogVersion(tablets, txnId, version);
         return true;
     }
 


### PR DESCRIPTION
There is no logical modification in this patch, just move some
codes in PublishVersionDaemon to lake.Utils for future
use(schema change on lake table).

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

