### PR TITLE
[Bugfix] Key columns cannot be pruned in the non-skip-aggr scan stage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -247,6 +247,14 @@ public class PlanFragmentBuilder {
             if (!ConnectContext.get().getSessionVariable().isAbleFilterUnusedColumnsInScanStage()) {
                 return;
             }
+
+            // Key columns and value columns cannot be pruned in the non-skip-aggr scan stage.
+            // - All the keys columns must be retained to merge and aggregate rows.
+            // - Value columns can only be used after merging and aggregating.
+            if (referenceTable.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
+                return;
+            }
+
             List<ColumnRefOperator> outputColumns = node.getOutputColumns();
             // if outputColumns is empty, skip this optimization
             if (outputColumns.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -99,10 +99,33 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test
     public void testFilterAggTable() throws Exception {
-        String sql = "select timestamp\n" +
-                "               from metrics_detail where value is NULL limit 10;";
-        String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        boolean prevEnable = connectContext.getSessionVariable().isAbleFilterUnusedColumnsInScanStage();
+
+        try {
+            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
+
+            // Key columns cannot be pruned in the non-skip-aggr scan stage.
+            String sql = "select timestamp from metrics_detail where tags_id > 1";
+            String plan = getThriftPlan(sql);
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+
+            sql = "select max(value) from metrics_detail where tags_id > 1";
+            plan = getThriftPlan(sql);
+            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+
+            // Key columns can be pruned in the skip-aggr scan stage.
+            sql = "select sum(value) from metrics_detail where tags_id > 1";
+            plan = getThriftPlan(sql);
+            Assert.assertTrue(plan.contains("unused_output_column_name:[tags_id]"));
+
+            // Value columns cannot be pruned in the non-skip-aggr scan stage.
+            sql = "select timestamp from metrics_detail where value is NULL limit 10;";
+            plan = getThriftPlan(sql);
+            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        } finally {
+            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(prevEnable);
+        }
     }
 
     @Test
@@ -126,32 +149,5 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         sql = "select t1a from test_all_type where t1f in (1.0, 2.0)";
         plan = getThriftPlan(sql);
         Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
-    }
-
-    @Test
-    public void testFilterAggregateKeyColumn() throws Exception {
-        boolean prevEnable = connectContext.getSessionVariable().isAbleFilterUnusedColumnsInScanStage();
-
-        try {
-            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
-
-            // Key columns cannot be pruned in the non-skip-aggr scan stage.
-            String sql = "select timestamp from metrics_detail where tags_id > 1";
-            String plan = getThriftPlan(sql);
-            System.out.println(plan);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
-
-            // Key columns can be pruned in the skip-aggr scan stage.
-            sql = "select sum(value) from metrics_detail where tags_id > 1";
-            plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[tags_id]"));
-
-            // Vlue columns cannot be pruned in the non-skip-aggr scan stage.
-            sql = "select max(value) from metrics_detail where tags_id > 1";
-            plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
-        } finally {
-            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(prevEnable);
-        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10814.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Key columns cannot be pruned in the non-skip-aggr scan stage, because they must be retained in `SegmentIterator`, `MergeIterator`, and `AggregateIterator` to  merge and aggregate rows.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
