### PR TITLE
[Cherry-Pick-2.4][Refactor] Remove default_cluster related code (#10607)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoleStmt.java
@@ -21,7 +21,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeNameFormat;
@@ -46,7 +45,6 @@ public class CreateRoleStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not create role");
-        role = ClusterNamespace.getFullName(role);
 
         // check if current user has GRANT priv on GLOBAL level.
         if (!GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropRoleStmt.java
@@ -21,7 +21,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeNameFormat;
@@ -46,7 +45,6 @@ public class DropRoleStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not drop role");
-        role = ClusterNamespace.getFullName(role);
 
         // check if current user has GRANT priv on GLOBAL level.
         if (!GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/GrantStmt.java
@@ -24,7 +24,6 @@ package com.starrocks.analysis;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.AccessPrivilege;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -127,7 +126,6 @@ public class GrantStmt extends DdlStmt {
             userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not grant to role");
-            role = ClusterNamespace.getFullName(role);
         }
 
         if (tblPattern != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/PauseRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/PauseRoutineLoadStmt.java
@@ -17,7 +17,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.ast.AstVisitor;
@@ -59,7 +58,6 @@ public class PauseRoutineLoadStmt extends DdlStmt {
     public String toSql() {
         String dbName = labelName.getDbName();
         String routineName = labelName.getLabelName();
-        dbName = ClusterNamespace.getNameFromFullName(dbName);
         return "PAUSE ROUTINE LOAD FOR " + dbName + "." + routineName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ResumeRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ResumeRoutineLoadStmt.java
@@ -17,7 +17,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.ast.AstVisitor;
@@ -60,7 +59,6 @@ public class ResumeRoutineLoadStmt extends DdlStmt {
     public String toSql() {
         String dbName = labelName.getDbName();
         String routineName = labelName.getLabelName();
-        dbName = ClusterNamespace.getNameFromFullName(dbName);
         return "RESUME ROUTINE LOAD FOR " + dbName + "." + routineName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RevokeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RevokeStmt.java
@@ -20,7 +20,6 @@ package com.starrocks.analysis;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.AccessPrivilege;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.mysql.privilege.PrivBitSet;
@@ -91,7 +90,6 @@ public class RevokeStmt extends DdlStmt {
             userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not revoke from role");
-            role = ClusterNamespace.getFullName(role);
         }
 
         if (tblPattern != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SetPassVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SetPassVar.java
@@ -21,7 +21,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -85,7 +84,7 @@ public class SetPassVar extends SetVar {
 
         // 2. No user can set password for root expect for root user itself
         if (userIdent.getQualifiedUser().equals(Auth.ROOT_USER)
-                && !ClusterNamespace.getNameFromFullName(ctx.getQualifiedUser()).equals(Auth.ROOT_USER)) {
+                && !ctx.getQualifiedUser().equals(Auth.ROOT_USER)) {
             throw new SemanticException("Can not set password for root user, except root itself");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowBackupStmt.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowDeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowDeleteStmt.java
@@ -24,7 +24,6 @@ package com.starrocks.analysis;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowExportStmt.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.starrocks.analysis.BinaryPredicate.Operator;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowProcesslistStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowProcesslistStmt.java
@@ -35,7 +35,6 @@ public class ShowProcesslistStmt extends ShowStmt {
                     .addColumn(new Column("Id", ScalarType.createType(PrimitiveType.BIGINT)))
                     .addColumn(new Column("User", ScalarType.createVarchar(16)))
                     .addColumn(new Column("Host", ScalarType.createVarchar(16)))
-                    .addColumn(new Column("Cluster", ScalarType.createVarchar(16)))
                     .addColumn(new Column("Db", ScalarType.createVarchar(16)))
                     .addColumn(new Column("Command", ScalarType.createVarchar(16)))
                     .addColumn(new Column("ConnectionStartTime", ScalarType.createVarchar(16)))

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRestoreStmt.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadStmt.java
@@ -21,7 +21,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -30,11 +29,7 @@ import com.starrocks.load.routineload.RoutineLoadFunctionalExprProvider;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.ast.SelectRelation;
-import com.starrocks.sql.ast.TableRelation;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowRoutineLoadTaskStmt.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ShowResultSetMetaData;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowSmallFilesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowSmallFilesStmt.java
@@ -24,7 +24,6 @@ package com.starrocks.analysis;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.InfoSchemaDb;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.QueryStatement;
@@ -81,9 +80,9 @@ public class ShowTableStmt extends ShowStmt {
         SelectList selectList = new SelectList();
         ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
         SelectListItem item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_NAME"),
-                NAME_COL_PREFIX + ClusterNamespace.getNameFromFullName(db));
+                NAME_COL_PREFIX + db);
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, NAME_COL_PREFIX + ClusterNamespace.getNameFromFullName(db)),
+        aliasMap.put(new SlotRef(null, NAME_COL_PREFIX + db),
                 item.getExpr().clone(null));
         if (isVerbose) {
             item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_TYPE"), TYPE_COL);
@@ -121,7 +120,7 @@ public class ShowTableStmt extends ShowStmt {
     public ShowResultSetMetaData getMetaData() {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         builder.addColumn(
-                new Column(NAME_COL_PREFIX + ClusterNamespace.getNameFromFullName(db), ScalarType.createVarchar(20)));
+                new Column(NAME_COL_PREFIX + db, ScalarType.createVarchar(20)));
         if (isVerbose) {
             builder.addColumn(new Column(TYPE_COL, ScalarType.createVarchar(20)));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTransactionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTransactionStmt.java
@@ -21,7 +21,6 @@ import com.google.common.base.Strings;
 import com.starrocks.analysis.BinaryPredicate.Operator;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/StopRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/StopRoutineLoadStmt.java
@@ -17,7 +17,6 @@
 
 package com.starrocks.analysis;
 
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.ast.AstVisitor;
@@ -59,7 +58,6 @@ public class StopRoutineLoadStmt extends DdlStmt {
     public String toSql() {
         String dbName = labelName.getDbName();
         String routineName = labelName.getLabelName();
-        dbName = ClusterNamespace.getNameFromFullName(dbName);
         return "STOP ROUTINE LOAD FOR " + dbName + "." + routineName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -167,12 +167,7 @@ public class TableName implements Writable {
             stringBuilder.append("`").append(catalog).append("`.");
         }
         if (db != null) {
-            String dbName = ClusterNamespace.getNameFromFullName(db);
-            if (dbName == null) {
-                stringBuilder.append("`").append(db).append("`.");
-            } else {
-                stringBuilder.append("`").append(dbName).append("`.");
-            }
+            stringBuilder.append("`").append(db).append("`.");
         }
         stringBuilder.append("`").append(tbl).append("`");
         return stringBuilder.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ClusterLoadStatistic.java
@@ -68,7 +68,7 @@ public class ClusterLoadStatistic {
         ImmutableMap<Long, Backend> backends = infoService.getIdToBackend();
         for (Backend backend : backends.values()) {
             BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(),
-                    backend.getOwnerClusterName(), infoService, invertedIndex);
+                    SystemInfoService.DEFAULT_CLUSTER, infoService, invertedIndex);
             try {
                 beStatistic.init();
             } catch (LoadBalanceException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -52,7 +52,7 @@ public class BackendsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES;
     static {
         ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
-                .add("BackendId").add("Cluster").add("IP").add("HeartbeatPort")
+                .add("BackendId").add("IP").add("HeartbeatPort")
                 .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat")
                 .add("Alive").add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
                 .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
@@ -114,7 +114,6 @@ public class BackendsProcDir implements ProcDirInterface {
             watch.stop();
             List<Comparable> backendInfo = Lists.newArrayList();
             backendInfo.add(String.valueOf(backendId));
-            backendInfo.add(backend.getOwnerClusterName());
             backendInfo.add(backend.getHost());
             backendInfo.add(String.valueOf(backend.getHeartbeatPort()));
             backendInfo.add(String.valueOf(backend.getBePort()));

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -25,7 +25,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(ComputeNodeProcDir.class);
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("ComputeNodeId").add("Cluster").add("IP").add("HeartbeatPort")
+            .add("ComputeNodeId").add("IP").add("HeartbeatPort")
             .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("ErrMsg")
             .add("Version").build();
@@ -76,7 +76,6 @@ public class ComputeNodeProcDir implements ProcDirInterface {
 
             List<Comparable> computeNodeInfo = Lists.newArrayList();
             computeNodeInfo.add(String.valueOf(computeNodeId));
-            computeNodeInfo.add(computeNode.getOwnerClusterName());
             computeNodeInfo.add(computeNode.getHost());
 
             computeNodeInfo.add(String.valueOf(computeNode.getHeartbeatPort()));

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -25,11 +25,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.UserIdentity;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.SystemInfoService;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -254,13 +252,12 @@ public abstract class BaseAction implements IAction {
         public String fullUserName;
         public String remoteIp;
         public String password;
-        public String cluster;
 
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
             sb.append("user: ").append(fullUserName).append(", remote ip: ").append(remoteIp);
-            sb.append(", password: ").append(password).append(", cluster: ").append(cluster);
+            sb.append(", password: ").append(password);
             return sb.toString();
         }
     }
@@ -337,12 +334,8 @@ public abstract class BaseAction implements IAction {
             int index = authString.indexOf(":");
             authInfo.fullUserName = authString.substring(0, index);
             final String[] elements = authInfo.fullUserName.split("@");
-            if (elements != null && elements.length < 2) {
-                authInfo.fullUserName = ClusterNamespace.getFullName(authInfo.fullUserName);
-                authInfo.cluster = SystemInfoService.DEFAULT_CLUSTER;
-            } else if (elements != null && elements.length == 2) {
-                authInfo.fullUserName = ClusterNamespace.getFullName(elements[0]);
-                authInfo.cluster = elements[1];
+            if (elements.length == 2) {
+                authInfo.fullUserName = elements[0];
             }
             authInfo.password = authString.substring(index + 1);
             authInfo.remoteIp = request.getHostString();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -92,9 +92,9 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         super(-1, LoadDataSourceType.KAFKA);
     }
 
-    public KafkaRoutineLoadJob(Long id, String name, String clusterName,
+    public KafkaRoutineLoadJob(Long id, String name,
                                long dbId, long tableId, String brokerList, String topic) {
-        super(id, name, clusterName, dbId, tableId, LoadDataSourceType.KAFKA);
+        super(id, name, dbId, tableId, LoadDataSourceType.KAFKA);
         this.brokerList = brokerList;
         this.topic = topic;
         this.progress = new KafkaProgress();
@@ -382,8 +382,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         // init kafka routine load job
         long id = GlobalStateMgr.getCurrentState().getNextId();
         KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(id, stmt.getName(),
-                SystemInfoService.DEFAULT_CLUSTER, db.getId(), tableId,
-                stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
+                db.getId(), tableId, stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
         kafkaRoutineLoadJob.setOptional(stmt);
         kafkaRoutineLoadJob.checkCustomProperties();
         kafkaRoutineLoadJob.checkCustomPartition();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -67,6 +67,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.StreamLoadTask;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TUniqueId;
@@ -144,7 +145,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected long id;
     protected String name;
-    protected String clusterName;
     protected long dbId;
     protected long tableId;
     // this code is used to verify be task request
@@ -250,11 +250,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         this.dataSourceType = type;
     }
 
-    public RoutineLoadJob(Long id, String name, String clusterName,
+    public RoutineLoadJob(Long id, String name,
                           long dbId, long tableId, LoadDataSourceType dataSourceType) {
         this(id, dataSourceType);
         this.name = name;
-        this.clusterName = clusterName;
         this.dbId = dbId;
         this.tableId = tableId;
         this.authCode = 0;
@@ -1390,7 +1389,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
         out.writeLong(id);
         Text.writeString(out, name);
-        Text.writeString(out, clusterName);
+        Text.writeString(out, SystemInfoService.DEFAULT_CLUSTER);
         out.writeLong(dbId);
         out.writeLong(tableId);
         out.writeInt(desireTaskConcurrentNum);
@@ -1437,7 +1436,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
         id = in.readLong();
         name = Text.readString(in);
-        clusterName = Text.readString(in);
+
+        // ignore the clusterName param
+        Text.readString(in);
+
         dbId = in.readLong();
         tableId = in.readLong();
         desireTaskConcurrentNum = in.readInt();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
@@ -30,7 +30,7 @@ import com.starrocks.system.SystemInfoService;
  */
 public class ScheduleRule {
 
-    private static int deadBeCount(String clusterName) {
+    private static int deadBeCount() {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         int total = systemInfoService.getTotalBackendNumber();
         int alive = systemInfoService.getAliveBackendNumber();
@@ -56,7 +56,7 @@ public class ScheduleRule {
          * Handle all backends are down.
          */
         if (jobRoutine.pauseReason != null && jobRoutine.pauseReason.getCode() == InternalErrorCode.REPLICA_FEW_ERR) {
-            int dead = deadBeCount(jobRoutine.clusterName);
+            int dead = deadBeCount();
             if (dead > Config.max_tolerable_backend_down_num) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.common.Config;
 import com.starrocks.mysql.privilege.Password;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.SystemInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -119,9 +118,8 @@ public class MysqlHandshakePacket extends MysqlPacket {
 
     // If user use kerberos for authentication, fe need to resend the handshake request.
     public void buildKrb5AuthRequest(MysqlSerializer serializer, String remoteIp, String user) throws Exception {
-        String fullUserName = SystemInfoService.DEFAULT_CLUSTER + ":" + user;
         Password password = GlobalStateMgr.getCurrentState().getAuth().getUserPrivTable()
-                .getPasswordByApproximate(fullUserName, remoteIp);
+                .getPasswordByApproximate(user, remoteIp);
         if (password == null) {
             String msg = String.format("Can not find password with [user: %s, remoteIp: %s].", user, remoteIp);
             LOG.error(msg);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -24,7 +24,6 @@ package com.starrocks.mysql;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.UserIdentity;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
@@ -50,30 +49,24 @@ public class MysqlProto {
     private static boolean authenticate(ConnectContext context, byte[] scramble, byte[] randomString, String user) {
         String usePasswd = scramble.length == 0 ? "NO" : "YES";
 
-        String tmpUser = user;
-        if (tmpUser == null || tmpUser.isEmpty()) {
+        if (user == null || user.isEmpty()) {
             ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, "", usePasswd);
             return false;
         }
 
-        // check cluster, user name may contains cluster name or cluster id.
-        // eg:
-        // user_name@cluster_name
-
-        String qualifiedUser = ClusterNamespace.getFullName(tmpUser);
         String remoteIp = context.getMysqlChannel().getRemoteIp();
 
         List<UserIdentity> currentUserIdentity = Lists.newArrayList();
-        if (!GlobalStateMgr.getCurrentState().getAuth().checkPassword(qualifiedUser, remoteIp,
+        if (!GlobalStateMgr.getCurrentState().getAuth().checkPassword(user, remoteIp,
                 scramble, randomString, currentUserIdentity)) {
-            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, qualifiedUser, usePasswd);
+            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, user, usePasswd);
             return false;
         }
         context.setAuthDataSalt(randomString);
         if (Config.enable_auth_check) {
             context.setCurrentUserIdentity(currentUserIdentity.get(0));
         }
-        context.setQualifiedUser(qualifiedUser);
+        context.setQualifiedUser(user);
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.ResourcePattern;
 import com.starrocks.analysis.TablePattern;
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -158,7 +159,7 @@ public class Role implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        Text.writeString(out, roleName);
+        Text.writeString(out, ClusterNamespace.getFullName(roleName));
         out.writeInt(tblPatternToPrivs.size());
         for (Map.Entry<TablePattern, PrivBitSet> entry : tblPatternToPrivs.entrySet()) {
             entry.getKey().write(out);
@@ -176,7 +177,7 @@ public class Role implements Writable {
     }
 
     public void readFields(DataInput in) throws IOException {
-        roleName = Text.readString(in);
+        roleName = ClusterNamespace.getNameFromFullName(Text.readString(in));
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             TablePattern tblPattern = TablePattern.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPropertyInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPropertyInfo.java
@@ -18,6 +18,7 @@
 package com.starrocks.mysql.privilege;
 
 import com.google.common.collect.Lists;
+import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -57,7 +58,7 @@ public class UserPropertyInfo implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        Text.writeString(out, user);
+        Text.writeString(out, ClusterNamespace.getFullName(user));
         out.writeInt(properties.size());
         for (Pair<String, String> entry : properties) {
             Text.writeString(out, entry.first);
@@ -66,7 +67,7 @@ public class UserPropertyInfo implements Writable {
     }
 
     public void readFields(DataInput in) throws IOException {
-        user = Text.readString(in);
+        user = ClusterNamespace.getNameFromFullName(Text.readString(in));
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             String key = Text.readString(in);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 import com.starrocks.analysis.ResourcePattern;
 import com.starrocks.analysis.TablePattern;
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.StarRocksFEMetaVersion;
 import com.starrocks.common.io.Text;
@@ -156,7 +157,7 @@ public class PrivInfo implements Writable {
 
         if (!Strings.isNullOrEmpty(role)) {
             out.writeBoolean(true);
-            Text.writeString(out, role);
+            Text.writeString(out, ClusterNamespace.getFullName(role));
         } else {
             out.writeBoolean(false);
         }
@@ -193,7 +194,7 @@ public class PrivInfo implements Writable {
         }
 
         if (in.readBoolean()) {
-            role = Text.readString(in);
+            role = ClusterNamespace.getNameFromFullName(Text.readString(in));
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -43,7 +43,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -588,7 +587,6 @@ public class ConnectContext {
             row.add("" + connectionId);
             row.add(ClusterNamespace.getNameFromFullName(qualifiedUser));
             row.add(getMysqlChannel().getRemoteHostPortString());
-            row.add(SystemInfoService.DEFAULT_CLUSTER);
             row.add(ClusterNamespace.getNameFromFullName(currentDb));
             // Command
             row.add(command.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -103,7 +103,6 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.View;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.CaseSensibility;
 import com.starrocks.common.ConfigBase;
@@ -514,18 +513,17 @@ public class ShowExecutor {
             matcher = PatternMatcher.createMysqlPattern(showDbStmt.getPattern(), CaseSensibility.DATABASE.getCaseSensibility());
         }
         Set<String> dbNameSet = Sets.newTreeSet();
-        for (String fullName : dbNames) {
-            final String db = ClusterNamespace.getNameFromFullName(fullName);
+        for (String dbName : dbNames) {
             // Filter dbname
-            if (matcher != null && !matcher.match(db)) {
+            if (matcher != null && !matcher.match(dbName)) {
                 continue;
             }
 
             if (!PrivilegeChecker.checkDbPriv(ConnectContext.get(), catalogName,
-                    fullName, PrivPredicate.SHOW)) {
+                    dbName, PrivPredicate.SHOW)) {
                 continue;
             }
-            dbNameSet.add(db);
+            dbNameSet.add(dbName);
         }
 
         for (String dbName : dbNameSet) {
@@ -653,9 +651,8 @@ public class ShowExecutor {
         if (db == null) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_DB_ERROR, showStmt.getDb());
         }
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE DATABASE `").append(ClusterNamespace.getNameFromFullName(showStmt.getDb())).append("`");
-        rows.add(Lists.newArrayList(ClusterNamespace.getNameFromFullName(showStmt.getDb()), sb.toString()));
+        rows.add(Lists.newArrayList(showStmt.getDb(),
+                "CREATE DATABASE `" + showStmt.getDb() + "`"));
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -846,11 +846,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     private void checkPasswordAndPrivs(String cluster, String user, String passwd, String db, String tbl,
                                        String clientIp, PrivPredicate predicate) throws AuthenticationException {
 
-        final String fullUserName = ClusterNamespace.getFullName(user);
         List<UserIdentity> currentUser = Lists.newArrayList();
         if (!GlobalStateMgr.getCurrentState().getAuth()
-                .checkPlainPassword(fullUserName, clientIp, passwd, currentUser)) {
-            throw new AuthenticationException("Access denied for " + fullUserName + "@" + clientIp);
+                .checkPlainPassword(user, clientIp, passwd, currentUser)) {
+            throw new AuthenticationException("Access denied for " + user + "@" + clientIp);
         }
 
         Preconditions.checkState(currentUser.size() == 1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -5,7 +5,6 @@ import com.google.common.base.Strings;
 import com.starrocks.analysis.AlterUserStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.UserIdentity;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -69,11 +68,10 @@ public class PrivilegeStmtAnalyzer {
                 // Remove it after all old methods migrate to the new framework
                 throw new SemanticException(e.getMessage());
             }
-            String qualifiedRole = ClusterNamespace.getFullName(roleName);
-            if (!session.getGlobalStateMgr().getAuth().doesRoleExist(qualifiedRole)) {
-                throw new SemanticException("role " + qualifiedRole + " not exist!");
+            if (!session.getGlobalStateMgr().getAuth().doesRoleExist(roleName)) {
+                throw new SemanticException("role " + roleName + " not exist!");
             }
-            return qualifiedRole;
+            return roleName;
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetUserPropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetUserPropertyAnalyzer.java
@@ -3,7 +3,6 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
 import com.starrocks.analysis.SetUserPropertyStmt;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.qe.ConnectContext;
 
@@ -18,7 +17,7 @@ public class SetUserPropertyAnalyzer {
         } else {
             // If param 'user' is set, check if it need to be full-qualified
             if (!user.equals(Auth.ROOT_USER)) {
-                statement.setUser(ClusterNamespace.getFullName(user));
+                statement.setUser(user);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowUserPropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowUserPropertyAnalyzer.java
@@ -3,7 +3,6 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
 import com.starrocks.analysis.ShowUserPropertyStmt;
-import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.qe.ConnectContext;
 
 public class ShowUserPropertyAnalyzer {
@@ -13,7 +12,7 @@ public class ShowUserPropertyAnalyzer {
         if (Strings.isNullOrEmpty(user)) {
             statment.setUser(context.getQualifiedUser());
         } else {
-            statment.setUser(ClusterNamespace.getFullName(user));
+            statment.setUser(user);
         }
         statment.setPattern(Strings.emptyToNull(statment.getPatter()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -300,7 +300,7 @@ public class Backend extends ComputeNode {
             entry.getValue().write(out);
         }
 
-        Text.writeString(out, getOwnerClusterName());
+        Text.writeString(out, SystemInfoService.DEFAULT_CLUSTER);
         out.writeInt(getBackendState().ordinal());
         out.writeInt(getDecommissionType().ordinal());
 
@@ -338,11 +338,11 @@ public class Backend extends ComputeNode {
             disksRef = ImmutableMap.copyOf(disks);
         }
         if (GlobalStateMgr.getCurrentStateJournalVersion() >= FeMetaVersion.VERSION_30) {
-            setOwnerClusterName(Text.readString(in));
+            // ignore clusterName
+            Text.readString(in);
             setBackendState(in.readInt());
             setDecommissionType(in.readInt());
         } else {
-            setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
             setBackendState(BackendState.using.ordinal());
             setDecommissionType(DecommissionType.SystemDecommission.ordinal());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -292,14 +292,6 @@ public class ComputeNode implements IComputable, Writable {
                 isAlive.get() + "]";
     }
 
-    public String getOwnerClusterName() {
-        return ownerClusterName;
-    }
-
-    public void setOwnerClusterName(String name) {
-        ownerClusterName = name;
-    }
-
     public void clearClusterName() {
         ownerClusterName = "";
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -148,7 +148,6 @@ public class SystemInfoService {
         final Cluster cluster = GlobalStateMgr.getCurrentState().getCluster();
         Preconditions.checkState(cluster != null);
         cluster.addComputeNode(computeNode.getId());
-        computeNode.setOwnerClusterName(DEFAULT_CLUSTER);
         computeNode.setBackendState(BackendState.using);
     }
 
@@ -194,7 +193,6 @@ public class SystemInfoService {
         final Cluster cluster = GlobalStateMgr.getCurrentState().getCluster();
         Preconditions.checkState(cluster != null);
         cluster.addBackend(backend.getId());
-        backend.setOwnerClusterName(DEFAULT_CLUSTER);
         backend.setBackendState(BackendState.using);
     }
 
@@ -293,7 +291,7 @@ public class SystemInfoService {
         if (null != cluster) {
             cluster.removeComputeNode(dropComputeNode.getId());
         } else {
-            LOG.error("Cluster " + dropComputeNode.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", SystemInfoService.DEFAULT_CLUSTER);
         }
         // log
         GlobalStateMgr.getCurrentState().getEditLog()
@@ -406,7 +404,7 @@ public class SystemInfoService {
 
             cluster.removeBackend(droppedBackend.getId());
         } else {
-            LOG.error("Cluster " + droppedBackend.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", SystemInfoService.DEFAULT_CLUSTER);
         }
         // log
         GlobalStateMgr.getCurrentState().getEditLog().logDropBackend(droppedBackend);
@@ -754,20 +752,6 @@ public class SystemInfoService {
         return ImmutableList.copyOf(backends);
     }
 
-    public ImmutableMap<Long, Backend> getBackendsInCluster(String cluster) {
-        if (Strings.isNullOrEmpty(cluster)) {
-            return idToBackendRef;
-        }
-
-        Map<Long, Backend> retMaps = Maps.newHashMap();
-        for (Backend backend : idToBackendRef.values().asList()) {
-            if (cluster.equals(backend.getOwnerClusterName())) {
-                retMaps.put(backend.getId(), backend);
-            }
-        }
-        return ImmutableMap.copyOf(retMaps);
-    }
-
     public long getBackendReportVersion(long backendId) {
         AtomicLong atomicLong;
         if ((atomicLong = idToReportVersionRef.get(backendId)) == null) {
@@ -909,7 +893,6 @@ public class SystemInfoService {
 
     public void replayAddComputeNode(ComputeNode newComputeNode) {
         // update idToComputeNode
-        newComputeNode.setOwnerClusterName(DEFAULT_CLUSTER);
         newComputeNode.setBackendState(BackendState.using);
         Map<Long, ComputeNode> copiedComputeNodes = Maps.newHashMap(idToComputeNodeRef);
         copiedComputeNodes.put(newComputeNode.getId(), newComputeNode);
@@ -931,7 +914,6 @@ public class SystemInfoService {
     public void replayAddBackend(Backend newBackend) {
         // update idToBackend
         if (GlobalStateMgr.getCurrentStateJournalVersion() < FeMetaVersion.VERSION_30) {
-            newBackend.setOwnerClusterName(DEFAULT_CLUSTER);
             newBackend.setBackendState(BackendState.using);
         }
         Map<Long, Backend> copiedBackends = Maps.newHashMap(idToBackendRef);
@@ -999,7 +981,7 @@ public class SystemInfoService {
                 GlobalStateMgr.getCurrentState().getStarOSAgent().removeWorkerFromMap(workerId, workerAddr);
             }
         } else {
-            LOG.error("Cluster " + backend.getOwnerClusterName() + " no exist.");
+            LOG.error("Cluster {} no exist.", SystemInfoService.DEFAULT_CLUSTER);
         }
     }
 
@@ -1024,7 +1006,6 @@ public class SystemInfoService {
         memoryBe.setLastStartTime(be.getLastStartTime());
         memoryBe.setDisks(be.getDisks());
         memoryBe.setBackendState(be.getBackendState());
-        memoryBe.setOwnerClusterName(be.getOwnerClusterName());
         memoryBe.setDecommissionType(be.getDecommissionType());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -211,7 +211,7 @@ public class AccessTestUtil {
             GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
 
             Auth auth = fetchBlockAccess();
-            Database db = mockDb("testCluster:testDb");
+            Database db = mockDb("testDb");
 
             new Expectations(globalStateMgr) {
                 {
@@ -223,11 +223,11 @@ public class AccessTestUtil {
                     minTimes = 0;
                     result = new DdlException("failed");
 
-                    globalStateMgr.getDb("testCluster:testDb");
+                    globalStateMgr.getDb("testDb");
                     minTimes = 0;
                     result = db;
 
-                    globalStateMgr.getDb("testCluster:emptyDb");
+                    globalStateMgr.getDb("emptyDb");
                     minTimes = 0;
                     result = null;
 
@@ -237,7 +237,7 @@ public class AccessTestUtil {
 
                     globalStateMgr.getDbNames();
                     minTimes = 0;
-                    result = Lists.newArrayList("testCluster:testDb");
+                    result = Lists.newArrayList("testDb");
 
                     globalStateMgr.getDb("emptyCluster");
                     minTimes = 0;
@@ -250,9 +250,7 @@ public class AccessTestUtil {
         }
     }
 
-    public static Analyzer fetchAdminAnalyzer(boolean withCluster) {
-        final String prefix = "testCluster:";
-
+    public static Analyzer fetchAdminAnalyzer() {
         Analyzer analyzer = new Analyzer(fetchAdminCatalog(), new ConnectContext(null));
         new Expectations(analyzer) {
             {
@@ -262,11 +260,11 @@ public class AccessTestUtil {
 
                 analyzer.getDefaultDb();
                 minTimes = 0;
-                result = withCluster ? prefix + "testDb" : "testDb";
+                result = "testDb";
 
                 analyzer.getQualifiedUser();
                 minTimes = 0;
-                result = withCluster ? prefix + "testUser" : "testUser";
+                result = "testUser";
 
                 analyzer.incrementCallDepth();
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupClauseTest.java
@@ -28,7 +28,7 @@ public class AddRollupClauseTest {
 
     @BeforeClass
     public static void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -24,7 +24,7 @@ public class AlterResourceStmtTest {
 
     @Before()
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
@@ -49,7 +49,7 @@ public class AlterRoutineLoadStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableStmtTest.java
@@ -47,7 +47,7 @@ public class AlterTableStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
@@ -40,28 +40,28 @@ public class AlterUserStmtTest {
 
         String sql = "ALTER USER 'user' IDENTIFIED BY 'passwd'";
         AlterUserStmt stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("ALTER USER 'default_cluster:user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
+        Assert.assertEquals("ALTER USER 'user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "ALTER USER 'user' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("default_cluster:user", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("user", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals(
-                "ALTER USER 'default_cluster:user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
+                "ALTER USER 'user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "ALTER USER 'user' IDENTIFIED BY ''";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("ALTER USER 'default_cluster:user'@'%'", stmt.toString());
+        Assert.assertEquals("ALTER USER 'user'@'%'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "ALTER USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'",
+        Assert.assertEquals("ALTER USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
@@ -69,21 +69,21 @@ public class AlterUserStmtTest {
         sql = "ALTER USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'",
+                "ALTER USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
 
         sql = "ALTER USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS ''";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD", stmt.toString());
+        Assert.assertEquals("ALTER USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
 
         sql = "ALTER USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'",
+                "ALTER USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
@@ -92,7 +92,7 @@ public class AlterUserStmtTest {
         sql = "ALTER USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'",
+                "ALTER USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
@@ -100,7 +100,7 @@ public class AlterUserStmtTest {
 
         sql = "ALTER USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE";
         stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("ALTER USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE",
+        Assert.assertEquals("ALTER USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE",
                 stmt.toString());
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
         Assert.assertNull(stmt.getUserForAuthPlugin());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/BackendStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/BackendStmtTest.java
@@ -29,7 +29,7 @@ public class BackendStmtTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     public BackendClause createStmt(int type) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateResourceStmtTest.java
@@ -43,7 +43,7 @@ public class CreateResourceStmtTest {
 
     @Before()
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
@@ -46,28 +46,28 @@ public class CreateUserStmtTest {
     public void testToString() throws Exception {
         String sql = "CREATE USER 'user' IDENTIFIED BY 'passwd'";
         CreateUserStmt stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("CREATE USER 'default_cluster:user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "CREATE USER 'user' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("default_cluster:user", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("user", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals(
-                "CREATE USER 'default_cluster:user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
+                "CREATE USER 'user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "CREATE USER 'user'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("CREATE USER 'default_cluster:user'@'%'", stmt.toString());
+        Assert.assertEquals("CREATE USER 'user'@'%'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertNull(stmt.getAuthPlugin());
 
         sql = "CREATE USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'",
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'passwd'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
@@ -75,14 +75,14 @@ public class CreateUserStmtTest {
         sql = "CREATE USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'",
+                "CREATE USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
 
         sql = "CREATE USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD",
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthPlugin());
@@ -90,7 +90,7 @@ public class CreateUserStmtTest {
         sql = "CREATE USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'",
+                "CREATE USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE AS 'uid=gengjun,ou=people,dc=example,dc=io'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
@@ -99,7 +99,7 @@ public class CreateUserStmtTest {
         sql = "CREATE USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
         Assert.assertEquals(
-                "CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'",
+                "CREATE USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE BY 'uid=gengjun,ou=people,dc=example,dc=io'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
@@ -107,7 +107,7 @@ public class CreateUserStmtTest {
 
         sql = "CREATE USER 'user' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE";
         stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
-        Assert.assertEquals("CREATE USER 'default_cluster:user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE",
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE",
                 stmt.toString());
         Assert.assertEquals(AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name(), stmt.getAuthPlugin());
         Assert.assertNull(stmt.getUserForAuthPlugin());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DeleteStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DeleteStmtTest.java
@@ -45,7 +45,7 @@ public class DeleteStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
@@ -58,7 +58,7 @@ public class DropMaterializedViewStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         MockedAuth.mockedAuth(auth);
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         analyzer = new Analyzer(globalStateMgr, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropRollupClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropRollupClauseTest.java
@@ -27,7 +27,7 @@ public class DropRollupClauseTest {
 
     @BeforeClass
     public static void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
@@ -37,7 +37,7 @@ public class DropUserStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropUserStmtTest.java
@@ -46,8 +46,8 @@ public class DropUserStmtTest {
     public void testNormal() throws UserException, AnalysisException {
         DropUserStmt stmt = new DropUserStmt(new UserIdentity("user", "%"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("DROP USER 'default_cluster:user'@'%'", stmt.toString());
-        Assert.assertEquals("default_cluster:user", stmt.getUserIdentity().getQualifiedUser());
+        Assert.assertEquals("DROP USER 'user'@'%'", stmt.toString());
+        Assert.assertEquals("user", stmt.getUserIdentity().getQualifiedUser());
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GrantStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GrantStmtTest.java
@@ -48,7 +48,7 @@ public class GrantStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         auth = new Auth();
 
         new Expectations() {
@@ -87,7 +87,7 @@ public class GrantStmtTest {
         List<AccessPrivilege> privileges = Lists.newArrayList(AccessPrivilege.ALL);
         stmt = new GrantStmt(new UserIdentity("testUser", "%"), null, new TablePattern("testDb", "*"), privileges);
         stmt.analyze(analyzer);
-        Assert.assertEquals("default_cluster:testUser", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("testUser", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals("testDb", stmt.getTblPattern().getQuolifiedDb());
 
         privileges = Lists.newArrayList(AccessPrivilege.READ_ONLY, AccessPrivilege.ALL);
@@ -108,7 +108,7 @@ public class GrantStmtTest {
         stmt = new GrantStmt(new UserIdentity("testUser", "%"), null, new ResourcePattern("*"), privileges);
         stmt.analyze(analyzer);
         Assert.assertEquals(Auth.PrivLevel.GLOBAL, stmt.getResourcePattern().getPrivLevel());
-        Assert.assertEquals("GRANT Usage_priv ON RESOURCE '*' TO 'default_cluster:testUser'@'%'", stmt.toSql());
+        Assert.assertEquals("GRANT Usage_priv ON RESOURCE '*' TO 'testUser'@'%'", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InstallPluginStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InstallPluginStmtTest.java
@@ -38,7 +38,7 @@ public class InstallPluginStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -404,7 +404,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testChooseResourceGroup() throws Exception {
         createResourceGroups();
-        String qualifiedUser = "default_cluster:rg1_user1";
+        String qualifiedUser = "rg1_user1";
         String remoteIp = "192.168.2.4";
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
@@ -420,7 +420,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testChooseResourceGroupWithDb() throws Exception {
         createResourceGroups();
-        String qualifiedUser = "default_cluster:rg1_user1";
+        String qualifiedUser = "rg1_user1";
         String remoteIp = "192.168.2.4";
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
@@ -460,7 +460,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testShowVisibleResourceGroups() throws Exception {
         createResourceGroups();
-        String qualifiedUser = "default_cluster:rg1_user1";
+        String qualifiedUser = "rg1_user1";
         String remoteIp = "192.168.2.4";
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetOperationStmtTest.java
@@ -38,7 +38,7 @@ public class SetOperationStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetPassVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetPassVarTest.java
@@ -56,15 +56,15 @@ public class SetPassVarTest {
         //  mode: SET PASSWORD FOR 'testUser' = 'testPass';
         stmt = new SetPassVar(new UserIdentity("testUser", "%"), "*88EEBA7D913688E7278E2AD071FDB5E76D76D34B");
         stmt.analyze();
-        Assert.assertEquals("default_cluster:testUser", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("testUser", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals("*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", new String(stmt.getPassword()));
-        Assert.assertEquals("SET PASSWORD FOR 'default_cluster:testUser'@'%' = '*XXX'",
+        Assert.assertEquals("SET PASSWORD FOR 'testUser'@'%' = '*XXX'",
                 stmt.toString());
 
         // empty password
         stmt = new SetPassVar(new UserIdentity("testUser", "%"), null);
         stmt.analyze();
-        Assert.assertEquals("SET PASSWORD FOR 'default_cluster:testUser'@'%' = '*XXX'", stmt.toString());
+        Assert.assertEquals("SET PASSWORD FOR 'testUser'@'%' = '*XXX'", stmt.toString());
 
         // empty user
         // empty password

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowIndexStmtTest.java
@@ -38,7 +38,7 @@ public class ShowIndexStmtTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         MockedAuth.mockedAuth(auth);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowProcesslistStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowProcesslistStmtTest.java
@@ -28,16 +28,15 @@ public class ShowProcesslistStmtTest {
         Assert.assertEquals(originStmt.toUpperCase(Locale.ROOT), stmt.toString());
         ShowResultSetMetaData metaData = stmt.getMetaData();
         Assert.assertNotNull(metaData);
-        Assert.assertEquals(10, metaData.getColumnCount());
+        Assert.assertEquals(9, metaData.getColumnCount());
         Assert.assertEquals("Id", metaData.getColumn(0).getName());
         Assert.assertEquals("User", metaData.getColumn(1).getName());
         Assert.assertEquals("Host", metaData.getColumn(2).getName());
-        Assert.assertEquals("Cluster", metaData.getColumn(3).getName());
-        Assert.assertEquals("Db", metaData.getColumn(4).getName());
-        Assert.assertEquals("Command", metaData.getColumn(5).getName());
-        Assert.assertEquals("ConnectionStartTime", metaData.getColumn(6).getName());
-        Assert.assertEquals("Time", metaData.getColumn(7).getName());
-        Assert.assertEquals("State", metaData.getColumn(8).getName());
-        Assert.assertEquals("Info", metaData.getColumn(9).getName());
+        Assert.assertEquals("Db", metaData.getColumn(3).getName());
+        Assert.assertEquals("Command", metaData.getColumn(4).getName());
+        Assert.assertEquals("ConnectionStartTime", metaData.getColumn(5).getName());
+        Assert.assertEquals("Time", metaData.getColumn(6).getName());
+        Assert.assertEquals("State", metaData.getColumn(7).getName());
+        Assert.assertEquals("Info", metaData.getColumn(8).getName());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -34,7 +34,6 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.system.Backend;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 
@@ -83,9 +82,6 @@ public class GlobalStateMgrTestUtil {
         Backend backend1 = createBackend(testBackendId1, "host1", 123, 124, 125);
         Backend backend2 = createBackend(testBackendId2, "host2", 123, 124, 125);
         Backend backend3 = createBackend(testBackendId3, "host3", 123, 124, 125);
-        backend1.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
-        backend2.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
-        backend3.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
         GlobalStateMgr.getCurrentSystemInfo().addBackend(backend1);
         GlobalStateMgr.getCurrentSystemInfo().addBackend(backend2);
         GlobalStateMgr.getCurrentSystemInfo().addBackend(backend3);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveResourceTest.java
@@ -26,7 +26,7 @@ public class HiveResourceTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiResourceTest.java
@@ -26,7 +26,7 @@ public class HudiResourceTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
@@ -28,7 +28,7 @@ public class IcebergResourceTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCResourceTest.java
@@ -19,7 +19,7 @@ public class JDBCResourceTest {
 
     @Before
     public void setUp() {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         FeConstants.runningUnitTest = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OdbcCatalogResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OdbcCatalogResourceTest.java
@@ -63,7 +63,7 @@ public class OdbcCatalogResourceTest {
         properties.put("port", port);
         properties.put("user", user);
         properties.put("password", passwd);
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
@@ -70,7 +70,7 @@ public class ResourceMgrTest {
         properties.put("spark.submit.deployMode", "cluster");
         properties.put("working_dir", workingDir);
         properties.put("broker", broker);
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         hiveMetastoreUris = "thrift://10.10.44.98:9083";
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SparkResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SparkResourceTest.java
@@ -64,7 +64,7 @@ public class SparkResourceTest {
         properties.put("spark.submit.deployMode", "cluster");
         properties.put("working_dir", workingDir);
         properties.put("broker", broker);
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -74,7 +74,6 @@ public class ClusterLoadStatisticsTest {
 
         be1.setDisks(ImmutableMap.copyOf(disks));
         be1.setAlive(true);
-        be1.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         // be2
         be2 = new Backend(10002, "192.168.0.2", 9052);
@@ -93,7 +92,6 @@ public class ClusterLoadStatisticsTest {
 
         be2.setDisks(ImmutableMap.copyOf(disks));
         be2.setAlive(true);
-        be2.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         // be3
         be3 = new Backend(10003, "192.168.0.3", 9053);
@@ -118,7 +116,6 @@ public class ClusterLoadStatisticsTest {
 
         be3.setDisks(ImmutableMap.copyOf(disks));
         be3.setAlive(true);
-        be3.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         systemInfoService = new SystemInfoService();
         systemInfoService.addBackend(be1);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -512,7 +512,6 @@ public class DiskAndTabletLoadReBalancerTest {
                                long pathHash) {
         Backend backend = new Backend(beId, host, 0);
         backend.updateOnce(0, 0, 0);
-        backend.setOwnerClusterName("cluster1");
         DiskInfo diskInfo = new DiskInfo("/data");
         diskInfo.setAvailableCapacityB(availableCapB);
         diskInfo.setDataUsedCapacityB(dataUsedCapB);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -93,7 +93,6 @@ public class TabletSchedCtxTest {
 
         be1.setDisks(ImmutableMap.copyOf(disks));
         be1.setAlive(true);
-        be1.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         // be2
         be2 = new Backend(10002, "192.168.0.2", 9052);
@@ -106,7 +105,6 @@ public class TabletSchedCtxTest {
 
         be2.setDisks(ImmutableMap.copyOf(disks));
         be2.setAlive(true);
-        be2.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
         systemInfoService = new SystemInfoService();
         systemInfoService.addBackend(be1);

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
@@ -183,6 +183,6 @@ public class BackendsProcDirTest {
 
     @Test    
     public void testIPTitle() {
-        Assert.assertTrue(BackendsProcDir.TITLE_NAMES.get(2).equals("IP"));
+        Assert.assertTrue(BackendsProcDir.TITLE_NAMES.get(1).equals("IP"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -86,7 +86,6 @@ abstract public class StarRocksHttpTestCase {
 
     private static HttpServer httpServer;
 
-    public static final String CLUSTER_NAME = "default_cluster";
     public static final String DB_NAME = "testDb";
     public static final String TABLE_NAME = "testTbl";
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -59,7 +59,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
     
     @After
     public void tearDown() {
-        GlobalStateMgr.getCurrentSystemInfo().dropBackend(new Backend(1234, CLUSTER_NAME, HTTP_PORT));
+        GlobalStateMgr.getCurrentSystemInfo().dropBackend(new Backend(1234, "localhost", HTTP_PORT));
     }
 
     @BeforeClass

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -128,7 +128,7 @@ public class DeleteTest {
     public void setUp() {
         deleteHandler = new DeleteHandler();
         auth = AccessTestUtil.fetchAdminAccess();
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         db = createDb();
         Backend backend = new Backend(backendId, "127.0.0.1", 1234);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -94,7 +94,7 @@ public class DeleteHandlerTest {
         globalTransactionMgr.setEditLog(editLog);
         deleteHandler = new DeleteHandler();
         auth = AccessTestUtil.fetchAdminAccess();
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
         try {
             db = CatalogMocker.mockDb();
         } catch (AnalysisException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -102,9 +102,6 @@ public class KafkaRoutineLoadJobTest {
         List<Long> beIds1 = Lists.newArrayList(1L);
         List<Long> beIds2 = Lists.newArrayList(1L, 2L, 3L, 4L);
 
-        String clusterName1 = "default1";
-        String clusterName2 = "default2";
-
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentSystemInfo();
@@ -123,19 +120,19 @@ public class KafkaRoutineLoadJobTest {
         };
 
         // 3 partitions, 4 be
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList2);
         Assert.assertEquals(3, routineLoadJob.calculateCurrentConcurrentTaskNum());
 
         // 4 partitions, 4 be
-        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList3);
         Assert.assertEquals(4, routineLoadJob.calculateCurrentConcurrentTaskNum());
 
         // 7 partitions, 4 be
-        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", clusterName2, 1L,
+        routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList4);
         Assert.assertEquals(4, routineLoadJob.calculateCurrentConcurrentTaskNum());
@@ -149,7 +146,7 @@ public class KafkaRoutineLoadJobTest {
         GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
 
         RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", "default", 1L,
+                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                         1L, "127.0.0.1:9020", "topic1");
 
         new Expectations(globalStateMgr) {
@@ -191,7 +188,7 @@ public class KafkaRoutineLoadJobTest {
         GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
 
         RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", "default", 1L,
+                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                         1L, "127.0.0.1:9020", "topic1");
         long maxBatchIntervalS = 10;
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -354,7 +354,7 @@ public class RoutineLoadJobTest {
     @Test
     public void testMergeLoadDescToOriginStatement() throws Exception {
         KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
-                "default_cluster", 2L, 3L, "192.168.1.2:10000", "topic");
+                2L, 3L, "192.168.1.2:10000", "topic");
         String originStmt = "CREATE ROUTINE LOAD job ON unknown " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")";

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -102,7 +102,7 @@ public class RoutineLoadManagerTest {
                 typeName, customProperties);
         createRoutineLoadStmt.setOrigStmt(new OriginStatement("dummy", 0));
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, "default_cluster", 1L, 1L,
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
                 serverAddress, topicName);
 
         new MockUp<KafkaRoutineLoadJob>() {
@@ -199,7 +199,7 @@ public class RoutineLoadManagerTest {
         String jobName = "job1";
         String topicName = "topic1";
         String serverAddress = "http://127.0.0.1:8080";
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, "default_cluster", 1L, 1L,
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
                 serverAddress, topicName);
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
@@ -207,7 +207,7 @@ public class RoutineLoadManagerTest {
         Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
         Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
         List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName, "default_cluster",
+        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
                 1L, 1L, serverAddress, topicName);
         routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
         nameToRoutineLoadJob.put(jobName, routineLoadJobList);
@@ -229,7 +229,7 @@ public class RoutineLoadManagerTest {
         String jobName = "job1";
         String topicName = "topic1";
         String serverAddress = "http://127.0.0.1:8080";
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, "default_cluster", 1L, 1L,
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
                 serverAddress, topicName);
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
@@ -245,7 +245,7 @@ public class RoutineLoadManagerTest {
         Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
         Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
         List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName, "default_cluster",
+        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
                 1L, 1L, serverAddress, topicName);
         Deencapsulation.setField(kafkaRoutineLoadJobWithSameName, "state", RoutineLoadJob.JobState.STOPPED);
         routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
@@ -784,7 +784,8 @@ public class RoutineLoadManagerTest {
 
         // 1. create a job that will be discard after image load
         long discardJobId = 1L;
-        RoutineLoadJob discardJob = new KafkaRoutineLoadJob(discardJobId, "discardJob", "default_cluster", 1, 1, "xxx", "xxtopic");
+        RoutineLoadJob discardJob = new KafkaRoutineLoadJob(discardJobId, "discardJob",
+                 1, 1, "xxx", "xxtopic");
         discardJob.setOrigStmt(new OriginStatement(createSQL, 0));
         leaderLoadManager.addRoutineLoadJob(discardJob, DB);
         discardJob.updateState(RoutineLoadJob.JobState.CANCELLED, new ErrorReason(InternalErrorCode.CREATE_TASKS_ERR, "fake"), false);
@@ -792,7 +793,8 @@ public class RoutineLoadManagerTest {
 
         // 2. create a new job that will keep for a while
         long goodJobId = 2L;
-        RoutineLoadJob goodJob = new KafkaRoutineLoadJob(goodJobId, "goodJob", "default_cluster", 1, 1, "xxx", "xxtopic");
+        RoutineLoadJob goodJob = new KafkaRoutineLoadJob(goodJobId, "goodJob",
+                1, 1, "xxx", "xxtopic");
         goodJob.setOrigStmt(new OriginStatement(createSQL, 0));
         leaderLoadManager.addRoutineLoadJob(goodJob, DB);
         goodJob.updateState(RoutineLoadJob.JobState.CANCELLED, new ErrorReason(InternalErrorCode.CREATE_TASKS_ERR, "fake"), false);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -62,7 +62,6 @@ public class RoutineLoadSchedulerTest {
                                       @Mocked StreamLoadPlanner planner,
                                       @Injectable OlapTable olapTable)
             throws LoadException, MetaNotFoundException {
-        String clusterName = "default";
         List<Long> beIds = Lists.newArrayList();
         beIds.add(1L);
         beIds.add(2L);
@@ -75,7 +74,7 @@ public class RoutineLoadSchedulerTest {
         RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
         Deencapsulation.setField(globalStateMgr, "routineLoadTaskScheduler", routineLoadTaskScheduler);
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", clusterName, 1L, 1L,
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
                 "xxx", "test");
         Deencapsulation.setField(kafkaRoutineLoadJob, "state", RoutineLoadJob.JobState.NEED_SCHEDULE);
         List<RoutineLoadJob> routineLoadJobList = new ArrayList<>();
@@ -134,7 +133,7 @@ public class RoutineLoadSchedulerTest {
             }
         };
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", "default_cluster", 1L, 1L,
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
                 "10.74.167.16:8092", "test");
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db");
@@ -167,7 +166,7 @@ public class RoutineLoadSchedulerTest {
         executorService.submit(routineLoadTaskScheduler);
 
         KafkaRoutineLoadJob kafkaRoutineLoadJob1 = new KafkaRoutineLoadJob(1L, "test_custom_partition",
-                "default_cluster", 1L, 1L, "xxx", "test_1");
+                 1L, 1L, "xxx", "test_1");
         List<Integer> customKafkaPartitions = new ArrayList<>();
         customKafkaPartitions.add(2);
         Deencapsulation.setField(kafkaRoutineLoadJob1, "customKafkaPartitions", customKafkaPartitions);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -65,9 +65,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -183,11 +181,10 @@ public class AuthTest {
 
         // 2. check if cmy from specified ip can access
         List<UserIdentity> currentUser = Lists.newArrayList();
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1", "12345",
+        Assert.assertTrue(auth.checkPlainPassword("cmy", "192.168.0.1", "12345",
                 currentUser));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1",
+        Assert.assertFalse(auth.checkPlainPassword("cmy", "192.168.0.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPassword("other:cmy", "192.168.0.1", "12345", null));
         Assert.assertTrue(currentUser.get(0).equals(userIdentity));
 
         // 3. create another user: zhangsan@"192.%"
@@ -202,11 +199,10 @@ public class AuthTest {
         userIdentity = createUserStmt.getUserIdent();
 
         // 4. check if zhangsan from specified ip can access
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1",
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "192.168.0.1",
                 "12345", null));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "172.168.0.1",
+        Assert.assertFalse(auth.checkPlainPassword("zhangsan", "172.168.0.1",
                 "12345", null));
-        Assert.assertFalse(auth.checkPlainPassword("zhangsan", "192.168.0.1", "12345", null));
 
         // 4.1 check if we can create same user
         Config.enable_password_reuse = true;
@@ -236,7 +232,7 @@ public class AuthTest {
             Assert.fail();
         }
 
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "172.18.1.1",
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "172.18.1.1",
                 "12345", null));
 
         // 5. create a user with domain [starrocks.domain]
@@ -253,12 +249,10 @@ public class AuthTest {
         resolver.runAfterCatalogReady();
 
         // 6. check if user from resolved ip can access
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1",
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "10.1.1.1",
                 "12345", null));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1",
+        Assert.assertFalse(auth.checkPlainPassword("zhangsan", "10.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "11.1.1.1",
-                "12345", null));
 
         // 7. add duplicated user@['starrocks.domain1']
         try {
@@ -290,11 +284,11 @@ public class AuthTest {
         // 8.1 resolve domain [starrocks.domain2]
         resolver.runAfterCatalogReady();
 
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1",
+        Assert.assertTrue(auth.checkPlainPassword("lisi", "20.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1",
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "10.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.2",
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "20.1.1.2",
                 "123455", null));
 
         /*
@@ -318,7 +312,7 @@ public class AuthTest {
         }
 
         List<UserIdentity> currentUser2 = Lists.newArrayList();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "172.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("cmy", "172.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         // check auth before grant
         Assert.assertFalse(auth.checkDbPriv(currentUser2.get(0), "db1",
@@ -335,8 +329,7 @@ public class AuthTest {
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db1",
                 PrivPredicate.CREATE));
         UserIdentity zhangsan1 =
-                UserIdentity.createAnalyzedUserIdentWithIp(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
-                        "172.1.1.1");
+                UserIdentity.createAnalyzedUserIdentWithIp("zhangsan", "172.1.1.1");
         Assert.assertFalse(auth.checkDbPriv(zhangsan1, "db1",
                 PrivPredicate.CREATE));
 
@@ -402,7 +395,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "192.168.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
 
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db1",
@@ -431,7 +424,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "192.168.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(auth.checkDbPriv(currentUser2.get(0), "db2",
                 PrivPredicate.SELECT));
@@ -460,7 +453,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db3",
                 PrivPredicate.ALTER));
@@ -485,18 +478,18 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db3",
                 PrivPredicate.SELECT));
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.2", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db3",
                 PrivPredicate.ALTER));
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.3", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.3", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db3",
                 PrivPredicate.DROP));
@@ -590,7 +583,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "172.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("cmy", "172.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db",
                 PrivPredicate.CREATE));
@@ -618,7 +611,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "192.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkTblPriv(currentUser2.get(0),  "db2",
                 "tbl2", PrivPredicate.ALTER));
@@ -630,7 +623,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "192.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(auth.checkTblPriv(currentUser2.get(0), "db2",
                 "tbl2", PrivPredicate.ALTER));
@@ -694,7 +687,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0),"db3",
                 PrivPredicate.DROP));
@@ -707,7 +700,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(auth.checkDbPriv(currentUser2.get(0), "db3",
                 PrivPredicate.DROP));
@@ -807,7 +800,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":wangwu", "10.17.2.1", "12345", currentUser2);
+        auth.checkPlainPassword("wangwu", "10.17.2.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db4",
                 PrivPredicate.DROP));
@@ -823,11 +816,11 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("chenliu", "20.1.1.1", "12345", currentUser2);
         Assert.assertEquals(0, currentUser2.size());
         resolver.runAfterCatalogReady();
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("chenliu", "20.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkDbPriv(currentUser2.get(0), "db4",
                 PrivPredicate.DROP));
@@ -869,7 +862,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("chenliu", "20.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(auth.checkDbPriv(currentUser2.get(0), "db4",
                 PrivPredicate.DROP));
@@ -890,7 +883,7 @@ public class AuthTest {
             Assert.fail();
         }
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345", currentUser2);
+        auth.checkPlainPassword("chenliu", "20.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(auth.checkDbPriv(currentUser2.get(0), "db4",
                 PrivPredicate.DROP));
@@ -911,8 +904,8 @@ public class AuthTest {
         }
 
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1", "12345", null));
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1",
+                auth.checkPlainPassword("cmy", "192.168.0.1", "12345", null));
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "192.168.0.1",
                 "12345", null));
 
         // 33. drop user zhangsan@"192.%"
@@ -924,7 +917,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1", "12345", null));
+                auth.checkPlainPassword("zhangsan", "192.168.0.1", "12345", null));
 
         try {
             auth.dropUser(dropUserStmt);
@@ -932,9 +925,9 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1", "12345", null));
+                auth.checkPlainPassword("zhangsan", "192.168.0.1", "12345", null));
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", null));
 
         // 34. create user zhangsan@'10.1.1.1' to overwrite one of zhangsan@['starrocks.domain1']
         createUserSql = "CREATE USER 'zhangsan'@'10.1.1.1' IDENTIFIED BY 'abcde'";
@@ -946,7 +939,7 @@ public class AuthTest {
         }
 
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", null));
 
         try {
             auth.createUser(createUserStmt);
@@ -955,9 +948,9 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "12345", null));
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "abcde", null));
 
         // 35. drop user zhangsan@['starrocks.domain1']
         dropUserStmt = new DropUserStmt(new UserIdentity("zhangsan", "starrocks.domain1", true));
@@ -968,7 +961,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.2", "12345", null));
 
         try {
             auth.dropUser(dropUserStmt);
@@ -976,13 +969,13 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.2", "12345", null));
 
         resolver.runAfterCatalogReady();
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.2", "12345", null));
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "abcde", null));
 
         // 36. drop user lisi@['starrocks.domain1']
         dropUserStmt = new DropUserStmt(new UserIdentity("lisi", "starrocks.domain2", true));
@@ -993,9 +986,9 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "20.1.1.1", "123456", null));
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "10.1.1.1", "123456", null));
 
         try {
             auth.dropUser(dropUserStmt);
@@ -1003,15 +996,15 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "20.1.1.1", "123456", null));
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "10.1.1.1", "123456", null));
 
         resolver.runAfterCatalogReady();
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "20.1.1.1", "123456", null));
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456", null));
+                auth.checkPlainPassword("lisi", "10.1.1.1", "123456", null));
 
         // 37. drop zhangsan@'172.18.1.1' and zhangsan@'10.1.1.1'
         dropUserStmt = new DropUserStmt(new UserIdentity("zhangsan", "172.18.1.1", false));
@@ -1042,7 +1035,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde", null));
+                auth.checkPlainPassword("zhangsan", "10.1.1.1", "abcde", null));
 
         // 38.1 grant node_priv to user
         privileges = Lists.newArrayList(AccessPrivilege.NODE_PRIV);
@@ -1083,7 +1076,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhaoliu", "", "12345", currentUser2);
+        auth.checkPlainPassword("zhaoliu", "", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkGlobalPriv(currentUser2.get(0), PrivPredicate.OPERATOR));
 
@@ -1122,7 +1115,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":sunqi", "", "12345", currentUser2);
+        auth.checkPlainPassword("sunqi", "", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(auth.checkGlobalPriv(currentUser2.get(0), PrivPredicate.OPERATOR));
 
@@ -1598,14 +1591,14 @@ public class AuthTest {
         }
 
         List<UserIdentity> currentUser = Lists.newArrayList();
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8", "123",
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "192.168.8.8", "123",
                 currentUser));
-        Assert.assertTrue(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8",
+        Assert.assertTrue(auth.checkPassword("zhangsan", "192.168.8.8",
                 "123".getBytes(StandardCharsets.UTF_8), null, currentUser));
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8", "456",
+                auth.checkPlainPassword("zhangsan", "192.168.8.8", "456",
                         currentUser));
-        Assert.assertFalse(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8",
+        Assert.assertFalse(auth.checkPassword("zhangsan", "192.168.8.8",
                 "456".getBytes(StandardCharsets.UTF_8), null, currentUser));
         List<List<String>> authInfos = auth.getAuthenticationInfo(currentUser.get(0));
         Assert.assertEquals(1, authInfos.size());
@@ -1625,14 +1618,14 @@ public class AuthTest {
         }
 
         currentUser = Lists.newArrayList();
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8", "123",
+        Assert.assertTrue(auth.checkPlainPassword("zhangsan", "192.168.8.8", "123",
                 currentUser));
-        Assert.assertTrue(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8",
+        Assert.assertTrue(auth.checkPassword("zhangsan", "192.168.8.8",
                 "123".getBytes(StandardCharsets.UTF_8), null, currentUser));
         Assert.assertFalse(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8", "456",
+                auth.checkPlainPassword("zhangsan", "192.168.8.8", "456",
                         currentUser));
-        Assert.assertFalse(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.8.8",
+        Assert.assertFalse(auth.checkPassword("zhangsan", "192.168.8.8",
                 "456".getBytes(StandardCharsets.UTF_8), null, currentUser));
         authInfos = auth.getAuthenticationInfo(currentUser.get(0));
         Assert.assertEquals(1, authInfos.size());
@@ -1655,11 +1648,11 @@ public class AuthTest {
         currentUser = Lists.newArrayList();
         byte[] seed = "dJSH\\]mcwKJlLH[bYunm".getBytes(StandardCharsets.UTF_8);
         byte[] scramble = MysqlPassword.scramble(seed, "123456");
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "123456",
+        Assert.assertTrue(auth.checkPlainPassword("lisi", "192.168.8.8", "123456",
                 currentUser));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "654321",
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "192.168.8.8", "654321",
                 currentUser));
-        Assert.assertTrue(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", scramble, seed,
+        Assert.assertTrue(auth.checkPassword("lisi", "192.168.8.8", scramble, seed,
                 currentUser));
         authInfos = auth.getAuthenticationInfo(currentUser.get(0));
         Assert.assertEquals(1, authInfos.size());
@@ -1685,11 +1678,11 @@ public class AuthTest {
         }
         currentUser = Lists.newArrayList();
         scramble = MysqlPassword.scramble(seed, "654321");
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "654321",
+        Assert.assertTrue(auth.checkPlainPassword("lisi", "192.168.8.8", "654321",
                 currentUser));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "123456",
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "192.168.8.8", "123456",
                 currentUser));
-        Assert.assertTrue(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", scramble, seed,
+        Assert.assertTrue(auth.checkPassword("lisi", "192.168.8.8", scramble, seed,
                 currentUser));
 
         // alter user lisi identified with mysql_native_password as '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
@@ -1710,11 +1703,11 @@ public class AuthTest {
         }
         currentUser = Lists.newArrayList();
         scramble = MysqlPassword.scramble(seed, "123456");
-        Assert.assertTrue(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "123456",
+        Assert.assertTrue(auth.checkPlainPassword("lisi", "192.168.8.8", "123456",
                 currentUser));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "654321",
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "192.168.8.8", "654321",
                 currentUser));
-        Assert.assertTrue(auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", scramble, seed,
+        Assert.assertTrue(auth.checkPassword("lisi", "192.168.8.8", scramble, seed,
                 currentUser));
 
         // alter user lisi identified with mysql_native_password
@@ -1734,11 +1727,11 @@ public class AuthTest {
         }
         currentUser = Lists.newArrayList();
         Assert.assertTrue(
-                auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", null, currentUser));
-        Assert.assertFalse(auth.checkPlainPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", "123456",
+                auth.checkPlainPassword("lisi", "192.168.8.8", null, currentUser));
+        Assert.assertFalse(auth.checkPlainPassword("lisi", "192.168.8.8", "123456",
                 currentUser));
         Assert.assertTrue(
-                auth.checkPassword(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "192.168.8.8", new byte[0], seed,
+                auth.checkPassword("lisi", "192.168.8.8", new byte[0], seed,
                         currentUser));
     }
 
@@ -1894,11 +1887,11 @@ public class AuthTest {
         auth.createUser(createUserStmt);
 
         Assert.assertNull(auth.getUserPrivTable().getPasswordByApproximate(
-                SystemInfoService.DEFAULT_CLUSTER + ":unknown_user", "10.1.1.1"));
+                "unknown_user", "10.1.1.1"));
         Assert.assertNotNull(auth.getUserPrivTable().getPasswordByApproximate(
-                SystemInfoService.DEFAULT_CLUSTER + ":test_user", "10.1.1.1"));
+                "test_user", "10.1.1.1"));
         Assert.assertNotNull(auth.getUserPrivTable().getPasswordByApproximate(
-                SystemInfoService.DEFAULT_CLUSTER + ":test_user", "localhost"));
+                "test_user", "localhost"));
     }
 
     /**
@@ -1937,9 +1930,9 @@ public class AuthTest {
         };
         for (String[] userHostAndMatchedUserHost : userHostAndMatchedUserHosts) {
             List<UserIdentity> identities = new ArrayList<>();
-            String remoteUser = SystemInfoService.DEFAULT_CLUSTER + ":" + userHostAndMatchedUserHost[0];
+            String remoteUser = "" + userHostAndMatchedUserHost[0];
             String remoteIp = userHostAndMatchedUserHost[1];
-            String expectQualifiedUser = SystemInfoService.DEFAULT_CLUSTER + ":" + userHostAndMatchedUserHost[2];
+            String expectQualifiedUser = "" + userHostAndMatchedUserHost[2];
             String expectHost = userHostAndMatchedUserHost[3];
 
             auth.checkPlainPassword(remoteUser, remoteIp, PASSWORD_STR, identities);
@@ -1969,7 +1962,7 @@ public class AuthTest {
         Assert.assertEquals(4, userHostResult.size());
         List<String> expect = new ArrayList<>();
         for (String[] userHost : userHostPatterns) {
-            expect.add(String.format("default_cluster:%s@%s", userHost[0], userHost[1]));
+            expect.add(String.format("%s@%s", userHost[0], userHost[1]));
         }
         Collections.sort(expect);
         Collections.sort(userHostResult);
@@ -1985,8 +1978,8 @@ public class AuthTest {
         }
         // expect match 2: user_1@10.1.1.1 & user_1@%
         Assert.assertEquals(2, userHostResult.size());
-        Assert.assertTrue(userHostResult.contains("default_cluster:user_1@10.1.1.1"));
-        Assert.assertTrue(userHostResult.contains("default_cluster:user_1@%"));
+        Assert.assertTrue(userHostResult.contains("user_1@10.1.1.1"));
+        Assert.assertTrue(userHostResult.contains("user_1@%"));
 
 
         // test grant
@@ -2014,7 +2007,7 @@ public class AuthTest {
         // check if user_1@10.1.1.1 can see two table
         List<UserIdentity> identities = new ArrayList<>();
         auth.checkPlainPassword(
-                SystemInfoService.DEFAULT_CLUSTER + ":user_1", "10.1.1.1", PASSWORD_STR, identities);
+                "user_1", "10.1.1.1", PASSWORD_STR, identities);
         Assert.assertEquals(1, identities.size());
         user = identities.get(0);
         Assert.assertEquals("10.1.1.1", user.getHost());
@@ -2026,7 +2019,7 @@ public class AuthTest {
         // check if user_1@10.1.1.2 can see one table
         identities.clear();
         auth.checkPlainPassword(
-                SystemInfoService.DEFAULT_CLUSTER + ":user_1", "10.1.1.2", PASSWORD_STR, identities);
+                "user_1", "10.1.1.2", PASSWORD_STR, identities);
         Assert.assertEquals(1, identities.size());
         user = identities.get(0);
         Assert.assertEquals("%", user.getHost());
@@ -2151,7 +2144,7 @@ public class AuthTest {
         Assert.assertEquals(1, infos.size());
         Assert.assertEquals(2, infos.get(0).size());
         Assert.assertEquals(emptyPrivilegeUser.toString(), infos.get(0).get(0));
-        Assert.assertEquals("GRANT Select_priv ON information_schema.* TO 'default_cluster:user1'@'%'", infos.get(0).get(1));
+        Assert.assertEquals("GRANT Select_priv ON information_schema.* TO 'user1'@'%'", infos.get(0).get(1));
 
         // 2. grant table privilege to onePrivilegeUser
         TablePattern table = new TablePattern("testdb", "table1");
@@ -2161,7 +2154,7 @@ public class AuthTest {
         Assert.assertEquals(1, infos.size());
         Assert.assertEquals(2, infos.get(0).size());
         Assert.assertEquals(onePrivilegeUser.toString(), infos.get(0).get(0));
-        String expectSQL = "GRANT Select_priv ON testdb.table1 TO 'default_cluster:user2'@'%'";
+        String expectSQL = "GRANT Select_priv ON testdb.table1 TO 'user2'@'%'";
         Assert.assertTrue(infos.get(0).get(1).contains(expectSQL));
 
         // 3. grant resource & table & global & impersonate to manyPrivilegeUser
@@ -2169,17 +2162,17 @@ public class AuthTest {
         TablePattern db = new TablePattern("testdb", "*");
         db.analyze();
         auth.grantPrivs(manyPrivilegeUser, db, PrivBitSet.of(Privilege.LOAD_PRIV, Privilege.SELECT_PRIV), false);
-        expectSQLs.add("GRANT Select_priv, Load_priv ON testdb.* TO 'default_cluster:user3'@'%'");
+        expectSQLs.add("GRANT Select_priv, Load_priv ON testdb.* TO 'user3'@'%'");
         TablePattern global = new TablePattern("*", "*");
         global.analyze();
         auth.grantPrivs(manyPrivilegeUser, global, PrivBitSet.of(Privilege.GRANT_PRIV), false);
-        expectSQLs.add("GRANT Grant_priv ON *.* TO 'default_cluster:user3'@'%'");
+        expectSQLs.add("GRANT Grant_priv ON *.* TO 'user3'@'%'");
         ResourcePattern resourcePattern = new ResourcePattern("test_resource");
         resourcePattern.analyze();
         auth.grantPrivs(manyPrivilegeUser, resourcePattern, PrivBitSet.of(Privilege.USAGE_PRIV), false);
-        expectSQLs.add("GRANT Usage_priv ON RESOURCE 'test_resource' TO 'default_cluster:user3'@'%'");
+        expectSQLs.add("GRANT Usage_priv ON RESOURCE 'test_resource' TO 'user3'@'%'");
         auth.grantImpersonate(new GrantImpersonateStmt(manyPrivilegeUser, emptyPrivilegeUser));
-        expectSQLs.add("GRANT IMPERSONATE ON 'default_cluster:user1'@'%' TO 'default_cluster:user3'@'%'");
+        expectSQLs.add("GRANT IMPERSONATE ON 'user1'@'%' TO 'user3'@'%'");
         infos = auth.getGrantsSQLs(manyPrivilegeUser);
         Assert.assertEquals(1, infos.size());
         Assert.assertEquals(2, infos.get(0).size());
@@ -2286,4 +2279,4 @@ public class AuthTest {
         newAuth.replayRevokeImpersonate(infos.get(0));
         Assert.assertFalse(newAuth.canImpersonate(harry, gregory));
     }
- }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
@@ -80,19 +80,19 @@ public class SetPasswordTest {
 
     @Test
     public void test() throws DdlException {
-        UserIdentity userIdentity = new UserIdentity("default_cluster:cmy", "%");
+        UserIdentity userIdentity = new UserIdentity("cmy", "%");
         userIdentity.setIsAnalyzed();
         CreateUserStmt stmt = new CreateUserStmt(new UserDesc(userIdentity));
         auth.createUser(stmt);
 
         ConnectContext ctx = new ConnectContext(null);
         // set password for 'cmy'@'%'
-        UserIdentity currentUser1 = new UserIdentity("default_cluster:cmy", "%");
+        UserIdentity currentUser1 = new UserIdentity("cmy", "%");
         currentUser1.setIsAnalyzed();
         ctx.setCurrentUserIdentity(currentUser1);
         ctx.setThreadLocalInfo();
 
-        UserIdentity user1 = new UserIdentity("default_cluster:cmy", "%");
+        UserIdentity user1 = new UserIdentity("cmy", "%");
         user1.setIsAnalyzed();
         SetPassVar setPassVar = new SetPassVar(user1, null);
         try {
@@ -112,12 +112,12 @@ public class SetPasswordTest {
         }
 
         // create user cmy2@'192.168.1.1'
-        UserIdentity userIdentity2 = new UserIdentity("default_cluster:cmy2", "192.168.1.1");
+        UserIdentity userIdentity2 = new UserIdentity("cmy2", "192.168.1.1");
         userIdentity2.setIsAnalyzed();
         stmt = new CreateUserStmt(new UserDesc(userIdentity2));
         auth.createUser(stmt);
 
-        UserIdentity currentUser2 = new UserIdentity("default_cluster:cmy2", "192.168.1.1");
+        UserIdentity currentUser2 = new UserIdentity("cmy2", "192.168.1.1");
         currentUser2.setIsAnalyzed();
         ctx.setCurrentUserIdentity(currentUser2);
         ctx.setThreadLocalInfo();
@@ -132,7 +132,7 @@ public class SetPasswordTest {
         }
 
         // set password for cmy2@'192.168.1.1'
-        UserIdentity user2 = new UserIdentity("default_cluster:cmy2", "192.168.1.1");
+        UserIdentity user2 = new UserIdentity("cmy2", "192.168.1.1");
         user2.setIsAnalyzed();
         SetPassVar setPassVar4 = new SetPassVar(user2, null);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
@@ -18,7 +18,6 @@
 package com.starrocks.mysql.privilege;
 
 import com.starrocks.analysis.UserIdentity;
-import com.starrocks.system.SystemInfoService;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,16 +25,16 @@ public class UserIdentityTest {
 
     @Test
     public void test() {
-        UserIdentity userIdent = new UserIdentity(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.%");
+        UserIdentity userIdent = new UserIdentity("cmy", "192.%");
         userIdent.setIsAnalyzed();
 
-        String str = "'" + SystemInfoService.DEFAULT_CLUSTER + ":cmy" + "'@'192.%'";
+        String str = "'" + "cmy" + "'@'192.%'";
         Assert.assertEquals(str, userIdent.toString());
 
         UserIdentity userIdent2 = UserIdentity.fromString(str);
         Assert.assertEquals(userIdent2.toString(), userIdent.toString());
 
-        String str2 = "'default_cluster:walletdc_write'@['cluster-leida.orp.all']";
+        String str2 = "'walletdc_write'@['cluster-leida.orp.all']";
         userIdent = UserIdentity.fromString(str2);
         Assert.assertNotNull(userIdent);
         Assert.assertTrue(userIdent.isDomain());

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -35,7 +35,6 @@ import com.starrocks.rpc.PFetchDataRequest;
 import com.starrocks.rpc.PTriggerProfileReportRequest;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.BackendService;
 import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.FrontendServiceVersion;
@@ -177,7 +176,6 @@ public class PseudoBackend {
         disks.put(diskInfo1.getRootPath(), diskInfo1);
         be.setDisks(ImmutableMap.copyOf(disks));
         be.setAlive(true);
-        be.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
         be.setBePort(beThriftPort);
         be.setBrpcPort(brpcPort);
         be.setHttpPort(httpPort);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -121,17 +121,16 @@ public class ConnectContextTest {
         Assert.assertNotNull(ctx.toThreadInfo());
         long currentTimeMillis = System.currentTimeMillis();
         List<String> row = ctx.toThreadInfo().toRow(currentTimeMillis, false);
-        Assert.assertEquals(10, row.size());
+        Assert.assertEquals(9, row.size());
         Assert.assertEquals("101", row.get(0));
         Assert.assertEquals("testUser", row.get(1));
         Assert.assertEquals("127.0.0.1:12345", row.get(2));
-        Assert.assertEquals("default_cluster", row.get(3));
-        Assert.assertEquals("testDb", row.get(4));
-        Assert.assertEquals("Ping", row.get(5));
-        Assert.assertEquals(TimeUtils.longToTimeString(ctx.getConnectionStartTime()), row.get(6));
-        Assert.assertEquals(Long.toString((currentTimeMillis - ctx.getConnectionStartTime()) / 1000), row.get(7));
+        Assert.assertEquals("testDb", row.get(3));
+        Assert.assertEquals("Ping", row.get(4));
+        Assert.assertEquals(TimeUtils.longToTimeString(ctx.getConnectionStartTime()), row.get(5));
+        Assert.assertEquals(Long.toString((currentTimeMillis - ctx.getConnectionStartTime()) / 1000), row.get(6));
+        Assert.assertEquals("", row.get(7));
         Assert.assertEquals("", row.get(8));
-        Assert.assertEquals("", row.get(9));
 
         // Start time
         ctx.setStartTime();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -310,7 +310,7 @@ public class ShowExecutorTest {
         ConnectScheduler scheduler = new ConnectScheduler(10);
         new Expectations(scheduler) {
             {
-                scheduler.listConnection("default_cluster:testUser");
+                scheduler.listConnection("testUser");
                 minTimes = 0;
                 result = Lists.newArrayList(ctx.toThreadInfo());
             }
@@ -318,7 +318,7 @@ public class ShowExecutorTest {
 
         ctx.setConnectScheduler(scheduler);
         ctx.setGlobalStateMgr(AccessTestUtil.fetchAdminCatalog());
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
 
         new Expectations(ctx) {
             {
@@ -450,7 +450,7 @@ public class ShowExecutorTest {
     @Test
     public void testDescribe() throws DdlException {
         ctx.setGlobalStateMgr(globalStateMgr);
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
 
         DescribeStmt stmt = (DescribeStmt) com.starrocks.sql.parser.SqlParser.parse("desc testTbl",
                 ctx.getSessionVariable().getSqlMode()).get(0);
@@ -522,7 +522,7 @@ public class ShowExecutorTest {
     @Test
     public void testShowCreateDb() throws AnalysisException, DdlException {
         ctx.setGlobalStateMgr(globalStateMgr);
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
 
         ShowCreateDbStmt stmt = new ShowCreateDbStmt("testDb");
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
@@ -537,7 +537,7 @@ public class ShowExecutorTest {
     @Test(expected = AnalysisException.class)
     public void testShowCreateNoDb() throws AnalysisException, DdlException {
         ctx.setGlobalStateMgr(globalStateMgr);
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
 
         ShowCreateDbStmt stmt = new ShowCreateDbStmt("emptyDb");
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
@@ -569,7 +569,7 @@ public class ShowExecutorTest {
     @Test
     public void testShowColumn() throws AnalysisException, DdlException {
         ctx.setGlobalStateMgr(globalStateMgr);
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
 
         ShowColumnStmt stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show columns from testTbl in testDb",
                 ctx.getSessionVariable().getSqlMode()).get(0);
@@ -617,7 +617,7 @@ public class ShowExecutorTest {
     @Test
     public void testShowColumnFromUnknownTable() throws AnalysisException, DdlException {
         ctx.setGlobalStateMgr(globalStateMgr);
-        ctx.setQualifiedUser("default_cluster:testUser");
+        ctx.setQualifiedUser("testUser");
         ShowColumnStmt stmt = new ShowColumnStmt(new TableName("emptyDb", "testTable"), null, null, false);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
@@ -684,15 +684,15 @@ public class ShowExecutorTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
-        Assert.assertEquals(26, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(25, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("BackendId", resultSet.getMetaData().getColumn(0).getName());
-        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(24).getName());
-        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(25).getName());
+        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(23).getName());
+        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(24).getName());
 
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("1", resultSet.getString(0));
-        Assert.assertEquals("0", resultSet.getString(24));
-        Assert.assertEquals("5", resultSet.getString(25));
+        Assert.assertEquals("0", resultSet.getString(23));
+        Assert.assertEquals("5", resultSet.getString(24));
 
         Config.integrate_starmgr = false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -103,6 +103,6 @@ public class AnalyzeShowTest {
         sql = "SHOW AUTHENTICATION FOR xx";
         stmt = (ShowAuthenticationStmt)analyzeSuccess(sql);
         Assert.assertFalse(stmt.isAll());
-        Assert.assertEquals("default_cluster:xx", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("xx", stmt.getUserIdent().getQualifiedUser());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -68,14 +68,14 @@ public class AnalyzeStmtTest {
     public void testShowUserProperty() {
         String sql = "SHOW PROPERTY FOR 'jack' LIKE '%load_cluster%'";
         ShowUserPropertyStmt showUserPropertyStmt = (ShowUserPropertyStmt) analyzeSuccess(sql);
-        Assert.assertEquals("default_cluster:jack", showUserPropertyStmt.getUser());
+        Assert.assertEquals("jack", showUserPropertyStmt.getUser());
     }
 
     @Test
     public void testSetUserProperty() {
         String sql = "SET PROPERTY FOR 'tom' 'max_user_connections' = 'value', 'test' = 'true'";
         SetUserPropertyStmt setUserPropertyStmt = (SetUserPropertyStmt) analyzeSuccess(sql);
-        Assert.assertEquals("default_cluster:tom", setUserPropertyStmt.getUser());
+        Assert.assertEquals("tom", setUserPropertyStmt.getUser());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -431,7 +431,7 @@ public class PrivilegeCheckerTest {
 
     @Test
     public void testSetUserProperty() throws Exception {
-        starRocksAssert.getCtx().setQualifiedUser("default_cluster:test");
+        starRocksAssert.getCtx().setQualifiedUser("test");
         String sql = "SET PROPERTY FOR 'test' 'max_user_connections' = 'value', 'test' = '400'";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assert.assertThrows(SemanticException.class,
@@ -658,7 +658,7 @@ public class PrivilegeCheckerTest {
         db1TablePattern.analyze();
 
         // Here we hack `create role` statement because it was still in old framework
-        auth.createRole(new CreateRoleStmt("default_cluster:test_role"));
+        auth.createRole(new CreateRoleStmt("test_role"));
 
         String sql = "grant test_role to test;";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
@@ -67,9 +67,9 @@ public class ExecuteAsStmtTest {
         ExecuteAsStmt stmt = (ExecuteAsStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "execute as user1 with no revert", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals("default_cluster:user1", stmt.getToUser().getQualifiedUser());
+        Assert.assertEquals("user1", stmt.getToUser().getQualifiedUser());
         Assert.assertEquals("%", stmt.getToUser().getHost());
-        Assert.assertEquals("EXECUTE AS 'default_cluster:user1'@'%' WITH NO REVERT", stmt.toString());
+        Assert.assertEquals("EXECUTE AS 'user1'@'%' WITH NO REVERT", stmt.toString());
         Assert.assertFalse(stmt.isAllowRevert());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -72,7 +72,7 @@ public class GrantRevokeImpersonateStmtTest {
         GrantImpersonateStmt stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant IMPERSONATE on user2 to user1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals("GRANT IMPERSONATE ON 'default_cluster:user2'@'%' TO 'default_cluster:user1'@'%'", stmt.toString());
+        Assert.assertEquals("GRANT IMPERSONATE ON 'user2'@'%' TO 'user1'@'%'", stmt.toString());
 
         stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant IMPERSONATE on user2 to ROLE role1", 1).get(0);
@@ -83,12 +83,12 @@ public class GrantRevokeImpersonateStmtTest {
         RevokeImpersonateStmt stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "revoke IMPERSONATE on user2 from user1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
-        Assert.assertEquals("REVOKE IMPERSONATE ON 'default_cluster:user2'@'%' FROM 'default_cluster:user1'@'%'", stmt2.toString());
+        Assert.assertEquals("REVOKE IMPERSONATE ON 'user2'@'%' FROM 'user1'@'%'", stmt2.toString());
 
         stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "revoke IMPERSONATE on user2 from ROLE role1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
-        Assert.assertEquals("REVOKE IMPERSONATE ON 'default_cluster:user2'@'%' FROM ROLE 'default_cluster:role1'",
+        Assert.assertEquals("REVOKE IMPERSONATE ON 'user2'@'%' FROM ROLE 'role1'",
                 stmt2.toString());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -77,7 +77,7 @@ public class GrantRevokeImpersonateStmtTest {
         stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant IMPERSONATE on user2 to ROLE role1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals("GRANT IMPERSONATE ON 'default_cluster:user2'@'%' TO ROLE 'default_cluster:role1'", stmt.toString());
+        Assert.assertEquals("GRANT IMPERSONATE ON 'user2'@'%' TO ROLE 'role1'", stmt.toString());
 
         // revoke
         RevokeImpersonateStmt stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
@@ -78,21 +78,22 @@ public class GrantRevokeRoleStmtTest {
         GrantRoleStmt stmt = (GrantRoleStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant test_role to test_user", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals("GRANT 'default_cluster:test_role' TO 'default_cluster:test_user'@'%'", stmt.toString());
+        Assert.assertEquals("GRANT 'test_role' TO 'test_user'@'%'", stmt.toString());
 
         // grant 2
         // user with host
         stmt = (GrantRoleStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant 'test_role' to 'test_user'@'localhost'", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals("GRANT 'default_cluster:test_role' TO 'default_cluster:test_user'@'localhost'", stmt.toString());
+        Assert.assertEquals("GRANT 'test_role' TO 'test_user'@'localhost'", stmt.toString());
 
         // revoke
         // user with domain
         RevokeRoleStmt stmt2 = (RevokeRoleStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "revoke 'test_role' from 'test_user'@['starrocks.com']", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
-        Assert.assertEquals("REVOKE 'default_cluster:test_role' FROM 'default_cluster:test_user'@['starrocks.com']", stmt2.toString());
+        Assert.assertEquals("REVOKE 'test_role' " +
+                "FROM 'test_user'@['starrocks.com']", stmt2.toString());
     }
 
     @Test(expected = SemanticException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -331,7 +331,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
 
-        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "test", "default_cluster", 1L, 1L, "host:port",
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L, "host:port",
                 "topic");
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
                 Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
@@ -405,7 +405,7 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo3);
 
         KafkaRoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "test", "default_cluster", 1L, 1L, "host:port", "topic");
+                new KafkaRoutineLoadJob(1L, "test", 1L, 1L, "host:port", "topic");
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
                 Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -80,7 +80,6 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.system.Backend;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.codec.binary.Hex;
@@ -295,7 +294,6 @@ public class UtFrameUtils {
         disks.put(diskInfo1.getRootPath(), diskInfo1);
         be.setDisks(ImmutableMap.copyOf(disks));
         be.setAlive(true);
-        be.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
         be.setBePort(backend.getBeThriftPort());
         be.setBrpcPort(backend.getBrpcPort());
         be.setHttpPort(backend.getHttpPort());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
This is the last PR (together with #10022 #9403 #9300 #9245 #9188 #9130 #9088) to remove default_cluster related code. To maintain compatibility with older versions, we append the "default_cluster" prefix to db/user/role when serializing and remove the "default_cluster" prefix from db/user/role when deserializing.
These are some commands whose result format are changed:
1. show proc '/dbs'; show proc '/statistic'; the "default_cluster" prefix is removed from dbName;
2. show proc '/auth'; the "default_cluster" prefix is removed from userIdentity;
3. show roles; the "default_cluster" prefix is removed from role name;
4. show backends; show proc '/backends'; show compute nodes; show proc '/compute_nodes'; the Column Cluster is removed;
5. show processlist; the Column Cluster is removed;

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
