### PR TITLE
[BugFix] Ranges may be lost when dynamic partitions are created.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -82,8 +82,7 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
     private boolean initialize;
 
     public enum State {
-        NORMAL,
-        ERROR
+        NORMAL, ERROR
     }
 
     public DynamicPartitionScheduler(String name, long intervalMs) {
@@ -146,10 +145,10 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
             idx = 0;
         }
         for (; idx <= dynamicPartitionProperty.getEnd(); idx++) {
-            String prevBorder = DynamicPartitionUtil.getPartitionRangeString(
-                    dynamicPartitionProperty, now, idx, partitionFormat);
-            String nextBorder = DynamicPartitionUtil.getPartitionRangeString(
-                    dynamicPartitionProperty, now, idx + 1, partitionFormat);
+            String prevBorder =
+                    DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty, now, idx, partitionFormat);
+            String nextBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty, now, idx + 1,
+                    partitionFormat);
             PartitionValue lowerValue = new PartitionValue(prevBorder);
             PartitionValue upperValue = new PartitionValue(nextBorder);
 
@@ -168,11 +167,24 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
                         db.getOriginName(), olapTable.getName());
                 continue;
             }
+
             for (Range<PartitionKey> partitionKeyRange : rangePartitionInfo.getIdToRange(false).values()) {
                 // only support single column partition now
                 try {
                     RangeUtils.checkRangeIntersect(partitionKeyRange, addPartitionKeyRange);
                 } catch (DdlException e) {
+                    /*
+                     * If the old partition range for [(' 2022-08-01 00:00:00), (' 2022-09-01 00:00:00)), the range of
+                     * the new partition for [(' 2022-08-29 00:00:00), (' 2022-09-05 00:00:00 ')), Is automatically cut
+                     * out for the new partition range [(' 2022-09-01 00:00:00), (' 2022-09-05 00:00:00))
+                     */
+                    if (partitionKeyRange.contains(addPartitionKeyRange.lowerEndpoint()) &&
+                            addPartitionKeyRange.contains(partitionKeyRange.upperEndpoint()) &&
+                            !addPartitionKeyRange.upperEndpoint().equals(partitionKeyRange.upperEndpoint())) {
+                        addPartitionKeyRange = Range.closedOpen(partitionKeyRange.upperEndpoint(),
+                                addPartitionKeyRange.upperEndpoint());
+                        continue;
+                    }
                     isPartitionExists = true;
                     if (addPartitionKeyRange.equals(partitionKeyRange)) {
                         clearCreatePartitionFailedMsg(olapTable.getName());
@@ -193,14 +205,14 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
             if (dynamicPartitionProperty.getReplicationNum() == DynamicPartitionProperty.NOT_SET_REPLICATION_NUM) {
                 partitionProperties.put("replication_num", String.valueOf(olapTable.getDefaultReplicationNum()));
             } else {
-                partitionProperties
-                        .put("replication_num", String.valueOf(dynamicPartitionProperty.getReplicationNum()));
+                partitionProperties.put("replication_num",
+                        String.valueOf(dynamicPartitionProperty.getReplicationNum()));
             }
-            String partitionName =
-                    dynamicPartitionProperty.getPrefix() + DynamicPartitionUtil.getFormattedPartitionName(
-                            dynamicPartitionProperty.getTimeZone(), prevBorder, dynamicPartitionProperty.getTimeUnit());
-            SingleRangePartitionDesc rangePartitionDesc = new SingleRangePartitionDesc(false, partitionName,
-                    partitionKeyDesc, partitionProperties);
+            String partitionName = dynamicPartitionProperty.getPrefix() +
+                    DynamicPartitionUtil.getFormattedPartitionName(dynamicPartitionProperty.getTimeZone(), prevBorder,
+                            dynamicPartitionProperty.getTimeUnit());
+            SingleRangePartitionDesc rangePartitionDesc =
+                    new SingleRangePartitionDesc(false, partitionName, partitionKeyDesc, partitionProperties);
 
             // construct distribution desc
             HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) olapTable.getDefaultDistributionInfo();
@@ -212,8 +224,7 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
                     new HashDistributionDesc(dynamicPartitionProperty.getBuckets(), distColumnNames);
 
             // add partition according to partition desc and distribution desc
-            addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, distributionDesc,
-                    null, false));
+            addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, distributionDesc, null, false));
         }
         return addPartitionClauses;
     }
@@ -232,10 +243,10 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
         }
 
         ZonedDateTime now = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
-        String lowerBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
-                now, dynamicPartitionProperty.getStart(), partitionFormat);
-        String upperBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
-                now, 0, partitionFormat);
+        String lowerBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty, now,
+                dynamicPartitionProperty.getStart(), partitionFormat);
+        String upperBorder =
+                DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty, now, 0, partitionFormat);
         PartitionValue lowerPartitionValue = new PartitionValue(lowerBorder);
         PartitionValue upperPartitionValue = new PartitionValue(upperBorder);
         Range<PartitionKey> reservePartitionKeyRange;
@@ -293,16 +304,15 @@ public class DynamicPartitionScheduler extends LeaderDaemon {
             try {
                 olapTable = (OlapTable) db.getTable(tableId);
                 // Only OlapTable has DynamicPartitionProperty
-                if (olapTable == null
-                        || !olapTable.dynamicPartitionExists()
-                        || !olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
+                if (olapTable == null || !olapTable.dynamicPartitionExists() ||
+                        !olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
                     iterator.remove();
                     continue;
                 }
 
                 if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
-                    String errorMsg = "Table[" + olapTable.getName() + "]'s state is not NORMAL."
-                            + "Do not allow doing dynamic add partition. table state=" + olapTable.getState();
+                    String errorMsg = "Table[" + olapTable.getName() + "]'s state is not NORMAL." +
+                            "Do not allow doing dynamic add partition. table state=" + olapTable.getState();
                     recordCreatePartitionFailedMsg(db.getOriginName(), olapTable.getName(), errorMsg);
                     skipAddPartition = true;
                 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
![84E1D5CF-1A8A-450C-A31A-084AA1036CD9](https://user-images.githubusercontent.com/45174089/187844819-42536f08-84f5-4474-961b-c68f843335c2.png)

If the partition type changes from the month dimension to the week dimension. Old dynamic partitioning for [(' 2022-08-01 00:00:00), (' 2022-09-01 00:00:00))
In this case, the new dynamic partition of the week dimension [('2022-08-29 00:00:00'), ('2022-09-05 00:00:00')) fails to be created. The next partition created successfully will be [('2022-09-05 00:00:00'), ('2022-09-12 00:00:00')). No partition can be found for the data from September 1 to September 4. Therefore, I added a dynamic clipping partition in this area. When this situation is detected, I clipped the starting position of the partition to create a partition for [('2022-09-01 00:00:00'), ('2022-09-05 00:00:00')).
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
