### PR TITLE
[BugFix] Fix mem_usage contention of some index readers in column reader.

### DIFF
--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -31,14 +31,14 @@
 namespace starrocks {
 
 StatusOr<bool> BitmapIndexReader::load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta,
-                                       bool use_page_cache, bool kept_in_memory) {
+                                       bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
     while (true) {
         auto curr_state = _state.load(std::memory_order_acquire);
         if (curr_state == kLoaded) {
             return false;
         }
         if (curr_state == kUnloaded && _state.compare_exchange_weak(curr_state, kLoading, std::memory_order_release)) {
-            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory);
+            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory, mem_tracker);
             if (st.ok()) {
                 _state.store(kLoaded, std::memory_order_release);
                 int r = bthread::futex_wake_private(&_state, INT_MAX);
@@ -59,7 +59,8 @@ StatusOr<bool> BitmapIndexReader::load(FileSystem* fs, const std::string& filena
 }
 
 Status BitmapIndexReader::do_load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta,
-                                  bool use_page_cache, bool kept_in_memory) {
+                                  bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
+    const auto old_mem_usage = mem_usage();
     _typeinfo = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
     const IndexedColumnMetaPB& dict_meta = meta.dict_column();
     const IndexedColumnMetaPB& bitmap_meta = meta.bitmap_column();
@@ -68,6 +69,8 @@ Status BitmapIndexReader::do_load(FileSystem* fs, const std::string& filename, c
     _bitmap_column_reader = std::make_unique<IndexedColumnReader>(fs, filename, bitmap_meta);
     RETURN_IF_ERROR(_dict_column_reader->load(use_page_cache, kept_in_memory));
     RETURN_IF_ERROR(_bitmap_column_reader->load(use_page_cache, kept_in_memory));
+    const auto new_mem_usage = mem_usage();
+    mem_tracker->consume(new_mem_usage - old_mem_usage);
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -27,6 +27,7 @@
 #include "fs/fs.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 #include "storage/column_block.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/indexed_column_reader.h"
@@ -57,7 +58,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+                        bool kept_in_memory, MemTracker* mem_tracker);
 
     // create a new column iterator. Client should delete returned iterator
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -91,7 +92,7 @@ private:
     };
 
     Status do_load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     std::atomic<State> _state;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -31,14 +31,14 @@
 namespace starrocks {
 
 StatusOr<bool> BloomFilterIndexReader::load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                                            bool use_page_cache, bool kept_in_memory) {
+                                            bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
     while (true) {
         auto curr_state = _state.load(std::memory_order_acquire);
         if (curr_state == kLoaded) {
             return false;
         }
         if (curr_state == kUnloaded && _state.compare_exchange_weak(curr_state, kLoading, std::memory_order_release)) {
-            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory);
+            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory, mem_tracker);
             if (st.ok()) {
                 _state.store(kLoaded, std::memory_order_release);
                 int r = bthread::futex_wake_private(&_state, INT_MAX);
@@ -59,13 +59,16 @@ StatusOr<bool> BloomFilterIndexReader::load(FileSystem* fs, const std::string& f
 }
 
 Status BloomFilterIndexReader::do_load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                                       bool use_page_cache, bool kept_in_memory) {
+                                       bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
+    const auto old_mem_usage = mem_usage();
     _typeinfo = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
     _algorithm = meta.algorithm();
     _hash_strategy = meta.hash_strategy();
     const IndexedColumnMetaPB& bf_index_meta = meta.bloom_filter();
     _bloom_filter_reader = std::make_unique<IndexedColumnReader>(fs, filename, bf_index_meta);
     RETURN_IF_ERROR(_bloom_filter_reader->load(use_page_cache, kept_in_memory));
+    const auto new_mem_usage = mem_usage();
+    mem_tracker->consume(new_mem_usage - old_mem_usage);
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/bloom_filter_index_reader.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
 #include "storage/column_block.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/indexed_column_reader.h"
@@ -59,7 +60,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                        bool use_page_cache, bool kept_in_memory);
+                        bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     // create a new column iterator.
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -85,7 +86,7 @@ private:
     };
 
     Status do_load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     std::atomic<State> _state;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -293,11 +293,9 @@ Status ColumnReader::_load_ordinal_index() {
     auto meta = _ordinal_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _ordinal_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load,
-                     _ordinal_index->load(fs, file_name(), *meta, num_rows(), use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load, _ordinal_index->load(fs, file_name(), *meta, num_rows(), use_page_cache,
+                                                           kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_ordinal_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_ordinal_index_meta->SpaceUsedLong());
         _ordinal_index_meta.reset();
     }
@@ -311,10 +309,9 @@ Status ColumnReader::_load_zonemap_index() {
     auto meta = _zonemap_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _zonemap_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load, _zonemap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load,
+                     _zonemap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_zonemap_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_zonemap_index_meta->SpaceUsedLong());
         _zonemap_index_meta.reset();
     }
@@ -328,10 +325,9 @@ Status ColumnReader::_load_bitmap_index() {
     auto meta = _bitmap_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _bitmap_index->mem_usage();
-    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+    ASSIGN_OR_RETURN(auto first_load,
+                     _bitmap_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_bitmap_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_bitmap_index_meta->SpaceUsedLong());
         _bitmap_index_meta.reset();
     }
@@ -345,11 +341,9 @@ Status ColumnReader::_load_bloom_filter_index() {
     auto meta = _bloom_filter_index_meta.get();
     auto use_page_cache = !config::disable_storage_page_cache;
     auto kept_in_memory = keep_in_memory();
-    int64_t unloaded_mem_usage = _bloom_filter_index->mem_usage();
     ASSIGN_OR_RETURN(auto first_load,
-                     _bloom_filter_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory));
+                     _bloom_filter_index->load(fs, file_name(), *meta, use_page_cache, kept_in_memory, mem_tracker()));
     if (UNLIKELY(first_load)) {
-        mem_tracker()->consume(_bloom_filter_index->mem_usage() - unloaded_mem_usage);
         mem_tracker()->release(_bloom_filter_index_meta->SpaceUsedLong());
         _bloom_filter_index_meta.reset();
     }

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -64,14 +64,15 @@ Status OrdinalIndexWriter::finish(WritableFile* wfile, ColumnIndexMetaPB* meta) 
 }
 
 StatusOr<bool> OrdinalIndexReader::load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta,
