### PR TITLE
[BugFix] Fix BE crash when enable filter_unused_columns with array column

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -93,9 +93,8 @@ void GlobalDriverExecutor::_worker_thread() {
 
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
-        CurrentThread::current().set_query_id(query_ctx->query_id());
-        CurrentThread::current().set_fragment_instance_id(fragment_ctx->fragment_instance_id());
-        CurrentThread::current().set_pipeline_driver_id(driver->driver_id());
+
+        SCOPED_SET_TRACE_INFO(driver->driver_id(), query_ctx->query_id(), fragment_ctx->fragment_instance_id());
 
         SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_ctx->query_trace(), fragment_ctx->fragment_instance_id(), driver);
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -308,11 +308,9 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id,
                           io_task_start_nano]() {
         if (auto sp = wp.lock()) {
-            // Set driver_id here to share some driver-local contents.
-            // Current it's used by ExprContext's driver-local state
-            CurrentThread::current().set_pipeline_driver_id(driver_id);
-            DeferOp defer([]() { CurrentThread::current().set_pipeline_driver_id(0); });
-
+            // set driver_id/query_id/fragment_instance_id to thread local
+            // driver_id will be used in some Expr such as regex_replace
+            SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
 
             [[maybe_unused]] std::string category = "chunk_source_" + std::to_string(chunk_source_index);

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -229,6 +229,16 @@ private:
 
 #define SCOPED_SET_CATCHED(catched) auto VARNAME_LINENUM(catched_setter) = CurrentThreadCatchSetter(catched)
 
+#define SCOPED_SET_TRACE_INFO(driver_id, query_id, fragment_instance_id)     \
+    CurrentThread::current().set_pipeline_driver_id(driver_id);              \
+    CurrentThread::current().set_query_id(query_id);                         \
+    CurrentThread::current().set_fragment_instance_id(fragment_instance_id); \
+    auto VARNAME_LINENUM(defer) = DeferOp([] {                               \
+        CurrentThread::current().set_pipeline_driver_id(0);                  \
+        CurrentThread::current().set_query_id({});                           \
+        CurrentThread::current().set_fragment_instance_id({});               \
+    });
+
 #define TRY_CATCH_ALLOC_SCOPE_START() \
     try {                             \
         SCOPED_SET_CATCHED(true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/physical/AddDecodeNodeForDictStringRule.java
@@ -1151,7 +1151,8 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
         // which are consistent with BE implementations.
         private boolean checkTypeCanPushDown(ScalarOperator scalarOperator) {
             Type leftType = scalarOperator.getChild(0).getType();
-            return !leftType.isFloatingPointType() && !leftType.isJsonType() && !leftType.isTime();
+            return !leftType.isFloatingPointType() && !leftType.isComplexType() && !leftType.isJsonType() &&
+                    !leftType.isTime();
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes https://github.com/StarRocks/starrocks/issues/10529

## Problem Summary(Required) ：

ArrayType couldn't push down to storage engine. so we shouldn't support filter_unused_columns for array type;

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
