### PR TITLE
[Cherry-pick 2.4][BugFix] persist grant/revoke role and support grant impersonate to role (#10596)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -368,7 +368,9 @@ public class JournalEntity implements Writable {
             case OperationType.OP_REVOKE_PRIV:
             case OperationType.OP_SET_PASSWORD:
             case OperationType.OP_CREATE_ROLE:
-            case OperationType.OP_DROP_ROLE: {
+            case OperationType.OP_DROP_ROLE:
+            case OperationType.OP_GRANT_ROLE:
+            case OperationType.OP_REVOKE_ROLE: {
                 data = PrivInfo.read(in);
                 isRead = true;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.StarRocksFE;
 import com.starrocks.analysis.AlterUserStmt;
 import com.starrocks.analysis.CreateRoleStmt;
@@ -47,9 +48,11 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
+import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.ImpersonatePrivInfo;
 import com.starrocks.persist.PrivInfo;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.GrantImpersonateStmt;
@@ -69,6 +72,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -628,7 +632,7 @@ public class Auth implements Writable {
 
             // 4. grant privs of role to user
             if (role != null) {
-                grantRoleInternal(role, userIdent, false);
+                grantRoleInternal(roleName, userIdent, false, true);
             }
 
             // other user properties
@@ -713,22 +717,37 @@ public class Auth implements Writable {
     public void grantRole(GrantRoleStmt stmt) throws DdlException {
         writeLock();
         try {
-            grantRoleInternal(this.roleManager.getRole(stmt.getQualifiedRole()), stmt.getUserIdent(), true);
+            grantRoleInternal(stmt.getQualifiedRole(), stmt.getUserIdent(), true, false);
         } finally {
             writeUnlock();
         }
     }
+
+    public void replayGrantRole(PrivInfo privInfo) throws DdlException {
+        writeLock();
+        try {
+            grantRoleInternal(privInfo.getRole(), privInfo.getUserIdent(), true, true);
+        } finally {
+            writeUnlock();
+        }
+    }
+
 
     /**
      * simply copy all privileges map from role to user.
      * TODO this is a temporary implement that make it impossible to safely revoke privilege from role.
      * We will refactor the whole user privilege framework later to ultimately fix this.
      *
-     * @param role
+     * @param roleName
      * @param userIdent
      * @throws DdlException
      */
-    private void grantRoleInternal(Role role, UserIdentity userIdent, boolean errOnNonExist) throws DdlException {
+    private void grantRoleInternal(String roleName, UserIdentity userIdent, boolean errOnNonExist, boolean isReplay)
+            throws DdlException {
+        Role role = roleManager.getRole(roleName);
+        if (role == null) {
+            throw new DdlException("Role: " + roleName + " does not exist");
+        }
         for (Map.Entry<TablePattern, PrivBitSet> entry : role.getTblPatternToPrivs().entrySet()) {
             // use PrivBitSet copy to avoid same object being changed synchronously
             grantInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
@@ -739,13 +758,31 @@ public class Auth implements Writable {
             grantInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
                     errOnNonExist /* err on non exist */, true /* is replay */);
         }
+        for (UserIdentity user : role.getImpersonateUsers()) {
+            grantImpersonateToUserInternal(userIdent, user, true);
+        }
+
         role.addUser(userIdent);
+        if (!isReplay) {
+            PrivInfo privInfo = new PrivInfo(userIdent, role.getRoleName());
+            GlobalStateMgr.getCurrentState().getEditLog().logGrantRole(privInfo);
+        }
+        LOG.info("grant {} to {}, isReplay = {}", roleName, userIdent, isReplay);
     }
 
     public void revokeRole(RevokeRoleStmt stmt) throws DdlException {
         writeLock();
         try {
-            revokeRoleInternal(this.roleManager.getRole(stmt.getQualifiedRole()), stmt.getUserIdent());
+            revokeRoleInternal(stmt.getQualifiedRole(), stmt.getUserIdent(), false);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void replayRevokeRole(PrivInfo privInfo) throws DdlException {
+        writeLock();
+        try {
+            revokeRoleInternal(privInfo.getRole(), privInfo.getUserIdent(), true);
         } finally {
             writeUnlock();
         }
@@ -756,41 +793,70 @@ public class Auth implements Writable {
      * TODO this is a temporary implement that make it impossible to safely revoke privilege from role.
      * We will refactor the whole user privilege framework later to ultimately fix this.
      *
-     * @param role
+     * @param roleName
      * @param userIdent
      * @throws DdlException
      */
-    private void revokeRoleInternal(Role role, UserIdentity userIdent) throws DdlException {
+    private void revokeRoleInternal(String roleName, UserIdentity userIdent, boolean isReplay) throws DdlException {
+        Role role = roleManager.getRole(roleName);
+        if (role == null) {
+            throw new DdlException("Role: " + roleName + " does not exist");
+        }
         for (Map.Entry<TablePattern, PrivBitSet> entry : role.getTblPatternToPrivs().entrySet()) {
             revokeInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
-                    false /* err on non exist */, false /* is replay */);
+                    false /* err on non exist */, true /* is replay */);
         }
         for (Map.Entry<ResourcePattern, PrivBitSet> entry : role.getResourcePatternToPrivs().entrySet()) {
             revokeInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
-                    false /* err on non exist */, false /* is replay */);
+                    false /* err on non exist */, true /* is replay */);
         }
+        for (UserIdentity user : role.getImpersonateUsers()) {
+            revokeImpersonateFromUserInternal(userIdent, user, true);
+        }
+
         role.dropUser(userIdent);
+        if (!isReplay) {
+            PrivInfo privInfo = new PrivInfo(userIdent, role.getRoleName());
+            GlobalStateMgr.getCurrentState().getEditLog().logRevokeRole(privInfo);
+        }
+        LOG.info("revoke {} from {}, isReplay = {}", roleName, userIdent, isReplay);
     }
 
     public void grantImpersonate(GrantImpersonateStmt stmt) throws DdlException {
-        grantImpersonateInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        if (stmt.getAuthorizedRoleName() == null) {
+            grantImpersonateToUserInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        } else {
+            grantImpersonateToRoleInternal(stmt.getAuthorizedRoleName(), stmt.getSecuredUser(), false);
+        }
     }
 
     public void replayGrantImpersonate(ImpersonatePrivInfo info) {
         try {
-            grantImpersonateInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            if (info.getAuthorizedRoleName() == null) {
+                grantImpersonateToUserInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            } else {
+                grantImpersonateToRoleInternal(info.getAuthorizedRoleName(), info.getSecuredUser(), true);
+            }
         } catch (DdlException e) {
             LOG.error("should not happend", e);
         }
     }
 
     public void revokeImpersonate(RevokeImpersonateStmt stmt) throws DdlException {
-        revokeImpersonateInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        if (stmt.getAuthorizedRoleName() == null) {
+            revokeImpersonateFromUserInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        } else {
+            revokeImpersonateFromRoleInternal(stmt.getAuthorizedRoleName(), stmt.getSecuredUser(), false);
+        }
     }
 
     public void replayRevokeImpersonate(ImpersonatePrivInfo info) {
         try {
-            revokeImpersonateInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            if (info.getAuthorizedRoleName() == null) {
+                revokeImpersonateFromUserInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            } else {
+                revokeImpersonateFromRoleInternal(info.getAuthorizedRoleName(), info.getSecuredUser(), true);
+            }
         } catch (DdlException e) {
             LOG.error("should not happend", e);
         }
@@ -987,7 +1053,7 @@ public class Auth implements Writable {
         }
     }
 
-    private void grantImpersonateInternal(
+    private void grantImpersonateToUserInternal(
             UserIdentity authorizedUser, UserIdentity securedUser, boolean isReplay) throws DdlException {
         writeLock();
         try {
@@ -999,7 +1065,7 @@ public class Auth implements Writable {
                 ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedUser, securedUser);
                 GlobalStateMgr.getCurrentState().getEditLog().logGrantImpersonate(info);
             }
-            LOG.debug("finished to grant impersonate. is replay: {}", isReplay);
+            LOG.info("grant impersonate on {} to {}, isReplay = {}", securedUser, authorizedUser, isReplay);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         } finally {
@@ -1007,7 +1073,28 @@ public class Auth implements Writable {
         }
     }
 
+    private void grantImpersonateToRoleInternal(
+            String authorizedRoleName, UserIdentity securedUser, boolean isReplay) throws DdlException {
+        writeLock();
+        try {
+            // grant privs to role, role must exist
+            Role newRole = new Role(authorizedRoleName, securedUser);
+            Role existingRole = roleManager.addRole(newRole, false /* err on exist */);
 
+            // update users' privs of this role
+            for (UserIdentity user : existingRole.getUsers()) {
+                grantImpersonateToUserInternal(user, securedUser, true);
+            }
+
+            if (!isReplay) {
+                ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedRoleName, securedUser);
+                GlobalStateMgr.getCurrentState().getEditLog().logGrantImpersonate(info);
+            }
+            LOG.info("grant impersonate on {} to role {}, isReplay = {}", securedUser, authorizedRoleName, isReplay);
+        } finally {
+            writeUnlock();
+        }
+    }
 
     // return true if user ident exist
     private boolean doesUserExist(UserIdentity userIdent) {
@@ -1138,7 +1225,7 @@ public class Auth implements Writable {
         }
     }
 
-    private void revokeImpersonateInternal(
+    private void revokeImpersonateFromUserInternal(
             UserIdentity authorizedUser, UserIdentity securedUser, boolean isReplay) throws DdlException {
         writeLock();
         try {
@@ -1150,9 +1237,32 @@ public class Auth implements Writable {
                 ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedUser, securedUser);
                 GlobalStateMgr.getCurrentState().getEditLog().logRevokeImpersonate(info);
             }
-            LOG.debug("finished to revoke impersonate. is replay: {}", isReplay);
+            LOG.info("revoke impersonate on {} from {}. is replay: {}", securedUser, authorizedUser, isReplay);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private void revokeImpersonateFromRoleInternal(
+            String authorizedRoleName, UserIdentity securedUser, boolean isReplay) throws DdlException {
+        writeLock();
+        try {
+            // revoke privs from role, role must exist
+            Role existingRole = roleManager.revokePrivs(authorizedRoleName, securedUser);
+
+            // revoke privs from users of this role
+            for (UserIdentity user : existingRole.getUsers()) {
+                revokeImpersonateFromUserInternal(user, securedUser, true);
+            }
+
+            if (!isReplay) {
+                ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedRoleName, securedUser);
+                GlobalStateMgr.getCurrentState().getEditLog().logRevokeImpersonate(info);
+            }
+            LOG.debug("revoke impersonate on {} from role {}. is replay: {}", securedUser, authorizedRoleName, isReplay);
+
         } finally {
             writeUnlock();
         }
@@ -1746,7 +1856,14 @@ public class Auth implements Writable {
      * newly added metadata entity should deserialize with gson in this method
      **/
     public long readAsGson(DataInput in, long checksum) throws IOException {
-        this.impersonateUserPrivTable = ImpersonateUserPrivTable.read(in);
+        SerializeData data = GsonUtils.GSON.fromJson(Text.readString(in), SerializeData.class);
+        try {
+            this.impersonateUserPrivTable.loadEntries(data.entries);
+            this.roleManager.loadImpersonateRoleToUser(data.impersonateRoleToUser);
+        } catch (AnalysisException e) {
+            LOG.error("failed to readAsGson, ", e);
+            throw new IOException(e.getMessage());
+        }
         checksum ^= this.impersonateUserPrivTable.size();
         return checksum;
     }
@@ -1755,7 +1872,10 @@ public class Auth implements Writable {
      * newly added metadata entity should serialize with gson in this method
      **/
     public long writeAsGson(DataOutput out, long checksum) throws IOException {
-        impersonateUserPrivTable.write(out);
+        SerializeData data = new SerializeData();
+        data.entries = impersonateUserPrivTable.dumpEntries();
+        data.impersonateRoleToUser = roleManager.dumpImpersonateRoleToUser();
+        Text.writeString(out, GsonUtils.GSON.toJson(data));
         checksum ^= impersonateUserPrivTable.size();
         return checksum;
     }
@@ -1784,6 +1904,12 @@ public class Auth implements Writable {
         sb.append(roleManager).append("\n");
         sb.append(propertyMgr).append("\n");
         return sb.toString();
+    }
+    private static class SerializeData {
+        @SerializedName("entries")
+        public List<ImpersonateUserPrivEntry> entries = new ArrayList<>();
+        @SerializedName("impersonateRoleToUser")
+        public Map<String, Set<UserIdentity>> impersonateRoleToUser = new HashMap<>();
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTable.java
@@ -2,15 +2,9 @@
 
 package com.starrocks.mysql.privilege;
 
-import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.io.Text;
-import com.starrocks.persist.gson.GsonUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,8 +15,6 @@ import java.util.List;
  * ImpersonateUserPrivTable saves all impersonate user privileges
  */
 public class ImpersonateUserPrivTable extends PrivTable {
-    private static final Logger LOG = LogManager.getLogger(ImpersonateUserPrivTable.class);
-
     /**
      * Return first priv which match the user@host on securedUser
      * The returned priv will be saved in 'savedPrivs'.
@@ -61,36 +53,29 @@ public class ImpersonateUserPrivTable extends PrivTable {
         return privBitSet.satisfy(PrivPredicate.IMPERSONATE);
     }
 
-    public static ImpersonateUserPrivTable read(DataInput in) throws IOException {
-        ImpersonateUserPrivTable table = new ImpersonateUserPrivTable();
-        SerializeData data = GsonUtils.GSON.fromJson(Text.readString(in), SerializeData.class);
-        for (ImpersonateUserPrivEntry entry : data.entries) {
-            try {
-                entry.analyse();
-            } catch (AnalysisException e) {
-                // TODO This is ugly, somewhere above AnalysisException should be allowed
-                throw new IOException(e);
-            }
+    protected void loadEntries(List<ImpersonateUserPrivEntry> dataEntries) throws AnalysisException {
+        for (ImpersonateUserPrivEntry entry : dataEntries) {
+            entry.analyse();
             UserIdentity newUser = entry.getUserIdent();
-            List<PrivEntry> entries = table.map.computeIfAbsent(newUser, k -> new ArrayList<>());
+            List<PrivEntry> entries = this.map.computeIfAbsent(newUser, k -> new ArrayList<>());
             entries.add(entry);
         }
-        return table;
+    }
+
+    public List<ImpersonateUserPrivEntry> dumpEntries() {
+        List<ImpersonateUserPrivEntry> dataEntries = new ArrayList<>();
+        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
+        while (iter.hasNext()) {
+            ImpersonateUserPrivEntry entry = (ImpersonateUserPrivEntry) iter.next();
+            dataEntries.add(entry);
+        }
+        return dataEntries;
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        SerializeData data = new SerializeData();
-        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
-        while (iter.hasNext()) {
-            ImpersonateUserPrivEntry entry = (ImpersonateUserPrivEntry) iter.next();
-            data.entries.add(entry);
-        }
-        Text.writeString(out, GsonUtils.GSON.toJson(data));
+        throw new IOException("not implement");
     }
 
-    private static class SerializeData {
-        @SerializedName("entries")
-        public List<ImpersonateUserPrivEntry> entries = new ArrayList<>();
-    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
@@ -55,6 +55,9 @@ public class Role implements Writable {
     private String roleName;
     private Map<TablePattern, PrivBitSet> tblPatternToPrivs = Maps.newConcurrentMap();
     private Map<ResourcePattern, PrivBitSet> resourcePatternToPrivs = Maps.newConcurrentMap();
+
+    // newly added in 2.3
+    private Set<UserIdentity> impersonateUsers = Sets.newConcurrentHashSet();
     // users which this role
     private Set<UserIdentity> users = Sets.newConcurrentHashSet();
 
@@ -83,6 +86,11 @@ public class Role implements Writable {
         this.resourcePatternToPrivs.put(resourcePattern, resourcePrivs);
     }
 
+    public Role(String roleName, UserIdentity securedUser) {
+        this.roleName = roleName;
+        this.impersonateUsers.add(securedUser);
+    }
+
     public String getRoleName() {
         return roleName;
     }
@@ -97,6 +105,14 @@ public class Role implements Writable {
 
     public Set<UserIdentity> getUsers() {
         return users;
+    }
+
+    public Set<UserIdentity> getImpersonateUsers() {
+        return impersonateUsers;
+    }
+
+    public void setImpersonateUsers(Set<UserIdentity> impersonateUsers) {
+        this.impersonateUsers = impersonateUsers;
     }
 
     public void merge(Role other) {
@@ -117,6 +133,7 @@ public class Role implements Writable {
                 resourcePatternToPrivs.put(entry.getKey(), entry.getValue());
             }
         }
+        this.impersonateUsers.addAll(other.impersonateUsers);
     }
 
     public void addUser(UserIdentity userIdent) {
@@ -187,6 +204,7 @@ public class Role implements Writable {
         sb.append("role: ").append(roleName).append(", db table privs: ").append(tblPatternToPrivs);
         sb.append(", resource privs: ").append(resourcePatternToPrivs);
         sb.append(", users: ").append(users);
+        sb.append(", impersonate: ").append(impersonateUsers);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -501,6 +501,16 @@ public class EditLog {
                     globalStateMgr.getAuth().replayDropRole(privInfo);
                     break;
                 }
+                case OperationType.OP_GRANT_ROLE: {
+                    PrivInfo privInfo = (PrivInfo) journal.getData();
+                    globalStateMgr.getAuth().replayGrantRole(privInfo);
+                    break;
+                }
+                case OperationType.OP_REVOKE_ROLE: {
+                    PrivInfo privInfo = (PrivInfo) journal.getData();
+                    globalStateMgr.getAuth().replayRevokeRole(privInfo);
+                    break;
+                }
                 case OperationType.OP_UPDATE_USER_PROPERTY: {
                     UserPropertyInfo propertyInfo = (UserPropertyInfo) journal.getData();
                     globalStateMgr.getAuth().replayUpdateUserProperty(propertyInfo);
@@ -1259,6 +1269,14 @@ public class EditLog {
 
     public void logFinishDecommissionBackend(DecommissionBackendJob job) {
         logEdit(OperationType.OP_FINISH_DECOMMISSION_BACKEND, job);
+    }
+
+    public void logGrantRole(PrivInfo info) {
+        logEdit(OperationType.OP_GRANT_ROLE, info);
+    }
+
+    public void logRevokeRole(PrivInfo info) {
+        logEdit(OperationType.OP_REVOKE_ROLE, info);
     }
 
     public void logDatabaseRename(DatabaseInfo databaseInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImpersonatePrivInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImpersonatePrivInfo.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 
 public class ImpersonatePrivInfo implements Writable {
     @SerializedName(value = "authorizedUser")
-    private UserIdentity authorizedUser;
+    private UserIdentity authorizedUser = null;
+    @SerializedName(value = "authorizedRoleName")
+    private String authorizedRoleName = null;
     @SerializedName(value = "securedUser")
     private UserIdentity securedUser;
 
@@ -28,6 +30,13 @@ public class ImpersonatePrivInfo implements Writable {
         this.securedUser = securedUser;
     }
 
+    public ImpersonatePrivInfo(String authorizedRoleName, UserIdentity securedUser) {
+        this.authorizedRoleName = authorizedRoleName;
+        // Just in case of NPE after rolled back. Worst case scenario, it's meaningless to impersonate as oneself.
+        this.authorizedUser = securedUser;
+        this.securedUser = securedUser;
+    }
+
     public UserIdentity getAuthorizedUser() {
         return authorizedUser;
     }
@@ -35,6 +44,11 @@ public class ImpersonatePrivInfo implements Writable {
     public UserIdentity getSecuredUser() {
         return securedUser;
     }
+
+    public String getAuthorizedRoleName() {
+        return authorizedRoleName;
+    }
+
     public static ImpersonatePrivInfo read(DataInput in) throws IOException {
         String json = Text.readString(in);
         return GsonUtils.GSON.fromJson(json, ImpersonatePrivInfo.class);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -224,6 +224,8 @@ public class OperationType {
     // grant & revoke impersonate
     public static final short OP_GRANT_IMPERSONATE = 10062;
     public static final short OP_REVOKE_IMPERSONATE = 10063;
+    public static final short OP_GRANT_ROLE = 10064;
+    public static final short OP_REVOKE_ROLE = 10065;
 
     // task 10071 ~ 10090
     public static final short OP_CREATE_TASK = 10071;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
@@ -78,6 +78,15 @@ public class PrivInfo implements Writable {
         this.role = role;
     }
 
+    public PrivInfo(UserIdentity userIdent, String role) {
+        this.userIdent = userIdent;
+        this.role = role;
+        this.tblPattern = null;
+        this.resourcePattern = null;
+        this.privs = null;
+        this.passwd = null;
+    }
+
     public UserIdentity getUserIdent() {
         return userIdent;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -89,12 +89,19 @@ public class PrivilegeStmtAnalyzer {
 
         /**
          * GRANT IMPERSONATE ON XX TO XX
-         * REVOKE IMPERSONATE ON XX TO XX
+         * GRANT IMPERSONATE ON XX TO ROLE XX
+         * REVOKE IMPERSONATE ON XX FROM XX
+         * REVOKE IMPERSONATE ON XX FROM ROLE XX
          */
         @Override
         public Void visitGrantRevokeImpersonateStatement(BaseGrantRevokeImpersonateStmt stmt, ConnectContext session) {
-            analyseUser(stmt.getAuthorizedUser(), session, true);
             analyseUser(stmt.getSecuredUser(), session, true);
+            if (stmt.getAuthorizedUser() != null) {
+                analyseUser(stmt.getAuthorizedUser(), session, true);
+            } else {
+                String qulifiedRole = analyseRoleName(stmt.getAuthorizedRoleName(), session);
+                stmt.setAuthorizedRoleName(qulifiedRole);
+            }
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeImpersonateStmt.java
@@ -8,16 +8,32 @@ import com.starrocks.analysis.UserIdentity;
 // GrantImpersonateStmt and RevokeImpersonateStmt share the same parameter and check logic
 public abstract class BaseGrantRevokeImpersonateStmt extends DdlStmt {
     protected UserIdentity authorizedUser;
+    protected String authorizedRoleName;
     protected UserIdentity securedUser;
     private String operationName;   // GRANT or REVOKE
     private String prepositionName; // TO or FROM
 
+    // GRANT IMPERSONATE ON securedUser To authorizedUser
     public BaseGrantRevokeImpersonateStmt(
             UserIdentity authorizedUser,
             UserIdentity securedUser,
             String operationName,
             String prepositionName) {
         this.authorizedUser = authorizedUser;
+        this.authorizedRoleName = null;
+        this.securedUser = securedUser;
+        this.operationName = operationName;
+        this.prepositionName = prepositionName;
+    }
+
+    // GRANT IMPERSONATE ON securedUser To ROLE authorizedRoleName
+    public BaseGrantRevokeImpersonateStmt(
+            String authorizedRoleName,
+            UserIdentity securedUser,
+            String operationName,
+            String prepositionName) {
+        this.authorizedUser = null;
+        this.authorizedRoleName = authorizedRoleName;
         this.securedUser = securedUser;
         this.operationName = operationName;
         this.prepositionName = prepositionName;
@@ -27,14 +43,23 @@ public abstract class BaseGrantRevokeImpersonateStmt extends DdlStmt {
         return authorizedUser;
     }
 
+    public String getAuthorizedRoleName() {
+        return authorizedRoleName;
+    }
+
     public UserIdentity getSecuredUser() {
         return securedUser;
     }
 
+    public void setAuthorizedRoleName(String authorizedRoleName) {
+        this.authorizedRoleName = authorizedRoleName;
+    }
+
     @Override
     public String toString() {
+        String authorizedEntity = authorizedUser == null ? "ROLE '" + authorizedRoleName + "'" : authorizedUser.toString();
         return String.format("%s IMPERSONATE ON %s %s %s",
-                operationName, securedUser.toString(), prepositionName, authorizedUser.toString());
+                operationName, securedUser.toString(), prepositionName, authorizedEntity);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantImpersonateStmt.java
@@ -12,6 +12,10 @@ public class GrantImpersonateStmt extends BaseGrantRevokeImpersonateStmt {
         super(authorizedUser, securedUser, "GRANT", "TO");
     }
 
+    public GrantImpersonateStmt(String authorizedRoleName, UserIdentity securedUser) {
+        super(authorizedRoleName, securedUser, "GRANT", "TO");
+    }
+
     @Override
     public boolean isSupportNewPlanner() {
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeImpersonateStmt.java
@@ -12,6 +12,10 @@ public class RevokeImpersonateStmt extends BaseGrantRevokeImpersonateStmt {
         super(authorizedUser, securedUser, "REVOKE", "FROM");
     }
 
+    public RevokeImpersonateStmt(String authorizedRoleName, UserIdentity securedUser) {
+        super(authorizedRoleName, securedUser, "REVOKE", "FROM");
+    }
+
     @Override
     public boolean isSupportNewPlanner() {
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2831,15 +2831,25 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitGrantImpersonate(StarRocksParser.GrantImpersonateContext context) {
         UserIdentity securedUser = ((UserIdentifier) visit(context.user(0))).getUserIdentity();
-        UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
-        return new GrantImpersonateStmt(authorizedUser, securedUser);
+        if (context.user(1) != null) {
+            UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
+            return new GrantImpersonateStmt(authorizedUser, securedUser);
+        } else {
+            String roleName = ((Identifier) visit(context.identifierOrString())).getValue();
+            return new GrantImpersonateStmt(roleName, securedUser);
+        }
     }
 
     @Override
     public ParseNode visitRevokeImpersonate(StarRocksParser.RevokeImpersonateContext context) {
         UserIdentity securedUser = ((UserIdentifier) visit(context.user(0))).getUserIdentity();
-        UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
-        return new RevokeImpersonateStmt(authorizedUser, securedUser);
+        if (context.user(1) != null) {
+            UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
+            return new RevokeImpersonateStmt(authorizedUser, securedUser);
+        } else {
+            String roleName = ((Identifier) visit(context.identifierOrString())).getValue();
+            return new RevokeImpersonateStmt(roleName, securedUser);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -138,9 +138,9 @@ statement
 
     // privilege
     | GRANT identifierOrString TO user                                                      #grantRole
-    | GRANT IMPERSONATE ON user TO user                                                     #grantImpersonate
+    | GRANT IMPERSONATE ON user TO ( user | ROLE identifierOrString )                       #grantImpersonate
     | REVOKE identifierOrString FROM user                                                   #revokeRole
-    | REVOKE IMPERSONATE ON user FROM user                                                  #revokeImpersonate
+    | REVOKE IMPERSONATE ON user FROM ( user | ROLE identifierOrString )                    #revokeImpersonate
     | EXECUTE AS user (WITH NO REVERT)?                                                     #executeAs
     | ALTER USER user authOption                                                            #alterUser
     | CREATE USER (IF NOT EXISTS)? user authOption? (DEFAULT ROLE string)?                  #createUser

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -2037,15 +2037,17 @@ public class AuthTest {
      @Test
      public void testGrantRevokeImpersonate() throws Exception {
          // 1. prepare
-         // 1.1create harry, gregory, albert
+         // 1.1create harry, gregory, albert, neville
          UserIdentity harry = new UserIdentity("Harry", "%");
          harry.analyze();
          UserIdentity gregory = new UserIdentity("Gregory", "%");
          gregory.analyze();
          UserIdentity albert = new UserIdentity("Albert", "%");
          albert.analyze();
+         UserIdentity neville = new UserIdentity("Neville", "%");
+         neville.analyze();
          String createUserSql = "CREATE USER '%s' IDENTIFIED BY '12345'";
-         String[] userNames = {"Harry", "Gregory", "Albert"};
+         String[] userNames = {"Harry", "Gregory", "Albert", "Neville"};
          for (String userName : userNames) {
              CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils
                      .parseStmtWithNewParser(String.format(createUserSql, userName), ctx);
@@ -2083,6 +2085,47 @@ public class AuthTest {
          // 4.2 assert
          Assert.assertFalse(auth.canImpersonate(harry, gregory));
          Assert.assertTrue(auth.canImpersonate(harry, albert));
+
+         // Auror usually has the ability to impersonate to others..
+         // 5.1 create role
+         String auror = "auror";
+         CreateRoleStmt roleStmt = new CreateRoleStmt(auror);
+         roleStmt.analyze(analyzer);
+         auth.createRole(roleStmt);
+         // 5.2 grant impersonate to gregory on role auror
+         grantStmt = new GrantImpersonateStmt(auror, gregory);
+         com.starrocks.sql.analyzer.Analyzer.analyze(grantStmt, ctx);
+         auth.grantImpersonate(grantStmt);
+         // 5.3 grant auror to neiville
+         GrantRoleStmt grantRoleStmt = new GrantRoleStmt(auror, neville);
+         com.starrocks.sql.analyzer.Analyzer.analyze(grantRoleStmt, ctx);
+         auth.grantRole(grantRoleStmt);
+         // 5.4 assert
+         Assert.assertTrue(auth.canImpersonate(neville, gregory));
+
+         // 6. grant impersonate to albert on role auror
+         // 6.1 grant
+         grantStmt = new GrantImpersonateStmt(auror, albert);
+         com.starrocks.sql.analyzer.Analyzer.analyze(grantStmt, ctx);
+         auth.grantImpersonate(grantStmt);
+         // 6.2 assert
+         Assert.assertTrue(auth.canImpersonate(neville, albert));
+
+         // 7. revert impersonate to gregory from role auror
+         // 7.1 revoke
+         revokeStmt = new RevokeImpersonateStmt(auror, gregory);
+         com.starrocks.sql.analyzer.Analyzer.analyze(revokeStmt, ctx);
+         auth.revokeImpersonate(revokeStmt);
+         // 7.2 assert
+         Assert.assertFalse(auth.canImpersonate(neville, gregory));
+
+         // 8. revoke role from neville
+         // 8.2 revoke
+         RevokeRoleStmt revokeRoleStmt = new RevokeRoleStmt(auror, neville);
+         com.starrocks.sql.analyzer.Analyzer.analyze(revokeRoleStmt, ctx);
+         auth.revokeRole(revokeRoleStmt);
+         // 8.2 assert
+         Assert.assertFalse(auth.canImpersonate(neville, albert));
      }
 
     @Test
@@ -2194,7 +2237,7 @@ public class AuthTest {
         };
 
         // 1. prepare
-        // 1.1create harry, gregory
+        // 1.1 create harry, gregory
         UserIdentity harry = new UserIdentity("Harry", "%");
         harry.analyze();
         UserIdentity gregory = new UserIdentity("Gregory", "%");

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ImpersonatePrivInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ImpersonatePrivInfoTest.java
@@ -2,8 +2,17 @@
 
 package com.starrocks.persist;
 
+import com.starrocks.analysis.CreateRoleStmt;
+import com.starrocks.analysis.CreateUserStmt;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.journal.JournalEntity;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.GrantImpersonateStmt;
+import com.starrocks.sql.ast.GrantRoleStmt;
+import com.starrocks.sql.ast.RevokeRoleStmt;
+import com.starrocks.utframe.UtFrameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -38,5 +47,104 @@ public class ImpersonatePrivInfoTest {
         ImpersonatePrivInfo readInfo = (ImpersonatePrivInfo) jeReader.getData();
         Assert.assertEquals(readInfo.getAuthorizedUser(), harry);
         Assert.assertEquals(readInfo.getSecuredUser(), gregory);
+    }
+
+    @Test
+    public void testPersistRole() throws Exception {
+        // SET UP
+        UtFrameUtils.setUpForPersistTest();
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+
+        // 1. prepare for test
+        // 1.1 create 3 users + 1 role
+        Auth auth = GlobalStateMgr.getCurrentState().getAuth();
+        UserIdentity harry = new UserIdentity("Harry", "%");
+        harry.analyze();
+        UserIdentity gregory = new UserIdentity("Gregory", "%");
+        gregory.analyze();
+        UserIdentity neville = new UserIdentity("Neville", "%");
+        neville.analyze();
+        String createUserSql = "CREATE USER '%s' IDENTIFIED BY '12345'";
+        String[] userNames = {"Harry", "Gregory", "Neville"};
+        for (String userName : userNames) {
+            CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils
+                    .parseStmtWithNewParser(String.format(createUserSql, userName), connectContext);
+            auth.createUser(createUserStmt);
+        }
+        String auror = "auror";
+        auth.createRole((CreateRoleStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                "CREATE ROLE " + auror, connectContext));
+
+        // 1.2 make initialized checkpoint here for later use
+        UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
+        auth.saveAuth(pseudoImage.getDataOutputStream(), -1);
+        // 1.3 ignore all irrelevant journals by resetting journal queue
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        LOG.info("========= master image dumped.");
+
+        // 2. master grant impersonate
+        // 2.1 grant role auror to harry
+        auth.grantRole((GrantRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "GRANT " + auror + " TO Harry", connectContext));
+        // 2.2 grant impersonate to role auror
+        auth.grantImpersonate((GrantImpersonateStmt) UtFrameUtils.parseStmtWithNewParser(
+                "GRANT Impersonate on Gregory To role " + auror, connectContext));
+        // 2.3 verify can impersonate
+        Assert.assertTrue(auth.canImpersonate(harry, gregory));
+        // 2.4 grant role auror to neville
+        auth.grantRole((GrantRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "GRANT " + auror + " TO Neville", connectContext));
+        // 2.5 verify can impersonate
+        Assert.assertTrue(auth.canImpersonate(neville, gregory));
+        // 2.6 revoke auror from neville
+        auth.revokeRole((RevokeRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "REVOKE " + auror + " FROM Neville", connectContext));
+        // 2.7 verify can't impersonate
+        Assert.assertFalse(auth.canImpersonate(neville, gregory));
+        LOG.info("========= master finished. start to load follower's image");
+
+        // 3. verify follower replay
+        // 3.1 follower load initialized checkpoint
+        Auth newAuth = Auth.read(pseudoImage.getDataInputStream());
+        LOG.info("========= load follower's image finished. start to replay");
+        // 3.2 follower replay: grant role auror to harry
+        PrivInfo privInfo = (PrivInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal();
+        newAuth.replayGrantRole(privInfo);
+        // 3.3 follower replay: grant impersonate to role auror
+        ImpersonatePrivInfo impersonatePrivInfo = (ImpersonatePrivInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal();
+        newAuth.replayGrantImpersonate(impersonatePrivInfo);
+        // 3.4 follower verify can impersonate
+        Assert.assertTrue(newAuth.canImpersonate(harry, gregory));
+        // 3.5 follower replay: grant role auror to neville
+        privInfo = (PrivInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal();
+        newAuth.replayGrantRole(privInfo);
+        // 3.6 follower verify can impersonate
+        Assert.assertTrue(newAuth.canImpersonate(neville, gregory));
+        // 3.7 follower replay: revoke auror from neville
+        privInfo = (PrivInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal();
+        newAuth.replayRevokeRole(privInfo);
+        // 3.8 follower verify can't impersonate
+        Assert.assertFalse(newAuth.canImpersonate(neville, gregory));
+        LOG.info("========= finished replay ");
+
+
+        // 4. verify image
+        // 4.1 dump image
+        pseudoImage = new UtFrameUtils.PseudoImage();
+        long writeChecksum = -1;
+        auth.saveAuth(pseudoImage.getDataOutputStream(), writeChecksum);
+        writeChecksum = auth.writeAsGson(pseudoImage.getDataOutputStream(), writeChecksum);
+        // 4.2 load image to a new auth
+        DataInputStream dis = pseudoImage.getDataInputStream();
+        newAuth = Auth.read(dis);
+        long readChecksum = -1;
+        readChecksum = newAuth.readAsGson(dis, readChecksum);
+        // 4.3 verify the consistency of metadata between the two
+        Assert.assertEquals(writeChecksum, readChecksum);
+        Assert.assertTrue(newAuth.canImpersonate(harry, gregory));
+        Assert.assertFalse(newAuth.canImpersonate(neville, gregory));
+
+        // TEAR DOWN
+        UtFrameUtils.tearDownForPersisTest();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -41,6 +41,10 @@ public class GrantRevokeImpersonateStmtTest {
                 auth.getUserPrivTable();
                 minTimes = 0;
                 result = userPrivTable;
+
+                auth.doesRoleExist((String) any);
+                minTimes = 0;
+                result = true;
             }
         };
 
@@ -70,12 +74,23 @@ public class GrantRevokeImpersonateStmtTest {
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("GRANT IMPERSONATE ON 'default_cluster:user2'@'%' TO 'default_cluster:user1'@'%'", stmt.toString());
 
+        stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "grant IMPERSONATE on user2 to ROLE role1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.assertEquals("GRANT IMPERSONATE ON 'default_cluster:user2'@'%' TO ROLE 'default_cluster:role1'", stmt.toString());
+
         // revoke
         RevokeImpersonateStmt stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "revoke IMPERSONATE on user2 from user1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
         Assert.assertEquals("REVOKE IMPERSONATE ON 'default_cluster:user2'@'%' FROM 'default_cluster:user1'@'%'", stmt2.toString());
-     }
+
+        stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "revoke IMPERSONATE on user2 from ROLE role1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
+        Assert.assertEquals("REVOKE IMPERSONATE ON 'default_cluster:user2'@'%' FROM ROLE 'default_cluster:role1'",
+                stmt2.toString());
+    }
 
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
@@ -89,6 +104,29 @@ public class GrantRevokeImpersonateStmtTest {
         };
         GrantImpersonateStmt stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant IMPERSONATE on user2 to user1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void testRoleNotExist() throws Exception {
+        // suppose current user doesn't exist, check for exception
+        new Expectations(userPrivTable) {
+            {
+                userPrivTable.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = true;
+            }
+        };
+        new Expectations(auth) {
+            {
+                auth.doesRoleExist((String) any);
+                minTimes = 0;
+                result = false;
+            }
+        };
+        GrantImpersonateStmt stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "grant IMPERSONATE on user2 to Role role1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.fail("No exception throws.");
     }


### PR DESCRIPTION
1. Support `GRANT IMPERSONATE ON user TO ROLE role` and `REVOKE IMPERSONATE ON user FROM ROLE role`.
Since the role model will be refactored later, I'm simply restoring impersonate privileges of a role in a simple Set.
2. Persist the relationship between role and user after `GRANT role To user`. The previous implementation will lose this metadata.

Fixes #10513
Fixes #10691

manully cherry-picked from 4d7266f883d6606b923a722a12630db0d3b9a1aa