### PR TITLE
[cherry-pick] [branch-2.4] [Enhancement] limit the number of migration task sent to BE (#10124)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -191,7 +192,8 @@ public class TabletInvertedIndex {
                                             LOG.debug("available storage medium type count is less than 1, " +
                                                             "no need to send migrate task. tabletId={}, backendId={}.",
                                                     tabletId, backendId);
-                                        } else {
+                                        } else if (tabletMigrationMap.size() <=
+                                                Config.tablet_sched_max_migration_task_sent_once) {
                                             tabletMigrationMap.put(storageMedium, tabletId);
                                         }
                                     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1094,6 +1094,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, aliases = {"max_clone_task_timeout_sec"})
     public static long tablet_sched_max_clone_task_timeout_sec = 2 * 60 * 60L; // 2h
 
+    @ConfField(mutable = true)
+    public static int tablet_sched_max_migration_task_sent_once = 1000;
+
     @Deprecated
     @ConfField(mutable = true)
     public static int report_queue_size = 100;


### PR DESCRIPTION
Add a new configuration `tablet_sched_max_migration_task_sent_once`
to control the number of migration task sent to BE on every tablet
report.