### PR TITLE
[Refactor] Remove the default constructor of `TabletSchema` prepared for easy mem statistics

### DIFF
--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -273,7 +273,7 @@ TabletColumn::TabletColumn(const TabletColumn& rhs)
     }
 }
 
-TabletColumn::TabletColumn(TabletColumn&& rhs)
+TabletColumn::TabletColumn(TabletColumn&& rhs) noexcept
         : _col_name(std::move(rhs._col_name)),
           _unique_id(rhs._unique_id),
           _length(rhs._length),
@@ -311,7 +311,7 @@ TabletColumn& TabletColumn::operator=(const TabletColumn& rhs) {
     return *this;
 }
 
-TabletColumn& TabletColumn::operator=(TabletColumn&& rhs) {
+TabletColumn& TabletColumn::operator=(TabletColumn&& rhs) noexcept {
     TabletColumn tmp(std::move(rhs));
     swap(&tmp);
     return *this;
@@ -435,9 +435,7 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& src_table
         auto* tablet_column = partial_tablet_schema_pb.add_column();
         src_tablet_schema.column(referenced_column_id).to_schema_pb(tablet_column);
     }
-    auto partial_tablet_schema = std::make_shared<TabletSchema>();
-    partial_tablet_schema->init_from_pb(partial_tablet_schema_pb);
-    return partial_tablet_schema;
+    return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 
 void TabletSchema::_init_schema() const {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -458,7 +458,7 @@ TabletSchema::~TabletSchema() {
     }
 }
 
-void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
+void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
     _id = schema.has_id() ? schema.id() : invalid_id();
     _keys_type = static_cast<uint8_t>(schema.keys_type());
     _num_key_columns = 0;

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -67,10 +67,10 @@ public:
     ~TabletColumn();
 
     TabletColumn(const TabletColumn& rhs);
-    TabletColumn(TabletColumn&& rhs);
+    TabletColumn(TabletColumn&& rhs) noexcept;
 
     TabletColumn& operator=(const TabletColumn& rhs);
-    TabletColumn& operator=(TabletColumn&& rhs);
+    TabletColumn& operator=(TabletColumn&& rhs) noexcept;
 
     void swap(TabletColumn* rhs);
 
@@ -80,7 +80,7 @@ public:
     ColumnUID unique_id() const { return _unique_id; }
     void set_unique_id(ColumnUID unique_id) { _unique_id = unique_id; }
 
-    std::string_view name() const { return std::string_view(_col_name.data(), _col_name.size()); }
+    std::string_view name() const { return {_col_name.data(), _col_name.size()}; }
     void set_name(std::string_view name) { _col_name.assign(name.data(), name.size()); }
 
     FieldType type() const { return _type; }
@@ -220,16 +220,14 @@ public:
     // file ./fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
     constexpr static SchemaId invalid_id() { return 0; }
 
-    TabletSchema() = default;
-    explicit TabletSchema(const TabletSchemaPB& schema_pb) { init_from_pb(schema_pb); }
+    explicit TabletSchema(const TabletSchemaPB& schema_pb) { _init_from_pb(schema_pb); }
     // Does NOT take ownership of |schema_map| and |schema_map| must outlive TabletSchema.
     TabletSchema(const TabletSchemaPB& schema_pb, TabletSchemaMap* schema_map) : _schema_map(schema_map) {
-        init_from_pb(schema_pb);
+        _init_from_pb(schema_pb);
     }
 
     ~TabletSchema();
 
-    void init_from_pb(const TabletSchemaPB& schema);
     void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
 
     // Caller should always check the returned value with `invalid_id()`.
@@ -252,7 +250,7 @@ public:
 
     // The in-memory property is no longer supported, but leave this API for compatibility.
     // Newly-added code should not rely on this method, it may be removed at any time.
-    bool is_in_memory() const { return false; }
+    static bool is_in_memory() { return false; }
 
     bool contains_format_v1_column() const;
     bool contains_format_v2_column() const;
@@ -280,6 +278,8 @@ private:
 
     friend bool operator==(const TabletSchema& a, const TabletSchema& b);
     friend bool operator!=(const TabletSchema& a, const TabletSchema& b);
+
+    void _init_from_pb(const TabletSchemaPB& schema);
 
     void _init_schema() const;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -155,6 +155,7 @@ set(EXEC_FILES
         ./storage/primary_index_test.cpp
         ./storage/primary_key_encoder_test.cpp
         ./storage/tablet_mgr_test.cpp
+        ./storage/tablet_schema_helper.cpp
         ./storage/version_graph_test.cpp
         ./storage/lake/async_delta_writer_test.cpp
         ./storage/lake/compaction_policy_test.cpp

--- a/be/test/exec/vectorized/agg_hash_map_test.cpp
+++ b/be/test/exec/vectorized/agg_hash_map_test.cpp
@@ -14,55 +14,9 @@
 #include "runtime/mem_pool.h"
 #include "runtime/primitive_type.h"
 
-namespace starrocks {
-namespace vectorized {
+namespace starrocks::vectorized {
 
 using StringAggHashMap = phmap::flat_hash_map<std::string, AggDataPtr>;
-
-template <class T>
-void hash_map_test(T& hashtable) {
-    int64_t sum = 0;
-    AggDataPtr agg_data = (AggDataPtr)(&sum);
-
-    hashtable.emplace(1, agg_data);
-
-    sum = 13;
-
-    using Iterator = typename T::iterator;
-
-    Iterator it = hashtable.find(1);
-    ASSERT_EQ(13, *(int64_t*)(it->second));
-
-    ASSERT_EQ(13, *(int64_t*)hashtable[1]);
-
-    int64_t sum2 = 10;
-    hashtable.emplace(2, (AggDataPtr)&sum2);
-
-    ASSERT_EQ(13, *(int64_t*)hashtable[1]);
-    ASSERT_EQ(10, *(int64_t*)hashtable[2]);
-
-    it = hashtable.find(2);
-    ASSERT_EQ(10, *(int64_t*)(it->second));
-
-    AggDataPtr data2 = it->second;
-    int64_t* sum3 = (int64_t*)data2;
-    *sum3 += 2048;
-
-    it = hashtable.find(2);
-    ASSERT_EQ(2058, *(int64_t*)(it->second));
-
-    ASSERT_EQ(13, *(int64_t*)hashtable[1]);
-    ASSERT_EQ(2058, *(int64_t*)hashtable[2]);
-
-    for (const auto& n : hashtable) {
-        std::cout << n.first << "  value is " << *(int64_t*)n.second << "\n";
-    }
-
-    T new_table(std::move(hashtable));
-    for (const auto& n : new_table) {
-        std::cout << n.first << "  value is " << *(int64_t*)n.second << "\n";
-    }
-}
 
 struct HashMapVariants {
     enum class Type { empty = 0, int32, string, int32_two_level };
@@ -89,7 +43,7 @@ struct HashMapVariants {
         case Type::string: {
             string = std::make_unique<StringAggHashMap>();
             break;
-        } break;
+        }
         }
     }
 };
@@ -259,5 +213,4 @@ TEST(HashMapTest, TwoLevelConvert) {
     }
 }
 
-} // namespace vectorized
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
+++ b/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
@@ -26,8 +26,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
@@ -38,7 +37,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     base_rowset_meta->set_num_segments(1);
     base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
     base_rowset_meta->set_empty(false);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 1; i <= 10; i++) {
@@ -49,7 +48,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -62,7 +62,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -79,8 +80,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
@@ -91,7 +91,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     base_rowset_meta->set_num_segments(1);
     base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
     base_rowset_meta->set_empty(false);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 10; i <= 14; i++) {
@@ -106,7 +106,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -125,8 +126,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
@@ -137,7 +137,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     base_rowset_meta->set_num_segments(1);
     base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
     base_rowset_meta->set_empty(false);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 10; i <= 20; i++) {
@@ -152,7 +152,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -171,8 +172,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_emp
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
@@ -181,7 +181,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_emp
     base_rowset_meta->set_creation_time(base_time);
     base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
     base_rowset_meta->set_empty(true);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 1; i <= 1; i++) {
@@ -192,7 +192,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_emp
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -211,8 +212,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
@@ -221,7 +221,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
     base_rowset_meta->set_creation_time(base_time);
     base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
     base_rowset_meta->set_empty(true);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 1; i <= 10; i++) {
@@ -235,7 +235,8 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }
@@ -254,8 +255,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_without_
     compaction_context->tablet = tablet;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
     int64_t base_time = UnixSeconds() - 100 * 60;
 
     {
@@ -266,7 +266,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_without_
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
         rowset_meta->set_num_segments(1);
         rowset_meta->set_total_disk_size(1024 * 1024);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset1", rowset_meta);
+        RowsetSharedPtr rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset1", rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
         rowsets.emplace_back(std::move(rowset));
     }

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -81,8 +81,7 @@ public:
         column_3->set_is_bf_column(false);
         column_3->set_aggregation("SUM");
 
