### PR TITLE
[Enhancement] Split skip-aggr AGG table physically not logically

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -411,8 +411,8 @@ StatusOr<bool> OlapScanNode::_could_split_tablet_physically(const std::vector<TS
     ASSIGN_OR_RETURN(TabletSharedPtr first_tablet, get_tablet(&(scan_ranges[0].scan_range.internal_scan_range)));
     KeysType keys_type = first_tablet->tablet_schema().keys_type();
     const auto skip_aggr = thrift_olap_scan_node().is_preaggregation;
-    bool is_keys_type_matched =
-            keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS || (keys_type == UNIQUE_KEYS && skip_aggr);
+    bool is_keys_type_matched = keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS ||
+                                ((keys_type == UNIQUE_KEYS || keys_type == AGG_KEYS) && skip_aggr);
     return is_keys_type_matched;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Although there is a `AggregateIterator` in the scan stage for skip-agg AGG table, it can be also split physically to avoid reading short key columns from disk, because this `AggregateIterator` is just to reduce the number of returning rows, not to aggregate all the versions of the same key to one row.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
