### PR TITLE
[Enhancement] BE support multiple s3 auth info

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -233,7 +233,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         native_file_path = file_path.native();
     }
 
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path));
+    const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path, FSOptions(&hdfs_scan_node)));
 
     COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
     HdfsScannerParams scanner_params;

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -116,6 +116,8 @@ const THdfsProperties* FSOptions::hdfs_properties() const {
         return &upload->hdfs_properties;
     } else if (download != nullptr && download->__isset.hdfs_properties) {
         return &download->hdfs_properties;
+    } else if (hdfs_scan_node != nullptr && hdfs_scan_node->__isset.hdfs_properties) {
+        return &hdfs_scan_node->hdfs_properties;
     }
     return nullptr;
 }

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -42,27 +42,32 @@ struct SpaceInfo {
 struct FSOptions {
 private:
     FSOptions(const TBrokerScanRangeParams* scan_range_params, const TExportSink* export_sink,
-              const ResultFileOptions* result_file_options, const TUploadReq* upload, const TDownloadReq* download)
+              const ResultFileOptions* result_file_options, const TUploadReq* upload, const TDownloadReq* download,
+              const THdfsScanNode* hdfs_scan_node)
             : scan_range_params(scan_range_params),
               export_sink(export_sink),
               result_file_options(result_file_options),
               upload(upload),
-              download(download) {}
+              download(download),
+              hdfs_scan_node(hdfs_scan_node) {}
 
 public:
-    FSOptions() : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr) {}
+    FSOptions() : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr) {}
 
     FSOptions(const TBrokerScanRangeParams* scan_range_params)
-            : FSOptions(scan_range_params, nullptr, nullptr, nullptr, nullptr) {}
+            : FSOptions(scan_range_params, nullptr, nullptr, nullptr, nullptr, nullptr) {}
 
-    FSOptions(const TExportSink* export_sink) : FSOptions(nullptr, export_sink, nullptr, nullptr, nullptr) {}
+    FSOptions(const TExportSink* export_sink) : FSOptions(nullptr, export_sink, nullptr, nullptr, nullptr, nullptr) {}
 
     FSOptions(const ResultFileOptions* result_file_options)
-            : FSOptions(nullptr, nullptr, result_file_options, nullptr, nullptr) {}
+            : FSOptions(nullptr, nullptr, result_file_options, nullptr, nullptr, nullptr) {}
 
-    FSOptions(const TUploadReq* upload) : FSOptions(nullptr, nullptr, nullptr, upload, nullptr) {}
+    FSOptions(const TUploadReq* upload) : FSOptions(nullptr, nullptr, nullptr, upload, nullptr, nullptr) {}
 
-    FSOptions(const TDownloadReq* download) : FSOptions(nullptr, nullptr, nullptr, nullptr, download) {}
+    FSOptions(const TDownloadReq* download) : FSOptions(nullptr, nullptr, nullptr, nullptr, download, nullptr) {}
+
+    FSOptions(const THdfsScanNode* hdfs_scan_node)
+            : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr, hdfs_scan_node) {}
 
     const THdfsProperties* hdfs_properties() const;
 
@@ -71,6 +76,7 @@ public:
     const ResultFileOptions* result_file_options;
     const TUploadReq* upload;
     const TDownloadReq* download;
+    const THdfsScanNode* hdfs_scan_node;
 };
 
 struct FileStatus {

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -60,12 +60,11 @@ public:
     // when bueket or credential change but properties of Aws::Client::ClientConfiguration unchanged
     struct ClientConfiguration {
         Aws::Client::ClientConfiguration client_config;
-        std::string bucket;
         std::string access_key_id;
         std::string secret_access_key;
 
         bool operator==(const ClientConfiguration& rhs) {
-            return client_config == rhs.client_config && bucket == rhs.bucket && access_key_id == rhs.access_key_id &&
+            return client_config == rhs.client_config && access_key_id == rhs.access_key_id &&
                    secret_access_key == rhs.secret_access_key;
         }
     };
@@ -161,7 +160,6 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
 
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri, const FSOptions& opts) {
     S3ClientFactory::ClientConfiguration config = S3ClientFactory::getClientConfig();
-    config.bucket = uri.bucket();
 
     Aws::Client::ClientConfiguration& client_config = config.client_config;
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -854,6 +854,8 @@ struct THdfsScanNode {
 
     // Flag to indicate wheather the column names are case sensitive
     12: optional bool case_sensitive;
+
+    13: optional THdfsProperties hdfs_properties;
 }
 
 struct TProjectNode {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

* S3ClientFactory can generate client using variant S3 auth info now.
* HdfsScanNode add THdfsProperties so that FE can pass different S3 auth info to BE

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
