### PR TITLE
[Bugfix] Connector WorkGroupScanTaskQueue uses different ShcedEntity from Olap (#10950)

### DIFF
--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -7,8 +7,8 @@
 
 namespace starrocks::workgroup {
 
-ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool)
-        : _task_queue(std::make_unique<WorkGroupScanTaskQueue>()), _thread_pool(std::move(thread_pool)) {}
+ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue)
+        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {}
 
 ScanExecutor::~ScanExecutor() {
     _task_queue->close();

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -13,7 +13,7 @@ class ScanTaskQueue;
 
 class ScanExecutor {
 public:
-    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool);
+    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue);
     virtual ~ScanExecutor();
 
     void initialize(int32_t num_threads);

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -82,7 +82,9 @@ private:
 
 class WorkGroupScanTaskQueue final : public ScanTaskQueue {
 public:
-    WorkGroupScanTaskQueue() = default;
+    enum SchedEntityType { OLAP, CONNECTOR };
+
+    WorkGroupScanTaskQueue(SchedEntityType sched_entity_type) : _sched_entity_type(sched_entity_type) {}
     ~WorkGroupScanTaskQueue() override = default;
 
     void close() override;
@@ -112,6 +114,9 @@ private:
     // The ideal runtime of a work group is the weighted average of the schedule period.
     int64_t _ideal_runtime_ns(workgroup::WorkGroupScanSchedEntity* wg_entity) const;
 
+    workgroup::WorkGroupScanSchedEntity* _sched_entity(workgroup::WorkGroup* wg);
+    const workgroup::WorkGroupScanSchedEntity* _sched_entity(const workgroup::WorkGroup* wg) const;
+
 private:
     static constexpr int64_t SCHEDULE_PERIOD_PER_WG_NS = 100'000'000;
     static constexpr int64_t BANDWIDTH_CONTROL_PERIOD_NS = 100'000'000;
@@ -121,6 +126,8 @@ private:
         bool operator()(const WorkGroupScanSchedEntityPtr& lhs, const WorkGroupScanSchedEntityPtr& rhs) const;
     };
     using WorkgroupSet = std::set<workgroup::WorkGroupScanSchedEntity*, WorkGroupScanSchedEntityComparator>;
