### PR TITLE
[Enhancement] Reduce the value-copy of task worker pool

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -229,8 +229,8 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
         return;
     }
 
-    phmap::flat_hash_map<TTaskType::type, std::vector<TAgentTaskRequest>> task_divider;
-    phmap::flat_hash_map<TPushType::type, std::vector<TAgentTaskRequest>> push_divider;
+    phmap::flat_hash_map<TTaskType::type, std::vector<const TAgentTaskRequest*>> task_divider;
+    phmap::flat_hash_map<TPushType::type, std::vector<const TAgentTaskRequest*>> push_divider;
 
     for (const auto& task : tasks) {
         VLOG_RPC << "submit one task: " << apache::thrift::ThriftDebugString(task).c_str();
@@ -240,7 +240,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
 #define HANDLE_TYPE(t_task_type, work_pool, req_member)                                             \
     case t_task_type:                                                                               \
         if (task.__isset.req_member) {                                                              \
-            task_divider[t_task_type].push_back(task);                                              \
+            task_divider[t_task_type].push_back(&task);                                             \
         } else {                                                                                    \
             ret_st = Status::InvalidArgument(                                                       \
                     strings::Substitute("task(signature=$0) has wrong request member", signature)); \
@@ -272,7 +272,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             }
             if (task.push_req.push_type == TPushType::LOAD_V2 || task.push_req.push_type == TPushType::DELETE ||
                 task.push_req.push_type == TPushType::CANCEL_DELETE) {
-                push_divider[task.push_req.push_type].push_back(task);
+                push_divider[task.push_req.push_type].push_back(&task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0, type=$1, push_type=$2) has wrong push_type", signature,
@@ -281,7 +281,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             break;
         case TTaskType::ALTER:
             if (task.__isset.alter_tablet_req || task.__isset.alter_tablet_req_v2) {
-                task_divider[TTaskType::ALTER].push_back(task);
+                task_divider[TTaskType::ALTER].push_back(&task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0) has wrong request member", signature));
@@ -315,46 +315,46 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
         auto all_tasks = task_item.second;
         switch (task_type) {
         case TTaskType::CREATE:
-            _create_tablet_workers->submit_tasks(&all_tasks);
+            _create_tablet_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::DROP:
-            _drop_tablet_workers->submit_tasks(&all_tasks);
+            _drop_tablet_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::PUBLISH_VERSION: {
             for (const auto& task : all_tasks) {
-                _publish_version_workers->submit_task(task);
+                _publish_version_workers->submit_task(*task);
             }
             break;
         }
         case TTaskType::CLEAR_TRANSACTION_TASK:
-            _clear_transaction_task_workers->submit_tasks(&all_tasks);
+            _clear_transaction_task_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::CLONE:
-            _clone_workers->submit_tasks(&all_tasks);
+            _clone_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::STORAGE_MEDIUM_MIGRATE:
-            _storage_medium_migrate_workers->submit_tasks(&all_tasks);
+            _storage_medium_migrate_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::CHECK_CONSISTENCY:
-            _check_consistency_workers->submit_tasks(&all_tasks);
+            _check_consistency_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::UPLOAD:
-            _upload_workers->submit_tasks(&all_tasks);
+            _upload_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::DOWNLOAD:
-            _download_workers->submit_tasks(&all_tasks);
+            _download_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::MAKE_SNAPSHOT:
-            _make_snapshot_workers->submit_tasks(&all_tasks);
+            _make_snapshot_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::RELEASE_SNAPSHOT:
-            _release_snapshot_workers->submit_tasks(&all_tasks);
+            _release_snapshot_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::MOVE:
-            _move_dir_workers->submit_tasks(&all_tasks);
+            _move_dir_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::UPDATE_TABLET_META_INFO:
-            _update_tablet_meta_info_workers->submit_tasks(&all_tasks);
+            _update_tablet_meta_info_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::REALTIME_PUSH:
         case TTaskType::PUSH: {
@@ -362,7 +362,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             break;
         }
         case TTaskType::ALTER:
-            _alter_tablet_workers->submit_tasks(&all_tasks);
+            _alter_tablet_workers->submit_tasks(all_tasks);
             break;
         default:
             ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0) has wrong task type", task_type));
@@ -378,11 +378,11 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             auto all_push_tasks = push_item.second;
             switch (push_type) {
             case TPushType::LOAD_V2:
-                _push_workers->submit_tasks(&all_push_tasks);
+                _push_workers->submit_tasks(all_push_tasks);
                 break;
             case TPushType::DELETE:
             case TPushType::CANCEL_DELETE:
-                _delete_workers->submit_tasks(&all_push_tasks);
+                _delete_workers->submit_tasks(all_push_tasks);
                 break;
             default:
                 ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0, push_type=$1) has wrong task type",

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -269,7 +269,9 @@ void TaskWorkerPool::submit_tasks(const std::vector<const TAgentTaskRequest*>& t
             }
         }
     }
-    LOG(INFO) << "fail to register task. type=" << type_str << ", signatures=[" << fail_ss.str() << "]";
+    if (fail_ss.str().length() > 0) {
+        LOG(INFO) << "fail to register task. type=" << type_str << ", signatures=[" << fail_ss.str() << "]";
+    }
 
     size_t queue_size = 0;
     {
@@ -296,8 +298,10 @@ void TaskWorkerPool::submit_tasks(const std::vector<const TAgentTaskRequest*>& t
         _worker_thread_condition_variable->notify_all();
     }
 
-    LOG(INFO) << "success to submit task. type=" << type_str << ", signature=[" << succ_ss.str()
-              << "], task_count_in_queue=" << queue_size;
+    if (succ_ss.str().length() > 0) {
+        LOG(INFO) << "success to submit task. type=" << type_str << ", signature=[" << succ_ss.str()
+                  << "], task_count_in_queue=" << queue_size;
+    }
 }
 
 size_t TaskWorkerPool::num_queued_tasks() const {

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -215,8 +215,9 @@ void TaskWorkerPool::submit_task(const TAgentTaskRequest& task) {
 
     if (_register_task_info(task_type, signature)) {
         // Set the receiving time of task so that we can determine whether it is timed out later
-        (const_cast<TAgentTaskRequest&>(task)).__set_recv_time(time(nullptr));
-        size_t task_count = _push_task(std::make_shared<TAgentTaskRequest>(task));
+        auto new_task = std::make_shared<TAgentTaskRequest>(task);
+        new_task->__set_recv_time(time(nullptr));
+        size_t task_count = _push_task(std::move(new_task));
         LOG(INFO) << "Submit task success. type=" << type_str << ", signature=" << signature
                   << ", task_count_in_queue=" << task_count;
     } else {
@@ -224,66 +225,78 @@ void TaskWorkerPool::submit_task(const TAgentTaskRequest& task) {
     }
 }
 
-void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
-    DCHECK(!tasks->empty());
+void TaskWorkerPool::submit_tasks(const std::vector<const TAgentTaskRequest*>& tasks) {
+    DCHECK(!tasks.empty());
     std::string type_str;
-    const TTaskType::type task_type = (*tasks)[0].task_type;
-    std::vector<TAgentTaskRequest> failed_task_vec;
+    size_t task_count = tasks.size();
+    const TTaskType::type task_type = tasks[0]->task_type;
+    std::vector<uint8_t> failed_task(task_count);
     EnumToString(TTaskType, task_type, type_str);
+    const auto recv_time = time(nullptr);
     {
         std::lock_guard task_signatures_lock(_s_task_signatures_locks[task_type]);
-        const auto recv_time = time(nullptr);
-        for (auto it = tasks->begin(); it != tasks->end();) {
-            TAgentTaskRequest& task_req = *it;
-            int64_t signature = task_req.signature;
+        for (size_t i = 0; i < tasks.size(); i++) {
+            int64_t signature = tasks[i]->signature;
 
             // batch register task info
             std::set<int64_t>& signature_set = _s_task_signatures[task_type];
             if (signature_set.insert(signature).second) {
-                task_req.__set_recv_time(recv_time);
-                ++it;
+                failed_task[i] = 0;
             } else {
-                failed_task_vec.push_back(*it);
-                it = tasks->erase(it);
+                failed_task[i] = 1;
             }
         }
     }
 
-    if (!failed_task_vec.empty()) {
-        std::stringstream ss;
-        for (int i = 0; i < failed_task_vec.size(); ++i) {
-            if (i != 0) {
-                ss << ",";
+    size_t non_zeros = SIMD::count_nonzero(failed_task);
+
+    std::stringstream fail_ss;
+    std::stringstream succ_ss;
+    size_t fail_counter = non_zeros;
+    size_t succ_counter = task_count - non_zeros;
+    for (int i = 0; i < failed_task.size(); ++i) {
+        if (failed_task[i] == 1) {
+            fail_ss << tasks[i]->signature;
+            fail_counter--;
+            if (fail_counter > 0) {
+                fail_ss << ",";
             }
-            ss << failed_task_vec[i].signature;
+        } else {
+            succ_ss << tasks[i]->signature;
+            succ_counter--;
+            if (succ_counter > 0) {
+                succ_ss << ",";
+            }
         }
-        LOG(INFO) << "fail to register task. type=" << type_str << ", signatures=[" << ss.str() << "]";
     }
+    LOG(INFO) << "fail to register task. type=" << type_str << ", signatures=[" << fail_ss.str() << "]";
 
     size_t queue_size = 0;
     {
         std::unique_lock l(_worker_thread_lock);
         if (UNLIKELY(task_type == TTaskType::REALTIME_PUSH &&
-                     (*tasks)[0].push_req.push_type == TPushType::CANCEL_DELETE)) {
-            for (auto const& task : *tasks) {
-                _tasks.emplace_front(std::make_shared<TAgentTaskRequest>(task));
+                     tasks[0]->push_req.push_type == TPushType::CANCEL_DELETE)) {
+            for (size_t i = 0; i < task_count; i++) {
+                if (failed_task[i] == 0) {
+                    auto new_task = std::make_shared<TAgentTaskRequest>(*tasks[i]);
+                    new_task->__set_recv_time(recv_time);
+                    _tasks.emplace_front(std::move(new_task));
+                }
             }
         } else {
-            for (auto const& task : *tasks) {
-                _tasks.emplace_back(std::make_shared<TAgentTaskRequest>(task));
+            for (size_t i = 0; i < task_count; i++) {
+                if (failed_task[i] == 0) {
+                    auto new_task = std::make_shared<TAgentTaskRequest>(*tasks[i]);
+                    new_task->__set_recv_time(recv_time);
+                    _tasks.emplace_back(std::move(new_task));
+                }
             }
         }
         queue_size = _tasks.size();
         _worker_thread_condition_variable->notify_all();
     }
-    std::stringstream ss;
-    for (int i = 0; i < (*tasks).size(); ++i) {
-        if (i != 0) {
-            ss << ",";
-        }
-        ss << (*tasks)[i].signature;
-    }
-    LOG(INFO) << "success to submit task. type=" << type_str << ", signature=[" << ss.str()
+
+    LOG(INFO) << "success to submit task. type=" << type_str << ", signature=[" << succ_ss.str()
               << "], task_count_in_queue=" << queue_size;
 }
 

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -86,7 +86,7 @@ public:
     // Input parameters:
     // * task: the task need callback thread to do
     void submit_task(const TAgentTaskRequest& task);
-    void submit_tasks(std::vector<TAgentTaskRequest>* task);
+    void submit_tasks(const std::vector<const TAgentTaskRequest*>& task);
 
     AgentStatus get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
                                 TTabletInfo* tablet_info);

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1153,7 +1153,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
         return Status::NotFound(strings::Substitute("tablet $0 not fount", tablet_id));
     }
 
-    LOG(INFO) << "Start to drop tablet" << tablet_id;
+    LOG(INFO) << "Start to drop tablet " << tablet_id;
     TabletSharedPtr dropped_tablet = it->second;
     tablet_map.erase(it);
     _remove_tablet_from_partition(*dropped_tablet);
@@ -1196,7 +1196,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
         DCHECK_EQ(kKeepMetaAndFiles, flag);
     }
     dropped_tablet->deregister_tablet_from_dir();
-    LOG(INFO) << "Succeed to drop tablet" << tablet_id;
+    LOG(INFO) << "Succeed to drop tablet " << tablet_id;
     return Status::OK();
 }
 

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -147,14 +147,14 @@ bool valid_datetime(const std::string& value_str);
 bool valid_bool(const std::string& value_str);
 
 // Util used to get string name of thrift enum item
-#define EnumToString(enum_type, index, out)                                                         \
-    do {                                                                                            \
-        std::map<int, const char*>::const_iterator it = _##enum_type##_VALUES_TO_NAMES.find(index); \
-        if (it == _##enum_type##_VALUES_TO_NAMES.end()) {                                           \
-            out = "NULL";                                                                           \
-        } else {                                                                                    \
-            out = it->second;                                                                       \
-        }                                                                                           \
+#define EnumToString(enum_type, index, out)                   \
+    do {                                                      \
+        auto it = _##enum_type##_VALUES_TO_NAMES.find(index); \
+        if (it == _##enum_type##_VALUES_TO_NAMES.end()) {     \
+            out = "NULL";                                     \
+        } else {                                              \
+            out = it->second;                                 \
+        }                                                     \
     } while (0)
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10388 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

TAgentTaskRequest will consume a lot of memory (3K~4K), current the tasks vector will copy multi times, the pr refactor the code preparing to reduce the memory usage of task worker pool.

the first: tasks -> task_drvider

```
void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vector<TAgentTaskRequest>& tasks) {
    ...

    phmap::flat_hash_map<TTaskType::type, std::vector<TAgentTaskRequest>> task_divider;
    phmap::flat_hash_map<TPushType::type, std::vector<TAgentTaskRequest>> push_divider;
}
```

the second: copy to one tmp vector

```
    for (const auto& task_item : task_divider) {
        const auto& task_type = task_item.first;
        auto all_tasks = task_item.second;
```

the third: copy to the task worker queue

```
            for (auto const& task : *tasks) {
                _tasks.emplace_back(std::make_shared<TAgentTaskRequest>(task));
            }
```

the fourth: copy to the failed task
```
    std::vector<TAgentTaskRequest> failed_task_vec;
    EnumToString(TTaskType, task_type, type_str);
    {
        std::lock_guard task_signatures_lock(_s_task_signatures_locks[task_type]);
        const auto recv_time = time(nullptr);
        for (auto it = tasks->begin(); it != tasks->end();) {
            TAgentTaskRequest& task_req = *it;
            int64_t signature = task_req.signature;

            // batch register task info
            std::set<int64_t>& signature_set = _s_task_signatures[task_type];
            if (signature_set.insert(signature).second) {
                task_req.__set_recv_time(recv_time);
                ++it;
            } else {
                failed_task_vec.push_back(*it);
                it = tasks->erase(it);
            }
        }
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
