### PR TITLE
[BugFix] Fix checking the existance of domained users fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1097,7 +1097,7 @@ public class Auth implements Writable {
     }
 
     // return true if user ident exist
-    private boolean doesUserExist(UserIdentity userIdent) {
+    public boolean doesUserExist(UserIdentity userIdent) {
         if (userIdent.isDomain()) {
             return propertyMgr.doesUserExist(userIdent);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -52,7 +52,7 @@ public class PrivilegeStmtAnalyzer {
 
             if (checkExist) {
                 // check if user exists
-                if (!session.getGlobalStateMgr().getAuth().getUserPrivTable().doesUserExist(userIdent)) {
+                if (!session.getGlobalStateMgr().getAuth().doesUserExist(userIdent)) {
                     throw new SemanticException("user " + userIdent + " not exist!");
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
@@ -34,7 +34,7 @@ public class AlterUserStmtTest {
 
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };
@@ -118,7 +118,7 @@ public class AlterUserStmtTest {
     public void testBadPass(@Mocked Auth auth) throws Exception {
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };
@@ -131,7 +131,7 @@ public class AlterUserStmtTest {
     public void testInvalidAuthPlugin(@Mocked Auth auth) throws Exception {
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
@@ -6,7 +6,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
 import com.starrocks.mysql.privilege.PrivPredicate;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
@@ -24,8 +23,6 @@ public class ShowGrantsStmtTest {
     private GlobalStateMgr globalStateMgr;
     @Mocked
     private Auth auth;
-    @Mocked
-    private UserPrivTable userPrivTable;
     @Mocked
     private ConnectContext ctx;
 
@@ -48,10 +45,6 @@ public class ShowGrantsStmtTest {
         };
         new Expectations(auth) {
             {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
-
                 auth.checkGlobalPriv(ctx, PrivPredicate.GRANT);
                 minTimes = 0;
                 result = true;
@@ -62,9 +55,9 @@ public class ShowGrantsStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity)any);
                 minTimes = 0;
                 result = true;
             }
@@ -76,9 +69,9 @@ public class ShowGrantsStmtTest {
     @Test(expected = AnalysisException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity)any);
                 minTimes = 0;
                 result = false;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class ExecuteAsStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -34,13 +31,6 @@ public class ExecuteAsStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
-            }
-        };
-        new Expectations(auth) {
-            {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
             }
         };
 
@@ -56,9 +46,9 @@ public class ExecuteAsStmtTest {
     @Test
     public void testWithNoRevert() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -76,9 +66,9 @@ public class ExecuteAsStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = false;
             }
@@ -92,9 +82,9 @@ public class ExecuteAsStmtTest {
     @Test(expected = SemanticException.class)
     public void testAllowRevert() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class GrantRevokeImpersonateStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -38,10 +35,6 @@ public class GrantRevokeImpersonateStmtTest {
         };
         new Expectations(auth) {
             {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
-
                 auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = true;
@@ -60,9 +53,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -96,9 +89,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = false;
             }
@@ -112,9 +105,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test(expected = SemanticException.class)
     public void testRoleNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class GrantRevokeRoleStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -34,13 +31,6 @@ public class GrantRevokeRoleStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
-            }
-        };
-        new Expectations(auth) {
-            {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
             }
         };
 
@@ -56,18 +46,14 @@ public class GrantRevokeRoleStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
         // suppose current role exists and has GRANT privilege
         new Expectations(auth) {
             {
                 auth.doesRoleExist((String) any);
+                minTimes = 0;
+                result = true;
+
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -99,16 +85,13 @@ public class GrantRevokeRoleStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
         // suppose current role exists
         new Expectations(auth) {
             {
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = false;
+
                 auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = true;
@@ -122,16 +105,13 @@ public class GrantRevokeRoleStmtTest {
     @Test(expected = SemanticException.class)
     public void testRoleNotExist() throws Exception {
         // suppose current exists
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
         // suppose current role doesn't exist, check for exception
         new Expectations(auth) {
             {
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = true;
+
                 auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = false;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10997 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

My original code checks if a user exits by looking through all the `GlobalPrivEntry` in `UserPrivTable`. But domained user won't store in `UserPrivTable`, it should be checked through `PropertyManager`. Luckily, there is already a function called `Auth.doesUserExist` that has done this job. I'm replacing `Auth.userPrivTable.doesUserExist` with `Auth.doesUserExist` to fix this bug.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
