### PR TITLE
[BugFix] Ranges may be lost when dynamic partitions are created.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -158,6 +158,16 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                         db.getFullName(), olapTable.getName());
                 continue;
             }
+
+            for (Range<PartitionKey> partitionKeyRange : rangePartitionInfo.getIdToRange(false).values()) {
+                if (partitionKeyRange.contains(addPartitionKeyRange.lowerEndpoint()) &&
+                        addPartitionKeyRange.contains(partitionKeyRange.upperEndpoint()) &&
+                        !addPartitionKeyRange.upperEndpoint().equals(partitionKeyRange.upperEndpoint())) {
+                    addPartitionKeyRange = Range.closedOpen(partitionKeyRange.upperEndpoint(),
+                            addPartitionKeyRange.upperEndpoint());
+                }
+            }
+
             for (Range<PartitionKey> partitionKeyRange : rangePartitionInfo.getIdToRange(false).values()) {
                 // only support single column partition now
                 try {


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
![84E1D5CF-1A8A-450C-A31A-084AA1036CD9](https://user-images.githubusercontent.com/45174089/187820772-0e57be9b-825d-40d2-94bd-6ebe63fe1e9e.png)


If the partition type changes from the month dimension to the week dimension.  Old dynamic partitioning for [(' 2022-08-01 00:00:00), (' 2022-09-01 00:00:00))
In this case, the new dynamic partition of the week dimension [('2022-08-29 00:00:00'), ('2022-09-05 00:00:00')) fails to be created.  The next partition created successfully will be [('2022-09-05 00:00:00'), ('2022-09-12 00:00:00')).  No partition can be found for the data from September 1 to September 4.  Therefore, I added a dynamic clipping partition in this area.  When this situation is detected, I clipped the starting position of the partition to create a partition for [('2022-09-01 00:00:00'), ('2022-09-05 00:00:00')).

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
