### PR TITLE
[Cherry-pick 2.4][Enhancement] Allow skip bad journal when replay (#10372)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1676,4 +1676,12 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;
+
+    /**
+     * Normally FE will quit when replaying a bad journal. This configuration provides a bypass mechanism.
+     * If this was set to a positive value, FE will skip the corresponding bad journals before it quits.
+     * e.g 495501,495503
+     */
+    @ConfField(mutable = true)
+    public static String metadata_journal_skip_bad_journal_ids = "";
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalCursor.java
@@ -33,4 +33,7 @@ public interface JournalCursor {
     public void refresh() throws InterruptedException, JournalException, JournalInconsistentException;
 
     public void close();
+
+    // skip current log
+    public void skipNext();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -321,4 +321,10 @@ public class BDBJournalCursor implements JournalCursor {
             database.close();
         }
     }
+
+    @Override
+    public void skipNext() {
+        LOG.error("!!! DANGER: CURSOR SKIP {} !!!", nextKey);
+        nextKey++;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
@@ -134,6 +134,9 @@ public class MockJournal implements Journal {
         @Override
         public void close() {
         }
+
+        @Override
+        public void skipNext() {}
     }
 
     public static class MockProtocol implements HAProtocol {


### PR DESCRIPTION
Add config `metadata_journal_skip_bad_journal_ids` to skip bad journals when replaying.
This can be used for handling metadata bugs.

manually cherry-picked from 74438d22ecc8e9c5aba2dd88be0f8ff79d623887