### PR TITLE
[BugFix] ignore flush pool in txn_manager for CN

### DIFF
--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -50,12 +50,15 @@ TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, int32
     _txn_map_locks = std::unique_ptr<std::shared_mutex[]>(new std::shared_mutex[_txn_map_shard_size]);
     _txn_tablet_maps = std::unique_ptr<txn_tablet_map_t[]>(new txn_tablet_map_t[_txn_map_shard_size]);
     _txn_partition_maps = std::unique_ptr<txn_partition_map_t[]>(new txn_partition_map_t[_txn_map_shard_size]);
-    auto st = ThreadPoolBuilder("meta-flush")
-                      .set_min_threads(1)
-                      .set_max_threads(store_num * 2)
-                      .set_idle_timeout(MonoDelta::FromSeconds(30))
-                      .build(&_flush_thread_pool);
-    CHECK(st.ok());
+    // we will get "store_num = 0" if it acts as cn, just ignore flush pool
+    if (store_num > 0) {
+        auto st = ThreadPoolBuilder("meta-flush")
+                          .set_min_threads(1)
+                          .set_max_threads(store_num * 2)
+                          .set_idle_timeout(MonoDelta::FromSeconds(30))
+                          .build(&_flush_thread_pool);
+        CHECK(st.ok());
+    }
 }
 
 Status TxnManager::prepare_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -272,7 +272,7 @@ Status TxnManager::persist_tablet_related_txns(const std::vector<TabletSharedPtr
     int i = 0;
     for (auto& tablet : to_flush_tablet) {
         auto dir = tablet->data_dir();
-        token->submit_func([&pair_vec, dir, i]() { pair_vec[i].first = std::move(dir->get_meta()->flush()); });
+        token->submit_func([&pair_vec, dir, i]() { pair_vec[i].first = dir->get_meta()->flush(); });
         pair_vec[i].second = tablet->tablet_id();
         i++;
     }
@@ -299,7 +299,7 @@ void TxnManager::flush_dirs(std::unordered_set<DataDir*>& affected_dirs) {
     std::vector<std::pair<Status, std::string>> pair_vec(affected_dirs.size());
     auto token = _flush_thread_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     for (auto dir : affected_dirs) {
-        token->submit_func([&pair_vec, dir, i]() { pair_vec[i].first = std::move(dir->get_meta()->flush()); });
+        token->submit_func([&pair_vec, dir, i]() { pair_vec[i].first = dir->get_meta()->flush(); });
         pair_vec[i].second = dir->path();
         i++;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9940

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
we will get "store_num = 0" if it acts as cn, just ignore flush pool

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
