### PR TITLE
[BugFix] fix delete predicate of array type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -602,8 +602,7 @@ public class DeleteHandler implements Writable {
             }
         }
 
-        LiteralExpr result =
-                LiteralExpr.create(value, Objects.requireNonNull(Type.fromPrimitiveType(column.getPrimitiveType())));
+        LiteralExpr result = LiteralExpr.create(value, Objects.requireNonNull(column.getType()));
         if (result instanceof DecimalLiteral) {
             ((DecimalLiteral) result).checkPrecisionAndScale(column.getPrecision(), column.getScale());
         } else if (result instanceof DateLiteral) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -10,8 +10,8 @@ import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.PartitionNames;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -65,16 +65,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class DeleteTest {
-    private long dbId = 1L;
-    private long tableId = 2L;
-    private long partitionId = 3L;
-    private long indexId = 4L;
-    private long tablet1Id = 10L;
-    private long tablet2Id = 11L;
-    private long backendId = 20L;
-    private String dbName = "db1";
-    private String tableName = "t1";
-    private String partitionName = "p1";
+    private final long dbId = 1L;
+    private final long tableId = 2L;
+    private final long partitionId = 3L;
+    private final long indexId = 4L;
+    private final long tablet1Id = 10L;
+    private final long tablet2Id = 11L;
+    private final long backendId = 20L;
+    private final String dbName = "db1";
+    private final String tableName = "t1";
+    private final String partitionName = "p1";
 
     @Mocked
     private GlobalStateMgr globalStateMgr;
@@ -98,7 +98,8 @@ public class DeleteTest {
         Column k1 = new Column("k1", Type.INT, true, null, "", "");
         columns.add(k1);
         columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
-        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
+        columns.add(new Column("v", Type.BIGINT, false, null, "0", ""));
+        columns.add(new Column("v1", Type.ARRAY_BIGINT, false, null, "0", ""));
 
         // Tablet
         Tablet tablet1 = new LakeTablet(tablet1Id);
@@ -117,7 +118,7 @@ public class DeleteTest {
         Partition partition = new Partition(partitionId, partitionName, index, distributionInfo);
 
         // Lake table
-        LakeTable table = new LakeTable(tableId, tableName, columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        LakeTable table = new LakeTable(tableId, tableName, columns, KeysType.DUP_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
         table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
@@ -127,12 +128,7 @@ public class DeleteTest {
         return db;
     }
 
-    @Before
-    public void setUp() {
-        deleteHandler = new DeleteHandler();
-        auth = AccessTestUtil.fetchAdminAccess();
-        analyzer = AccessTestUtil.fetchAdminAnalyzer();
-        db = createDb();
+    public void setUpExpectation() {
         Backend backend = new Backend(backendId, "127.0.0.1", 1234);
 
         new Expectations() {
@@ -155,8 +151,17 @@ public class DeleteTest {
         };
     }
 
+    @Before
+    public void setUp() {
+        deleteHandler = new DeleteHandler();
+        auth = AccessTestUtil.fetchAdminAccess();
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
+        db = createDb();
+    }
+
     @Test
     public void testNormal() throws UserException, RpcException {
+        setUpExpectation();
         TransactionState transactionState = new TransactionState();
         transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
 
@@ -228,7 +233,8 @@ public class DeleteTest {
     }
 
     @Test(expected = DdlException.class)
-    public void testBeDeleteFail() throws DdlException, QueryStateException {
+    public void testBeDeleteFail() throws UserException {
+        setUpExpectation();
         new MockUp<BrpcProxy>() {
             @Mock
             public LakeService getLakeService(String host, int port) {
@@ -283,5 +289,46 @@ public class DeleteTest {
         }
 
         deleteHandler.process(deleteStmt);
+    }
+
+    public void setUpExpectationWithoutExec() {
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getDb(anyString);
+                result = db;
+
+                GlobalStateMgr.getCurrentGlobalTransactionMgr();
+                result = globalTransactionMgr;
+
+            }
+        };
+    }
+
+    @Test
+    public void testBeDeleteArrayType() throws UserException {
+        setUpExpectationWithoutExec();
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) {
+                return lakeService;
+            }
+        };
+
+        // Not supported type
+        BinaryPredicate binaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.GT, new SlotRef(null, "v1"),
+                new StringLiteral("[]"));
+        DeleteStmt deleteStmt = new DeleteStmt(new TableName(dbName, tableName),
+                new PartitionNames(false, Lists.newArrayList(partitionName)), binaryPredicate);
+
+        deleteStmt.analyze(analyzer);
+        try {
+            deleteHandler.process(deleteStmt);
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("Type[ARRAY<bigint(20)>] not supported"));
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


`Delete from t0 where c1 = 1` , where `c1` column is `array<int>`, which could generate an exception, because `ArrayType::getPrimitive()` would return `INVALID_TYPE`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
