### PR TITLE
[BugFix] validate privilege before grant to role

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -828,24 +828,27 @@ public class Auth implements Writable {
                                PrivBitSet privs, boolean errOnNonExist, boolean isReplay)
             throws DdlException {
 
-        // check privilege
-        switch (tblPattern.getPrivLevel()) {
-            case DATABASE:
-                if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-                    throw new DdlException(
-                            "Db privilege can not contains global or resource or impersonate privileges: " + privs);
-                }
-                break;
+        if (! isReplay) {
+            // check privilege only on leader, in case of replaying old journal
+            switch (tblPattern.getPrivLevel()) {
+                case DATABASE:
+                    if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
+                        throw new DdlException(
+                                "Db privilege can not contains global or resource or impersonate privileges: " + privs);
+                    }
+                    break;
 
-            case TABLE:
-                if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-                    throw new DdlException(
-                            "Table privilege can not contains global or resource or impersonate privileges: " + privs);
-                }
-                break;
+                case TABLE:
+                    if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
+                        throw new DdlException(
+                                "Table privilege can not contains global or resource or impersonate privileges: " +
+                                        privs);
+                    }
+                    break;
 
-            default:
-                break;
+                default:
+                    break;
+            }
         }
         writeLock();
         try {
@@ -877,16 +880,19 @@ public class Auth implements Writable {
 
     private void grantInternal(UserIdentity userIdent, String role, ResourcePattern resourcePattern, PrivBitSet privs,
                                boolean errOnNonExist, boolean isReplay) throws DdlException {
-        // check privilege
-        switch (resourcePattern.getPrivLevel()) {
-            case RESOURCE:
-                if (privs.containsNodePriv() || privs.containsDbTablePriv() || privs.containsImpersonatePriv()) {
-                    throw new DdlException(
-                            "Resource privilege can not contains node or db or table or impersonate privileges: " + privs);
-                }
-                break;
-            default:
-                break;
+        if (! isReplay) {
+            // check privilege only on leader, in case of replaying old journal
+            switch (resourcePattern.getPrivLevel()) {
+                case RESOURCE:
+                    if (privs.containsNodePriv() || privs.containsDbTablePriv() || privs.containsImpersonatePriv()) {
+                        throw new DdlException(
+                                "Resource privilege can not contains node or db or table or impersonate privileges: " +
+                                        privs);
+                    }
+                    break;
+                default:
+                    break;
+            }
         }
 
         writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -828,21 +828,18 @@ public class Auth implements Writable {
                                PrivBitSet privs, boolean errOnNonExist, boolean isReplay)
             throws DdlException {
 
-        if (! isReplay) {
+        if (!isReplay) {
             // check privilege only on leader, in case of replaying old journal
             switch (tblPattern.getPrivLevel()) {
                 case DATABASE:
                     if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-                        throw new DdlException(
-                                "Db privilege can not contains global or resource or impersonate privileges: " + privs);
+                        throw new DdlException("Some of the privileges are not for database: " + privs);
                     }
                     break;
 
                 case TABLE:
                     if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-                        throw new DdlException(
-                                "Table privilege can not contains global or resource or impersonate privileges: " +
-                                        privs);
+                        throw new DdlException("Some of the privileges are not for table: " + privs);
                     }
                     break;
 
@@ -880,14 +877,12 @@ public class Auth implements Writable {
 
     private void grantInternal(UserIdentity userIdent, String role, ResourcePattern resourcePattern, PrivBitSet privs,
                                boolean errOnNonExist, boolean isReplay) throws DdlException {
-        if (! isReplay) {
+        if (!isReplay) {
             // check privilege only on leader, in case of replaying old journal
             switch (resourcePattern.getPrivLevel()) {
                 case RESOURCE:
                     if (privs.containsNodePriv() || privs.containsDbTablePriv() || privs.containsImpersonatePriv()) {
-                        throw new DdlException(
-                                "Resource privilege can not contains node or db or table or impersonate privileges: " +
-                                        privs);
+                        throw new DdlException("Some of the privileges are not for resource: " + privs);
                     }
                     break;
                 default:

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -827,6 +827,26 @@ public class Auth implements Writable {
     private void grantInternal(UserIdentity userIdent, String role, TablePattern tblPattern,
                                PrivBitSet privs, boolean errOnNonExist, boolean isReplay)
             throws DdlException {
+
+        // check privilege
+        switch (tblPattern.getPrivLevel()) {
+            case DATABASE:
+                if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
+                    throw new DdlException(
+                            "Db privilege can not contains global or resource or impersonate privileges: " + privs);
+                }
+                break;
+
+            case TABLE:
+                if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
+                    throw new DdlException(
+                            "Table privilege can not contains global or resource or impersonate privileges: " + privs);
+                }
+                break;
+
+            default:
+                break;
+        }
         writeLock();
         try {
             if (role != null) {
@@ -857,6 +877,18 @@ public class Auth implements Writable {
 
     private void grantInternal(UserIdentity userIdent, String role, ResourcePattern resourcePattern, PrivBitSet privs,
                                boolean errOnNonExist, boolean isReplay) throws DdlException {
+        // check privilege
+        switch (resourcePattern.getPrivLevel()) {
+            case RESOURCE:
+                if (privs.containsNodePriv() || privs.containsDbTablePriv() || privs.containsImpersonatePriv()) {
+                    throw new DdlException(
+                            "Resource privilege can not contains node or db or table or impersonate privileges: " + privs);
+                }
+                break;
+            default:
+                break;
+        }
+
         writeLock();
         try {
             if (role != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
@@ -61,10 +61,6 @@ public class DbPrivEntry extends PrivEntry {
 
     public static DbPrivEntry create(String host, String db, String user, boolean isDomain, PrivBitSet privs)
             throws AnalysisException {
-        if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-            throw new AnalysisException(
-                    "Db privilege can not contains global or resource or impersonate privileges: " + privs);
-        }
         DbPrivEntry dbPrivEntry = new DbPrivEntry(host, user, isDomain, privs, db);
         dbPrivEntry.analyse();
         return dbPrivEntry;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivEntry.java
@@ -57,10 +57,6 @@ public class ResourcePrivEntry extends PrivEntry {
     public static ResourcePrivEntry create(String host, String resourceName, String user, boolean isDomain,
                                            PrivBitSet privs)
             throws AnalysisException {
-        if (privs.containsNodePriv() || privs.containsDbTablePriv() || privs.containsImpersonatePriv()) {
-            throw new AnalysisException(
-                    "Resource privilege can not contains node or db or table or impersonate privileges: " + privs);
-        }
 
         ResourcePrivEntry resourcePrivEntry = new ResourcePrivEntry(host, user, isDomain, privs, resourceName);
         resourcePrivEntry.analyse();

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivEntry.java
@@ -56,10 +56,6 @@ public class TablePrivEntry extends DbPrivEntry {
 
     public static TablePrivEntry create(String host, String db, String user, String tbl, boolean isDomain,
                                         PrivBitSet privs) throws AnalysisException {
-        if (privs.containsNodePriv() || privs.containsResourcePriv() || privs.containsImpersonatePriv()) {
-            throw new AnalysisException(
-                    "Table privilege can not contains global or resource or impersonate privileges: " + privs);
-        }
 
         TablePrivEntry tablePrivEntry = new TablePrivEntry(host, user, isDomain, privs, db, tbl);
         tablePrivEntry.analyse();

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -1219,6 +1219,20 @@ public class AuthTest {
         Assert.assertEquals(false, auth.checkDbPriv(userIdentity, dbName, PrivPredicate.LOAD));
         Assert.assertEquals(false, auth.checkResourcePriv(userIdentity, resouceName, PrivPredicate.USAGE));
         Assert.assertEquals(1, auth.getRoleNamesByUser(userIdentity).size());
+
+        // 9. grant usage on db
+        boolean hasException = false;
+        try {
+            privileges = Lists.newArrayList(AccessPrivilege.USAGE_PRIV);
+            tablePattern = new TablePattern("db1", "*");
+            grantStmt = new GrantStmt(null, selectRoleName, tablePattern, privileges);
+            grantStmt.analyze(analyzer);
+            auth.grant(grantStmt);
+        } catch (DdlException e) {
+            // expect exception;
+            hasException = true;
+        }
+        Assert.assertTrue(hasException);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10414 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the previous implementation, privileges will only be validated before granting to a user. 
Suppose we're granting a `USAGE` privilege on a database; since the `USAGE` privilege is only meaningful on resources like Spark, this action should end in error. Unfortunately, it will execute successfully when granted to a role.

```
grant usage_priv on db.* to role 'role1';
Query OK, 0 rows affected (0.01 sec)
grant usage_priv on db.* to user;
ERROR 1064 (HY000): Db privilege can not contains global or resource or impersonate privileges: Usage_priv
```

This PR validates privilege before adding to RoleManager or PrivTable.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
