### PR TITLE
[BugFix] avoid translate into cross join when conjunct is not empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -109,7 +109,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         OptExpression root;
         if (joinEqPredicate == null) {
             JoinOperator joinType =
-                    (join.getOnPredicate() == null || join.getJoinType().isCrossJoin() || conjunctList.isEmpty()) ?
+                    (join.getOnPredicate() == null || join.getJoinType().isCrossJoin()) ?
                             JoinOperator.CROSS_JOIN : join.getJoinType();
             LogicalJoinOperator nestLoop = new LogicalJoinOperator.Builder().withOperator(join)
                     .setJoinType(joinType)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -105,7 +105,7 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan,
                 plan.contains("  3:NESTLOOP JOIN\n" +
-                        "  |  join op: CROSS JOIN\n" +
+                        "  |  join op: INNER JOIN\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  \n" +
                         "  |----2:EXCHANGE\n" +
@@ -724,7 +724,7 @@ public class JoinTest extends PlanTestBase {
         String sql = "select * from t0 as x0 join t1 as x1 on (1 = 2) is not null;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "3:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN\n" +
+                "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -32,6 +32,16 @@ public class NestLoopJoinTest extends PlanTestBase {
         String sql = "SELECT * from t0 join test_all_type where t0.v1 = 2;";
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment, planFragment.contains("NESTLOOP JOIN"));
+
+        // Outer join
+        PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
+        sql = "SELECT * from t0 left join test_all_type t1 on 2 = t1.t1c";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment, planFragment.contains("LEFT OUTER JOIN"));
+
+        sql = "SELECT * from t0 left join test_all_type t1 on 2 = t0.v1";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment, planFragment.contains("LEFT OUTER JOIN"));
     }
 
     private void assertNestloopJoin(String sql, String joinType, String onPredicate) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -617,7 +617,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  8:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason:");
             assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -630,7 +630,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on (select count(*) from t0 where t0.v2 = t1.v5) = t1.v5";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  8:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  5:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -684,7 +684,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t1 where t0.v2 = t1.v5 and t0.v3 = t1.v6)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  8:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -721,7 +721,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select v4 from t1 where t0.v2 = t1.v5)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  10:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -747,7 +747,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select v4 from t1 where t0.v2 = t1.v5 and t1.v5 = 10 and t1.v6 != 3)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  11:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  5:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -763,7 +763,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on (select v1 from t0,t2 where t0.v2 = t1.v5 and t0.v2 = t2.v7) * 2 = t1.v4";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  15:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  10:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
@@ -799,7 +799,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t3 join t4)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  16:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason:");
             assertContains(plan, "  12:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -811,7 +811,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on (select count(*) from t3) = t1.v5";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  11:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  8:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -823,7 +823,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t1)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  11:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -835,7 +835,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select count(*) from t0)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  11:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -884,7 +884,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select t2.v8 from t2 where t2.v7 = 10)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  11:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -896,7 +896,7 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = (select t2.v7 + t3.v10 from t2 join t3)";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  14:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  10:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -962,7 +962,7 @@ public class SubqueryTest extends PlanTestBase {
                     "t0.v1 = (exists (select v7 from t2 where t2.v8 = 1))";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  10:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  6:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
@@ -977,7 +977,7 @@ public class SubqueryTest extends PlanTestBase {
                     "and t1.v4 = (exists(select v10 from t3 where t3.v11 < 5))";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  17:NESTLOOP JOIN\n" +
-                    "  |  join op: CROSS JOIN\n" +
+                    "  |  join op: INNER JOIN\n" +
                     "  |  colocate: false, reason: ");
             assertContains(plan, "  6:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
@@ -226,7 +226,7 @@ RIGHT SEMI JOIN (join-predicate [5: v5 = 1: v1] post-join-predicate [null])
 [sql]
 select v1,v2,v3,v4 from t0 inner join t1 on v1=v5 and 1>2
 [result]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
+INNER JOIN (join-predicate [null] post-join-predicate [null])
     VALUES
     EXCHANGE BROADCAST
         VALUES

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
@@ -28,7 +28,7 @@ INNER JOIN (join-predicate [2: v2 = 5: v5 AND 1: v1 > 4: v4] post-join-predicate
 [sql]
 select v1 from t0 inner join t1 on v1 = v2
 [result]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
+INNER JOIN (join-predicate [null] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[1: v1 = 2: v2])
     EXCHANGE BROADCAST
         SCAN (columns[4: v4] predicate[null])


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10996

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

An outer join should not be translated into cross join when conjuncts is not empty.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
