### PR TITLE
[BugFix] Fix mem_usage contention of some index readers in column reader.

### DIFF
--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -27,6 +27,7 @@
 #include "fs/fs.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 #include "storage/column_block.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/indexed_column_reader.h"
@@ -58,7 +59,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+                        bool kept_in_memory, MemTracker* mem_tracker);
 
     // create a new column iterator. Client should delete returned iterator
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -86,7 +87,7 @@ private:
     friend class BitmapIndexIterator;
 
     Status do_load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/bloom_filter_index_reader.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 #include "storage/column_block.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/indexed_column_reader.h"
@@ -60,7 +61,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                        bool use_page_cache, bool kept_in_memory);
+                        bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     // create a new column iterator.
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -80,7 +81,7 @@ public:
 
 private:
     Status do_load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -293,11 +293,9 @@ Status ColumnReader::_load_ordinal_index() {
     auto meta = _ordinal_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _ordinal_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load,
-                     _ordinal_index->load(fs, file_name(), *meta, num_rows(), use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load, _ordinal_index->load(fs, file_name(), *meta, num_rows(), use_page_cache,
+                                                           kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_ordinal_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_ordinal_index_meta->SpaceUsedLong());
         _ordinal_index_meta.reset();
     }
@@ -311,10 +309,9 @@ Status ColumnReader::_load_zonemap_index() {
     auto meta = _zonemap_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _zonemap_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load, _zonemap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load,
+                     _zonemap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_zonemap_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_zonemap_index_meta->SpaceUsedLong());
         _zonemap_index_meta.reset();
     }
@@ -328,10 +325,9 @@ Status ColumnReader::_load_bitmap_index() {
     auto meta = _bitmap_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _bitmap_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load,
+                     _bitmap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_bitmap_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_bitmap_index_meta->SpaceUsedLong());
         _bitmap_index_meta.reset();
     }
@@ -345,11 +341,9 @@ Status ColumnReader::_load_bloom_filter_index() {
     auto meta = _bloom_filter_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _bloom_filter_index->mem_usage();
     ASSIGN_OR_RETURN(auto first_load,
-                     _bloom_filter_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+                     _bloom_filter_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_bloom_filter_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_bloom_filter_index_meta->SpaceUsedLong());
         _bloom_filter_index_meta.reset();
     }

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -27,6 +27,7 @@
 
 #include "common/status.h"
 #include "gutil/macros.h"
+#include "runtime/mem_tracker.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/index_page.h"
 #include "storage/rowset/page_pointer.h"
@@ -73,7 +74,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                        bool use_page_cache, bool kept_in_memory);
+                        bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     OrdinalPageIndexIterator seek_at_or_before(ordinal_t ordinal);
@@ -107,7 +108,7 @@ private:
     friend OrdinalPageIndexIterator;
 
     Status do_load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                   bool use_page_cache, bool kept_in_memory);
+                   bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     OnceFlag _load_once;
     // valid after load

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -75,7 +75,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+                        bool kept_in_memory, MemTracker* mem_tracker);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     const std::vector<ZoneMapPB>& page_zone_maps() const { return _page_zone_maps; }
@@ -89,7 +89,7 @@ public:
 
 private:
     Status do_load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     OnceFlag _load_once;
     std::vector<ZoneMapPB> _page_zone_maps;

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1005,7 +1005,7 @@ PARALLEL_TEST(ArrayColumnTest, test_assign) {
     offsets->append(6);
 
     // assign
-    column->assign(4,0);
+    column->assign(4, 0);
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
     ASSERT_EQ("[1, 2, 3]", column->debug_item(1));

--- a/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
+++ b/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
@@ -262,7 +262,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_without_
         RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
         rowset_meta->set_start_version(10);
         rowset_meta->set_end_version(19);
-        rowset_meta->set_creation_time(base_time +1);
+        rowset_meta->set_creation_time(base_time + 1);
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -185,9 +185,8 @@ public:
             tablet_meta->add_rs_meta(src_rowset->rowset_meta());
         }
 
-        TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
-                                                starrocks::StorageEngine::instance()->get_stores()[0]);
+        TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
+                                                                 starrocks::StorageEngine::instance()->get_stores()[0]);
         tablet->init();
         tablet->calculate_cumulative_point();
 

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -164,9 +164,8 @@ public:
             tablet_meta->add_rs_meta(src_rowset->rowset_meta());
         }
 
