### PR TITLE
[BugFix]Fix colocate state inaccuracy bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -260,6 +260,8 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                     } else {
                                         tablet.setLastStatusCheckTime(checkStartTime);
                                     }
+                                } else {
+                                    isGroupStable = false;
                                 }
                                 idx++;
                             }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -142,7 +142,7 @@ public class UtFrameUtils {
             ");";
 
     // Help to create a mocked ConnectContext.
-    public static ConnectContext createDefaultCtx() throws IOException {
+    public static ConnectContext createDefaultCtx() {
         ConnectContext ctx = new ConnectContext(null);
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
         ctx.setQualifiedUser(Auth.ROOT_USER);


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR #9354 added the check logic that if the tablet has been in the tablet scheduler queue, then do not check the health status. But the isGroupStable will remain true if all the tablets are in the tablet scheduler queue, which makes the status  inaccurate. Set isGroupStable to false if there is tablet in the tablet scheduler queue.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
