### PR TITLE
[Enhancement] Modify the implementation of the parse root path property

### DIFF
--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -28,6 +28,7 @@
 #include "common/status.h"
 #include "fs/fs.h"
 #include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
 #include "util/path_util.h"
 
 namespace starrocks {
@@ -83,9 +84,8 @@ Status parse_root_path(const string& root_path, StorePath* path) {
         string value;
         std::pair<string, string> pair = strings::Split(tmp_vec[i], strings::delimiter::Limit(":", 1));
         if (pair.second.empty()) {
-            // deprecated
-            // format_1: <value> only supports setting capacity
-            property = CAPACITY_UC;
+            LOG(WARNING) << "invalid property of store path, " << tmp_vec[i];
+            return Status::InvalidArgument(strings::Substitute("invalid property of store path, $0", tmp_vec[i]));
         } else {
             // format_2
             property = to_upper(pair.first);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9965 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

![image](https://user-images.githubusercontent.com/11428742/186811917-40c9ac89-b2e0-412f-bb64-558cad10b2c6.png)

The reason is that the path is parsed into property and ignored directly, resulting in one less disk and triggering a large number of clone task.

the usage such as `/data,50` has been removed long long ago. So if we get only one value from parsing property, we will report error directly. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
