### PR TITLE
[Enhancement] Add more detail mem_tracker for metadata

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -345,7 +345,19 @@ Status ExecEnv::init_mem_tracker() {
     _load_mem_tracker = new MemTracker(MemTracker::LOAD, load_mem_limit, "load", _mem_tracker);
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
     _metadata_mem_tracker = new MemTracker(-1, "metadata", nullptr);
-    _tablet_schema_mem_tracker = new MemTracker(-1, "tablet_schema", _metadata_mem_tracker);
+
+    _tablet_metadata_mem_tracker = new MemTracker(-1, "tablet_metadata", _metadata_mem_tracker);
+    _rowset_metadata_mem_tracker = new MemTracker(-1, "rowset_metadata", _metadata_mem_tracker);
+    _segment_metadata_mem_tracker = new MemTracker(-1, "segment_metadata", _metadata_mem_tracker);
+    _column_metadata_mem_tracker = new MemTracker(-1, "column_metadata", _metadata_mem_tracker);
+
+    _tablet_schema_mem_tracker = new MemTracker(-1, "tablet_schema", _tablet_metadata_mem_tracker);
+    _segment_zonemap_mem_tracker = new MemTracker(-1, "segment_zonemap", _segment_metadata_mem_tracker);
+    _short_key_index_mem_tracker = new MemTracker(-1, "short_key_index", _segment_metadata_mem_tracker);
+    _column_zonemap_index_mem_tracker = new MemTracker(-1, "column_zonemap_index", _column_metadata_mem_tracker);
+    _ordinal_index_mem_tracker = new MemTracker(-1, "ordinal_index", _column_metadata_mem_tracker);
+    _bitmap_index_mem_tracker = new MemTracker(-1, "bitmap_index", _column_metadata_mem_tracker);
+    _bloom_filter_index_mem_tracker = new MemTracker(-1, "bloom_filter_index", _column_metadata_mem_tracker);
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_mem_tracker->limit());
     _compaction_mem_tracker = new MemTracker(compaction_mem_limit, "compaction", _mem_tracker);