-                                        ordinal_t num_values, bool use_page_cache, bool kept_in_memory) {
+                                        ordinal_t num_values, bool use_page_cache, bool kept_in_memory,
+                                        MemTracker* mem_tracker) {
     while (true) {
         auto curr_state = _state.load(std::memory_order_acquire);
         if (curr_state == kLoaded) {
             return false;
         }
         if (curr_state == kUnloaded && _state.compare_exchange_weak(curr_state, kLoading, std::memory_order_release)) {
-            auto st = do_load(fs, filename, meta, num_values, use_page_cache, kept_in_memory);
+            auto st = do_load(fs, filename, meta, num_values, use_page_cache, kept_in_memory, mem_tracker);
             if (st.ok()) {
                 _state.store(kLoaded, std::memory_order_release);
                 int r = bthread::futex_wake_private(&_state, INT_MAX);
@@ -92,7 +93,9 @@ StatusOr<bool> OrdinalIndexReader::load(FileSystem* fs, const std::string& filen
 }
 
 Status OrdinalIndexReader::do_load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta,
-                                   ordinal_t num_values, bool use_page_cache, bool kept_in_memory) {
+                                   ordinal_t num_values, bool use_page_cache, bool kept_in_memory,
+                                   MemTracker* mem_tracker) {
+    const auto old_mem_usage = mem_usage();
     if (meta.root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;
@@ -136,6 +139,8 @@ Status OrdinalIndexReader::do_load(FileSystem* fs, const std::string& filename, 
         _pages[i] = reader.get_value(i);
     }
     _ordinals[_num_pages] = num_values;
+    const auto new_mem_usage = mem_usage();
+    mem_tracker->consume(new_mem_usage - old_mem_usage);
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -27,6 +27,7 @@
 
 #include "common/status.h"
 #include "gutil/macros.h"
+#include "runtime/mem_tracker.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/index_page.h"
 #include "storage/rowset/page_pointer.h"
@@ -72,7 +73,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                        bool use_page_cache, bool kept_in_memory);
+                        bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     OrdinalPageIndexIterator seek_at_or_before(ordinal_t ordinal);
@@ -112,7 +113,7 @@ private:
     };
 
     Status do_load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                   bool use_page_cache, bool kept_in_memory);
+                   bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker);
 
     std::atomic<State> _state;
     // valid after load

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -191,14 +191,14 @@ Status ZoneMapIndexWriterImpl<type>::finish(WritableFile* wfile, ColumnIndexMeta
 }
 
 StatusOr<bool> ZoneMapIndexReader::load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta,
-                                        bool use_page_cache, bool kept_in_memory) {
+                                        bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
     while (true) {
         auto curr_state = _state.load(std::memory_order_acquire);
         if (curr_state == kLoaded) {
             return false;
         }
         if (curr_state == kUnloaded && _state.compare_exchange_weak(curr_state, kLoading, std::memory_order_release)) {
-            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory);
+            auto st = do_load(fs, filename, meta, use_page_cache, kept_in_memory, mem_tracker);
             if (st.ok()) {
                 _state.store(kLoaded, std::memory_order_release);
                 int r = bthread::futex_wake_private(&_state, INT_MAX);
@@ -219,7 +219,8 @@ StatusOr<bool> ZoneMapIndexReader::load(FileSystem* fs, const std::string& filen
 }
 
 Status ZoneMapIndexReader::do_load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta,
-                                   bool use_page_cache, bool kept_in_memory) {
+                                   bool use_page_cache, bool kept_in_memory, MemTracker* mem_tracker) {
+    const auto old_mem_usage = mem_usage();
     IndexedColumnReader reader(fs, filename, meta.page_zone_maps());
     RETURN_IF_ERROR(reader.load(use_page_cache, kept_in_memory));
     std::unique_ptr<IndexedColumnIterator> iter;
@@ -247,6 +248,8 @@ Status ZoneMapIndexReader::do_load(FileSystem* fs, const std::string& filename, 
         }
         pool.clear();
     }
+    const auto new_mem_usage = mem_usage();
+    mem_tracker->consume(new_mem_usage - old_mem_usage);
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -74,7 +74,7 @@ public:
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
     StatusOr<bool> load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+                        bool kept_in_memory, MemTracker* mem_tracker);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     const std::vector<ZoneMapPB>& page_zone_maps() const { return _page_zone_maps; }
@@ -94,7 +94,7 @@ private:
     };
 
     Status do_load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                   bool kept_in_memory);