-        _tablet_schema.reset(new TabletSchema);
-        _tablet_schema->init_from_pb(tablet_schema_pb);
+        _tablet_schema = std::make_unique<TabletSchema>(tablet_schema_pb);
     }
 
     void create_tablet_meta(TabletMeta* tablet_meta) {

--- a/be/test/storage/compaction_context_test.cpp
+++ b/be/test/storage/compaction_context_test.cpp
@@ -9,7 +9,6 @@
 #include <random>
 
 #include "storage/rowset/rowset.h"
-#include "storage/tablet_schema.h"
 #include "storage/tablet_schema_helper.h"
 
 namespace starrocks {
@@ -18,20 +17,20 @@ TEST(CompactionContextTest, test_rowset_comparator) {
     std::set<Rowset*, RowsetComparator> sorted_rowsets_set;
 
     std::vector<RowsetSharedPtr> rowsets;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
     base_rowset_meta->set_start_version(0);
     base_rowset_meta->set_end_version(9);
-    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    RowsetSharedPtr base_rowset = std::make_shared<Rowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     rowsets.emplace_back(std::move(base_rowset));
 
     for (int i = 1; i <= 10; i++) {
         RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
         rowset_meta->set_start_version(i * 10);
         rowset_meta->set_end_version((i + 1) * 10 - 1);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         rowsets.emplace_back(std::move(rowset));
     }
 
@@ -39,7 +38,8 @@ TEST(CompactionContextTest, test_rowset_comparator) {
         RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
         rowset_meta->set_start_version(i);
         rowset_meta->set_end_version(i);
-        RowsetSharedPtr rowset = std::make_shared<Rowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        RowsetSharedPtr rowset =
+                std::make_shared<Rowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         rowsets.emplace_back(std::move(rowset));
     }
 

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -84,8 +84,7 @@ public:
         column_3->set_is_bf_column(false);
         column_3->set_aggregation("SUM");
 
-        _tablet_schema = std::make_unique<TabletSchema>();
-        _tablet_schema->init_from_pb(tablet_schema_pb);
+        _tablet_schema = std::make_unique<TabletSchema>(tablet_schema_pb);
     }
 
     void create_tablet_meta(TabletMeta* tablet_meta) {

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -53,9 +53,7 @@ static shared_ptr<TabletSchema> create_tablet_schema(const string& desc, int nke
     tspb.set_keys_type(key_type);
     tspb.set_next_column_unique_id(cid);
     tspb.set_num_short_key_columns(nkey);
-    shared_ptr<TabletSchema> ts(new TabletSchema());
-    ts->init_from_pb(tspb);
-    return ts;
+    return std::make_shared<TabletSchema>(tspb);
 }
 
 static unique_ptr<Schema> create_schema(const string& desc, int nkey) {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -44,6 +44,7 @@
 #include "storage/tablet_manager.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
 #include "storage/union_iterator.h"
 #include "storage/update_manager.h"
 #include "storage/vectorized_column_predicate.h"
@@ -100,50 +101,7 @@ protected:
         StoragePageCache::release_global_cache();
     }
 
-    // (k1 int, k2 varchar(20), k3 int) duplicated key (k1, k2)
-    void create_tablet_schema(TabletSchema* tablet_schema) {
-        TabletSchemaPB tablet_schema_pb;
-        tablet_schema_pb.set_keys_type(DUP_KEYS);
-        tablet_schema_pb.set_num_short_key_columns(2);
-        tablet_schema_pb.set_num_rows_per_row_block(1024);
-        tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
-        tablet_schema_pb.set_next_column_unique_id(4);
-
-        ColumnPB* column_1 = tablet_schema_pb.add_column();
-        column_1->set_unique_id(1);
-        column_1->set_name("k1");
-        column_1->set_type("INT");
-        column_1->set_is_key(true);
-        column_1->set_length(4);
-        column_1->set_index_length(4);
-        column_1->set_is_nullable(true);
-        column_1->set_is_bf_column(false);
-
-        ColumnPB* column_2 = tablet_schema_pb.add_column();
-        column_2->set_unique_id(2);
-        column_2->set_name("k2");
-        column_2->set_type("INT"); // TODO change to varchar(20) when dict encoding for string is supported
-        column_2->set_length(4);
-        column_2->set_index_length(4);
-        column_2->set_is_nullable(true);
-        column_2->set_is_key(true);
-        column_2->set_is_nullable(true);
-        column_2->set_is_bf_column(false);
-
-        ColumnPB* column_3 = tablet_schema_pb.add_column();
-        column_3->set_unique_id(3);
-        column_3->set_name("v1");
-        column_3->set_type("INT");
-        column_3->set_length(4);
-        column_3->set_is_key(false);
-        column_3->set_is_nullable(false);
-        column_3->set_is_bf_column(false);
-        column_3->set_aggregation("SUM");
-
-        tablet_schema->init_from_pb(tablet_schema_pb);
-    }
-
-    void create_primary_tablet_schema(TabletSchema* tablet_schema) {
+    std::shared_ptr<TabletSchema> create_primary_tablet_schema() {
         TabletSchemaPB tablet_schema_pb;
         tablet_schema_pb.set_keys_type(PRIMARY_KEYS);
         tablet_schema_pb.set_num_short_key_columns(2);
@@ -181,7 +139,7 @@ protected:
         column_3->set_is_bf_column(false);
         column_3->set_aggregation("REPLACE");
 
-        tablet_schema->init_from_pb(tablet_schema_pb);
+        return std::make_shared<TabletSchema>(tablet_schema_pb);
     }
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
@@ -271,19 +229,18 @@ private:
 };
 
 TEST_F(RowsetTest, FinalMergeTest) {
-    TabletSchema tablet_schema;
-    create_primary_tablet_schema(&tablet_schema);
+    auto tablet_schema = create_primary_tablet_schema();
     RowsetSharedPtr rowset;
     const uint32_t rows_per_segment = 1024;
 
     RowsetWriterContext writer_context;
-    create_rowset_writer_context(&tablet_schema, &writer_context);
+    create_rowset_writer_context(tablet_schema.get(), &writer_context);
     writer_context.segments_overlap = OVERLAP_UNKNOWN;
 
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
 
     {
         auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
@@ -333,7 +290,7 @@ TEST_F(RowsetTest, FinalMergeTest) {
     std::string segment_file =
             Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet_schema);
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, tablet_schema.get());
     ASSERT_NE(segment->num_rows(), 0);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -607,11 +564,10 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 }
 
 TEST_F(RowsetTest, VerticalWriteTest) {
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     RowsetWriterContext writer_context;
-    create_rowset_writer_context(&tablet_schema, &writer_context);
+    create_rowset_writer_context(tablet_schema.get(), &writer_context);
     writer_context.max_rows_per_segment = 5000;
     writer_context.writer_type = kVertical;
 
@@ -624,7 +580,7 @@ TEST_F(RowsetTest, VerticalWriteTest) {
     {
         // k1 k2
         std::vector<uint32_t> column_indexes{0, 1};
-        auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -641,7 +597,7 @@ TEST_F(RowsetTest, VerticalWriteTest) {
     {
         // v1
         std::vector<uint32_t> column_indexes{2};
-        auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, column_indexes);
+        auto schema = ChunkHelper::convert_schema_to_format_v2(*tablet_schema, column_indexes);
         auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
@@ -665,7 +621,7 @@ TEST_F(RowsetTest, VerticalWriteTest) {
     rs_opts.sorted = true;
     rs_opts.version = 0;
     rs_opts.stats = &_stats;
-    auto schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema);
+    auto schema = ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
     auto res = rowset->new_iterator(schema, rs_opts);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
 

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -50,22 +50,6 @@ protected:
         StoragePageCache::release_global_cache();
     }
 
-    std::unique_ptr<TabletSchema> create_schema(const std::vector<TabletColumn>& columns,
-                                                int num_short_key_columns = -1) {
-        std::unique_ptr<TabletSchema> res;
-        res.reset(new TabletSchema());
-        int num_key_columns = 0;
-        for (auto& col : columns) {
-            if (col.is_key()) {
-                num_key_columns++;
-            }
-            res->_cols.push_back(col);
-        }
-        res->_num_key_columns = num_key_columns;
-        res->_num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
-        return res;
-    }
-
     const std::string kSegmentDir = "./ut_dir/segment_rewriter_test";
 
     std::shared_ptr<FileSystem> _fs;
@@ -74,8 +58,8 @@ protected:
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {
-    std::unique_ptr<TabletSchema> partial_tablet_schema =
-            create_schema({create_int_key(1), create_int_key(2), create_int_value(4)});
+    std::unique_ptr<TabletSchema> partial_tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(4)});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -114,8 +98,9 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     auto partial_segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, partial_tablet_schema.get());
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
-    std::unique_ptr<TabletSchema> tablet_schema = create_schema(
-            {create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4), create_int_value(5)});
+    std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4),
+             create_int_value_pb(5)});
     std::string dst_file_name = kSegmentDir + "/rewrite_rowset";
     std::vector<uint32_t> read_column_ids{2, 4};
     std::vector<std::unique_ptr<vectorized::Column>> write_columns(read_column_ids.size());

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -71,23 +71,6 @@ protected:
 
     void TearDown() override { StoragePageCache::release_global_cache(); }
 
