### PR TITLE
[cherry-pick][branch-2.2][BugFix] Write file repeat close bug (#10927)

### DIFF
--- a/be/src/env/env_broker.cpp
+++ b/be/src/env/env_broker.cpp
@@ -280,7 +280,7 @@ public:
             return Status::OK();
         }
         Status st = broker_close_writer(_broker, _fd, _timeout_ms);
-        _closed = st.ok();
+        _closed = true;
         return st;
     }
 


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10926

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

In the current implementation, if we fail to close a hdfs/file, we will not set _closed to be true.
The file handler is released, and when the destructor of WritableFile is called,
we will close the file again, close a released file handler in libhdfs will lead to BE crash.