@@ -381,216 +393,77 @@ Status ExecEnv::_init_storage_page_cache() {
 }
 
 void ExecEnv::_destroy() {
-    if (_agent_server) {
-        delete _agent_server;
-        _agent_server = nullptr;
-    }
-    if (_runtime_filter_worker) {
-        delete _runtime_filter_worker;
-        _runtime_filter_worker = nullptr;
-    }
-    if (_profile_report_worker) {
-        delete _profile_report_worker;
-        _profile_report_worker = nullptr;
-    }
-    if (_heartbeat_flags) {
-        delete _heartbeat_flags;
-        _heartbeat_flags = nullptr;
-    }
-    if (_small_file_mgr) {
-        delete _small_file_mgr;
-        _small_file_mgr = nullptr;
-    }
-    if (_transaction_mgr) {
-        delete _transaction_mgr;
-        _transaction_mgr = nullptr;
-    }
-    if (_stream_context_mgr) {
-        delete _stream_context_mgr;
-        _stream_context_mgr = nullptr;
-    }
-    if (_routine_load_task_executor) {
-        delete _routine_load_task_executor;
-        _routine_load_task_executor = nullptr;
-    }
-    if (_stream_load_executor) {
-        delete _stream_load_executor;
-        _stream_load_executor = nullptr;
-    }
-    if (_brpc_stub_cache) {
-        delete _brpc_stub_cache;
-        _brpc_stub_cache = nullptr;
-    }
-    if (_load_stream_mgr) {
-        delete _load_stream_mgr;
-        _load_stream_mgr = nullptr;
-    }
-    if (_load_channel_mgr) {
-        delete _load_channel_mgr;
-        _load_channel_mgr = nullptr;
-    }
-    if (_broker_mgr) {
-        delete _broker_mgr;
-        _broker_mgr = nullptr;
-    }
-    if (_bfd_parser) {
-        delete _bfd_parser;
-        _bfd_parser = nullptr;
-    }
-    if (_load_path_mgr) {
-        delete _load_path_mgr;
-        _load_path_mgr = nullptr;
-    }
-    if (_driver_executor) {
-        delete _driver_executor;
-        _driver_executor = nullptr;
-    }
-    if (_wg_driver_executor) {
-        delete _wg_driver_executor;
-        _wg_driver_executor = nullptr;
-    }
-    if (_driver_limiter) {
-        delete _driver_limiter;
-        _driver_limiter = nullptr;
-    }
-    if (_fragment_mgr) {
-        delete _fragment_mgr;
-        _fragment_mgr = nullptr;
-    }
-    if (_udf_call_pool) {
-        delete _udf_call_pool;
-        _udf_call_pool = nullptr;
-    }
-    if (_pipeline_prepare_pool) {
-        delete _pipeline_prepare_pool;
-        _pipeline_prepare_pool = nullptr;
-    }
-    if (_scan_executor_without_workgroup) {
-        delete _scan_executor_without_workgroup;
-        _scan_executor_without_workgroup = nullptr;
-    }
-    if (_scan_executor_with_workgroup) {
-        delete _scan_executor_with_workgroup;
-        _scan_executor_with_workgroup = nullptr;
-    }
-    if (_connector_scan_executor_without_workgroup) {
-        delete _connector_scan_executor_without_workgroup;
-        _connector_scan_executor_without_workgroup = nullptr;
-    }
-    if (_connector_scan_executor_with_workgroup) {
-        delete _connector_scan_executor_with_workgroup;
-        _connector_scan_executor_with_workgroup = nullptr;
-    }
-    if (_runtime_filter_cache) {
-        delete _runtime_filter_cache;
-        _runtime_filter_cache = nullptr;
-    }
-    if (_thread_pool) {
-        delete _thread_pool;
-        _thread_pool = nullptr;
-    }
-    if (_thread_mgr) {
-        delete _thread_mgr;
-        _thread_mgr = nullptr;
-    }
-    if (_consistency_mem_tracker) {
-        delete _consistency_mem_tracker;
-        _consistency_mem_tracker = nullptr;
-    }
-    if (_clone_mem_tracker) {
-        delete _clone_mem_tracker;
-        _clone_mem_tracker = nullptr;
-    }
-    if (_chunk_allocator_mem_tracker) {
-        delete _chunk_allocator_mem_tracker;
-        _chunk_allocator_mem_tracker = nullptr;
-    }
-    if (_update_mem_tracker) {
-        delete _update_mem_tracker;
-        _update_mem_tracker = nullptr;
-    }
-    if (_page_cache_mem_tracker) {
-        delete _page_cache_mem_tracker;
-        _page_cache_mem_tracker = nullptr;
-    }
-    if (_column_pool_mem_tracker) {
-        delete _column_pool_mem_tracker;
-        _column_pool_mem_tracker = nullptr;
-    }
-    if (_schema_change_mem_tracker) {
-        delete _schema_change_mem_tracker;
-        _schema_change_mem_tracker = nullptr;
-    }
-    if (_compaction_mem_tracker) {
-        delete _compaction_mem_tracker;
-        _compaction_mem_tracker = nullptr;
-    }
+    SAFE_DELETE(_agent_server);
+    SAFE_DELETE(_runtime_filter_worker);
+    SAFE_DELETE(_profile_report_worker);
+    SAFE_DELETE(_heartbeat_flags);
+    SAFE_DELETE(_small_file_mgr);
+    SAFE_DELETE(_transaction_mgr);
+    SAFE_DELETE(_stream_context_mgr);
+    SAFE_DELETE(_routine_load_task_executor);
+    SAFE_DELETE(_stream_load_executor);
+    SAFE_DELETE(_brpc_stub_cache);
+    SAFE_DELETE(_load_stream_mgr);
+    SAFE_DELETE(_load_channel_mgr);
+    SAFE_DELETE(_broker_mgr);
+    SAFE_DELETE(_bfd_parser);
+    SAFE_DELETE(_load_path_mgr);
+    SAFE_DELETE(_driver_executor);
+    SAFE_DELETE(_wg_driver_executor);
+    SAFE_DELETE(_driver_limiter);
+    SAFE_DELETE(_fragment_mgr);
+    SAFE_DELETE(_udf_call_pool);
+    SAFE_DELETE(_pipeline_prepare_pool);
+    SAFE_DELETE(_scan_executor_without_workgroup);
+    SAFE_DELETE(_scan_executor_with_workgroup);
+    SAFE_DELETE(_connector_scan_executor_without_workgroup);
+    SAFE_DELETE(_connector_scan_executor_with_workgroup);
+    SAFE_DELETE(_runtime_filter_cache);
+    SAFE_DELETE(_thread_pool);
+    SAFE_DELETE(_thread_mgr);
+    SAFE_DELETE(_consistency_mem_tracker);
+    SAFE_DELETE(_clone_mem_tracker);
+    SAFE_DELETE(_chunk_allocator_mem_tracker);
+    SAFE_DELETE(_update_mem_tracker);
+    SAFE_DELETE(_page_cache_mem_tracker);
+    SAFE_DELETE(_column_pool_mem_tracker);
+    SAFE_DELETE(_schema_change_mem_tracker);
+    SAFE_DELETE(_compaction_mem_tracker);
 
     _lake_tablet_manager->prune_metacache();
 
-    if (_tablet_schema_mem_tracker) {
-        delete _tablet_schema_mem_tracker;
-        _tablet_schema_mem_tracker = nullptr;
-    }
+    SAFE_DELETE(_bloom_filter_index_mem_tracker);
+    SAFE_DELETE(_bitmap_index_mem_tracker);
+    SAFE_DELETE(_ordinal_index_mem_tracker);
+    SAFE_DELETE(_column_zonemap_index_mem_tracker);
+    SAFE_DELETE(_segment_zonemap_mem_tracker);
+    SAFE_DELETE(_short_key_index_mem_tracker);
+    SAFE_DELETE(_tablet_schema_mem_tracker);
 
-    if (_metadata_mem_tracker) {
-        delete _metadata_mem_tracker;
-        _metadata_mem_tracker = nullptr;
-    }
-    if (_load_mem_tracker) {
-        delete _load_mem_tracker;
-        _load_mem_tracker = nullptr;
-    }
+    SAFE_DELETE(_column_metadata_mem_tracker);
+    SAFE_DELETE(_segment_metadata_mem_tracker);
+    SAFE_DELETE(_rowset_metadata_mem_tracker);
+    SAFE_DELETE(_tablet_schema_mem_tracker);
+
+    SAFE_DELETE(_metadata_mem_tracker);
+
+    SAFE_DELETE(_load_mem_tracker);
+
     // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate _query_pool_mem_tracker.
     workgroup::WorkGroupManager::instance()->destroy();
-    if (_query_pool_mem_tracker) {
-        delete _query_pool_mem_tracker;
-        _query_pool_mem_tracker = nullptr;
-    }
-    if (_query_context_mgr) {
-        delete _query_context_mgr;
-        _query_context_mgr = nullptr;
-    }
-    if (_mem_tracker) {
-        delete _mem_tracker;
-        _mem_tracker = nullptr;
-    }
-    if (_broker_client_cache) {
-        delete _broker_client_cache;
-        _broker_client_cache = nullptr;
-    }
-    if (_frontend_client_cache) {
-        delete _frontend_client_cache;
-        _frontend_client_cache = nullptr;
-    }
-    if (_backend_client_cache) {
-        delete _backend_client_cache;
-        _backend_client_cache = nullptr;
-    }
-    if (_result_queue_mgr) {
-        delete _result_queue_mgr;
-        _result_queue_mgr = nullptr;
-    }
-    if (_result_mgr) {
-        delete _result_mgr;
-        _result_mgr = nullptr;
-    }
-    if (_stream_mgr) {
-        delete _stream_mgr;
-        _stream_mgr = nullptr;
-    }
-    if (_external_scan_context_mgr) {
-        delete _external_scan_context_mgr;
-        _external_scan_context_mgr = nullptr;
-    }
-    if (_lake_tablet_manager) {
-        delete _lake_tablet_manager;
-        _lake_tablet_manager = nullptr;
-    }
-    if (_lake_location_provider) {
-        delete _lake_location_provider;
-        _lake_location_provider = nullptr;
-    }
+    SAFE_DELETE(_query_pool_mem_tracker);
+    SAFE_DELETE(_query_context_mgr);
+    SAFE_DELETE(_mem_tracker);
+    SAFE_DELETE(_broker_client_cache);
+    SAFE_DELETE(_frontend_client_cache);
+    SAFE_DELETE(_backend_client_cache);
+    SAFE_DELETE(_result_queue_mgr);
+    SAFE_DELETE(_result_mgr);
+    SAFE_DELETE(_stream_mgr);
+    SAFE_DELETE(_external_scan_context_mgr);
+    SAFE_DELETE(_lake_tablet_manager);
+    SAFE_DELETE(_lake_location_provider);
+
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -128,7 +128,17 @@ public:
     MemTracker* query_pool_mem_tracker() { return _query_pool_mem_tracker; }
     MemTracker* load_mem_tracker() { return _load_mem_tracker; }
     MemTracker* metadata_mem_tracker() { return _metadata_mem_tracker; }
-    MemTracker* tablet_schema_mem_tacker() { return _tablet_schema_mem_tracker; }
+    MemTracker* tablet_metadata_mem_tracker() { return _tablet_metadata_mem_tracker; }
+    MemTracker* rowset_metadata_mem_tracker() { return _rowset_metadata_mem_tracker; }
+    MemTracker* segment_metadata_mem_tracker() { return _segment_metadata_mem_tracker; }
+    MemTracker* column_metadata_mem_tracker() { return _column_metadata_mem_tracker; }
+    MemTracker* tablet_schema_mem_tracker() { return _tablet_schema_mem_tracker; }
+    MemTracker* column_zonemap_index_mem_tracker() { return _column_zonemap_index_mem_tracker; }
+    MemTracker* ordinal_index_mem_tracker() { return _ordinal_index_mem_tracker; }
+    MemTracker* bitmap_index_mem_tracker() { return _bitmap_index_mem_tracker; }
+    MemTracker* bloom_filter_index_mem_tracker() { return _bloom_filter_index_mem_tracker; }
+    MemTracker* segment_zonemap_mem_tracker() { return _segment_zonemap_mem_tracker; }
+    MemTracker* short_key_index_mem_tracker() { return _short_key_index_mem_tracker; }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker; }
     MemTracker* schema_change_mem_tracker() { return _schema_change_mem_tracker; }
     MemTracker* column_pool_mem_tracker() { return _column_pool_mem_tracker; }
