### PR TITLE
[Enhancement] Add more safe lock function to Database

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -158,7 +158,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
-    public boolean readLockAndExist() {
+    public boolean readLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         Thread formerOwner = rwLock.getOwner();
         this.rwLock.readLock().lock();
@@ -188,7 +188,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
-    public boolean tryReadLockAndExist(long timeout, TimeUnit unit) {
+    public boolean tryReadLockAndCheckExist(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             Thread formerOwner = rwLock.getOwner();
@@ -222,7 +222,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
-    public boolean writeLockAndExist() {
+    public boolean writeLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         Thread formerOwner = rwLock.getOwner();
         this.rwLock.writeLock().lock();
@@ -252,7 +252,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
-    public boolean tryWriteLockAndExist(long timeout, TimeUnit unit) {
+    public boolean tryWriteLockAndCheckExist(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             Thread formerOwner = rwLock.getOwner();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -99,6 +99,12 @@ public class Database extends MetaObject implements Writable {
 
     private long lastSlowLockLogTime = 0;
 
+    // This param is used to make sure db not dropped when lead node writes wal,
+    // so this param need not to persist,
+    // and this param maybe not right when the db is dropped and the catalog has done a checkpoint,
+    // but that'ok to meet our needs.
+    private boolean exist = true;
+
     public Database() {
         this(0, null);
     }
@@ -151,6 +157,20 @@ public class Database extends MetaObject implements Writable {
         logSlowLockEventIfNeeded(startMs, "readLock", formerOwner);
     }
 
+    // this function make sure lock can only be obtained if the db has not been dropped
+    public boolean readLockAndExist() {
+        long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+        Thread formerOwner = rwLock.getOwner();
+        this.rwLock.readLock().lock();
+        logSlowLockEventIfNeeded(startMs, "readLock", formerOwner);
+        if (exist) {
+            return true;
+        } else {
+            this.rwLock.readLock().unlock();
+            return false;
+        }
+    }
+
     public boolean tryReadLock(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
@@ -167,6 +187,29 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
+    // this function make sure lock can only be obtained if the db has not been dropped
+    public boolean tryReadLockAndExist(long timeout, TimeUnit unit) {
+        try {
+            long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+            Thread formerOwner = rwLock.getOwner();
+            if (!this.rwLock.readLock().tryLock(timeout, unit)) {
+                logTryLockFailureEvent("readLock");
+                return false;
+            }
+            logSlowLockEventIfNeeded(startMs, "tryReadLock", formerOwner);
+            if (exist) {
+                return true;
+            } else {
+                this.rwLock.readLock().unlock();
+                return false;
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("failed to try read lock at db[" + id + "]", e);
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
     public void readUnlock() {
         this.rwLock.readLock().unlock();
     }
@@ -176,6 +219,20 @@ public class Database extends MetaObject implements Writable {
         Thread formerOwner = rwLock.getOwner();
         this.rwLock.writeLock().lock();
         logSlowLockEventIfNeeded(startMs, "writeLock", formerOwner);
+    }
+
+    // this function make sure lock can only be obtained if the db has not been dropped
+    public boolean writeLockAndExist() {
+        long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+        Thread formerOwner = rwLock.getOwner();
+        this.rwLock.writeLock().lock();
+        logSlowLockEventIfNeeded(startMs, "writeLock", formerOwner);
+        if (exist) {
+            return true;
+        } else {
+            this.rwLock.writeLock().unlock();
+            return false;
+        }
     }
 
     public boolean tryWriteLock(long timeout, TimeUnit unit) {
@@ -190,6 +247,29 @@ public class Database extends MetaObject implements Writable {
             return true;
         } catch (InterruptedException e) {
             LOG.warn("failed to try write lock at db[" + id + "]", e);
+            return false;
+        }
+    }
+
+    // this function make sure lock can only be obtained if the db has not been dropped
+    public boolean tryWriteLockAndExist(long timeout, TimeUnit unit) {
+        try {
+            long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+            Thread formerOwner = rwLock.getOwner();
+            if (!this.rwLock.writeLock().tryLock(timeout, unit)) {
+                logTryLockFailureEvent("tryWriteLock");
+                return false;
+            }
+            logSlowLockEventIfNeeded(startMs, "tryWriteLock", formerOwner);
+            if (exist) {
+                return true;
+            } else {
+                this.rwLock.writeLock().unlock();
+                return false;
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("failed to try write lock at db[" + id + "]", e);
+            Thread.currentThread().interrupt();
             return false;
         }
     }
@@ -760,5 +840,10 @@ public class Database extends MetaObject implements Writable {
 
     public boolean isInfoSchemaDb() {
         return fullQualifiedName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME);
+    }
+
+    // the invoker should hold db's writeLock
+    public void setExist(boolean exist) {
+        this.exist = exist;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -99,8 +99,8 @@ public class Database extends MetaObject implements Writable {
 
     private long lastSlowLockLogTime = 0;
 
-    // This param is used to make sure db not dropped when lead node writes wal,
-    // so this param need not to persist,
+    // This param is used to make sure db not dropped when leader node writes wal,
+    // so this param dose not need to be persistent,
     // and this param maybe not right when the db is dropped and the catalog has done a checkpoint,
     // but that'ok to meet our needs.
     private boolean exist = true;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -103,7 +103,7 @@ public class Database extends MetaObject implements Writable {
     // so this param dose not need to be persistent,
     // and this param maybe not right when the db is dropped and the catalog has done a checkpoint,
     // but that'ok to meet our needs.
-    private boolean exist = true;
+    private volatile boolean exist = true;
 
     public Database() {
         this(0, null);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -370,6 +370,9 @@ public class LocalMetastore implements ConnectorMetadata {
     public void unprotectCreateDb(Database db) {
         idToDb.put(db.getId(), db);
         fullNameToDb.put(db.getFullName(), db);
+        db.writeLock();
+        db.setExist(true);
+        db.writeUnlock();
         final Cluster cluster = defaultCluster;
         cluster.addDb(db.getFullName(), db.getId());
         stateMgr.getGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());
@@ -420,6 +423,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } else {
                     stateMgr.onEraseDatabase(db.getId());
                 }
+                db.setExist(true);
             } finally {
                 db.writeUnlock();
             }
@@ -468,6 +472,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } else {
                     stateMgr.onEraseDatabase(db.getId());
                 }
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }
@@ -509,6 +514,9 @@ public class LocalMetastore implements ConnectorMetadata {
 
             fullNameToDb.put(db.getFullName(), db);
             idToDb.put(db.getId(), db);
+            db.writeLock();
+            db.setExist(true);
+            db.writeUnlock();
             final Cluster cluster = defaultCluster;
             cluster.addDb(db.getFullName(), db.getId());
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -423,7 +423,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } else {
                     stateMgr.onEraseDatabase(db.getId());
                 }
-                db.setExist(true);
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Many places call db.writeLock after getting db from catalog, and then write bdb log. But the db may be dropped in the process of writing bdb log, which will cause the NPE error when replay bdb log. To solve this problem, add an exist flag to mark whether db is dropped, and users can only obtain the lock when this flag is true. 
This PR only add the new lock functions. Subsequent PRs will change the operational logic of the upper layers.
In the future, only a few scenes can get the lock without checking whether the db is dropped, and the others should call the newly added function to get the lock.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