-    std::unique_ptr<TabletSchema> create_schema(const std::vector<TabletColumn>& columns,
-                                                int num_short_key_columns = -1) {
-        std::unique_ptr<TabletSchema> res;
-        res.reset(new TabletSchema());
-
-        int num_key_columns = 0;
-        for (auto& col : columns) {
-            if (col.is_key()) {
-                num_key_columns++;
-            }
-            res->_cols.push_back(col);
-        }
-        res->_num_key_columns = num_key_columns;
-        res->_num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
-        return res;
-    }
-
     void build_segment(SegmentWriterOptions opts, const TabletSchema& build_schema, const TabletSchema& query_schema,
                        size_t nrows, const ValueGenerator& generator, shared_ptr<Segment>* res) {
         static int seg_id = 0;
@@ -126,14 +109,9 @@ protected:
 TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
     size_t num_rows_per_block = 10;
 
-    std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_key_columns = 3;
-    tablet_schema->_num_short_key_columns = 2;
-    tablet_schema->_num_rows_per_row_block = num_rows_per_block;
-    tablet_schema->_cols.push_back(create_int_key(1));
-    tablet_schema->_cols.push_back(create_int_key(2));
-    tablet_schema->_cols.push_back(create_int_key(3));
-    tablet_schema->_cols.push_back(create_int_value(4));
+    auto tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_key_pb(3), create_int_value_pb(4)}, 2);
+    tablet_schema->_num_rows_per_row_block = 2;
 
     // segment write
     std::string dname = "/segment_write_size";
