### PR TITLE
[Enhance] use single-quote escape array<json>

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -34,7 +34,7 @@ void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx
     if (!json_str.ok()) {
         buf->push_null();
     } else {
-        buf->push_string(json_str->data(), json_str->size());
+        buf->push_string(json_str->data(), json_str->size(), false);
     }
 }
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -34,7 +34,7 @@ void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx
     if (!json_str.ok()) {
         buf->push_null();
     } else {
-        buf->push_string(json_str->data(), json_str->size(), false);
+        buf->push_string(json_str->data(), json_str->size(), '\'');
     }
 }
 

--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -119,31 +119,23 @@ void MysqlRowBuffer::push_number(T data) {
     _data.resize(pos - _data.data());
 }
 
-void MysqlRowBuffer::push_string(const char* str, size_t length, bool double_quote_escape) {
+void MysqlRowBuffer::push_string(const char* str, size_t length, char escape_char) {
     if (_array_level == 0) {
         _push_string_normal(str, length);
-    } else if (!double_quote_escape) {
-        char* pos = _resize_extra(length + 2);
-        *pos++ = '\'';
-        strings::memcpy_inlined(pos, str, length);
-        pos += length;
-        *pos++ = '\'';
-        DCHECK_EQ(_data.data() + _data.size(), pos);
-        _data.resize(pos - _data.data());
     } else {
-        const size_t escaped_len = 2 + _length_after_escape(str, length);
-        //                  ^^^ Surround the string with two double-quotas.
+        // Surround the string with two double-quotas.
+        const size_t escaped_len = 2 + _length_after_escape(str, length, escape_char);
         char* pos = _resize_extra(escaped_len);
-        *pos++ = '"';
+        *pos++ = escape_char;
         if (escaped_len == length + 2) {
             // No '\' or '"' exists in |str|, copy directly.
             strings::memcpy_inlined(pos, str, length);
             pos += length;
         } else {
             // Escape '\' and '"'.
-            pos = _escape(pos, str, length);
+            pos = _escape(pos, str, length, escape_char);
         }
-        *pos++ = '"';
+        *pos++ = escape_char;
         DCHECK_EQ(_data.data() + _data.size(), pos);
         _data.resize(pos - _data.data());
     }
@@ -201,30 +193,26 @@ void MysqlRowBuffer::separator(char c) {
     _data.push_back(c);
 }
 
-size_t MysqlRowBuffer::_length_after_escape(const char* str, size_t length) {
+size_t MysqlRowBuffer::_length_after_escape(const char* str, size_t length, char escape_char) {
     size_t new_len = length;
     for (size_t i = 0; i < length; i++) {
-        new_len += ((str[i] == '"') | (str[i] == '\\'));
+        new_len += ((str[i] == escape_char) | (str[i] == '\\'));
         //                         ^^ use '|' or instead of '||' intentionally.
     }
     return new_len;
 }
 
-char* MysqlRowBuffer::_escape(char* dst, const char* src, size_t length) {
+char* MysqlRowBuffer::_escape(char* dst, const char* src, size_t length, char escape_char) {
     for (size_t i = 0; i < length; i++) {
         char c = src[i];
-        switch (c) {
-        case '"':
+        if (c == escape_char) {
             *dst++ = '\\';
-            *dst++ = '"';
-            break;
-        case '\\':
+            *dst++ = escape_char;
+        } else if (c == '\\') {
             *dst++ = '\\';
             *dst++ = '\\';
-            break;
-        default:
+        } else {
             *dst++ = c;
-            break;
         }
     }
     return dst;

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -44,7 +44,7 @@ public:
     void push_largeint(__int128 data) { push_number(data); }
     void push_float(float data) { push_number(data); }
     void push_double(double data) { push_number(data); }
-    void push_string(const char* str, size_t length, bool double_quote_escape = true);
+    void push_string(const char* str, size_t length, char escape_char = '"');
     void push_string(const Slice& s) { push_string(s.data, s.size); }
 
     template <typename T>
@@ -78,8 +78,8 @@ private:
 
     void _enter_scope(char c);
     void _leave_scope(char c);
-    size_t _length_after_escape(const char* str, size_t length);
-    char* _escape(char* dst, const char* src, size_t length);
+    size_t _length_after_escape(const char* str, size_t length, char escape_char = '"');
+    char* _escape(char* dst, const char* src, size_t length, char escape_char = '"');
     void _push_string_normal(const char* str, size_t lenght);
 
     raw::RawString _data;

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -44,7 +44,7 @@ public:
     void push_largeint(__int128 data) { push_number(data); }
     void push_float(float data) { push_number(data); }
     void push_double(double data) { push_number(data); }
-    void push_string(const char* str, size_t length);
+    void push_string(const char* str, size_t length, bool double_quote_escape = true);
     void push_string(const Slice& s) { push_string(s.data, s.size); }
 
     template <typename T>

--- a/be/test/util/mysql_row_buffer_test.cpp
+++ b/be/test/util/mysql_row_buffer_test.cpp
@@ -387,7 +387,7 @@ TEST_F(MysqlRowBufferTest, test_array) {
         row_buffer.begin_push_array();
 
         Slice json = R"({"k1": "v1"})";
-        row_buffer.push_string(json.data, json.size, false);
+        row_buffer.push_string(json.data, json.size, '\'');
 
         row_buffer.finish_push_array();
 

--- a/be/test/util/mysql_row_buffer_test.cpp
+++ b/be/test/util/mysql_row_buffer_test.cpp
@@ -381,6 +381,22 @@ TEST_F(MysqlRowBufferTest, test_array) {
         ASSERT_EQ("[[1,2],[],null]", data.value());
         ASSERT_EQ("", slice);
     }
+    // json array
+    {
+        MysqlRowBuffer row_buffer;
+        row_buffer.begin_push_array();
+
+        Slice json = R"({"k1": "v1"})";
+        row_buffer.push_string(json.data, json.size, false);
+
+        row_buffer.finish_push_array();
+
+        Slice slice(row_buffer.data());
+        auto data = decode_mysql_row(&slice);
+
+        ASSERT_EQ(R"(['{"k1": "v1"}'])", data.value());
+        ASSERT_EQ("", slice);
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10790

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- Before: `["{\"k1\":\"v1\"}", "{\"k2\": \"v2\"}"]`
- After: `['{"k1": "v1"}', '{"k2": "v2"}']`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
