### PR TITLE
[Bugfix]Fix bug truncate partition bucketNum following table not previous partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4079,7 +4079,7 @@ public class LocalMetastore implements ConnectorMetadata {
         TableName dbTbl = tblRef.getName();
 
         // check, and save some info which need to be checked again later
-        Map<String, Long> origPartitions = Maps.newHashMap();
+        Map<String, Partition> origPartitions = Maps.newHashMap();
         OlapTable copiedTbl;
         Database db = getDb(dbTbl.getDb());
         if (db == null) {
@@ -4110,11 +4110,11 @@ public class LocalMetastore implements ConnectorMetadata {
                         throw new DdlException("Partition " + partName + " does not exist");
                     }
 
-                    origPartitions.put(partName, partition.getId());
+                    origPartitions.put(partName, partition);
                 }
             } else {
                 for (Partition partition : olapTable.getPartitions()) {
-                    origPartitions.put(partition.getName(), partition.getId());
+                    origPartitions.put(partition.getName(), partition);
                 }
             }
 
@@ -4128,8 +4128,8 @@ public class LocalMetastore implements ConnectorMetadata {
         // tabletIdSet to save all newly created tablet ids.
         Set<Long> tabletIdSet = Sets.newHashSet();
         try {
-            for (Map.Entry<String, Long> entry : origPartitions.entrySet()) {
-                long oldPartitionId = entry.getValue();
+            for (Map.Entry<String, Partition> entry : origPartitions.entrySet()) {
+                long oldPartitionId = entry.getValue().getId();
                 long newPartitionId = getNextId();
                 String newPartitionName = entry.getKey();
 
@@ -4142,6 +4142,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (copiedTbl.isLakeTable()) {
                     partitionInfo.setStorageInfo(newPartitionId, partitionInfo.getStorageInfo(oldPartitionId));
                 }
+
+                copiedTbl.setDefaultDistributionInfo(entry.getValue().getDistributionInfo());
 
                 Partition newPartition =
                         createPartition(db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet);
@@ -4169,8 +4171,8 @@ public class LocalMetastore implements ConnectorMetadata {
             }
 
             // check partitions
-            for (Map.Entry<String, Long> entry : origPartitions.entrySet()) {
-                Partition partition = copiedTbl.getPartition(entry.getValue());
+            for (Map.Entry<String, Partition> entry : origPartitions.entrySet()) {
+                Partition partition = copiedTbl.getPartition(entry.getValue().getId());
                 if (partition == null || !partition.getName().equalsIgnoreCase(entry.getKey())) {
                     throw new DdlException("Partition [" + entry.getKey() + "] is changed");
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/TruncateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/TruncateTableStmtTest.java
@@ -1,0 +1,69 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.Config;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+
+public class TruncateTableStmtTest {
+
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // set timeout to a really long time so that ut can pass even when load of ut machine is very high
+        Config.bdbje_heartbeat_timeout_second = 60;
+        Config.bdbje_replica_ack_timeout_second = 60;
+        Config.bdbje_lock_timeout_second = 60;
+        // set some parameters to speedup test
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        PseudoCluster.getOrCreateWithRandomPort(true, 3);
+        GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql(null, "create database test");
+        cluster.runSql("test",
+                "CREATE TABLE bucket1 (\n" +
+                        "day date NOT NULL COMMENT \"\",\n" +
+                        "date_time datetime NOT NULL COMMENT \"\",\n" +
+                        "product varchar(64) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP\n" +
+                        "UNIQUE KEY(day, date_time)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "PARTITION BY RANGE(day)\n" +
+                        "(\n" +
+                        "PARTITION p20220630 VALUES [('2022-06-30'), ('2022-07-01')))\n" +
+                        "DISTRIBUTED BY HASH(date_time) BUCKETS 10\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\"\n" +
+                        ");");
+    }
+    @Test
+    public void testCatalogModifyColumn() throws Exception {
+        String alterStmt = "alter table bucket1 add PARTITION p20220706 VALUES LESS THAN ('2022-07-07') " +
+                "DISTRIBUTED BY HASH(date_time) BUCKETS 20;";
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql("test", alterStmt);
+        List<Long> tablets = cluster.listTablets("test", "bucket1");
+        Assert.assertEquals(30, tablets.size());
+        String truncateStmt = "truncate table bucket1 PARTITION(p20220706)";
+        cluster.runSql("test", truncateStmt);
+        tablets = cluster.listTablets("test", "bucket1");
+        Assert.assertEquals(30, tablets.size());
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        PseudoCluster.getInstance().shutdown(true);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10435

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The truncate partition is now the bucketNum on the table, and now it is changed to the distribution of the old partition before.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
