### PR TITLE
[BugFix] fix bugs of lambda functions and correct some comments

### DIFF
--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -964,6 +964,10 @@ ColumnPtr ArrayFunctions::array_map([[maybe_unused]] FunctionContext* context, c
     return nullptr;
 }
 
+ColumnPtr ArrayFunctions::array_filter(FunctionContext* context, const Columns& columns) {
+    return ArrayFilter::process(context, columns);
+}
+
 class ArrayArithmeticImpl {
 public:
     using ArithmeticType = typename ArrayFunctions::ArithmeticType;

--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -79,13 +79,6 @@ public:
     APPLY_COMMONE_TYPES_FOR_ARRAY(DEFINE_ARRAY_OVERLAP_FN)
 #undef DEFINE_ARRAY_OVERLAP_FN
 
-#define DEFINE_ARRAY_FILTER_FN(NAME, PT)                                                     \
-    static ColumnPtr array_filter_##NAME(FunctionContext* context, const Columns& columns) { \
-        return ArrayFilter<PT>::process(context, columns);                                   \
-    }
-    APPLY_COMMONE_TYPES_FOR_ARRAY(DEFINE_ARRAY_FILTER_FN)
-#undef DEFINE_ARRAY_FILTER_FN
-
 #define DEFINE_ARRAY_INTERSECT_FN(NAME, PT)                                                     \
     static ColumnPtr array_intersect_##NAME(FunctionContext* context, const Columns& columns) { \
         return ArrayIntersect<PT>::process(context, columns);                                   \
@@ -170,6 +163,7 @@ public:
     DEFINE_VECTORIZED_FN(array_contains_any);
     DEFINE_VECTORIZED_FN(array_contains_all);
     DEFINE_VECTORIZED_FN(array_map);
+    DEFINE_VECTORIZED_FN(array_filter);
 
     enum ArithmeticType { SUM, AVG, MIN, MAX };
 

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -1031,11 +1031,11 @@ private:
     }
 };
 
-template <PrimitiveType PT>
 class ArrayFilter {
 public:
-    using CppType = RunTimeCppType<PT>;
-    static ColumnPtr process(FunctionContext* ctx, const Columns& columns) { return _array_filter(columns); }
+    static ColumnPtr process([[maybe_unused]] FunctionContext* ctx, const Columns& columns) {
+        return _array_filter(columns);
+    }
 
 private:
     static ColumnPtr _array_filter(const Columns& columns) {

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -71,43 +71,45 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
                 throw std::runtime_error("Input array element's size is not equal in array_map().");
             }
         }
-        if (cur_array->elements_column()->size() == 0) { // all elements are null
-            return child_col;
-        } else {
-            inputs.push_back(cur_array->elements_column());
+        inputs.push_back(cur_array->elements_column());
+    }
+
+    ColumnPtr column;
+    if (input_array->elements_column()->size() == 0) { // arrays may be null or empty
+        column = input_array->elements_column();
+    } else {
+        // construct a new chunk to evaluate the lambda expression.
+        auto cur_chunk = std::make_shared<vectorized::Chunk>();
+        // put all arguments into the new chunk
+        vector<SlotId> arguments_ids;
+        auto lambda_func = dynamic_cast<LambdaFunction*>(_children[0]);
+        int argument_num = lambda_func->get_lambda_arguments_ids(&arguments_ids);
+        DCHECK(argument_num == inputs.size());
+        for (int i = 0; i < argument_num; ++i) {
+            cur_chunk->append_column(inputs[i], arguments_ids[i]); // column ref
         }
-    }
+        // put captured columns into the new chunk aligning with the first array's offsets
+        vector<SlotId> slot_ids;
+        _children[0]->get_slot_ids(&slot_ids);
+        for (auto id : slot_ids) {
+            DCHECK(id > 0);
+            auto captured = chunk->get_column_by_slot_id(id);
+            auto aligned_col = captured->clone_empty();
+            cur_chunk->append_column(
+                    ColumnHelper::duplicate_column(captured, std::move(aligned_col), input_array->offsets_column()),
+                    id);
+        }
+        column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
+        // construct the result array
+        DCHECK(column != nullptr);
+        // the elements of the new array should be nullable and not const.
+        column = ColumnHelper::unpack_and_duplicate_const_column(column->size(), column);
 
