### PR TITLE
[Enhancement] Adjust calculation of OverallThroughput

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -124,7 +124,9 @@ void SinkBuffer::update_profile(RuntimeProfile* profile) {
 
     auto* network_timer = ADD_TIMER(profile, "NetworkTime");
     auto* wait_timer = ADD_TIMER(profile, "WaitTime");
+    auto* overall_timer = ADD_TIMER(profile, "OverallTime");
     COUNTER_SET(network_timer, _network_time());
+    COUNTER_SET(overall_timer, _last_receive_time - _first_send_time);
 
     // WaitTime consists two parts
     // 1. buffer full time
@@ -145,9 +147,15 @@ void SinkBuffer::update_profile(RuntimeProfile* profile) {
     }
 
     profile->add_derived_counter(
-            "OverallThroughput", TUnit::BYTES_PER_SECOND,
+            "NetworkBandwidth", TUnit::BYTES_PER_SECOND,
             [bytes_sent_counter, network_timer] {
                 return RuntimeProfile::units_per_second(bytes_sent_counter, network_timer);
+            },
+            "");
+    profile->add_derived_counter(
+            "OverallThroughput", TUnit::BYTES_PER_SECOND,
+            [bytes_sent_counter, overall_timer] {
+                return RuntimeProfile::units_per_second(bytes_sent_counter, overall_timer);
             },
             "");
 }
@@ -174,6 +182,7 @@ void SinkBuffer::cancel_one_sinker() {
 
 void SinkBuffer::_update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
                                       const int64_t receive_timestamp) {
+    _last_receive_time = MonotonicNanos();
     int32_t concurrency = _num_in_flight_rpcs[instance_id.lo];
     _network_times[instance_id.lo].update(receive_timestamp - send_timestamp, concurrency);
 }
@@ -284,6 +293,10 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, std::function<vo
 
         auto* closure = new DisposableClosure<PTransmitChunkResult, ClosureContext>(
                 {instance_id, request.params->sequence(), GetCurrentTimeNanos()});
+        if (_first_send_time == -1) {
+            int64_t expected = -1;
+            _first_send_time.compare_exchange_weak(expected, MonotonicNanos());
+        }
 
         closure->addFailedHandler([this](const ClosureContext& ctx) noexcept {
             _is_finishing = true;

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -294,8 +294,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, std::function<vo
         auto* closure = new DisposableClosure<PTransmitChunkResult, ClosureContext>(
                 {instance_id, request.params->sequence(), GetCurrentTimeNanos()});
         if (_first_send_time == -1) {
-            int64_t expected = -1;
-            _first_send_time.compare_exchange_weak(expected, MonotonicNanos());
+            _first_send_time = MonotonicNanos();
         }
 
         closure->addFailedHandler([this](const ClosureContext& ctx) noexcept {

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -165,6 +165,9 @@ private:
     int64_t _pending_timestamp = -1;
     mutable std::atomic<int64_t> _last_full_timestamp = -1;
     mutable std::atomic<int64_t> _full_time = 0;
+
+    std::atomic<int64_t> _first_send_time = -1;
+    std::atomic<int64_t> _last_receive_time = -1;
 }; // namespace starrocks::pipeline
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -166,8 +166,10 @@ private:
     mutable std::atomic<int64_t> _last_full_timestamp = -1;
     mutable std::atomic<int64_t> _full_time = 0;
 
-    std::atomic<int64_t> _first_send_time = -1;
-    std::atomic<int64_t> _last_receive_time = -1;
+    // These two fields are used to calculate the overthroughput
+    // Non-atomic type is enough because the concurrency inconsistency is acceptable
+    int64_t _first_send_time = -1;
+    int64_t _last_receive_time = -1;
 }; // namespace starrocks::pipeline
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Change the way of calculating `OverallThroughput`, the difference is that the way time is calculated has changed

* Before: Using `NetworkTime`, which only contains the real network time
* This pr: The time interval between sending the first packet and receiving the last packet

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
