### PR TITLE
[cherry-pick][branch-2.2][BugFix] string column writer will check data's length even it is null (backport #10350)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -295,6 +295,7 @@ CONF_mInt32(update_compaction_trace_threshold, "20");
 // the columns will be divided into groups for vertical compaction.
 CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 
+CONF_Bool(enable_check_string_lengths, "true");
 // Max row source mask memory bytes, default is 200M.
 // Should be smaller than compaction_mem_limit.
 // When the row source mask buffer exceeds this, it will be persisted to a temporary file on the disk.

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -907,7 +907,9 @@ StringColumnWriter::StringColumnWriter(const ColumnWriterOptions& opts, std::uni
         : ColumnWriter(std::move(field), opts.meta->is_nullable()), _scalar_column_writer(std::move(column_writer)) {}
 
 Status StringColumnWriter::append(const vectorized::Column& column) {
-    RETURN_IF_ERROR(check_string_lengths(column));
+    if (config::enable_check_string_lengths) {
+        RETURN_IF_ERROR(check_string_lengths(column));
+    }
     if (_is_speculated) {
         return _scalar_column_writer->append(column);
     }
@@ -991,9 +993,16 @@ Status StringColumnWriter::finish() {
 Status StringColumnWriter::check_string_lengths(const vectorized::Column& column) {
     size_t limit = get_field()->length();
     const Slice* slices = (const Slice*)column.raw_data();
+    const uint8_t* null =
+            is_nullable() ? down_cast<const vectorized::NullableColumn*>(&column)->null_column()->raw_data() : nullptr;
     for (size_t i = 0; i < column.size(); i++) {
+        // skip string length check if it is null
+        if (null != nullptr && null[i] == starrocks::vectorized::DATUM_NULL) {
+            continue;
+        }
         if (slices[i].get_size() > limit) {
-            return Status::InvalidArgument(fmt::format("string length({}) > limit({})", slices[i].get_size(), limit));
+            return Status::InvalidArgument(fmt::format("string length({}) > limit({}), string: {}",
+                                                       slices[i].get_size(), limit, slices[i].get_data()));
         }
     }
     return Status::OK();


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10380

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
