### PR TITLE
[BugFix] Add min readable version report

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -382,7 +382,6 @@ void AlterTableTaskWorkerPool::_alter_tablet(const TAlterTabletReqV2& agent_task
             // Following are unused for LakeTablet but they are defined as required thrift fields, have to init them.
             tablet_info.__set_schema_hash(0);
             tablet_info.__set_version(0);
-            tablet_info.__set_version_hash(0);
             tablet_info.__set_row_count(0);
             tablet_info.__set_data_size(0);
             tablet_info.__set_version_count(1);

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1056,6 +1056,8 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
             // and perform state modification operations.
         }
         tablet_info->__set_version(max_version);
+        // TODO: support getting minReadableVersion
+        tablet_info->__set_min_readable_version(_timestamped_version_tracker.get_min_readable_version());
         tablet_info->__set_version_count(_tablet_meta->version_count());
         tablet_info->__set_row_count(_tablet_meta->num_rows());
         tablet_info->__set_data_size(_tablet_meta->tablet_footprint());

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1979,6 +1979,7 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
 }
 
 void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
+    int64_t min_readable_version = 0;
     int64_t version = 0;
     bool has_pending = false;
     vector<uint32_t> rowsets;
@@ -1987,6 +1988,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
         if (_edit_version_infos.empty()) {
             LOG(WARNING) << "tablet delete when get_tablet_info_extra tablet:" << _tablet.tablet_id();
         } else {
+            min_readable_version = _edit_version_infos[0]->version.major();
             auto& last = _edit_version_infos.back();
             version = last->version.major();
             rowsets = last->rowsets;
@@ -2014,6 +2016,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
                                  << " rowset=" << err_rowsets;
     }
     info->__set_version(version);
+    info->__set_min_readable_version(min_readable_version);
     info->__set_version_miss(has_pending);
     info->__set_version_count(rowsets.size());
     info->__set_row_count(total_row);

--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -35,7 +35,7 @@ void TimestampedVersionTracker::_construct_versioned_tracker(const std::vector<R
     int64_t max_version = 0;
 
     // construct the roset graph
-    _version_graph.reconstruct_version_graph(rs_metas, &max_version);
+    _version_graph.construct_version_graph(rs_metas, &max_version);
 }
 
 void TimestampedVersionTracker::construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