-        TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
-                                                starrocks::StorageEngine::instance()->get_stores()[0]);
+        TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
+                                                                 starrocks::StorageEngine::instance()->get_stores()[0]);
         tablet->init();
 
         config::cumulative_compaction_skip_window_seconds = -2;

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -4,16 +4,16 @@
 
 #include <gtest/gtest.h>
 
-#include "column/fixed_length_column.h"
 #include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/fixed_location_provider.h"
-#include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
 

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -53,7 +53,7 @@ protected:
     void get_bitmap_reader_iter(std::string& file_name, const ColumnIndexMetaPB& meta, BitmapIndexReader** reader,
                                 BitmapIndexIterator** iter) {
         *reader = new BitmapIndexReader();
-        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), file_name, meta.bitmap_index(), true, false));
+        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), file_name, meta.bitmap_index(), true, false, &_tracker));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(iter));
     }
@@ -247,7 +247,8 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
             while (count.load() < count) {
                 ;
             }
-            ASSIGN_OR_ABORT(auto first_load, reader->load(_fs.get(), file_name, meta.bitmap_index(), false, false));
+            ASSIGN_OR_ABORT(auto first_load,
+                            reader->load(_fs.get(), file_name, meta.bitmap_index(), false, false, &_tracker));
             loads.fetch_add(first_load);
         });
     }

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -83,7 +83,8 @@ protected:
         std::string fname = kTestDir + "/" + file_name;
 
         *reader = new BloomFilterIndexReader();
-        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), fname, meta.bloom_filter_index(), true, false));
+        ASSIGN_OR_ABORT(auto r,
+                        (*reader)->load(_fs.get(), fname, meta.bloom_filter_index(), true, false, _mem_tracker.get()));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(iter));
     }

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -75,8 +75,8 @@ TEST_F(OrdinalPageIndexTest, normal) {
     }
 
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r,
-                    index.load(_fs.get(), filename, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1, true, false));
+    ASSIGN_OR_ABORT(auto r, index.load(_fs.get(), filename, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1, true,
+                                       false, _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(16 * 1024, index.num_data_pages());
     ASSERT_EQ(1, index.get_first_ordinal(0));
@@ -131,7 +131,8 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
     }
 
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r, index.load(_fs.get(), "", index_meta.ordinal_index(), num_values, true, false));
+    ASSIGN_OR_ABORT(auto r,
+                    index.load(_fs.get(), "", index_meta.ordinal_index(), num_values, true, false, _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(1, index.num_data_pages());
     ASSERT_EQ(0, index.get_first_ordinal(0));

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -603,8 +603,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 
     ASSERT_TRUE(tablet->rowset_commit(2, rowset).ok());
     EXPECT_EQ(rows_per_segment * 2, read_tablet_and_compare(tablet, partial_schema, 2, rows_per_segment * 2));
-    ASSERT_OK(starrocks::StorageEngine::instance()->update_manager()->on_rowset_finished(tablet.get(),
-                                                                                                        rowset.get()));
+    ASSERT_OK(starrocks::StorageEngine::instance()->update_manager()->on_rowset_finished(tablet.get(), rowset.get()));
 }
 
 TEST_F(RowsetTest, VerticalWriteTest) {

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -77,7 +77,8 @@ protected:
         }
 
         ZoneMapIndexReader column_zone_map;
-        ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+        ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false,
+                                                     _mem_tracker.get()));
         ASSERT_TRUE(r);
         ASSERT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -131,7 +132,8 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     }
 
     ZoneMapIndexReader column_zone_map;
-    ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+    ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false,
+                                                 _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(3, column_zone_map.num_pages());
     const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9809

