### PR TITLE
[Enhancement] Add mem statistics for segment for segment metadata

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -251,7 +251,7 @@ Status PhysicalSplitMorselQueue::_init_segment() {
     if (_tablet_seek_ranges.empty()) {
         _segment_scan_range.add(vectorized::Range(0, segment->num_rows()));
     } else {
-        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
+        RETURN_IF_ERROR(segment->load_index());
         for (const auto& range : _tablet_seek_ranges) {
             rowid_t lower_rowid = 0;
             rowid_t upper_rowid = segment->num_rows();
@@ -513,7 +513,7 @@ StatusOr<SegmentGroupPtr> LogicalSplitMorselQueue::_create_segment_group(Rowset*
     }
 
     for (const auto& segment : segments) {
-        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
+        RETURN_IF_ERROR(segment->load_index());
     }
 
     return std::make_unique<SegmentGroup>(std::move(segments));

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -97,8 +97,7 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
     }
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(location));
-    ASSIGN_OR_RETURN(segment, Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, location, seg_id,
-                                            std::move(tablet_schema), footer_size_hint));
+    ASSIGN_OR_RETURN(segment, Segment::open(fs, location, seg_id, std::move(tablet_schema), footer_size_hint));
     if (fill_cache) {
         _mgr->cache_segment(location, segment);
     }

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -481,8 +481,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
         }
         std::string tmp_segment_file =
                 Rowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-        auto segment_ptr = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), _fs, tmp_segment_file, seg_id,
-                                         _context.tablet_schema);
+        auto segment_ptr = Segment::open(_fs, tmp_segment_file, seg_id, _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();

--- a/be/src/storage/rowset/page_handle.h
+++ b/be/src/storage/rowset/page_handle.h
@@ -64,12 +64,12 @@ public:
         }
     }
 
-    void release_memory() {
+    void reset() {
         if (_is_data_owner) {
             delete[] _data.data;
-            _data.data = nullptr;
-            _data.size = 0;
+            _is_data_owner = false;
         }
+        _data.clear();
     }
 
     // the return slice contains uncompressed page body, page footer, and footer size

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -30,7 +30,6 @@
 #include "fs/fs_util.h"
 #include "gutil/strings/substitute.h"
 #include "rowset_options.h"
-#include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "segment_options.h"
 #include "storage/chunk_helper.h"
@@ -42,7 +41,6 @@
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/storage_engine.h"
 #include "storage/union_iterator.h"
-#include "storage/update_manager.h"
 #include "storage/utils.h"
 #include "util/defer_op.h"
 #include "util/time.h"
@@ -130,8 +128,8 @@ Status Rowset::do_load() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, seg_id, _schema,
-                                 &footer_size_hint, rowset_meta()->partial_rowset_footer(seg_id));
+        auto res = Segment::open(fs, seg_path, seg_id, _schema, &footer_size_hint,
+                                 rowset_meta()->partial_rowset_footer(seg_id));
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             _segments.clear();
@@ -150,8 +148,7 @@ Status Rowset::reload() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, seg_id, _schema,
-                                 &footer_size_hint);
+        auto res = Segment::open(fs, seg_path, seg_id, _schema, &footer_size_hint);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             _segments.clear();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -62,30 +62,24 @@ namespace starrocks {
 
 using strings::Substitute;
 
-StatusOr<std::shared_ptr<Segment>> Segment::open(MemTracker* mem_tracker, std::shared_ptr<FileSystem> fs,
-                                                 const std::string& path, uint32_t segment_id,
-                                                 const TabletSchema* tablet_schema, size_t* footer_length_hint,
+StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                                 uint32_t segment_id, const TabletSchema* tablet_schema,
+                                                 size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer) {
-    auto segment = std::shared_ptr<Segment>(
-            new Segment(private_type(0), std::move(fs), path, segment_id, tablet_schema, mem_tracker),
-            DeleterWithMemTracker<Segment>(mem_tracker));
-    mem_tracker->consume(segment->mem_usage());
+    auto segment = std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, tablet_schema);
 
-    RETURN_IF_ERROR(segment->_open(mem_tracker, footer_length_hint, partial_rowset_footer));
+    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer));
     return std::move(segment);
 }
 
