### PR TITLE
[Bugfix] Init connector_scan_executor for compute_node

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -181,6 +181,34 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _wg_driver_executor =
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
     _wg_driver_executor->initialize(_max_executor_threads);
+
+    int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
+    CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
+
+    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("con_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(connector_num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&connector_scan_worker_thread_pool_without_workgroup));
+    _connector_scan_executor_without_workgroup = new workgroup::ScanExecutor(
+            std::move(connector_scan_worker_thread_pool_without_workgroup),
+            std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+    _connector_scan_executor_without_workgroup->initialize(connector_num_io_threads);
+
+    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(connector_num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&connector_scan_worker_thread_pool_with_workgroup));
+    _connector_scan_executor_with_workgroup =
+            new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
+                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>());
+    _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
+
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
     _load_path_mgr = new LoadPathMgr(this);
@@ -231,33 +259,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                 new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
                                             std::make_unique<workgroup::WorkGroupScanTaskQueue>());
         _scan_executor_with_workgroup->initialize(num_io_threads);
-
-        int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
-        CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
-
-        std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;
-        RETURN_IF_ERROR(ThreadPoolBuilder("con_scan_io")
-                                .set_min_threads(0)
-                                .set_max_threads(connector_num_io_threads)
-                                .set_max_queue_size(1000)
-                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                                .build(&connector_scan_worker_thread_pool_without_workgroup));
-        _connector_scan_executor_without_workgroup = new workgroup::ScanExecutor(
-                std::move(connector_scan_worker_thread_pool_without_workgroup),
-                std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
-        _connector_scan_executor_without_workgroup->initialize(connector_num_io_threads);
-
-        std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
-        RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
-                                .set_min_threads(0)
-                                .set_max_threads(connector_num_io_threads)
-                                .set_max_queue_size(1000)
-                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                                .build(&connector_scan_worker_thread_pool_with_workgroup));
-        _connector_scan_executor_with_workgroup =
-                new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
-                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>());
-        _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
 
         Status status = _load_path_mgr->init();
         if (!status.ok()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10894.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The initialization codes in the block of `if (!store_paths.empty())` in `Exec::init` are not executed for the compute node.
Therefore, move the initialization work for `connector_scan_executor` outside of `if (!store_paths.empty())`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
