### PR TITLE
[Enhance] introduce fastpath for merge nullable column

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -53,7 +53,7 @@ public:
         UniformInt uniform_int;
         uniform_int.param(UniformInt::param_type(1, 100'000 * std::pow(2, slot_index)));
 
-        int null_count = uniform_int(rng) % (config::vector_chunk_size / 100); // make 1/100 datums are null
+        int null_count = config::vector_chunk_size / 100;
         std::vector<int32_t> elements(config::vector_chunk_size - null_count);
         std::generate(elements.begin(), elements.end(), [&]() { return uniform_int(rng); });
         std::sort(elements.begin(), elements.end());
@@ -62,6 +62,7 @@ public:
         for (int32_t x : elements) {
             column->append_datum(Datum((int32_t)x));
         }
+        down_cast<NullableColumn*>(column.get())->update_has_null();
 
         return {column, std::move(expr)};
     }

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -170,10 +170,10 @@ public:
         // Fast path
         if (!_left_col->has_null() && !_right_col->has_null()) {
             DCHECK(_left_col->is_nullable() && _right_col->is_nullable());
-            const auto& lhs_data = down_cast<const NullableColumn*>(_left_col)->data_column_ref();
-            const auto& rhs_data = down_cast<const NullableColumn*>(_right_col)->data_column_ref();
-            MergeTwoColumn merge2({_sort_order, _null_first}, &lhs_data, &rhs_data, _equal_ranges, _perm);
-            return _left_col->accept(&merge2);
+            const auto* lhs_data = down_cast<const NullableColumn*>(_left_col)->data_column().get();
+            const auto* rhs_data = down_cast<const NullableColumn*>(_right_col)->data_column().get();
+            MergeTwoColumn merge2({_sort_order, _null_first}, lhs_data, rhs_data, _equal_ranges, _perm);
+            return lhs_data->accept(&merge2);
         }
 
         // Slow path

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -106,7 +106,7 @@ public:
 
     // General implementation
     template <class ColumnType>
-    Status do_visit(const ColumnType&) {
+    Status do_visit_slow(const ColumnType&) {
         auto cmp = [&](size_t lhs_index, size_t rhs_index) {
             int x = _left_col->compare_at(lhs_index, rhs_index, *_right_col, _null_first);
             if (_sort_order == -1) {
@@ -142,6 +142,11 @@ public:
         return do_merge(cmp, cmp_left, cmp_right);
     }
 
+    template <class ColumnType>
+    Status do_visit(const ColumnType& _) {
+        return do_visit_slow(_);
+    }
+
     // Specific version for FixedlengthColumn
     template <class T>
     Status do_visit(const FixedLengthColumn<T>& _) {
@@ -161,10 +166,19 @@ public:
         return merge_ordinary_column<Container, Slice>(left_data, right_data);
     }
 
-    // TODO: Murphy
-    // Status do_visit(const NullableColumn& _) {
-    // return Status::NotSupported("TODO");
-    // }
+    Status do_visit(const NullableColumn& _) {
+        // Fast path
+        if (!_left_col->has_null() && !_right_col->has_null()) {
+            DCHECK(_left_col->is_nullable() && _right_col->is_nullable());
+            const auto& lhs_data = down_cast<const NullableColumn*>(_left_col)->data_column_ref();
+            const auto& rhs_data = down_cast<const NullableColumn*>(_right_col)->data_column_ref();
+            MergeTwoColumn merge2({_sort_order, _null_first}, &lhs_data, &rhs_data, _equal_ranges, _perm);
+            return _left_col->accept(&merge2);
+        }
+
+        // Slow path
+        return do_visit_slow(_);
+    }
 
 private:
     constexpr static uint32_t kLeftIndex = 0;

--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -202,9 +202,12 @@ public:
             assert(rhs.capacity_ == kInitialCapacity);
             ASAN_UNPOISON_MEMORY_REGION(initial_data_, kInitialCapacity);
             ASAN_UNPOISON_MEMORY_REGION(rhs.initial_data_, kInitialCapacity);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
             memcpy(tmp_buff, initial_data_, kInitialCapacity);
             memcpy(initial_data_, rhs.initial_data_, kInitialCapacity);
             memcpy(rhs.initial_data_, tmp_buff, kInitialCapacity);
+#pragma GCC diagnostic pop
             std::swap(len_, rhs.len_);
         } else if (data_ == initial_data_) {
             assert(capacity_ == kInitialCapacity);

--- a/be/test/column/bytes_test.cpp
+++ b/be/test/column/bytes_test.cpp
@@ -326,7 +326,7 @@ TEST(BytesTest, test_hook_pvalloc) {
 TEST(BytesTest, test_hook_posix_memalign) {
     srand((int)time(NULL));
 
-    void* ptr;
+    void* ptr = nullptr;
     int before;
     int after;
     int size;

--- a/be/test/exec/vectorized/arrow_converter_test.cpp
+++ b/be/test/exec/vectorized/arrow_converter_test.cpp
@@ -623,7 +623,7 @@ VALUE_GUARD(ArrowTypeId, DateTimeATGuard, at_is_datetime, ArrowTypeId::DATE32, A
 
 template <ArrowTypeId AT, typename ArrowType, typename ArrowCppType = typename arrow::TypeTraits<ArrowType>::CType>
 ArrowCppType string_to_arrow_datetime(std::shared_ptr<ArrowType> type, const std::string& value) {
-    ArrowCppType datetime_value;
+    ArrowCppType datetime_value = {};
     TimestampValue tv;
     tv.from_string(value.c_str(), value.size());
     auto unix_seconds = tv.to_unix_second();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Merge `NullableColumn` needs to be performed in row-wise, which is pretty slow. So we introduce a fastpath for it if it does not contains null datums.

## Experiment Result
As benchmark result, merge `NullableColumn` is much slower than normal column, so this optimization could achieve some benefits in non-null cases.

```
BM_merge_columnwise/2               184215 ns       184190 ns         3670 items_per_second=44.3997M/s
BM_merge_columnwise/6              1110737 ns      1110633 ns          631 items_per_second=21.9929M/s
BM_merge_columnwise/10             2189901 ns      2189480 ns          311 items_per_second=18.6117M/s
BM_merge_columnwise/14             3344204 ns      3343591 ns          206 items_per_second=17.0122M/s
BM_merge_columnwise/18             4569135 ns      4568422 ns          155 items_per_second=16.1032M/s
BM_merge_columnwise/22             5702717 ns      5702183 ns          120 items_per_second=15.6873M/s
BM_merge_columnwise/26             7237213 ns      7236017 ns           97 items_per_second=14.6923M/s
BM_merge_columnwise/30             8318747 ns      8317740 ns           83 items_per_second=14.7444M/s
BM_merge_columnwise/34             9830872 ns      9829731 ns           72 items_per_second=14.095M/s
BM_merge_columnwise/38            11051449 ns     11050333 ns           61 items_per_second=14.051M/s
BM_merge_columnwise/42            12629722 ns     12628535 ns           57 items_per_second=13.6092M/s
BM_merge_columnwise/46            13862942 ns     13861652 ns           47 items_per_second=13.4765M/s
BM_merge_columnwise/50            15780122 ns     15778650 ns           46 items_per_second=12.8908M/s
BM_merge_columnwise/54            17066532 ns     17064833 ns           42 items_per_second=12.8854M/s
BM_merge_columnwise/58            18831904 ns     18830144 ns           39 items_per_second=12.5486M/s
BM_merge_columnwise/62            20746702 ns     20744757 ns           35 items_per_second=12.161M/s
BM_merge_columnwise_nullable/2      367079 ns       367044 ns         1961 items_per_second=22.3188M/s
BM_merge_columnwise_nullable/6     2548951 ns      2548701 ns          278 items_per_second=9.64256M/s
BM_merge_columnwise_nullable/10    5243321 ns      5242831 ns          135 items_per_second=7.81257M/s
BM_merge_columnwise_nullable/14    8074353 ns      8073594 ns           87 items_per_second=7.10266M/s
BM_merge_columnwise_nullable/18    9646131 ns      9645229 ns           59 items_per_second=7.64399M/s
BM_merge_columnwise_nullable/22   14834784 ns     14833397 ns           48 items_per_second=6.07494M/s
BM_merge_columnwise_nullable/26   18250523 ns     18248693 ns           39 items_per_second=5.83582M/s
BM_merge_columnwise_nullable/30   21717895 ns     21715867 ns           33 items_per_second=5.65854M/s
BM_merge_columnwise_nullable/34   25339625 ns     25337265 ns           28 items_per_second=5.49641M/s
BM_merge_columnwise_nullable/38   29536876 ns     29534105 ns           24 items_per_second=5.27011M/s
BM_merge_columnwise_nullable/42   33548381 ns     33545041 ns           21 items_per_second=5.12839M/s
BM_merge_columnwise_nullable/46   37530215 ns     37526710 ns           19 items_per_second=5.02085M/s
BM_merge_columnwise_nullable/50   41891001 ns     41887072 ns           17 items_per_second=4.88934M/s
BM_merge_columnwise_nullable/54   46184711 ns     46180150 ns           15 items_per_second=4.78959M/s
BM_merge_columnwise_nullable/58   50009037 ns     50004334 ns           14 items_per_second=4.75095M/s
BM_merge_columnwise_nullable/62   54388986 ns     54383875 ns           12 items_per_second=4.66962M/s
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