+                   bool kept_in_memory, MemTracker* mem_tracker);
 
     std::atomic<State> _state;
     std::vector<ZoneMapPB> _page_zone_maps;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2349,7 +2349,6 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
               << " time:" << watch.get_elapse_second() << "s"
               << " #column:" << _tablet.tablet_schema().num_columns() << " #rowset:" << src_rowsets.size()
               << " #file:" << total_files << " #row:" << total_rows << " bytes:" << total_bytes;
-    ;
     return Status::OK();
 }
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1213,7 +1213,6 @@ TEST_F(OrcChunkReaderTest, TestColumnWithUpperCase) {
         Slice s = char_col->get(0).get_slice();
         std::string res(s.data, s.size);
         EXPECT_EQ(res, "nihao");
-
     }
 }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2,8 +2,9 @@
 
 #include "formats/parquet/file_reader.h"
 
-#include <filesystem>
 #include <gtest/gtest.h>
+
+#include <filesystem>
 
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
@@ -62,7 +63,7 @@ private:
     static vectorized::ChunkPtr _create_chunk_for_not_exist();
     static void _append_column_for_chunk(PrimitiveType column_type, vectorized::ChunkPtr* chunk);
 
-    THdfsScanRange* _create_scan_range(const std::string& file_path, size_t scan_length=0);
+    THdfsScanRange* _create_scan_range(const std::string& file_path, size_t scan_length = 0);
 
     // Description: A simple parquet file that all columns are null
     //
@@ -72,7 +73,7 @@ private:
     // NULL    NULL    NULL    NULL
     // NULL    NULL    NULL    NULL
     // NULL    NULL    NULL    NULL
-    std::string _file1_path= "./be/test/exec/test_data/parquet_scanner/file_reader_test.parquet1";
+    std::string _file1_path = "./be/test/exec/test_data/parquet_scanner/file_reader_test.parquet1";
 
     // Description: A simple parquet file contains single page
     //
@@ -515,8 +516,7 @@ vectorized::ChunkPtr FileReaderTest::_create_chunk_for_not_exist() {
 TEST_F(FileReaderTest, TestInit) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path));;
