### PR TITLE
[BugFix] fix right join on empty left table

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -57,7 +57,7 @@ private:
     void _advance_join_stage(JoinStage stage) const;
     bool _skip_probe() const;
     void _check_post_probe() const;
-    void _init_build_match();
+    void _init_build_match() const;
     void _permute_probe_row(RuntimeState* state, ChunkPtr chunk);
     ChunkPtr _permute_chunk(RuntimeState* state);
     Status _permute_right_join(RuntimeState* state);
@@ -87,7 +87,7 @@ private:
     vectorized::Chunk* _curr_build_chunk = nullptr;
     size_t _prev_chunk_start = 0;
     size_t _prev_chunk_size = 0;
-    std::vector<uint8_t> _self_build_match_flag;
+    mutable std::vector<uint8_t> _self_build_match_flag;
 
     // Probe states
     vectorized::ChunkPtr _probe_chunk = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10722

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

If left table is empty, the `_build_match_flag` would not be initialized, so right join would not work.

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