@@ -102,6 +102,10 @@ void TimestampedVersionTracker::get_stale_version_path_json_doc(rapidjson::Docum
 
 int64_t TimestampedVersionTracker::get_max_continuous_version() const {
     return _version_graph.max_continuous_version();
+}
+
+int64_t TimestampedVersionTracker::get_min_readable_version() const {
+    return _version_graph.min_readable_version();
 }
 
 void TimestampedVersionTracker::add_version(const Version& version) {
@@ -219,6 +223,9 @@ std::vector<TimestampedVersionSharedPtr>& TimestampedVersionPathContainer::times
 }
 
 void VersionGraph::construct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version) {
+    _version_graph.clear();
+    _max_continuous_version = -1;
+    _min_readable_version = -1;
     if (rs_metas.empty()) {
         VLOG(3) << "there is no version in the header.";
         return;
@@ -234,12 +241,14 @@ void VersionGraph::construct_version_graph(const std::vector<RowsetMetaSharedPtr
         }
     }
     _max_continuous_version = _get_max_continuous_version_from(0);
-}
-
-void VersionGraph::reconstruct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version) {
-    _version_graph.clear();
-    _max_continuous_version = -1;
-    construct_version_graph(rs_metas, max_version);
+    _min_readable_version = -1;
+    for (const auto& rs_meta : rs_metas) {
+        const auto& version = rs_meta->version();
+        if (version.second <= _max_continuous_version && version.first != version.second) {
+            // it's a compacted version
+            _min_readable_version = std::max(version.second, _min_readable_version);
+        }
+    }
 }
 
 void VersionGraph::add_version_to_graph(const Version& version) {
@@ -327,6 +336,9 @@ Status VersionGraph::delete_version_from_graph(const Version& version) {
         _version_graph.erase(end_iter);
     }
 
+    if (version.second <= _max_continuous_version) {
+        _min_readable_version = std::max(_min_readable_version, version.second);
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -34,7 +34,7 @@ namespace starrocks {
 void TimestampedVersionTracker::_construct_versioned_tracker(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
     int64_t max_version = 0;
 
-    // construct the roset graph
+    // construct the rowset graph
     _version_graph.construct_version_graph(rs_metas, &max_version);
 }
 

--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -51,8 +51,6 @@ public:
     /// Use rs_metas to construct the graph including vertex and edges, and return the
     /// max_version in metas.
     void construct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version);
-    /// Reconstruct the graph, begin construction the vertex vec and edges list will be cleared.
-    void reconstruct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version);
     /// Add a version to this graph, graph will add the version and edge in version.
     void add_version_to_graph(const Version& version);
     /// Delete a version from graph. Notice that this del operation only remove this edges and
@@ -66,6 +64,8 @@ public:
 
     // Get max continuous version from 0
     int64_t max_continuous_version() const { return _max_continuous_version; }
+
+    int64_t min_readable_version() const { return _min_readable_version; }
 
 private:
     /// Private method add a version to graph.
@@ -82,6 +82,17 @@ private:
     std::unordered_map<int64_t, std::unique_ptr<Vertex>> _version_graph;
     // max continuous version from -1
     int64_t _max_continuous_version{-1};
+    // minReadableVersion should:
+    // >= compaction output's version.second if compaction's input rowsets are stale and removed from graph
+    // <= _max_continuous_version
+    // for example, suppose graph is:
+    // [0-5] 6 7 8 9 10 11 12
+    //       \-[6-10]-/
+    // minReadableVersion is 5
+    // and when 6, 7, 8, 9, 10 are stale and removed from graph by GC, graph became
+    // [0-5] [6-10] 11 12
+    // minReadableVersion will be updated to 10
+    int64_t _min_readable_version{-1};
 };
 
 /// TimestampedVersion class which is implemented to maintain multi-version path of rowsets.
@@ -183,6 +194,8 @@ public:
 
     // Get max continuous version from 0
     int64_t get_max_continuous_version() const;