-StatusOr<std::shared_ptr<Segment>> Segment::open(MemTracker* mem_tracker, std::shared_ptr<FileSystem> fs,
-                                                 const std::string& path, uint32_t segment_id,
-                                                 std::shared_ptr<const TabletSchema> tablet_schema,
+StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                                 uint32_t segment_id, std::shared_ptr<const TabletSchema> tablet_schema,
                                                  size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer) {
-    auto segment = std::shared_ptr<Segment>(
-            new Segment(private_type(0), std::move(fs), path, segment_id, std::move(tablet_schema), mem_tracker),
-            DeleterWithMemTracker<Segment>(mem_tracker));
-    mem_tracker->consume(segment->mem_usage());
+    auto segment =
+            std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, std::move(tablet_schema));
 
-    RETURN_IF_ERROR(segment->_open(mem_tracker, footer_length_hint, partial_rowset_footer));
+    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer));
     return std::move(segment);
 }
 
@@ -180,28 +174,31 @@ Status Segment::parse_segment_footer(RandomAccessFile* read_file, SegmentFooterP
 }
 
 Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-                 const TabletSchema* tablet_schema, MemTracker* mem_tracker)
-        : _fs(std::move(fs)),
-          _fname(std::move(path)),
-          _tablet_schema(tablet_schema),
-          _segment_id(segment_id),
-          _mem_tracker(mem_tracker) {}
+                 const TabletSchema* tablet_schema)
+        : _fs(std::move(fs)), _fname(std::move(path)), _tablet_schema(tablet_schema), _segment_id(segment_id) {
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+}
 
 Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-                 std::shared_ptr<const TabletSchema> tablet_schema, MemTracker* mem_tracker)
+                 std::shared_ptr<const TabletSchema> tablet_schema)
         : _fs(std::move(fs)),
           _fname(std::move(path)),
           _tablet_schema(std::move(tablet_schema)),
-          _segment_id(segment_id),
-          _mem_tracker(mem_tracker) {}
+          _segment_id(segment_id) {
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+}
 
-Status Segment::_open(MemTracker* mem_tracker, size_t* footer_length_hint,
-                      const FooterPointerPB* partial_rowset_footer) {
+Segment::~Segment() {
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->short_key_index_mem_tracker(), _short_key_index_mem_usage());
+}
+
+Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer) {
     SegmentFooterPB footer;
     ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(_fname));
     RETURN_IF_ERROR(Segment::parse_segment_footer(read_file.get(), &footer, footer_length_hint, partial_rowset_footer));
 
-    RETURN_IF_ERROR(_create_column_readers(mem_tracker, &footer));
+    RETURN_IF_ERROR(_create_column_readers(&footer));
     _num_rows = footer.num_rows();
     _short_key_index_page = PagePointer(footer.short_key_index_page());
     _prepare_adapter_info();
@@ -248,43 +245,55 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const vectorized::Schema& schem
     }
 }
 
