### PR TITLE
[BugFix] write file repeat close bug

### DIFF
--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -237,7 +237,7 @@ public:
             return Status::OK();
         }
         Status st = broker_close_writer(_broker, _fd, _timeout_ms);
-        _closed = st.ok();
+        _closed = true;
         return st;
     }
 

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -49,7 +49,7 @@ HdfsInputStream::~HdfsInputStream() {
         if (r == 0) {
             return Status::OK();
         } else {
-            return Status::IOError("");
+            return Status::IOError("close error, file: {}"_format(_file_name));
         }
     });
     Status st = ret->get_future().get();
@@ -191,9 +191,7 @@ Status HDFSWritableFile::close() {
     });
     Status st = ret->get_future().get();
     PLOG_IF(ERROR, !st.ok()) << "close " << _path << " failed";
-    if (st.ok()) {
-        _closed = true;
-    }
+    _closed = true;
     return st;
 }
 

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -230,13 +230,12 @@ public:
 
         int ret;
         RETRY_ON_EINTR(ret, ::close(_fd));
+        _closed = true;
         if (ret < 0) {
             if (s.ok()) {
                 s = io_error(_filename, errno);
             }
         }
-
-        _closed = true;
         return s;
     }
 


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10926

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

In the current implementation, if we fail to close a hdfs/file, we will not set _closed to be true.
The file handler is released, and when the destructor of WritableFile is called,
we will close the file again, close a released file handler in libhdfs will lead to BE crash.
