### PR TITLE
[BugFix] add dropped flag to avoid db dropped after db got from catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -660,7 +660,9 @@ public class Alter {
         List<Column> newFullSchema = alterViewInfo.getNewFullSchema();
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new DdlException("db has been dropped");
+        }
         try {
             View view = (View) db.getTable(tableId);
             String viewName = view.getName();
@@ -789,7 +791,10 @@ public class Alter {
 
     public void replayModifyPartition(ModifyPartitionInfo info) {
         Database db = GlobalStateMgr.getCurrentState().getDb(info.getDbId());
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            LOG.warn("db: {} has been dropped", info.getDbId());
+            return;
+        }
         try {
             OlapTable olapTable = (OlapTable) db.getTable(info.getTableId());
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -129,12 +129,10 @@ public class Alter {
         // check db quota
         db.checkQuota();
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-            }
             Table table = db.getTable(tableName);
             if (table.getType() != TableType.OLAP) {
                 throw new DdlException("Do not support alter non-OLAP table[" + tableName + "]");
@@ -165,12 +163,10 @@ public class Alter {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-            }
             Table table = null;
             if (stmt.getTblName() != null) {
                 table = db.getTable(stmt.getTblName());
@@ -233,12 +229,10 @@ public class Alter {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
         MaterializedView materializedView = null;
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-            }
             final Table table = db.getTable(oldMvName);
             if (table instanceof MaterializedView) {
                 materializedView = (MaterializedView) table;
@@ -412,12 +406,10 @@ public class Alter {
         boolean needProcessOutsideDatabaseLock = false;
         String tableName = dbTableName.getTbl();
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-            }
             Table table = db.getTable(tableName);
             if (table == null) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
@@ -511,12 +503,10 @@ public class Alter {
                 ((SchemaChangeHandler) schemaChangeHandler).updatePartitionsInMemoryMeta(
                         db, tableName, partitionNames, properties);
 
-                db.writeLock();
+                if (!db.writeLockAndExist()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+                }
                 try {
-                    // DCheck db exists
-                    if (db.isDropped()) {
-                        ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-                    }
                     OlapTable olapTable = (OlapTable) db.getTable(tableName);
                     modifyPartitionsProperty(db, olapTable, partitionNames, properties);
                 } finally {
@@ -622,12 +612,10 @@ public class Alter {
         }
 
         String tableName = dbTableName.getTbl();
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-            }
             Table table = db.getTable(tableName);
             if (table == null) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -131,6 +131,10 @@ public class Alter {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             Table table = db.getTable(tableName);
             if (table.getType() != TableType.OLAP) {
                 throw new DdlException("Do not support alter non-OLAP table[" + tableName + "]");
@@ -163,6 +167,10 @@ public class Alter {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             Table table = null;
             if (stmt.getTblName() != null) {
                 table = db.getTable(stmt.getTblName());
@@ -227,6 +235,10 @@ public class Alter {
         MaterializedView materializedView = null;
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             final Table table = db.getTable(oldMvName);
             if (table instanceof MaterializedView) {
                 materializedView = (MaterializedView) table;
@@ -402,6 +414,10 @@ public class Alter {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             Table table = db.getTable(tableName);
             if (table == null) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
@@ -497,6 +513,10 @@ public class Alter {
 
                 db.writeLock();
                 try {
+                    // DCheck db exists
+                    if (db.isDropped()) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+                    }
                     OlapTable olapTable = (OlapTable) db.getTable(tableName);
                     modifyPartitionsProperty(db, olapTable, partitionNames, properties);
                 } finally {
@@ -604,6 +624,10 @@ public class Alter {
         String tableName = dbTableName.getTbl();
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             Table table = db.getTable(tableName);
             if (table == null) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -215,10 +215,6 @@ public abstract class AlterJobV2 implements Writable {
 
         db.writeLock();
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new AlterCancelException("Database " + dbId + " does not exist");
-            }
             if (!isStable) {
                 errMsg = "table is unstable";
                 LOG.warn("wait table {} to be stable before doing {} job", tableId, type);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -215,6 +215,10 @@ public abstract class AlterJobV2 implements Writable {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new AlterCancelException("Database " + dbId + " does not exist");
+            }
             if (!isStable) {
                 errMsg = "table is unstable";
                 LOG.warn("wait table {} to be stable before doing {} job", tableId, type);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -213,7 +213,9 @@ public abstract class AlterJobV2 implements Writable {
             db.readUnlock();
         }
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new AlterCancelException("db: " + db.getFullName() + " has been dropped");
+        }
         try {
             if (!isStable) {
                 errMsg = "table is unstable";

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -717,12 +717,10 @@ public class MaterializedViewHandler extends AlterHandler {
 
     public void processBatchDropRollup(List<AlterClause> dropRollupClauses, Database db, OlapTable olapTable)
             throws DdlException, MetaNotFoundException {
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new MetaNotFoundException("db: " + db.getFullName() + " has been dropped");
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new MetaNotFoundException("db: " + db.getFullName() + " has been dropped");
-            }
             // check drop rollup index operation
             for (AlterClause alterClause : dropRollupClauses) {
                 DropRollupClause dropRollupClause = (DropRollupClause) alterClause;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -719,6 +719,10 @@ public class MaterializedViewHandler extends AlterHandler {
             throws DdlException, MetaNotFoundException {
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new MetaNotFoundException("db: " + db.getFullName() + " has been dropped");
+            }
             // check drop rollup index operation
             for (AlterClause alterClause : dropRollupClauses) {
                 DropRollupClause dropRollupClause = (DropRollupClause) alterClause;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1199,12 +1199,10 @@ public class SchemaChangeHandler extends AlterHandler {
             updatePartitionTabletMeta(db, olapTable.getName(), partition.getName(), metaValue, metaType);
         }
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new DdlException("db " + db.getFullName() + " has been dropped");
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new DdlException("db " + db.getFullName() + " has been dropped");
-            }
             GlobalStateMgr.getCurrentState().modifyTableMeta(db, olapTable, properties, metaType);
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1201,6 +1201,10 @@ public class SchemaChangeHandler extends AlterHandler {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new DdlException("db " + db.getFullName() + " has been dropped");
+            }
             GlobalStateMgr.getCurrentState().modifyTableMeta(db, olapTable, properties, metaType);
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -850,7 +850,10 @@ public class ColocateTableIndex implements Writable {
         Map<String, String> properties = info.getPropertyMap();
 
         Database db = GlobalStateMgr.getCurrentState().getDb(info.getGroupId().dbId);
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            LOG.warn("db: {} has been dropped", db.getFullName());
+            return;
+        }
         try {
             OlapTable table = (OlapTable) db.getTable(tableId);
             modifyTableColocate(db, table, properties.get(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH), true,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -33,7 +33,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
-import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -99,6 +99,8 @@ public class Database extends MetaObject implements Writable {
 
     private long lastSlowLockLogTime = 0;
 
+    private boolean dropped = false;
+
     public Database() {
         this(0, null);
     }
@@ -760,5 +762,13 @@ public class Database extends MetaObject implements Writable {
 
     public boolean isInfoSchemaDb() {
         return fullQualifiedName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME);
+    }
+
+    public void setDropped() {
+        dropped = true;
+    }
+
+    public boolean isDropped() {
+        return dropped;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -99,6 +99,10 @@ public class Database extends MetaObject implements Writable {
 
     private long lastSlowLockLogTime = 0;
 
+    // This param is used to make sure db not dropped when lead node writes wal,
+    // so this param need not to persist,
+    // and this param maybe not right when the db is dropped and the catalog has done a checkpoint,
+    // but that'ok to meet our needs.
     private boolean exist = true;
 
     public Database() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -99,7 +99,7 @@ public class Database extends MetaObject implements Writable {
 
     private long lastSlowLockLogTime = 0;
 
-    private boolean dropped = false;
+    private boolean exist = true;
 
     public Database() {
         this(0, null);
@@ -149,10 +149,9 @@ public class Database extends MetaObject implements Writable {
     @Deprecated
     // use readLockAndExist()
     public void readLock() {
-        readLockAndExist();
     }
 
-    // return false if the db has been dropped
+    // no
     public boolean readLockAndExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         Thread formerOwner = rwLock.getOwner();
@@ -812,7 +811,24 @@ public class Database extends MetaObject implements Writable {
     }
 
     // the invoker should hold db's writeLock
-    public void setDropped() {
-        dropped = true;
+    public void setExist(boolean exist) {
+        this.exist = exist;
+    }
+
+    public static class LockState {
+        boolean locked;
+        boolean exist;
+        public LockState(boolean locked, boolean exist) {
+            this.locked = locked;
+            this.exist = exist;
+        }
+
+        public boolean isLocked() {
+            return locked;
+        }
+
+        public boolean isExist() {
+            return exist;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -764,10 +764,12 @@ public class Database extends MetaObject implements Writable {
         return fullQualifiedName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME);
     }
 
+    // the invoker should hold db's writeLock
     public void setDropped() {
         dropped = true;
     }
 
+    // the invoker should hold db's lock(write or read)
     public boolean isDropped() {
         return dropped;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -307,12 +307,10 @@ public class ExternalOlapTable extends OlapTable {
         externalTableInfo.setTableId(meta.getTable_id());
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        if (db == null) {
+        if (db == null || !db.writeLockAndExist()) {
             throw new DdlException("database " + dbId + " does not exist");
         }
-        db.writeLock();
         long start = System.currentTimeMillis();
-
         try {
             lastExternalMeta = meta;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -281,12 +281,10 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             throw new DdlException("Not found database " + dbName);
         }
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new DdlException("Not found database " + dbName);
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new DdlException("Not found database " + dbName);
-            }
             fullSchema.clear();
             nameToColumn.clear();
             dataColumnNames.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -283,6 +283,10 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new DdlException("Not found database " + dbName);
+            }
             fullSchema.clear();
             nameToColumn.clear();
             dataColumnNames.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -194,7 +194,8 @@ public class ColocateTableBalancer extends LeaderDaemon {
             }
 
             boolean isGroupStable = true;
-            db.readLock();
+            // ignore the result, because the tablet in dropped db can still be repaired
+            db.readLockAndExist();
             try {
                 OUT:
                 for (Long tableId : tableIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -877,7 +877,8 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             return 0;
         }
 
-        db.readLock();
+        // ignore the result, because the tablet in dropped be should still be calculated.
+        db.readLockAndExist();
         try {
             OlapTable table = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tableId);
             if (table == null) {
@@ -1209,8 +1210,8 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             return result;
         }
 
+        db.readLock();
         try {
-            db.readLock();
             OlapTable table = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tableId);
             if (table == null) {
                 return result;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -339,13 +339,11 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
             }
 
             for (DropPartitionClause dropPartitionClause : dropPartitionClauses) {
-                db.writeLock();
+                if (!db.writeLockAndExist()) {
+                    iterator.remove();
+                    continue OUTER_LOOP;
+                }
                 try {
-                    // DCheck db exists
-                    if (db.isDropped()) {
-                        iterator.remove();
-                        continue OUTER_LOOP;
-                    }
                     GlobalStateMgr.getCurrentState().dropPartition(db, olapTable, dropPartitionClause);
                     clearDropPartitionFailedMsg(tableName);
                 } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -904,12 +904,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
         }
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
-            }
             OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tblId);
             if (olapTable == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -906,6 +906,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         }
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
+            }
             OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tblId);
             if (olapTable == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -575,12 +575,10 @@ public class TabletScheduler extends LeaderDaemon {
         }
 
         Pair<TabletStatus, TabletSchedCtx.Priority> statusPair;
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
-            }
             OlapTable tbl = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tabletCtx.getTblId());
             if (tbl == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -577,6 +577,10 @@ public class TabletScheduler extends LeaderDaemon {
         Pair<TabletStatus, TabletSchedCtx.Priority> statusPair;
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new SchedException(Status.UNRECOVERABLE, "db does not exist");
+            }
             OlapTable tbl = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tabletCtx.getTblId());
             if (tbl == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -205,7 +205,9 @@ public class CheckConsistencyJob {
 
         if (state != JobState.RUNNING) {
             // failed to send task. set tablet's checked version to avoid choosing it again
-            db.writeLock();
+            if (!db.writeLockAndExist()) {
+                return false;
+            }
             try {
                 tablet.setCheckedVersion(checkedVersion);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -252,6 +252,11 @@ public class CheckConsistencyJob {
         boolean isConsistent = true;
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                LOG.warn("db[{}] does not exist", tabletMeta.getDbId());
+                return -1;
+            }
             Table table = db.getTable(tabletMeta.getTableId());
             if (table == null) {
                 LOG.warn("table[{}] does not exist", tabletMeta.getTableId());

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -250,13 +250,11 @@ public class CheckConsistencyJob {
         }
 
         boolean isConsistent = true;
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            LOG.warn("db[{}] does not exist", tabletMeta.getDbId());
+            return -1;
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                LOG.warn("db[{}] does not exist", tabletMeta.getDbId());
-                return -1;
-            }
             Table table = db.getTable(tabletMeta.getTableId());
             if (table == null) {
                 LOG.warn("table[{}] does not exist", tabletMeta.getTableId());

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -370,7 +370,10 @@ public class ConsistencyChecker extends LeaderDaemon {
 
     public void replayFinishConsistencyCheck(ConsistencyCheckInfo info, GlobalStateMgr globalStateMgr) {
         Database db = globalStateMgr.getDb(info.getDbId());
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            LOG.warn("db: {} has been dropped", db.getFullName());
+            return;
+        }
         try {
             OlapTable table = (OlapTable) db.getTable(info.getTableId());
             Partition partition = table.getPartition(info.getPartitionId());

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -931,12 +931,10 @@ public class ReportHandler extends Daemon {
             if (db == null) {
                 continue;
             }
-            db.writeLock();
+            if (!db.writeLockAndExist()) {
+                continue;
+            }
             try {
-                // DCheck db exists
-                if (db.isDropped()) {
-                    continue;
-                }
                 List<Long> tabletIds = tabletRecoveryMap.get(dbId);
                 List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                 for (int i = 0; i < tabletMetaList.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -933,6 +933,10 @@ public class ReportHandler extends Daemon {
             }
             db.writeLock();
             try {
+                // DCheck db exists
+                if (db.isDropped()) {
+                    continue;
+                }
                 List<Long> tabletIds = tabletRecoveryMap.get(dbId);
                 List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                 for (int i = 0; i < tabletMetaList.size(); i++) {
@@ -1014,6 +1018,7 @@ public class ReportHandler extends Daemon {
 
         if (!backendTabletsInfo.isEmpty()) {
             // need to write edit log the sync the bad info to other FEs
+            //
             GlobalStateMgr.getCurrentState().getEditLog().logBackendTabletsInfo(backendTabletsInfo);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1016,7 +1016,6 @@ public class ReportHandler extends Daemon {
 
         if (!backendTabletsInfo.isEmpty()) {
             // need to write edit log the sync the bad info to other FEs
-            //
             GlobalStateMgr.getCurrentState().getEditLog().logBackendTabletsInfo(backendTabletsInfo);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -10,6 +10,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
@@ -193,15 +194,15 @@ public class InsertOverwriteJobRunner {
         }
     }
 
-    private void createTempPartitions() {
+    private void createTempPartitions() throws MetaNotFoundException {
         try {
             long createPartitionStartTimestamp = System.currentTimeMillis();
             PartitionUtils.createAndAddTempPartitionsForTable(db, targetTable, postfix,
                     job.getSourcePartitionIds(), job.getTmpPartitionIds());
             createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;
-        } catch (Throwable t) {
-            LOG.warn("create temp partitions failed", t);
-            throw t;
+        } catch (MetaNotFoundException e) {
+            LOG.warn("create temp partitions failed", e);
+            throw e;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -15,7 +15,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.persist.AddPartitionsInfo;
 import com.starrocks.persist.PartitionPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
-import org.apache.hudi.exception.MetadataNotFoundException;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -26,12 +26,10 @@ public class PartitionUtils {
         try {
             List<Partition> newTempPartitions = GlobalStateMgr.getCurrentState().createTempPartitionsFromPartitions(
                     db, targetTable, postfix, sourcePartitionIds, tmpPartitionIds);
-            db.writeLock();
+            if (!db.writeLockAndExist()) {
+                throw new MetaNotFoundException("db " + db.getFullName() + " has been dropped");
+            }
             try {
-                // DCheck db exists
-                if (db.isDropped()) {
-                    throw new MetaNotFoundException("db " + db.getFullName() + " has been dropped");
-                }
                 List<Partition> sourcePartitions = sourcePartitionIds.stream()
                         .map(id -> targetTable.getPartition(id)).collect(Collectors.toList());
                 PartitionInfo partitionInfo = targetTable.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -282,6 +282,10 @@ public class BrokerLoadJob extends BulkLoadJob {
         }
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new MetaNotFoundException("Database " + dbId + " already has been deleted");
+            }
             LOG.info(new LogBuilder(LogKey.LOAD_JOB, id)
                     .add("txn_id", transactionId)
                     .add("msg", "Load job try to commit txn")

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -54,7 +54,6 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import scala.xml.dtd.impl.Base;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -149,12 +149,10 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
 
     private void updateMeta(ExecPlan execPlan) throws MetaNotFoundException {
         // update the meta if succeed
-        database.writeLock();
+        if (!database.writeLockAndExist()) {
+            throw new MetaNotFoundException("db " + database.getFullName() + " has been dropped");
+        }
         try {
-            // DCheck db exists
-            if (database.isDropped()) {
-                throw new MetaNotFoundException("db " + database.getFullName() + " has been dropped");
-            }
             MaterializedView.AsyncRefreshContext refreshContext =
                     materializedView.getRefreshScheme().getAsyncRefreshContext();
             Map<Long, Map<String, MaterializedView.BasePartitionInfo>> currentlVersionMap =
@@ -542,12 +540,10 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     private void dropPartition(Database database, MaterializedView materializedView, String mvPartitionName)
             throws MetaNotFoundException {
         String dropPartitionName = materializedView.getPartition(mvPartitionName).getName();
-        database.writeLock();
+        if (!database.writeLockAndExist()) {
+            throw new MetaNotFoundException("db " + database.getFullName() + " has been dropped");
+        }
         try {
-            // DCheck db exists
-            if (database.isDropped()) {
-                throw new MetaNotFoundException("db " + database.getFullName() + " has been dropped");
-            }
             GlobalStateMgr.getCurrentState().dropPartition(
                     database, materializedView,
                     new DropPartitionClause(false, dropPartitionName, false, true));

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -369,6 +369,9 @@ public class LocalMetastore implements ConnectorMetadata {
     public void unprotectCreateDb(Database db) {
         idToDb.put(db.getId(), db);
         fullNameToDb.put(db.getFullName(), db);
+        db.writeLockAndExist();
+        db.setExist(true);
+        db.writeUnlock();
         final Cluster cluster = defaultCluster;
         cluster.addDb(db.getFullName(), db.getId());
         stateMgr.getGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());
@@ -419,7 +422,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } else {
                     stateMgr.onEraseDatabase(db.getId());
                 }
-                db.setDropped();
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }
@@ -468,6 +471,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } else {
                     stateMgr.onEraseDatabase(db.getId());
                 }
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }
@@ -509,6 +513,9 @@ public class LocalMetastore implements ConnectorMetadata {
 
             fullNameToDb.put(db.getFullName(), db);
             idToDb.put(db.getId(), db);
+            db.writeLockAndExist();
+            db.setExist(true);
+            db.writeUnlock();
             final Cluster cluster = defaultCluster;
             cluster.addDb(db.getFullName(), db.getId());
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -162,12 +162,10 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             throw new MetaNotFoundException("database " + getDbId() + " does not exist");
         }
 
-        db.writeLock();
+        if (!db.writeLockAndExist()) {
+            throw new MetaNotFoundException("database " + getDbId() + " does not exist");
+        }
         try {
-            // DCheck db exists
-            if (db.isDropped()) {
-                throw new MetaNotFoundException("database " + getDbId() + " does not exist");
-            }
             OlapTable tbl = (OlapTable) db.getTable(getTableId());
             if (tbl == null) {
                 throw new MetaNotFoundException("tbl " + getTableId() + " does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -164,6 +164,10 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
 
         db.writeLock();
         try {
+            // DCheck db exists
+            if (db.isDropped()) {
+                throw new MetaNotFoundException("database " + getDbId() + " does not exist");
+            }
             OlapTable tbl = (OlapTable) db.getTable(getTableId());
             if (tbl == null) {
                 throw new MetaNotFoundException("tbl " + getTableId() + " does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -846,7 +846,7 @@ public class DatabaseTransactionMgr {
         }
 
         Database db = globalStateMgr.getDb(transactionState.getDbId());
-        if (db == null) {
+        if (db == null || !db.writeLockAndExist()) {
             writeLock();
             try {
                 transactionState.setTransactionStatus(TransactionStatus.ABORTED);
@@ -859,7 +859,6 @@ public class DatabaseTransactionMgr {
             }
         }
         Span finishSpan = TraceManager.startSpan("finishTransaction", transactionState.getTxnSpan());
-        db.writeLock();
         try {
             boolean hasError = false;
             for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
@@ -1584,7 +1583,7 @@ public class DatabaseTransactionMgr {
 
     public void finishTransactionNew(TransactionState transactionState, Set<Long> publishErrorReplicas) throws UserException {
         Database db = globalStateMgr.getDb(transactionState.getDbId());
-        if (db == null) {
+        if (db == null || !db.writeLockAndExist()) {
             writeLock();
             try {
                 transactionState.setTransactionStatus(TransactionStatus.ABORTED);
@@ -1597,7 +1596,6 @@ public class DatabaseTransactionMgr {
             }
         }
         Span finishSpan = TraceManager.startSpan("finishTransaction", transactionState.getTxnSpan());
-        db.writeLock();
         finishSpan.addEvent("db_lock");
         try {
             boolean txnOperated = false;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1598,7 +1598,6 @@ public class DatabaseTransactionMgr {
         }
         Span finishSpan = TraceManager.startSpan("finishTransaction", transactionState.getTxnSpan());
         db.writeLock();
-        finishSpan.addEvent("db_lock");
         try {
             boolean txnOperated = false;
             writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1598,6 +1598,7 @@ public class DatabaseTransactionMgr {
         }
         Span finishSpan = TraceManager.startSpan("finishTransaction", transactionState.getTxnSpan());
         db.writeLock();
+        finishSpan.addEvent("db_lock");
         try {
             boolean txnOperated = false;
             writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -364,7 +364,7 @@ public class GlobalTransactionMgr implements Writable {
         VisibleStateWaiter waiter;
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
-        if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        if (!db.tryWriteLockAndExist(timeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new UserException("get database write lock timeout, database="
                     + db.getFullName() + ", timeoutMillis=" + timeoutMillis);
         }
@@ -396,7 +396,7 @@ public class GlobalTransactionMgr implements Writable {
             throws UserException {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
-        if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        if (!db.tryWriteLockAndExist(timeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new UserException("get database write lock timeout, database="
                     + db.getOriginName() + ", timeoutMillis=" + timeoutMillis);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -366,7 +366,7 @@ public class GlobalTransactionMgr implements Writable {
         stopWatch.start();
         if (!db.tryWriteLockAndExist(timeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new UserException("get database write lock timeout, database="
-                    + db.getFullName() + ", timeoutMillis=" + timeoutMillis);
+                    + db.getFullName() + ", timeoutMillis=" + timeoutMillis + ", or it has been dropped");
         }
         try {
             waiter = getDatabaseTransactionMgr(db.getId()).commitPreparedTransaction(transactionId);
@@ -398,7 +398,7 @@ public class GlobalTransactionMgr implements Writable {
         stopWatch.start();
         if (!db.tryWriteLockAndExist(timeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new UserException("get database write lock timeout, database="
-                    + db.getOriginName() + ", timeoutMillis=" + timeoutMillis);
+                    + db.getOriginName() + ", timeoutMillis=" + timeoutMillis + ", or it has been dropped");
         }
         VisibleStateWaiter waiter;
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -135,11 +135,11 @@ public class DatabaseTest {
         // drop not exist tableFamily
         db.dropTable("invalid");
         Assert.assertEquals(1, db.getTables().size());
-        db.dropTableWithLock("invalid");
+        db.dropTable("invalid");
         Assert.assertEquals(1, db.getTables().size());
 
         // drop normal
-        db.dropTableWithLock(table.getName());
+        db.dropTable(table.getName());
         Assert.assertEquals(0, db.getTables().size());
 
         db.createTable(table);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -34,7 +34,7 @@ public class InfoSchemaDbTest {
         Assert.assertFalse(db.createTable(null));
         Assert.assertFalse(db.createTableWithLock(null, false));
         db.dropTable("authors");
-        db.dropTableWithLock("authors");
+        db.dropTable("authors");
         db.write(null);
         Assert.assertNull(db.getTable("authors"));
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10381
Fixes #10346

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Many places call db.writelock after getting db from catalog, and then write bdb log. But after getting db from catalog, the db may still be dropped, which will cause the NPE error when replay bdb log. So add a dropped flag to cover this case. The set and check of dropped flag should be in the db lock.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
