### PR TITLE
[Bugfix] Fix compile error unused return value

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -86,9 +86,9 @@ static void failure_writer(const char* data, int size) {
         res = sprintf(buffer + res, "fragment_instance:") + res;
         res = print_unique_id(buffer + res, query_id) + res;
         res = sprintf(buffer + res, "\n") + res;
-        write(STDERR_FILENO, buffer, res);
+        [[maybe_unused]] auto wt = write(STDERR_FILENO, buffer, res);
     }
-    write(STDERR_FILENO, data, size);
+    [[maybe_unused]] auto wt = write(STDERR_FILENO, data, size);
     start_dump = true;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

```
/home/decster/projects/starrocks/be/src/common/logconfig.cpp: In function ‘void starrocks::failure_writer(const char*, int)’:
/home/decster/projects/starrocks/be/src/common/logconfig.cpp:89:14: error: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   89 |         write(STDERR_FILENO, buffer, res);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/decster/projects/starrocks/be/src/common/logconfig.cpp:91:10: error: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   91 |     write(STDERR_FILENO, data, size);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/common/CMakeFiles/Common.dir/build.make:102: src/common/CMakeFiles/Common.dir/logconfig.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:777: src/common/CMakeFiles/Common.dir/all] Error 2

```