### PR TITLE
[BugFix] fix be may cause a heap-buffer-over in order by limit

### DIFF
--- a/be/src/exec/vectorized/sorting/compare_column.cpp
+++ b/be/src/exec/vectorized/sorting/compare_column.cpp
@@ -10,6 +10,7 @@
 #include "exec/vectorized/sorting/sort_helper.h"
 #include "exec/vectorized/sorting/sort_permute.h"
 #include "exec/vectorized/sorting/sorting.h"
+#include "glog/logging.h"
 #include "runtime/primitive_type.h"
 #include "simd/selector.h"
 
@@ -91,7 +92,8 @@ public:
         CompareVector cmp_vector(null_data.size());
         // TODO: use IMD select_if
         auto merge_cmp_vector = [](CompareVector& a, CompareVector& b) {
-            for (int i = 0; i < a.size(); ++i) {
+            DCHECK_EQ(a.size(), b.size());
+            for (size_t i = 0; i < a.size(); ++i) {
                 a[i] = a[i] == 0 ? b[i] : a[i];
             }
         };


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
Fixes #10987 

## Problem Summary(Required) ：
we should only compare elements when _cmp_vector[i] == 0

a simple solution is we only merge the result when _cmp_vector == 0

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

## 
it's hard to build a query to reproduce this case. but this UT could cover this case.
```
Expected equality of these values:
  include_num
    Which is: 4294967295
  inc
    Which is: 0
[  FAILED  ] ChunksSorterTest.get_filter_test (4 ms)
[----------] 1 test from ChunksSorterTest (4 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ChunksSorterTest.get_filter_test
```
