### PR TITLE
[Bugfix] hive external table array type pattern compatible with array<struct<>>

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 public class Utils {
     public static final String DECIMAL_PATTERN = "^decimal\\((\\d+),(\\d+)\\)";
-    public static final String ARRAY_PATTERN = "^array<([0-9a-z<>(),]+)>";
+    public static final String ARRAY_PATTERN = "^array<([0-9a-z<>(),:]+)>";
     public static final String CHAR_PATTERN = "^char\\(([0-9]+)\\)";
     public static final String VARCHAR_PATTERN = "^varchar\\(([0-9,-1]+)\\)";
 


### PR DESCRIPTION
…<struct<>>

## What type of PR is this：
- [ ] bugfix
- [x] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the hive table with column like array<struct<k1:int>>, it will fail to load hive external table.

before fix:
stack overflow
after fix:
![image](https://user-images.githubusercontent.com/91597003/187826507-691ca744-9551-4293-b0c1-4023705a4d90.png)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
