### PR TITLE
[BugFix] subquery operator cast bugfix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -9,6 +9,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 
 import java.time.LocalDateTime;
@@ -38,6 +39,11 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
+        // @Todo: remove the check later
+        if (operator.getChild(0) instanceof SubqueryOperator) {
+            return operator;
+        }
+
         // remove duplicate cast
         if (operator.getChild(0) instanceof CastOperator && checkCastTypeReduceAble(operator.getType(),
                 operator.getChild(0).getType(), operator.getChild(0).getChild(0).getType())) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1424,7 +1424,7 @@ public class SubqueryTest extends PlanTestBase {
     public void testSubqueryTypeCast() throws Exception {
         String sql = "select * from test_all_type where t1a like (select t1a from test_all_type_not_null);";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "   5:NESTLOOP JOIN\n" +
+        assertContains(plan, "5:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other join predicates: 1: t1a LIKE 11: t1a");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1419,4 +1419,14 @@ public class SubqueryTest extends PlanTestBase {
                     "WHEN 17: count > 20 THEN 22: avg ELSE CAST(26: min AS DOUBLE) END");
         }
     }
+
+    @Test
+    public void testSubqueryTypeCast() throws Exception {
+        String sql = "select * from test_all_type where t1a like (select t1a from test_all_type_not_null);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "   5:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  other join predicates: 1: t1a LIKE 11: t1a");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTERatioTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTERatioTest.java
@@ -139,7 +139,6 @@ public class TPCDSCTERatioTest extends TPCDSPlanTestBase {
         QUERY47      6,143          28,724         0.21
      */
 
-    @Test
     public void printCosts() throws Exception {
         System.out.printf("%-10s%-30s%-30s%-30s\n", "Name", "CTE", "Inline", "Inline/CTE");
         List<Boolean> expect = Lists.newArrayList();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
```
select * from test_all_type where t1a like (select t1a from test_all_type_not_null);
```

```
com.starrocks.sql.common.StarRocksPlannerException: Planner rewrite scalar operator over limit
	at com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter.rewrite(ScalarOperatorRewriter.java:69)
	at com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator.translate(SqlToScalarOperatorTranslator.java:130)
	at com.starrocks.sql.optimizer.transformer.QueryTransformer.filter(QueryTransformer.java:187)
	at com.starrocks.sql.optimizer.transformer.QueryTransformer.plan(QueryTransformer.java:64)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.visitSelect(RelationTransformer.java:201)

```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
