### PR TITLE
[BugFix] Just load WAL for shards which appended.

### DIFF
--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -20,7 +20,6 @@ message MutableIndexMetaPB {
     uint32 format_version = 1;
     IndexSnapshotMetaPB snapshot = 2;
     repeated IndexWalMetaPB wals = 3;
-    repeated ShardInfoPB shard_infos = 4;
 }
 
 // Do not modify the parameters order because of compatibility


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10919

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In shards' append WAL phase, not every shard (all of the various key size shards) do append:
https://github.com/StarRocks/starrocks/blob/31895a312527ed69b1e2ceb47b9cecf2395031af/be/src/storage/persistent_index.cpp#L1621-L1628
but in the load WAL phase, every shard do load:
https://github.com/StarRocks/starrocks/blob/31895a312527ed69b1e2ceb47b9cecf2395031af/be/src/storage/persistent_index.cpp#L1800-L1806
this will cause the data not correct bug.
so this PR just does load WAL for shards that had appended