### PR TITLE
[branch-2.3] [cherry-pick] [Enhancement] Modify the default config for tcmalloc gc (#10252)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -46,9 +46,9 @@ CONF_String(priority_networks, "");
 //// tcmalloc gc parameter
 ////
 // Min memory for TCmalloc, when used memory is smaller than this, do not returned to OS.
-CONF_mInt64(tc_use_memory_min, "10737418240");
+CONF_mInt64(tc_use_memory_min, "0");
 // free memory rate.[0-100]
-CONF_mInt64(tc_free_memory_rate, "20");
+CONF_mInt64(tc_free_memory_rate, "0");
 // tcmalloc gc period, default 60, it should be between [1, 180]
 CONF_mInt64(tc_gc_period, "60");
 


### PR DESCRIPTION
The main purpose of these two BE configurations is to reserve a part of free memory for BE, and not to return to the OS. Next time you apply for memory again, the performance will be better.

At present, BE has already supported the release of free memory to the OS gradually

At present, this has caused doubts among many users, thinking it is a memory leak, why the memory can't come down when it goes up.

Later, if we turn on jemalloc by default, this configuration is meaningless.
