### PR TITLE
[bugfix] Predicate statistics calculation considers the evaluation of EQ_FOR_NULL expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -229,7 +229,8 @@ public class StatisticUtils {
                     return Optional.of(Double.parseDouble(statistic));
             }
         } catch (Exception e) {
-            LOG.warn("Statistic convert error, type" + type.toSql() + ", statistic " + statistic + ", " + e.getMessage());
+            LOG.warn(String.format("Statistic convert error, type %s, statistic %s, %s",
+                    type.toSql(), statistic, e.getMessage()));
             return Optional.empty();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -22,6 +22,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -32,6 +34,8 @@ import java.util.Optional;
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 
 public class StatisticUtils {
+    private static final Logger LOG = LogManager.getLogger(StatisticUtils.class);
+
     private static final List<String> COLLECT_DATABASES_BLACKLIST = ImmutableList.<String>builder()
             .add(StatsConstants.STATISTICS_DB_NAME)
             .add("starrocks_monitor")
@@ -204,24 +208,29 @@ public class StatisticUtils {
         if (!type.canStatistic()) {
             throw new StarRocksPlannerException("Error statistic type : " + type.toSql(), ErrorType.INTERNAL_ERROR);
         }
-        switch (type.getPrimitiveType()) {
-            case BOOLEAN:
-                if (statistic.equalsIgnoreCase("TRUE")) {
-                    return Optional.of(1D);
-                } else {
-                    return Optional.of(0D);
-                }
-            case DATE:
-                return Optional.of((double) getLongFromDateTime(DateUtils.parseStringWithDefaultHSM(
-                        statistic, DateUtils.DATE_FORMATTER_UNIX)));
-            case DATETIME:
-                return Optional.of((double) getLongFromDateTime(DateUtils.parseStringWithDefaultHSM(
-                        statistic, DateUtils.DATE_TIME_FORMATTER_UNIX)));
-            case CHAR:
-            case VARCHAR:
-                return Optional.empty();
-            default:
-                return Optional.of(Double.parseDouble(statistic));
+        try {
+            switch (type.getPrimitiveType()) {
+                case BOOLEAN:
+                    if (statistic.equalsIgnoreCase("TRUE")) {
+                        return Optional.of(1D);
+                    } else {
+                        return Optional.of(0D);
+                    }
+                case DATE:
+                    return Optional.of((double) getLongFromDateTime(DateUtils.parseStringWithDefaultHSM(
+                            statistic, DateUtils.DATE_FORMATTER_UNIX)));
+                case DATETIME:
+                    return Optional.of((double) getLongFromDateTime(DateUtils.parseStringWithDefaultHSM(
+                            statistic, DateUtils.DATE_TIME_FORMATTER_UNIX)));
+                case CHAR:
+                case VARCHAR:
+                    return Optional.empty();
+                default:
+                    return Optional.of(Double.parseDouble(statistic));
+            }
+        } catch (Exception e) {
+            LOG.warn("Statistic convert error, type" + type.toSql() + ", statistic " + statistic + ", " + e.getMessage());
+            return Optional.empty();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -82,4 +82,19 @@ public class PredicateStatisticsCalculatorTest {
         Assert.assertEquals(10, estimatedStatistics.getColumnStatistic(c2).getDistinctValuesCount(), 0.001);
         Assert.assertEquals(0, estimatedStatistics.getColumnStatistic(c2).getNullsFraction(), 0.001);
     }
+
+    @Test
+    public void testNullEqStatistic() throws Exception {
+        ColumnRefOperator c1 = new ColumnRefOperator(0, Type.INT, "c1", true);
+        Statistics statistics = Statistics.builder()
+                .addColumnStatistic(c1, ColumnStatistic.builder().setNullsFraction(0.5).setDistinctValuesCount(10).build())
+                .setOutputRowCount(10000).build();
+
+        BinaryPredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(
+                BinaryPredicateOperator.BinaryType.EQ_FOR_NULL, c1, ConstantOperator.createNull(Type.INT));
+        Statistics estimatedStatistics =
+                PredicateStatisticsCalculator.statisticsCalculate(binaryPredicateOperator, statistics);
+        Assert.assertEquals(5000, estimatedStatistics.getOutputRowCount(), 0.001);
+        Assert.assertEquals(1, estimatedStatistics.getColumnStatistic(c1).getNullsFraction(), 0.001);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
At present, we do not distinguish the difference between EQ and EQ_FOR_NULL when calculating the predicate filtering degree. This results in incorrect estimates for scenarios such as col <=> null. The modification of this PR handles this scenario separately, while in other scenarios, the processing logic remains the same as before.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
