### PR TITLE
[BugFix] Fix in-subquery rewrite to cte bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -157,12 +157,18 @@ public class CTEContext {
 
     /*
      * Inline CTE consume sense:
+     * 0. All CTEConsumer been pruned
      * 1. Disable CTE reuse, must inline all CTE
      * 2. CTE consume only use once, it's meanings none CTE data reuse
      * 3. CTE ratio less zero
      * 4. limit CTE num strategy
      */
     public boolean needInline(int cteId) {
+        // 0. All CTEConsumer been pruned
+        if (!consumeNums.containsKey(cteId)) {
+            return true;
+        }
+
         if (forceCTEList.contains(cteId)) {
             return false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -611,7 +611,25 @@ public class CTEPlanTest extends PlanTestBase {
                 "select * from x6;";
         String plan = getFragmentPlan(sql);
         connectContext.getSessionVariable().setCboCTEMaxLimit(10);
-        System.out.println(plan);
         Assert.assertEquals(5, StringUtils.countMatches(plan, "MultiCastDataSinks"));
+    }
+
+    @Test
+    public void testAllCTEConsumePruned() throws Exception {
+        String sql = "select * from t0 where (abs(2) = 1 or v1 in (select v4 from t1)) and v1 = 2 and v1 = 5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  |----2:EXCHANGE\n" +
+                "  |    \n" +
+                "  0:EMPTYSET\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 02\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  1:EMPTYSET");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
Mysql > select * from t0 where (abs(2) = 1 or v1 in (select v4 from t1)) and v1 = 2 and v1 = 5;
(1064, "MultiCastPlanFragment don't support return result")
```

In-subquery rewrite to CTE-Plan, but CTEConsume transform to EmptyNode becase predicate (v1 = 2 and v1 =5) always false, but CTEProduce doesn't remove

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
