### PR TITLE
[BugFix] Fix bug of broadcast global runtime filter

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -60,7 +60,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_pool.h"
-#include "runtime/runtime_filter_worker.h"
+#include "runtime/runtime_filter_cache.h"
 #include "runtime/runtime_state.h"
 #include "simd/simd.h"
 #include "util/debug_util.h"
@@ -147,7 +147,10 @@ void ExecNode::push_down_join_runtime_filter_to_children(RuntimeState* state,
 
 void ExecNode::register_runtime_filter_descriptor(RuntimeState* state,
                                                   vectorized::RuntimeFilterProbeDescriptor* rf_desc) {
+    rf_desc->set_probe_plan_node_id(_id);
     _runtime_filter_collector.add_descriptor(rf_desc);
+    ExecEnv::GetInstance()->add_rf_event({state->query_id(), rf_desc->filter_id(), BackendOptions::get_localhost(),
+                                          strings::Substitute("REGISTER_GRF(probe_node_id=$0", _id)});
     state->runtime_filter_port()->add_listener(rf_desc);
 }
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -222,6 +222,10 @@ Status OperatorFactory::prepare(RuntimeState* state) {
                 continue;
             }
             auto grf = state->exec_env()->runtime_filter_cache()->get(state->query_id(), filter_id);
+            ExecEnv::GetInstance()->add_rf_event({_state->query_id(), filter_id, BackendOptions::get_localhost(),
+                                                  strings::Substitute("INSTALL_GRF_TO_OPERATOR(op_id=$0, success=$1",
+                                                                      this->_plan_node_id, grf != nullptr)});
+
             if (grf == nullptr) {
                 continue;
             }

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -121,6 +121,8 @@ public:
     JoinRuntimeFilter::RunningContext* runtime_filter_ctx() { return &_runtime_filter_ctx; }
     bool is_local() const { return _is_local; }
     TPlanNodeId build_plan_node_id() const { return _build_plan_node_id; }
+    TPlanNodeId probe_plan_node_id() const { return _probe_plan_node_id; }
+    void set_probe_plan_node_id(TPlanNodeId id) { _probe_plan_node_id = id; }
     const std::vector<int32_t>* bucketseq_to_partition() { return &_bucketseq_to_partition; }
 
 private:
@@ -130,6 +132,7 @@ private:
     ExprContext* _probe_expr_ctx = nullptr;
     bool _is_local;
     TPlanNodeId _build_plan_node_id;
+    TPlanNodeId _probe_plan_node_id;
     std::atomic<const JoinRuntimeFilter*> _runtime_filter = nullptr;
     std::shared_ptr<const JoinRuntimeFilter> _shared_runtime_filter = nullptr;
     JoinRuntimeFilter::RunningContext _runtime_filter_ctx;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -61,6 +61,23 @@ void RuntimeFilterPort::add_listener(vectorized::RuntimeFilterProbeDescriptor* r
     auto& wait_list = _listeners.find(rf_id)->second;
     wait_list.emplace_back(rf_desc);
 }
+std::string RuntimeFilterPort::listeners(int32_t filter_id) {
+    std::stringstream ss;
+    if (!_listeners.count(filter_id)) {
+        return "[]";
+    }
+    auto& listener_list = _listeners[filter_id];
+    if (listener_list.empty()) {
+        return "[]";
+    }
+    auto it = listener_list.begin();
+    ss << "[" << (*it)->probe_plan_node_id();
+    while (++it != listener_list.end()) {
+        ss << ", " << (*it)->probe_plan_node_id();
+    }
+    ss << "]";
+    return ss.str();
+}
 
 void RuntimeFilterPort::publish_runtime_filters(std::list<vectorized::RuntimeFilterBuildDescriptor*>& rf_descs) {
     RuntimeState* state = _state;
@@ -504,6 +521,8 @@ static inline Status receive_total_runtime_filter_pipeline(
     // we conservatively consider that global rf arrives in advance, so cache it for later use.
     if (!query_ctx) {
         ExecEnv::GetInstance()->runtime_filter_cache()->put_if_absent(query_id, params.filter_id(), shared_rf);
+        ExecEnv::GetInstance()->add_rf_event({params.query_id(), params.filter_id(), BackendOptions::get_localhost(),
+                                              "PUT_TOTAL_RF_IN_CACHE_QUERY_NOT_READY"});
     }
     // race condition exists among rf caching, FragmentContext's registration and OperatorFactory's preparation
     query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(query_id);
@@ -527,6 +546,9 @@ static inline Status receive_total_runtime_filter_pipeline(
         // we conservatively consider that global rf arrives in advance, so cache it for later use.
         if (!fragment_ctx) {
             ExecEnv::GetInstance()->runtime_filter_cache()->put_if_absent(query_id, params.filter_id(), shared_rf);
+            ExecEnv::GetInstance()->add_rf_event({params.query_id(), params.filter_id(),
+                                                  BackendOptions::get_localhost(),
+                                                  "PUT_TOTAL_RF_IN_CACHE_FRAGMENT_INSTANCE_NOT_READY"});
         }
         // race condition exists among rf caching, FragmentContext's registration and OperatorFactory's preparation
         fragment_ctx = query_ctx->fragment_mgr()->get(finst_id);
@@ -538,6 +560,11 @@ static inline Status receive_total_runtime_filter_pipeline(
             continue;
         }
         fragment_ctx->runtime_filter_port()->receive_shared_runtime_filter(params.filter_id(), shared_rf);
+        ExecEnv::GetInstance()->add_rf_event(
+                {params.query_id(), params.filter_id(), BackendOptions::get_localhost(),
+                 strings::Substitute("INSTALL_GRF(num_waiters=$0, instance_id=$1)",
+                                     fragment_ctx->runtime_filter_port()->listeners(params.filter_id()),
+                                     print_id(finst_id))});
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -39,6 +39,7 @@ public:
     void receive_runtime_filter(int32_t filter_id, const vectorized::JoinRuntimeFilter* rf);
     void receive_shared_runtime_filter(int32_t filter_id,
                                        const std::shared_ptr<const vectorized::JoinRuntimeFilter>& rf);
+    std::string listeners(int32_t filter_id);
 
 private:
     std::map<int32_t, std::list<vectorized::RuntimeFilterProbeDescriptor*>> _listeners;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -220,6 +220,10 @@ public class RuntimeFilterDescription {
         this.broadcastGRFDestinations = broadcastGRFDestinations;
     }
 
+    public List<TRuntimeFilterDestination> getBroadcastGRFDestinations() {
+        return broadcastGRFDestinations;
+    }
+
     public String toExplainString(int probeNodeId) {
         StringBuilder sb = new StringBuilder();
         sb.append("filter_id = ").append(filterId);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1127,7 +1127,7 @@ public class Coordinator {
                     probeParamList.add(probeParam);
                 }
                 if (usePipeline && kv.getValue().isBroadcastJoin() && kv.getValue().isHasRemoteTargets()) {
-                    broadcastGRFProbersMap.put(kv.getKey(), probeParamList);
+                    broadcastGRFProbersMap.computeIfAbsent(kv.getKey(), k -> new ArrayList<>()).addAll(probeParamList);
                 } else {
                     idToProbePrams.computeIfAbsent(kv.getKey(), k -> new ArrayList<>()).addAll(probeParamList);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
@@ -4,6 +4,7 @@ package com.starrocks.qe;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.TPCDSPlanTest;
 import com.starrocks.sql.plan.TPCDSPlanTestBase;
@@ -17,6 +18,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TPCDSCoordTest extends TPCDSPlanTestBase {
 
@@ -77,5 +81,64 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
         PlanFragmentId topFragmentId = coord.getFragments().get(0).getFragmentId();
         Coordinator.FragmentExecParams params = coord.getFragmentExecParamsMap().get(topFragmentId);
         Assert.assertEquals(params.runtimeFilterParams.id_to_prober_params.get(1).size(), 10);
+    }
+
+    @Test
+    public void testSubQueryExtractedFromQ5() throws Exception {
+        FeConstants.runningUnitTest = true;
+        ConnectContext ctx = starRocksAssert.getCtx();
+        ctx.setExecutionId(new TUniqueId(0x33, 0x0));
+        ConnectContext.threadLocalInfo.set(ctx);
+        ctx.getSessionVariable().setParallelExecInstanceNum(8);
+        ctx.getSessionVariable().setEnablePipelineEngine(true);
+        setTPCDSFactor(1);
+
+        // make sure global runtime filter been push-downed to two fragments.
+        String sql = "SELECT COUNT(1)\n" +
+                "from \n" +
+                "(select wsr_web_site_sk, date_sk,sales_price,profit,return_amt,net_loss,d_date_sk, d_date\n" +
+                "FROM (\n" +
+                "    SELECT ws_web_site_sk AS wsr_web_site_sk, ws_sold_date_sk AS date_sk, " +
+                "           ws_ext_sales_price AS sales_price, ws_net_profit AS profit, " +
+                "           CAST(0 AS decimal(7, 2)) AS return_amt,\n" +
+                "           CAST(0 AS decimal(7, 2)) AS net_loss\n" +
+                "    FROM web_sales\n" +
+                "    UNION ALL\n" +
+                "    SELECT ws_web_site_sk AS wsr_web_site_sk, wr_returned_date_sk AS date_sk, " +
+                "           CAST(0 AS decimal(7, 2)) AS sales_price, CAST(0 AS decimal(7, 2)) AS profit," +
+                "           wr_return_amt AS return_amt,\n" +
+                "           wr_net_loss AS net_loss\n" +
+                "    FROM web_sales\n" +
+                "        INNER JOIN web_returns\n" +
+                "        ON wr_item_sk = ws_item_sk\n" +
+                "            AND wr_order_number = ws_order_number\n" +
+                ") salesreturns inner join[broadcast] date_dim on date_sk = d_date_sk) t " +
+                "   inner join[broadcast] web_site on wsr_web_site_sk = web_site_sk\n" +
+                "WHERE \n" +
+                "    d_date BETWEEN CAST('2000-08-23' AS date) AND date_add(CAST('2000-08-23' AS date), 14)";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String[] ss = plan.split("\\n");
+        List<String> filterLines = Stream.of(ss).filter(s -> s.contains("filter_id = 2")).collect(Collectors.toList());
+        System.out.println(filterLines.size());
+        Assert.assertTrue(filterLines.size() == 5);
+        ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
+        Coordinator coord = new Coordinator(ctx, execPlan.getFragments(), execPlan.getScanNodes(),
+                execPlan.getDescTbl().toThrift());
+        coord.prepareExec();
+
+        int filterId = 2;
+        boolean rfExists = false;
+        for (Coordinator.FragmentExecParams params : coord.getFragmentExecParamsMap().values()) {
+            Map<Integer, RuntimeFilterDescription> buildRfFilters = params.fragment.getBuildRuntimeFilters();
+            if (buildRfFilters == null || !buildRfFilters.containsKey(filterId)) {
+                continue;
+            }
+            RuntimeFilterDescription rf = buildRfFilters.get(filterId);
+            Assert.assertTrue(rf.isHasRemoteTargets() && rf.isBroadcastJoin());
+            Assert.assertFalse(rf.getBroadcastGRFDestinations().isEmpty());
+            Assert.assertTrue(rf.getBroadcastGRFDestinations().stream().anyMatch(d -> d.getFinstance_ids().size() > 1));
+            rfExists = true;
+        }
+        Assert.assertTrue(rfExists);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Q1:
```
select count(1)  from   ( select  ws_web_site_sk as wsr_web_site_sk,             ws_sold_date_sk  as date_sk,             ws_ext_sales_price as sales_price,             ws_net_profit
as profit,             cast(0 as decimal(7,2)) as return_amt,             cast(0 as decimal(7,2)) as net_loss     from web_sales     union all select ws_web_site_sk as wsr_web_site_sk,
      wr_returned_date_sk as date_sk,            cast(0 as decimal(7,2)) as sales_price,            cast(0 as decimal(7,2)) as profit,            wr_return_amt as return_amt,            wr_net_loss as net_loss     from  web_sales inner join  web_returns  on          ( wr_item_sk = ws_item_sk            and wr_order_number = ws_order_number)    ) salesreturns,      date_dim,
  web_site  where date_sk = d_date_sk        and d_date between cast('2000-08-23' as date)                   and date_add(cast('2000-08-23' as date),  14)        and wsr_web_site_sk = web_site_sk;
```
Q1 in non-pipline engine runs as 2~3 times fast as pipeline engine. The reason is that in the plan tree: broadcast HashJoin(plan_node_id=12) generates a broadcast grf but fails to deliver it to the OlapScan(plan_node_id=4), so no rows are filtered in pipeline engine, but in the non-pipeline engine, the GRF show 1% selectivity.

The bug is quite stupid, but the procedure to find out the root cause is quite hard. after I fixed this bug.
data filtered in pipeline engine are as many as that in the non-pipeline engine.  now Q1 in pipeline_engine(0.14s) runs as time times fast as in non-pipeline(0.22s).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
