### PR TITLE
[Enhancement] Add logic to cancel export job when be has crashed before

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -139,8 +139,8 @@ public final class ExportChecker extends LeaderDaemon {
         List<ExportJob> jobs = GlobalStateMgr.getCurrentState().getExportMgr().getExportJobs(JobState.EXPORTING);
         LOG.debug("exporting export job num: {}", jobs.size());
         for (ExportJob job : jobs) {
-            boolean cancalled = checkBeStatus(job);
-            if (cancalled) {
+            boolean cancelled = checkJobNeedCancel(job);
+            if (cancelled) {
                 continue;
             }
             try {
@@ -154,7 +154,7 @@ public final class ExportChecker extends LeaderDaemon {
         }
     }
 
-    private boolean checkBeStatus(ExportJob job) {
+    private boolean checkJobNeedCancel(ExportJob job) {
 
         boolean beHasErr = false;
         String errMsg = "";

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -160,7 +160,7 @@ public final class ExportChecker extends LeaderDaemon {
         String errMsg = "";
         for (Long beId : job.getBeStartTimeMap().keySet()) {
             Backend be = GlobalStateMgr.getCurrentSystemInfo().getBackend(beId);
-            if (!be.isAvailable()) {
+            if (!be.isAlive()) {
                 beHasErr = true;
                 errMsg = "be not available during exec export job. be:" + beId;
                 LOG.warn(errMsg + " job: {}", job);

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -164,11 +164,13 @@ public final class ExportChecker extends LeaderDaemon {
                 beHasErr = true;
                 errMsg = "be not available during exec export job. be:" + beId;
                 LOG.warn(errMsg + " job: {}", job);
+                break;
             }
             if (be.getLastStartTime() > job.getBeStartTimeMap().get(beId)) {
                 beHasErr = true;
                 errMsg = "be has rebooted during exec export job. be:" + beId;
                 LOG.warn(errMsg + " job: {}", job);
+                break;
             }
         }
         if (beHasErr) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -160,9 +160,17 @@ public final class ExportChecker extends LeaderDaemon {
         String errMsg = "";
         for (Long beId : job.getBeStartTimeMap().keySet()) {
             Backend be = GlobalStateMgr.getCurrentSystemInfo().getBackend(beId);
+            if (null == be) {
+                // The current implementation, if the be in the job is not found, 
+                // the job will be cancelled
+                beHasErr = true;
+                errMsg = "be not found during exec export job. be:" + beId;
+                LOG.warn(errMsg + " job: {}", job);
+                break;
+            }
             if (!be.isAlive()) {
                 beHasErr = true;
-                errMsg = "be not available during exec export job. be:" + beId;
+                errMsg = "be not alive during exec export job. be:" + beId;
                 LOG.warn(errMsg + " job: {}", job);
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportFailMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportFailMsg.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 public class ExportFailMsg implements Writable {
     public enum CancelType {
-        BE_REBOOT,
+        BE_STATUS_ERR,
         USER_CANCEL,
         SUBMIT_FAIL,
         RUN_FAIL,

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportFailMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportFailMsg.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 public class ExportFailMsg implements Writable {
     public enum CancelType {
+        BE_REBOOT,
         USER_CANCEL,
         SUBMIT_FAIL,
         RUN_FAIL,

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -117,6 +117,9 @@ public class ExportJob implements Writable {
     private final AtomicInteger nextId = new AtomicInteger(0);
     // backedn_address => snapshot path
     private final List<Pair<TNetworkAddress, String>> snapshotPaths = Lists.newArrayList();
+    // backend id => backend lastStartTime 
+    private final Map<Long, Long> beLastStartTime = Maps.newHashMap();
+
     private long id;
     private UUID queryId;
     private long dbId;
@@ -404,6 +407,14 @@ public class ExportJob implements Writable {
                     id, i, DebugUtil.printId(queryId));
         }
         LOG.info("create {} coordintors for export job: {}", coordList.size(), id);
+    }
+
+    public void setBeStartTime(long beId, long lastStartTime) {
+        this.beLastStartTime.put(beId, lastStartTime);
+    }
+
+    public Map<Long, Long> getBeStartTimeMap() {
+        return this.beLastStartTime;
     }
 
     public long getId() {

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -81,10 +81,10 @@ public class ExportExportingTask extends LeaderTask {
         }
         if (hasRebootBe) {
             try {
-				job.cancel(ExportFailMsg.CancelType.BE_REBOOT, "be has rebooted during exec export job.");
-			} catch (UserException e) {
-				LOG.warn("try to cancel a completed job. job: {}", job);
-			}
+                job.cancel(ExportFailMsg.CancelType.BE_REBOOT, "be has rebooted during exec export job.");
+            } catch (UserException e) {
+                LOG.warn("try to cancel a completed job. job: {}", job);
+            }
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -39,7 +39,6 @@ import com.starrocks.load.ExportJob;
 import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.logging.log4j.LogManager;
@@ -70,24 +69,6 @@ public class ExportExportingTask extends LeaderTask {
 
     @Override
     protected void exec() {
-
-        boolean hasRebootBe = false;
-        for (Long beId : job.getBeStartTimeMap().keySet()) {
-            Backend be = GlobalStateMgr.getCurrentSystemInfo().getBackend(beId);
-            if (be.getLastStartTime() > job.getBeStartTimeMap().get(beId)) {
-                hasRebootBe = true;
-                LOG.info("be has rebooted during exec export job. job: {}, be: {}", job, beId);
-            }
-        }
-        if (hasRebootBe) {
-            try {
-                job.cancel(ExportFailMsg.CancelType.BE_REBOOT, "be has rebooted during exec export job.");
-            } catch (UserException e) {
-                LOG.warn("try to cancel a completed job. job: {}", job);
-            }
-            return;
-        }
-
         if (job.getState() != ExportJob.JobState.EXPORTING) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
@@ -117,6 +117,7 @@ public class ExportPendingTask extends LeaderTask {
                 if (!GlobalStateMgr.getCurrentSystemInfo().checkBackendAvailable(backendId)) {
                     return Status.CANCELLED;
                 }
+                this.job.setBeStartTime(backendId, backend.getLastStartTime());
                 Status status;
                 if (job.exportLakeTable()) {
                     status = lockTabletMetadata(internalScanRange, backend);

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -21,7 +21,6 @@ public class ExportCheckerTest {
     public void testCheckBeStatus() throws NoSuchFieldException, SecurityException, 
         IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 
-
         new MockUp<ExportJob>() {
             @Mock
             public synchronized void cancel(ExportFailMsg.CancelType type, String msg) throws UserException {
@@ -51,7 +50,7 @@ public class ExportCheckerTest {
         
         Map<JobState, ExportChecker> map = (Map<JobState, ExportChecker>) obj;
         ExportChecker checker = map.get(JobState.EXPORTING);
-        Method method = ExportChecker.class.getDeclaredMethod("checkBeStatus", ExportJob.class);
+        Method method = ExportChecker.class.getDeclaredMethod("checkJobNeedCancel", ExportJob.class);
         method.setAccessible(true);
 
         ExportJob job = new ExportJob();

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -55,8 +55,8 @@ public class ExportCheckerTest {
 
         ExportJob job = new ExportJob();
         job.setBeStartTime(1, 1000L);
-        boolean cancalled = (boolean) method.invoke(checker, job);
-        Assert.assertTrue(cancalled);
+        boolean cancelled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(cancelled);
 
         new MockUp<Backend>() {
             @Mock
@@ -67,12 +67,12 @@ public class ExportCheckerTest {
 
         be.setLastStartTime(1001L);
 
-        cancalled = (boolean) method.invoke(checker, job);
-        Assert.assertTrue(cancalled);
+        cancelled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(cancelled);
 
         be.setLastStartTime(999L);
 
-        cancalled = (boolean) method.invoke(checker, job);
-        Assert.assertTrue(!cancalled);
+        cancelled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(!cancelled);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -74,5 +74,15 @@ public class ExportCheckerTest {
 
         cancelled = (boolean) method.invoke(checker, job);
         Assert.assertTrue(!cancelled);
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long backendId) {
+                return null;
+            }
+        };
+
+        cancelled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(cancelled);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -60,7 +60,7 @@ public class ExportCheckerTest {
 
         new MockUp<Backend>() {
             @Mock
-            public boolean isAvailable() {
+            public boolean isAlive() {
                 return true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -1,0 +1,79 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.load;
+
+import com.starrocks.common.UserException;
+import com.starrocks.load.ExportJob.JobState;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class ExportCheckerTest {
+    
+    @Test
+    public void testCheckBeStatus() throws NoSuchFieldException, SecurityException, 
+        IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+
+
+        new MockUp<ExportJob>() {
+            @Mock
+            public synchronized void cancel(ExportFailMsg.CancelType type, String msg) throws UserException {
+            }
+        };
+
+        Backend be = new Backend();
+        
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long backendId) {
+                return be;
+            }
+        };
+
+        new MockUp<Backend>() {
+            @Mock
+            public boolean isAvailable() {
+                return false;
+            }
+        };
+
+        ExportChecker.init(1000L);
+        Field field = ExportChecker.class.getDeclaredField("checkers");
+        field.setAccessible(true);
+        Object obj = field.get(ExportChecker.class);
+        
+        Map<JobState, ExportChecker> map = (Map<JobState, ExportChecker>) obj;
+        ExportChecker checker = map.get(JobState.EXPORTING);
+        Method method = ExportChecker.class.getDeclaredMethod("checkBeStatus", ExportJob.class);
+        method.setAccessible(true);
+
+        ExportJob job = new ExportJob();
+        job.setBeStartTime(1, 1000L);
+        boolean cancalled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(cancalled);
+
+        new MockUp<Backend>() {
+            @Mock
+            public boolean isAvailable() {
+                return true;
+            }
+        };
+
+        be.setLastStartTime(1001L);
+
+        cancalled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(cancalled);
+
+        be.setLastStartTime(999L);
+
+        cancalled = (boolean) method.invoke(checker, job);
+        Assert.assertTrue(!cancalled);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10704 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fe cannot perceive rebooting BE. So that the export task thread is stuck and the overall task progress is stuck at 99%.
This PR uses lastStartTime to determine if the backend has restarted, and if it has, it will cancel the corresponding job.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
