### PR TITLE
[Enhancement] add memory tracker for rowset/segment/column_reader

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -342,6 +342,11 @@ Status ExecEnv::init_mem_tracker() {
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
     _metadata_mem_tracker = new MemTracker(-1, "metadata", nullptr);
     _tablet_schema_mem_tracker = new MemTracker(-1, "tablet_schema", _metadata_mem_tracker);
+    _rowset_meta_mem_tracker = new MemTracker(-1, "rowset_meta", nullptr);
+    _segment_meta_mem_tracker = new MemTracker(-1, "segment_meta", nullptr);
+    _segment_index_mem_tracker = new MemTracker(-1, "segment_index_meta", nullptr);
+    _column_reader_meta_mem_tracker = new MemTracker(-1, "column_reader_meta", nullptr);
+    _column_reader_index_mem_tracker = new MemTracker(-1, "column_reader_index_meta", nullptr);
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_mem_tracker->limit());
     _compaction_mem_tracker = new MemTracker(compaction_mem_limit, "compaction", _mem_tracker);
@@ -528,6 +533,28 @@ void ExecEnv::_destroy() {
     if (_metadata_mem_tracker) {
         delete _metadata_mem_tracker;
         _metadata_mem_tracker = nullptr;
+    }
+    if (_rowset_meta_mem_tracker) {
+        delete _rowset_meta_mem_tracker;
+        _rowset_meta_mem_tracker = nullptr;
+    }
+    if (_segment_meta_mem_tracker) {
+        delete _segment_meta_mem_tracker;
+        _segment_meta_mem_tracker = nullptr;
+    }
+
+    if (_column_reader_meta_mem_tracker) {
+        delete _column_reader_meta_mem_tracker;
+        _column_reader_meta_mem_tracker = nullptr;
+    }
+    if (_segment_index_mem_tracker) {
+        delete _segment_index_mem_tracker;
+        _segment_index_mem_tracker = nullptr;
+    }
+
+    if (_column_reader_index_mem_tracker) {
+        delete _column_reader_index_mem_tracker;
+        _column_reader_index_mem_tracker = nullptr;
     }
     if (_load_mem_tracker) {
         delete _load_mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -127,6 +127,11 @@ public:
     MemTracker* load_mem_tracker() { return _load_mem_tracker; }
     MemTracker* metadata_mem_tracker() { return _metadata_mem_tracker; }
     MemTracker* tablet_schema_mem_tacker() { return _tablet_schema_mem_tracker; }
+    MemTracker* rowset_meta_mem_tracker() { return _rowset_meta_mem_tracker; }
+    MemTracker* segment_meta_mem_tracker() { return _segment_meta_mem_tracker; }
+    MemTracker* segment_index_mem_tracker() { return _segment_index_mem_tracker; }
+    MemTracker* column_reader_meta_mem_tracker() { return _column_reader_meta_mem_tracker; }
+    MemTracker* column_reader_index_mem_tracker() { return _column_reader_index_mem_tracker; }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker; }
     MemTracker* schema_change_mem_tracker() { return _schema_change_mem_tracker; }
     MemTracker* column_pool_mem_tracker() { return _column_pool_mem_tracker; }
@@ -217,6 +222,21 @@ private:
     // The memory for tablet meta
     MemTracker* _metadata_mem_tracker = nullptr;
     MemTracker* _tablet_schema_mem_tracker = nullptr;
+
+    // The memory for rowset meta
+    MemTracker* _rowset_meta_mem_tracker = nullptr;
+
+    // The memory for segment meta
+    MemTracker* _segment_meta_mem_tracker = nullptr;
+
+    // The memory for segment index meta
+    MemTracker* _segment_index_mem_tracker = nullptr;
+
+    // The memory for column reader meta
+    MemTracker* _column_reader_meta_mem_tracker = nullptr;
+
+    // The memory for column reader index meta
+    MemTracker* _column_reader_index_mem_tracker = nullptr;
 
     // The memory used for compaction
     MemTracker* _compaction_mem_tracker = nullptr;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -122,7 +122,7 @@ private:
 
 class Rowset : public std::enable_shared_from_this<Rowset> {
 public:
-    virtual ~Rowset() = default;
+    ~Rowset() { ExecEnv::GetInstance()->rowset_meta_mem_tracker()->release(mem_usage()); }
 
     Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
 
@@ -131,6 +131,7 @@ public:
         auto rowset = std::shared_ptr<Rowset>(new Rowset(schema, std::move(rowset_path), std::move(rowset_meta)),
                                               DeleterWithMemTracker<Rowset>(mem_tracker));
         mem_tracker->consume(rowset->mem_usage());
+        ExecEnv::GetInstance()->rowset_meta_mem_tracker()->consume(rowset->mem_usage());
         return rowset;
     }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -94,7 +94,7 @@ public:
     Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
             std::shared_ptr<const TabletSchema> tablet_schema, MemTracker* mem_tracker);
 
