### PR TITLE
[Enhancement]Add s3 auth info to resource properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -195,6 +195,7 @@ public class IcebergTable extends Table {
         IcebergResource icebergResource = (IcebergResource) resource;
         IcebergCatalogType type = icebergResource.getCatalogType();
         icebergProperties.put(ICEBERG_CATALOG, type.name());
+        icebergProperties.putAll(icebergResource.getProperties());
         LOG.info("Iceberg table type is " + type.name());
 
         String fileIOCacheMaxTotalBytes = copiedProps.get(IcebergCachingFileIO.FILEIO_CACHE_MAX_TOTAL_BYTES);

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergHiveCatalog.java
@@ -37,6 +37,7 @@ import static com.starrocks.external.iceberg.IcebergUtil.convertToSRDatabase;
 
 public class IcebergHiveCatalog extends BaseMetastoreCatalog implements IcebergCatalog {
     private static final Logger LOG = LogManager.getLogger(IcebergHiveCatalog.class);
+    public static final String FS_S3_CONF_PREFIX = "fs.s3a";
 
     private static final ConcurrentHashMap<String, IcebergHiveCatalog> METASTORE_URI_TO_CATALOG =
             new ConcurrentHashMap<>();
@@ -102,6 +103,14 @@ public class IcebergHiveCatalog extends BaseMetastoreCatalog implements IcebergC
         if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
             this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
                     properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+        }
+
+        // NOTE: remove core-site.xml, because the s3-auth of resource maybe difference
+        // if properties is null or no s3-auth info, new  Configuration will load default.
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey().startsWith(FS_S3_CONF_PREFIX)) {
+                this.conf.set(entry.getKey(), entry.getValue());
+            }
         }
 
         String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -21,12 +21,15 @@ import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergResource;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
@@ -839,7 +842,10 @@ public class PlanFragmentBuilder {
             }
 
             icebergScanNode.setLimit(node.getLimit());
-
+            String resourceName = ((IcebergTable) referenceTable).getResourceName();
+            Resource resource = GlobalStateMgr.getCurrentState().getResourceMgr().getResource(resourceName);
+            IcebergResource icebergResource = (IcebergResource) resource;
+            icebergScanNode.setTHdfsProperties(icebergResource.getProperties());
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(icebergScanNode);
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -860,6 +860,7 @@ struct THdfsScanNode {
 
     // Flag to indicate wheather the column names are case sensitive
     12: optional bool case_sensitive;
+    13: optional THdfsProperties hdfs_properties
 }
 
 struct TProjectNode {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

craete  iceberg resource with s3 auth info,  so we can use multi  hms with difference s3 account.
if no s3 auth info,  will use default when `new Configuration`

```
CREATE EXTERNAL RESOURCE "iceberg" 
PROPERTIES (
    "type" = "iceberg", 
    "starrocks.catalog-type"="HIVE", 
    "iceberg.catalog.hive.metastore.uris"="thrift://127.0.0.1:9083",
    "fs.s3a.access.key" = "********",
    "fs.s3a.secret.key" = "*******", 
    "fs.s3a.endpoint" = "cos.ap-guangzhou.myqcloud.com",
    "fs.s3a.region" = "ap-guangzhou",
    "fs.s3a.path.style.access" = "false",
    "fs.s3a.connection.ssl.enabled" = "false"
);
```

## Checklist:

- [ ] I have added user document for my new feature or new function
- [ ] I have added test cases for my bug fix or my new feature