## Problem Summary(Required) ：
if call ZoneMapIndexReader::mem_usage() as this
https://github.com/StarRocks/starrocks/blob/156404be5709858d583bd62840fae39453cb7917/be/src/storage/rowset/column_reader.cpp#L307-L322
when execute ZoneMapIndexReader::mem_usage(), elsewhere will operate the _page_zone_maps
https://github.com/StarRocks/starrocks/blob/156404be5709858d583bd62840fae39453cb7917/be/src/storage/rowset/zone_map_index.cpp#L230-L237
result in crash like this:
```
Core was generated by `/home/disk2/sr/stability_master_01/be-7063d832-9520-477b-ba14-d391fc64b9b2/lib/'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00000000049a9210 in google::protobuf::Message::GetReflection (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x559889b30) at ./google/protobuf/message.h:359
359        ./google/protobuf/message.h: No such file or directory.
[Current thread is 1 (Thread 0x7f38b2dbf700 (LWP 25566))]
(gdb) bt
Python Exception <type 'exceptions.ImportError'> No module named gdb.frames:
#0  0x00000000049a9210 in google::protobuf::Message::GetReflection (this=0x559889b30) at ./google/protobuf/message.h:359
#1  google::protobuf::Message::SpaceUsedLong (this=0x559889b30) at google/protobuf/[message.cc:162](http://message.cc:162/)
#2  0x0000000001ff7c14 in starrocks::ZoneMapIndexReader::mem_usage (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=<optimized out>) at /root/starrocks/be/src/storage/rowset/zone_map_index.cpp:234
#3  0x0000000001f77480 in starrocks::ColumnReader::_load_zonemap_index (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x3464c19e0) at /root/starrocks/be/src/storage/rowset/column_reader.cpp:314
#4  0x0000000001f775d0 in starrocks::ColumnReader::zone_map_filter (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x3464c19e0, Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
predicates=..., del_predicate=0x0, del_partial_filtered_pages=0x71adfbc00,
    row_ranges=row_ranges@entry=0x7f38b2db8fe0) at /root/starrocks/be/src/storage/rowset/column_reader.cpp:379
#5  0x0000000001fc5399 in starrocks::ScalarColumnIterator::get_row_ranges_by_zone_map (this=<optimized out>, predicates=..., del_predicate=<optimized out>,
    row_ranges=0x7f38b2db8fe0) at /root/starrocks/be/src/storage/rowset/scalar_column_iterator.cpp:319
#6  0x0000000001e0b932 in starrocks::vectorized::SegmentIterator::_get_row_ranges_by_zone_map (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510) at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:581
#7  0x0000000001e0c753 in starrocks::vectorized::SegmentIterator::_init (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510) at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:359
#8  0x0000000001e0cf69 in starrocks::vectorized::SegmentIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510, chunk=0x225d05d50)
    at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:772
#9  0x0000000001e665c2 in starrocks::vectorized::ChunkIterator::get_next (chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#10 starrocks::vectorized::ProjectionIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x74ba37910, chunk=0x78c3bcc00) at /root/starrocks/be/src/storage/projection_iterator.cpp:69
#11 0x0000000002333ba5 in starrocks::vectorized::ChunkIterator::get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:42
#12 starrocks::SegmentIteratorWrapper::do_get_next (this=<optimized out>, chunk=<optimized out>) at /root/starrocks/be/src/storage/rowset/rowset.cpp:314
#13 0x000000000200a193 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x78c3bcc00, this=0x41acca010) at /root/starrocks/be/src/util/stopwatch.hpp:76
#14 starrocks::vectorized::TimedChunkIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x7502de130, chunk=0x78c3bcc00) at /root/starrocks/be/src/storage/chunk_iterator.cpp:37
#15 0x0000000001e932de in starrocks::vectorized::ChunkIterator::get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#16 starrocks::vectorized::TabletReader::do_get_next (this=<optimized out>, chunk=<optimized out>) at /root/starrocks/be/src/storage/tablet_reader.cpp:86
#17 0x0000000002d34dd4 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x78c3bcc00, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#18 starrocks::vectorized::TabletScanner::get_chunk (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x26cc24240, state=<optimized out>, chunk=0x78c3bcc00) at /root/starrocks/be/src/exec/vectorized/tablet_scanner.cpp:255
#19 0x00000000029ee035 in starrocks::vectorized::OlapScanNode::_scanner_thread (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x82cbaa900, scanner=<optimized out>) at /root/starrocks/be/src/exec/exec_node.h:303
#20 0x0000000002359150 in std::function<void ()>::operator()() const (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x7f38b2db95d8) at /usr/include/c++/10.3.0/bits/std_function.h:248
#21 starrocks::PriorityThreadPool::work_thread (this=0x9e13600, thread_id=14) at /root/starrocks/be/src/util/priority_thread_pool.hpp:180
#22 0x0000000004575ba7 in boost::(anonymous namespace)::thread_proxy (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
param=<optimized out>) at libs/thread/src/pthread/thread.cpp:179
#23 0x00007f38d4bfbea5 in start_thread () from /lib64/libpthread.so.0
Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
#24 0x00007f38d4216b0d in clone () from /lib64/libc.so.6
(gdb) q
```
so put the mem_usage into load to avoid contention in this PR, not only ZoneMapIndexReader, but also OrdinalIndexReader, BitmapIndexReader, BloomFilterIndexReader should do this change.