### PR TITLE
[Enhancement][Cherry-pick][Branch-2.4] Remove varlen key limitation of persistent index (#10474)

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1019,8 +1019,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     // load persistent index if enable persistent index meta
     size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
 
-    // persistent_index does't support variable length columns(varchar/char) as key column for now
-    if (tablet->get_enable_persistent_index() && (fix_size <= 64 && fix_size > 0)) {
+    if (tablet->get_enable_persistent_index() && (fix_size <= 128)) {
         // TODO
         // PersistentIndex and tablet data are currently stored in the same directory
         // We may need to support the separation of PersistentIndex and Tablet data

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1596,12 +1596,6 @@ public class SchemaChangeHandler extends AlterHandler {
             if (metaValue == olapTable.enablePersistentIndex()) {
                 return;
             }
-            if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS && metaValue) {
-                if (!olapTable.checkPersistentIndex()) {
-                    throw new DdlException("PrimaryKey table using persistent index don't support " + 
-                         "varchar(char) as key so far, and key length should be no more than 64 Bytes");
-                }
-            }
         } else {
             LOG.warn("meta type: {} does not support", metaType);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1542,28 +1542,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
         tableProperty.buildEnablePersistentIndex();
     }
 
-    public Boolean checkPersistentIndex() {
-        // check key type and length
-        int keyLength = 0;
-        for (Column column : getFullSchema()) {
-            if (!column.isKey()) {
-                continue;
-            }
-            if (column.getPrimitiveType() == PrimitiveType.VARCHAR
-                    || column.getPrimitiveType() == PrimitiveType.CHAR) {
-                LOG.warn("PrimaryKey table using persistent index doesn't support varchar(char) so far");
-                return false;
-            }
-            // calculate key size
-            keyLength += column.getOlapColumnIndexSize();
-        }
-        if (keyLength > 64) {
-            LOG.warn("Primary key size of primaryKey table using persistent index should be no more than 64Bytes");
-            return false;
-        }
-        return true;
-    }
-
     public void setStorageMedium(TStorageMedium storageMedium) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1974,13 +1974,6 @@ public class LocalMetastore implements ConnectorMetadata {
                         false);
         olapTable.setEnablePersistentIndex(enablePersistentIndex);
 
-        if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS && olapTable.enablePersistentIndex()) {
-            if (!olapTable.checkPersistentIndex()) {
-                throw new DdlException("PrimaryKey table using persistent index don't support varchar(char) as key so far," +
-                        " and key length should be no more than 64 Bytes");
-            }
-        }
-
         TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
         try {
             tabletType = PropertyAnalyzer.analyzeTabletType(properties);

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -45,11 +45,7 @@ message ImmutableIndexMetaPB {
     EditVersionPB version = 2;
     uint64 size = 3;
     repeated ImmutableIndexShardMetaPB shards = 4;
-    // only support fixed length KVs currently
-    // will add varlen KV in future
-    uint64 fixed_key_size = 5; // Deprecated, will be delete in future
-    uint64 fixed_value_size = 6; // Deprecated, will be delete in future
-    repeated ShardInfoPB shard_info = 7;
+    repeated ShardInfoPB shard_info = 5;
 }
 
 message PersistentIndexMetaPB {
@@ -60,4 +56,5 @@ message PersistentIndexMetaPB {
     // l1's meta stored in l1 file
     // only store a version to get file name
     EditVersionPB l1_version = 5;
+    uint32 format_version = 6;
 }


### PR DESCRIPTION
We support varlen key for persistent index for now, so we can remove the limitation for varlen key.

## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10469 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We support varlen key for persistent index for now, so we can remove the limitation for varlen key.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
