### PR TITLE
[Feature] Print lake table's metadata in json by meta tool

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -73,7 +73,7 @@ const std::string HEADER_PREFIX = "tabletmeta_";
 DEFINE_string(root_path, "", "storage root path");
 DEFINE_string(operation, "get_meta",
               "valid operation: get_meta, flag, load_meta, delete_meta, delete_rowset_meta, "
-              "show_meta, check_table_meta_consistency print_lake_metadata print_lake_txn_log");
+              "show_meta, check_table_meta_consistency, print_lake_metadata, print_lake_txn_log");
 DEFINE_int64(tablet_id, 0, "tablet_id for tablet meta");
 DEFINE_string(tablet_uid, "", "tablet_uid for tablet meta");
 DEFINE_int64(table_id, 0, "table id for table meta");
@@ -82,6 +82,7 @@ DEFINE_int32(schema_hash, 0, "schema_hash for tablet meta");
 DEFINE_string(json_meta_path, "", "absolute json meta file path");
 DEFINE_string(pb_meta_path, "", "pb meta file path");
 DEFINE_string(tablet_file, "", "file to save a set of tablets");
+DEFINE_string(file, "", "segment file path");
 DEFINE_string(file, "", "segment file path");
 
 std::string get_usage(const std::string& progname) {
@@ -565,7 +566,7 @@ int meta_tool_main(int argc, char** argv) {
     } else if (FLAGS_operation == "print_lake_metadata") {
         starrocks::lake::TabletMetadataPB metadata;
         if (!metadata.ParseFromIstream(&std::cin)) {
-            std::cerr << "Fail to parse tablet metadata";
+            std::cerr << "Fail to parse tablet metadata\n";
             return -1;
         }
         json2pb::Pb2JsonOptions options;
@@ -573,14 +574,14 @@ int meta_tool_main(int argc, char** argv) {
         std::string json;
         std::string error;
         if (!json2pb::ProtoMessageToJson(metadata, &json, options, &error)) {
-            std::cerr << "Fail to convert protobuf to json: " << error;
+            std::cerr << "Fail to convert protobuf to json: " << error << '\n';
             return -1;
         }
         std::cout << json << '\n';
     } else if (FLAGS_operation == "print_lake_txn_log") {
         starrocks::lake::TxnLogPB txn_log;
         if (!txn_log.ParseFromIstream(&std::cin)) {
-            std::cerr << "Fail to parse txn log";
+            std::cerr << "Fail to parse txn log\n";
             return -1;
         }
         json2pb::Pb2JsonOptions options;
@@ -588,7 +589,7 @@ int meta_tool_main(int argc, char** argv) {
         std::string json;
         std::string error;
         if (!json2pb::ProtoMessageToJson(txn_log, &json, options, &error)) {
-            std::cerr << "Fail to convert protobuf to json: " << error;
+            std::cerr << "Fail to convert protobuf to json: " << error << '\n';
             return -1;
         }
         std::cout << json << '\n';

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -580,7 +580,7 @@ int meta_tool_main(int argc, char** argv) {
     } else if (FLAGS_operation == "print_lake_txn_log") {
         starrocks::lake::TxnLogPB txn_log;
         if (!txn_log.ParseFromIstream(&std::cin)) {
-            std::cerr << "Fail to parse tablet metadata";
+            std::cerr << "Fail to parse txn log";
             return -1;
         }
         json2pb::Pb2JsonOptions options;

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -83,7 +83,6 @@ DEFINE_string(json_meta_path, "", "absolute json meta file path");
 DEFINE_string(pb_meta_path, "", "pb meta file path");
 DEFINE_string(tablet_file, "", "file to save a set of tablets");
 DEFINE_string(file, "", "segment file path");
-DEFINE_string(file, "", "segment file path");
 
 std::string get_usage(const std::string& progname) {
     std::stringstream ss;

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -29,6 +29,7 @@
 #include "common/status.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gen_cpp/segment.pb.h"
 #include "gutil/strings/numbers.h"
@@ -72,7 +73,7 @@ const std::string HEADER_PREFIX = "tabletmeta_";
 DEFINE_string(root_path, "", "storage root path");
 DEFINE_string(operation, "get_meta",
               "valid operation: get_meta, flag, load_meta, delete_meta, delete_rowset_meta, "
-              "show_meta, check_table_meta_consistency");
+              "show_meta, check_table_meta_consistency print_lake_metadata print_lake_txn_log");
 DEFINE_int64(tablet_id, 0, "tablet_id for tablet meta");
 DEFINE_string(tablet_uid, "", "tablet_uid for tablet meta");
 DEFINE_int64(table_id, 0, "table id for table meta");
@@ -107,7 +108,9 @@ std::string get_usage(const std::string& progname) {
     ss << "./meta_tool --operation=show_meta --pb_meta_path=path\n";
     ss << "./meta_tool --operation=show_segment_footer --file=/path/to/segment/file\n";
     ss << "./meta_tool --operation=check_table_meta_consistency --root_path=/path/to/storage/path "
-          "--table_id=tableid";
+          "--table_id=tableid\n";
+    ss << "cat 0001000000001394_0000000000000004.meta | ./meta_tool --operation=print_lake_metadata\n";
+    ss << "cat 0001000000001391_0000000000000001.log | ./meta_tool --operation=print_lake_txn_log\n";
     return ss.str();
 }
 
@@ -559,6 +562,36 @@ int meta_tool_main(int argc, char** argv) {
             return -1;
         }
         show_segment_footer(FLAGS_file);
+    } else if (FLAGS_operation == "print_lake_metadata") {
+        starrocks::lake::TabletMetadataPB metadata;
+        if (!metadata.ParseFromIstream(&std::cin)) {
+            std::cerr << "Fail to parse tablet metadata";
+            return -1;
+        }
+        json2pb::Pb2JsonOptions options;
+        options.pretty_json = true;
+        std::string json;
+        std::string error;
+        if (!json2pb::ProtoMessageToJson(metadata, &json, options, &error)) {
+            std::cerr << "Fail to convert protobuf to json: " << error;
+            return -1;
+        }
+        std::cout << json << '\n';
+    } else if (FLAGS_operation == "print_lake_txn_log") {
+        starrocks::lake::TxnLogPB txn_log;
+        if (!txn_log.ParseFromIstream(&std::cin)) {
+            std::cerr << "Fail to parse tablet metadata";
+            return -1;
+        }
+        json2pb::Pb2JsonOptions options;
+        options.pretty_json = true;
+        std::string json;
+        std::string error;
+        if (!json2pb::ProtoMessageToJson(txn_log, &json, options, &error)) {
+            std::cerr << "Fail to convert protobuf to json: " << error;
+            return -1;
+        }
+        std::cout << json << '\n';
     } else {
         // operations that need root path should be written here
         std::set<std::string> valid_operations = {"get_meta",


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Example usage
``` shell
>  ossutil64 cat oss://bucket/65a57777-b63f-478d-a7d2-7f209525825c/16017/meta/0001000000001394_0000000000000007.meta | head -n 1 | tr -d '\n' |  output/be/bin/meta_tool.sh --operation=print_lake_metadata
{
    "id": 281474976715668,
    "version": 7,
    "schema": {
        "keys_type": "DUP_KEYS",
        "column": [
            {
                "unique_id": 0,
                "name": "c0",
                "type": "INT",
                "is_key": true,
                "aggregation": "NONE",
                "is_nullable": true,
                "precision": 0,
                "frac": 0,
                "length": 4,
                "index_length": 4
            }
        ],
        "num_short_key_columns": 1,
        "num_rows_per_row_block": 1024,
        "compress_kind": "COMPRESS_LZ4",
        "next_column_unique_id": 1,
        "compression_type": "LZ4_FRAME",
        "id": 16018
    },
    "rowsets": [
        {
            "id": 2,
            "overlapped": false,
            "segments": [
                "f6e423e9-d97b-4a19-b5a0-e541eb7b4c34.dat"
            ],
            "num_rows": 1,
            "data_size": 232
        },
        {
            "id": 3,
            "overlapped": false,
            "segments": [
                "7b095819-4481-4f8e-aea5-0f177dbfee52.dat"
            ],
            "num_rows": 1,
            "data_size": 233
        }
    ],
    "next_rowset_id": 4,
    "cumulative_point": 1
}
```
