### PR TITLE
use double instead of decimal128(38,9) to compute variance and stddev…

### DIFF
--- a/be/src/exprs/vectorized/arithmetic_operation.h
+++ b/be/src/exprs/vectorized/arithmetic_operation.h
@@ -229,7 +229,7 @@ public:
     }
 
     Type value() const { return _value; }
-    Type double_value() const {
+    double double_value() const {
         double result = 0;
         DecimalV3Cast::to_float<Type, double>(_value, scale_factor, &result);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -491,6 +491,18 @@ public class FunctionSet {
             .add(FunctionSet.FIRST_VALUE_REWRITE)
             .build();
 
+    public static final Set<String> varianceFunctions = ImmutableSet.<String>builder()
+            .add(FunctionSet.VAR_POP)
+            .add(FunctionSet.VAR_SAMP)
+            .add(FunctionSet.VARIANCE)
+            .add(FunctionSet.VARIANCE_POP)
+            .add(FunctionSet.VARIANCE_SAMP)
+            .add(FunctionSet.STD)
+            .add(FunctionSet.STDDEV)
+            .add(FunctionSet.STDDEV_POP)
+            .add(FunctionSet.STDDEV_SAMP)
+            .add(FunctionSet.STDDEV_VAL).build();
+
     public FunctionSet() {
         vectorizedFunctions = Maps.newHashMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -553,6 +553,13 @@ public class ExpressionAnalyzer {
                 // lacking of specific decimal type process defined in `getDecimalV3Function`. So we force round functions
                 // to go through `getDecimalV3Function` here
                 if (FunctionSet.varianceFunctions.contains(fnName)) {
+                    // When decimal values are too small, the stddev and variance alogrithm of decimal-version do not
+                    // work incorrectly. because we use decimal128(38,9) multiplication in this algorithm,
+                    // decimal128(38,9) * decimal128(38,9) produces a result of decimal128(38,9). if two numbers are
+                    // too small, for an example, 0.000000001 * 0.000000001 produces 0.000000000, so the algorithm
+                    // can not work. Because of this reason, stddev and variance on very small decimal numbers always
+                    // yields a zero, so we use double instead of decimal128(38,9) to compute stddev and variance of
+                    // decimal types.
                     Type[] doubleArgTypes = Stream.of(argumentTypes).map(t -> Type.DOUBLE).toArray(Type[]::new);
                     fn = Expr.getBuiltinFunction(fnName, doubleArgTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -304,7 +304,8 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimal32Stddev() throws Exception {
         String sql = "select stddev(col_decimal32p9s2) from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))";
+        String snippet = "aggregate: stddev[(cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DOUBLE)); " +
+                "args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]";
         Assert.assertTrue(plan.contains(snippet));
     }
 
@@ -312,7 +313,8 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     public void testDecimal32Variance() throws Exception {
         String sql = "select variance(col_decimal32p9s2) from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))";
+        String snippet = "aggregate: variance[(cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DOUBLE)); " +
+                "args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]";
         Assert.assertTrue(plan.contains(snippet));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -794,7 +794,6 @@ public class AnalyzeDecimalV3Test {
                 Assert.assertEquals(((FunctionCallExpr) expr).getFn().getReturnType(), Type.DOUBLE);
                 Assert.assertEquals(((AggregateFunction) ((FunctionCallExpr) expr).getFn()).getIntermediateType(),
                         Type.VARCHAR);
-                Assert.assertEquals(expr.getChild(0).getType(), Type.DOUBLE);
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -787,15 +787,14 @@ public class AnalyzeDecimalV3Test {
             List<Expr> items = ((SelectRelation) queryRelation).getOutputExpr();
 
             Assert.assertEquals(items.size(), 24);
-            Type decimal128p38s9 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
             for (int i = 0; i < items.size(); ++i) {
                 Expr expr = items.get(i);
-                Assert.assertEquals(expr.getType(), decimal128p38s9);
-                Assert.assertEquals(((FunctionCallExpr) expr).getFn().getArgs()[0], decimal128p38s9);
-                Assert.assertEquals(((FunctionCallExpr) expr).getFn().getReturnType(), decimal128p38s9);
+                Assert.assertEquals(expr.getType(), Type.DOUBLE);
+                Assert.assertEquals(((FunctionCallExpr) expr).getFn().getArgs()[0], Type.DOUBLE);
+                Assert.assertEquals(((FunctionCallExpr) expr).getFn().getReturnType(), Type.DOUBLE);
                 Assert.assertEquals(((AggregateFunction) ((FunctionCallExpr) expr).getFn()).getIntermediateType(),
                         Type.VARCHAR);
-                Assert.assertEquals(expr.getChild(0).getType(), decimal128p38s9);
+                Assert.assertEquals(expr.getChild(0).getType(), Type.DOUBLE);
             }
         }
     }


### PR DESCRIPTION
… of decimal type

## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When decimal values are too small, the stddev and variance alogrithm of decimal-version do not work incorrectly. because we use decimal128(38,9) multiplication in this algorithm,  decimal128(38,9) * decimal128(38,9) produces a result of  decimal128(38,9). if two numbers are too small, for an example, 0.000000001 * 0.000000001 produces 0.000000000, so the algorithm can not work. the code snippet.
```cpp
    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                size_t row_num) const override {
        DCHECK(columns[0]->is_numeric() || columns[0]->is_decimal());

        const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);

        int64_t temp = 1 + this->data(state).count;

        TResult delta;
        delta = column->get_data()[row_num] - this->data(state).mean;

        TResult r;
        if constexpr (pt_is_decimalv2<PT>) {
            r = delta / DecimalV2Value(temp, 0);
        } else if constexpr (pt_is_decimal128<PT>) {
            r = (Decimal128P38S9(delta) / temp).value();
        } else {
            r = delta / temp;
        }

        this->data(state).mean += r;
        if constexpr (pt_is_decimalv2<PT>) {
            this->data(state).m2 += DecimalV2Value(this->data(state).count, 0) * delta * r;
        } else if constexpr (pt_is_decimal128<PT>) {
            this->data(state).m2 += this->data(state).count * (Decimal128P38S9(delta) * Decimal128P38S9(r)).value();
        } else {
            this->data(state).m2 += this->data(state).count * delta * r;
        }

        this->data(state).count = temp;
    }
```
because of this reason, stddev and variance on very small decimal numers always yields a zero.
so we use double instead of decimal128(38,9) to compute stddev and variance of decimal types.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
