### PR TITLE
[Bugfix] Use re2 when hyperscan report errors (#10361)

### DIFF
--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -29,24 +29,52 @@ static const re2::RE2 LIKE_SUBSTRING_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+)(?:%+))
 static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
 static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
 static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
+static const char* PROMPT_INFO = " so we switch to use re2.";
 
-Status LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
-                                                   starrocks_udf::FunctionContext* context, const Slice& slice) {
+bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
+                                                 starrocks_udf::FunctionContext* context, const Slice& slice) {
     if (hs_compile(pattern.c_str(), HS_FLAG_ALLOWEMPTY | HS_FLAG_DOTALL | HS_FLAG_UTF8 | HS_FLAG_SINGLEMATCH,
                    HS_MODE_BLOCK, nullptr, &state->database, &state->compile_err) != HS_SUCCESS) {
         std::stringstream error;
-        error << "Invalid regex expression: " << slice.data << ": " << state->compile_err->message;
-        context->set_error(error.str().c_str());
+        error << "Invalid hyperscan expression: " << std::string(slice.data, slice.size) << ": "
+              << state->compile_err->message << PROMPT_INFO;
+        LOG(WARNING) << error.str().c_str();
         hs_free_compile_error(state->compile_err);
-        return Status::InvalidArgument(error.str());
+        return false;
     }
 
     if (hs_alloc_scratch(state->database, &state->scratch) != HS_SUCCESS) {
         std::stringstream error;
-        error << "ERROR: Unable to allocate scratch space.";
-        context->set_error(error.str().c_str());
+        error << "ERROR: Unable to allocate scratch space," << PROMPT_INFO;
+        LOG(WARNING) << error.str().c_str();
         hs_free_database(state->database);
-        return Status::InvalidArgument(error.str());
+        return false;
+    }
+
+    return true;
+}
+
+template <bool full_match>
+Status LikePredicate::compile_with_hyperscan_or_re2(const std::string& pattern, LikePredicateState* state,
+                                                    starrocks_udf::FunctionContext* context, const Slice& slice) {
+    if (!hs_compile_and_alloc_scratch(pattern, state, context, slice)) {
+        RE2::Options opts;
+        opts.set_never_nl(false);
+        opts.set_dot_nl(true);
+        opts.set_log_errors(false);
+
+        state->re2 = std::make_shared<re2::RE2>(pattern, opts);
+        if (!state->re2->ok()) {
+            std::stringstream error;
+            error << "Invalid re2 expression: " << pattern;
+            return Status::InvalidArgument(error.str());
+        }
+
+        if constexpr (full_match) {
+            state->function = &like_fn_with_long_constant_pattern;
+        } else {
+            state->function = &regex_fn_with_long_constant_pattern;
+        }
     }
 
     return Status::OK();
@@ -98,8 +126,9 @@ Status LikePredicate::like_prepare(starrocks_udf::FunctionContext* context,
         state->function = &constant_substring_fn;
     } else {
         auto re_pattern = LikePredicate::template convert_like_pattern<true>(context, pattern);
-        RETURN_IF_ERROR(hs_compile_and_alloc_scratch(re_pattern, state, context, pattern));
+        RETURN_IF_ERROR(compile_with_hyperscan_or_re2<true>(re_pattern, state, context, pattern));
     }
+
     return Status::OK();
 }
 
@@ -159,8 +188,7 @@ Status LikePredicate::regex_prepare(starrocks_udf::FunctionContext* context,
         state->set_search_string(search_string);
         state->function = &constant_substring_fn;
     } else {
-        std::string re_pattern(pattern.data, pattern.size);
-        RETURN_IF_ERROR(hs_compile_and_alloc_scratch(re_pattern, state, context, pattern));
+        RETURN_IF_ERROR(compile_with_hyperscan_or_re2<false>(pattern_str, state, context, pattern));
     }
 
     return Status::OK();
@@ -188,6 +216,44 @@ ColumnPtr LikePredicate::like_fn(FunctionContext* context, const starrocks::vect
 
 ColumnPtr LikePredicate::regex_fn(FunctionContext* context, const Columns& columns) {
     return regex_match(context, columns, false);
+}
+
+ColumnPtr LikePredicate::like_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns) {
+    return match_fn_with_long_constant_pattern<true>(context, columns);
+}
+
+ColumnPtr LikePredicate::regex_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns) {
+    return match_fn_with_long_constant_pattern<false>(context, columns);
+}
+
+template <bool full_match>
+ColumnPtr LikePredicate::match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns) {
+    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+
+    const auto& value_column = VECTORIZED_FN_ARGS(0);
+    auto [all_const, num_rows] = ColumnHelper::num_packed_rows(columns);
+
+    ColumnViewer<TYPE_VARCHAR> value_viewer(value_column);
+    ColumnBuilder<TYPE_BOOLEAN> result(num_rows);
+
+    for (int row = 0; row < num_rows; ++row) {
+        if (value_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+
+        bool v = false;
+        if constexpr (full_match) {
+            v = RE2::FullMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
+                               *(state->re2));
+        } else {
+            v = RE2::PartialMatch(re2::StringPiece(value_viewer.value(row).data, value_viewer.value(row).size),
+                                  *(state->re2));
+        }
+        result.append(v);
+    }
+
+    return result.build(all_const);
 }
 
 // constant_ends
