### PR TITLE
[Enhance] limit maximum length of JSON string to 16MB

### DIFF
--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -24,6 +24,9 @@ static bool is_json_start_char(char ch) {
 }
 
 StatusOr<JsonValue> JsonValue::parse_json_or_string(const Slice& src) {
+    if (src.size > kJSONLengthLimit) {
+        return Status::NotSupported("JSON string exceed maximum length 16MB");
+    }
     try {
         if (src.empty()) {
             return JsonValue(noneJsonSlice());
@@ -52,6 +55,9 @@ Status JsonValue::parse(const Slice& src, JsonValue* out) {
         if (src.empty()) {
             *out = JsonValue(noneJsonSlice());
             return Status::OK();
+        }
+        if (src.size > kJSONLengthLimit) {
+            return Status::NotSupported("JSON string exceed maximum length 16MB");
         }
         auto b = vpack::Parser::fromJson(src.get_data(), src.get_size());
         out->assign(*b);

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -29,6 +29,9 @@ enum JsonType {
     JSON_OBJECT = 5,
 };
 
+// Maximum length of JSON string is 16MB
+constexpr size_t kJSONLengthLimit = 16 << 20;
+
 class JsonValue {
 public:
     using VSlice = vpack::Slice;

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -39,6 +39,14 @@ PARALLEL_TEST(JsonColumnTest, test_parse) {
         ASSERT_TRUE(json.value().to_string().ok());
         ASSERT_EQ(json_str, json.value().to_string().value());
     }
+    {
+        // Exceed length limitation
+        Slice slice;
+        slice.data = json_str.data();
+        slice.size = kJSONLengthLimit + 1;
+        auto maybe_json = JsonValue::parse_json_or_string(slice);
+        ASSERT_FALSE(maybe_json.ok());
+    }
 }
 
 PARALLEL_TEST(JsonColumnTest, test_to_string) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Limit the maximum length of JSON string to 16MB, to avoid memory allocation and storage issues.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
