### PR TITLE
[Refactor] remove default_cluster from privEntry and UserProperty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/DbPrivEntry.java
@@ -106,7 +106,7 @@ public class DbPrivEntry extends PrivEntry {
             return -res;
         }
 
-        return -origUser.compareTo(otherEntry.origUser);
+        return -realOrigUser.compareTo(otherEntry.realOrigUser);
     }
 
     @Override
@@ -116,7 +116,7 @@ public class DbPrivEntry extends PrivEntry {
         }
 
         DbPrivEntry otherEntry = (DbPrivEntry) other;
-        if (origHost.equals(otherEntry.origHost) && origUser.equals(otherEntry.origUser)
+        if (origHost.equals(otherEntry.origHost) && realOrigUser.equals(otherEntry.realOrigUser)
                 && origDb.equals(otherEntry.origDb) && isDomain == otherEntry.isDomain) {
             return true;
         }
@@ -127,7 +127,7 @@ public class DbPrivEntry extends PrivEntry {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("db priv. host: ").append(origHost).append(", db: ").append(origDb);
-        sb.append(", user: ").append(origUser);
+        sb.append(", user: ").append(realOrigUser);
         sb.append(", priv: ").append(privSet).append(", set by resolver: ").append(isSetByDomainResolver);
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/GlobalPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/GlobalPrivEntry.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 
 public class GlobalPrivEntry extends PrivEntry {
     private static final Logger LOG = LogManager.getLogger(GlobalPrivEntry.class);
-
     private Password password;
     // set domainUserIdent when this a password entry and is set by domain resolver.
     // so that when user checking password with user@'IP' and match a entry set by the resolver,
@@ -118,7 +117,7 @@ public class GlobalPrivEntry extends PrivEntry {
             return -res;
         }
 
-        return -origUser.compareTo(otherEntry.origUser);
+        return -realOrigUser.compareTo(otherEntry.realOrigUser);
     }
 
     @Override
@@ -128,7 +127,7 @@ public class GlobalPrivEntry extends PrivEntry {
         }
 
         GlobalPrivEntry otherEntry = (GlobalPrivEntry) other;
-        if (origHost.equals(otherEntry.origHost) && origUser.equals(otherEntry.origUser)
+        if (origHost.equals(otherEntry.origHost) && realOrigUser.equals(otherEntry.realOrigUser)
                 && isDomain == otherEntry.isDomain) {
             return true;
         }
@@ -138,7 +137,7 @@ public class GlobalPrivEntry extends PrivEntry {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("global priv. host: ").append(origHost).append(", user: ").append(origUser);
+        sb.append("global priv. host: ").append(origHost).append(", user: ").append(realOrigUser);
         sb.append(", priv: ").append(privSet).append(", set by resolver: ").append(isSetByDomainResolver);
         sb.append(", domain user ident: ").append(domainUserIdent);
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ImpersonateUserPrivEntry.java
@@ -42,7 +42,7 @@ public class ImpersonateUserPrivEntry extends PrivEntry {
         }
 
         ImpersonateUserPrivEntry otherEntry = (ImpersonateUserPrivEntry) other;
-        return origHost.equals(otherEntry.origHost) && origUser.equals(otherEntry.origUser)
+        return origHost.equals(otherEntry.origHost) && realOrigUser.equals(otherEntry.realOrigUser)
                 && securedUserIdentity.equals(otherEntry.securedUserIdentity) && isDomain == otherEntry.isDomain;
     }
 
@@ -50,7 +50,7 @@ public class ImpersonateUserPrivEntry extends PrivEntry {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("impersonate user priv. host: ").append(origHost).append(", securedUser: ").append(securedUserIdentity);
-        sb.append(", user: ").append(origUser);
+        sb.append(", user: ").append(realOrigUser);
         sb.append(", priv: ").append(privSet).append(", set by resolver: ").append(isSetByDomainResolver);
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/ResourcePrivEntry.java
@@ -88,7 +88,7 @@ public class ResourcePrivEntry extends PrivEntry {
             return -res;
         }
 
-        return -origUser.compareTo(otherEntry.origUser);
+        return -realOrigUser.compareTo(otherEntry.realOrigUser);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class ResourcePrivEntry extends PrivEntry {
         }
 
         ResourcePrivEntry otherEntry = (ResourcePrivEntry) other;
-        if (origHost.equals(otherEntry.origHost) && origUser.equals(otherEntry.origUser)
+        if (origHost.equals(otherEntry.origHost) && realOrigUser.equals(otherEntry.realOrigUser)
                 && origResource.equals(otherEntry.origResource) && isDomain == otherEntry.isDomain) {
             return true;
         }
@@ -109,7 +109,7 @@ public class ResourcePrivEntry extends PrivEntry {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("resource priv. host: ").append(origHost).append(", resource: ").append(origResource);
-        sb.append(", user: ").append(origUser);
+        sb.append(", user: ").append(realOrigUser);
         sb.append(", priv: ").append(privSet).append(", set by resolver: ").append(isSetByDomainResolver);
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/TablePrivEntry.java
@@ -91,7 +91,7 @@ public class TablePrivEntry extends DbPrivEntry {
             return -res;
         }
 
-        res = origUser.compareTo(otherEntry.origUser);
+        res = realOrigUser.compareTo(otherEntry.realOrigUser);
         if (res != 0) {
             return -res;
         }
@@ -106,7 +106,7 @@ public class TablePrivEntry extends DbPrivEntry {
         }
 
         TablePrivEntry otherEntry = (TablePrivEntry) other;
-        if (origHost.equals(otherEntry.origHost) && origUser.equals(otherEntry.origUser)
+        if (origHost.equals(otherEntry.origHost) && realOrigUser.equals(otherEntry.realOrigUser)
                 && origDb.equals(otherEntry.origDb) && origTbl.equals(otherEntry.origTbl)
                 && isDomain == otherEntry.isDomain) {
             return true;
@@ -118,7 +118,7 @@ public class TablePrivEntry extends DbPrivEntry {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("db priv. host: ").append(origHost).append(", db: ").append(origDb);
-        sb.append(", user: ").append(origUser).append(", tbl: ").append(origTbl);
+        sb.append(", user: ").append(realOrigUser).append(", tbl: ").append(origTbl);
         sb.append(", priv: ").append(privSet).append(", set by resolver: ").append(isSetByDomainResolver);
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserProperty.java
@@ -213,7 +213,7 @@ public class UserProperty implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        Text.writeString(out, qualifiedUser);
+        Text.writeString(out, ClusterNamespace.getFullName(qualifiedUser));
         out.writeLong(maxConn);
 
         UserResource.write(out);
@@ -236,7 +236,7 @@ public class UserProperty implements Writable {
         if (GlobalStateMgr.getCurrentStateJournalVersion() < FeMetaVersion.VERSION_30) {
             qualifiedUser = ClusterNamespace.getFullName(Text.readString(in));
         } else {
-            qualifiedUser = Text.readString(in);
+            qualifiedUser = ClusterNamespace.getNameFromFullName(Text.readString(in));
         }
 
         if (GlobalStateMgr.getCurrentStateJournalVersion() < FeMetaVersion.VERSION_43) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For compatible with old version, remove the "default_cluster" prefix from origUser when deserializing and add the "default_cluster" prefix to origUser when serializing. 
We cannot change the origUser when serialize using json format, because the origUser can be used at runtime, so we have to use another property (origUserForJsonPersist) to store the changed value for persist.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