-Status Segment::load_index(MemTracker* mem_tracker) {
-    auto res = success_once(_load_index_once, [this, mem_tracker] {
+Status Segment::load_index() {
+    auto res = success_once(_load_index_once, [this] {
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
-        // read and parse short key index page
-        ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(_fname));
 
-        PageReadOptions opts;
-        opts.use_page_cache = !config::disable_storage_page_cache;
-        opts.read_file = read_file.get();
-        opts.page_pointer = _short_key_index_page;
-        opts.codec = nullptr; // short key index page uses NO_COMPRESSION for now
-        OlapReaderStatistics tmp_stats;
-        opts.stats = &tmp_stats;
-
-        Slice body;
-        PageFooterPB footer;
-        RETURN_IF_ERROR(PageIO::read_and_decompress_page(opts, &_sk_index_handle, &body, &footer));
-
-        mem_tracker->consume(_sk_index_handle.mem_usage());
-
-        DCHECK_EQ(footer.type(), SHORT_KEY_PAGE);
-        DCHECK(footer.has_short_key_page_footer());
-
-        _sk_index_decoder = std::make_unique<ShortKeyIndexDecoder>();
-        Status st = _sk_index_decoder->parse(body, footer.short_key_page_footer());
-        mem_tracker->consume(_sk_index_decoder->mem_usage());
-
+        Status st = _load_index();
+        if (st.ok()) {
+            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->short_key_index_mem_tracker(),
+                                     _short_key_index_mem_usage());
+        } else {
+            _reset();
+        }
         return st;
     });
     return res.status();
+}
+
+Status Segment::_load_index() {
+    // read and parse short key index page
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(_fname));
+
+    PageReadOptions opts;
+    opts.use_page_cache = !config::disable_storage_page_cache;
+    opts.read_file = read_file.get();
+    opts.page_pointer = _short_key_index_page;
+    opts.codec = nullptr; // short key index page uses NO_COMPRESSION for now
+    OlapReaderStatistics tmp_stats;
+    opts.stats = &tmp_stats;
+
+    Slice body;
+    PageFooterPB footer;
+    RETURN_IF_ERROR(PageIO::read_and_decompress_page(opts, &_sk_index_handle, &body, &footer));
+
+    DCHECK_EQ(footer.type(), SHORT_KEY_PAGE);
+    DCHECK(footer.has_short_key_page_footer());
+
+    _sk_index_decoder = std::make_unique<ShortKeyIndexDecoder>();
+    return _sk_index_decoder->parse(body, footer.short_key_page_footer());
+}
+
+void Segment::_reset() {
+    _sk_index_handle.reset();
+    _sk_index_decoder.reset();
 }
 
 bool Segment::has_loaded_index() const {
     return invoked(_load_index_once);
 }
 
-Status Segment::_create_column_readers(MemTracker* mem_tracker, SegmentFooterPB* footer) {
+Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     std::unordered_map<uint32_t, uint32_t> column_id_to_footer_ordinal;
     for (uint32_t ordinal = 0, sz = footer->columns().size(); ordinal < sz; ++ordinal) {
         const auto& column_pb = footer->columns(ordinal);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <cstdint>
-#include <memory> // for unique_ptr
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -72,15 +72,14 @@ class Segment : public std::enable_shared_from_this<Segment> {
 
 public:
     // Does NOT take the ownership of |tablet_schema|.
-    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, std::shared_ptr<FileSystem> fs,
-                                                   const std::string& path, uint32_t segment_id,
-                                                   const TabletSchema* tablet_schema,
+    static StatusOr<std::shared_ptr<Segment>> open(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                                   uint32_t segment_id, const TabletSchema* tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
                                                    const FooterPointerPB* partial_rowset_footer = nullptr);
 
     // Like above but share the ownership of |tablet_schema|.
-    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, std::shared_ptr<FileSystem> fs,
-                                                   const std::string& path, uint32_t segment_id,
+    static StatusOr<std::shared_ptr<Segment>> open(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                                   uint32_t segment_id,
                                                    std::shared_ptr<const TabletSchema> tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
                                                    const FooterPointerPB* partial_rowset_footer = nullptr);
@@ -89,12 +88,12 @@ public:
                                        const FooterPointerPB* partial_rowset_footer);
 
     Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-            const TabletSchema* tablet_schema, MemTracker* mem_tracker);
+            const TabletSchema* tablet_schema);
 
     Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-            std::shared_ptr<const TabletSchema> tablet_schema, MemTracker* mem_tracker);
+            std::shared_ptr<const TabletSchema> tablet_schema);
 
