### PR TITLE
[BugFix] SliceMutableIndex's snapshot size is calculated incorrectly

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1063,7 +1063,10 @@ public:
     }
 
     // return the dump file size if dump _set into a new file
-    size_t dump_bound() { return sizeof(size_t) + _total_kv_pairs_usage + sizeof(size_t) * size(); }
+    //  ｜--------    snapshot file      --------｜
+    //  |  size_t ||   size_t  ||  char[]  | ... |   size_t  ||  char[]  |
+    //  |total num|| data size ||  data    | ... | data size ||  data    |
+    size_t dump_bound() { return sizeof(size_t) * (1 + size()) + _total_kv_pairs_usage; }
 
     bool dump(phmap::BinaryOutputArchive& ar) {
         if (!ar.dump(size())) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1063,9 +1063,7 @@ public:
     }
 
     // return the dump file size if dump _set into a new file
-    // If _set is empty, the real snapshot file will only wite a size_(type is size_t) into file. So we
-    // will use `sizeof(size_t)` as return value.
-    size_t dump_bound() { return sizeof(size_t) + _total_kv_pairs_usage; }
+    size_t dump_bound() { return sizeof(size_t) + _total_kv_pairs_usage + sizeof(size_t) * size(); }
 
     bool dump(phmap::BinaryOutputArchive& ar) {
         if (!ar.dump(size())) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10666

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The snapshot size of SliceMutableIndex is incorrect, so we may get an unexpected error when we try to build a persistent index from existing files.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