@@ -177,8 +155,8 @@ TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
 
 TEST_F(SegmentReaderWriterTest, TestBloomFilterIndexUniqueModel) {
     std::unique_ptr<TabletSchema> schema =
-            create_schema({create_int_key(1), create_int_key(2), create_int_key(3),
-                           create_int_value(4, OLAP_FIELD_AGGREGATION_REPLACE, true, "", true)});
+            TabletSchemaHelper::create_tablet_schema({create_int_key_pb(1), create_int_key_pb(2), create_int_key_pb(3),
+                                                      create_int_value_pb(4, "REPLACE", true, "", true)});
 
     // for not base segment
     SegmentWriterOptions opts1;
@@ -194,8 +172,8 @@ TEST_F(SegmentReaderWriterTest, TestBloomFilterIndexUniqueModel) {
 }
 
 TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
-    std::unique_ptr<TabletSchema> tablet_schema =
-            create_schema({create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
+    std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -257,9 +235,10 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     EXPECT_EQ(count, num_rows);
 }
 
+// NOLINTNEXTLINE
 TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
-    std::unique_ptr<TabletSchema> tablet_schema =
-            create_schema({create_int_key(1), create_int_key(2), create_int_value(3), create_int_value(4)});
+    std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;
@@ -371,12 +350,12 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     std::string s8("hbcdefghijklmnopqrstuvwxyz");
     std::vector<Slice> data_strs{s1, s2, s3, s4, s5, s6, s7, s8};
 
-    TabletColumn c1 = create_int_key(1);
-    TabletColumn c2 = create_int_key(2);
-    TabletColumn c3 = create_with_default_value<OLAP_FIELD_TYPE_VARCHAR>("");
+    ColumnPB c1 = create_int_key_pb(1);
+    ColumnPB c2 = create_int_key_pb(2);
+    ColumnPB c3 = create_with_default_value_pb("VARCHAR", "");
     c3.set_length(65535);
 
-    std::unique_ptr<TabletSchema> tablet_schema = create_schema({c1, c2, c3});
+    std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema({c1, c2, c3});
 
     SegmentWriterOptions opts;
     opts.num_rows_per_block = 10;

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -25,6 +25,7 @@ class SchemaChangeTest : public testing::Test {
         }
     }
 
+protected:
     void SetCreateTabletReq(TCreateTabletReq* request, int64_t tablet_id, TKeysType::type type = TKeysType::DUP_KEYS) {
         request->tablet_id = tablet_id;
         request->__set_version(1);
@@ -90,8 +91,9 @@ class SchemaChangeTest : public testing::Test {
         ASSERT_TRUE(tablet->add_rowset(new_rowset, false).ok());
     }
 
-    void SetTabletSchema(const std::string& name, const std::string& type, const std::string& aggregation,
-                         uint32_t length, bool is_allow_null, bool is_key, TabletSchema* tablet_schema) {
+    std::shared_ptr<TabletSchema> SetTabletSchema(const std::string& name, const std::string& type,
+                                                  const std::string& aggregation, uint32_t length, bool is_allow_null,
+                                                  bool is_key) {
         TabletSchemaPB tablet_schema_pb;
         ColumnPB* column = tablet_schema_pb.add_column();
         column->set_unique_id(0);
@@ -101,20 +103,17 @@ class SchemaChangeTest : public testing::Test {
         column->set_is_nullable(is_allow_null);
         column->set_length(length);
         column->set_aggregation(aggregation);
-        tablet_schema->init_from_pb(tablet_schema_pb);
+        return std::make_shared<TabletSchema>(tablet_schema_pb);
     }
 
     template <typename T>
     void test_convert_to_varchar(FieldType type, int type_size, T val, const std::string& expect_val) {
-        TabletSchema src_tablet_schema;
-        SetTabletSchema("SrcColumn", field_type_to_string(type), "REPLACE", type_size, false, false,
-                        &src_tablet_schema);
+        auto src_tablet_schema =
+                SetTabletSchema("SrcColumn", field_type_to_string(type), "REPLACE", type_size, false, false);
+        auto dst_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
 
-        TabletSchema dst_tablet_schema;
-        SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false, &dst_tablet_schema);
-
-        Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-        Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+        Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+        Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
         Datum src_datum;
         src_datum.set<T>(val);
@@ -129,15 +128,12 @@ class SchemaChangeTest : public testing::Test {
 
     template <typename T>
     void test_convert_from_varchar(FieldType type, int type_size, std::string val, T expect_val) {
-        TabletSchema src_tablet_schema;
-        SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false, &src_tablet_schema);
+        auto src_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
+        auto dst_tablet_schema =
+                SetTabletSchema("DstColumn", field_type_to_string(type), "REPLACE", type_size, false, false);
 
-        TabletSchema dst_tablet_schema;
-        SetTabletSchema("DstColumn", field_type_to_string(type), "REPLACE", type_size, false, false,
-                        &dst_tablet_schema);
-
-        Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-        Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+        Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+        Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
         Datum src_datum;
         Slice slice;
@@ -213,14 +209,11 @@ TEST_F(SchemaChangeTest, convert_varchar_to_double) {
 }
 
 TEST_F(SchemaChangeTest, convert_float_to_double) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("SrcColumn", "FLOAT", "REPLACE", 4, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("SrcColumn", "FLOAT", "REPLACE", 4, false, false);
+    auto dst_tablet_schema = SetTabletSchema("VarcharColumn", "DOUBLE", "REPLACE", 8, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("VarcharColumn", "DOUBLE", "REPLACE", 8, false, false, &dst_tablet_schema);
-
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
     src_datum.set_float(1.2345);
@@ -234,14 +227,11 @@ TEST_F(SchemaChangeTest, convert_float_to_double) {
 }
 
 TEST_F(SchemaChangeTest, convert_datetime_to_date) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false);
+    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false, &dst_tablet_schema);
-
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
@@ -263,14 +253,11 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
 }
 
 TEST_F(SchemaChangeTest, convert_date_to_datetime) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
+    auto dst_tablet_schema = SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false, &dst_tablet_schema);
-
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
     std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
@@ -290,14 +277,11 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
+    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE V2", "REPLACE", 3, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("DateColumn", "DATE V2", "REPLACE", 3, false, false, &dst_tablet_schema);
-
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
@@ -315,14 +299,11 @@ TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_date) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
+    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false, &dst_tablet_schema);
-
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
@@ -341,18 +322,15 @@ TEST_F(SchemaChangeTest, convert_int_to_date) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_bitmap) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
+    auto dst_tablet_schema = SetTabletSchema("BitmapColumn", "OBJECT", "BITMAP_UNION", 8, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("BitmapColumn", "OBJECT", "BITMAP_UNION", 8, false, false, &dst_tablet_schema);
-
-    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(src_tablet_schema), 4096);
-    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(dst_tablet_schema), 4096);
+    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*src_tablet_schema), 4096);
+    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
     src_datum.set_int32(2);