+
+    int64_t get_min_readable_version() const;
 
 private:
     /// Construct rowsets version tracker with stale rowsets.

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -81,7 +81,6 @@ void tear_down() {
 void set_default_create_tablet_request(TCreateTabletReq* request) {
     request->tablet_id = random();
     request->__set_version(1);
-    request->__set_version_hash(0);
     request->tablet_schema.schema_hash = 270068375;
     request->tablet_schema.short_key_column_count = 2;
     request->tablet_schema.keys_type = TKeysType::AGG_KEYS;
@@ -162,7 +161,6 @@ void set_default_create_tablet_request(TCreateTabletReq* request) {
 void set_create_duplicate_tablet_request(TCreateTabletReq* request) {
     request->tablet_id = random();
     request->__set_version(1);
-    request->__set_version_hash(0);
     request->tablet_schema.schema_hash = 270068376;
     request->tablet_schema.short_key_column_count = 2;
     request->tablet_schema.keys_type = TKeysType::DUP_KEYS;

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -89,7 +89,6 @@ TEST_F(LakeTabletManagerTest, create_and_delete_tablet) {
     TCreateTabletReq req;
     req.tablet_id = 65535;
     req.__set_version(1);
-    req.__set_version_hash(0);
     req.tablet_schema.schema_hash = 270068375;
     req.tablet_schema.short_key_column_count = 2;
     EXPECT_OK(_tablet_manager->create_tablet(req));
@@ -326,7 +325,6 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         TCreateTabletReq req;
         req.tablet_id = 65535;
         req.__set_version(1);
-        req.__set_version_hash(0);
         req.tablet_schema.__set_id(1);
         req.tablet_schema.__set_schema_hash(0);
         req.tablet_schema.__set_short_key_column_count(1);
@@ -363,7 +361,6 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         TCreateTabletReq req;
         req.tablet_id = 65536;
         req.__set_version(1);
-        req.__set_version_hash(0);
         req.__set_base_tablet_id(65535);
         req.tablet_schema.__set_id(2);
         req.tablet_schema.__set_schema_hash(0);
@@ -413,7 +410,6 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         TCreateTabletReq req;
         req.tablet_id = 65537;
         req.__set_version(1);
-        req.__set_version_hash(0);
         req.__set_base_tablet_id(65536);
         req.tablet_schema.__set_id(3);
         req.tablet_schema.__set_schema_hash(0);

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -847,7 +847,6 @@ TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
     TCreateTabletReq request;
     request.tablet_id = tablet_id;
     request.__set_version(1);
-    request.__set_version_hash(0);
     request.tablet_schema.schema_hash = schema_hash;
     request.tablet_schema.short_key_column_count = 6;
     request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -143,7 +143,6 @@ protected:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 2;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -127,7 +127,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 6;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -80,7 +80,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 6;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -29,7 +29,6 @@ protected:
     void SetCreateTabletReq(TCreateTabletReq* request, int64_t tablet_id, TKeysType::type type = TKeysType::DUP_KEYS) {
         request->tablet_id = tablet_id;
         request->__set_version(1);
-        request->__set_version_hash(0);
         request->tablet_schema.schema_hash = 270068375;
         request->tablet_schema.short_key_column_count = 2;
         request->tablet_schema.keys_type = type;

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -96,7 +96,6 @@ public:
         create_tablet_req.__set_tablet_schema(tablet_schema);
         create_tablet_req.__set_tablet_id(tablet_id);
         create_tablet_req.__set_version(2);
-        create_tablet_req.__set_version_hash(3333);
         return create_tablet_req;
     }
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -168,7 +168,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
@@ -219,7 +218,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 6;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
@@ -258,7 +256,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 6;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -76,7 +76,6 @@ public:
     static void set_default_create_tablet_request(TCreateTabletReq* request) {
         request->tablet_id = 12345;
         request->__set_version(1);
-        request->__set_version_hash(0);
         request->tablet_schema.schema_hash = 1111;
         request->tablet_schema.short_key_column_count = 2;
         request->tablet_schema.keys_type = TKeysType::DUP_KEYS;

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -70,7 +70,6 @@ public:
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
-        request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 6;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;

--- a/be/test/storage/version_graph_test.cpp
+++ b/be/test/storage/version_graph_test.cpp
@@ -212,7 +212,7 @@ TEST(VersionGraphTest, capture) {
 
     rs_meta.clear();
     max_version = -1;
-    graph.reconstruct_version_graph(rs_meta, &max_version);
+    graph.construct_version_graph(rs_meta, &max_version);
 
     EXPECT_EQ(max_version, -1);
 }
@@ -340,17 +340,22 @@ TEST(VersionGraphTest, max_continuous_version) {
     auto input1 = gen_meta({{0, 1}, {2, 2}, {3, 3}, {4, 4}, {6, 6}});
     graph.construct_version_graph(input1, nullptr);
     EXPECT_EQ(graph.max_continuous_version(), 4);
+    EXPECT_EQ(graph.min_readable_version(), 1);
     graph.add_version_to_graph(Version(5, 5));
     EXPECT_EQ(graph.max_continuous_version(), 6);
+    EXPECT_EQ(graph.min_readable_version(), 1);
     graph.add_version_to_graph(Version(7, 7));
     EXPECT_EQ(graph.max_continuous_version(), 7);
+    EXPECT_EQ(graph.min_readable_version(), 1);
 
     // The following case may be happened in schema change
     // 1. Schema change first remove the existing rowset
     // 2. Add new version rowset into new tablet
     graph.delete_version_from_graph(Version(0, 1));
+    EXPECT_EQ(graph.min_readable_version(), 1);
     for (int i = 2; i <= 7; i++) {
         graph.delete_version_from_graph(Version(i, i));
+        EXPECT_EQ(graph.min_readable_version(), i);
     }
     EXPECT_EQ(graph.max_continuous_version(), 7);
     graph.add_version_to_graph(Version(0, 10));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -242,6 +242,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             if (state.canQuery()) {
                 // replica.getSchemaHash() == -1 is for compatibility
                 if (replica.checkVersionCatchUp(visibleVersion, false)
+                        && replica.getMinReadableVersion() <= visibleVersion
                         && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
                     allQuerableReplicas.add(replica);
                     if (localBeId != -1 && replica.getBackendId() == localBeId) {
@@ -268,6 +269,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             if (state.canQuery()) {
                 // replica.getSchemaHash() == -1 is for compatibility
                 if (replica.checkVersionCatchUp(visibleVersion, false)
+                        && replica.getMinReadableVersion() <= visibleVersion
                         && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
                     size++;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -239,7 +239,7 @@ public class TabletInvertedIndex {
                                             } else {
                                                 TPartitionVersionInfo versionInfo =
                                                         new TPartitionVersionInfo(tabletMeta.getPartitionId(),
-                                                                partitionCommitInfo.getVersion(), 0);
+                                                                partitionCommitInfo.getVersion());
                                                 ListMultimap<Long, TPartitionVersionInfo> map =
                                                         transactionsToPublish.get(transactionState.getDbId());
                                                 if (map == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -978,6 +978,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
         Preconditions.checkArgument(reportedTablet.isSetPath_hash());
         replica.setPathHash(reportedTablet.getPath_hash());
+        replica.updateVersion(reportedTablet.version);
     }
 
     private void unprotectedFinishClone(TFinishTaskRequest request, Database db, Partition partition,
@@ -1012,7 +1013,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     "replica does not exist. backend id: " + destBackendId);
         }
 
-        replica.updateRowCount(reportedTablet.getVersion(),
+        replica.updateRowCount(reportedTablet.getVersion(), reportedTablet.getMin_readable_version(),
                 reportedTablet.getData_size(), reportedTablet.getRow_count());
         if (reportedTablet.isSetPath_hash()) {
             replica.setPathHash(reportedTablet.getPath_hash());
@@ -1036,7 +1037,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 reportedTablet.getData_size(),
                 reportedTablet.getRow_count(),
                 replica.getLastFailedVersion(),
-                replica.getLastSuccessVersion());
+                replica.getLastSuccessVersion(),
+                reportedTablet.getMin_readable_version());
 
         if (replica.getState() == ReplicaState.CLONE) {
             replica.setState(ReplicaState.NORMAL);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -526,6 +526,7 @@ public class ReportHandler extends Daemon {
                         if (replica.getState() == ReplicaState.NORMAL) {
                             long metaVersion = replica.getVersion();
                             long backendVersion = -1L;
+                            long backendMinReadableVersion = 0;
                             long rowCount = -1L;
                             long dataSize = -1L;
                             // schema change maybe successfully in fe, but not inform be, then be will
@@ -534,6 +535,7 @@ public class ReportHandler extends Daemon {
                             for (TTabletInfo tabletInfo : backendTablets.get(tabletId).getTablet_infos()) {
                                 if (tabletInfo.getSchema_hash() == schemaHash) {
                                     backendVersion = tabletInfo.getVersion();
+                                    backendMinReadableVersion = tabletInfo.getMin_readable_version();
                                     rowCount = tabletInfo.getRow_count();
                                     dataSize = tabletInfo.getData_size();
                                     break;
@@ -567,7 +569,7 @@ public class ReportHandler extends Daemon {
                                 // 1. PUSH finished in BE but failed or not yet report to FE
                                 // 2. repair for VERSION_INCOMPLETE finished in BE, but failed or not yet report
                                 // to FE
-                                replica.updateRowCount(backendVersion, dataSize, rowCount);
+                                replica.updateRowCount(backendVersion, backendMinReadableVersion, dataSize, rowCount);
 
                                 if (replica.getLastFailedVersion() < 0 && !isInitVersion) {
                                     // last failed version < 0 means this replica becomes health after sync,
@@ -578,7 +580,8 @@ public class ReportHandler extends Daemon {
                                             replica.getVersion(), schemaHash,
                                             dataSize, rowCount,
                                             replica.getLastFailedVersion(),
-                                            replica.getLastSuccessVersion());
+                                            replica.getLastSuccessVersion(),
+                                            replica.getMinReadableVersion());
                                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateReplica(info);
                                     ++logSyncCounter;
                                 }
@@ -1162,6 +1165,7 @@ public class ReportHandler extends Daemon {
 
         int schemaHash = backendTabletInfo.getSchema_hash();
         long version = backendTabletInfo.getVersion();
+        long minReadableVersion = backendTabletInfo.getMin_readable_version();
         long dataSize = backendTabletInfo.getData_size();
         long rowCount = backendTabletInfo.getRow_count();
 
@@ -1264,7 +1268,7 @@ public class ReportHandler extends Daemon {
                 ReplicaPersistInfo info = ReplicaPersistInfo.createForAdd(dbId, tableId, partitionId, indexId,
                         tabletId, backendId, replicaId,
                         version, schemaHash, dataSize, rowCount,
-                        lastFailedVersion, version);
+                        lastFailedVersion, version, minReadableVersion);
 
                 GlobalStateMgr.getCurrentState().getEditLog().logAddReplica(info);
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -228,7 +228,7 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
                             replica.getId(), replica.getVersion(), -1,
                             replica.getDataSize(), replica.getRowCount(),
                             replica.getLastFailedVersion(),
-                            replica.getLastSuccessVersion());
+                            replica.getLastSuccessVersion(), 0);
                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateReplica(info);
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/CheckConsistencyTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CheckConsistencyTask.java
@@ -48,7 +48,7 @@ public class CheckConsistencyTask extends AgentTask {
     }
 
     public TCheckConsistencyReq toThrift() {
-        TCheckConsistencyReq request = new TCheckConsistencyReq(tabletId, schemaHash, version, 0);
+        TCheckConsistencyReq request = new TCheckConsistencyReq(tabletId, schemaHash, version);
         return request;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
@@ -154,7 +154,6 @@ public class ExportPendingTask extends LeaderTask {
         snapshotRequest.setTablet_id(internalScanRange.getTablet_id());
         snapshotRequest.setSchema_hash(Integer.parseInt(internalScanRange.getSchema_hash()));
         snapshotRequest.setVersion(Long.parseLong(internalScanRange.getVersion()));
-        snapshotRequest.setVersion_hash(0);
         snapshotRequest.setTimeout(job.getTimeoutSecond());
         snapshotRequest.setPreferred_snapshot_format(TypesConstants.TPREFER_SNAPSHOT_REQ_VERSION);
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -122,7 +122,7 @@ public class PushTask extends AgentTask {
     }
 
     public TPushReq toThrift() {
-        TPushReq request = new TPushReq(tabletId, schemaHash, version, 0, timeoutSecond, pushType);
+        TPushReq request = new TPushReq(tabletId, schemaHash, version, timeoutSecond, pushType);
         if (taskType == TTaskType.REALTIME_PUSH) {
             request.setPartition_id(partitionId);
             request.setTransaction_id(transactionId);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -855,7 +855,7 @@ public class TransactionState implements Writable {
         List<TPartitionVersionInfo> partitionVersions = new ArrayList<>(partitionCommitInfos.size());
         for (PartitionCommitInfo commitInfo : partitionCommitInfos) {
             TPartitionVersionInfo version = new TPartitionVersionInfo(commitInfo.getPartitionId(),
-                    commitInfo.getVersion(), 0);
+                    commitInfo.getVersion());
             partitionVersions.add(version);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/bdb/BDBToolTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/bdb/BDBToolTest.java
@@ -76,7 +76,7 @@ public class BDBToolTest {
             }
 
             // write something
-            ReplicaPersistInfo info = ReplicaPersistInfo.createForAdd(1, 2, 3, 4, 5, 6, 7, 8, 0, 10, 11, 12, 14);
+            ReplicaPersistInfo info = ReplicaPersistInfo.createForAdd(1, 2, 3, 4, 5, 6, 7, 8, 0, 10, 11, 12, 14, 0);
             JournalEntity entity = new JournalEntity();
             entity.setOpCode(OperationType.OP_ADD_REPLICA);
             entity.setData(info);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/ReplicaMinReadableVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/ReplicaMinReadableVersionTest.java
@@ -1,0 +1,67 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.pseudocluster;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Replica;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReplicaMinReadableVersionTest {
+    private static final Logger LOG = LogManager.getLogger(ReplicaMinReadableVersionTest.class);
+    static PseudoCluster cluster;
+    static String tableName = "test";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Config.tablet_sched_checker_interval_seconds = 2;
+        Config.tablet_sched_repair_delay_factor_second = 2;
+        FeConstants.default_scheduler_interval_millisecond = 5000;
+        PseudoCluster.getOrCreateWithRandomPort(true, 3);
+        cluster = PseudoCluster.getInstance();
+        cluster.runSql(null, "create database test");
+        String createTable = PseudoCluster.newCreateTableSqlBuilder().setTableName(tableName).setBuckets(1).setReplication(3)
+                .build();
+        cluster.runSql("test", createTable);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        PseudoCluster.getInstance().shutdown(true);
+    }
+
+    @Test
+    public void testReplicaMinReadableVersionReported() throws Exception {
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable(tableName);
+        long tableId = olapTable.getId();
+        PseudoBackend be = cluster.getBackend(10001);
+        Tablet tablet = be.getTabletsByTable(tableId).get(0);
+        String insert = PseudoCluster.buildInsertSql("test", tableName);
+        for (int i = 0; i < 10; i++) {
+            cluster.runSql(null, insert, true);
+        }
+        Assert.assertEquals(11, tablet.maxContinuousVersion());
+        // remove a replica, then wait it to be cloned again, the cloned replica will only have version 11,
+        // so it's minReadableVersion should change to 11
+        cluster.runSql(null, "ADMIN SET REPLICA STATUS PROPERTIES(\"tablet_id\" = \"" + tablet.id +
+                "\", \"backend_id\" = \"10001\", \"status\" = \"bad\");", true);
+        while (true) {
+            Replica replica = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplica(tablet.id, 10001);
+            if (replica == null) {
+                LOG.info("replica null\n");
+            } else {
+                LOG.info("replica minversion: %d version: %d\n", replica.getMinReadableVersion(), replica.getVersion());
+                if (replica.getMinReadableVersion() == 11) {
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
@@ -90,6 +90,7 @@ public class Tablet {
         info.setPath_hash(PseudoBackend.PATH_HASH);
         info.setIs_in_memory(false);
         info.setVersion(maxContinuousVersion());
+        info.setMin_readable_version(minVersion());
         info.setVersion_miss(!pendingRowsets.isEmpty());
         info.setRow_count(getRowCount());
         info.setData_size(getDataSize());
@@ -323,7 +324,8 @@ public class Tablet {
     }
 
     public TTabletInfo getTabletInfo() {
-        TTabletInfo info = new TTabletInfo(id, schemaHash, maxContinuousVersion(), 1, getRowCount(), getDataSize());
+        TTabletInfo info = new TTabletInfo(id, schemaHash, maxContinuousVersion(), getRowCount(), getDataSize());
+        info.setMin_readable_version(minVersion());
         return info;
     }
 
@@ -390,8 +392,11 @@ public class Tablet {
             totalIncrementalClone.incrementAndGet();
             totalClone.incrementAndGet();
             cloneExecuted.incrementAndGet();
-            LOG.info("tablet:{} incremental clone src:{} {} before:{} after:{}", id, srcBackendId, src.versionInfo(),
-                    oldInfo, versionInfo());
+            String msg =
+                    String.format("tablet:%d incremental clone src:%d %s before:%s after:%s", id, srcBackendId, src.versionInfo(),
+                            oldInfo, versionInfo());
+            System.out.println(msg);
+            LOG.info(msg);
         }
     }
 
@@ -412,8 +417,10 @@ public class Tablet {
         totalFullClone.incrementAndGet();
         totalClone.incrementAndGet();
         cloneExecuted.incrementAndGet();
-        LOG.info("tablet:{} full clone src:{} {} before:{} after:{}", id, srcBackendId, src.versionInfo(), oldInfo,
-                versionInfo());
+        String msg = String.format("tablet:%d full clone src:%d %s before:%s after:%s", id, srcBackendId, src.versionInfo(),
+                oldInfo, versionInfo());
+        System.out.println(msg);
+        LOG.info(msg);
     }
 
     public synchronized void versionGC() {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -60,7 +60,6 @@ struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
     3: optional Types.TVersion version
-    4: optional Types.TVersionHash version_hash // Deprecated
     5: optional Types.TStorageMedium storage_medium
     6: optional bool in_restore_mode
     // this new tablet should be colocate with base tablet
@@ -100,7 +99,6 @@ struct TAlterTabletReqV2 {
     4: required Types.TSchemaHash new_schema_hash
     // version of data which this alter task should transform
     5: optional Types.TVersion alter_version
-    6: optional Types.TVersionHash alter_version_hash // Deprecated
     7: optional list<TAlterMaterializedViewParam> materialized_view_params
     8: optional TTabletType tablet_type
     9: optional i64 txn_id
@@ -121,7 +119,6 @@ struct TPushReq {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TVersion version
-    4: required Types.TVersionHash version_hash // Deprecated
     5: required i64 timeout
     6: required Types.TPushType push_type
     7: optional string http_file_path
@@ -152,7 +149,6 @@ struct TCloneReq {
     4: optional Types.TStorageMedium storage_medium
     // these are visible version(hash) actually
     5: optional Types.TVersion committed_version
-    6: optional Types.TVersionHash committed_version_hash // Deprecated
     7: optional i32 task_version
     8: optional i64 src_path_hash
     9: optional i64 dest_path_hash
@@ -172,14 +168,12 @@ struct TCancelDeleteDataReq {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TVersion version
-    4: required Types.TVersionHash version_hash // Deprecated
 }
 
 struct TCheckConsistencyReq {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TVersion version
-    4: required Types.TVersionHash version_hash // Deprecated
 }
 
 struct TUploadReq {
@@ -214,7 +208,6 @@ struct TSnapshotRequest {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: optional Types.TVersion version // not used
-    4: optional Types.TVersionHash version_hash // Deprecated
     5: optional i64 timeout
     6: optional list<Types.TVersion> missing_version
     7: optional bool list_files
@@ -239,7 +232,6 @@ struct TClearRemoteFileReq {
 struct TPartitionVersionInfo {
     1: required Types.TPartitionId partition_id
     2: required Types.TVersion version
-    3: required Types.TVersionHash version_hash // Deprecated
 }
 
 struct TMoveDirReq {
@@ -277,7 +269,6 @@ struct TRecoverTabletReq {
     1: optional Types.TTabletId tablet_id
     2: optional Types.TSchemaHash schema_hash
     3: optional Types.TVersion version
-    4: optional Types.TVersionHash version_hash // Deprecated
 }
 
 enum TTabletMetaType {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -32,7 +32,6 @@ struct TTabletInfo {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TVersion version
-    4: required Types.TVersionHash version_hash // Deprecated
     5: required Types.TCount row_count
     6: required Types.TSize data_size
     7: optional Types.TStorageMedium storage_medium
@@ -44,6 +43,7 @@ struct TTabletInfo {
     13: optional Types.TPartitionId partition_id
     14: optional bool is_in_memory
     15: optional bool enable_persistent_index
+    16: optional Types.TVersion min_readable_version
 }
 
 struct TTabletVersionPair {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -30,7 +30,6 @@ typedef i32 TSlotId
 typedef i64 TTableId
 typedef i64 TTabletId
 typedef i64 TVersion
-typedef i64 TVersionHash
 typedef i32 TSchemaHash
 typedef i32 TPort
 typedef i64 TCount


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10419 #5313

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When a newly cloned replica is added to Tablet's replica list, it only has a single version V1. Still, when FE executes a query, it may read the tablet with a version Vr < V1. Because V1 > Vr,  it's a valid candidate for the tablet's read. If FE chooses this replica for the reading when executing ScanNode, a "version not found" error will occur, and the query will fail. This situation is also possible if version Vr is compacted and GCed, but less likely than the clone situation.

This PR adds minimal readable version information to the Replica object in FE. When the clone finishes or BE reports tablet infos, BE will report the replica's minReadableVersion to FE, and FE can update this value. So when scheduling a replica for a scan, replicas without the specified readable version can be skipped, avoiding the "version not found"/"version is compacted" error.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
