### PR TITLE
[BugFix] NPE when abort txn on HiveTable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1245,7 +1245,7 @@ public class DatabaseTransactionMgr {
                 if (table != null) {
                     TransactionStateListener listener = stateListenerFactory.create(this, table);
                     if (listener != null) {
-                        listeners.add(stateListenerFactory.create(this, table));
+                        listeners.add(listener);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1243,7 +1243,10 @@ public class DatabaseTransactionMgr {
             for (Long tableId : transactionState.getTableIdList()) {
                 Table table = db.getTable(tableId);
                 if (table != null) {
-                    listeners.add(stateListenerFactory.create(this, table));
+                    TransactionStateListener listener = stateListenerFactory.create(this, table);
+                    if (listener != null) {
+                        listeners.add(stateListenerFactory.create(this, table));
+                    }
                 }
             }
         } finally {


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix this NPE.
```
2022-08-31 15:23:16,838 WARN (thrift-server-pool-413|24710) [FrontendServiceImpl.loadTxnRollback():1138] catch unknown result.
java.lang.NullPointerException: null
        at com.starrocks.transaction.DatabaseTransactionMgr.abortTransaction(DatabaseTransactionMgr.java:1300) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.abortTransaction(DatabaseTransactionMgr.java:1238) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.abortTransaction(GlobalTransactionMgr.java:424) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.loadTxnRollbackImpl(FrontendServiceImpl.java:1165) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.loadTxnRollback(FrontendServiceImpl.java:1128) [starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$loadTxnRollback.getResult(FrontendService.java:2306) [starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$loadTxnRollback.getResult(FrontendService.java:2286) [starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) [libthrift-0.13.0.jar:0.13.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) [libthrift-0.13.0.jar:0.13.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:310) [starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]

```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
