### PR TITLE
[Emhancement] Remove a duplicate Filter definition

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -276,7 +276,6 @@ public:
 
     // REQUIRES: size of |filter| equals to the size of this column.
     // Removes elements that don't match the filter.
-    using Filter = Buffer<uint8_t>;
     inline size_t filter(const Filter& filter) {
         DCHECK_EQ(size(), filter.size());
         return filter_range(filter, 0, filter.size());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`Filter` already defined in https://github.com/StarRocks/starrocks/blob/main/be/src/column/vectorized_fwd.h#L100, so remove the duplicated definition in `Column`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
