### PR TITLE
[cherry-pick] [branch-2.4] [Enhancement] Reduce the value-copy of task worker pool (#10396)

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -229,8 +229,8 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
         return;
     }
 
-    phmap::flat_hash_map<TTaskType::type, std::vector<TAgentTaskRequest>> task_divider;
-    phmap::flat_hash_map<TPushType::type, std::vector<TAgentTaskRequest>> push_divider;
+    phmap::flat_hash_map<TTaskType::type, std::vector<const TAgentTaskRequest*>> task_divider;
+    phmap::flat_hash_map<TPushType::type, std::vector<const TAgentTaskRequest*>> push_divider;
 
     for (const auto& task : tasks) {
         VLOG_RPC << "submit one task: " << apache::thrift::ThriftDebugString(task).c_str();
@@ -240,7 +240,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
 #define HANDLE_TYPE(t_task_type, work_pool, req_member)                                             \
     case t_task_type:                                                                               \
         if (task.__isset.req_member) {                                                              \
-            task_divider[t_task_type].push_back(task);                                              \
+            task_divider[t_task_type].push_back(&task);                                             \
         } else {                                                                                    \
             ret_st = Status::InvalidArgument(                                                       \
                     strings::Substitute("task(signature=$0) has wrong request member", signature)); \
@@ -272,7 +272,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             }
             if (task.push_req.push_type == TPushType::LOAD_V2 || task.push_req.push_type == TPushType::DELETE ||
                 task.push_req.push_type == TPushType::CANCEL_DELETE) {
-                push_divider[task.push_req.push_type].push_back(task);
+                push_divider[task.push_req.push_type].push_back(&task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0, type=$1, push_type=$2) has wrong push_type", signature,
@@ -281,7 +281,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             break;
         case TTaskType::ALTER:
             if (task.__isset.alter_tablet_req || task.__isset.alter_tablet_req_v2) {
-                task_divider[TTaskType::ALTER].push_back(task);
+                task_divider[TTaskType::ALTER].push_back(&task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0) has wrong request member", signature));
@@ -315,46 +315,46 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
         auto all_tasks = task_item.second;
         switch (task_type) {
         case TTaskType::CREATE:
-            _create_tablet_workers->submit_tasks(&all_tasks);
+            _create_tablet_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::DROP:
-            _drop_tablet_workers->submit_tasks(&all_tasks);
+            _drop_tablet_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::PUBLISH_VERSION: {
             for (const auto& task : all_tasks) {
-                _publish_version_workers->submit_task(task);
+                _publish_version_workers->submit_task(*task);
             }
             break;
         }
         case TTaskType::CLEAR_TRANSACTION_TASK:
-            _clear_transaction_task_workers->submit_tasks(&all_tasks);
+            _clear_transaction_task_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::CLONE:
-            _clone_workers->submit_tasks(&all_tasks);
+            _clone_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::STORAGE_MEDIUM_MIGRATE:
-            _storage_medium_migrate_workers->submit_tasks(&all_tasks);
+            _storage_medium_migrate_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::CHECK_CONSISTENCY:
-            _check_consistency_workers->submit_tasks(&all_tasks);
+            _check_consistency_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::UPLOAD:
-            _upload_workers->submit_tasks(&all_tasks);
+            _upload_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::DOWNLOAD:
-            _download_workers->submit_tasks(&all_tasks);
+            _download_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::MAKE_SNAPSHOT:
-            _make_snapshot_workers->submit_tasks(&all_tasks);
+            _make_snapshot_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::RELEASE_SNAPSHOT:
-            _release_snapshot_workers->submit_tasks(&all_tasks);
+            _release_snapshot_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::MOVE:
-            _move_dir_workers->submit_tasks(&all_tasks);
+            _move_dir_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::UPDATE_TABLET_META_INFO:
-            _update_tablet_meta_info_workers->submit_tasks(&all_tasks);
+            _update_tablet_meta_info_workers->submit_tasks(all_tasks);
             break;
         case TTaskType::REALTIME_PUSH:
         case TTaskType::PUSH: {
@@ -362,7 +362,7 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             break;
         }
         case TTaskType::ALTER:
-            _alter_tablet_workers->submit_tasks(&all_tasks);
+            _alter_tablet_workers->submit_tasks(all_tasks);
             break;
         default:
             ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0) has wrong task type", task_type));
@@ -378,11 +378,11 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             auto all_push_tasks = push_item.second;
             switch (push_type) {
             case TPushType::LOAD_V2:
-                _push_workers->submit_tasks(&all_push_tasks);
+                _push_workers->submit_tasks(all_push_tasks);
                 break;
             case TPushType::DELETE:
             case TPushType::CANCEL_DELETE:
-                _delete_workers->submit_tasks(&all_push_tasks);
+                _delete_workers->submit_tasks(all_push_tasks);
                 break;
             default:
                 ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0, push_type=$1) has wrong task type",

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -86,7 +86,7 @@ public:
     // Input parameters:
     // * task: the task need callback thread to do
     void submit_task(const TAgentTaskRequest& task);
-    void submit_tasks(std::vector<TAgentTaskRequest>* task);
+    void submit_tasks(const std::vector<const TAgentTaskRequest*>& task);
 
     AgentStatus get_tablet_info(TTabletId tablet_id, TSchemaHash schema_hash, int64_t signature,
                                 TTabletInfo* tablet_info);

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1177,7 +1177,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
         return Status::NotFound(strings::Substitute("tablet $0 not fount", tablet_id));
     }
 
-    LOG(INFO) << "Start to drop tablet" << tablet_id;
+    LOG(INFO) << "Start to drop tablet " << tablet_id;
     TabletSharedPtr dropped_tablet = it->second;
     tablet_map.erase(it);
     _remove_tablet_from_partition(*dropped_tablet);
@@ -1220,7 +1220,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
         DCHECK_EQ(kKeepMetaAndFiles, flag);
     }
     dropped_tablet->deregister_tablet_from_dir();
-    LOG(INFO) << "Succeed to drop tablet" << tablet_id;
+    LOG(INFO) << "Succeed to drop tablet " << tablet_id;
     return Status::OK();
 }
 

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -147,14 +147,14 @@ bool valid_datetime(const std::string& value_str);
 bool valid_bool(const std::string& value_str);
 
 // Util used to get string name of thrift enum item
-#define EnumToString(enum_type, index, out)                                                         \
-    do {                                                                                            \
-        std::map<int, const char*>::const_iterator it = _##enum_type##_VALUES_TO_NAMES.find(index); \
-        if (it == _##enum_type##_VALUES_TO_NAMES.end()) {                                           \
-            out = "NULL";                                                                           \
-        } else {                                                                                    \
-            out = it->second;                                                                       \
-        }                                                                                           \
+#define EnumToString(enum_type, index, out)                   \
+    do {                                                      \
+        auto it = _##enum_type##_VALUES_TO_NAMES.find(index); \
+        if (it == _##enum_type##_VALUES_TO_NAMES.end()) {     \
+            out = "NULL";                                     \
+        } else {                                              \
+            out = it->second;                                 \
+        }                                                     \
     } while (0)
 
 } // namespace starrocks


### PR DESCRIPTION
TAgentTaskRequest will consume a lot of memory (3K~4K), current the tasks vector will copy multi times, the pr refactor the code preparing to reduce the memory usage of task worker pool.