-    ~Segment() = default;
+    ~Segment();
 
     // may return EndOfFile
     StatusOr<ChunkIteratorPtr> new_iterator(const vectorized::Schema& schema,
@@ -144,6 +144,18 @@ public:
         }
         return size;
     }
+
+    int64_t meta_mem_usage() { return sizeof(Segment); }
+
+    int64_t index_mem_usage() {
+        int64_t size = _sk_index_handle.mem_usage();
+        if (_sk_index_decoder != nullptr) {
+            size += _sk_index_decoder->mem_usage();
+        }
+        return size;
+    }
+
+    inline MemTracker* mem_tracker() { return _mem_tracker; }
 
     MemTracker* mem_tracker() const { return _mem_tracker; }
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -217,6 +217,11 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("load_mem_bytes", &_memory_metrics->load_mem_bytes);
     registry->register_metric("metadata_mem_bytes", &_memory_metrics->metadata_mem_bytes);
     registry->register_metric("tablet_schema_mem_bytes", &_memory_metrics->tablet_schema_mem_bytes);
+    registry->register_metric("rowset_meta_mem_tracker", &_memory_metrics->rowset_meta_mem_tracker);
+    registry->register_metric("segment_meta_mem_tracker", &_memory_metrics->segment_meta_mem_tracker);
+    registry->register_metric("segment_index_mem_tracker", &_memory_metrics->segment_index_mem_tracker);
+    registry->register_metric("column_reader_meta_mem_tracker", &_memory_metrics->column_reader_meta_mem_tracker);
+    registry->register_metric("column_reader_index_mem_tracker", &_memory_metrics->column_reader_index_mem_tracker);
     registry->register_metric("compaction_mem_bytes", &_memory_metrics->compaction_mem_bytes);
     registry->register_metric("schema_change_mem_bytes", &_memory_metrics->schema_change_mem_bytes);
     registry->register_metric("column_pool_mem_bytes", &_memory_metrics->column_pool_mem_bytes);
@@ -309,6 +314,26 @@ void SystemMetrics::_update_memory_metrics() {
     if (ExecEnv::GetInstance()->tablet_schema_mem_tacker() != nullptr) {
         _memory_metrics->tablet_schema_mem_bytes.set_value(
                 ExecEnv::GetInstance()->tablet_schema_mem_tacker()->consumption());
+    }
+    if (ExecEnv::GetInstance()->rowset_meta_mem_tracker() != nullptr) {
+        _memory_metrics->rowset_meta_mem_tracker.set_value(
+                ExecEnv::GetInstance()->rowset_meta_mem_tracker()->consumption());
+    }
+    if (ExecEnv::GetInstance()->segment_meta_mem_tracker() != nullptr) {
+        _memory_metrics->segment_meta_mem_tracker.set_value(
+                ExecEnv::GetInstance()->segment_meta_mem_tracker()->consumption());
+    }
+    if (ExecEnv::GetInstance()->segment_index_mem_tracker() != nullptr) {
+        _memory_metrics->segment_index_mem_tracker.set_value(
+                ExecEnv::GetInstance()->segment_index_mem_tracker()->consumption());
+    }
+    if (ExecEnv::GetInstance()->column_reader_meta_mem_tracker() != nullptr) {
+        _memory_metrics->column_reader_meta_mem_tracker.set_value(
+                ExecEnv::GetInstance()->column_reader_meta_mem_tracker()->consumption());
+    }
+    if (ExecEnv::GetInstance()->column_reader_index_mem_tracker() != nullptr) {
+        _memory_metrics->column_reader_index_mem_tracker.set_value(
+                ExecEnv::GetInstance()->column_reader_index_mem_tracker()->consumption());
     }
     if (ExecEnv::GetInstance()->compaction_mem_tracker() != nullptr) {
         _memory_metrics->compaction_mem_bytes.set_value(


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10873

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

Currently we only collect memory statistics at the granularity of table,
we don't know how many memory consume for rowset/segment/column_reader.

This pr add memory tracker for rowset/segment/column_reader