@@ -368,18 +346,15 @@ TEST_F(SchemaChangeTest, convert_int_to_bitmap) {
 }
 
 TEST_F(SchemaChangeTest, convert_varchar_to_hll) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("IntColumn", "VARCHAR", "REPLACE", 255, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("IntColumn", "VARCHAR", "REPLACE", 255, false, false);
+    auto dst_tablet_schema = SetTabletSchema("HLLColumn", "HLL", "HLL_UNION", 8, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("HLLColumn", "HLL", "HLL_UNION", 8, false, false, &dst_tablet_schema);
-
-    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(src_tablet_schema), 4096);
-    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(dst_tablet_schema), 4096);
+    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*src_tablet_schema), 4096);
+    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
     std::string str = "test string";
@@ -397,18 +372,15 @@ TEST_F(SchemaChangeTest, convert_varchar_to_hll) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_count) {
-    TabletSchema src_tablet_schema;
-    SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false, &src_tablet_schema);
+    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
+    auto dst_tablet_schema = SetTabletSchema("CountColumn", "BIGINT", "SUM", 8, false, false);
 
-    TabletSchema dst_tablet_schema;
-    SetTabletSchema("CountColumn", "BIGINT", "SUM", 8, false, false, &dst_tablet_schema);
-
-    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(src_tablet_schema), 4096);
-    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(dst_tablet_schema), 4096);
+    ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*src_tablet_schema), 4096);
+    ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema_to_format_v2(*dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
-    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
+    Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
     src_datum.set_int32(2);

--- a/be/test/storage/table_schema_test.cpp
+++ b/be/test/storage/table_schema_test.cpp
@@ -54,8 +54,7 @@ TEST(TabletSchemaTest, test_estimate_row_size) {
     c7->set_type("VARCHAR");
     c7->set_is_key(false);
 
-    TabletSchema tablet_schema;
-    tablet_schema.init_from_pb(schema_pb);
+    TabletSchema tablet_schema(schema_pb);
     size_t row_size = tablet_schema.estimate_row_size(100);
     ASSERT_EQ(row_size, 134);
 }

--- a/be/test/storage/tablet_schema_helper.cpp
+++ b/be/test/storage/tablet_schema_helper.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<TabletSchema> TabletSchemaHelper::create_tablet_schema(const std
     return std::make_unique<TabletSchema>(schema_pb);
 }
 
-inline std::shared_ptr<TabletSchema> TabletSchemaHelper::create_tablet_schema() {
+std::shared_ptr<TabletSchema> TabletSchemaHelper::create_tablet_schema() {
     TabletSchemaPB tablet_schema_pb;
     tablet_schema_pb.set_keys_type(DUP_KEYS);
     tablet_schema_pb.set_num_short_key_columns(2);

--- a/be/test/storage/tablet_schema_helper.cpp
+++ b/be/test/storage/tablet_schema_helper.cpp
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/tablet_schema_helper.h"
+
+namespace starrocks {
+
+std::unique_ptr<TabletSchema> TabletSchemaHelper::create_tablet_schema(const std::vector<ColumnPB>& columns,
+                                                                       int num_short_key_columns) {
+    TabletSchemaPB schema_pb;
+
+    int num_key_columns = 0;
+    for (auto& col : columns) {
+        if (col.is_key()) {
+            num_key_columns++;
+        }
+        auto* col_pb = schema_pb.add_column();
+        *col_pb = col;
+    }
+
+    if (num_short_key_columns == -1) {
+        schema_pb.set_num_short_key_columns(num_key_columns);
+    } else {
+        schema_pb.set_num_short_key_columns(num_short_key_columns);
+    }
+    return std::make_unique<TabletSchema>(schema_pb);
+}
+
+inline std::shared_ptr<TabletSchema> TabletSchemaHelper::create_tablet_schema() {
+    TabletSchemaPB tablet_schema_pb;
+    tablet_schema_pb.set_keys_type(DUP_KEYS);
+    tablet_schema_pb.set_num_short_key_columns(2);
+    tablet_schema_pb.set_num_rows_per_row_block(1024);
+    tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
+    tablet_schema_pb.set_next_column_unique_id(4);
+
+    ColumnPB* column_1 = tablet_schema_pb.add_column();
+    column_1->set_unique_id(1);
+    column_1->set_name("k1");
+    column_1->set_type("INT");
+    column_1->set_is_key(true);
+    column_1->set_length(4);
+    column_1->set_index_length(4);
+    column_1->set_is_nullable(true);
+    column_1->set_is_bf_column(false);
+
+    ColumnPB* column_2 = tablet_schema_pb.add_column();
+    column_2->set_unique_id(2);
+    column_2->set_name("k2");
+    column_2->set_type("INT"); // TODO change to varchar(20) when dict encoding for string is supported
+    column_2->set_length(4);
+    column_2->set_index_length(4);
+    column_2->set_is_nullable(true);
+    column_2->set_is_key(true);
+    column_2->set_is_nullable(true);
+    column_2->set_is_bf_column(false);
+
+    ColumnPB* column_3 = tablet_schema_pb.add_column();
+    column_3->set_unique_id(3);
+    column_3->set_name("v1");
+    column_3->set_type("INT");
+    column_3->set_length(4);
+    column_3->set_is_key(false);
+    column_3->set_is_nullable(false);
+    column_3->set_is_bf_column(false);
+    column_3->set_aggregation("SUM");
+
+    return std::make_shared<TabletSchema>(tablet_schema_pb);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10458 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

* Remove the default constructor of `TabletSchema` prepared for easy mem statistics
* Refactor the test case

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
