### PR TITLE
[BugFix] Fix zstd single input compress bug

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -621,8 +621,8 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
         if (use_compression_pool(_compress_codec->type())) {
             Slice compressed_slice;
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
-                                      &_compression_scratch);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
+                                                      &_compression_scratch));
         } else {
             int max_compressed_size = _compress_codec->max_compressed_len(uncompressed_size);
 
@@ -633,7 +633,7 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
             Slice compressed_slice{_compression_scratch.data(), _compression_scratch.size()};
 
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice));
             _compression_scratch.resize(compressed_slice.size);
         }
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -285,8 +285,8 @@ Status NodeChannel::_serialize_chunk(const vectorized::Chunk* src, ChunkPB* dst)
         if (use_compression_pool(_compress_codec->type())) {
             Slice compressed_slice;
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
-                                      &_compression_scratch);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
+                                                      &_compression_scratch));
         } else {
             int max_compressed_size = _compress_codec->max_compressed_len(uncompressed_size);
 
@@ -297,7 +297,7 @@ Status NodeChannel::_serialize_chunk(const vectorized::Chunk* src, ChunkPB* dst)
             Slice compressed_slice{_compression_scratch.data(), _compression_scratch.size()};
 
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice));
             _compression_scratch.resize(compressed_slice.size);
         }
 

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -711,8 +711,8 @@ Status DataStreamSender::serialize_chunk(const vectorized::Chunk* src, ChunkPB* 
         if (use_compression_pool(_compress_codec->type())) {
             Slice compressed_slice;
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
-                                      &_compression_scratch);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice, true, uncompressed_size, nullptr,
+                                                      &_compression_scratch));
         } else {
             int max_compressed_size = _compress_codec->max_compressed_len(uncompressed_size);
 
@@ -723,7 +723,7 @@ Status DataStreamSender::serialize_chunk(const vectorized::Chunk* src, ChunkPB* 
             Slice compressed_slice{_compression_scratch.data(), _compression_scratch.size()};
 
             Slice input(dst->data());
-            _compress_codec->compress(input, &compressed_slice);
+            RETURN_IF_ERROR(_compress_codec->compress(input, &compressed_slice));
             _compression_scratch.resize(compressed_slice.size);
         }
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -708,16 +708,8 @@ public:
 
     Status compress(const Slice& input, Slice* output, bool use_compression_buffer, size_t uncompressed_size,
                     faststring* compressed_body1, raw::RawString* compressed_body2) const override {
-        // For ZSTD_compress, default ZSTD_COMPRESS_HEAPMODE is off, and
-        // allocate ZSTD_CCtx on stack. So here we didn't integrate it into the
-        // compression context pool.
-        size_t ret = ZSTD_compress(output->data, output->size, input.data, input.size, ZSTD_CLEVEL_DEFAULT);
-        if (ZSTD_isError(ret)) {
-            return Status::InvalidArgument(
-                    strings::Substitute("ZSTD compress failed: $0", ZSTD_getErrorString(ZSTD_getErrorCode(ret))));
-        }
-        output->size = ret;
-        return Status::OK();
+        return _compress({input}, output, use_compression_buffer, uncompressed_size, compressed_body1,
+                         compressed_body2);
     }
 
     Status compress(const std::vector<Slice>& inputs, Slice* output, bool use_compression_buffer,


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10721

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

In current implementation, we will enable compression pool for LZ4_FRAME, ZSTD, LZ4, and also
enable use_compression_buffer for them.
Enable use_compression_buffer means that we don't need to pass in `output` buffer for compression,
and each CompressionContext will maintain a internal buffer itself(context->compression_buffer).

For ZSTD compress single input function (compress(const Slice& input, xxxx)), it still use the old compression logic,
it assume doesn't enable compression buffer, actually this buffer is enable, and pass in output buffer is nullptr,
everytime we perform compress, we will save it to a nullptr output, which leads to an error.