### PR TITLE
[BugFix][cherry-pick][Branch-2.4] column_from_field_type not support array, use column_from_field. (#10303)

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -213,6 +213,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         }
     }
 
+    auto read_column_schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, read_column_ids);
     std::vector<std::unique_ptr<vectorized::Column>> read_columns(read_column_ids.size());
     size_t num_segments = rowset->num_segments();
     _partial_update_states.resize(num_segments);
@@ -220,9 +221,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         _partial_update_states[i].write_columns.resize(read_columns.size());
         _partial_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
         for (uint32_t j = 0; j < read_columns.size(); ++j) {
-            const auto read_column_id = read_column_ids[j];
-            auto tablet_column = tablet_schema.column(read_column_id);
-            auto column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+            auto column = ChunkHelper::column_from_field(*read_column_schema.field(j).get());
             read_columns[j] = column->clone_empty();
             _partial_update_states[i].write_columns[j] = column->clone_empty();
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10274