### PR TITLE
[Bugfix] "SHOW MATERIALIZED VIEW" should return a sql text like "CREATE MATERIALIZED VIEW xxx" for async materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -331,7 +331,7 @@ public class ShowExecutor {
                 }
                 MaterializedView mvTable = (MaterializedView) materializedView;
                 List<String> resultRow = Lists.newArrayList(String.valueOf(mvTable.getId()), mvTable.getName(), dbName,
-                        GlobalStateMgr.getMaterializedViewDdtStmt(mvTable), String.valueOf(mvTable.getRowCount()));
+                        GlobalStateMgr.getMaterializedViewDdlStmt(mvTable), String.valueOf(mvTable.getRowCount()));
                 rowSets.add(resultRow);
             }
             for (Table table : db.getTables()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -331,7 +331,7 @@ public class ShowExecutor {
                 }
                 MaterializedView mvTable = (MaterializedView) materializedView;
                 List<String> resultRow = Lists.newArrayList(String.valueOf(mvTable.getId()), mvTable.getName(), dbName,
-                        mvTable.getViewDefineSql(), String.valueOf(mvTable.getRowCount()));
+                        GlobalStateMgr.getMaterializedViewDdtStmt(mvTable), String.valueOf(mvTable.getRowCount()));
                 rowSets.add(resultRow);
             }
             for (Table table : db.getTables()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1814,7 +1814,7 @@ public class GlobalStateMgr {
         localMetastore.replayRecoverPartition(info);
     }
 
-    public static String getMaterializedViewDdtStmt(MaterializedView mv) {
+    public static String getMaterializedViewDdlStmt(MaterializedView mv) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE MATERIALIZED VIEW `").append(mv.getName()).append("`");
         if (!Strings.isNullOrEmpty(mv.getComment())) {
@@ -1891,7 +1891,7 @@ public class GlobalStateMgr {
         // 1.1 materialized view
         if (table.getType() == TableType.MATERIALIZED_VIEW) {
             MaterializedView mv = (MaterializedView) table;
-            createTableStmt.add(getMaterializedViewDdtStmt(mv));
+            createTableStmt.add(getMaterializedViewDdlStmt(mv));
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1814,6 +1814,70 @@ public class GlobalStateMgr {
         localMetastore.replayRecoverPartition(info);
     }
 
+    public static String getMaterializedViewDdtStmt(MaterializedView mv) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE MATERIALIZED VIEW `").append(mv.getName()).append("`");
+        if (!Strings.isNullOrEmpty(mv.getComment())) {
+            sb.append("\nCOMMENT \"").append(mv.getComment()).append("\"");
+        }
+
+        // partition
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (!(partitionInfo instanceof SinglePartitionInfo)) {
+            sb.append("\n").append(partitionInfo.toSql(mv, null));
+        }
+
+        // distribution
+        DistributionInfo distributionInfo = mv.getDefaultDistributionInfo();
+        sb.append("\n").append(distributionInfo.toSql());
+
+        // refresh schema
+        MaterializedView.MvRefreshScheme refreshScheme = mv.getRefreshScheme();
+        sb.append("\nREFRESH ").append(refreshScheme.getType());
+        if (refreshScheme.getType() == MaterializedView.RefreshType.ASYNC) {
+            MaterializedView.AsyncRefreshContext asyncRefreshContext = refreshScheme.getAsyncRefreshContext();
+            if (asyncRefreshContext.isDefineStartTime()) {
+                sb.append(" START(\"").append(Utils.getDatetimeFromLong(asyncRefreshContext.getStartTime())
+                                .format(DateUtils.DATE_TIME_FORMATTER))
+                        .append("\")");
+            }
+            if (asyncRefreshContext.getTimeUnit() != null) {
+                sb.append(" EVERY(INTERVAL ").append(asyncRefreshContext.getStep()).append(" ")
+                        .append(asyncRefreshContext.getTimeUnit()).append(")");
+            }
+        }
+
+        // properties
+        sb.append("\nPROPERTIES (\n");
+
+        // replicationNum
+        Short replicationNum = mv.getDefaultReplicationNum();
+        sb.append("\"").append(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM).append("\" = \"");
+        sb.append(replicationNum).append("\"");
+
+        // storageMedium
+        String storageMedium = mv.getStorageMedium();
+        sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)
+                .append("\" = \"");
+        sb.append(storageMedium).append("\"");
+
+        // storageCooldownTime
+        Map<String, String> properties = mv.getTableProperty().getProperties();
+        if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)) {
+            sb.append("\n");
+        } else {
+            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)
+                    .append("\" = \"");
+            sb.append(TimeUtils.longToTimeString(
+                    Long.parseLong(properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)))).append("\"");
+            sb.append("\n");
+        }
+        sb.append(")");
+        sb.append("\nAS ").append(mv.getViewDefineSql());
+        sb.append(";");
+        return sb.toString();
+    }
+
     public static void getDdlStmt(Table table, List<String> createTableStmt, List<String> addPartitionStmt,
                                   List<String> createRollupStmt, boolean separatePartition,
                                   boolean hidePassword) {
@@ -1823,74 +1887,15 @@ public class GlobalStateMgr {
     public static void getDdlStmt(String dbName, Table table, List<String> createTableStmt,
                                   List<String> addPartitionStmt,
                                   List<String> createRollupStmt, boolean separatePartition, boolean hidePassword) {
-        StringBuilder sb = new StringBuilder();
-
         // 1. create table
         // 1.1 materialized view
         if (table.getType() == TableType.MATERIALIZED_VIEW) {
             MaterializedView mv = (MaterializedView) table;
-            sb.append("CREATE MATERIALIZED VIEW `").append(table.getName()).append("`");
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
-
-            // partition
-            PartitionInfo partitionInfo = mv.getPartitionInfo();
-            if (!(partitionInfo instanceof SinglePartitionInfo)) {
-                sb.append("\n").append(partitionInfo.toSql(mv, null));
-            }
-
-            // distribution
-            DistributionInfo distributionInfo = mv.getDefaultDistributionInfo();
-            sb.append("\n").append(distributionInfo.toSql());
-
-            // refresh schema
-            MaterializedView.MvRefreshScheme refreshScheme = mv.getRefreshScheme();
-            sb.append("\nREFRESH ").append(refreshScheme.getType());
-            if (refreshScheme.getType() == MaterializedView.RefreshType.ASYNC) {
-                MaterializedView.AsyncRefreshContext asyncRefreshContext = refreshScheme.getAsyncRefreshContext();
-                if (asyncRefreshContext.isDefineStartTime()) {
-                    sb.append(" START(\"").append(Utils.getDatetimeFromLong(asyncRefreshContext.getStartTime())
-                                    .format(DateUtils.DATE_TIME_FORMATTER))
-                            .append("\")");
-                }
-                if (asyncRefreshContext.getTimeUnit() != null) {
-                    sb.append(" EVERY(INTERVAL ").append(asyncRefreshContext.getStep()).append(" ")
-                            .append(asyncRefreshContext.getTimeUnit()).append(")");
-                }
-            }
-
-            // properties
-            sb.append("\nPROPERTIES (\n");
-
-            // replicationNum
-            Short replicationNum = mv.getDefaultReplicationNum();
-            sb.append("\"").append(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM).append("\" = \"");
-            sb.append(replicationNum).append("\"");
-
-            // storageMedium
-            String storageMedium = mv.getStorageMedium();
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)
-                    .append("\" = \"");
-            sb.append(storageMedium).append("\"");
-
-            // storageCooldownTime
-            Map<String, String> properties = mv.getTableProperty().getProperties();
-            if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)) {
-                sb.append("\n");
-            } else {
-                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)
-                        .append("\" = \"");
-                sb.append(TimeUtils.longToTimeString(
-                        Long.parseLong(properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME)))).append("\"");
-                sb.append("\n");
-            }
-            sb.append(")");
-            sb.append("\nAS ").append(mv.getViewDefineSql());
-            sb.append(";");
-            createTableStmt.add(sb.toString());
+            createTableStmt.add(getMaterializedViewDdtStmt(mv));
             return;
         }
