### PR TITLE
[BugFix] Fix fe node deleted from bdb cluster by mistake

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -237,7 +237,7 @@ public class BDBHA implements HAProtocol {
         }
     }
 
-    public void removeNodeIfExist(String host, int port) {
+    public void removeNodeIfExist(String host, int port, String excludeNodeName) {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {
             return;
@@ -246,6 +246,9 @@ public class BDBHA implements HAProtocol {
         List<String> conflictNodes = Lists.newArrayList();
         Set<ReplicationNode> nodes = replicationGroupAdmin.getGroup().getElectableNodes();
         for (ReplicationNode node : nodes) {
+            if (node.getName().equals(excludeNodeName)) {
+                continue;
+            }
             if (node.getHostName().equals(host) && node.getPort() == port) {
                 conflictNodes.add(node.getName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -696,7 +696,7 @@ public class NodeMgr {
                 // So we should remove those nodes before joining the group,
                 // or it will throws NodeConflictException (New or moved node:xxxx, is configured with the socket address:
                 // xxx. It conflicts with the socket already used by the member: xxxx)
-                bdbha.removeNodeIfExist(host, editLogPort);
+                bdbha.removeNodeIfExist(host, editLogPort, nodeName);
             }
 
             stateMgr.getEditLog().logAddFrontend(fe);


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10485

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the process of adding a new FE node, if the FE node started first, there is a chance that the node gets its info from the leader before the adding process is completed because the get info API is not protected by a lock. So if the new node joins the cluster node before the clean node function, the newly added node will be deleted by mistake.
To fix this bug:
1. hold the lock in the get node info function.
2. exclude the newly added node in the clean node function.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