-    ~Segment() = default;
+    ~Segment();
 
     // may return EndOfFile
     StatusOr<ChunkIteratorPtr> new_iterator(const vectorized::Schema& schema,
@@ -137,16 +136,6 @@ public:
 
     const ColumnReader* column(size_t i) const { return _column_readers[i].get(); }
 
-    int64_t mem_usage() {
-        int64_t size = sizeof(Segment) + _sk_index_handle.mem_usage();
-        if (_sk_index_decoder != nullptr) {
-            size += _sk_index_decoder->mem_usage();
-        }
-        return size;
-    }
-
-    MemTracker* mem_tracker() const { return _mem_tracker; }
-
     FileSystem* file_system() const { return _fs.get(); }
 
     bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
@@ -157,10 +146,12 @@ public:
 
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.
-    Status load_index(MemTracker* mem_tracker);
+    Status load_index();
     bool has_loaded_index() const;
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
+
+    int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
     DISALLOW_COPY_AND_MOVE(Segment);
 
@@ -188,16 +179,29 @@ private:
         std::shared_ptr<const TabletSchema> _schema;
     };
 
+    Status _load_index();
+
+    void _reset();
+
+    int64_t _basic_info_mem_usage() { return static_cast<int64_t>(sizeof(Segment) + _fname.size()); }
+
+    int64_t _short_key_index_mem_usage() {
+        int64_t size = _sk_index_handle.mem_usage();
+        if (_sk_index_decoder != nullptr) {
+            size += _sk_index_decoder->mem_usage();
+        }
+        return size;
+    }
+
     // open segment file and read the minimum amount of necessary information (footer)
-    Status _open(MemTracker* mem_tracker, size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer);
-    Status _create_column_readers(MemTracker* mem_tracker, SegmentFooterPB* footer);
+    Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer);
+    Status _create_column_readers(SegmentFooterPB* footer);
 
     StatusOr<ChunkIteratorPtr> _new_iterator(const vectorized::Schema& schema,
                                              const vectorized::SegmentReadOptions& read_options);
 
     void _prepare_adapter_info();
 
-    friend class SegmentIterator;
     friend class vectorized::SegmentIterator;
 
     std::shared_ptr<FileSystem> _fs;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -467,7 +467,7 @@ Status SegmentIterator::_get_row_ranges_by_key_ranges() {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(_segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
+    RETURN_IF_ERROR(_segment->load_index());
     for (const SeekRange& range : _opts.ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();
@@ -498,7 +498,7 @@ Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(_segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
+    RETURN_IF_ERROR(_segment->load_index());
     for (const auto& short_key_range : _opts.short_key_ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2964,8 +2964,7 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
         }
         std::string seg_path =
                 Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        auto segment = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, rssid - iter->first,
-                                     &rowset->schema());
+        auto segment = Segment::open(fs, seg_path, rssid - iter->first, &rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -217,7 +217,7 @@ protected:
         auto path = _location_provider->segment_location(tablet_id, filename);
         std::cerr << path << '\n';
 
-        ASSIGN_OR_ABORT(auto seg, Segment::open(_mem_tracker.get(), fs, path, 0, _tablet_schema.get()));
+        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0, _tablet_schema.get()));
 
         OlapReaderStatistics statistics;
         vectorized::SegmentReadOptions opts;

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -2,10 +2,8 @@
 
 #include "storage/lake/async_delta_writer.h"
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <random>
 
 #include "column/chunk.h"
@@ -15,7 +13,6 @@
 #include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_util.h"
-#include "gutil/strings/util.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -224,7 +221,7 @@ TEST_F(AsyncDeltaWriterTest, test_write) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
     auto path0 = _location_provider->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(_mem_tracker.get(), fs, path0, 0, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema.get()));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -319,7 +316,7 @@ TEST_F(AsyncDeltaWriterTest, test_write_concurrently) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
     auto path0 = _location_provider->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(_mem_tracker.get(), fs, path0, 0, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema.get()));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -2,10 +2,8 @@
 
 #include "storage/lake/delta_writer.h"
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <random>
 
 #include "column/chunk.h"
