### PR TITLE
[Bugfix] Add detect for bitmap function

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -820,4 +820,12 @@ CONF_Int32(cardinality_of_inject, "10");
 CONF_String(directory_of_inject,
             "/src/exec/pipeline/hashjoin,/src/exec/pipeline/scan,/src/exec/pipeline/aggregate,/src/exec/pipeline/"
             "crossjoin,/src/exec/pipeline/sort,/src/exec/pipeline/exchange,/src/exec/pipeline/analysis");
+CONF_String(directory_of_inject, "/src/exec,/src/exprs");
+
+// Used by to_base64
+CONF_Int64(max_length_for_to_base64, "200000");
+// Used by bitmap_to_string
+CONF_Int64(max_length_for_bitmap_to_string, "200000");
+// Used by bitmap_to_array
+CONF_Int64(max_length_for_bitmap_to_array, "200000");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -820,7 +820,6 @@ CONF_Int32(cardinality_of_inject, "10");
 CONF_String(directory_of_inject,
             "/src/exec/pipeline/hashjoin,/src/exec/pipeline/scan,/src/exec/pipeline/aggregate,/src/exec/pipeline/"
             "crossjoin,/src/exec/pipeline/sort,/src/exec/pipeline/exchange,/src/exec/pipeline/analysis");
-CONF_String(directory_of_inject, "/src/exec,/src/exprs");
 
 // Used by to_base64
 CONF_Int64(max_length_for_to_base64, "200000");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -824,8 +824,6 @@ CONF_String(directory_of_inject, "/src/exec,/src/exprs");
 
 // Used by to_base64
 CONF_Int64(max_length_for_to_base64, "200000");
-// Used by bitmap_to_string
-CONF_Int64(max_length_for_bitmap_to_string, "200000");
-// Used by bitmap_to_array
-CONF_Int64(max_length_for_bitmap_to_array, "200000");
+// Used by bitmap functions
+CONF_Int64(max_length_for_bitmap_function, "1000000");
 } // namespace starrocks::config

--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -144,9 +144,9 @@ ColumnPtr BitmapFunctions::bitmap_and(FunctionContext* context, const starrocks:
 
 // bitmap_to_string
 DEFINE_STRING_UNARY_FN_WITH_IMPL(bitmapToStingImpl, bitmap_ptr) {
-    if (bitmap_ptr->cardinality() > config::max_length_for_bitmap_to_string) {
+    if (bitmap_ptr->cardinality() > config::max_length_for_bitmap_function) {
         std::stringstream ss;
-        ss << "bitmap_to_string not supported size > " << config::max_length_for_bitmap_to_string;
+        ss << "bitmap_to_string not supported size > " << config::max_length_for_bitmap_function;
         throw std::runtime_error(ss.str());
     }
     return bitmap_ptr->to_string();
@@ -295,9 +295,9 @@ ColumnPtr BitmapFunctions::bitmap_to_array(FunctionContext* context, const starr
         for (int row = 0; row < size; ++row) {
             if (!lhs.is_null(row)) {
                 const auto cardinality = lhs.value(row)->cardinality();
-                if (cardinality > config::max_length_for_bitmap_to_array) {
+                if (cardinality > config::max_length_for_bitmap_function) {
                     std::stringstream ss;
-                    ss << "bitmap_to_array not supported size > " << config::max_length_for_bitmap_to_array;
+                    ss << "bitmap_to_array not supported size > " << config::max_length_for_bitmap_function;
                     throw std::runtime_error(ss.str());
                 }
                 data_size += cardinality;
@@ -306,9 +306,9 @@ ColumnPtr BitmapFunctions::bitmap_to_array(FunctionContext* context, const starr
     } else {
         for (int row = 0; row < size; ++row) {
             const auto cardinality = lhs.value(row)->cardinality();
-            if (cardinality > config::max_length_for_bitmap_to_array) {
+            if (cardinality > config::max_length_for_bitmap_function) {
                 std::stringstream ss;
-                ss << "bitmap_to_array not supported size > " << config::max_length_for_bitmap_to_array;
+                ss << "bitmap_to_array not supported size > " << config::max_length_for_bitmap_function;
                 throw std::runtime_error(ss.str());
             }
             data_size += cardinality;

--- a/be/src/exprs/vectorized/bitmap_functions.h
+++ b/be/src/exprs/vectorized/bitmap_functions.h
@@ -106,6 +106,7 @@ public:
      * @return ARRAY_BIGINT
      */
     DEFINE_VECTORIZED_FN(bitmap_to_array);
+    static void detect_bitmap_cardinality(size_t* data_size, const int64_t cardinality);
 
     /**
      * @param:

--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -129,6 +129,10 @@ ColumnPtr EncryptionFunctions::to_base64(FunctionContext* ctx, const Columns& co
         if (src_value.size == 0) {
             result.append_null();
             continue;
+        } else if (src_value.size > config::max_length_for_to_base64) {
+            std::stringstream ss;
+            ss << "to_base64 not supported length > " << config::max_length_for_to_base64;
+            throw std::runtime_error(ss.str());
         }
 
         int cipher_len = (size_t)(4.0 * ceil((double)src_value.size / 3.0)) + 1;


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When size of bitmap is large, we should end expansion function in advance, so add three config to detect in **to_base64(max_length_for_to_base64), bitmap_to_string(max_length_for_bitmap_to_string), bitmap_to_array(max_length_for_bitmap_to_array)**.