### PR TITLE
[Enhancement] add session variable tablet_internal_parallel_mode

### DIFF
--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -75,11 +75,13 @@ static std::map<int, pipeline::MorselQueuePtr> uniform_distribute_morsels(pipeli
 StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel_queue_factory(
         const std::vector<TScanRangeParams>& global_scan_ranges,
         const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
-        int pipeline_dop, bool enable_tablet_internal_parallel) {
+        int pipeline_dop, bool enable_tablet_internal_parallel,
+        TTabletInternalParallelMode::type tablet_internal_parallel_mode) {
     if (scan_ranges_per_driver_seq.empty()) {
-        ASSIGN_OR_RETURN(auto morsel_queue, convert_scan_range_to_morsel_queue(
-                                                    global_scan_ranges, node_id, pipeline_dop,
-                                                    enable_tablet_internal_parallel, global_scan_ranges.size()));
+        ASSIGN_OR_RETURN(auto morsel_queue,
+                         convert_scan_range_to_morsel_queue(global_scan_ranges, node_id, pipeline_dop,
+                                                            enable_tablet_internal_parallel,
+                                                            tablet_internal_parallel_mode, global_scan_ranges.size()));
         int scan_dop = std::min<int>(std::max<int>(1, morsel_queue->max_degree_of_parallelism()), pipeline_dop);
         int io_parallelism = scan_dop * io_tasks_per_scan_operator();
 
@@ -100,9 +102,9 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
 
         std::map<int, pipeline::MorselQueuePtr> queue_per_driver_seq;
         for (const auto& [dop, scan_ranges] : scan_ranges_per_driver_seq) {
-            ASSIGN_OR_RETURN(auto queue, convert_scan_range_to_morsel_queue(scan_ranges, node_id, pipeline_dop,
-                                                                            enable_tablet_internal_parallel,
-                                                                            num_total_scan_ranges));
+            ASSIGN_OR_RETURN(auto queue, convert_scan_range_to_morsel_queue(
+                                                 scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel,
+                                                 tablet_internal_parallel_mode, num_total_scan_ranges));
             queue_per_driver_seq.emplace(dop, std::move(queue));
         }
 
@@ -113,7 +115,8 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
 
 StatusOr<pipeline::MorselQueuePtr> ScanNode::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
-        bool enable_tablet_internal_parallel, size_t num_total_scan_ranges) {
+        bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
+        size_t num_total_scan_ranges) {
     pipeline::Morsels morsels;
     // If this scan node does not accept non-empty scan ranges, create a placeholder one.
     if (!accept_empty_scan_ranges() && scan_ranges.empty()) {

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -70,10 +70,12 @@ public:
     StatusOr<pipeline::MorselQueueFactoryPtr> convert_scan_range_to_morsel_queue_factory(
             const std::vector<TScanRangeParams>& scan_ranges,
             const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
-            int pipeline_dop, bool enable_tablet_internal_parallel);
+            int pipeline_dop, bool enable_tablet_internal_parallel,
+            TTabletInternalParallelMode::type tablet_internal_parallel_mode);
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
-            bool enable_tablet_internal_parallel, size_t num_total_scan_ranges);
+            bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
+            size_t num_total_scan_ranges);
 
     // If this scan node accept empty scan ranges.
     virtual bool accept_empty_scan_ranges() const { return true; }

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -55,7 +55,8 @@ public:
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
-            bool enable_tablet_internal_parallel, size_t num_total_scan_ranges) override;
+            bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
+            size_t num_total_scan_ranges) override;
 
     void debug_string(int indentation_level, std::stringstream* out) const override {
         *out << "vectorized::OlapScanNode";
@@ -138,6 +139,7 @@ private:
 
     StatusOr<bool> _could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
                                                    int32_t pipeline_dop, size_t num_total_scan_ranges,
+                                                   TTabletInternalParallelMode::type tablet_internal_parallel_mode,
                                                    int64_t* scan_dop, int64_t* splitted_scan_rows) const;
     StatusOr<bool> _could_split_tablet_physically(const std::vector<TScanRangeParams>& scan_ranges) const;
 

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -275,7 +275,8 @@ void PipeLineFileScanNodeTest::generate_morse_queue(std::vector<starrocks::vecto
     for (auto& i : scan_nodes) {
         ScanNode* scan_node = (ScanNode*)(i);
         auto morsel_queue_factory = scan_node->convert_scan_range_to_morsel_queue_factory(
-                scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, true);
+                scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, true,
+                TTabletInternalParallelMode::type::AUTO);
         DCHECK(morsel_queue_factory.ok());
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory).value());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SetVar.java
@@ -35,6 +35,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.HeartbeatFlags;
+import com.starrocks.thrift.TTabletInternalParallelMode;
 import org.apache.commons.lang3.StringUtils;
 
 // change one variable.