@@ -219,9 +229,23 @@ private:
     // Limit the memory used by load
     MemTracker* _load_mem_tracker = nullptr;
 
-    // The memory for tablet meta
+    // metadata l0
     MemTracker* _metadata_mem_tracker = nullptr;
+
+    // metadata l1
+    MemTracker* _tablet_metadata_mem_tracker = nullptr;
+    MemTracker* _rowset_metadata_mem_tracker = nullptr;
+    MemTracker* _segment_metadata_mem_tracker = nullptr;
+    MemTracker* _column_metadata_mem_tracker = nullptr;
+
+    // metadata l2
     MemTracker* _tablet_schema_mem_tracker = nullptr;
+    MemTracker* _segment_zonemap_mem_tracker = nullptr;
+    MemTracker* _short_key_index_mem_tracker = nullptr;
+    MemTracker* _column_zonemap_index_mem_tracker = nullptr;
+    MemTracker* _ordinal_index_mem_tracker = nullptr;
+    MemTracker* _bitmap_index_mem_tracker = nullptr;
+    MemTracker* _bloom_filter_index_mem_tracker = nullptr;
 
     // The memory used for compaction
     MemTracker* _compaction_mem_tracker = nullptr;
@@ -258,8 +282,8 @@ private:
     pipeline::QueryContextManager* _query_context_mgr = nullptr;
     pipeline::DriverExecutor* _driver_executor = nullptr;
     pipeline::DriverExecutor* _wg_driver_executor = nullptr;