-    // construct a new chunk to evaluate the lambda expression.
-    auto cur_chunk = std::make_shared<vectorized::Chunk>();
-    // put all arguments into the new chunk
-    vector<SlotId> arguments_ids;
-    auto lambda_func = dynamic_cast<LambdaFunction*>(_children[0]);
-    int argument_num = lambda_func->get_lambda_arguments_ids(&arguments_ids);
-    DCHECK(argument_num == inputs.size());
-    for (int i = 0; i < argument_num; ++i) {
-        cur_chunk->append_column(inputs[i], arguments_ids[i]); // column ref
-    }
-    // put captured columns into the new chunk aligning with the first array's offsets
-    vector<SlotId> slot_ids;
-    _children[0]->get_slot_ids(&slot_ids);
-    for (auto id : slot_ids) {
-        DCHECK(id > 0);
-        auto captured = chunk->get_column_by_slot_id(id);
-        auto aligned_col = captured->clone_empty();
-        cur_chunk->append_column(
-                ColumnHelper::duplicate_column(captured, std::move(aligned_col), input_array->offsets_column()), id);
-    }
-    auto column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
-
-    // construct the result array
-    DCHECK(column != nullptr);
-    // the elements of the new array should be nullable and not const.
-    column = ColumnHelper::unpack_and_duplicate_const_column(column->size(), column);
-    if (auto nullable = std::dynamic_pointer_cast<NullableColumn>(column);
-        nullable == nullptr && !column->is_nullable()) {
-        NullColumnPtr null_col = NullColumn::create(column->size(), 0);
-        column = NullableColumn::create(std::move(column), null_col);
+        if (auto nullable = std::dynamic_pointer_cast<NullableColumn>(column);
+            nullable == nullptr && !column->is_nullable()) {
+            NullColumnPtr null_col = NullColumn::create(column->size(), 0);
+            column = NullableColumn::create(std::move(column), null_col);
+        }
     }
     auto array_col = std::make_shared<ArrayColumn>(column, input_array->offsets_column());
     if (input_null_map != nullptr) {

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -27,7 +27,7 @@ inline bool offsets_equal(UInt32Column::Ptr array1, UInt32Column::Ptr array2) {
 }
 
 // The input array column maybe nullable, so first remove the wrap of nullable property.
-// The result of lambda expressions does not change the offsets of the current array and the null map.
+// The result of lambda expressions do not change the offsets of the current array and the null map.
 ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
     std::vector<ColumnPtr> inputs;
     NullColumnPtr input_null_map = nullptr;
@@ -88,7 +88,7 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
     for (int i = 0; i < argument_num; ++i) {
         cur_chunk->append_column(inputs[i], arguments_ids[i]); // column ref
     }
-    // put captured columns into the new chunks aligning with the first array's offsets
+    // put captured columns into the new chunk aligning with the first array's offsets
     vector<SlotId> slot_ids;
     _children[0]->get_slot_ids(&slot_ids);
     for (auto id : slot_ids) {

--- a/be/src/exprs/vectorized/lambda_function.cpp
+++ b/be/src/exprs/vectorized/lambda_function.cpp
@@ -3,6 +3,7 @@
 #include "exprs/vectorized/lambda_function.h"
 
 #include <fmt/format.h>
+
 #include <iostream>
 
 namespace starrocks::vectorized {

--- a/be/src/exprs/vectorized/lambda_function.cpp
+++ b/be/src/exprs/vectorized/lambda_function.cpp
@@ -2,7 +2,9 @@
 
 #include "exprs/vectorized/lambda_function.h"
 
+#include <fmt/format.h>
 #include <iostream>
+
 namespace starrocks::vectorized {
 LambdaFunction::LambdaFunction(const TExprNode& node) : Expr(node, false) {}
 
@@ -13,8 +15,10 @@ Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprCo
     for (int i = 1; i < child_num; ++i) {
         get_child(i)->get_slot_ids(&_arguments_ids);
     }
-    DCHECK(child_num - 1 == _arguments_ids.size());
-
+    if (child_num - 1 != _arguments_ids.size()) {
+        return Status::InternalError(fmt::format("Lambda arguments get ids failed, just get {} ids from {} arguments.",
+                                                 _arguments_ids.size(), child_num - 1));
+    }
     // get slot ids from the lambda expression
     get_child(0)->get_slot_ids(&_captured_slot_ids);
 

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -4349,7 +4349,7 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable) {
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{(bool)1, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_TINYINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->is_nullable());
@@ -4376,7 +4376,7 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint) {
     src_column2->append_datum(DatumArray{Datum()});
     src_column2->append_datum(DatumArray{(bool)0, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_TINYINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(!dest_column->is_nullable());
@@ -4404,7 +4404,7 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable_notnull) {
     src_column2->append_datum(DatumArray{Datum()});
     src_column2->append_datum(DatumArray{(bool)0, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_TINYINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->is_nullable());
@@ -4431,7 +4431,7 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_notnull_nullable) {
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{(bool)1, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_TINYINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(!dest_column->is_nullable());
@@ -4459,7 +4459,7 @@ TEST_F(ArrayFunctionsTest, array_filter_bigint_with_nullable) {
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{(bool)1, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_BIGINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->is_nullable());
@@ -4486,7 +4486,7 @@ TEST_F(ArrayFunctionsTest, array_filter_bigint) {
     src_column2->append_datum(DatumArray{Datum()});
     src_column2->append_datum(DatumArray{(bool)0, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_BIGINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(!dest_column->is_nullable());
@@ -4514,7 +4514,7 @@ TEST_F(ArrayFunctionsTest, array_filter_double_with_nullable) {
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{(bool)1, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_DOUBLE> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->is_nullable());
@@ -4541,7 +4541,7 @@ TEST_F(ArrayFunctionsTest, array_filter_double) {
     src_column2->append_datum(DatumArray{Datum()});
     src_column2->append_datum(DatumArray{(bool)0, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_DOUBLE> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(!dest_column->is_nullable());
@@ -4569,7 +4569,7 @@ TEST_F(ArrayFunctionsTest, array_filter_varchar_with_nullable) {
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{(bool)1, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_VARCHAR> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->is_nullable());
@@ -4596,7 +4596,7 @@ TEST_F(ArrayFunctionsTest, array_filter_varchar) {
     src_column2->append_datum(DatumArray{Datum()});
     src_column2->append_datum(DatumArray{(bool)0, Datum()});
 
-    ArrayFilter<PrimitiveType::TYPE_VARCHAR> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(!dest_column->is_nullable());
@@ -4615,7 +4615,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
 
     auto src_column2 = ColumnHelper::create_const_null_column(1);
 
-    ArrayFilter<PrimitiveType::TYPE_TINYINT> filter;
+    ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
     ASSERT_TRUE(dest_column->only_null());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1149,7 +1149,7 @@ public class FunctionSet {
                     LOGGER.warn("could not determine polymorphic type because input has non-match types");
                     return null;
                 }
-            } else if (declType == Type.FUNCTION) {
+            } else if (declType.matchesType(realType) || Type.canCastTo(realType, declType)) { // non-pseudo types
                 continue;
             } else {
                 LOGGER.warn("has unhandled pseudo type '{}'", declType);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -688,14 +688,18 @@ public class ExpressionAnalyzer {
             } else if (FunctionSet.STR_TO_DATE.equals(fnName)) {
                 fn = getStrToDateFunction(node, argumentTypes);
             } else if (fnName.equals(FunctionSet.ARRAY_FILTER)) {
-                Preconditions.checkState(node.getChildren().size() == 2,
-                        FunctionSet.ARRAY_FILTER + " should have 2 array inputs or lambda functions.");
-                Preconditions.checkState(node.getChild(0).getType().isArrayType() ||
-                                node.getChild(0).getType().isNull(),
-                        "The first input of " + FunctionSet.ARRAY_FILTER + " should be an array or a lambda function.");
-                Preconditions.checkState(node.getChild(1).getType().isArrayType() ||
-                                node.getChild(1).getType().isNull(),
-                        "The second input of " + FunctionSet.ARRAY_FILTER + " should be an array or a lambda function.");
+                if (node.getChildren().size() != 2) {
+                    throw new SemanticException(
+                            FunctionSet.ARRAY_FILTER + " should have 2 array inputs or lambda functions.");
+                }
+                if (!node.getChild(0).getType().isArrayType() && !node.getChild(0).getType().isNull()) {
+                    throw new SemanticException("The first input of " + FunctionSet.ARRAY_FILTER +
+                            " should be an array or a lambda function.");
+                }
+                if (!node.getChild(1).getType().isArrayType() && !node.getChild(1).getType().isNull()) {
+                    throw new SemanticException("The second input of " + FunctionSet.ARRAY_FILTER +
+                            " should be an array or a lambda function.");
+                }
                 // force the second array be of Type.ARRAY_BOOLEAN
                 node.setChild(1, new CastExpr(Type.ARRAY_BOOLEAN, node.getChild(1)));
                 argumentTypes[1] = Type.ARRAY_BOOLEAN;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -688,13 +688,14 @@ public class ExpressionAnalyzer {
             } else if (FunctionSet.STR_TO_DATE.equals(fnName)) {
                 fn = getStrToDateFunction(node, argumentTypes);
             } else if (fnName.equals(FunctionSet.ARRAY_FILTER)) {
-                Preconditions.checkState(node.getChildren().size() == 2, "ARRAY_FILTER should have 2 array inputs.");
+                Preconditions.checkState(node.getChildren().size() == 2,
+                        FunctionSet.ARRAY_FILTER + " should have 2 array inputs or lambda functions.");
                 Preconditions.checkState(node.getChild(0).getType().isArrayType() ||
                                 node.getChild(0).getType().isNull(),
-                        "The first input of ARRAY_FILTER() should be an array.");
+                        "The first input of " + FunctionSet.ARRAY_FILTER + " should be an array or a lambda function.");
                 Preconditions.checkState(node.getChild(1).getType().isArrayType() ||
                                 node.getChild(1).getType().isNull(),
-                        "The second input of ARRAY_FILTER() should be an array.");
+                        "The second input of " + FunctionSet.ARRAY_FILTER + " should be an array or a lambda function.");
                 // force the second array be of Type.ARRAY_BOOLEAN
                 node.setChild(1, new CastExpr(Type.ARRAY_BOOLEAN, node.getChild(1)));
                 argumentTypes[1] = Type.ARRAY_BOOLEAN;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -687,6 +687,18 @@ public class ExpressionAnalyzer {
                 }
             } else if (FunctionSet.STR_TO_DATE.equals(fnName)) {
                 fn = getStrToDateFunction(node, argumentTypes);
+            } else if (fnName.equals(FunctionSet.ARRAY_FILTER)) {
+                Preconditions.checkState(node.getChildren().size() == 2, "ARRAY_FILTER should have 2 array inputs.");
+                Preconditions.checkState(node.getChild(0).getType().isArrayType() ||
+                                node.getChild(0).getType().isNull(),
+                        "The first input of ARRAY_FILTER() should be an array.");
+                Preconditions.checkState(node.getChild(1).getType().isArrayType() ||
+                                node.getChild(1).getType().isNull(),
+                        "The second input of ARRAY_FILTER() should be an array.");
+                // force the second array be of Type.ARRAY_BOOLEAN
+                node.setChild(1, new CastExpr(Type.ARRAY_BOOLEAN, node.getChild(1)));
+                argumentTypes[1] = Type.ARRAY_BOOLEAN;
+                fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             } else {
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -157,6 +157,10 @@ public class ExpressionAnalyzer {
                 throw new SemanticException("Lambda inputs should be arrays.");
             }
             Type itemType = ((ArrayType) expr.getType()).getItemType();
+            if (itemType == Type.NULL) { // Since slot_ref with Type.NULL is rewritten to Literal in toThrift(),
+                // rather than a common columnRef, so change its type here.
+                itemType = Type.BOOLEAN;
+            }
             scope.putLambdaInput(new PlaceHolderExpr(-1, expr.isNullable(), itemType));
         }
         // visit LambdaFunction

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -62,7 +62,11 @@ public class FunctionAnalyzer {
 
         if (fnName.getFunction().equals(FunctionSet.ARRAY_MAP)) {
             Preconditions.checkState(functionCallExpr.getChildren().size() > 1);
-            functionCallExpr.setType(new ArrayType(functionCallExpr.getChild(0).getChild(1).getType()));
+            // the normalized high_order functions:
+            // high-order function(lambda_func(lambda_expr, lambda_arguments), input_arrays),
+            // which puts various arguments/inputs at the tail e.g.,
+            // array_map(x+y <- (x,y), arr1, arr2)
+            functionCallExpr.setType(new ArrayType(functionCallExpr.getChild(0).getChild(0).getType()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -45,9 +45,6 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
     @Override
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
         Function fn = call.getFunction();
-        if (fn.functionName().equals(FunctionSet.ARRAY_MAP)) { // array_map does not need to implicit cast.
-            return call;
-        }
         if (fn == null) {
             for (int i = 0; i < call.getChildren().size(); ++i) {
                 Type type = call.getType();
@@ -56,6 +53,9 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                 }
             }
         } else {
+            if (fn.functionName().equals(FunctionSet.ARRAY_MAP)) { // array_map does not need to implicit cast.
+                return call;
+            }
             if (!call.isAggregate() || FunctionSet.AVG.equalsIgnoreCase(fn.functionName())) {
                 Preconditions.checkArgument(Arrays.stream(fn.getArgs()).noneMatch(Type::isWildcardDecimal),
                         String.format("Resolved function %s has wildcard decimal as argument type", fn.functionName()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -45,6 +45,9 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
     @Override
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
         Function fn = call.getFunction();
+        if (fn.functionName().equals(FunctionSet.ARRAY_MAP)) { // array_map does not need to implicit cast.
+            return call;
+        }
         if (fn == null) {
             for (int i = 0; i < call.getChildren().size(); ++i) {
                 Type type = call.getType();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -261,9 +261,9 @@ public final class SqlToScalarOperatorTranslator {
             Scope scope = new Scope(args, expressionMapping.getScope());
             ExpressionMapping old = expressionMapping;
             expressionMapping = new ExpressionMapping(scope, refs, expressionMapping);
-            ScalarOperator arg = visit(node.getChild(0));
-            expressionMapping = old; // recovery it
-            node.setTransformed(new LambdaFunctionOperator(refs, arg, Type.FUNCTION));
+            ScalarOperator lambda = visit(node.getChild(0));
+            expressionMapping = old; // recover it
+            node.setTransformed(new LambdaFunctionOperator(refs, lambda, Type.FUNCTION));
             return node.getTransformed();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -129,5 +129,8 @@ public class AnalyzeExprTest {
         analyzeFail("select arrayFilter([1], x -> x)");
         analyzeFail("select array_filter(x -> z,[1])");
         analyzeFail("select array_filter(x -> x,[1],null)");
+        analyzeFail("select array_filter(1,[2])");
+        analyzeFail("select array_filter([],[],[])");
+        analyzeFail("select array_filter([2],1)");
     }
 }

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -752,18 +752,7 @@ vectorized_functions = [
     # reserve 150281
     [150282, 'array_contains_all', 'BOOLEAN', ['ANY_ARRAY', 'ANY_ARRAY'], 'ArrayFunctions::array_contains_all'],
 
-    [150300, 'array_filter', 'ARRAY_DATE',      ['ARRAY_DATE', 'ARRAY_BOOLEAN'],      'ArrayFunctions::array_filter_date'],
-    [150301, 'array_filter', 'ARRAY_DATETIME',  ['ARRAY_DATETIME', 'ARRAY_BOOLEAN'],  'ArrayFunctions::array_filter_datetime'],
-    [150302, 'array_filter', 'ARRAY_BOOLEAN',   ['ARRAY_BOOLEAN', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_filter_boolean'],
-    [150303, 'array_filter', 'ARRAY_TINYINT',   ['ARRAY_TINYINT', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_filter_tinyint'],
-    [150304, 'array_filter', 'ARRAY_SMALLINT',  ['ARRAY_SMALLINT', 'ARRAY_BOOLEAN'],  'ArrayFunctions::array_filter_smallint'],
-    [150305, 'array_filter', 'ARRAY_INT',       ['ARRAY_INT', 'ARRAY_BOOLEAN'],       'ArrayFunctions::array_filter_int'],
-    [150306, 'array_filter', 'ARRAY_BIGINT',    ['ARRAY_BIGINT', 'ARRAY_BOOLEAN'],    'ArrayFunctions::array_filter_bigint'],
-    [150307, 'array_filter', 'ARRAY_LARGEINT',  ['ARRAY_LARGEINT', 'ARRAY_BOOLEAN'],  'ArrayFunctions::array_filter_largeint'],
-    [150308, 'array_filter', 'ARRAY_FLOAT',     ['ARRAY_FLOAT', 'ARRAY_BOOLEAN'],     'ArrayFunctions::array_filter_float'],
-    [150309, 'array_filter', 'ARRAY_DOUBLE',    ['ARRAY_DOUBLE', 'ARRAY_BOOLEAN'],    'ArrayFunctions::array_filter_double'],
-    [150310, 'array_filter', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2', 'ARRAY_BOOLEAN'], 'ArrayFunctions::array_filter_decimalv2'],
-    [150311, 'array_filter', 'ARRAY_VARCHAR',   ['ARRAY_VARCHAR', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_filter_varchar'],
+    [150300, 'array_filter', 'ANY_ARRAY',   ['ANY_ARRAY', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_filter'],
 
     # high-order functions related to lambda functions.
     [160100, 'array_map','ANY_ARRAY',['FUNCTION','ANY_ARRAY', "..."],'ArrayFunctions::array_map'],


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### problem 1:
array_map(x -> x is null, [null]) where [null] should be expressed as `columnRef`, but toThrift() change slot_ref(Type.NULL) to NULL literal, which is not as expected, so change type.null to type.boolean.

https://github.com/StarRocks/starrocks/blob/0321f122b6d7530b925d0cc33fd56566510e862a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java#L725-L731

this bug is introduced when solving comments but checked by release mode binary, which does not trigger the `DCHECK(child_num - 1 == arguments.size())`, so change it `DCHECK(child_num - 1 == arguments.size())` to `if(child_num - 1 != arguments.size()){return error}`, checking the requirement by force.

tested by
`elect array_map(x -> x is null,[null,null]);`
### problem 2:
after refactor lambdaArguments to several lambdaArgument, 
`lambda function = lambda arguments, lambda expr ` is changed to `lambda expr, lambda argument, lambda argument ...` so the lambda expr lay at the first placement of a lambda function.

https://github.com/StarRocks/starrocks/blob/0321f122b6d7530b925d0cc33fd56566510e862a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java#L65

### problem 3:
remove the implicit casts for array_map, which casts the non-first arguments' data type to the first argument's data type. for example:
```
select array_map((x,y)->length(x)+y, ['abcdefg','aer;ladf'],[2,4])
```
the second argument `[2,4]` is implicitly casted to array of varchar, which is unexpected.

### problem 4:
speically process the `[]` and `null` array, they have the same elements and offsets with different null property, where elements are empty and offsets = [0,0]. Since empty elements results in empty chunk, violating `DCHECK(!chunk->empty)` in ExprContext->evalute() in DEBUG mode, so directly get results for this case, instead of invoke `lambda_expr->evalute()`.

### problem 5:
array_filter should support nested arrays, so change the function defination.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature. | https://github.com/StarRocks/StarRocksTest/pull/1058
- [x] I have added user document for my new feature or new function
