### PR TITLE
[Enhancement] Fold LimitOperator if of no use

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2332,6 +2332,7 @@ public class Coordinator {
             fragmentProfile.removeAllChildren();
             instanceProfile0.getChildList().forEach(pair -> {
                 RuntimeProfile pipelineProfile = pair.first;
+                foldUnnecessaryLimitOperators(pipelineProfile);
                 fragmentProfile.addChild(pipelineProfile);
             });
         }
@@ -2381,6 +2382,35 @@ public class Coordinator {
                 }
             }
         }
+    }
+
+    /**
+     * Remove unnecessary LimitOperator, which has same input rows and output rows
+     * to keep the profile concise
+     */
+    private void foldUnnecessaryLimitOperators(RuntimeProfile pipelineProfile) {
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        if (!sessionVariable.isProfileLimitFold()) {
+            return;
+        }
+
+        List<String> foldNames = Lists.newArrayList();
+        for (Pair<RuntimeProfile, Boolean> child : pipelineProfile.getChildList()) {
+            RuntimeProfile operatorProfile = child.first;
+            if (operatorProfile.getName().contains("LIMIT")) {
+                RuntimeProfile commonMetrics = operatorProfile.getChild("CommonMetrics");
+                Preconditions.checkNotNull(commonMetrics);
+                Counter pullRowNum = commonMetrics.getCounter("PullRowNum");
+                Counter pushRowNum = commonMetrics.getCounter("PushRowNum");
+                Preconditions.checkNotNull(pullRowNum);
+                Preconditions.checkNotNull(pushRowNum);
+                if (Objects.equals(pullRowNum.getValue(), pushRowNum.getValue())) {
+                    foldNames.add(operatorProfile.getName());
+                }
+            }
+        }
+
+        foldNames.forEach(pipelineProfile::removeChild);
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -164,6 +164,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PIPELINE_DOP = "pipeline_dop";
 
     public static final String PROFILE_TIMEOUT = "profile_timeout";
+    public static final String PROFILE_LIMIT_FOLD = "profile_limit_fold";
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
 
     public static final String RESOURCE_GROUP_ID = "workgroup_id";
@@ -469,6 +470,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
     private int profileTimeout = 2;
+
+    @VariableMgr.VarAttr(name = PROFILE_LIMIT_FOLD, flag = VariableMgr.INVISIBLE)
+    private boolean profileLimitFold = true;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_LEVEL)
     private int pipelineProfileLevel = 1;
@@ -996,6 +1000,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getProfileTimeout() {
         return profileTimeout;
+    }
+
+    public boolean isProfileLimitFold() {
+        return profileLimitFold;
     }
 
     public int getPipelineProfileLevel() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -582,7 +582,7 @@ public class StmtExecutor {
         initProfile(beginTimeInNanoSecond);
         profile.computeTimeInChildProfile();
         long profileEndTime = System.currentTimeMillis();
-        profile.getChildMap().get("Summary")
+        profile.getChild("Summary")
                 .addInfoString(ProfileManager.PROFILE_TIME,
                         DebugUtil.getPrettyStringMs(profileEndTime - profileBeginTime));
         StringBuilder builder = new StringBuilder();
@@ -1231,12 +1231,9 @@ public class StmtExecutor {
                 dataSink.complete();
             }
 
-
-
             coord = new Coordinator(context, execPlan.getFragments(), execPlan.getScanNodes(),
                     execPlan.getDescTbl().toThrift());
             coord.setQueryType(TQueryType.LOAD);
-
 
             List<ScanNode> scanNodes = execPlan.getScanNodes();
 
@@ -1263,7 +1260,6 @@ public class StmtExecutor {
                     createTime,
                     estimateScanRows);
             coord.setJobId(jobId);
-
 
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), coord);
             coord.exec();
@@ -1413,8 +1409,9 @@ public class StmtExecutor {
             // cancel insert load job
             try {
                 if (jobId != -1) {
-                    context.getGlobalStateMgr().getLoadManager().recordFinishedOrCacnelledLoadJob(jobId, EtlJobType.INSERT,
-                            "Cancelled, msg: " + t.getMessage(), coord.getTrackingUrl());
+                    context.getGlobalStateMgr().getLoadManager()
+                            .recordFinishedOrCacnelledLoadJob(jobId, EtlJobType.INSERT,
+                                    "Cancelled, msg: " + t.getMessage(), coord.getTrackingUrl());
                     jobId = -1;
                 }
             } catch (Exception abortTxnException) {
@@ -1425,8 +1422,9 @@ public class StmtExecutor {
             if (insertError) {
                 try {
                     if (jobId != -1) {
-                        context.getGlobalStateMgr().getLoadManager().recordFinishedOrCacnelledLoadJob(jobId, EtlJobType.INSERT,
-                                "Cancelled", coord.getTrackingUrl());
+                        context.getGlobalStateMgr().getLoadManager()
+                                .recordFinishedOrCacnelledLoadJob(jobId, EtlJobType.INSERT,
+                                        "Cancelled", coord.getTrackingUrl());
                         jobId = -1;
                     }
                 } catch (Exception abortTxnException) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
The previous pr #3431 add LimitOperator for almost every operator. 

Sometimes, if the limit is small, for example 10 smaller than 4096(chunk size), then the LimitOperator is of no use if the previous operator handle limit already for that paralleliasm.

So, in order to make the profile more concisely, we can remove the LimitOperator if the condition `PushRowNums = PullRowNums` satisfies

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