@@ -179,6 +180,10 @@ public class SetVar implements ParseNode {
                 }
             }
         }
+
+        if (getVariable().equalsIgnoreCase(SessionVariable.TABLET_INTERNAL_PARALLEL_MODE)) {
+            validateTabletInternalParallelModeValue(getResolvedExpression().getStringValue());
+        }
     }
 
     public String toSql() {
@@ -199,6 +204,14 @@ public class SetVar implements ParseNode {
             }
         } catch (NumberFormatException ex) {
             throw new SemanticException(field + " is not a number");
+        }
+    }
+
+    private void validateTabletInternalParallelModeValue(String val) {
+        try {
+            TTabletInternalParallelMode.valueOf(val.toUpperCase());
+        } catch (Exception ignored) {
+            throw new SemanticException("Invalid tablet_internal_parallel_mode, now we support {auto, force_split}.");
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -33,6 +33,7 @@ import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TTabletInternalParallelMode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
@@ -157,6 +158,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL = "enable_tablet_internal_parallel";
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL_V2 = "enable_tablet_internal_parallel_v2";
+
+    public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
@@ -303,6 +306,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_TABLET_INTERNAL_PARALLEL_V2,
             alias = ENABLE_TABLET_INTERNAL_PARALLEL, show = ENABLE_TABLET_INTERNAL_PARALLEL)
     private boolean enableTabletInternalParallel = true;
+
+    // The strategy mode of TabletInternalParallel, which is effective only when enableTabletInternalParallel is true.
+    // The optional values are "auto" and "force_split".
+    @VariableMgr.VarAttr(name = TABLET_INTERNAL_PARALLEL_MODE, flag = VariableMgr.INVISIBLE)
+    private String tabletInternalParallelMode = "auto";
 
     @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
     private boolean enableSharedScan = false;
@@ -1169,6 +1177,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
 
         tResult.setEnable_tablet_internal_parallel(enableTabletInternalParallel);
+        tResult.setTablet_internal_parallel_mode(
+                TTabletInternalParallelMode.valueOf(tabletInternalParallelMode.toUpperCase()));
+
         tResult.setEnable_query_debug_trace(enableQueryDebugTrace);
 
         return tResult;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -34,6 +34,12 @@ public class AnalyzeSetVariableTest {
         analyzeSuccess(sql);
         sql = "set LOCAL query_timeout = 10";
         analyzeSuccess(sql);
+        sql = "set tablet_internal_parallel_mode = auto";
+        analyzeSuccess(sql);
+        sql = "set tablet_internal_parallel_mode = force_split";
+        analyzeSuccess(sql);
+        sql = "set tablet_internal_parallel_mode = force";
+        analyzeFail(sql);
     }
 
     @Test

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -88,6 +88,11 @@ enum TPipelineProfileLevel {
   DETAIL
 }
 
+enum TTabletInternalParallelMode {
+  AUTO,
+  FORCE_SPLIT
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   1: optional bool abort_on_error = 0
@@ -173,6 +178,8 @@ struct TQueryOptions {
   61: optional bool enable_query_debug_trace;
 
   62: optional Types.TCompressionType load_transmission_compression_type;
+
+  63: optional TTabletInternalParallelMode tablet_internal_parallel_mode;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add a session variables `tablet_internal_parallel_mode` to make it possible to split tablet forcefully, which is useful for test.

The optional value are `auto` and `force_split`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
