### PR TITLE
[BugFix] Add start option host_type in start_fe.sh

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -24,16 +24,19 @@ OPTS=$(getopt \
   -o '' \
   -l 'daemon' \
   -l 'helper:' \
+  -l 'host_type:' \
   -- "$@")
 
 eval set -- "$OPTS"
 
 RUN_DAEMON=0
 HELPER=
+HOST_TYPE=
 while true; do
     case "$1" in
         --daemon) RUN_DAEMON=1 ; shift ;;
         --helper) HELPER=$2 ; shift 2 ;;
+        --host_type) HOST_TYPE=$2 ; shift 2 ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
     esac
@@ -114,10 +117,15 @@ if [ x"$HELPER" != x"" ]; then
     HELPER="-helper $HELPER"
 fi
 
+if [ x"$HOST_TYPE" != x"" ]; then
+    # change it to '-host_type' to be compatible with code in Frontend
+    HOST_TYPE="-host_type $HOST_TYPE"
+fi
+
 if [ ${RUN_DAEMON} -eq 1 ]; then
-    nohup $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null &
+    nohup $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null &
 else
-    $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null
+    $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} "$@" >> $LOG_DIR/fe.out 2>&1 </dev/null
 fi
 
 echo $! > $pidfile


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10911

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The host_type parameter is not added to the start_fe.sh, so FE cannot use the host_type to specify IP or FQDN properly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