-
+                                                    std::filesystem::file_size(_file1_path));
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -526,8 +526,7 @@ TEST_F(FileReaderTest, TestInit) {
 TEST_F(FileReaderTest, TestGetNext) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path));;
-
+                                                    std::filesystem::file_size(_file1_path));
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -546,8 +545,7 @@ TEST_F(FileReaderTest, TestGetNext) {
 TEST_F(FileReaderTest, TestGetNextPartition) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path));;
-
+                                                    std::filesystem::file_size(_file1_path));
     // init
     auto* ctx = _create_context_for_partition();
     Status status = file_reader->init(ctx);
@@ -566,8 +564,7 @@ TEST_F(FileReaderTest, TestGetNextPartition) {
 TEST_F(FileReaderTest, TestGetNextEmpty) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path));;
-
+                                                    std::filesystem::file_size(_file1_path));
     // init
     auto* ctx = _create_context_for_not_exist();
     Status status = file_reader->init(ctx);
@@ -586,8 +583,7 @@ TEST_F(FileReaderTest, TestGetNextEmpty) {
 TEST_F(FileReaderTest, TestMinMaxConjunct) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path));;
-
+                                                    std::filesystem::file_size(_file2_path));
     // init
     auto* ctx = _create_context_for_min_max();
     Status status = file_reader->init(ctx);
@@ -609,8 +605,7 @@ TEST_F(FileReaderTest, TestMinMaxConjunct) {
 TEST_F(FileReaderTest, TestFilterFile) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path));;
-
+                                                    std::filesystem::file_size(_file2_path));
     // init
     auto* ctx = _create_context_for_filter_file();
     Status status = file_reader->init(ctx);
@@ -627,8 +622,7 @@ TEST_F(FileReaderTest, TestFilterFile) {
 TEST_F(FileReaderTest, TestGetNextDictFilter) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path));;
-
+                                                    std::filesystem::file_size(_file2_path));
     // init
     auto* ctx = _create_context_for_dict_filter();
     Status status = file_reader->init(ctx);
@@ -654,8 +648,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
 TEST_F(FileReaderTest, TestGetNextOtherFilter) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path));;
-
+                                                    std::filesystem::file_size(_file2_path));
     // init
     auto* ctx = _create_context_for_other_filter();
     Status status = file_reader->init(ctx);
@@ -682,8 +675,7 @@ TEST_F(FileReaderTest, TestGetNextOtherFilter) {
 TEST_F(FileReaderTest, TestSkipRowGroup) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path));;
-
+                                                    std::filesystem::file_size(_file2_path));
     // c1 > 10000
     auto* ctx = _create_context_for_skip_group();
     Status status = file_reader->init(ctx);
@@ -702,8 +694,7 @@ TEST_F(FileReaderTest, TestSkipRowGroup) {
 TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
     auto file = _create_file(_file3_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file3_path));;
-
+                                                    std::filesystem::file_size(_file3_path));
     // c3 = "c", c1 >= 4
     auto* ctx = _create_context_for_multi_filter();
     Status status = file_reader->init(ctx);
@@ -734,8 +725,7 @@ TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
 TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
     auto file = _create_file(_file3_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file3_path));;
-
+                                                    std::filesystem::file_size(_file3_path));
     // c1 >= 4080
     auto* ctx = _create_context_for_late_materialization();
     Status status = file_reader->init(ctx);
@@ -763,25 +753,24 @@ TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
 TEST_F(FileReaderTest, TestReadStructUpperColumns) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path));;
+                                                    std::filesystem::file_size(_file4_path));
+    // init
+    auto* ctx = _create_context_for_struct_solumn();
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
 
-	// init
-	auto* ctx = _create_context_for_struct_solumn();
-	Status status = file_reader->init(ctx);
-	ASSERT_TRUE(status.ok());
+    // c3 is dict filter column
+    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_filter_columns.size());
+    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_filter_columns[0].slot_id);
 
