### PR TITLE
[BugFix] BE crashed on invalid JSON input with jsonpath

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -525,7 +525,7 @@ Status JsonReader::_construct_row_in_object_order(simdjson::ondemand::object* ro
         if (col_name == "__op") {
             // special treatment for __op column, fill default value '0' rather than null
             if (column->is_binary()) {
-                column->append_strings(std::vector{Slice{"0"}});
+                std::ignore = column->append_strings(std::vector{Slice{"0"}});
             } else {
                 column->append_datum(Datum((uint8_t)0));
             }
@@ -554,7 +554,7 @@ Status JsonReader::_construct_row_in_slot_order(simdjson::ondemand::object* row,
             if (col_name == "__op") {
                 // special treatment for __op column, fill default value '0' rather than null
                 if (column->is_binary()) {
-                    column->append_strings(std::vector{Slice{"0"}});
+                    std::ignore = column->append_strings(std::vector{Slice{"0"}});
                 } else {
                     column->append_datum(Datum((uint8_t)0));
                 }

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -118,16 +118,16 @@ Status JsonFunctions::json_path_close(starrocks_udf::FunctionContext* context,
 
 Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const std::vector<SimpleJsonPath>& jsonpath,
                                           simdjson::ondemand::value* value) noexcept {
-#define HANDLE_SIMDJSON_ERROR(err, msg)                                                                           \
-    do {                                                                                                          \
-        const simdjson::error_code& _err = err;                                                                   \
-        const std::string& _msg = msg;                                                                            \
+#define HANDLE_SIMDJSON_ERROR(err, msg)                                                                            \
+    do {                                                                                                           \
+        const simdjson::error_code& _err = err;                                                                    \
+        const std::string& _msg = msg;                                                                             \
         if (UNLIKELY(_err)) {                                                                                      \
-            if (_err == simdjson::NO_SUCH_FIELD || _err == simdjson::INDEX_OUT_OF_BOUNDS) {                       \
-                return Status::NotFound(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg));     \
-            }                                                                                                     \
-            return Status::DataQualityError(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg)); \
-        }                                                                                                         \
+            if (_err == simdjson::NO_SUCH_FIELD || _err == simdjson::INDEX_OUT_OF_BOUNDS) {                        \
+                return Status::NotFound(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), _msg));     \
+            }                                                                                                      \
+            return Status::DataQualityError(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), _msg)); \
+        }                                                                                                          \
     } while (false);
 
     if (jsonpath.size() <= 1) {

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -118,15 +118,16 @@ Status JsonFunctions::json_path_close(starrocks_udf::FunctionContext* context,
 
 Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const std::vector<SimpleJsonPath>& jsonpath,
                                           simdjson::ondemand::value* value) noexcept {
-#define HANDLE_SIMDJSON_ERROR(err, msg)                                                                       \
-    do {                                                                                                      \
-        if (UNLIKELY(err)) break;                                                                             \
-        const simdjson::error_code& _err = err;                                                               \
-        const std::string& _msg = msg;                                                                        \
-        if (_err == simdjson::NO_SUCH_FIELD) {                                                                \
-            return Status::NotFound(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg));     \
-        }                                                                                                     \
-        return Status::DataQualityError(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg)); \
+#define HANDLE_SIMDJSON_ERROR(err, msg)                                                                           \
+    do {                                                                                                          \
+        const simdjson::error_code& _err = err;                                                                   \
+        const std::string& _msg = msg;                                                                            \
+        if (UNLIKELY(err)) {                                                                                      \
+            if (_err == simdjson::NO_SUCH_FIELD) {                                                                \
+                return Status::NotFound(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg));     \
+            }                                                                                                     \
+            return Status::DataQualityError(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg)); \
+        }                                                                                                         \
     } while (false);
 
     if (jsonpath.size() <= 1) {

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -149,6 +149,7 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
 
         // Since the simdjson::ondemand::object cannot be converted to simdjson::ondemand::value,
         // we have to do some special treatment for the second elem of json path.
+        // If the key is not found in json object, simdjson::NO_SUCH_FIELD would be returned.
         if (i == 1) {
             HANDLE_SIMDJSON_ERROR(obj.find_field_unordered(col).get(tvalue),
                                   fmt::format("unable to find field: {}", col));
@@ -159,6 +160,7 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
 
         if (index != -1) {
             // try to access tvalue as array.
+            // If the index is beyond the length of array, simdjson::INDEX_OUT_OF_BOUNDS would be returned.
             simdjson::ondemand::array arr;
             HANDLE_SIMDJSON_ERROR(tvalue.get_array().get(arr),
                                   fmt::format("failed to access field as array, field: {}", col));

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -122,8 +122,8 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
     do {                                                                                                          \
         const simdjson::error_code& _err = err;                                                                   \
         const std::string& _msg = msg;                                                                            \
-        if (UNLIKELY(err)) {                                                                                      \
-            if (_err == simdjson::NO_SUCH_FIELD) {                                                                \
+        if (UNLIKELY(_err)) {                                                                                      \
+            if (_err == simdjson::NO_SUCH_FIELD || _err == simdjson::INDEX_OUT_OF_BOUNDS) {                       \
                 return Status::NotFound(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg));     \
             }                                                                                                     \
             return Status::DataQualityError(fmt::format("err: {}, msg: {}", simdjson::error_message(_err), msg)); \
@@ -162,14 +162,6 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
             simdjson::ondemand::array arr;
             HANDLE_SIMDJSON_ERROR(tvalue.get_array().get(arr),
                                   fmt::format("failed to access field as array, field: {}", col));
-
-            size_t sz;
-            HANDLE_SIMDJSON_ERROR(arr.count_elements().get(sz), fmt::format("failed to get array size, field: ", col));
-
-            if (index >= sz) {
-                return Status::NotFound(
-                        fmt::format("index beyond array size, field: {}, index: {}, array size: {}", col, index, sz));
-            }
 
             HANDLE_SIMDJSON_ERROR(arr.at(index).get(tvalue),
                                   fmt::format("failed to access array field: {}, index: {}", col, index));

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -979,4 +979,31 @@ TEST_F(JsonScannerTest, test_illegal_input) {
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
 }
 
+TEST_F(JsonScannerTest, test_illegal_input_with_jsonpath) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TYPE_INT);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = false;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = "[\"$.f_float\", \"$.f_bool\", \"$.f_int\", \"$.f_float_in_string\", \"$.f_int_in_string\"]";
+    range.__isset.json_root = false;
+    range.__set_path("./be/test/exec/test_data/json_scanner/illegal.json");
+    ranges.emplace_back(range);
+
+    auto scanner =
+            create_json_scanner(types, ranges, {"f_float", "f_bool", "f_int", "f_float_in_string", "f_int_in_string"});
+
+    ASSERT_OK(scanner->open());
+    ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
+}
+
+
 } // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -771,6 +771,9 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STATUS(Status::NotFound(""),
                   test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output));
 
+    EXPECT_STATUS(Status::NotFound(""),
+                  test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[3].key", &output));
+
     EXPECT_STATUS(Status::DataQualityError(""), test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
 }
 

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -770,6 +770,8 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
 
     EXPECT_STATUS(Status::NotFound(""),
                   test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output));
+
+    EXPECT_STATUS(Status::DataQualityError(""), test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
 }
 
 class JsonLengthTestFixture : public ::testing::TestWithParam<std::tuple<std::string, std::string, int>> {};


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/10804

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The JSONReader does not return an error when the input is invalid JSON and with jsonpath, leading to the BE crash. 
This PR divides the return error of `JsonFunctions::extract_from_object` as 2 types:
1. NotFound: The key is not found. 
2. DataQualityError: the input is invalid.
When `JsonFunctions::extract_from_object` returns NotFound, the next key will continue to be looked up in the object. When the DataQualityError is returned, the input is valid, and the JSONReader returns the error directly.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
