### PR TITLE
[Cherry-pick 2.3][BugFix] Allow select from view when user is only granted on view #10508

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -21,7 +21,6 @@ import com.starrocks.analysis.ShowTableStatusStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.UpdateStmt;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.mysql.privilege.PrivPredicate;
@@ -31,13 +30,18 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseGrantRevokeImpersonateStmt;
 import com.starrocks.sql.ast.BaseGrantRevokeRoleStmt;
+import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.ExecuteAsStmt;
+import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.MetaUtils;
-
-import java.util.Map;
 
 public class PrivilegeChecker {
     public static void check(StatementBase statement, ConnectContext session) {
@@ -178,14 +182,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitQueryStatement(QueryStatement stmt, ConnectContext session) {
-            Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(stmt);
-            for (Map.Entry<TableName, Table> table : tables.entrySet()) {
-                TableName tableName = table.getKey();
-                if (!checkTblPriv(session, tableName, PrivPredicate.SELECT)) {
-                    ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
-                            session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
-                }
-            }
+            new TablePrivilegeChecker(session).visit(stmt);
             return null;
         }
 
@@ -318,4 +315,69 @@ public class PrivilegeChecker {
             return null;
         }
     }
+
+    private static class TablePrivilegeChecker extends AstVisitor<Void, Void> {
+        private ConnectContext session;
+        public TablePrivilegeChecker(ConnectContext session) {
+            this.session = session;
+        }
+        @Override
+        public Void visitQueryStatement(QueryStatement node, Void context) {
+            return visit(node.getQueryRelation());
+        }
+
+        @Override
+        public Void visitSubquery(SubqueryRelation node, Void context) {
+            return visit(node.getQueryStatement());
+        }
+
+        @Override
+        public Void visitView(ViewRelation node, Void context) {
+            // if user has select privilege for the view, then there's no need to check base table
+            if (checkTblPriv(session, node.getName(), PrivPredicate.SELECT)) {
+                return null;
+            }
+            return visit(node.getQueryStatement());
+        }
+
+        @Override
+        public Void visitSelect(SelectRelation node, Void context) {
+            if (node.hasWithClause()) {
+                node.getCteRelations().forEach(this::visit);
+            }
+
+            return visit(node.getRelation());
+        }
+
+        @Override
+        public Void visitSetOp(SetOperationRelation node, Void context) {
+            if (node.hasWithClause()) {
+                node.getRelations().forEach(this::visit);
+            }
+            node.getRelations().forEach(this::visit);
+            return null;
+        }
+
+        @Override
+        public Void visitJoin(JoinRelation node, Void context) {
+            visit(node.getLeft());
+            visit(node.getRight());
+            return null;
+        }
+
+        @Override
+        public Void visitCTE(CTERelation node, Void context) {
+            return visit(node.getCteQueryStatement());
+        }
+
+        @Override
+        public Void visitTable(TableRelation node, Void context) {
+            if (!checkTblPriv(session, node.getName(), PrivPredicate.SELECT)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
+                        session.getQualifiedUser(), session.getRemoteIP(), node.getTable());
+            }
+            return null;
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -443,4 +443,44 @@ public class PrivilegeCheckerTest {
         statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
     }
+
+    @Test
+    public void testSelectView() throws Exception {
+        auth = starRocksAssert.getCtx().getGlobalStateMgr().getAuth();
+        starRocksAssert.getCtx().setQualifiedUser("test");
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
+        starRocksAssert.getCtx().setRemoteIP("%");
+
+        // create view
+        TablePattern tablePattern = new TablePattern("db1", "tbl1");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        tablePattern = new TablePattern("db1", "*");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.CREATE_PRIV), false);
+        String sql = "create view db1.view1 as select k1 from db1.tbl1;";
+        starRocksAssert.withView(sql);
+
+        // select privilege on base table
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(
+                "select * from db1.view1", starRocksAssert.getCtx());
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+        // revoke select privilege on base table
+        tablePattern = new TablePattern("db1", "tbl1");
+        tablePattern.analyze("default_cluster");
+        auth.revokePrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        // grant select privilege on view
+        tablePattern = new TablePattern("db1", "view1");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+        // no select privilege on neither the base table nor the view
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser2);
+        Assert.assertThrows(SemanticException.class,
+                () -> PrivilegeChecker.check(statementBase, starRocksAssert.getCtx()));
+
+    }
+
 }


### PR DESCRIPTION
When checking the privileges of a query statement, instead of checking the select privileges of all the relative tables, we traversal all nodes and handle them separately. As to view, the operation will be allowed when the user has the privilege to the view itself, otherwise, it will keep looking for select privileges on all the base tables as it used to be.

cherry-pick 6fd8ae5b70df4d7b0505005d909fd4f8c50804ae

Fixes #10472