@@ -15,7 +13,6 @@
 #include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_util.h"
-#include "gutil/strings/util.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -188,8 +185,8 @@ TEST_F(DeltaWriterTest, test_write) {
     auto path0 = _location_provider->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
     auto path1 = _location_provider->segment_location(tablet_id, txnlog->op_write().rowset().segments(1));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(_mem_tracker.get(), fs, path0, 0, _tablet_schema.get()));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(_mem_tracker.get(), fs, path1, 1, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, path1, 1, _tablet_schema.get()));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -2,7 +2,6 @@
 
 #include "storage/lake/tablet_writer.h"
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "column/chunk.h"
@@ -12,7 +11,6 @@
 #include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_util.h"
-#include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
@@ -36,7 +34,6 @@ using VChunk = starrocks::vectorized::Chunk;
 class DuplicateTabletWriterTest : public testing::Test {
 public:
     DuplicateTabletWriterTest() {
-        _mem_tracker = std::make_unique<MemTracker>(-1);
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
         _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), 0);
         _tablet_metadata = std::make_unique<TabletMetadata>();
@@ -87,7 +84,6 @@ public:
 protected:
     constexpr static const char* const kTestGroupPath = "test_lake_tablet_writer";
 
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
@@ -139,12 +135,10 @@ TEST_F(DuplicateTabletWriterTest, test_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(_mem_tracker.get(), fs,
-                                             _location_provider->segment_location(_tablet_metadata->id(), files[0]), 0,
-                                             _tablet_schema.get()));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(_mem_tracker.get(), fs,
-                                             _location_provider->segment_location(_tablet_metadata->id(), files[1]), 1,
-                                             _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _location_provider->segment_location(_tablet_metadata->id(), files[0]),
+                                             0, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _location_provider->segment_location(_tablet_metadata->id(), files[1]),
+                                             1, _tablet_schema.get()));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -305,11 +305,13 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithSeg) {
 
     size_t ret_num_rows = 0;
     bool ret_eos = true;
-    ASSERT_TRUE(flush_token->submit(std::move(mem_table), false,
-        [&](std::unique_ptr<SegmentPB> seg, bool eos){
-            ret_num_rows = seg->num_rows();
-            ret_eos = eos;
-    }).ok());
+    ASSERT_TRUE(flush_token
+                        ->submit(std::move(mem_table), false,
+                                 [&](std::unique_ptr<SegmentPB> seg, bool eos) {
+                                     ret_num_rows = seg->num_rows();
+                                     ret_eos = eos;
+                                 })
+                        .ok());
 
     ASSERT_TRUE(flush_token->wait().ok());
 
@@ -335,11 +337,13 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithNullSeg) {
 
     bool ret_eos = false;
     std::unique_ptr<SegmentPB> ret_seg = make_unique<SegmentPB>();
-    ASSERT_TRUE(flush_token->submit(std::move(mem_table), true,
-        [&](std::unique_ptr<SegmentPB> seg, bool eos){
-            ret_seg = std::move(seg);
-            ret_eos = eos;
-    }).ok());
+    ASSERT_TRUE(flush_token
+                        ->submit(std::move(mem_table), true,
+                                 [&](std::unique_ptr<SegmentPB> seg, bool eos) {
+                                     ret_seg = std::move(seg);
+                                     ret_eos = eos;
+                                 })
+                        .ok());
 
     ASSERT_TRUE(flush_token->wait().ok());
 

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -60,8 +60,6 @@ static const std::string TEST_DIR = "/column_reader_writer_test";
 class ColumnReaderWriterTest : public testing::Test {
 public:
     ColumnReaderWriterTest() {
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
-
         TabletSchemaPB schema_pb;
         auto* c0 = schema_pb.add_column();
         c0->set_name("pk");
@@ -88,8 +86,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema.get(),
-                                         _metadata_mem_tracker.get());
+        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema.get());
     }
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version>
@@ -556,7 +553,6 @@ protected:
     }
 
     MemPool _pool;
