### PR TITLE
[Feature] dump query id and fragment instance id when be crash

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -19,13 +19,16 @@
 #include <glog/vlog_is_on.h>
 
 #include <cerrno>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <mutex>
 
 #include "common/config.h"
+#include "gutil/endian.h"
 #include "gutil/stringprintf.h"
+#include "runtime/current_thread.h"
 #include "util/logging.h"
 
 namespace starrocks {
@@ -47,6 +50,48 @@ static bool iequals(const std::string& a, const std::string& b) {
     return true;
 }
 
+// avoid to allocate extra memory
+static int print_unique_id(char* buffer, const TUniqueId& uid) {
+    char buff[32];
+    struct {
+        int64_t hi;
+        int64_t lo;
+    } data;
+    data.hi = gbswap_64(uid.hi);
+    data.lo = gbswap_64(uid.lo);
+    to_hex(data.hi, buff + 16);
+    to_hex(data.lo, buff);
+
+    auto* raw = reinterpret_cast<int16_t*>(buff);
+    std::reverse(raw, raw + 16);
+
+    memset(buffer, '-', 36);
+    memcpy(buffer, buff, 8);
+    memcpy(buffer + 8 + 1, buff + 8, 4);
+    memcpy(buffer + 8 + 4 + 2, buff + 8 + 4, 4);
+    memcpy(buffer + 8 + 4 + 4 + 3, buff + 8 + 4 + 4, 4);
+    memcpy(buffer + 8 + 4 + 4 + 4 + 4, buff + 8 + 4 + 4 + 4, 12);
+    return 36;
+}
+
+static void failure_writer(const char* data, int size) {
+    static bool start_dump = false;
+    if (!start_dump) {
+        auto query_id = CurrentThread::current().query_id();
+        auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
+        char buffer[256] = {};
+        int res = sprintf(buffer, "query_id:");
+        res = print_unique_id(buffer + res, query_id) + res;
+        res = sprintf(buffer + res, ", ") + res;
+        res = sprintf(buffer + res, "fragment_instance:") + res;
+        res = print_unique_id(buffer + res, query_id) + res;
+        res = sprintf(buffer + res, "\n") + res;
+        write(STDERR_FILENO, buffer, res);
+    }
+    write(STDERR_FILENO, data, size);
+    start_dump = true;
+}
+
 bool init_glog(const char* basename, bool install_signal_handler) {
     std::lock_guard<std::mutex> logging_lock(logging_mutex);
 
@@ -57,6 +102,8 @@ bool init_glog(const char* basename, bool install_signal_handler) {
     if (install_signal_handler) {
         google::InstallFailureSignalHandler();
     }
+
+    google::InstallFailureWriter(failure_writer);
 
     // Don't log to stderr.
     FLAGS_stderrthreshold = 5;

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -55,6 +55,7 @@ public:
     void set_fragment_instance_id(const starrocks::TUniqueId& fragment_instance_id) {
         _fragment_instance_id = fragment_instance_id;
     }
+    const starrocks::TUniqueId& fragment_instance_id() { return _fragment_instance_id; }
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
     int32_t get_driver_id() const { return _driver_id; }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
dump log will like this:
```
start time: Mon Aug 29 20:52:29 CST 2022
query_id:7a126a33-2799-11ed-864e-8a3a5c80aaf3,fragment_instance:7a126a33-2799-11ed-864e-8a3a5c80aaf3
*** Aborted at 1661777565 (unix time) try "date -d @1661777565" if you are using GNU date ***
PC: @          0x60f892c starrocks::vectorized::ChunkIterator::get_next()
*** SIGSEGV (@0x0) received by PID 221378 (TID 0x7f1654957700) from PID 0; stack trace: ***
    @          0xd082572 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f176966f630 (unknown)
    @          0x60f892c starrocks::vectorized::ChunkIterator::get_next()
    @          0x9b289dc starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage()
    @          0x9b27b40 starrocks::pipeline::OlapChunkSource::_read_chunk()
    @          0x9b1b121 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x9545132 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @          0x9549686   
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
