### PR TITLE
[Enhancement]Added setting to limit parse large statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -192,7 +192,7 @@ public class TableQueryPlanAction extends RestBaseAction {
              */
             context.getSessionVariable().setSingleNodeExecPlan(true);
             statementBase =
-                    com.starrocks.sql.parser.SqlParser.parse(sql, context.getSessionVariable().getSqlMode()).get(0);
+                    com.starrocks.sql.parser.SqlParser.parse(sql, context.getSessionVariable()).get(0);
             execPlan = new StatementPlanner().plan(statementBase, context);
             context.getSessionVariable().setSingleNodeExecPlan(false);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -284,7 +284,7 @@ public class ConnectProcessor {
             ctx.setQueryId(UUIDUtil.genUUID());
             List<StatementBase> stmts;
             try {
-                stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode());
+                stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable());
             } catch (ParsingException parsingException) {
                 throw new AnalysisException(parsingException.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -253,6 +253,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_QUERY_DEBUG_TRACE = "enable_query_debug_trace";
 
+    public static final String PARSE_TOKENS_LIMIT = "parse_tokens_limit";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(ENABLE_SPILLING)
@@ -603,6 +605,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_PRUNE_SHUFFLE_COLUMN_RATE, flag = VariableMgr.INVISIBLE)
     private double cboPruneShuffleColumnRate = 0.1;
+
+    @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
+    private int parseTokensLimit = 3500000;
 
     public void setCboCTEMaxLimit(int cboCTEMaxLimit) {
         this.cboCTEMaxLimit = cboCTEMaxLimit;
@@ -1090,6 +1095,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getloadTransmissionCompressionType() {
         return loadTransmissionCompressionType;
+    }
+
+    public int getParseTokensLimit() {
+        return parseTokensLimit;
+    }
+
+    public void setParseTokensLimit(int parseTokensLimit) {
+        this.parseTokensLimit = parseTokensLimit;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -539,7 +539,7 @@ public class StmtExecutor {
             List<StatementBase> stmts;
             try {
                 stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt.originStmt,
-                        context.getSessionVariable().getSqlMode());
+                        context.getSessionVariable());
                 parsedStmt = stmts.get(originStmt.idx);
                 parsedStmt.setOrigStmt(originStmt);
             } catch (ParsingException parsingException) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -408,7 +408,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         ctx.setThreadLocalInfo();
         String definition = mvContext.getDefinition();
         InsertStmt insertStmt =
-                (InsertStmt) SqlParser.parse(definition, ctx.getSessionVariable().getSqlMode()).get(0);
+                (InsertStmt) SqlParser.parse(definition, ctx.getSessionVariable()).get(0);
         insertStmt.setTargetPartitionNames(new PartitionNames(false, new ArrayList<>(materializedViewPartitions)));
         QueryStatement queryStatement = insertStmt.getQueryStatement();
         Map<String, TableRelation> tableRelations =

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -25,7 +25,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
                     .setCatalog(ctx.getCurrentCatalog());
             ctx.getPlannerProfile().reset();
             String definition = context.getDefinition();
-            StatementBase sqlStmt = SqlParser.parse(definition, ctx.getSessionVariable().getSqlMode()).get(0);
+            StatementBase sqlStmt = SqlParser.parse(definition, ctx.getSessionVariable()).get(0);
             sqlStmt.setOrigStmt(new OriginStatement(definition, 0));
             executor = new StmtExecutor(ctx, sqlStmt);
             ctx.setExecutor(executor);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -790,7 +790,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 db.readUnlock();
             }
             StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(createTableStmt.get(0),
-                    ConnectContext.get().getSessionVariable().getSqlMode()).get(0);
+                    ConnectContext.get().getSessionVariable()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ConnectContext.get());
             if (statementBase instanceof CreateTableStmt) {
                 CreateTableStmt parsedCreateTableStmt = (CreateTableStmt) statementBase;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
@@ -92,7 +92,7 @@ public class SqlWithIdUtils {
         for (Table table : tableMap.values()) {
             sql = sql.replaceAll(TABLE_ID_PREFIX + table.getId() + COMMON_SUFFIX, table.getName());
         }
-        return SqlParser.parse(sql, context.getSessionVariable().getSqlMode()).get(0);
+        return SqlParser.parse(sql, context.getSessionVariable()).get(0);
     }
 
     private static class SqlEncoderVisitor extends AST2SQL.SQLBuilder {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/OperationNotAllowedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/OperationNotAllowedException.java
@@ -4,7 +4,7 @@ package com.starrocks.sql.parser;
 
 import static java.lang.String.format;
 
-public class OperationNotAllowedException extends ParsingException{
+public class OperationNotAllowedException extends ParsingException {
 
     public OperationNotAllowedException(String message) {
         super(message);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/OperationNotAllowedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/OperationNotAllowedException.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.parser;
+
+import static java.lang.String.format;
+
+public class OperationNotAllowedException extends ParsingException{
+
+    public OperationNotAllowedException(String message) {
+        super(message);
+    }
+
+    public OperationNotAllowedException(String formatString, Object... args) {
+        super(format(formatString, args));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -66,11 +66,12 @@ public class SqlParser {
         parser.addParseListener(new TokenNumberListener(sessionVariable.getParseTokensLimit()));
     }
 
-    @Deprecated
+
     /**
      * We need not only sqlMode but also other parameters to define the property of parser.
      * Please consider use {@link #parse(String, SessionVariable)}
      */
+    @Deprecated
     public static List<StatementBase> parse(String originSql, long sqlMode) {
         SessionVariable sessionVariable = new SessionVariable();
         sessionVariable.setSqlMode(sqlMode);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -59,7 +59,7 @@ public class SqlParser {
     }
 
     public static void setParserProperty(StarRocksParser parser, SessionVariable sessionVariable) {
-        parser.sqlMode = sessionVariable.getSqlMode();
+        StarRocksParser.sqlMode = sessionVariable.getSqlMode();
         parser.removeErrorListeners();
         parser.addErrorListener(new ErrorHandler());
         parser.removeParseListeners();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -67,6 +67,10 @@ public class SqlParser {
     }
 
     @Deprecated
+    /**
+     * We need not only sqlMode but also other parameters to define the property of parser.
+     * Please consider use {@link #parse(String, SessionVariable)}
+     */
     public static List<StatementBase> parse(String originSql, long sqlMode) {
         SessionVariable sessionVariable = new SessionVariable();
         sessionVariable.setSqlMode(sqlMode);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
@@ -1,0 +1,23 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.parser;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+public class TokenNumberListener extends StarRocksBaseListener {
+
+    private int maxTokensNum;
+
+    public TokenNumberListener(int maxTokensNum) {
+        this.maxTokensNum = maxTokensNum;
+    }
+
+    @Override
+    public void visitTerminal(TerminalNode node) {
+        int index = node.getSymbol().getTokenIndex();
+        if (index >= maxTokensNum) {
+            throw new OperationNotAllowedException("Sql exceeds %d tokens, please consider modify parse_tokens_limit variable.",
+                    maxTokensNum);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TokenNumberListener.java
@@ -16,8 +16,8 @@ public class TokenNumberListener extends StarRocksBaseListener {
     public void visitTerminal(TerminalNode node) {
         int index = node.getSymbol().getTokenIndex();
         if (index >= maxTokensNum) {
-            throw new OperationNotAllowedException("Sql exceeds %d tokens, please consider modify parse_tokens_limit variable.",
-                    maxTokensNum);
+            throw new OperationNotAllowedException("Statement exceeds maximum length limit, please consider modify " +
+                    "parse_tokens_limit variable.");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -570,7 +570,7 @@ public class ShowExecutorTest {
         ctx.setQualifiedUser("default_cluster:testUser");
 
         ShowColumnStmt stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show columns from testTbl in testDb",
-                ctx.getSessionVariable().getSqlMode()).get(0);
+                ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
@@ -585,7 +585,7 @@ public class ShowExecutorTest {
 
         // verbose
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full columns from testTbl in testDb",
-                ctx.getSessionVariable().getSqlMode()).get(0);
+                ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         executor = new ShowExecutor(ctx, stmt);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -20,7 +20,7 @@ public class AdminSetTest {
     @Test
     public void testAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
-        analyzeFail("admin set frontend config;", "Syntax error in line 1");
+        analyzeFail("admin set frontend config;", "the right syntax to use near '<EOF>'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -75,7 +75,7 @@ public class AnalyzeJoinTest {
         analyzeSuccess("select * from tnotnull inner join (select * from t0) t using (v1)");
 
         analyzeSuccess("select * from (t0 join tnotnull using(v1)) , t1");
-        analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1", "Syntax error");
+        analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1", "the right syntax to use near 't'");
         analyzeFail("select v1 from (t0 join tnotnull using(v1)), t1", "Column 'v1' is ambiguous");
         analyzeSuccess("select a.v1 from (t0 a join tnotnull b using(v1)), t1");
     }
@@ -175,7 +175,7 @@ public class AnalyzeJoinTest {
         analyzeSuccess(sql);
 
         sql = "select * from (t0 a, (t1) b)";
-        analyzeFail(sql, "Syntax error");
+        analyzeFail(sql, "the right syntax to use near 'b'");
 
         sql = "select * from (t0 a, t1 a)";
         analyzeFail(sql, "Not unique table/alias: 'a'");
@@ -190,7 +190,7 @@ public class AnalyzeJoinTest {
         analyzeFail(sql, "Not unique table/alias: 't1'");
 
         sql = "select * from (t0 join t1) t,t1";
-        analyzeFail(sql, "Syntax error");
+        analyzeFail(sql, "the right syntax to use near 't'");
 
         sql = "select * from (t0 join t1 t) ,t1";
         analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -191,13 +191,13 @@ public class AnalyzeTestUtil {
     public static StatementBase analyzeSuccess(String originStmt) {
         try {
             StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(originStmt,
-                    connectContext.getSessionVariable().getSqlMode()).get(0);
+                    connectContext.getSessionVariable()).get(0);
             Analyzer.analyze(statementBase, connectContext);
 
             if (statementBase instanceof QueryStatement) {
                 StatementBase viewStatement =
                         com.starrocks.sql.parser.SqlParser.parse(ViewDefBuilder.build(statementBase),
-                                connectContext.getSessionVariable().getSqlMode()).get(0);
+                                connectContext.getSessionVariable()).get(0);
                 Analyzer.analyze(viewStatement, connectContext);
             }
 
@@ -212,7 +212,7 @@ public class AnalyzeTestUtil {
     public static StatementBase analyzeWithoutTestView(String originStmt) {
         try {
             StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(originStmt,
-                    connectContext.getSessionVariable().getSqlMode()).get(0);
+                    connectContext.getSessionVariable()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             return statementBase;
         } catch (Exception ex) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserBench.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -56,20 +57,33 @@ public class ParserBench {
     @Param({"100", "1000", "5000", "10000"})
     public int times;
 
+    @Param({"true", "false"})
+    public boolean isRightSql;
+
+    @Param({"true", "false"})
+    public boolean isLimit;
+
     @Benchmark
     public void parseInsertIntoValues() {
         parseSql(sql);
     }
 
     private String generateSQL() {
-        List<String> values = Lists.newArrayList("K0.14044384266968246155471433667116798460483551025390625",
+        List<String> wrongValues = Lists.newArrayList("K0.14044384266968246155471433667116798460483551025390625",
                 "-1869445626", "K0.17698452552099786", "K127", "k-366217216");
-        String joined = String.join(",", values);
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < times; i++) {
-            result.append("(").append(joined).append("), ");
+        List<String> rightValues = Lists.newArrayList("0.14044384266968246155471433667116798460483551025390625",
+                "-1869445626", "0.17698452552099786", "127", "-366217216");
+
+        String joined;
+        if (isRightSql) {
+            joined = String.join(",", rightValues);
+        } else {
+            joined = String.join(",", wrongValues);
         }
-        result.append("(").append(joined).append(")");
+        StringJoiner result = new StringJoiner(",", "(", ")");
+        for (int i = 0; i < times; i++) {
+            result.add(joined);
+        }
         return "INSERT INTO test_load_decimal_1_0 VALUES " + result + ";";
     }
 
@@ -80,6 +94,10 @@ public class ParserBench {
         StarRocksParser.sqlMode = SqlModeHelper.MODE_DEFAULT;
         parser.removeErrorListeners();
         parser.addErrorListener(new BaseErrorListener());
+        parser.removeParseListeners();
+        if (isLimit) {
+            parser.addParseListener(new TokenNumberListener(1000000));
+        }
         parser.getInterpreter().setPredictionMode(mode.equals("SLL") ? PredictionMode.SLL : PredictionMode.LL);
         StarRocksParser.SqlStatementsContext sqlStatements = parser.sqlStatements();
         return (StatementBase) new AstBuilder(SqlModeHelper.MODE_DEFAULT)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/TokenLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/TokenLimitTest.java
@@ -9,7 +9,7 @@ import static com.starrocks.sql.plan.PlanTestBase.assertContains;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
-public class TokenLimitTest {
+class TokenLimitTest {
 
     @Test
     void tokensExceedLimitTest() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/TokenLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/TokenLimitTest.java
@@ -1,0 +1,35 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.parser;
+
+import com.starrocks.qe.SessionVariable;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.plan.PlanTestBase.assertContains;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+public class TokenLimitTest {
+
+    @Test
+    void tokensExceedLimitTest() {
+        String sql = "select 1";
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setParseTokensLimit(1);
+        assertThrows(OperationNotAllowedException.class, () -> SqlParser.parse(sql, sessionVariable));
+    }
+
+    @Test
+    void sqlParseErrorInfoTest() {
+        String sql = "select 1 form tbl";
+        SessionVariable sessionVariable = new SessionVariable();
+        try {
+            SqlParser.parse(sql, sessionVariable);
+            fail("sql should fail to parse.");
+        } catch (Exception e) {
+            assertContains(e.getMessage(), "You have an error in your SQL syntax");
+        }
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -214,7 +214,7 @@ public class StarRocksAssert {
     public void executeResourceGroupDdlSql(String sql) throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 32);
-        StatementBase statement = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        StatementBase statement = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
         Analyzer.analyze(statement, ctx);
 
         Assert.assertTrue(statement.getClass().getSimpleName().contains("ResourceGroupStmt"));

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -398,7 +398,7 @@ public class UtFrameUtils {
 
     public static String getStmtDigest(ConnectContext connectContext, String originStmt) throws Exception {
         StatementBase statementBase =
-                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable())
                         .get(0);
         Preconditions.checkState(statementBase instanceof QueryStatement);
         QueryStatement queryStmt = (QueryStatement) statementBase;
@@ -553,7 +553,7 @@ public class UtFrameUtils {
         Map<String, Database> dbs = null;
         try {
             StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(replaySql,
-                    connectContext.getSessionVariable().getSqlMode()).get(0);
+                    connectContext.getSessionVariable()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, connectContext);
 
             dbs = AnalyzerUtils.collectAllDatabase(connectContext, statementBase);


### PR DESCRIPTION

## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. When parsing large sql, it costs a large amount of memory easily lead to FULL GC. We add a option `parse_tokens_limit` to prevent parsing sql exceeds the number of this option. I have tested its performance. This operation doesn't add extra time cost almostly.
2. In order to ensure compatibility, we use the old parser to parse sql again when the new parser throws an exception. When the old parser also failed, it swallowed the new parser exception contains meaningful error info but returned a useless error info provided by the old parser to client. This pr fixed this by throwing new parser exception when old parser encountered exception.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
