### PR TITLE
[BugFix] BE crash when table use snappy compression (#10883)

### DIFF
--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -546,7 +546,7 @@ public:
         // we should assure that *len is not 0
         *len = _slices[_cur_slice].size - _slice_off;
         DCHECK(*len != 0);
-        return _slices[_cur_slice].data;
+        return _slices[_cur_slice].data + _slice_off;
     }
 
     // Skip the next n bytes.  Invalidates any buffer returned by


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes https://github.com/StarRocks/starrocks/issues/10881

## Problem Summary(Required) ：
Problem:
When we use snappy for page compression, be may crash. The reason is that the original snappy lib does not support multiple discontinue memory for compression. So we reform the input parameter for it, which is SnappySlicesSource. But the member function Peek may return the wrong pointer which causes this problem.

Solution:
Make SnappySlicesSource.Peek return the correct pointer.
