### PR TITLE
[BugFix] Fix semi join with limit reorder error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -324,7 +324,8 @@ public abstract class JoinOrder {
 
         Operator.Builder builder = OperatorBuilderFactory.build(exprInfo.expr.getOp());
         exprInfo.expr = OptExpression.create(
-                builder.withOperator(exprInfo.expr.getOp()).setProjection(new Projection(resultMap)).build(),
+                builder.withOperator(exprInfo.expr.getOp()).setLimit(Operator.DEFAULT_LIMIT)
+                        .setProjection(new Projection(resultMap)).build(),
                 exprInfo.expr.getInputs());
         exprInfo.expr.deriveLogicalPropertyItself();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
@@ -25,7 +25,7 @@ public class MultiJoinNode {
     // other operator like a group by or a full outer join.
     private final LinkedHashSet<OptExpression> atoms;
     private final List<ScalarOperator> predicates;
-    private Map<ColumnRefOperator, ScalarOperator> expressionMap;
+    private final Map<ColumnRefOperator, ScalarOperator> expressionMap;
 
     public MultiJoinNode(LinkedHashSet<OptExpression> atoms, List<ScalarOperator> predicates,
                          Map<ColumnRefOperator, ScalarOperator> expressionMap) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -26,10 +26,15 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
+/*
  * JoinReorder Rule for Semi/Anti and other JoinNode
- * <p>
  * Semi(Join(X, Y), Z) => Join(Semi(X, Z), Y)
+ *
+ *       Semi-Join                 Join
+ *       /       \               /      \
+ *     Join       Z  ===>    Semi-Join   Y
+ *    /    \                 /       \
+ *   X      Y               X        Z
  */
 public class SemiReorderRule extends TransformationRule {
     public SemiReorderRule() {
@@ -52,7 +57,7 @@ public class SemiReorderRule extends TransformationRule {
             return false;
         }
 
-        if (bottomJoin.getJoinType().isOuterJoin()) {
+        if (bottomJoin.getJoinType().isOuterJoin() || bottomJoin.hasLimit()) {
             return false;
         }
 
@@ -62,11 +67,7 @@ public class SemiReorderRule extends TransformationRule {
         usedInRewriteSemiJoin.union(input.inputAt(0).inputAt(0).getOutputColumns());
         usedInRewriteSemiJoin.union(input.inputAt(1).getOutputColumns());
 
-        if (!usedInRewriteSemiJoin.containsAll(topJoin.getOnPredicate().getUsedColumns())) {
-            return false;
-        }
-
-        return true;
+        return usedInRewriteSemiJoin.containsAll(topJoin.getOnPredicate().getUsedColumns());
     }
 
     @Override
@@ -78,6 +79,7 @@ public class SemiReorderRule extends TransformationRule {
 
         LogicalJoinOperator newTopJoin = new LogicalJoinOperator.Builder().withOperator(leftChildJoin)
                 .setProjection(topJoin.getProjection())
+                .setLimit(topJoin.getLimit())
                 .build();
 
         ColumnRefSet leftChildInputColumns = new ColumnRefSet();
@@ -142,10 +144,12 @@ public class SemiReorderRule extends TransformationRule {
         // build new semi join projection
         if (semiExpression.isEmpty()) {
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
+                    .setLimit(Operator.DEFAULT_LIMIT)
                     .setProjection(new Projection(projectMap)).build();
         } else {
             semiExpression.putAll(projectMap);
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
+                    .setLimit(Operator.DEFAULT_LIMIT)
                     .setProjection(new Projection(semiExpression)).build();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -434,8 +434,9 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testShuffleBucketShuffle() throws Exception {
         FeConstants.runningUnitTest = true;
-        String sql = "select a.v1, a.v4 from (select v1, v2, v4 from t0 join[shuffle] t1 on t0.v1 = t1.v4) a join[shuffle] " +
-                "(select v7,v8, v10 from t2 join[shuffle] t3 on t2.v7 = t3.v10) b on a.v1 = b.v7 and a.v2 = b.v8";
+        String sql =
+                "select a.v1, a.v4 from (select v1, v2, v4 from t0 join[shuffle] t1 on t0.v1 = t1.v4) a join[shuffle] " +
+                        "(select v7,v8, v10 from t2 join[shuffle] t3 on t2.v7 = t3.v10) b on a.v1 = b.v7 and a.v2 = b.v8";
         String plan = getFragmentPlan(sql);
         assertContains(plan, " 11:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
@@ -914,8 +915,8 @@ public class JoinTest extends PlanTestBase {
 
         sql = "select a.v1, a.v4, b.v7, b.v10 " +
                 "from (select v1, v2, v4 from t0 join[shuffle] t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5) a join[shuffle] " +
-                        "(select v7, v8, v10 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
-                        "on a.v2 = b.v8 and a.v1 = b.v7";
+                "(select v7, v8, v10 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
+                "on a.v2 = b.v8 and a.v1 = b.v7";
         plan = getFragmentPlan(sql);
         assertContains(plan, "12:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
@@ -938,8 +939,8 @@ public class JoinTest extends PlanTestBase {
         // check can not adjust column orders
         sql = "select a.v1, a.v4, b.v7, b.v10 from " +
                 "(select v1, v2, v4, v5 from t0 join[shuffle] t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5) a join[shuffle] " +
-                        "(select v7, v8, v10, v11 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
-                        "on a.v2 = b.v8 and a.v4 = b.v8";
+                "(select v7, v8, v10, v11 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
+                "on a.v2 = b.v8 and a.v4 = b.v8";
         plan = getFragmentPlan(sql);
         assertContains(plan, "14:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
@@ -961,8 +962,8 @@ public class JoinTest extends PlanTestBase {
         // check can not adjust column orders
         sql = "select a.v1, a.v4, b.v7, b.v10 " +
                 "from (select v1, v2, v4, v5 from t0 join[shuffle] t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5) a join[shuffle] " +
-                        "(select v7, v8, v10, v11 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
-                        "on a.v2 = b.v8 and a.v4 = b.v10";
+                "(select v7, v8, v10, v11 from t2 join[shuffle] t3 on t2.v7 = t3.v10 and t2.v8 = t3.v11) b " +
+                "on a.v2 = b.v8 and a.v4 = b.v10";
         plan = getFragmentPlan(sql);
         assertContains(plan, "14:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
@@ -1704,7 +1705,7 @@ public class JoinTest extends PlanTestBase {
     public void testJoinConst() throws Exception {
         String sql = "with user_info as (select 2 as user_id, 'mike' as user_name), " +
                 "address as (select 1 as user_id, 'newzland' as address_name) \n" +
-                        "select * from address a right join user_info b on b.user_id=a.user_id;";
+                "select * from address a right join user_info b on b.user_id=a.user_id;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  6:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
@@ -2458,7 +2459,7 @@ public class JoinTest extends PlanTestBase {
         {
             String sql = "select * from ( select * from colocate_t0 " +
                     "join[colocate] colocate_t1 on colocate_t0.v1 = colocate_t1.v4 ) s1 " +
-                            "join[bucket] colocate_t2 on s1.v4 = colocate_t2.v7";
+                    "join[bucket] colocate_t2 on s1.v4 = colocate_t2.v7";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
                     "  |  colocate: false, reason: \n" +
@@ -2467,9 +2468,9 @@ public class JoinTest extends PlanTestBase {
         {
             String sql = "select * from ( select * from colocate_t0 " +
                     "join[colocate] colocate_t1 on colocate_t0.v1 = colocate_t1.v4 ) s1, " +
-                            "( select * from colocate_t2 join[colocate] colocate_t3 " +
+                    "( select * from colocate_t2 join[colocate] colocate_t3 " +
                     "on colocate_t2.v7 = colocate_t3.v10 ) s2 " +
-                            "where s1.v4 = s2.v10";
+                    "where s1.v4 = s2.v10";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1301,4 +1301,25 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     rollup: agg_mv\n" +
                 "     tabletRatio=1050/1050");
     }
+
+    @Test
+    public void testLimitSemiJoin() throws Exception {
+        String sql = "select * from t0 " +
+                "        left semi join t2 on t0.v1 = t2.v7 " +
+                "        left semi join t1 on t0.v1 = t1.v4 " +
+                "limit 25;";
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan, "  7:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 7: v4\n" +
+                "  |  limit: 25");
+        assertContains(plan, "  3:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v7\n" +
+                "  |  \n" +
+                "  |----2:EXCHANGE");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10326

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The reason is Top-Semi Join has limit, and the limit is transf to the child node follow the transform process

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