-	// c3 is dict filter column
-	ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_filter_columns.size());
-	ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_filter_columns[0].slot_id);
-
-	// get next
-	auto chunk = _create_struct_chunk();
-	status = file_reader->get_next(&chunk);
-	ASSERT_TRUE(status.ok());
-	ASSERT_EQ(3, chunk->num_rows());
-	for (int i = 0; i < chunk->num_rows(); ++i) {
-		std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-	}
+    // get next
+    auto chunk = _create_struct_chunk();
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(3, chunk->num_rows());
+    for (int i = 0; i < chunk->num_rows(); ++i) {
+        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
+    }
 
     ColumnPtr int_col = chunk->get_column_by_slot_id(0);
     int i = int_col->get(0).get_int32();

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -53,7 +53,7 @@ protected:
     void get_bitmap_reader_iter(std::string& file_name, const ColumnIndexMetaPB& meta, BitmapIndexReader** reader,
                                 BitmapIndexIterator** iter) {
         *reader = new BitmapIndexReader();
-        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), file_name, meta.bitmap_index(), true, false));
+        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), file_name, meta.bitmap_index(), true, false, &_tracker));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(iter));
     }
@@ -247,7 +247,8 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
             while (count.load() < count) {
                 ;
             }
-            ASSIGN_OR_ABORT(auto first_load, reader->load(_fs.get(), file_name, meta.bitmap_index(), false, false));
+            ASSIGN_OR_ABORT(auto first_load,
+                            reader->load(_fs.get(), file_name, meta.bitmap_index(), false, false, &_tracker));
             loads.fetch_add(first_load);
         });
     }

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -83,7 +83,8 @@ protected:
         std::string fname = kTestDir + "/" + file_name;
 
         *reader = new BloomFilterIndexReader();
-        ASSIGN_OR_ABORT(auto r, (*reader)->load(_fs.get(), fname, meta.bloom_filter_index(), true, false));
+        ASSIGN_OR_ABORT(auto r,
+                        (*reader)->load(_fs.get(), fname, meta.bloom_filter_index(), true, false, _mem_tracker.get()));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(iter));
     }

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -75,8 +75,8 @@ TEST_F(OrdinalPageIndexTest, normal) {
     }
 
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r,
-                    index.load(_fs.get(), filename, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1, true, false));
+    ASSIGN_OR_ABORT(auto r, index.load(_fs.get(), filename, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1, true,
+                                       false, _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(16 * 1024, index.num_data_pages());
     ASSERT_EQ(1, index.get_first_ordinal(0));
@@ -131,7 +131,8 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
     }
 
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r, index.load(_fs.get(), "", index_meta.ordinal_index(), num_values, true, false));
+    ASSIGN_OR_ABORT(auto r,
+                    index.load(_fs.get(), "", index_meta.ordinal_index(), num_values, true, false, _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(1, index.num_data_pages());
     ASSERT_EQ(0, index.get_first_ordinal(0));

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -77,7 +77,8 @@ protected:
         }
 
         ZoneMapIndexReader column_zone_map;
-        ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+        ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false,
+                                                     _mem_tracker.get()));
         ASSERT_TRUE(r);
         ASSERT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -131,7 +132,8 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     }
 
     ZoneMapIndexReader column_zone_map;
-    ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+    ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false,
+                                                 _mem_tracker.get()));
     ASSERT_TRUE(r);
     ASSERT_EQ(3, column_zone_map.num_pages());
     const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9809

## Problem Summary(Required) ：
if call ZoneMapIndexReader::mem_usage() as this
https://github.com/StarRocks/starrocks/blob/156404be5709858d583bd62840fae39453cb7917/be/src/storage/rowset/column_reader.cpp#L307-L322
when execute ZoneMapIndexReader::mem_usage(), elsewhere will operate the _page_zone_maps
https://github.com/StarRocks/starrocks/blob/156404be5709858d583bd62840fae39453cb7917/be/src/storage/rowset/zone_map_index.cpp#L230-L237
result in crash like this:
```
Core was generated by `/home/disk2/sr/stability_master_01/be-7063d832-9520-477b-ba14-d391fc64b9b2/lib/'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00000000049a9210 in google::protobuf::Message::GetReflection (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x559889b30) at ./google/protobuf/message.h:359
359        ./google/protobuf/message.h: No such file or directory.
[Current thread is 1 (Thread 0x7f38b2dbf700 (LWP 25566))]
(gdb) bt
Python Exception <type 'exceptions.ImportError'> No module named gdb.frames:
#0  0x00000000049a9210 in google::protobuf::Message::GetReflection (this=0x559889b30) at ./google/protobuf/message.h:359
#1  google::protobuf::Message::SpaceUsedLong (this=0x559889b30) at google/protobuf/[message.cc:162](http://message.cc:162/)
#2  0x0000000001ff7c14 in starrocks::ZoneMapIndexReader::mem_usage (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=<optimized out>) at /root/starrocks/be/src/storage/rowset/zone_map_index.cpp:234
#3  0x0000000001f77480 in starrocks::ColumnReader::_load_zonemap_index (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x3464c19e0) at /root/starrocks/be/src/storage/rowset/column_reader.cpp:314
#4  0x0000000001f775d0 in starrocks::ColumnReader::zone_map_filter (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x3464c19e0, Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
predicates=..., del_predicate=0x0, del_partial_filtered_pages=0x71adfbc00,
    row_ranges=row_ranges@entry=0x7f38b2db8fe0) at /root/starrocks/be/src/storage/rowset/column_reader.cpp:379