-    pipeline::DriverLimiter* _driver_limiter;
-    int64_t _max_executor_threads; // Max thread number of executor
+    pipeline::DriverLimiter* _driver_limiter = nullptr;
+    int64_t _max_executor_threads = 0; // Max thread number of executor
 
     LoadPathMgr* _load_path_mgr = nullptr;
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -447,16 +447,16 @@ vectorized::Schema* TabletSchema::schema() const {
 
 TabletSchema::TabletSchema(const TabletSchemaPB& schema_pb) {
     _init_from_pb(schema_pb);
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tacker(), mem_usage())
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
 }
 
 TabletSchema::TabletSchema(const TabletSchemaPB& schema_pb, TabletSchemaMap* schema_map) : _schema_map(schema_map) {
     _init_from_pb(schema_pb);
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tacker(), mem_usage())
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
 }
 
 TabletSchema::~TabletSchema() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_schema_mem_tacker(), mem_usage())
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
     if (_schema_map != nullptr) {
         _schema_map->erase(_id);
     }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -216,7 +216,17 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("query_mem_bytes", &_memory_metrics->query_mem_bytes);
     registry->register_metric("load_mem_bytes", &_memory_metrics->load_mem_bytes);
     registry->register_metric("metadata_mem_bytes", &_memory_metrics->metadata_mem_bytes);
