### PR TITLE
[BugFix] Reject query when non-existing column appear in the update statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -52,7 +52,11 @@ public class UpdateAnalyzer {
         List<ColumnAssignment> assignmentList = updateStmt.getAssignments();
         Map<String, ColumnAssignment> assignmentByColName = assignmentList.stream().collect(
                 Collectors.toMap(assign -> assign.getColumn().toLowerCase(), a -> a));
-
+        for (String colName : assignmentByColName.keySet()) {
+            if (table.getColumn(colName) == null) {
+                throw new SemanticException("table '%s' do not existing column '%s'", tableName.getTbl(), colName);
+            }
+        }
         SelectList selectList = new SelectList();
         for (Column col : table.getBaseSchema()) {
             SelectListItem item;


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10907

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
mysql> create table pri_tbl(c1 int,c2 varchar,c3 date) primary key(c1) distributed by hash(c1);
Query OK, 0 rows affected (0.02 sec)

mysql> insert into pri_tbl values(1,'A','2022-09-01'),(2,'B','2022-09-02');
Query OK, 2 rows affected (0.03 sec)
{'label':'insert_37a891ff-2ddd-11ed-8960-00163e14c85e', 'status':'VISIBLE', 'txnId':'11135'}

mysql> update pri_tbl set c4=10 where c1>0;
Query OK, 2 rows affected (0.03 sec)
{'label':'update_3d1cbfe4-2ddd-11ed-8960-00163e14c85e', 'status':'VISIBLE', 'txnId':'11137'}
```
As mentioned above, update query still success even though target column does not exist in the table, not right.
So this PR reject query when non-existing column appear in target columns of update set assignment list.