@@ -346,7 +412,7 @@ ColumnPtr LikePredicate::_predicate_const_regex(FunctionContext* context, Column
 
         bool v = false;
         auto value_size = value_viewer.value(row).size;
-        auto status = hs_scan(
+        [[maybe_unused]] auto status = hs_scan(
                 // Use &_DUMMY_STRING_FOR_EMPTY_PATTERN instead of nullptr to avoid crash.
                 state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_FOR_EMPTY_PATTERN,
                 value_size, 0, scratch,

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -72,6 +72,8 @@ private:
      */
     DEFINE_VECTORIZED_FN(regex_fn);
 
+    DEFINE_VECTORIZED_FN(regex_fn_with_long_constant_pattern);
+    DEFINE_VECTORIZED_FN(like_fn_with_long_constant_pattern);
     /**
      * use for:
      *  a like "xxxx%"
@@ -134,6 +136,9 @@ private:
 
     static ColumnPtr regex_match_partial(FunctionContext* context, const Columns& columns);
 
+    template <bool full_match>
+    static ColumnPtr match_fn_with_long_constant_pattern(FunctionContext* context, const Columns& columns);
+
     /// Convert a LIKE pattern (with embedded % and _) into the corresponding
     /// regular expression pattern. Escaped chars are copied verbatim.
     template <bool fullMatch>
@@ -150,13 +155,16 @@ private:
     // to avoid crash with hs_scan.
     static inline char _DUMMY_STRING_FOR_EMPTY_PATTERN = 'A';
 
-    class LikePredicateState;
-    static Status hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
-                                               const Slice& slice);
-
+    struct LikePredicateState;
+    static bool hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
+                                             const Slice& slice);
+    template <bool full_match>
+    static Status compile_with_hyperscan_or_re2(const std::string& pattern, LikePredicateState* state,
+                                                starrocks_udf::FunctionContext* context, const Slice& slice);
     struct LikePredicateState {
         char escape_char{'\\'};
 
+        std::shared_ptr<re2::RE2> re2 = nullptr;
         /// This is the function, set in the prepare function, that will be used to determine
         /// the value of the predicate. It will be set depending on whether the expression is
         /// a LIKE, RLIKE or REGEXP predicate, whether the pattern is a constant argument

--- a/be/test/exprs/vectorized/like_test.cpp
+++ b/be/test/exprs/vectorized/like_test.cpp
@@ -170,6 +170,41 @@ TEST_F(LikeTest, haystackConstantLike) {
                         .ok());
 }
 
+TEST_F(LikeTest, haystackConstantLikeLargerThanHyperscan) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto haystack = ColumnHelper::create_const_column<TYPE_VARCHAR>("CHINA", 1);
+
+#define LONG_PATTERN_LEN 16384
+    char large_pattern[LONG_PATTERN_LEN];
+    memset(large_pattern, 'a', LONG_PATTERN_LEN);
+    large_pattern[LONG_PATTERN_LEN - 1] = 0;
+    large_pattern[0] = 'N';
+    large_pattern[1] = '%';
+    large_pattern[2] = 'I';
+    large_pattern[3] = '%';
+#undef LONG_PATTERN_LEN
+
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
+
+    columns.push_back(haystack);
+    columns.push_back(pattern);
+
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns);
+
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
 TEST_F(LikeTest, haystackNullableLike) {
     auto context = FunctionContext::create_test_context();
     std::unique_ptr<FunctionContext> ctx(context);
@@ -542,6 +577,71 @@ TEST_F(LikeTest, constValueRegexp) {
     for (int i = 0; i < num_rows; ++i) {
         ASSERT_EQ(expected[i], v->get_data()[i]);
     }
+
+    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, constValueRegexpLargerThanHyperscan) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto haystack = ColumnHelper::create_const_column<TYPE_VARCHAR>("CHINA", 1);
+
+#define LONG_PATTERN_LEN 16384
+    char large_pattern[LONG_PATTERN_LEN];
+    memset(large_pattern, 'a', LONG_PATTERN_LEN);
+    large_pattern[LONG_PATTERN_LEN - 1] = 0;
+    large_pattern[2] = '.';
+#undef LONG_PATTERN_LEN
+
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
+
+    columns.push_back(haystack);
+    columns.push_back(pattern);
+
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::regex(context, columns);
+
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
+
+    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto haystack = ColumnHelper::create_const_column<TYPE_VARCHAR>("CHINA", 1);
+
+    std::string large_pattern =
+            "(肉|便|便|胃|补钙|不喝奶|心|胖|服|食|不.{0,3}(想|要|愿|喜欢|爱|肯|好好|怎么).{0,3}(吃|喝)|擦鼻涕|肠梗阻|("
+            "肠|胃).{0,2}(敏感|弱|好|适应|舒服|难受|差|问题|炎)|吃不下饭|吃撑了|吃(的|得).{0,2}(少|多|饱|吐)|吃奶|打嗝|"
+            "低血糖|肚子饿|肚子疼|断奶|断食|饿肚子|饿坏了|发胖|发腮|肥胖|疯狂吃|腹泻|感冒|干呕|过敏|咳嗽|没吃饱|(好|很|"
+            "太|有点|有些)胖|(好|很|太|有点|有些)瘦|怀孕|换口味|减肥|焦虑|戒奶|拉肚子|拉稀|精神不好|拒绝吃|口臭|口炎|"
+            "狂吃|拉屎|cccccccccc|细小|毛囊炎|没精神|磨牙|奶.{0,2}不(够|足)|没有奶|奶癣|呕吐|胖不起来|皮肤病|偏瘦|缺钙|"
+            "缺维耐|便|火|好|竭|生|振|了|病|吃|病|(吃|喝)奶|不(好|了|良)|牙.{0,2}不好|牙(疼|痛)|腺|抑|(好|够|足|良)|越|"
+            "增|毛|胖|牙|奶|肉|毒|暑|总).{0,5}(永)";
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
+
+    columns.push_back(haystack);
+    columns.push_back(pattern);
+
+    context->impl()->set_constant_columns(columns);
+
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::regex(context, columns);
+
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
 
     ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
                         .ok());


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
We use re2 instead of hyperscan when hyperscan report errors.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