+    registry->register_metric("tablet_metadata_mem_bytes", &_memory_metrics->tablet_metadata_mem_bytes);
+    registry->register_metric("rowset_metadata_mem_bytes", &_memory_metrics->rowset_metadata_mem_bytes);
+    registry->register_metric("segment_metadata_mem_bytes", &_memory_metrics->segment_metadata_mem_bytes);
+    registry->register_metric("column_metadata_mem_bytes", &_memory_metrics->column_metadata_mem_bytes);
     registry->register_metric("tablet_schema_mem_bytes", &_memory_metrics->tablet_schema_mem_bytes);
+    registry->register_metric("column_zonemap_index_mem_bytes", &_memory_metrics->column_zonemap_index_mem_bytes);
+    registry->register_metric("ordinal_index_mem_bytes", &_memory_metrics->ordinal_index_mem_bytes);
+    registry->register_metric("bitmap_index_mem_bytes", &_memory_metrics->bitmap_index_mem_bytes);
+    registry->register_metric("bloom_filter_index_mem_bytes", &_memory_metrics->bloom_filter_index_mem_bytes);
+    registry->register_metric("segment_zonemap_mem_bytes", &_memory_metrics->segment_zonemap_mem_bytes);
+    registry->register_metric("short_key_index_mem_bytes", &_memory_metrics->short_key_index_mem_bytes);
     registry->register_metric("compaction_mem_bytes", &_memory_metrics->compaction_mem_bytes);
     registry->register_metric("schema_change_mem_bytes", &_memory_metrics->schema_change_mem_bytes);
     registry->register_metric("column_pool_mem_bytes", &_memory_metrics->column_pool_mem_bytes);
