### PR TITLE
[Cherry-pick 2.3][BugFix] persist grant/revoke role and support grant impersonate to role (#10596)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -343,7 +343,9 @@ public class JournalEntity implements Writable {
             case OperationType.OP_REVOKE_PRIV:
             case OperationType.OP_SET_PASSWORD:
             case OperationType.OP_CREATE_ROLE:
-            case OperationType.OP_DROP_ROLE: {
+            case OperationType.OP_DROP_ROLE:
+            case OperationType.OP_GRANT_ROLE:
+            case OperationType.OP_REVOKE_ROLE: {
                 data = PrivInfo.read(in);
                 isRead = true;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.StarRocksFE;
 import com.starrocks.analysis.AlterUserStmt;
 import com.starrocks.analysis.CreateRoleStmt;
@@ -48,9 +49,11 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
+import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.ImpersonatePrivInfo;
 import com.starrocks.persist.PrivInfo;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.GrantImpersonateStmt;
@@ -71,6 +74,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -630,7 +634,7 @@ public class Auth implements Writable {
 
             // 4. grant privs of role to user
             if (role != null) {
-                grantRoleInternal(role, userIdent, false);
+                grantRoleInternal(roleName, userIdent, false, true);
             }
 
             // other user properties
@@ -722,22 +726,37 @@ public class Auth implements Writable {
     public void grantRole(GrantRoleStmt stmt) throws DdlException {
         writeLock();
         try {
-            grantRoleInternal(this.roleManager.getRole(stmt.getQualifiedRole()), stmt.getUserIdent(), true);
+            grantRoleInternal(stmt.getQualifiedRole(), stmt.getUserIdent(), true, false);
         } finally {
             writeUnlock();
         }
     }
+
+    public void replayGrantRole(PrivInfo privInfo) throws DdlException {
+        writeLock();
+        try {
+            grantRoleInternal(privInfo.getRole(), privInfo.getUserIdent(), true, true);
+        } finally {
+            writeUnlock();
+        }
+    }
+
 
     /**
      * simply copy all privileges map from role to user.
      * TODO this is a temporary implement that make it impossible to safely revoke privilege from role.
      * We will refactor the whole user privilege framework later to ultimately fix this.
      *
-     * @param role
+     * @param roleName
      * @param userIdent
      * @throws DdlException
      */
-    private void grantRoleInternal(Role role, UserIdentity userIdent, boolean errOnNonExist) throws DdlException {
+    private void grantRoleInternal(String roleName, UserIdentity userIdent, boolean errOnNonExist, boolean isReplay)
+            throws DdlException {
+        Role role = roleManager.getRole(roleName);
+        if (role == null) {
+            throw new DdlException("Role: " + roleName + " does not exist");
+        }
         for (Map.Entry<TablePattern, PrivBitSet> entry : role.getTblPatternToPrivs().entrySet()) {
             // use PrivBitSet copy to avoid same object being changed synchronously
             grantInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
@@ -748,13 +767,31 @@ public class Auth implements Writable {
             grantInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
                     errOnNonExist /* err on non exist */, true /* is replay */);
         }
+        for (UserIdentity user : role.getImpersonateUsers()) {
+            grantImpersonateToUserInternal(userIdent, user, true);
+        }
+
         role.addUser(userIdent);
+        if (!isReplay) {
+            PrivInfo privInfo = new PrivInfo(userIdent, role.getRoleName());
+            GlobalStateMgr.getCurrentState().getEditLog().logGrantRole(privInfo);
+        }
+        LOG.info("grant {} to {}, isReplay = {}", roleName, userIdent, isReplay);
     }
 
     public void revokeRole(RevokeRoleStmt stmt) throws DdlException {
         writeLock();
         try {
-            revokeRoleInternal(this.roleManager.getRole(stmt.getQualifiedRole()), stmt.getUserIdent());
+            revokeRoleInternal(stmt.getQualifiedRole(), stmt.getUserIdent(), false);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void replayRevokeRole(PrivInfo privInfo) throws DdlException {
+        writeLock();
+        try {
+            revokeRoleInternal(privInfo.getRole(), privInfo.getUserIdent(), true);
         } finally {
             writeUnlock();
         }
@@ -765,41 +802,70 @@ public class Auth implements Writable {
      * TODO this is a temporary implement that make it impossible to safely revoke privilege from role.
      * We will refactor the whole user privilege framework later to ultimately fix this.
      *
-     * @param role
+     * @param roleName
      * @param userIdent
      * @throws DdlException
      */
-    private void revokeRoleInternal(Role role, UserIdentity userIdent) throws DdlException {
+    private void revokeRoleInternal(String roleName, UserIdentity userIdent, boolean isReplay) throws DdlException {
+        Role role = roleManager.getRole(roleName);
+        if (role == null) {
+            throw new DdlException("Role: " + roleName + " does not exist");
+        }
         for (Map.Entry<TablePattern, PrivBitSet> entry : role.getTblPatternToPrivs().entrySet()) {
             revokeInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
-                    false /* err on non exist */, false /* is replay */);
+                    false /* err on non exist */, true /* is replay */);
         }
         for (Map.Entry<ResourcePattern, PrivBitSet> entry : role.getResourcePatternToPrivs().entrySet()) {
             revokeInternal(userIdent, null /* role */, entry.getKey(), entry.getValue().copy(),
-                    false /* err on non exist */, false /* is replay */);
+                    false /* err on non exist */, true /* is replay */);
         }
+        for (UserIdentity user : role.getImpersonateUsers()) {
+            revokeImpersonateFromUserInternal(userIdent, user, true);
+        }
+
         role.dropUser(userIdent);
+        if (!isReplay) {
+            PrivInfo privInfo = new PrivInfo(userIdent, role.getRoleName());
+            GlobalStateMgr.getCurrentState().getEditLog().logRevokeRole(privInfo);
+        }
+        LOG.info("revoke {} from {}, isReplay = {}", roleName, userIdent, isReplay);
     }
 
     public void grantImpersonate(GrantImpersonateStmt stmt) throws DdlException {
-        grantImpersonateInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        if (stmt.getAuthorizedRoleName() == null) {
+            grantImpersonateToUserInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        } else {
+            grantImpersonateToRoleInternal(stmt.getAuthorizedRoleName(), stmt.getSecuredUser(), false);
+        }
     }
 
     public void replayGrantImpersonate(ImpersonatePrivInfo info) {
         try {
-            grantImpersonateInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            if (info.getAuthorizedRoleName() == null) {
+                grantImpersonateToUserInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            } else {
+                grantImpersonateToRoleInternal(info.getAuthorizedRoleName(), info.getSecuredUser(), true);
+            }
         } catch (DdlException e) {
             LOG.error("should not happend", e);
         }
     }
 
     public void revokeImpersonate(RevokeImpersonateStmt stmt) throws DdlException {
-        revokeImpersonateInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        if (stmt.getAuthorizedRoleName() == null) {
+            revokeImpersonateFromUserInternal(stmt.getAuthorizedUser(), stmt.getSecuredUser(), false);
+        } else {
+            revokeImpersonateFromRoleInternal(stmt.getAuthorizedRoleName(), stmt.getSecuredUser(), false);
+        }
     }
 
     public void replayRevokeImpersonate(ImpersonatePrivInfo info) {
         try {
-            revokeImpersonateInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            if (info.getAuthorizedRoleName() == null) {
+                revokeImpersonateFromUserInternal(info.getAuthorizedUser(), info.getSecuredUser(), true);
+            } else {
+                revokeImpersonateFromRoleInternal(info.getAuthorizedRoleName(), info.getSecuredUser(), true);
+            }
         } catch (DdlException e) {
             LOG.error("should not happend", e);
         }
@@ -996,7 +1062,7 @@ public class Auth implements Writable {
         }
     }
 
-    private void grantImpersonateInternal(
+    private void grantImpersonateToUserInternal(
             UserIdentity authorizedUser, UserIdentity securedUser, boolean isReplay) throws DdlException {
         writeLock();
         try {
@@ -1008,7 +1074,7 @@ public class Auth implements Writable {
                 ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedUser, securedUser);
                 GlobalStateMgr.getCurrentState().getEditLog().logGrantImpersonate(info);
             }
-            LOG.debug("finished to grant impersonate. is replay: {}", isReplay);
+            LOG.info("grant impersonate on {} to {}, isReplay = {}", securedUser, authorizedUser, isReplay);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         } finally {
@@ -1016,7 +1082,28 @@ public class Auth implements Writable {
         }
     }
 
+    private void grantImpersonateToRoleInternal(
+            String authorizedRoleName, UserIdentity securedUser, boolean isReplay) throws DdlException {
+        writeLock();
+        try {
+            // grant privs to role, role must exist
+            Role newRole = new Role(authorizedRoleName, securedUser);
+            Role existingRole = roleManager.addRole(newRole, false /* err on exist */);
 
+            // update users' privs of this role
+            for (UserIdentity user : existingRole.getUsers()) {
+                grantImpersonateToUserInternal(user, securedUser, true);
+            }
+
+            if (!isReplay) {
+                ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedRoleName, securedUser);
+                GlobalStateMgr.getCurrentState().getEditLog().logGrantImpersonate(info);
+            }
+            LOG.info("grant impersonate on {} to role {}, isReplay = {}", securedUser, authorizedRoleName, isReplay);
+        } finally {
+            writeUnlock();
+        }
+    }
 
     // return true if user ident exist
     private boolean doesUserExist(UserIdentity userIdent) {
@@ -1147,7 +1234,7 @@ public class Auth implements Writable {
         }
     }
 
-    private void revokeImpersonateInternal(
+    private void revokeImpersonateFromUserInternal(
             UserIdentity authorizedUser, UserIdentity securedUser, boolean isReplay) throws DdlException {
         writeLock();
         try {
@@ -1159,9 +1246,32 @@ public class Auth implements Writable {
                 ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedUser, securedUser);
                 GlobalStateMgr.getCurrentState().getEditLog().logRevokeImpersonate(info);
             }
-            LOG.debug("finished to revoke impersonate. is replay: {}", isReplay);
+            LOG.info("revoke impersonate on {} from {}. is replay: {}", securedUser, authorizedUser, isReplay);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private void revokeImpersonateFromRoleInternal(
+            String authorizedRoleName, UserIdentity securedUser, boolean isReplay) throws DdlException {
+        writeLock();
+        try {
+            // revoke privs from role, role must exist
+            Role existingRole = roleManager.revokePrivs(authorizedRoleName, securedUser);
+
+            // revoke privs from users of this role
+            for (UserIdentity user : existingRole.getUsers()) {
+                revokeImpersonateFromUserInternal(user, securedUser, true);
+            }
+
+            if (!isReplay) {
+                ImpersonatePrivInfo info = new ImpersonatePrivInfo(authorizedRoleName, securedUser);
+                GlobalStateMgr.getCurrentState().getEditLog().logRevokeImpersonate(info);
+            }
+            LOG.debug("revoke impersonate on {} from role {}. is replay: {}", securedUser, authorizedRoleName, isReplay);
+
         } finally {
             writeUnlock();
         }
@@ -1791,7 +1901,14 @@ public class Auth implements Writable {
      * newly added metadata entity should deserialize with gson in this method
      **/
     public long readAsGson(DataInput in, long checksum) throws IOException {
-        this.impersonateUserPrivTable = ImpersonateUserPrivTable.read(in);
+        SerializeData data = GsonUtils.GSON.fromJson(Text.readString(in), SerializeData.class);
+        try {
+            this.impersonateUserPrivTable.loadEntries(data.entries);
+            this.roleManager.loadImpersonateRoleToUser(data.impersonateRoleToUser);
+        } catch (AnalysisException e) {
+            LOG.error("failed to readAsGson, ", e);
+            throw new IOException(e.getMessage());
+        }
         checksum ^= this.impersonateUserPrivTable.size();
         return checksum;
     }
@@ -1800,7 +1917,10 @@ public class Auth implements Writable {
      * newly added metadata entity should serialize with gson in this method
      **/
     public long writeAsGson(DataOutput out, long checksum) throws IOException {
-        impersonateUserPrivTable.write(out);
+        SerializeData data = new SerializeData();
+        data.entries = impersonateUserPrivTable.dumpEntries();
+        data.impersonateRoleToUser = roleManager.dumpImpersonateRoleToUser();
+        Text.writeString(out, GsonUtils.GSON.toJson(data));
         checksum ^= impersonateUserPrivTable.size();
         return checksum;
     }
@@ -1829,6 +1949,12 @@ public class Auth implements Writable {
         sb.append(roleManager).append("\n");
         sb.append(propertyMgr).append("\n");
         return sb.toString();
+    }
+    private static class SerializeData {
+        @SerializedName("entries")
+        public List<ImpersonateUserPrivEntry> entries = new ArrayList<>();
+        @SerializedName("impersonateRoleToUser")
+        public Map<String, Set<UserIdentity>> impersonateRoleToUser = new HashMap<>();
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTable.java
@@ -2,15 +2,9 @@
 
 package com.starrocks.mysql.privilege;
 
-import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.io.Text;
-import com.starrocks.persist.gson.GsonUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,8 +15,6 @@ import java.util.List;
  * ImpersonateUserPrivTable saves all impersonate user privileges
  */
 public class ImpersonateUserPrivTable extends PrivTable {
-    private static final Logger LOG = LogManager.getLogger(ImpersonateUserPrivTable.class);
-
     /**
      * Return first priv which match the user@host on securedUser
      * The returned priv will be saved in 'savedPrivs'.
@@ -61,36 +53,29 @@ public class ImpersonateUserPrivTable extends PrivTable {
         return privBitSet.satisfy(PrivPredicate.IMPERSONATE);
     }
 
-    public static ImpersonateUserPrivTable read(DataInput in) throws IOException {
-        ImpersonateUserPrivTable table = new ImpersonateUserPrivTable();
-        SerializeData data = GsonUtils.GSON.fromJson(Text.readString(in), SerializeData.class);
-        for (ImpersonateUserPrivEntry entry : data.entries) {
-            try {
-                entry.analyse();
-            } catch (AnalysisException e) {
-                // TODO This is ugly, somewhere above AnalysisException should be allowed
-                throw new IOException(e);
-            }
+    protected void loadEntries(List<ImpersonateUserPrivEntry> dataEntries) throws AnalysisException {
+        for (ImpersonateUserPrivEntry entry : dataEntries) {
+            entry.analyse();
             UserIdentity newUser = entry.getUserIdent();
-            List<PrivEntry> entries = table.map.computeIfAbsent(newUser, k -> new ArrayList<>());
+            List<PrivEntry> entries = this.map.computeIfAbsent(newUser, k -> new ArrayList<>());
             entries.add(entry);
         }
-        return table;
+    }
+
+    public List<ImpersonateUserPrivEntry> dumpEntries() {
+        List<ImpersonateUserPrivEntry> dataEntries = new ArrayList<>();
+        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
+        while (iter.hasNext()) {
+            ImpersonateUserPrivEntry entry = (ImpersonateUserPrivEntry) iter.next();
+            dataEntries.add(entry);
+        }
+        return dataEntries;
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        SerializeData data = new SerializeData();
-        Iterator<PrivEntry> iter = this.getFullReadOnlyIterator();
-        while (iter.hasNext()) {
-            ImpersonateUserPrivEntry entry = (ImpersonateUserPrivEntry) iter.next();
-            data.entries.add(entry);
-        }
-        Text.writeString(out, GsonUtils.GSON.toJson(data));
+        throw new IOException("not implement");
     }
 
-    private static class SerializeData {
-        @SerializedName("entries")
-        public List<ImpersonateUserPrivEntry> entries = new ArrayList<>();
-    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Role.java
@@ -55,6 +55,9 @@ public class Role implements Writable {
     private String roleName;
     private Map<TablePattern, PrivBitSet> tblPatternToPrivs = Maps.newConcurrentMap();
     private Map<ResourcePattern, PrivBitSet> resourcePatternToPrivs = Maps.newConcurrentMap();
+
+    // newly added in 2.3
+    private Set<UserIdentity> impersonateUsers = Sets.newConcurrentHashSet();
     // users which this role
     private Set<UserIdentity> users = Sets.newConcurrentHashSet();
 
@@ -83,6 +86,11 @@ public class Role implements Writable {
         this.resourcePatternToPrivs.put(resourcePattern, resourcePrivs);
     }
 
+    public Role(String roleName, UserIdentity securedUser) {
+        this.roleName = roleName;
+        this.impersonateUsers.add(securedUser);
+    }
+
     public String getRoleName() {
         return roleName;
     }
@@ -97,6 +105,14 @@ public class Role implements Writable {
 
     public Set<UserIdentity> getUsers() {
         return users;
+    }
+
+    public Set<UserIdentity> getImpersonateUsers() {
+        return impersonateUsers;
+    }
+
+    public void setImpersonateUsers(Set<UserIdentity> impersonateUsers) {
+        this.impersonateUsers = impersonateUsers;
     }
 
     public void merge(Role other) {
@@ -117,6 +133,7 @@ public class Role implements Writable {
                 resourcePatternToPrivs.put(entry.getKey(), entry.getValue());
             }
         }
+        this.impersonateUsers.addAll(other.impersonateUsers);
     }
 
     public void addUser(UserIdentity userIdent) {
@@ -187,6 +204,7 @@ public class Role implements Writable {
         sb.append("role: ").append(roleName).append(", db table privs: ").append(tblPatternToPrivs);
         sb.append(", resource privs: ").append(resourcePatternToPrivs);
         sb.append(", users: ").append(users);
+        sb.append(", impersonate: ").append(impersonateUsers);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -481,6 +481,16 @@ public class EditLog {
                     globalStateMgr.getAuth().replayDropRole(privInfo);
                     break;
                 }
+                case OperationType.OP_GRANT_ROLE: {
+                    PrivInfo privInfo = (PrivInfo) journal.getData();
+                    globalStateMgr.getAuth().replayGrantRole(privInfo);
+                    break;
+                }
+                case OperationType.OP_REVOKE_ROLE: {
+                    PrivInfo privInfo = (PrivInfo) journal.getData();
+                    globalStateMgr.getAuth().replayRevokeRole(privInfo);
+                    break;
+                }
                 case OperationType.OP_UPDATE_USER_PROPERTY: {
                     UserPropertyInfo propertyInfo = (UserPropertyInfo) journal.getData();
                     globalStateMgr.getAuth().replayUpdateUserProperty(propertyInfo);
@@ -1199,6 +1209,14 @@ public class EditLog {
 
     public void logFinishDecommissionBackend(DecommissionBackendJob job) {
         logEdit(OperationType.OP_FINISH_DECOMMISSION_BACKEND, job);
+    }
+
+    public void logGrantRole(PrivInfo info) {
+        logEdit(OperationType.OP_GRANT_ROLE, info);
+    }
+
+    public void logRevokeRole(PrivInfo info) {
+        logEdit(OperationType.OP_REVOKE_ROLE, info);
     }
 
     public void logDatabaseRename(DatabaseInfo databaseInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImpersonatePrivInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImpersonatePrivInfo.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 
 public class ImpersonatePrivInfo implements Writable {
     @SerializedName(value = "authorizedUser")
-    private UserIdentity authorizedUser;
+    private UserIdentity authorizedUser = null;
+    @SerializedName(value = "authorizedRoleName")
+    private String authorizedRoleName = null;
     @SerializedName(value = "securedUser")
     private UserIdentity securedUser;
 
@@ -28,6 +30,13 @@ public class ImpersonatePrivInfo implements Writable {
         this.securedUser = securedUser;
     }
 
+    public ImpersonatePrivInfo(String authorizedRoleName, UserIdentity securedUser) {
+        this.authorizedRoleName = authorizedRoleName;
+        // Just in case of NPE after rolled back. Worst case scenario, it's meaningless to impersonate as oneself.
+        this.authorizedUser = securedUser;
+        this.securedUser = securedUser;
+    }
+
     public UserIdentity getAuthorizedUser() {
         return authorizedUser;
     }
@@ -35,6 +44,11 @@ public class ImpersonatePrivInfo implements Writable {
     public UserIdentity getSecuredUser() {
         return securedUser;
     }
+
+    public String getAuthorizedRoleName() {
+        return authorizedRoleName;
+    }
+
     public static ImpersonatePrivInfo read(DataInput in) throws IOException {
         String json = Text.readString(in);
         return GsonUtils.GSON.fromJson(json, ImpersonatePrivInfo.class);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -218,6 +218,8 @@ public class OperationType {
     // grant & revoke impersonate
     public static final short OP_GRANT_IMPERSONATE = 10062;
     public static final short OP_REVOKE_IMPERSONATE = 10063;
+    public static final short OP_GRANT_ROLE = 10064;
+    public static final short OP_REVOKE_ROLE = 10065;
 
     // task 10071 ~ 10090
     public static final short OP_CREATE_TASK = 10071;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/PrivInfo.java
@@ -78,6 +78,15 @@ public class PrivInfo implements Writable {
         this.role = role;
     }
 
+    public PrivInfo(UserIdentity userIdent, String role) {
+        this.userIdent = userIdent;
+        this.role = role;
+        this.tblPattern = null;
+        this.resourcePattern = null;
+        this.privs = null;
+        this.passwd = null;
+    }
+
     public UserIdentity getUserIdent() {
         return userIdent;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -75,12 +75,19 @@ public class PrivilegeStmtAnalyzer {
 
         /**
          * GRANT IMPERSONATE ON XX TO XX
-         * REVOKE IMPERSONATE ON XX TO XX
+         * GRANT IMPERSONATE ON XX TO ROLE XX
+         * REVOKE IMPERSONATE ON XX FROM XX
+         * REVOKE IMPERSONATE ON XX FROM ROLE XX
          */
         @Override
         public Void visitGrantRevokeImpersonateStatement(BaseGrantRevokeImpersonateStmt stmt, ConnectContext session) {
-            analyseUserAndCheckExist(stmt.getAuthorizedUser(), session);
             analyseUserAndCheckExist(stmt.getSecuredUser(), session);
+            if (stmt.getAuthorizedUser() != null) {
+                analyseUserAndCheckExist(stmt.getAuthorizedUser(), session);
+            } else {
+                String qulifiedRole = analyseRoleName(stmt.getAuthorizedRoleName(), session);
+                stmt.setAuthorizedRoleName(qulifiedRole);
+            }
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokeImpersonateStmt.java
@@ -8,16 +8,32 @@ import com.starrocks.analysis.UserIdentity;
 // GrantImpersonateStmt and RevokeImpersonateStmt share the same parameter and check logic
 public abstract class BaseGrantRevokeImpersonateStmt extends DdlStmt {
     protected UserIdentity authorizedUser;
+    protected String authorizedRoleName;
     protected UserIdentity securedUser;
     private String operationName;   // GRANT or REVOKE
     private String prepositionName; // TO or FROM
 
+    // GRANT IMPERSONATE ON securedUser To authorizedUser
     public BaseGrantRevokeImpersonateStmt(
             UserIdentity authorizedUser,
             UserIdentity securedUser,
             String operationName,
             String prepositionName) {
         this.authorizedUser = authorizedUser;
+        this.authorizedRoleName = null;
+        this.securedUser = securedUser;
+        this.operationName = operationName;
+        this.prepositionName = prepositionName;
+    }
+
+    // GRANT IMPERSONATE ON securedUser To ROLE authorizedRoleName
+    public BaseGrantRevokeImpersonateStmt(
+            String authorizedRoleName,
+            UserIdentity securedUser,
+            String operationName,
+            String prepositionName) {
+        this.authorizedUser = null;
+        this.authorizedRoleName = authorizedRoleName;
         this.securedUser = securedUser;
         this.operationName = operationName;
         this.prepositionName = prepositionName;
@@ -27,14 +43,23 @@ public abstract class BaseGrantRevokeImpersonateStmt extends DdlStmt {
         return authorizedUser;
     }
 
+    public String getAuthorizedRoleName() {
+        return authorizedRoleName;
+    }
+
     public UserIdentity getSecuredUser() {
         return securedUser;
     }
 
+    public void setAuthorizedRoleName(String authorizedRoleName) {
+        this.authorizedRoleName = authorizedRoleName;
+    }
+
     @Override
     public String toString() {
+        String authorizedEntity = authorizedUser == null ? "ROLE '" + authorizedRoleName + "'" : authorizedUser.toString();
         return String.format("%s IMPERSONATE ON %s %s %s",
-                operationName, securedUser.toString(), prepositionName, authorizedUser.toString());
+                operationName, securedUser.toString(), prepositionName, authorizedEntity);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GrantImpersonateStmt.java
@@ -11,4 +11,8 @@ public class GrantImpersonateStmt extends BaseGrantRevokeImpersonateStmt {
     public GrantImpersonateStmt(UserIdentity authorizedUser, UserIdentity securedUser) {
         super(authorizedUser, securedUser, "GRANT", "TO");
     }
+
+    public GrantImpersonateStmt(String authorizedRoleName, UserIdentity securedUser) {
+        super(authorizedRoleName, securedUser, "GRANT", "TO");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeImpersonateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RevokeImpersonateStmt.java
@@ -11,4 +11,8 @@ public class RevokeImpersonateStmt extends BaseGrantRevokeImpersonateStmt {
     public RevokeImpersonateStmt(UserIdentity authorizedUser, UserIdentity securedUser) {
         super(authorizedUser, securedUser, "REVOKE", "FROM");
     }
+
+    public RevokeImpersonateStmt(String authorizedRoleName, UserIdentity securedUser) {
+        super(authorizedRoleName, securedUser, "REVOKE", "FROM");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1633,15 +1633,25 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitGrantImpersonate(StarRocksParser.GrantImpersonateContext context) {
         UserIdentity securedUser = ((UserIdentifier) visit(context.user(0))).getUserIdentity();
-        UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
-        return new GrantImpersonateStmt(authorizedUser, securedUser);
+        if (context.user(1) != null) {
+            UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
+            return new GrantImpersonateStmt(authorizedUser, securedUser);
+        } else {
+            String roleName = ((Identifier) visit(context.identifierOrString())).getValue();
+            return new GrantImpersonateStmt(roleName, securedUser);
+        }
     }
 
     @Override
     public ParseNode visitRevokeImpersonate(StarRocksParser.RevokeImpersonateContext context) {
         UserIdentity securedUser = ((UserIdentifier) visit(context.user(0))).getUserIdentity();
-        UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
-        return new RevokeImpersonateStmt(authorizedUser, securedUser);
+        if (context.user(1) != null) {
+            UserIdentity authorizedUser = ((UserIdentifier) visit(context.user(1))).getUserIdentity();
+            return new RevokeImpersonateStmt(authorizedUser, securedUser);
+        } else {
+            String roleName = ((Identifier) visit(context.identifierOrString())).getValue();
+            return new RevokeImpersonateStmt(roleName, securedUser);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -76,9 +76,9 @@ statement
 
     // privilege
     | GRANT identifierOrString TO user                                                      #grantRole
-    | GRANT IMPERSONATE ON user TO user                                                     #grantImpersonate
+    | GRANT IMPERSONATE ON user TO ( user | ROLE identifierOrString )                       #grantImpersonate
     | REVOKE identifierOrString FROM user                                                   #revokeRole
-    | REVOKE IMPERSONATE ON user FROM user                                                  #revokeImpersonate
+    | REVOKE IMPERSONATE ON user FROM ( user | ROLE identifierOrString )                    #revokeImpersonate
     | EXECUTE AS user (WITH NO REVERT)?                                                     #executeAs
     | showAuthenticationStatement                                                           #showAuthentication
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/ImpersonateUserPrivTableTest.java
@@ -14,6 +14,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.List;
 
 public class ImpersonateUserPrivTableTest {
     private static final Logger LOG = LogManager.getLogger(ImpersonateUserPrivTableTest.class);
@@ -36,16 +37,12 @@ public class ImpersonateUserPrivTableTest {
         Assert.assertEquals(1, table.size());
         LOG.info("current table: {}", table);
 
-        // 1.2 dump to file
-        File tempFile = File.createTempFile("ImpersonateUserPrivTableTest", ".image");
-        LOG.info("dump to file {}", tempFile.getAbsolutePath());
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(tempFile));
-        table.write(dos);
-        dos.close();
+        // 1.2 dump to entries
+        List<ImpersonateUserPrivEntry> entries = table.dumpEntries();
 
-        // 1.3 load from file
-        DataInputStream dis = new DataInputStream(new FileInputStream(tempFile));
-        ImpersonateUserPrivTable loadTable = ImpersonateUserPrivTable.read(dis);
+        // 1.3 load from entries
+        ImpersonateUserPrivTable loadTable = new ImpersonateUserPrivTable();
+        loadTable.loadEntries(entries);
         LOG.info("load table: {}", loadTable);
 
         // 1.4 check & cleanup
@@ -54,7 +51,6 @@ public class ImpersonateUserPrivTableTest {
         loadTable.getPrivs(harry, gregory, privBitSet);
         Assert.assertTrue(privBitSet.satisfy(ONLY_IMPERSONATE));
         Assert.assertTrue(loadTable.canImpersonate(harry, gregory));
-        tempFile.delete();
 
         // 2. grant impersonate on Albert to Harry
         // 2.1 grant
@@ -63,16 +59,12 @@ public class ImpersonateUserPrivTableTest {
         table.addEntry(entry, true, false);
         LOG.info("current table: {}", table);
 
-        // 2.2. dump to file
-        tempFile = File.createTempFile("ImpersonateUserPrivTableTest", ".image");
-        LOG.info("dump to file {}", tempFile.getAbsolutePath());
-        dos = new DataOutputStream(new FileOutputStream(tempFile));
-        table.write(dos);
-        dos.close();
+        // 2.2. dump to entries
+        entries = table.dumpEntries();
 
-        // 2.3 load from file
-        dis = new DataInputStream(new FileInputStream(tempFile));
-        loadTable = ImpersonateUserPrivTable.read(dis);
+        // 2.3 load from entries
+        loadTable = new ImpersonateUserPrivTable();
+        loadTable.loadEntries(entries);
         LOG.info("load table: {}", loadTable);
 
         // 2.4 check & cleanup
@@ -85,7 +77,6 @@ public class ImpersonateUserPrivTableTest {
         loadTable.getPrivs(harry, albert, privBitSet);
         Assert.assertTrue(privBitSet.satisfy(ONLY_IMPERSONATE));
         Assert.assertTrue(loadTable.canImpersonate(harry, albert));
-        tempFile.delete();
 
         // 3. grant impersonate on Vincent to Ron
         // 3.1 grant
@@ -95,16 +86,12 @@ public class ImpersonateUserPrivTableTest {
         table.addEntry(entry, true, false);
         LOG.info("current table: {}", table);
 
-        // 3.2 dump to file
-        tempFile = File.createTempFile("ImpersonateUserPrivTableTest", ".image");
-        LOG.info("dump to file {}", tempFile.getAbsolutePath());
-        dos = new DataOutputStream(new FileOutputStream(tempFile));
-        table.write(dos);
-        dos.close();
+        // 3.2. dump to entries
+        entries = table.dumpEntries();
 
-        // 3.3 load from file
-        dis = new DataInputStream(new FileInputStream(tempFile));
-        loadTable = ImpersonateUserPrivTable.read(dis);
+        // 3.3 load from entries
+        loadTable = new ImpersonateUserPrivTable();
+        loadTable.loadEntries(entries);
         LOG.info("load table: {}", loadTable);
 
         // 3.4 check & cleanup
@@ -121,6 +108,5 @@ public class ImpersonateUserPrivTableTest {
         loadTable.getPrivs(ron, vincent, privBitSet);
         Assert.assertTrue(privBitSet.satisfy(ONLY_IMPERSONATE));
         Assert.assertTrue(loadTable.canImpersonate(ron, vincent));
-        tempFile.delete();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ImpersonatePrivInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ImpersonatePrivInfoTest.java
@@ -2,6 +2,8 @@
 
 package com.starrocks.persist;
 
+import com.starrocks.analysis.CreateRoleStmt;
+import com.starrocks.analysis.CreateUserStmt;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.system.SystemInfoService;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -41,6 +41,10 @@ public class GrantRevokeImpersonateStmtTest {
                 auth.getUserPrivTable();
                 minTimes = 0;
                 result = userPrivTable;
+
+                auth.doesRoleExist((String) any);
+                minTimes = 0;
+                result = true;
             }
         };
 
@@ -74,12 +78,24 @@ public class GrantRevokeImpersonateStmtTest {
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("GRANT IMPERSONATE ON 'test_cluster:user2'@'%' TO 'test_cluster:user1'@'%'", stmt.toString());
 
+        stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "grant IMPERSONATE on user2 to ROLE role1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.assertEquals("GRANT IMPERSONATE ON 'test_cluster:user2'@'%' TO ROLE 'test_cluster:role1'", stmt.toString());
+
         // revoke
         RevokeImpersonateStmt stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "revoke IMPERSONATE on user2 from user1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
-        Assert.assertEquals("REVOKE IMPERSONATE ON 'test_cluster:user2'@'%' FROM 'test_cluster:user1'@'%'", stmt2.toString());
-     }
+        Assert.assertEquals("REVOKE IMPERSONATE ON 'test_cluster:user2'@'%' FROM 'test_cluster:user1'@'%'",
+                stmt2.toString());
+
+        stmt2 = (RevokeImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "revoke IMPERSONATE on user2 from ROLE role1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt2, ctx);
+        Assert.assertEquals("REVOKE IMPERSONATE ON 'test_cluster:user2'@'%' FROM ROLE 'test_cluster:role1'",
+                stmt2.toString());
+    }
 
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
@@ -93,6 +109,29 @@ public class GrantRevokeImpersonateStmtTest {
         };
         GrantImpersonateStmt stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
                 "grant IMPERSONATE on user2 to user1", 1).get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void testRoleNotExist() throws Exception {
+        // suppose current user doesn't exist, check for exception
+        new Expectations(userPrivTable) {
+            {
+                userPrivTable.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = true;
+            }
+        };
+        new Expectations(auth) {
+            {
+                auth.doesRoleExist((String) any);
+                minTimes = 0;
+                result = false;
+            }
+        };
+        GrantImpersonateStmt stmt = (GrantImpersonateStmt) com.starrocks.sql.parser.SqlParser.parse(
+                "grant IMPERSONATE on user2 to Role role1", 1).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.fail("No exception throws.");
     }


### PR DESCRIPTION
1. Support `GRANT IMPERSONATE ON user TO ROLE role` and `REVOKE IMPERSONATE ON user FROM ROLE role`.
Since the role model will be refactored later, I'm simply restoring impersonate privileges of a role in a simple Set.
2. Persist the relationship between role and user after `GRANT role To user`. The previous implementation will lose this metadata.

Fixes #10513
Fixes #10691

manully cherry-picked from 4d7266f883d6606b923a722a12630db0d3b9a1aa