+
+    const SchedEntityType _sched_entity_type;
 
     mutable std::mutex _global_mutex;
     std::condition_variable _cv;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -39,10 +39,15 @@ WorkGroup::WorkGroup(const std::string& name, int64_t id, int64_t version, size_
           _memory_limit(memory_limit),
           _concurrency_limit(concurrency),
           _driver_sched_entity(this),
-          _scan_sched_entity(this) {}
+          _scan_sched_entity(this),
+          _connector_scan_sched_entity(this) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg)
-        : _name(twg.name), _id(twg.id), _driver_sched_entity(this), _scan_sched_entity(this) {
+        : _name(twg.name),
+          _id(twg.id),
+          _driver_sched_entity(this),
+          _scan_sched_entity(this),
+          _connector_scan_sched_entity(this) {
     if (twg.__isset.cpu_core_limit) {
         _cpu_limit = twg.cpu_core_limit;
     } else {
@@ -113,6 +118,8 @@ void WorkGroup::init() {
 
     _driver_sched_entity.set_queue(std::make_unique<pipeline::QuerySharedDriverQueue>());
     _scan_sched_entity.set_queue(std::make_unique<PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+    _connector_scan_sched_entity.set_queue(
+            std::make_unique<PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
 }
 
 std::string WorkGroup::to_string() const {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -103,6 +103,8 @@ public:
     const WorkGroupDriverSchedEntity* driver_sched_entity() const { return &_driver_sched_entity; }
     WorkGroupScanSchedEntity* scan_sched_entity() { return &_scan_sched_entity; }
     const WorkGroupScanSchedEntity* scan_sched_entity() const { return &_scan_sched_entity; }
+    WorkGroupScanSchedEntity* connector_scan_sched_entity() { return &_connector_scan_sched_entity; }
+    const WorkGroupScanSchedEntity* connector_scan_sched_entity() const { return &_connector_scan_sched_entity; }
 
     void incr_num_running_drivers();
     void decr_num_running_drivers();
@@ -177,6 +179,7 @@ private:
 
     WorkGroupDriverSchedEntity _driver_sched_entity;
     WorkGroupScanSchedEntity _scan_sched_entity;
+    WorkGroupScanSchedEntity _connector_scan_sched_entity;
 
     std::atomic<bool> _is_marked_del = false;
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -187,6 +187,38 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _wg_driver_executor =
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
     _wg_driver_executor->initialize(_max_executor_threads);
+<<<<<<< HEAD
+=======
+
+    int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
+    CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
+
+    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("con_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(connector_num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&connector_scan_worker_thread_pool_without_workgroup));
+    _connector_scan_executor_without_workgroup = new workgroup::ScanExecutor(
+            std::move(connector_scan_worker_thread_pool_without_workgroup),
+            std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+    _connector_scan_executor_without_workgroup->initialize(connector_num_io_threads);
+
+    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(connector_num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&connector_scan_worker_thread_pool_with_workgroup));
+    _connector_scan_executor_with_workgroup =
+            new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
+                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
+    _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
+
+>>>>>>> b4c664baf ([Bugfix] Connector WorkGroupScanTaskQueue uses different ShcedEntity from Olap (#10950))
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
     _master_info = new TMasterInfo();
@@ -224,9 +256,18 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                 .set_max_threads(num_io_threads)
                                 .set_max_queue_size(1000)
                                 .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+<<<<<<< HEAD
                                 .build(&scan_worker_thread_pool));
         _scan_executor = new workgroup::ScanExecutor(std::move(scan_worker_thread_pool));
         _scan_executor->initialize(num_io_threads);
+=======
+                                .build(&scan_worker_thread_pool_with_workgroup));
+        _scan_executor_with_workgroup =
+                new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
+                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                    workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
+        _scan_executor_with_workgroup->initialize(num_io_threads);
+>>>>>>> b4c664baf ([Bugfix] Connector WorkGroupScanTaskQueue uses different ShcedEntity from Olap (#10950))
 
         Status status = _load_path_mgr->init();
         if (!status.ok()) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -152,7 +152,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&hdfs_scan_worker_thread_pool));
-    _hdfs_scan_executor = new workgroup::ScanExecutor(std::move(hdfs_scan_worker_thread_pool));
+    _hdfs_scan_executor =
+            new workgroup::ScanExecutor(std::move(hdfs_scan_worker_thread_pool),
+                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
     _hdfs_scan_executor->initialize(hdfs_num_io_threads);
 
     _udf_call_pool = new PriorityThreadPool("udf", config::udf_thread_pool_size, config::udf_thread_pool_size);
@@ -187,38 +190,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _wg_driver_executor =
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
     _wg_driver_executor->initialize(_max_executor_threads);
-<<<<<<< HEAD
-=======
 
-    int connector_num_io_threads = config::pipeline_hdfs_scan_thread_pool_thread_num;
-    CHECK_GT(connector_num_io_threads, 0) << "pipeline_hdfs_scan_thread_pool_thread_num should greater than 0";
-
-    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;
-    RETURN_IF_ERROR(ThreadPoolBuilder("con_scan_io")
-                            .set_min_threads(0)
-                            .set_max_threads(connector_num_io_threads)
-                            .set_max_queue_size(1000)
-                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                            .build(&connector_scan_worker_thread_pool_without_workgroup));
-    _connector_scan_executor_without_workgroup = new workgroup::ScanExecutor(
-            std::move(connector_scan_worker_thread_pool_without_workgroup),
-            std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
-    _connector_scan_executor_without_workgroup->initialize(connector_num_io_threads);
-
-    std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
-    RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
-                            .set_min_threads(0)
-                            .set_max_threads(connector_num_io_threads)
-                            .set_max_queue_size(1000)
-                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                            .build(&connector_scan_worker_thread_pool_with_workgroup));
-    _connector_scan_executor_with_workgroup =
-            new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
-                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
-                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
-    _connector_scan_executor_with_workgroup->initialize(connector_num_io_threads);
-
->>>>>>> b4c664baf ([Bugfix] Connector WorkGroupScanTaskQueue uses different ShcedEntity from Olap (#10950))
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
     _master_info = new TMasterInfo();
@@ -256,18 +228,11 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                 .set_max_threads(num_io_threads)
                                 .set_max_queue_size(1000)
                                 .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-<<<<<<< HEAD
                                 .build(&scan_worker_thread_pool));
-        _scan_executor = new workgroup::ScanExecutor(std::move(scan_worker_thread_pool));
+        _scan_executor = new workgroup::ScanExecutor(std::move(scan_worker_thread_pool),
+                                                     std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                             workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
         _scan_executor->initialize(num_io_threads);
-=======
-                                .build(&scan_worker_thread_pool_with_workgroup));
-        _scan_executor_with_workgroup =
-                new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
-                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>(
-                                                    workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
-        _scan_executor_with_workgroup->initialize(num_io_threads);
->>>>>>> b4c664baf ([Bugfix] Connector WorkGroupScanTaskQueue uses different ShcedEntity from Olap (#10950))
 
         Status status = _load_path_mgr->init();
         if (!status.ok()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from #10950.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
