### PR TITLE
[BugFix] Fix Hive column statistics of decimal type not compute Min/Max value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
@@ -3,6 +3,7 @@
 package com.starrocks.external.hive;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
@@ -13,6 +14,7 @@ import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -210,6 +212,14 @@ public class HiveColumnStats {
                     DecimalColumnStatsData decimalStats = statsData.getDecimalStats();
                     numNulls = decimalStats.getNumNulls();
                     numDistinctValues = decimalStats.getNumDVs();
+                    if (decimalStats.isSetHighValue()) {
+                        maxValue = HiveDecimal.create(new BigInteger(decimalStats.getHighValue().getUnscaled()),
+                                decimalStats.getHighValue().getScale()).doubleValue();
+                    }
+                    if (decimalStats.isSetLowValue()) {
+                        minValue = HiveDecimal.create(new BigInteger(decimalStats.getLowValue().getUnscaled()),
+                                decimalStats.getLowValue().getScale()).doubleValue();
+                    }
                 }
                 break;
             default:


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