@@ -294,52 +304,35 @@ void SystemMetrics::_update_memory_metrics() {
     _memory_metrics->pageheap_unmapped_bytes.set_value(value);
 #endif
 
-    if (ExecEnv::GetInstance()->process_mem_tracker() != nullptr) {
-        _memory_metrics->process_mem_bytes.set_value(ExecEnv::GetInstance()->process_mem_tracker()->consumption());
+#define SET_MEM_METRIC_VALUE(tracker, key)                                                \
+    if (ExecEnv::GetInstance()->tracker() != nullptr) {                                   \
+        _memory_metrics->key.set_value(ExecEnv::GetInstance()->tracker()->consumption()); \
     }
-    if (ExecEnv::GetInstance()->query_pool_mem_tracker() != nullptr) {
-        _memory_metrics->query_mem_bytes.set_value(ExecEnv::GetInstance()->query_pool_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->load_mem_tracker() != nullptr) {
-        _memory_metrics->load_mem_bytes.set_value(ExecEnv::GetInstance()->load_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->metadata_mem_tracker() != nullptr) {
-        _memory_metrics->metadata_mem_bytes.set_value(ExecEnv::GetInstance()->metadata_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->tablet_schema_mem_tacker() != nullptr) {
-        _memory_metrics->tablet_schema_mem_bytes.set_value(
-                ExecEnv::GetInstance()->tablet_schema_mem_tacker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->compaction_mem_tracker() != nullptr) {
-        _memory_metrics->compaction_mem_bytes.set_value(
-                ExecEnv::GetInstance()->compaction_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->schema_change_mem_tracker() != nullptr) {
-        _memory_metrics->schema_change_mem_bytes.set_value(
-                ExecEnv::GetInstance()->schema_change_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->page_cache_mem_tracker() != nullptr) {
-        _memory_metrics->storage_page_cache_mem_bytes.set_value(
-                ExecEnv::GetInstance()->page_cache_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->update_mem_tracker() != nullptr) {
-        _memory_metrics->update_mem_bytes.set_value(ExecEnv::GetInstance()->update_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->chunk_allocator_mem_tracker() != nullptr) {
-        _memory_metrics->chunk_allocator_mem_bytes.set_value(
-                ExecEnv::GetInstance()->chunk_allocator_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->clone_mem_tracker() != nullptr) {
-        _memory_metrics->clone_mem_bytes.set_value(ExecEnv::GetInstance()->clone_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->column_pool_mem_tracker() != nullptr) {
-        _memory_metrics->column_pool_mem_bytes.set_value(
-                ExecEnv::GetInstance()->column_pool_mem_tracker()->consumption());
-    }
-    if (ExecEnv::GetInstance()->consistency_mem_tracker() != nullptr) {
-        _memory_metrics->consistency_mem_bytes.set_value(
-                ExecEnv::GetInstance()->consistency_mem_tracker()->consumption());
-    }
+
+    SET_MEM_METRIC_VALUE(process_mem_tracker, process_mem_bytes)
+    SET_MEM_METRIC_VALUE(query_pool_mem_tracker, query_mem_bytes)
+    SET_MEM_METRIC_VALUE(load_mem_tracker, load_mem_bytes)
+    SET_MEM_METRIC_VALUE(metadata_mem_tracker, metadata_mem_bytes)
+    SET_MEM_METRIC_VALUE(tablet_metadata_mem_tracker, tablet_metadata_mem_bytes)
+    SET_MEM_METRIC_VALUE(rowset_metadata_mem_tracker, rowset_metadata_mem_bytes)
+    SET_MEM_METRIC_VALUE(segment_metadata_mem_tracker, segment_metadata_mem_bytes)
+    SET_MEM_METRIC_VALUE(column_metadata_mem_tracker, column_metadata_mem_bytes)
+    SET_MEM_METRIC_VALUE(tablet_schema_mem_tracker, tablet_schema_mem_bytes)
+    SET_MEM_METRIC_VALUE(column_zonemap_index_mem_tracker, column_zonemap_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(ordinal_index_mem_tracker, ordinal_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(bitmap_index_mem_tracker, bitmap_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(bloom_filter_index_mem_tracker, bloom_filter_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(segment_zonemap_mem_tracker, segment_zonemap_mem_bytes)
+    SET_MEM_METRIC_VALUE(short_key_index_mem_tracker, short_key_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(compaction_mem_tracker, compaction_mem_bytes)
+    SET_MEM_METRIC_VALUE(schema_change_mem_tracker, schema_change_mem_bytes)
+    SET_MEM_METRIC_VALUE(page_cache_mem_tracker, storage_page_cache_mem_bytes)
+    SET_MEM_METRIC_VALUE(update_mem_tracker, update_mem_bytes)
+    SET_MEM_METRIC_VALUE(chunk_allocator_mem_tracker, chunk_allocator_mem_bytes)
+    SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)
+    SET_MEM_METRIC_VALUE(column_pool_mem_tracker, compaction_mem_bytes)
+    SET_MEM_METRIC_VALUE(consistency_mem_tracker, consistency_mem_bytes)
+#undef SET_MEM_METRIC_VALUE
 
 #define UPDATE_COLUMN_POOL_METRIC(var, type)                                         \
     value = vectorized::describe_column_pool<vectorized::type>().central_free_bytes; \

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -51,18 +51,22 @@ public:
     METRIC_DEFINE_INT_GAUGE(jemalloc_retained_bytes, MetricUnit::BYTES);
 #endif
     // MemPool metrics
-    // Process memory usage
     METRIC_DEFINE_INT_GAUGE(process_mem_bytes, MetricUnit::BYTES);
-    // Query memory usage
     METRIC_DEFINE_INT_GAUGE(query_mem_bytes, MetricUnit::BYTES);
-    // Load memory usage
     METRIC_DEFINE_INT_GAUGE(load_mem_bytes, MetricUnit::BYTES);
-    // Tablet meta memory usage
     METRIC_DEFINE_INT_GAUGE(metadata_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(tablet_metadata_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(rowset_metadata_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(segment_metadata_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(column_metadata_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(tablet_schema_mem_bytes, MetricUnit::BYTES);
-    // Compaction memory usage
+    METRIC_DEFINE_INT_GAUGE(column_zonemap_index_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(ordinal_index_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(bitmap_index_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(bloom_filter_index_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(segment_zonemap_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(short_key_index_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(compaction_mem_bytes, MetricUnit::BYTES);
-    // SchemaChange memory usage
     METRIC_DEFINE_INT_GAUGE(schema_change_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(column_pool_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(storage_page_cache_mem_bytes, MetricUnit::BYTES);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10458 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently it is too hard to troubleshoot metadata memory problem, and more detailed statistics are required.

Add more detail `mem_tracker` for metadata

- metadata
  - tablet
    - tablet_schema
  - rowset
  - segment
    - segment_zone_map
    - short_key_index 
  - column
    - column_zone_map
    - ordinal_index
    - bitmap_index
    - bloom_filter_index

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
