### PR TITLE
[BugFix] Clear dumped_shard_idxes in meta before dump a new snapshot

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1676,7 +1676,7 @@ bool ShardByLengthMutableIndex::load_snapshot(phmap::BinaryInputArchive& ar, con
 
 size_t ShardByLengthMutableIndex::dump_bound() {
     return std::accumulate(_shards.begin(), _shards.end(), 0,
-                           [](size_t s, const auto& e) { return e->size() > 0 ? s + e->size() : s; });
+                           [](size_t s, const auto& e) { return e->size() > 0 ? s + e->dump_bound() : s; });
 }
 
 bool ShardByLengthMutableIndex::dump(phmap::BinaryOutputArchive& ar_out, std::set<uint32_t>& dumped_shard_idxes) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1742,6 +1742,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         PagePointerPB* data = snapshot->mutable_data();
         data->set_offset(0);
         data->set_size(snapshot_size);
+        snapshot->clear_dumped_shard_idxes();
         snapshot->mutable_dumped_shard_idxes()->Add(dumped_shard_idxes.begin(), dumped_shard_idxes.end());
         meta->set_format_version(PERSISTENT_INDEX_VERSION_2);
         _offset = snapshot_size;
@@ -1774,7 +1775,11 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
     const auto snapshot_size = page_pb.size();
     std::set<uint32_t> dumped_shard_idxes;
     for (auto i = 0; i < snapshot_meta.dumped_shard_idxes_size(); ++i) {
-        dumped_shard_idxes.insert(snapshot_meta.dumped_shard_idxes(i));
+        auto [_, insert] = dumped_shard_idxes.insert(snapshot_meta.dumped_shard_idxes(i));
+        if (!insert) {
+            LOG(WARNING) << "duplicate shard idx: " << snapshot_meta.dumped_shard_idxes(i);
+            return Status::InternalError("duplicate shard idx");
+        }
     }
     std::string index_file_name = get_l0_index_file_name(_path, start_version);
     std::shared_ptr<FileSystem> fs;
@@ -2490,6 +2495,8 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     //   2. delete WALs because maybe PersistentIndexMetaPB has expired wals
     //   3. reset SnapshotMeta
     //   4. write all data into new tmp _l0 index file (tmp file will be delete in _build_commit())
+    index_meta.clear_l0_meta();
+    index_meta.clear_l1_version();
     index_meta.set_key_size(_key_size);
     index_meta.set_format_version(PERSISTENT_INDEX_VERSION_2);
     lastest_applied_version.to_pb(index_meta.mutable_version());


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/10891

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we dump a new snapshot of ShardByLengthMutableIndex, we need to clear up`dumped_shard_idxes` before adding the shard_idxes, otherwise it will cause unpredictable errors when loading snapshot.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
