### PR TITLE
[enhancement ] Modify the schedule of statistics collection to speed up statistics collection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1376,7 +1376,7 @@ public class Config extends ConfigBase {
      * Max row count in statistics collect per query
      */
     @ConfField(mutable = true)
-    public static long statistic_collect_max_row_count_per_query = 5000000;
+    public static long statistic_collect_max_row_count_per_query = 5000000000L; //5 billion
 
     /**
      * default bucket size of histogram statistics

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -43,8 +43,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             if (partition.getRowCount() == 0) {
                 partitionSize = columns.size();
             } else {
-                partitionSize = (int) (Config.statistic_collect_max_row_count_per_query
-                        / (partition.getRowCount() * columns.size()) + 1);
+                partitionSize = (int) (Config.statistic_collect_max_row_count_per_query / partition.getRowCount() + 1);
             }
 
             for (List<String> splitColItem : Lists.partition(columns, partitionSize)) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
@@ -51,8 +51,7 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
         long sampleRowCount = Long.parseLong(properties.getOrDefault(StatsConstants.STATISTIC_SAMPLE_COLLECT_ROWS,
                 String.valueOf(Config.statistic_sample_collect_rows)));
 
-        int partitionSize = (int) (Config.statistic_collect_max_row_count_per_query
-                / (sampleRowCount * columns.size()) + 1);
+        int partitionSize = (int) (Config.statistic_collect_max_row_count_per_query / sampleRowCount + 1);
 
         for (List<String> splitColItem : Lists.partition(columns, partitionSize)) {
             String sql = buildSampleInsertSQL(db.getId(), table.getId(), splitColItem, sampleRowCount);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -13,7 +13,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
-import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -200,7 +199,6 @@ public class StatisticExecutor {
 
         try {
             ConnectContext context = StatisticUtils.buildConnectContext();
-            context.setQueryId(UUIDUtil.genUUID());
             GlobalStateMgr.getCurrentAnalyzeMgr().registerConnection(analyzeStatus.getId(), context);
             statsJob.collect(context);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -86,6 +86,7 @@ public abstract class StatisticsCollectJob {
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
         context.setExecutor(executor);
         context.setQueryId(UUIDUtil.genUUID());
+        context.setStartTime();
         executor.execute();
 
         if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Increase statistic_collect_max_row_count_per_query
2. It takes 112 minutes to collect tpcds-1t before adjustment, and 6 minutes after adjustment
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
