### PR TITLE
[Bugfix] Connector uses different resource group SchedEntity from Olap

### DIFF
--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -80,7 +80,9 @@ private:
 
 class WorkGroupScanTaskQueue final : public ScanTaskQueue {
 public:
-    WorkGroupScanTaskQueue() = default;
+    enum SchedEntityType { OLAP, CONNECTOR };
+
+    WorkGroupScanTaskQueue(SchedEntityType sched_entity_type) : _sched_entity_type(sched_entity_type) {}
     ~WorkGroupScanTaskQueue() override = default;
 
     void close() override;
@@ -110,6 +112,9 @@ private:
     // The ideal runtime of a work group is the weighted average of the schedule period.
     int64_t _ideal_runtime_ns(workgroup::WorkGroupScanSchedEntity* wg_entity) const;
 
+    workgroup::WorkGroupScanSchedEntity* _sched_entity(workgroup::WorkGroup* wg);
+    const workgroup::WorkGroupScanSchedEntity* _sched_entity(const workgroup::WorkGroup* wg) const;
+
 private:
     static constexpr int64_t SCHEDULE_PERIOD_PER_WG_NS = 100'000'000;
     static constexpr int64_t BANDWIDTH_CONTROL_PERIOD_NS = 100'000'000;
@@ -119,6 +124,8 @@ private:
         bool operator()(const WorkGroupScanSchedEntityPtr& lhs, const WorkGroupScanSchedEntityPtr& rhs) const;
     };
     using WorkgroupSet = std::set<workgroup::WorkGroupScanSchedEntity*, WorkGroupScanSchedEntityComparator>;
+
+    const SchedEntityType _sched_entity_type;
 
     mutable std::mutex _global_mutex;
     std::condition_variable _cv;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -38,10 +38,15 @@ WorkGroup::WorkGroup(const std::string& name, int64_t id, int64_t version, size_
           _memory_limit(memory_limit),
           _concurrency_limit(concurrency),
           _driver_sched_entity(this),
-          _scan_sched_entity(this) {}
+          _scan_sched_entity(this),
+          _connector_scan_sched_entity(this) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg)
-        : _name(twg.name), _id(twg.id), _driver_sched_entity(this), _scan_sched_entity(this) {
+        : _name(twg.name),
+          _id(twg.id),
+          _driver_sched_entity(this),
+          _scan_sched_entity(this),
+          _connector_scan_sched_entity(this) {
     if (twg.__isset.cpu_core_limit) {
         _cpu_limit = twg.cpu_core_limit;
     } else {
@@ -111,6 +116,8 @@ void WorkGroup::init() {
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
     _driver_sched_entity.set_queue(std::make_unique<pipeline::QuerySharedDriverQueue>());
     _scan_sched_entity.set_queue(std::make_unique<PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+    _connector_scan_sched_entity.set_queue(
+            std::make_unique<PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
 }
 
 std::string WorkGroup::to_string() const {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -103,6 +103,8 @@ public:
     const WorkGroupDriverSchedEntity* driver_sched_entity() const { return &_driver_sched_entity; }
     WorkGroupScanSchedEntity* scan_sched_entity() { return &_scan_sched_entity; }
     const WorkGroupScanSchedEntity* scan_sched_entity() const { return &_scan_sched_entity; }
+    WorkGroupScanSchedEntity* connector_scan_sched_entity() { return &_connector_scan_sched_entity; }
+    const WorkGroupScanSchedEntity* connector_scan_sched_entity() const { return &_connector_scan_sched_entity; }
 
     void incr_num_running_drivers();
     void decr_num_running_drivers();
@@ -177,6 +179,7 @@ private:
 
     WorkGroupDriverSchedEntity _driver_sched_entity;
     WorkGroupScanSchedEntity _scan_sched_entity;
+    WorkGroupScanSchedEntity _connector_scan_sched_entity;
 
     std::atomic<bool> _is_marked_del = false;
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -208,7 +208,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                             .build(&connector_scan_worker_thread_pool_with_workgroup));
     _connector_scan_executor_with_workgroup =
             new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
-                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>());
+                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
     _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
 
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
@@ -260,7 +261,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                 .build(&scan_worker_thread_pool_with_workgroup));
         _scan_executor_with_workgroup =
                 new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
-                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>());
+                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                    workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
         _scan_executor_with_workgroup->initialize(num_io_threads);
 
         Status status = _load_path_mgr->init();


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10959.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`GroupScanTaskQueue` is a two-level queue, where the first level is workgroups and the second level is the scan tasks of a specific workgroup.

`connector_executor` and `scan_executor` uses different `GroupScanTaskQueue`. However, the second level of them are the same.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
