### PR TITLE
[Bugfix] Fix to detach chunk sources

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -57,7 +57,6 @@ void ConnectorScanOperator::attach_chunk_source(int32_t source_index) {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     auto& active_inputs = factory->get_active_inputs();
     auto key = std::make_pair(_driver_sequence, source_index);
-    DCHECK(!active_inputs.contains(key));
     active_inputs.emplace(key);
 }
 
@@ -65,7 +64,6 @@ void ConnectorScanOperator::detach_chunk_source(int32_t source_index) {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     auto& active_inputs = factory->get_active_inputs();
     auto key = std::make_pair(_driver_sequence, source_index);
-    DCHECK(active_inputs.contains(key));
     active_inputs.erase(key);
 }
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -12,7 +12,6 @@ using namespace vectorized;
 /// OlapScanContext.
 void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
-    DCHECK(_active_inputs.count(key) == 0);
     VLOG_ROW << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,
                             _active_inputs.size());
     _active_inputs.emplace(key);
@@ -20,7 +19,6 @@ void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_i
 
 void OlapScanContext::detach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
-    DCHECK(_active_inputs.count(key) == 1);
     VLOG_ROW << fmt::format("detach_shared_input ({}, {}), remain {}", operator_seq, source_index,
                             _active_inputs.size());
     _active_inputs.erase(key);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -178,8 +178,15 @@ bool ScanOperator::is_finished() const {
     return true;
 }
 
+void ScanOperator::_detach_chunk_sources() {
+    for (size_t i = 0; i < _chunk_sources.size(); i++) {
+        detach_chunk_source(i);
+    }
+}
+
 Status ScanOperator::set_finishing(RuntimeState* state) {
     std::lock_guard guard(_task_mutex);
+    _detach_chunk_sources();
     _is_finished = true;
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -83,6 +83,8 @@ private:
     void _close_chunk_source(RuntimeState* state, int index);
     void _finish_chunk_source_task(RuntimeState* state, int chunk_source_index, int64_t cpu_time_ns, int64_t scan_rows,
                                    int64_t scan_bytes);
+    void _detach_chunk_sources();
+
     void _merge_chunk_source_profiles();
     size_t _buffer_unplug_threshold() const;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/10439

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For sql like
```
select id_int from test_all_type_select_for_stuck limit 10000000;
```
when execute with pipeline engine and dop = 0, if a pipeline_driver's input datas is consumed, but limit is not enough(less than 10000000), so this pipeline_driver will blocked in poller queue, and it will blocked forever by shared_chunk_source.
**So we should detach chunk sources early.**
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
