### PR TITLE
[Enhancement] Reduce the memory consumed when parsing insert values clause (#10537)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -284,7 +284,7 @@ public class ConnectProcessor {
             ctx.setQueryId(UUIDUtil.genUUID());
             List<StatementBase> stmts;
             try {
-                stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode());
+                stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable());
             } catch (ParsingException parsingException) {
                 throw new AnalysisException(parsingException.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -253,6 +253,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_QUERY_DEBUG_TRACE = "enable_query_debug_trace";
 
+    public static final String PARSE_TOKENS_LIMIT = "parse_tokens_limit";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(ENABLE_SPILLING)
@@ -611,6 +613,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getCboCTEMaxLimit() {
         return cboCTEMaxLimit;
     }
+
+    @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
+    private int parseTokensLimit = 3500000;
 
     public double getCboPruneShuffleColumnRate() {
         return cboPruneShuffleColumnRate;
@@ -1090,6 +1095,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getloadTransmissionCompressionType() {
         return loadTransmissionCompressionType;
+    }
+
+    public int getParseTokensLimit() {
+        return parseTokensLimit;
+    }
+
+    public void setParseTokensLimit(int parseTokensLimit) {
+        this.parseTokensLimit = parseTokensLimit;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3258,7 +3258,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             case StarRocksLexer.PLUS_SYMBOL:
                 return child;
             default:
-                throw new UnsupportedOperationException("Unsupported sign for insert values clause. sign: " + context.operator.getText());
+                throw new UnsupportedOperationException("Unsupported sign for insert values clause. sign: "
+                        + context.operator.getText());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -8,6 +8,7 @@ import com.starrocks.analysis.StatementBase;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.SqlParserUtils;
 import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.StatementPlanner;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -16,6 +17,51 @@ import java.io.StringReader;
 import java.util.List;
 
 public class SqlParser {
+
+    public static List<StatementBase> parse(String originSql, SessionVariable sessionVariable) {
+        List<String> splitSql = splitSQL(originSql);
+        List<StatementBase> statements = Lists.newArrayList();
+        for (int idx = 0; idx < splitSql.size(); ++idx) {
+            String sql = splitSql.get(idx);
+            StatementBase statement = parseSingleSql(sql, sessionVariable);
+            statement.setOrigStmt(new OriginStatement(sql, idx));
+            statements.add(statement);
+        }
+        return statements;
+    }
+
+    public static StatementBase parseSingleSql(String sql, SessionVariable sessionVariable) {
+        StarRocksLexer lexer = new StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        StarRocksParser parser = new StarRocksParser(tokenStream);
+        setParserProperty(parser, sessionVariable);
+        StatementBase statement;
+        try {
+            StarRocksParser.SqlStatementsContext sqlStatements = parser.sqlStatements();
+            statement = (StatementBase) new AstBuilder(sessionVariable.getSqlMode())
+                    .visitSingleStatement(sqlStatements.singleStatement(0));
+            return statement;
+        } catch (ParsingException parsingException) {
+            try {
+                statement = parseWithOldParser(sql, sessionVariable.getSqlMode(), 0);
+            } catch (Exception e) {
+                // both new and old parser failed. We return new parser error info to client.
+                throw parsingException;
+            }
+            if (StatementPlanner.supportedByNewPlanner(statement)) {
+                throw parsingException;
+            }
+            return statement;
+        }
+    }
+
+    public static void setParserProperty(StarRocksParser parser, SessionVariable sessionVariable) {
+        parser.sqlMode = sessionVariable.getSqlMode();
+        parser.removeErrorListeners();
+        parser.addErrorListener(new ErrorHandler());
+        parser.removeParseListeners();
+        parser.addParseListener(new TokenNumberListener(sessionVariable.getParseTokensLimit()));
+    }
     public static List<StatementBase> parse(String originSql, long sqlMode) {
         List<String> splitSql = splitSQL(originSql);
         List<StatementBase> statements = Lists.newArrayList();
@@ -35,7 +81,14 @@ public class SqlParser {
                 statement.setOrigStmt(new OriginStatement(sql, idx));
                 statements.add(statement);
             } catch (ParsingException parsingException) {
-                StatementBase statement = parseWithOldParser(sql, sqlMode, 0);
+                StatementBase statement;
+                try {
+                    statement = parseWithOldParser(sql, sqlMode, 0);
+                } catch (Exception e) {
+                    // both new and old parser failed. We return new parser error info to client.
+                    throw parsingException;
+                }
+
                 if (StatementPlanner.supportedByNewPlanner(statement)) {
                     throw parsingException;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -62,6 +62,7 @@ public class SqlParser {
         parser.removeParseListeners();
         parser.addParseListener(new TokenNumberListener(sessionVariable.getParseTokensLimit()));
     }
+
     public static List<StatementBase> parse(String originSql, long sqlMode) {
         List<String> splitSql = splitSQL(originSql);
         List<StatementBase> statements = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1492,7 +1492,7 @@ baseType
     | BITMAP
     | HLL
     | PERCENTILE
-    | ARROW
+    | JSON
     ;
 
 decimalType

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
@@ -1,0 +1,23 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.parser;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+public class TokenNumberListener extends StarRocksBaseListener {
+
+    private int maxTokensNum;
+
+    public TokenNumberListener(int maxTokensNum) {
+        this.maxTokensNum = maxTokensNum;
+    }
+
+    @Override
+    public void visitTerminal(TerminalNode node) {
+        int index = node.getSymbol().getTokenIndex();
+        if (index >= maxTokensNum) {
+            throw new ParsingException("Sql exceeds %d tokens, please consider modify parse_tokens_limit variable.",
+                    maxTokensNum);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -20,7 +20,7 @@ public class AdminSetTest {
     @Test
     public void testAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
-        analyzeFail("admin set frontend config;", "You have an error in your SQL syntax");
+        analyzeFail("admin set frontend config;", "the right syntax to use near '<EOF>'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -20,7 +20,7 @@ public class AdminSetTest {
     @Test
     public void testAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
-        analyzeFail("admin set frontend config;", "Syntax error in line 1");
+        analyzeFail("admin set frontend config;", "You have an error in your SQL syntax");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -33,13 +33,19 @@ public class AnalyzeInsertTest {
         analyzeFail("insert into t0 values (170141183460469231731687303715884105728)", "Number Overflow. literal");
 
         analyzeFail("insert into tall(ta) values(min('x'))", "Values clause cannot contain aggregations");
+
+        // don't support case when in insert value clause
         analyzeFail("insert into tall(ta) values(case min('x') when 'x' then 'x' end)",
-                "Values clause cannot contain aggregations");
-        analyzeFail("insert into tall(ta) values(min('x') over())", "Values clause cannot contain window function");
+                "the right syntax to use near 'case'");
+
+        // don't support window function in insert value clause
+        analyzeFail("insert into tall(ta) values(min('x') over())", "the right syntax to use near 'over'");
 
         analyzeSuccess("INSERT INTO tp  PARTITION(p1) VALUES(1,2,3)");
 
         analyzeSuccess("insert into t0 with label l1 select * from t0");
         analyzeSuccess("insert into t0 with label `l1` select * from t0");
     }
+
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -175,7 +175,7 @@ public class AnalyzeJoinTest {
         analyzeSuccess(sql);
 
         sql = "select * from (t0 a, (t1) b)";
-        analyzeFail(sql, "You have an error in your SQL syntax");
+        analyzeFail(sql, "the right syntax to use near 'b'");
 
         sql = "select * from (t0 a, t1 a)";
         analyzeFail(sql, "Not unique table/alias: 'a'");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -75,7 +75,7 @@ public class AnalyzeJoinTest {
         analyzeSuccess("select * from tnotnull inner join (select * from t0) t using (v1)");
 
         analyzeSuccess("select * from (t0 join tnotnull using(v1)) , t1");
-        analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1", "Syntax error");
+        analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1", "the right syntax to use near 't'");
         analyzeFail("select v1 from (t0 join tnotnull using(v1)), t1", "Column 'v1' is ambiguous");
         analyzeSuccess("select a.v1 from (t0 a join tnotnull b using(v1)), t1");
     }
@@ -175,7 +175,7 @@ public class AnalyzeJoinTest {
         analyzeSuccess(sql);
 
         sql = "select * from (t0 a, (t1) b)";
-        analyzeFail(sql, "Syntax error");
+        analyzeFail(sql, "You have an error in your SQL syntax");
 
         sql = "select * from (t0 a, t1 a)";
         analyzeFail(sql, "Not unique table/alias: 'a'");
@@ -190,7 +190,7 @@ public class AnalyzeJoinTest {
         analyzeFail(sql, "Not unique table/alias: 't1'");
 
         sql = "select * from (t0 join t1) t,t1";
-        analyzeFail(sql, "Syntax error");
+        analyzeFail(sql, "the right syntax to use near 't'");
 
         sql = "select * from (t0 join t1 t) ,t1";
         analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/InsertMultipleValuesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/InsertMultipleValuesTest.java
@@ -1,0 +1,94 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.parser;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.InsertStmt;
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.ValuesRelation;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.plan.PlanTestBase.assertContains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+public class InsertMultipleValuesTest {
+
+    private static final int ROW_NUM = 20000;
+
+    @Test
+    public void parserRowsTest() {
+        String sql = generateSql();
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setParseTokensLimit(Integer.MAX_VALUE);
+        List<StatementBase> sqlStatements = SqlParser.parse(sql, sessionVariable);
+        InsertStmt insertStmt = (InsertStmt) sqlStatements.get(0);
+        assertEquals(ROW_NUM, ((ValuesRelation) insertStmt.getQueryStatement()
+                .getQueryRelation()).getRows().size());
+    }
+
+    private static String generateSql() {
+        StringJoiner joiner = new StringJoiner(", ");
+        List<String> list = new ArrayList<>();
+        String value = "(6968246155471433667, 'k-1869445626llllllll', 'k-1869445626llllllll', " +
+                "'k-1869445626llllllll', 'k-1869445626llllllll', 'k-1869445626llllllll', " +
+                "'k-1869445626llllllll', 'k-1869445626llllllll', 'k-1869445626llllllll')";
+        for (int i = 0; i < ROW_NUM; i++) {
+            joiner.add(value);
+            list.add(value);
+        }
+        String insertClause = "insert into tbl values ";
+        return insertClause + joiner;
+    }
+
+    @Test
+    public void parseInsertValuesTest() {
+        List<String> values = ImmutableList.of("default", "null", "1", "-1", "+1", "1.23", "-1.23",
+                ".23", "'abc'", "'abcd'", "true", "false", "datetime '2021-01-12 12:00:00'", "date '2021-01-12'",
+                "1+1", "1-1", "1*1", "1/1", "1%1", "-1+2", "-1*2", "+1+2*1+1/3", "cast (1 as boolean)", "now()",
+                "abs(1)", "JSON_OBJECT('a', '1')", "-abs(abs(1) + abs(-1))", "PARSE_JSON('{\"a\": 1}')",
+                "date_add(cast ('2021-01-01' as date), INTERVAL 2 DAY)", "[1,2,3]", "[]",
+                "array_intersect(['SQL'], ['MySQL'], array_slice([1,2,4,5,6], 3, 2))");
+        StringJoiner joiner = new StringJoiner(",", "(", ")");
+
+        for (String value : values) {
+            joiner.add(value);
+        }
+
+        String insertSql = "insert into tbl values " + joiner.toString() + "," + joiner.toString();
+        SessionVariable sessionVariable = new SessionVariable();
+        List<StatementBase> sqlStatements = SqlParser.parse(insertSql, sessionVariable);
+        InsertStmt insertStmt = (InsertStmt) sqlStatements.get(0);
+        ValuesRelation valuesRelation = (ValuesRelation) insertStmt.getQueryStatement().getQueryRelation();
+        List<Expr> exprList = valuesRelation.getRow(0).stream().filter(expr -> expr != null).collect(Collectors.toList());
+        assertEquals(values.size(), exprList.size());
+    }
+
+    @Test
+    public void tokensExceedLimitTest() {
+        String sql = "select 1";
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setParseTokensLimit(1);
+        assertThrows(ParsingException.class, () -> SqlParser.parse(sql, sessionVariable));
+    }
+
+    @Test
+    public void sqlParseErrorInfoTest() {
+        String sql = "select 1 form tbl";
+        SessionVariable sessionVariable = new SessionVariable();
+        try {
+            SqlParser.parse(sql, sessionVariable);
+            fail("sql should fail to parse.");
+        } catch (Exception e) {
+            assertContains(e.getMessage(), "You have an error in your SQL syntax");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/InsertMultipleValuesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/InsertMultipleValuesTest.java
@@ -4,9 +4,9 @@ package com.starrocks.sql.parser;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.InsertStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.ValuesRelation;
 import org.junit.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
@@ -51,7 +51,7 @@ public class ParserBench {
         sql = generateSQL();
     }
 
-    @Param({"SLL"})
+    @Param({"SLL", "LL"})
     public String mode;
 
     @Param({"100", "1000", "5000", "10000"})

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -50,11 +51,17 @@ public class ParserBench {
         sql = generateSQL();
     }
 
-    @Param({"SLL", "LL"})
+    @Param({"SLL"})
     public String mode;
 
     @Param({"100", "1000", "5000", "10000"})
     public int times;
+
+    @Param({"true"})
+    public boolean isRightSql;
+
+    @Param({"true", "false"})
+    public boolean isLimit;
 
     @Benchmark
     public void parseInsertIntoValues() {
@@ -62,14 +69,21 @@ public class ParserBench {
     }
 
     private String generateSQL() {
-        List<String> values = Lists.newArrayList("K0.14044384266968246155471433667116798460483551025390625",
+        List<String> wrongValues = Lists.newArrayList("K0.14044384266968246155471433667116798460483551025390625",
                 "-1869445626", "K0.17698452552099786", "K127", "k-366217216");
-        String joined = String.join(",", values);
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < times; i++) {
-            result.append("(").append(joined).append("), ");
+        List<String> rightValues = Lists.newArrayList("0.14044384266968246155471433667116798460483551025390625",
+                "-1869445626", "0.17698452552099786", "127", "-366217216");
+
+        String joined;
+        if (isRightSql) {
+            joined = String.join(",", rightValues);
+        } else {
+            joined = String.join(",", wrongValues);
         }
-        result.append("(").append(joined).append(")");
+        StringJoiner result = new StringJoiner(",", "(", ")");
+        for (int i = 0; i < times; i++) {
+            result.add(joined);
+        }
         return "INSERT INTO test_load_decimal_1_0 VALUES " + result + ";";
     }
 
@@ -80,6 +94,10 @@ public class ParserBench {
         StarRocksParser.sqlMode = SqlModeHelper.MODE_DEFAULT;
         parser.removeErrorListeners();
         parser.addErrorListener(new BaseErrorListener());
+        parser.removeParseListeners();
+        if (isLimit) {
+            parser.addParseListener(new TokenNumberListener(1000000));
+        }
         parser.getInterpreter().setPredictionMode(mode.equals("SLL") ? PredictionMode.SLL : PredictionMode.LL);
         StarRocksParser.SqlStatementsContext sqlStatements = parser.sqlStatements();
         return (StatementBase) new AstBuilder(SqlModeHelper.MODE_DEFAULT)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

Fixes #[10537](https://github.com/StarRocks/starrocks/issues/10537)

## Problem Summary(Required) ：
1. Simplified the syntax rules for the insert values statement to reduce memory cost
    In old version parser, it can parse insert clause with 126w values  in JVM configuration `-Xms2g -Xmx4g`.
    When modified the parser, it can parse insert clause with 207w values in the same JVM configuration.
    In this version, the col value in insert value clause supports function, arithmetic operation and literal value.
2. Added a parser listen to prevent parse large statements which does't add extra time consumption. 
3. Optimize the parsing error message。

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
