### PR TITLE
[enhancement] Can build statistics collection SQL across partitions and columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -1,21 +1,23 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.statistic;
 
-import com.google.common.collect.Lists;
+import com.google.common.base.Joiner;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import org.apache.velocity.VelocityContext;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
     private static final String COLLECT_FULL_STATISTIC_TEMPLATE =
-            " SELECT $tableId, $partitionId, '$columnName', $dbId," +
+            "SELECT $tableId, $partitionId, '$columnName', $dbId," +
                     " '$dbName.$tableName', '$partitionName'," +
                     " COUNT(1), $dataSize, $countDistinctFunction, $countNullFunction, $maxFunction, $minFunction, NOW() "
                     + "FROM $dbName.$tableName partition $partitionName";
@@ -35,48 +37,69 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
     @Override
     public void collect(ConnectContext context) throws Exception {
-        for (Long partitionId : partitionIdList) {
-            Partition partition = table.getPartition(partitionId);
-            for (List<String> splitColItem : Lists.partition(columns, splitColumns(partition.getRowCount()))) {
-                String sql = buildCollectFullStatisticSQL(db, table, partition, splitColItem);
-                collectStatisticSync(sql, context);
-            }
+        for (String sql : buildCollectSQLList()) {
+            collectStatisticSync(sql, context);
         }
     }
 
-    public String buildCollectFullStatisticSQL(Database database, Table table, Partition partition,
-                                               List<String> columnNames) {
-        StringBuilder builder = new StringBuilder("INSERT INTO column_statistics").append(" ");
-
-        for (String name : columnNames) {
-            VelocityContext context = new VelocityContext();
-            Column column = table.getColumn(name);
-
-            context.put("dbId", database.getId());
-            context.put("tableId", table.getId());
-            context.put("partitionId", partition.getId());
-            context.put("columnName", name);
-            context.put("dbName", database.getOriginName());
-            context.put("tableName", table.getName());
-            context.put("partitionName", partition.getName());
-            context.put("dataSize", getDataSize(column, false));
-
-            if (!column.getType().canStatistic()) {
-                context.put("countDistinctFunction", "hll_empty()");
-                context.put("countNullFunction", "0");
-                context.put("maxFunction", "''");
-                context.put("minFunction", "''");
-            } else {
-                context.put("countDistinctFunction", "IFNULL(hll_union(hll_hash(`" + name + "`)), hll_empty())");
-                context.put("countNullFunction", "COUNT(1) - COUNT(`" + name + "`)");
-                context.put("maxFunction", "IFNULL(MAX(`" + name + "`), '')");
-                context.put("minFunction", "IFNULL(MIN(`" + name + "`), '')");
+    /*
+     * Split tasks at the partition and column levels,
+     * and the number of rows to scan is the number of rows in the partition
+     * where the column is located.
+     * The number of rows is accumulated in turn until the maximum number of rows is accumulated.
+     * Use UNION ALL connection between multiple tasks and collect them in one query
+     */
+    public List<String> buildCollectSQLList() {
+        List<String> collectSQLList = new ArrayList<>();
+        List<String> sqlInUnion = new ArrayList<>();
+        long scanRowCount = 0;
+        for (Long partitionId : partitionIdList) {
+            Partition partition = table.getPartition(partitionId);
+            for (String columnName : columns) {
+                sqlInUnion.add(buildCollectFullStatisticSQL(db, table, partition, columnName));
+                scanRowCount += partition.getRowCount();
+                if (scanRowCount >= Config.statistic_collect_max_row_count_per_query) {
+                    collectSQLList.add("INSERT INTO column_statistics " + Joiner.on(" UNION ALL ").join(sqlInUnion));
+                    scanRowCount = 0;
+                    sqlInUnion.clear();
+                }
             }
-
-            builder.append(build(context, COLLECT_FULL_STATISTIC_TEMPLATE));
-            builder.append(" UNION ALL ");
         }
 
-        return builder.substring(0, builder.length() - "UNION ALL ".length());
+        if (!sqlInUnion.isEmpty()) {
+            collectSQLList.add("INSERT INTO column_statistics " + Joiner.on(" UNION ALL ").join(sqlInUnion));
+        }
+
+        return collectSQLList;
+    }
+
+    private String buildCollectFullStatisticSQL(Database database, Table table, Partition partition, String columnNames) {
+        StringBuilder builder = new StringBuilder();
+        VelocityContext context = new VelocityContext();
+        Column column = table.getColumn(columnNames);
+
+        context.put("dbId", database.getId());
+        context.put("tableId", table.getId());
+        context.put("partitionId", partition.getId());
+        context.put("columnName", columnNames);
+        context.put("dbName", database.getOriginName());
+        context.put("tableName", table.getName());
+        context.put("partitionName", partition.getName());
+        context.put("dataSize", getDataSize(column, false));
+
+        if (!column.getType().canStatistic()) {
+            context.put("countDistinctFunction", "hll_empty()");
+            context.put("countNullFunction", "0");
+            context.put("maxFunction", "''");
+            context.put("minFunction", "''");
+        } else {
+            context.put("countDistinctFunction", "IFNULL(hll_union(hll_hash(`" + columnNames + "`)), hll_empty())");
+            context.put("countNullFunction", "COUNT(1) - COUNT(`" + columnNames + "`)");
+            context.put("maxFunction", "IFNULL(MAX(`" + columnNames + "`), '')");
+            context.put("minFunction", "IFNULL(MIN(`" + columnNames + "`), '')");
+        }
+
+        builder.append(build(context, COLLECT_FULL_STATISTIC_TEMPLATE));
+        return builder.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -166,15 +166,13 @@ public class AnalyzeStmtTest {
                 Lists.newArrayList(10003L),
                 Lists.newArrayList("v1", "v2"), StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
                 Maps.newHashMap());
-        Assert.assertEquals("INSERT INTO column_statistics  SELECT 10004, 10003, 'v1', 10002, 'test.t0', 't0', " +
+        Assert.assertEquals("INSERT INTO column_statistics SELECT 10004, 10003, 'v1', 10002, 'test.t0', 't0', " +
                         "COUNT(1), COUNT(1) * 8, IFNULL(hll_union(hll_hash(`v1`)), hll_empty()), COUNT(1) - COUNT(`v1`), " +
                         "IFNULL(MAX(`v1`), ''), IFNULL(MIN(`v1`), ''), NOW() FROM test.t0 partition t0 " +
-                        "UNION ALL  " +
-                        "SELECT 10004, 10003, 'v2', 10002, 'test.t0', 't0', COUNT(1), COUNT(1) * 8, " +
-                        "IFNULL(hll_union(hll_hash(`v2`)), " +
-                        "hll_empty()), COUNT(1) - COUNT(`v2`), IFNULL(MAX(`v2`), ''), IFNULL(MIN(`v2`), ''), NOW() " +
-                        "FROM test.t0 partition t0 ",
-                collectJob.buildCollectFullStatisticSQL(database, table, partition, Lists.newArrayList("v1", "v2")));
+                        "UNION ALL SELECT 10004, 10003, 'v2', 10002, 'test.t0', 't0', COUNT(1), COUNT(1) * 8, " +
+                        "IFNULL(hll_union(hll_hash(`v2`)), hll_empty()), COUNT(1) - COUNT(`v2`), IFNULL(MAX(`v2`), ''), " +
+                        "IFNULL(MIN(`v2`), ''), NOW() FROM test.t0 partition t0",
+                collectJob.buildCollectSQLList().get(0));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
    /*
     * Modified to split tasks at the partition and column levels,
     * and the number of rows to scan is the number of rows in the partition
     * where the column is located.
     * The number of rows is accumulated in turn until the maximum number of rows is accumulated.
     * Use UNION ALL connection between multiple tasks and collect them in one query
     */
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
