### PR TITLE
[Refactor] remove the nodicard annotation from Column::append_nulls

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -183,7 +183,7 @@ public:
 
     // Append multiple `null` values into this column.
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.
-    [[nodiscard]] virtual bool append_nulls(size_t count) = 0;
+    virtual bool append_nulls(size_t count) = 0;
 
     // Append multiple strings into this column.
     // Return false if the column is not a binary column.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [x] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The `Column::append_nulls` is annotated with `[[no_discard]]`, but actually most callers don't care about it and ignore the return value, which generates a lot of warning in compiler and code check.

Instead, the caller of this function should make sure it's a `NullableColumn` and not rely on the return value.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