#5  0x0000000001fc5399 in starrocks::ScalarColumnIterator::get_row_ranges_by_zone_map (this=<optimized out>, predicates=..., del_predicate=<optimized out>,
    row_ranges=0x7f38b2db8fe0) at /root/starrocks/be/src/storage/rowset/scalar_column_iterator.cpp:319
#6  0x0000000001e0b932 in starrocks::vectorized::SegmentIterator::_get_row_ranges_by_zone_map (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510) at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:581
#7  0x0000000001e0c753 in starrocks::vectorized::SegmentIterator::_init (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510) at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:359
#8  0x0000000001e0cf69 in starrocks::vectorized::SegmentIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x69e597510, chunk=0x225d05d50)
    at /root/starrocks/be/src/storage/rowset/segment_iterator.cpp:772
#9  0x0000000001e665c2 in starrocks::vectorized::ChunkIterator::get_next (chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#10 starrocks::vectorized::ProjectionIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x74ba37910, chunk=0x78c3bcc00) at /root/starrocks/be/src/storage/projection_iterator.cpp:69
#11 0x0000000002333ba5 in starrocks::vectorized::ChunkIterator::get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:42
#12 starrocks::SegmentIteratorWrapper::do_get_next (this=<optimized out>, chunk=<optimized out>) at /root/starrocks/be/src/storage/rowset/rowset.cpp:314
#13 0x000000000200a193 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x78c3bcc00, this=0x41acca010) at /root/starrocks/be/src/util/stopwatch.hpp:76
#14 starrocks::vectorized::TimedChunkIterator::do_get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x7502de130, chunk=0x78c3bcc00) at /root/starrocks/be/src/storage/chunk_iterator.cpp:37
#15 0x0000000001e932de in starrocks::vectorized::ChunkIterator::get_next (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
chunk=<optimized out>, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#16 starrocks::vectorized::TabletReader::do_get_next (this=<optimized out>, chunk=<optimized out>) at /root/starrocks/be/src/storage/tablet_reader.cpp:86
#17 0x0000000002d34dd4 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x78c3bcc00, this=<optimized out>) at /root/starrocks/be/src/storage/chunk_iterator.h:40
#18 starrocks::vectorized::TabletScanner::get_chunk (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x26cc24240, state=<optimized out>, chunk=0x78c3bcc00) at /root/starrocks/be/src/exec/vectorized/tablet_scanner.cpp:255
#19 0x00000000029ee035 in starrocks::vectorized::OlapScanNode::_scanner_thread (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x82cbaa900, scanner=<optimized out>) at /root/starrocks/be/src/exec/exec_node.h:303
#20 0x0000000002359150 in std::function<void ()>::operator()() const (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
this=0x7f38b2db95d8) at /usr/include/c++/10.3.0/bits/std_function.h:248
#21 starrocks::PriorityThreadPool::work_thread (this=0x9e13600, thread_id=14) at /root/starrocks/be/src/util/priority_thread_pool.hpp:180
#22 0x0000000004575ba7 in boost::(anonymous namespace)::thread_proxy (Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
param=<optimized out>) at libs/thread/src/pthread/thread.cpp:179
#23 0x00007f38d4bfbea5 in start_thread () from /lib64/libpthread.so.0
Python Exception <type 'exceptions.NameError'> Installation error: gdb._execute_unwinders function is missing:
#24 0x00007f38d4216b0d in clone () from /lib64/libc.so.6
(gdb) q
```
so put the mem_usage into load to avoid contention in this PR, not only ZoneMapIndexReader, but also OrdinalIndexReader, BitmapIndexReader, BloomFilterIndexReader should do this change.