### PR TITLE
[BugFix] simplify expr hashCode calculating

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -395,6 +395,9 @@ public class AnalyticExpr extends Expr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fnCall, partitionExprs, orderByElements, window);
+        // all children information is contained in the group of fnCall, partitionExprs, orderByElements and window,
+        // so need to calculate super's hashCode.
+        // field window is correlated with field resetWindow, so no need to add resetWindow when calculating hashCode.
+        return Objects.hash(type, opcode, fnCall, partitionExprs, orderByElements, window);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -443,7 +443,7 @@ public class ArithmeticExpr extends Expr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(op);
+        return Objects.hash(super.hashCode(), op);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CompoundPredicate.java
@@ -125,7 +125,7 @@ public class CompoundPredicate extends Predicate {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(op);
+        return Objects.hash(super.hashCode(), op);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -32,8 +32,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TDateLiteral;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -447,7 +445,7 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(unixTimestamp(TimeZone.getDefault()));
+        return Objects.hash(super.hashCode(), Objects.hashCode(unixTimestamp(TimeZone.getDefault())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -485,6 +485,6 @@ public class DecimalLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ExistsPredicate.java
@@ -26,6 +26,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.thrift.TExprNode;
 
+import java.util.Objects;
+
 public class ExistsPredicate extends Predicate {
     private boolean notExists = false;
 
@@ -74,7 +76,7 @@ public class ExistsPredicate extends Predicate {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Boolean.hashCode(notExists);
+        return Objects.hash(super.hashCode(), notExists);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 public class FloatLiteral extends LiteralExpr {
     private double value;
@@ -212,7 +213,7 @@ public class FloatLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Double.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -23,7 +23,6 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -440,12 +439,8 @@ public class FunctionCallExpr extends Expr {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + Objects.hashCode(opcode);
-        result = 31 * result + Objects.hashCode(fnName);
-        result = 31 * result + Objects.hashCode(fnParams);
-        result = 31 * result + Objects.hashCode(nondeterministicId);
-        return result;
+        // fnParams contains all information of children Expr. No need to calculate super's hashcode again.
+        return java.util.Objects.hash(type, opcode, fnName, fnParams, nondeterministicId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -40,6 +40,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class FunctionCallExpr extends Expr {
@@ -440,7 +441,7 @@ public class FunctionCallExpr extends Expr {
     @Override
     public int hashCode() {
         // fnParams contains all information of children Expr. No need to calculate super's hashcode again.
-        return java.util.Objects.hash(type, opcode, fnName, fnParams, nondeterministicId);
+        return Objects.hash(type, opcode, fnName, fnParams, nondeterministicId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.NotImplementedException;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TIntLiteral;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 public class IntLiteral extends LiteralExpr {
     public static final long TINY_INT_MIN = Byte.MIN_VALUE; // -2^7 ~ 2^7 - 1
@@ -333,6 +333,6 @@ public class IntLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Long.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
@@ -232,6 +232,6 @@ public class LargeIntLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LikePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LikePredicate.java
@@ -94,7 +94,7 @@ public class LikePredicate extends Predicate {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(op);
+        return Objects.hash(super.hashCode(), op);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/StringLiteral.java
@@ -245,6 +245,6 @@ public class StringLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
@@ -1,27 +1,12 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
-package com.starrocks.sql.ast;
+package com.starrocks.analysis;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.AnalyticExpr;
-import com.starrocks.analysis.AnalyticWindow;
-import com.starrocks.analysis.ArithmeticExpr;
-import com.starrocks.analysis.BinaryPredicate;
-import com.starrocks.analysis.CompoundPredicate;
-import com.starrocks.analysis.DateLiteral;
-import com.starrocks.analysis.DecimalLiteral;
-import com.starrocks.analysis.ExistsPredicate;
-import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.FloatLiteral;
-import com.starrocks.analysis.FunctionCallExpr;
-import com.starrocks.analysis.IntLiteral;
-import com.starrocks.analysis.LargeIntLiteral;
-import com.starrocks.analysis.LikePredicate;
-import com.starrocks.analysis.SelectList;
-import com.starrocks.analysis.StringLiteral;
-import com.starrocks.analysis.Subquery;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExprHashCodeTest.java
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.AnalyticExpr;
+import com.starrocks.analysis.AnalyticWindow;
+import com.starrocks.analysis.ArithmeticExpr;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.DecimalLiteral;
+import com.starrocks.analysis.ExistsPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FloatLiteral;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LargeIntLiteral;
+import com.starrocks.analysis.LikePredicate;
+import com.starrocks.analysis.SelectList;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.Subquery;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExprHashCodeTest {
+
+    private Set<Expr> exprSet = Sets.newHashSet();
+
+    @ParameterizedTest
+    @MethodSource("generateExprStream")
+    void testExprHashCode(Expr expr) {
+        assertTrue(exprSet.add(expr));
+    }
+
+
+    private static Stream<Arguments> generateExprStream() throws Exception{
+        FloatLiteral floatLiteral = new FloatLiteral(1.0d);
+        IntLiteral intLiteral = new IntLiteral(1);
+        LargeIntLiteral largeIntLiteral = new LargeIntLiteral("123");
+        StringLiteral stringLiteral = new StringLiteral("test");
+        DateLiteral dateLiteral = new DateLiteral(2000L,10L,10L);
+        DecimalLiteral decimalLiteral = new DecimalLiteral(new BigDecimal(100));
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("abs", ImmutableList.of(intLiteral));
+        LikePredicate likePredicate = new LikePredicate(LikePredicate.Operator.LIKE, stringLiteral, stringLiteral);
+        SelectRelation selectRelation = new SelectRelation
+                (new SelectList(), null, null, null, null);
+        ExistsPredicate existsPredicate = new ExistsPredicate(new Subquery(new QueryStatement(selectRelation)), false);
+        BinaryPredicate predicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, stringLiteral, stringLiteral);
+        CompoundPredicate compoundPredicate = new CompoundPredicate(CompoundPredicate.Operator.OR,
+                predicate, predicate);
+        ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, intLiteral, largeIntLiteral);
+        AnalyticExpr analyticExpr = new AnalyticExpr(functionCallExpr, ImmutableList.of(stringLiteral),
+                null, AnalyticWindow.DEFAULT_WINDOW);
+        List<Expr> exprList = Lists.newArrayList(floatLiteral, intLiteral, largeIntLiteral, stringLiteral, dateLiteral,
+                decimalLiteral, functionCallExpr, likePredicate, existsPredicate, predicate, compoundPredicate,
+                arithmeticExpr, analyticExpr);
+        return exprList.stream().map(e -> Arguments.of(e));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExprHashCodeTest.java
@@ -43,18 +43,17 @@ class ExprHashCodeTest {
         assertTrue(exprSet.add(expr));
     }
 
-
-    private static Stream<Arguments> generateExprStream() throws Exception{
+    private static Stream<Arguments> generateExprStream() throws Exception {
         FloatLiteral floatLiteral = new FloatLiteral(1.0d);
         IntLiteral intLiteral = new IntLiteral(1);
         LargeIntLiteral largeIntLiteral = new LargeIntLiteral("123");
         StringLiteral stringLiteral = new StringLiteral("test");
-        DateLiteral dateLiteral = new DateLiteral(2000L,10L,10L);
+        DateLiteral dateLiteral = new DateLiteral(2000L, 10L, 10L);
         DecimalLiteral decimalLiteral = new DecimalLiteral(new BigDecimal(100));
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("abs", ImmutableList.of(intLiteral));
         LikePredicate likePredicate = new LikePredicate(LikePredicate.Operator.LIKE, stringLiteral, stringLiteral);
-        SelectRelation selectRelation = new SelectRelation
-                (new SelectList(), null, null, null, null);
+        SelectRelation selectRelation = new SelectRelation(new SelectList(),
+                null, null, null, null);
         ExistsPredicate existsPredicate = new ExistsPredicate(new Subquery(new QueryStatement(selectRelation)), false);
         BinaryPredicate predicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, stringLiteral, stringLiteral);
         CompoundPredicate compoundPredicate = new CompoundPredicate(CompoundPredicate.Operator.OR,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
@@ -42,8 +42,8 @@ public class SqlToScalarOperatorTranslatorTest {
         for (int i = 0; i < 100; i++) {
             complexFunc = new FunctionCallExpr("if",  ImmutableList.of(predicate, test, complexFunc));
         }
-        CallOperator so = (CallOperator) SqlToScalarOperatorTranslator.translate
-                (complexFunc, new ExpressionMapping(null, Collections.emptyList()), new ColumnRefFactory());
+        CallOperator so = (CallOperator) SqlToScalarOperatorTranslator.translate(complexFunc,
+                new ExpressionMapping(null, Collections.emptyList()), new ColumnRefFactory());
         assertEquals("if", so.getFnName());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
@@ -2,9 +2,14 @@
 
 package com.starrocks.sql.optimizer.transformer;
 
+import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import org.junit.Test;
@@ -25,5 +30,20 @@ public class SqlToScalarOperatorTranslatorTest {
 
         assertEquals(OperatorType.CONSTANT, so.getOpType());
         assertEquals(LocalDateTime.of(2000, 12, 1, 0, 0), ((ConstantOperator) so).getDate());
+    }
+
+    @Test
+    public void testTranslateComplexFunction() {
+        StringLiteral test = new StringLiteral("test");
+        StringLiteral defaultStr = new StringLiteral("default");
+        BinaryPredicate predicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, defaultStr, test);
+        FunctionCallExpr baseFunc = new FunctionCallExpr("if", ImmutableList.of(predicate, test, defaultStr));
+        FunctionCallExpr complexFunc = baseFunc;
+        for (int i = 0; i < 100; i++) {
+            complexFunc = new FunctionCallExpr("if",  ImmutableList.of(predicate, test, complexFunc));
+        }
+        CallOperator so = (CallOperator) SqlToScalarOperatorTranslator.translate
+                (complexFunc, new ExpressionMapping(null, Collections.emptyList()), new ColumnRefFactory());
+        assertEquals("if", so.getFnName());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2660,4 +2660,20 @@ public class JoinTest extends PlanTestBase {
                 "  |  equal join conjunct: 1: v1 = 4: v1");
         FeConstants.runningUnitTest = false;
     }
+
+    @Test
+    public void testComplexExpr() throws Exception {
+        String sql = "select count(v1) as c, if(v4 is not null, v4, '未知') as k2 from ( select A.v1, B.v4 from " +
+                "( select v1 from t0 where v2 = 1 ) A left join ( select v4, if( v5 = 0, '未知', if( v5 = 1, '广东', " +
+                "if( v5 = 2, '广西', if( v5 = 3, '北京', if( v5 = 4, '海南', if( v5 = 5, '福建', if( v5 = 6, '天津', " +
+                "if( v5 = 7, '湖南', if( v5 = 8, '湖北', if( v5 = 9, '河南', if( v5 = 10, '河北', if( v5 = 11, '山东', " +
+                "if( v5 = 12, '山西', if( v5 = 13, '黑龙江', if( v5 = 14, '辽宁', if( v5 = 15, '上海', if( v5 = 16, '甘肃', " +
+                "if( v5 = 17, '青海', if( v5 = 18, '新疆', if( v5 = 19, '西藏', if( v5 = 20, '宁夏', if( v5 = 21, '四川', " +
+                "if( v5 = 22, '云南', if( v5 = 23, '吉林', if( v5 = 24, '内蒙古', if( v5 = 25, '陕西', if( v5 = 26, '安徽', " +
+                "if( v5 = 27, '贵州', if( v5 = 28, '江苏', if( v5 = 29, '重庆', if( v5 = 30, '浙江', if( v5 = 31, '江西', " +
+                "if( v5 = 32, '国外', if( v5 = 33, '台湾', if(v5 = 34, '香港', if(v5 = 35, '澳门', 'Default')) ) ) ) ) ) ) " +
+                ") ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) as k from t1 ) B on A.v1 = B.k ) C group by v4;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "if(5: v5 = 0, '未知',");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2674,6 +2674,6 @@ public class JoinTest extends PlanTestBase {
                 "if( v5 = 32, '国外', if( v5 = 33, '台湾', if(v5 = 34, '香港', if(v5 = 35, '澳门', 'Default')) ) ) ) ) ) ) " +
                 ") ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) as k from t1 ) B on A.v1 = B.k ) C group by v4;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "if(5: v5 = 0, '未知',");
+        assertContains(plan, "if(5: v5 = 0, '未知'");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When there are nested functionCallExprs in the parameters of a functionCallExpr, the original hashcode calculating process is inefficient. This pr simplify the calculating process by only using necessary info to ensure it meet linear time complexity.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
