### PR TITLE
[BugFix] Fix concurrency bug of insert overwrite with drop table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobManager.java
@@ -5,8 +5,6 @@ package com.starrocks.load;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.CreateInsertOverwriteJobLog;
@@ -16,7 +14,6 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.common.MetaUtils;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,10 +66,8 @@ public class InsertOverwriteJobManager implements Writable, GsonPostProcessable 
             throw new RuntimeException("register insert overwrite job failed");
         }
         try {
-            // get db and table
-            Database database = MetaUtils.getDatabase(context, job.getTargetDbId());
-            OlapTable table = (OlapTable) MetaUtils.getTable(context, database.getId(), job.getTargetTableId());
-            InsertOverwriteJobRunner jobRunner = new InsertOverwriteJobRunner(job, context, stmtExecutor, database, table);
+            InsertOverwriteJobRunner jobRunner =
+                    new InsertOverwriteJobRunner(job, context, stmtExecutor);
             jobRunner.run();
         } finally {
             deregisterOverwriteJob(job.getJobId());

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -44,8 +44,6 @@ public class InsertOverwriteJobRunner {
     private ConnectContext context;
     private long dbId;
     private long tableId;
-    // private Database db;
-    // private OlapTable targetTable;
     private String postfix;
 
     private long createPartitionElapse;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -204,8 +204,13 @@ public class InsertOverwriteJobRunner {
 
     private void createTempPartitions() throws DdlException {
         long createPartitionStartTimestamp = System.currentTimeMillis();
-        Database db = getAndWriteLockDatabase(dbId);
-        OlapTable targetTable = checkAndGetTable(db, tableId);
+        Database db = getAndReadLockDatabase(dbId);
+        OlapTable targetTable = null;
+        try {
+            targetTable = checkAndGetTable(db, tableId);
+        } finally {
+            db.readUnlock();
+        }
         PartitionUtils.createAndAddTempPartitionsForTable(db, targetTable, postfix,
                 job.getSourcePartitionIds(), job.getTmpPartitionIds());
         createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -9,6 +9,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
 import com.starrocks.qe.ConnectContext;
@@ -41,21 +42,22 @@ public class InsertOverwriteJobRunner {
     private InsertStmt insertStmt;
     private StmtExecutor stmtExecutor;
     private ConnectContext context;
-    private Database db;
-    private OlapTable targetTable;
+    private long dbId;
+    private long tableId;
+    // private Database db;
+    // private OlapTable targetTable;
     private String postfix;
 
     private long createPartitionElapse;
     private long insertElapse;
 
-    public InsertOverwriteJobRunner(InsertOverwriteJob job, ConnectContext context, StmtExecutor stmtExecutor,
-                                    Database db, OlapTable targetTable) {
+    public InsertOverwriteJobRunner(InsertOverwriteJob job, ConnectContext context, StmtExecutor stmtExecutor) {
         this.job = job;
         this.context = context;
         this.stmtExecutor = stmtExecutor;
         this.insertStmt = job.getInsertStmt();
-        this.db = db;
-        this.targetTable = targetTable;
+        this.dbId = job.getTargetDbId();
+        this.tableId = job.getTargetTableId();
         this.postfix = "_" + job.getJobId();
         this.createPartitionElapse = 0;
         this.insertElapse = 0;
@@ -64,8 +66,8 @@ public class InsertOverwriteJobRunner {
     // for replay
     public InsertOverwriteJobRunner(InsertOverwriteJob job) {
         this.job = job;
-        this.db = GlobalStateMgr.getCurrentState().getDb(job.getTargetDbId());
-        this.targetTable = (OlapTable) db.getTable(job.getTargetTableId());
+        this.dbId = job.getTargetDbId();
+        this.tableId = job.getTargetTableId();
         this.postfix = "_" + job.getJobId();
         this.createPartitionElapse = 0;
         this.insertElapse = 0;
@@ -164,10 +166,7 @@ public class InsertOverwriteJobRunner {
         if (state == InsertOverwriteJobState.OVERWRITE_SUCCESS) {
             Preconditions.checkState(job.getJobState() == InsertOverwriteJobState.OVERWRITE_RUNNING);
         }
-        if (!db.writeLockAndCheckExist()) {
-            LOG.warn("database:{} do not exist.", db.getFullName());
-            return;
-        }
+        Database db = getAndWriteLockDatabase(dbId);
         try {
             InsertOverwriteStateChangeInfo info =
                     new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(), state,
@@ -182,7 +181,7 @@ public class InsertOverwriteJobRunner {
 
     private void prepare() throws Exception {
         Preconditions.checkState(job.getJobState() == InsertOverwriteJobState.OVERWRITE_PENDING);
-        // get tmpPartitionIds first because they used to drop created partitions when restart.
+        // get tmpPartitionIds first because they are used to drop created partitions when restart.
         List<Long> tmpPartitionIds = Lists.newArrayList();
         for (int i = 0; i < job.getSourcePartitionIds().size(); ++i) {
             tmpPartitionIds.add(GlobalStateMgr.getCurrentState().getNextId());
@@ -205,6 +204,8 @@ public class InsertOverwriteJobRunner {
 
     private void createTempPartitions() throws DdlException {
         long createPartitionStartTimestamp = System.currentTimeMillis();
+        Database db = getAndWriteLockDatabase(dbId);
+        OlapTable targetTable = checkAndGetTable(db, tableId);
         PartitionUtils.createAndAddTempPartitionsForTable(db, targetTable, postfix,
                 job.getSourcePartitionIds(), job.getTmpPartitionIds());
         createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;
@@ -212,10 +213,16 @@ public class InsertOverwriteJobRunner {
 
     private void gc() {
         LOG.info("start to garbage collect");
-        db.writeLock();
+        Database db = getAndWriteLockDatabase(dbId);
         try {
+            Table table = db.getTable(tableId);
+            if (table == null) {
+                throw new DmlException("table:% does not exist in database:%s", tableId, db.getFullName());
+            }
+            Preconditions.checkState(table instanceof OlapTable);
+            OlapTable targetTable = (OlapTable) table;
             if (job.getTmpPartitionIds() != null) {
-                for (Long pid : job.getTmpPartitionIds()) {
+                for (long pid : job.getTmpPartitionIds()) {
                     LOG.info("drop temp partition:{}", pid);
 
                     Partition partition = targetTable.getPartition(pid);
@@ -234,8 +241,9 @@ public class InsertOverwriteJobRunner {
     }
 
     private void doCommit() {
-        db.writeLock();
+        Database db = getAndWriteLockDatabase(dbId);
         try {
+            OlapTable targetTable = checkAndGetTable(db, tableId);
             List<String> sourcePartitionNames = job.getSourcePartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
@@ -243,7 +251,6 @@ public class InsertOverwriteJobRunner {
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
             if (targetTable.getPartitionInfo().getType() == PartitionType.RANGE) {
-
                 targetTable.replaceTempPartitions(sourcePartitionNames, tmpPartitionNames, true, false);
             } else {
                 targetTable.replacePartition(sourcePartitionNames.get(0), tmpPartitionNames.get(0));
@@ -261,8 +268,12 @@ public class InsertOverwriteJobRunner {
         Preconditions.checkState(job.getJobState() == InsertOverwriteJobState.OVERWRITE_RUNNING);
         Preconditions.checkState(insertStmt != null);
 
-        db.readLock();
+        Database db = getAndReadLockDatabase(dbId);
         try {
+            OlapTable targetTable = checkAndGetTable(db, tableId);
+            if (job.getTmpPartitionIds().stream().anyMatch(id -> targetTable.getPartition(id) == null)) {
+                throw new DmlException("partitions changed during insert");
+            }
             List<String> tmpPartitionNames = job.getTmpPartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
@@ -276,5 +287,38 @@ public class InsertOverwriteJobRunner {
         } finally {
             db.readUnlock();
         }
+    }
+
+    // when this function return, write lock of db is acquired
+    private Database getAndWriteLockDatabase(long dbId) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            throw new DmlException("database id:%s does not exist", dbId);
+        }
+        if (!db.writeLockAndCheckExist()) {
+            throw new DmlException("insert overwrite commit failed because db:%s lock failed", dbId);
+        }
+        return db;
+    }
+
+    // when this function return, read lock of db is acquired
+    private Database getAndReadLockDatabase(long dbId) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            throw new DmlException("database id:%s does not exist", dbId);
+        }
+        if (!db.readLockAndCheckExist()) {
+            throw new DmlException("insert overwrite commit failed because db:%s lock failed", dbId);
+        }
+        return db;
+    }
+
+    private OlapTable checkAndGetTable(Database db, long tableId) {
+        Table table = db.getTable(tableId);
+        if (table == null) {
+            throw new DmlException("table:% does not exist in database:%s", tableId, db.getFullName());
+        }
+        Preconditions.checkState(table instanceof OlapTable);
+        return  (OlapTable) table;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -104,8 +104,7 @@ public class InsertOverwriteJobRunnerTest {
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable olapTable = (OlapTable) table;
         InsertOverwriteJob insertOverwriteJob = new InsertOverwriteJob(100L, insertStmt, database.getId(), olapTable.getId());
-        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(insertOverwriteJob,
-                connectContext, executor, database, olapTable);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(insertOverwriteJob, connectContext, executor);
         Assert.assertFalse(runner.isFinished());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10681

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
insert overwrite will lead to restart fe failure. the reason is that there is concurrency bug when add partition during insert overwrite. fix it by checking whether the target table exists during insert overwrite

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
