### PR TITLE
[Enhancement] Fix lazy load fields in conjunct like `(a<1) or (a>7)`

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -166,7 +166,18 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
     for (ExprContext* ctx : cloned_conjunct_ctxs) {
         const Expr* root_expr = ctx->root();
         std::vector<SlotId> slot_ids;
-        if (root_expr->get_slot_ids(&slot_ids) != 1) {
+        root_expr->get_slot_ids(&slot_ids);
+
+        // For some conjunct like (a < 1) or (a > 7)
+        // slot_ids = (a, a), but actually there is only one slot.
+        bool single_slot = true;
+        for (int i = 1; i < slot_ids.size(); i++) {
+            if (slot_ids[i] != slot_ids[0]) {
+                single_slot = false;
+                break;
+            }
+        }
+        if (!single_slot) {
             _scanner_conjunct_ctxs.emplace_back(ctx);
             continue;
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For conjunct like `(a < 1) or (a>7)`,  `expr->get_slot_ids()` returns 2, but there is only one slot in it.

This change affects late materialization. For following query 1TB ssbflat

> select max(lo_orderdate), max(lo_orderkey), max(lo_linenumber), max(lo_custkey), max(lo_partkey), max(lo_suppkey), max(lo_orderpriority), max(lo_shippriority), max(lo_quantity), max(lo_extendedprice), max(lo_ordtotalprice), max(lo_discount), max(lo_revenue), max(lo_supplycost), max(lo_tax), max(lo_commitdate), max(lo_shipmode), max(c_name), max(c_address), max(c_city), max(c_nation), max(c_region), max(c_phone), max(c_mktsegment), max(s_name), max(s_address), max(s_city), max(s_nation), max(s_region), max(s_phone), max(p_name), max(p_mfgr), max(p_category), max(p_brand), max(p_color), max(p_type), max(p_size), max(p_container) from lineorder_flat_100_10_orc where lo_linenumber < 1 or lo_linenumber > 7;
 
the running time is cut down from 2min down to 8sec.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