+
+        StringBuilder sb = new StringBuilder();
         // 1.2 view
         if (table.getType() == TableType.VIEW) {
             View view = (View) table;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -37,9 +37,12 @@ import com.starrocks.analysis.ShowProcedureStmt;
 import com.starrocks.analysis.ShowRoutineLoadStmt;
 import com.starrocks.analysis.ShowUserStmt;
 import com.starrocks.analysis.ShowVariablesStmt;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.ListPartitionInfoTest;
 import com.starrocks.catalog.MaterializedIndex;
@@ -50,6 +53,7 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -85,7 +89,11 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_COLDOWN_TIME;
+import static com.starrocks.thrift.TStorageMedium.SSD;
 
 public class ShowExecutorTest {
 
@@ -186,11 +194,44 @@ public class ShowExecutorTest {
 
                 mv.getViewDefineSql();
                 minTimes = 0;
-                result = "create materialized view testMv select col1, col2 from table1";
+                result = "select col1, col2 from table1";
 
                 mv.getRowCount();
                 minTimes = 0;
                 result = 10L;
+
+                mv.getComment();
+                minTimes = 0;
+                result = "TEST MATERIALIZED VIEW";
+
+                mv.getPartitionInfo();
+                minTimes = 0;
+                result = new ExpressionRangePartitionInfo(
+                        Collections.singletonList(
+                                new SlotRef(
+                                        new TableName("test", "testMv"), column1.getName())),
+                        Collections.singletonList(column1));
+
+                mv.getDefaultDistributionInfo();
+                minTimes = 0;
+                result = new HashDistributionInfo(10, Collections.singletonList(column1));
+
+                mv.getRefreshScheme();
+                minTimes = 0;
+                result = new MaterializedView.MvRefreshScheme();
+
+                mv.getDefaultReplicationNum();
+                minTimes = 0;
+                result = 1;
+
+                mv.getStorageMedium();
+                minTimes = 0;
+                result = SSD.name();
+
+                mv.getTableProperty();
+                minTimes = 0;
+                result = new TableProperty(
+                        Collections.singletonMap(PROPERTIES_STORAGE_COLDOWN_TIME, "100"));
             }
         };
 
@@ -764,14 +805,7 @@ public class ShowExecutorTest {
         ShowMaterializedViewStmt stmt = new ShowMaterializedViewStmt("testDb", (String) null);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
-
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("1000", resultSet.getString(0));
-        Assert.assertEquals("testMv", resultSet.getString(1));
-        Assert.assertEquals("testDb", resultSet.getString(2));
-        Assert.assertEquals("create materialized view testMv select col1, col2 from table1", resultSet.getString(3));
-        Assert.assertEquals("10", resultSet.getString(4));
-        Assert.assertFalse(resultSet.next());
+        verifyShowMaterializedViewResult(resultSet);
     }
 
     @Test
@@ -793,11 +827,27 @@ public class ShowExecutorTest {
         stmt = new ShowMaterializedViewStmt("testDb", "%test%");
         executor = new ShowExecutor(ctx, stmt);
         resultSet = executor.execute();
+        verifyShowMaterializedViewResult(resultSet);
+    }
+
+    private void verifyShowMaterializedViewResult(ShowResultSet resultSet) throws AnalysisException, DdlException {
+        String expectedSqlText = "CREATE MATERIALIZED VIEW `testMv`\n" +
+                "COMMENT \"TEST MATERIALIZED VIEW\"\n" +
+                "PARTITION BY (`col1`)\n" +
+                "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"storage_medium\" = \"SSD\",\n" +
+                "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\"\n" +
+                ")\n" +
+                "AS select col1, col2 from table1;";
+
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("1000", resultSet.getString(0));
         Assert.assertEquals("testMv", resultSet.getString(1));
         Assert.assertEquals("testDb", resultSet.getString(2));
-        Assert.assertEquals("create materialized view testMv select col1, col2 from table1", resultSet.getString(3));
+        Assert.assertEquals(expectedSqlText, resultSet.getString(3));
         Assert.assertEquals("10", resultSet.getString(4));
         Assert.assertFalse(resultSet.next());
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9842

## Problem Summary(Required) ：
  `SHOW MATERIALIZED VIEW` will return sql texts with different styles for  `REFRESH SYNC` and `REFRESH ASYNC` materialized views. And the style for the `ASYNC` materialized view should follow the original style of the `SYNC` mv, which is like  `CREATE MATERIALIZED VIEW xxx`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