-    std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
 };
 

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -294,7 +294,7 @@ TEST_F(RowsetTest, FinalMergeTest) {
     std::string segment_file =
             Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, tablet_schema.get());
+    auto segment = *Segment::open(seg_options.fs, segment_file, 0, tablet_schema.get());
     ASSERT_NE(segment->num_rows(), 0);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -393,8 +393,7 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     std::string segment_file =
             Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
-    auto segment =
-            *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet->tablet_schema());
+    auto segment = *Segment::open(seg_options.fs, segment_file, 0, &tablet->tablet_schema());
     ASSERT_NE(segment->num_rows(), 0);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -731,7 +730,7 @@ TEST_F(RowsetTest, SegmentWriteTest) {
 
         butil::IOBuf data;
         auto buf = new uint8[seg_info->data_size()];
-        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
 
         ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
         auto st = segment_rowset_writer->flush_segment(*seg_info, data);
@@ -774,6 +773,5 @@ TEST_F(RowsetTest, SegmentWriteTest) {
         EXPECT_EQ(count, num_rows);
     }
 }
-
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -26,7 +26,6 @@ public:
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -35,7 +34,6 @@ public:
     const std::string kSegmentDir = "/segment_test";
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 // NOLINTNEXTLINE
@@ -107,7 +105,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -227,7 +225,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -9,10 +9,8 @@
 
 #include "column/datum_tuple.h"
 #include "common/logging.h"
-#include "fs/fs_memory.h"
 #include "fs/fs_util.h"
 #include "gen_cpp/olap_file.pb.h"
-#include "gutil/strings/substitute.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
@@ -41,7 +39,6 @@ protected:
         ASSERT_OK(_fs->create_dir_recursive(kSegmentDir));
 
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -54,7 +51,6 @@ protected:
 
     std::shared_ptr<FileSystem> _fs;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker;
-    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {
@@ -95,7 +91,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_position(footer_position);
     partial_rowset_footer.set_size(file_size - footer_position);
 
-    auto partial_segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, partial_tablet_schema.get());
+    auto partial_segment = *Segment::open(_fs, file_name, 0, partial_tablet_schema.get());
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -117,7 +113,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, *tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, dst_file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, dst_file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -168,7 +164,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     }
     ASSERT_OK(SegmentRewriter::rewrite(file_name, *tablet_schema, read_column_ids, new_write_columns,
                                        partial_segment->id(), partial_rowset_footer));
-    auto rewrite_segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto rewrite_segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
 
     ASSERT_EQ(rewrite_segment->num_rows(), num_rows);
     res = rewrite_segment->new_iterator(schema, seg_options);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -56,7 +56,7 @@ using ValueGenerator = std::function<vectorized::Datum(size_t rid, int cid, int 
 // 10, 11, 12, 13
 // 20, 21, 22, 23
 static vectorized::Datum DefaultIntGenerator(size_t rid, int cid, int block_id) {
-    return vectorized::Datum(static_cast<int32_t>(rid * 10 + cid));
+    return {static_cast<int32_t>(rid * 10 + cid)};
 }
 
 class SegmentReaderWriterTest : public ::testing::Test {
@@ -65,7 +65,6 @@ protected:
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -95,7 +94,7 @@ protected:
         uint64_t file_size, index_size, footer_position;
         ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-        *res = *Segment::open(_metadata_mem_tracker.get(), _fs, filename, 0, &query_schema);
+        *res = *Segment::open(_fs, filename, 0, &query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -103,7 +102,6 @@ protected:
 
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
@@ -205,7 +203,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     uint64_t footer_position;
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -307,7 +305,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
 
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -406,7 +404,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     }
 
     ASSERT_OK(writer.finalize_footer(&file_size));
-    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10458 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently it is too hard to troubleshoot metadata memory problem, and more detailed statistics are required.
Add mem statistics for segment for segment metadata.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
