### PR TITLE
[Feature] Add committed state for broker/spark load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -292,7 +292,7 @@ public abstract class BulkLoadJob extends LoadJob {
             // So the callback of txn is executed when log of txn aborted is replayed.
             return;
         }
-        unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment());
+        unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment(), true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -666,7 +666,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             // label
             jobInfo.add(label);
             // state
-            if (state.name() == "COMMITTED") {
+            if (state == JobState.COMMITTED) {
                 jobInfo.add("PREPARED");
             } else {
                 jobInfo.add(state.name());

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -634,13 +634,25 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                         state, failMsg));
     }
 
-    public void unprotectReadEndOperation(LoadJobFinalOperation loadJobFinalOperation) {
+    public void unprotectReadEndOperation(LoadJobFinalOperation loadJobFinalOperation, boolean isReplay) {
         loadingStatus = loadJobFinalOperation.getLoadingStatus();
         progress = loadJobFinalOperation.getProgress();
         loadStartTimestamp = loadJobFinalOperation.getLoadStartTimestamp();
         finishTimestamp = loadJobFinalOperation.getFinishTimestamp();
-        state = loadJobFinalOperation.getJobState();
+        if (isReplay) {
+            state = loadJobFinalOperation.getJobState();
+        }
         failMsg = loadJobFinalOperation.getFailMsg();
+    }
+
+    public void unprotectUpdateLoadingStatus(TransactionState txnState) {
+        if (txnState.getTxnCommitAttachment() == null) {
+            // The txn attachment maybe null when broker load has been cancelled without attachment.
+            // The end log of broker load has been record but the callback id of txnState hasn't been removed
+            // So the callback of txn is executed when log of txn aborted is replayed.
+            return;
+        }
+        unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment(), false);
     }
 
     public List<Comparable> getShowInfo() throws DdlException {
@@ -654,8 +666,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             // label
             jobInfo.add(label);
             // state
-            jobInfo.add(state.name());
-
+            if (state.name() == "COMMITTED") {
+                jobInfo.add("PREPARED");
+            } else {
+                jobInfo.add(state.name());
+            }
             // progress
             switch (state) {
                 case PENDING:
@@ -770,11 +785,12 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     @Override
     public void afterCommitted(TransactionState txnState, boolean txnOperated) throws UserException {
-        if (txnOperated) {
+        if (!txnOperated) {
             return;
         }
         writeLock();
         try {
+            unprotectUpdateLoadingStatus(txnState);
             isCommitting = false;
             state = JobState.COMMITTED;
         } finally {
@@ -787,6 +803,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         writeLock();
         try {
             replayTxnAttachment(txnState);
+            progress = 99;
             transactionId = txnState.getTransactionId();
             state = JobState.COMMITTED;
         } finally {
@@ -815,7 +832,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 return;
             }
             // record attachment in load job
-            replayTxnAttachment(txnState);
+            unprotectUpdateLoadingStatus(txnState);
             // cancel load job
             unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), false);
         } finally {
@@ -854,7 +871,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         if (!txnOperated) {
             return;
         }
-        replayTxnAttachment(txnState);
+        unprotectUpdateLoadingStatus(txnState);
         updateState(JobState.FINISHED);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -214,7 +214,7 @@ public class LoadManager implements Writable {
             LOG.warn("job does not exist when replaying end load job edit log: {}", operation);
             return;
         }
-        job.unprotectReadEndOperation(operation);
+        job.unprotectReadEndOperation(operation, true);
         LOG.info(new LogBuilder(LogKey.LOAD_JOB, operation.getId())
                 .add("operation", operation)
                 .add("msg", "replay end load job")


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bugfix
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10654

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

BrokerLoad state transfer from PENDING->LOADING->FINISHED->CANCELLED
SparkLoad state transfer from PENDING->ETL->LOADING->FINISHED->CANCELLED
Here we add a new inner state between LOADING and FINISHED (COMMITTED),
in order not to mislead user, committed state is an internal state, output state is prepared