### PR TITLE
[Feature] Support broker load priority

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterLoadStmt.java
@@ -1,0 +1,104 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.analysis;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeNameFormat;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.LoadPriority;
+import com.starrocks.sql.ast.AstVisitor;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ALTER LOAD FOR db.label
+ * PROPERTIES(
+ * ...
+ * )
+ */
+public class AlterLoadStmt extends DdlStmt {
+
+    private static final String NAME_TYPE = "ROUTINE LOAD NAME";
+
+    private static final ImmutableSet<String> CONFIGURABLE_PROPERTIES_SET = new ImmutableSet.Builder<String>()
+            .add(LoadStmt.PRIORITY)
+            .build();
+
+    private final LabelName labelName;
+    private final Map<String, String> jobProperties;
+
+    // save analyzed job properties.
+    // analyzed data source properties are saved in dataSourceProperties.
+    private Map<String, String> analyzedJobProperties = Maps.newHashMap();
+
+    /**
+     * @param labelName
+     * @param jobProperties
+     */
+    public AlterLoadStmt(LabelName labelName, Map<String, String> jobProperties) {
+        this.labelName = labelName;
+        this.jobProperties = jobProperties != null ? jobProperties : Maps.newHashMap();
+    }
+
+    public String getDbName() {
+        return labelName.getDbName();
+    }
+
+    public void setDbName(String dbName) {
+        labelName.setDbName(dbName);
+    }
+
+    public String getLabel() {
+        return labelName.getLabelName();
+    }
+
+    public Map<String, String> getAnalyzedJobProperties() {
+        return analyzedJobProperties;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws UserException {
+        super.analyze(analyzer);
+
+        labelName.analyze(analyzer);
+        FeNameFormat.checkCommonName(NAME_TYPE, labelName.getLabelName());
+        // check routine load job properties include desired concurrent number etc.
+        checkJobProperties();
+
+        if (analyzedJobProperties.isEmpty()) {
+            throw new AnalysisException("No properties are specified");
+        }
+    }
+
+    public void checkJobProperties() throws UserException {
+        Optional<String> optional = jobProperties.keySet().stream().filter(
+                entity -> !CONFIGURABLE_PROPERTIES_SET.contains(entity)).findFirst();
+        if (optional.isPresent()) {
+            throw new AnalysisException(optional.get() + " is invalid property");
+        }
+
+        if (jobProperties.containsKey(LoadStmt.PRIORITY)) {
+            final String priorityProperty = jobProperties.get(LoadStmt.PRIORITY);
+            if (priorityProperty != null) {
+                if (LoadPriority.priorityByName(priorityProperty) == null) {
+                    throw new AnalysisException(LoadStmt.PRIORITY + " should in HIGHEST/HIGH/NORMAL/LOW/LOWEST");
+                }
+            }
+            analyzedJobProperties.put(LoadStmt.PRIORITY, priorityProperty);
+        }
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterLoadStatement(this, context);
+    }
+
+    @Override
+    public boolean isSupportNewPlanner() {
+        return true;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
@@ -23,6 +23,7 @@ package com.starrocks.analysis;
 
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.LoadPriority;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.Load;
@@ -73,6 +74,7 @@ public class LoadStmt extends DdlStmt {
     public static final String STRICT_MODE = "strict_mode";
     public static final String TIMEZONE = "timezone";
     public static final String PARTIAL_UPDATE = "partial_update";
+    public static final String PRIORITY = "priority";
 
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
@@ -109,6 +111,7 @@ public class LoadStmt extends DdlStmt {
             .add(VERSION)
             .add(TIMEZONE)
             .add(PARTIAL_UPDATE)
+            .add(PRIORITY)
             .build();
 
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions,
@@ -244,6 +247,14 @@ public class LoadStmt extends DdlStmt {
         if (timezone != null) {
             properties.put(TIMEZONE, TimeUtils.checkTimeZoneValidAndStandardize(
                     properties.getOrDefault(LoadStmt.TIMEZONE, TimeUtils.DEFAULT_TIME_ZONE)));
+        }
+
+        // load priority
+        final String priorityProperty = properties.get(PRIORITY);
+        if (priorityProperty != null) {
+            if (LoadPriority.priorityByName(priorityProperty) == null) {
+                throw new DdlException(PRIORITY + " should in HIGHEST/HIGH/NORMAL/LOW/LOWEST");
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/PriorityFutureTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/PriorityFutureTask.java
@@ -1,0 +1,41 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common;
+
+import java.util.concurrent.FutureTask;
+
+public class PriorityFutureTask<V> extends FutureTask<V> implements
+        Comparable<PriorityFutureTask<V>> {
+
+    private PriorityRunnable run;
+
+    public PriorityFutureTask(PriorityRunnable runnable, V result) {
+        super(runnable, result);
+        this.run = runnable;
+    }
+
+    public int getPriority() {
+        return run.getPriority();
+    }
+
+    public void setPriority(int priority) {
+        run.setPriority(priority);
+    }
+
+    public PriorityRunnable getRun() {
+        return run;
+    }
+
+    @Override
+    public int compareTo(PriorityFutureTask<V> other) {
+        if (other == null || !(other instanceof PriorityFutureTask)) {
+            return -1;
+        }
+        return this.run.compareTo(other.run);
+    }
+
+    @Override
+    public String toString() {
+        return "PriorityFutureTask{" + "priority=" + getPriority() + ", runnable=" + getRun() + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/PriorityRunnable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/PriorityRunnable.java
@@ -1,0 +1,53 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public abstract class PriorityRunnable
+        implements Runnable, Comparable<PriorityRunnable> {
+
+    private final long seqNum;
+    private int priority = 0;
+
+    static final AtomicLong SEQ = new AtomicLong(0);
+
+    public PriorityRunnable(int priority) {
+        seqNum = SEQ.getAndIncrement();
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public Runnable getRun() {
+        return this;
+    }
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public int compareTo(PriorityRunnable other) {
+        int res = 0;
+        if (this.priority == other.priority) {
+            if (other != this) {
+                res = (seqNum < other.seqNum ? -1 : 1);
+            }
+        } else {
+            res = this.priority > other.priority ? -1 : 1;
+        }
+        return res;
+    }
+
+    @Override
+    public String toString() {
+        return "PriorityRunnable{" + "priority=" + getPriority() + ", runnable=" + getRun() + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/PriorityThreadPoolExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/PriorityThreadPoolExecutor.java
@@ -1,0 +1,55 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common;
+
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityThreadPoolExecutor extends ThreadPoolExecutor {
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                                      PriorityBlockingQueue<Runnable> workQueue) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                                      PriorityBlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                                      PriorityBlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                                      PriorityBlockingQueue<Runnable> workQueue, ThreadFactory threadFactory,
+                                      RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    /* (non-Javadoc)
+     * @see java.util.concurrent.AbstractExecutorService#submit(java.lang.Runnable)
+     */
+    public PriorityFutureTask<Void> submit(PriorityRunnable task) {
+        if (task == null) {
+            throw new NullPointerException();
+        }
+        final PriorityFutureTask<Void> ftask = new PriorityFutureTask(task, null);
+        execute(ftask);
+        return ftask;
+    }
+
+    public synchronized <T> boolean updatePriority(PriorityFutureTask<T> task, int priority) {
+        if (remove(task)) {
+            task.setPriority(priority);
+            execute(task);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -119,6 +120,18 @@ public class ThreadPoolManager {
         return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(queueSize),
                 new BlockedPolicy(poolName, 60), poolName, needRegisterMetric);
+    }
+
+    public static PriorityThreadPoolExecutor newDaemonFixedPriorityThreadPool(int numThread, int queueSize,
+            String poolName, boolean needRegisterMetric) {
+        ThreadFactory threadFactory = namedThreadFactory(poolName);
+        PriorityThreadPoolExecutor threadPool = new PriorityThreadPoolExecutor(numThread, numThread, KEEP_ALIVE_TIME,
+                TimeUnit.SECONDS, new PriorityBlockingQueue<>(queueSize), threadFactory,
+                new BlockedPolicy(poolName, 60));
+        if (needRegisterMetric) {
+            nameToThreadPoolMap.put(poolName, threadPool);
+        }
+        return threadPool;
     }
 
     public static ThreadPoolExecutor newDaemonThreadPool(int corePoolSize,

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class LoadProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("State").add("Progress")
-            .add("Type").add("EtlInfo").add("TaskInfo").add("ErrorMsg").add("CreateTime")
+            .add("Type").add("Priority").add("EtlInfo").add("TaskInfo").add("ErrorMsg").add("CreateTime")
             .add("EtlStartTime").add("EtlFinishTime").add("LoadStartTime").add("LoadFinishTime")
             .add("URL").add("JobDetails")
             .build();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LoadPriority.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LoadPriority.java
@@ -1,0 +1,46 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+
+public class LoadPriority {
+    public static final String NORMAL = "NORMAL";
+    public static final String HIGH = "HIGH";
+    public static final String HIGHEST = "HIGHEST";
+    public static final String LOW = "LOW";
+    public static final String LOWEST = "LOWEST";
+
+    public static final Integer NORMAL_VALUE = 0;
+    public static final Integer HIGH_VALUE = 1;
+    public static final Integer HIGHEST_VALUE = 2;
+    public static final Integer LOW_VALUE = -1;
+    public static final Integer LOWEST_VALUE = -2;
+
+    private static final ImmutableMap<String, Integer> T_NAME_TO_PRIORITY =
+            (new ImmutableSortedMap.Builder<String, Integer>(String.CASE_INSENSITIVE_ORDER))
+                    .put(HIGHEST, HIGHEST_VALUE)
+                    .put(HIGH, HIGH_VALUE)
+                    .put(NORMAL, NORMAL_VALUE)
+                    .put(LOW, LOW_VALUE)
+                    .put(LOWEST, LOWEST_VALUE)
+                    .build();
+
+    private static final ImmutableMap<Integer, String> T_PRIORITY_TO_NAME =
+            (new ImmutableMap.Builder<Integer, String>())
+                    .put(HIGHEST_VALUE, HIGHEST)
+                    .put(HIGH_VALUE, HIGH)
+                    .put(NORMAL_VALUE, NORMAL)
+                    .put(LOW_VALUE, LOW)
+                    .put(LOWEST_VALUE, LOWEST)
+                    .build();
+
+    public static Integer priorityByName(String name) {
+        return T_NAME_TO_PRIORITY.get(name);
+    }
+
+    public static String priorityToName(Integer priority) {
+        return T_PRIORITY_TO_NAME.get(priority);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -52,6 +52,7 @@ import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.mysql.privilege.UserPropertyInfo;
 import com.starrocks.persist.AddPartitionsInfo;
 import com.starrocks.persist.AddPartitionsInfoV2;
+import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.AlterViewInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
@@ -596,6 +597,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_ALTER_ROUTINE_LOAD_JOB: {
                 data = AlterRoutineLoadJobOperationLog.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_ALTER_LOAD_JOB: {
+                data = AlterLoadJobOperationLog.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -30,8 +30,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.task.ExportExportingTask;
 import com.starrocks.task.ExportPendingTask;
-import com.starrocks.task.LeaderTask;
 import com.starrocks.task.LeaderTaskExecutor;
+import com.starrocks.task.PriorityLeaderTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -125,7 +125,7 @@ public final class ExportChecker extends LeaderDaemon {
 
         for (ExportJob job : pendingJobs) {
             try {
-                LeaderTask task = new ExportPendingTask(job);
+                PriorityLeaderTask task = new ExportPendingTask(job);
                 if (executors.get(JobState.PENDING).submit(task)) {
                     LOG.info("run pending export job. job: {}", job);
                 }
@@ -144,7 +144,7 @@ public final class ExportChecker extends LeaderDaemon {
                 continue;
             }
             try {
-                LeaderTask task = new ExportExportingTask(job);
+                PriorityLeaderTask task = new ExportExportingTask(job);
                 if (executors.get(JobState.EXPORTING).submit(task)) {
                     LOG.info("run exporting export job. job: {}", job);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
@@ -48,7 +48,7 @@ public class BrokerLoadPendingTask extends LoadTask {
     public BrokerLoadPendingTask(BrokerLoadJob loadTaskCallback,
                                  Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                  BrokerDesc brokerDesc) {
-        super(loadTaskCallback, TaskType.PENDING);
+        super(loadTaskCallback, TaskType.PENDING, 0);
         this.retryTime = 3;
         this.attachment = new BrokerPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -84,6 +84,8 @@ public abstract class BulkLoadJob extends LoadJob {
     // we persist these sessionVariables due to the session is not available when replaying the job.
     protected Map<String, String> sessionVariables = Maps.newHashMap();
 
+    protected static final String PRIORITY_SESSION_VARIABLE_KEY = "priority.session.variable.key";
+
     // only for log replay
     public BulkLoadJob() {
         super();
@@ -133,6 +135,10 @@ public abstract class BulkLoadJob extends LoadJob {
                     throw new DdlException("Unknown load job type.");
             }
             bulkLoadJob.setJobProperties(stmt.getProperties());
+            if (bulkLoadJob.priority != 0) {
+                bulkLoadJob.sessionVariables.put(BulkLoadJob.PRIORITY_SESSION_VARIABLE_KEY,
+                        Integer.toString(bulkLoadJob.priority));
+            }
             bulkLoadJob.checkAndSetDataSourceInfo(db, stmt.getDataDescriptions());
             return bulkLoadJob;
         } catch (MetaNotFoundException e) {
@@ -236,7 +242,7 @@ public abstract class BulkLoadJob extends LoadJob {
                     if (loadTask.getTaskType() == LoadTask.TaskType.PENDING) {
                         submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), loadTask);
                     } else if (loadTask.getTaskType() == LoadTask.TaskType.LOADING) {
-                        submitTask(GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler(), loadTask);
+                        GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler().submit(loadTask);
                     } else {
                         throw new LoadException(String.format("Unknown load task type: %s. task id: %d, job id, %d",
                                 loadTask.getTaskType(), loadTask.getSignature(), id));
@@ -336,6 +342,9 @@ public abstract class BulkLoadJob extends LoadJob {
                 String key = Text.readString(in);
                 String value = Text.readString(in);
                 sessionVariables.put(key, value);
+            }
+            if (sessionVariables.containsKey(PRIORITY_SESSION_VARIABLE_KEY)) {
+                priority = Integer.parseInt(sessionVariables.get(PRIORITY_SESSION_VARIABLE_KEY));
             }
         } else {
             // old version of load does not have sqlmode, set it to default

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.LoadStmt;
 import com.starrocks.catalog.AuthorizationInfo;
 import com.starrocks.catalog.Database;
@@ -43,6 +44,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.LoadPriority;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.TimeUtils;
@@ -54,12 +56,14 @@ import com.starrocks.load.Load;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.mysql.privilege.Privilege;
+import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.LeaderTaskExecutor;
+import com.starrocks.task.PriorityLeaderTask;
 import com.starrocks.thrift.TEtlState;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.AbstractTxnStateChangeCallback;
@@ -105,6 +109,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected boolean strictMode = false; // default is false
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     protected boolean partialUpdate = false;
+    protected int priority = LoadPriority.NORMAL_VALUE;
     // reuse deleteFlag as partialUpdate
     // @Deprecated
     // protected boolean deleteFlag = false;
@@ -137,6 +142,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // only for persistence param. see readFields() for usage
     private boolean isJobTypeRead = false;
 
+    private boolean startLoad = false;
 
     // only for log replay
     public LoadJob() {
@@ -217,6 +223,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     public void initLoadProgress(TUniqueId loadId, Set<TUniqueId> fragmentIds, List<Long> relatedBackendIds) {
         loadingStatus.getLoadStatistic().initLoad(loadId, fragmentIds, relatedBackendIds);
+        startLoad = true;
     }
 
     public void updateProgess(Long beId, TUniqueId loadId, TUniqueId fragmentId, 
@@ -309,6 +316,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             } else if (ConnectContext.get() != null) {
                 // get timezone for session variable
                 timezone = ConnectContext.get().getSessionVariable().getTimeZone();
+            }
+
+            if (properties.containsKey(LoadStmt.PRIORITY)) {
+                priority = LoadPriority.priorityByName(properties.get(LoadStmt.PRIORITY));
             }
         }
     }
@@ -489,6 +500,12 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
     }
 
+    public void alterJob(AlterLoadStmt stmt) throws DdlException {
+    }
+
+    public void replayAlterJob(AlterLoadJobOperationLog log) {
+    }
+
     private void checkAuth(String command) throws DdlException {
         if (authorizationInfo == null) {
             // use the old method to check priv
@@ -555,7 +572,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
         // get load ids of all loading tasks, we will cancel their coordinator process later
         List<TUniqueId> loadIds = Lists.newArrayList();
-        for (LoadTask loadTask : idToTasks.values()) {
+        for (PriorityLeaderTask loadTask : idToTasks.values()) {
             if (loadTask instanceof LoadLoadingTask) {
                 loadIds.add(((LoadLoadingTask) loadTask).getLoadId());
             }
@@ -670,6 +687,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             // state
             if (state == JobState.COMMITTED) {
                 jobInfo.add("PREPARED");
+            } else if (state == JobState.LOADING && !startLoad) {
+                jobInfo.add("QUEUEING");
             } else {
                 jobInfo.add(state.name());
             }
@@ -691,6 +710,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
             // type
             jobInfo.add(jobType);
+            // priority
+            jobInfo.add(LoadPriority.priorityToName(priority));
 
             // etl info
             if (loadingStatus.getCounters().size() == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -78,8 +78,8 @@ public class LoadLoadingTask extends LoadTask {
             long jobDeadlineMs, long execMemLimit, boolean strictMode,
             long txnId, LoadTaskCallback callback, String timezone,
             long timeoutS, long createTimestamp, boolean partialUpdate, Map<String, String> sessionVariables, 
-            ConnectContext context, TLoadJobType loadJobType) {
-        super(callback, TaskType.LOADING);
+            ConnectContext context, TLoadJobType loadJobType, int priority) {
+        super(callback, TaskType.LOADING, priority);
         this.db = db;
         this.table = table;
         this.brokerDesc = brokerDesc;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.LoadStmt;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
@@ -43,6 +44,7 @@ import com.starrocks.load.EtlJobType;
 import com.starrocks.load.FailMsg;
 import com.starrocks.load.FailMsg.CancelType;
 import com.starrocks.load.Load;
+import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CancelLoadStmt;
@@ -123,6 +125,36 @@ public class LoadManager implements Writable {
         // The job must be submitted after edit log.
         // It guarantee that load job has not been changed before edit log.
         loadJobScheduler.submitJob(loadJob);
+    }
+
+    public void alterLoadJob(AlterLoadStmt stmt) throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(stmt.getDbName());
+        if (db == null) {
+            throw new DdlException("Db does not exist. name: " + stmt.getDbName());
+        }
+
+        LoadJob loadJob = null;
+        readLock();
+        try {
+            Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(db.getId());
+            if (labelToLoadJobs == null) {
+                throw new DdlException("Load job does not exist");
+            }
+            List<LoadJob> loadJobList = labelToLoadJobs.get(stmt.getLabel());
+            if (loadJobList == null) {
+                throw new DdlException("Load job does not exist");
+            }
+            Optional<LoadJob> loadJobOptional = loadJobList.stream().filter(entity -> !entity.isTxnDone()).findFirst();
+            if (!loadJobOptional.isPresent()) {
+                throw new DdlException("There is no uncompleted job which label is " + stmt.getLabel());
+            }
+            loadJob = loadJobOptional.get();
+
+        } finally {
+            readUnlock();
+        }
+
+        loadJob.alterJob(stmt);
     }
 
     public void replayCreateLoadJob(LoadJob loadJob) {
@@ -263,6 +295,17 @@ public class LoadManager implements Writable {
             LOG.info("remove expired job: {}", job);
             unprotectedRemoveJobReleatedMeta(job);
         }
+    }
+
+    public void replayAlterLoadJob(AlterLoadJobOperationLog op) {
+        long jobId = op.getJobId();
+        LoadJob job = idToLoadJob.get(jobId);
+        if (job == null) {
+            LOG.warn("replay alter load job state failed. error: job not found, id: {}", jobId);
+            return;
+        }
+
+        job.replayAlterJob(op);
     }
 
     public long getLoadJobNum(JobState jobState, long dbId) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -27,11 +27,11 @@ import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.FailMsg;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.task.LeaderTask;
+import com.starrocks.task.PriorityLeaderTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public abstract class LoadTask extends LeaderTask {
+public abstract class LoadTask extends PriorityLeaderTask {
     public enum TaskType {
         PENDING,
         LOADING
@@ -45,7 +45,8 @@ public abstract class LoadTask extends LeaderTask {
     protected FailMsg failMsg = new FailMsg();
     protected int retryTime = 1;
 
-    public LoadTask(LoadTaskCallback callback, TaskType taskType) {
+    public LoadTask(LoadTaskCallback callback, TaskType taskType, int priority) {
+        super(priority);
         this.taskType = taskType;
         this.signature = GlobalStateMgr.getCurrentState().getNextId();
         this.callback = callback;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -51,6 +51,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.LoadPriority;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import com.starrocks.load.FailMsg;
@@ -94,7 +95,7 @@ public class SparkLoadPendingTask extends LoadTask {
     public SparkLoadPendingTask(SparkLoadJob loadTaskCallback,
                                 Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                 SparkResource resource, BrokerDesc brokerDesc) {
-        super(loadTaskCallback, TaskType.PENDING);
+        super(loadTaskCallback, TaskType.PENDING, LoadPriority.NORMAL_VALUE);
         this.retryTime = 3;
         this.attachment = new SparkPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterLoadJobOperationLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterLoadJobOperationLog.java
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+
+public class AlterLoadJobOperationLog implements Writable {
+
+    @SerializedName(value = "jobId")
+    private long jobId;
+    @SerializedName(value = "jobProperties")
+    private Map<String, String> jobProperties;
+
+    public AlterLoadJobOperationLog(long jobId, Map<String, String> jobProperties) {
+        this.jobId = jobId;
+        this.jobProperties = jobProperties;
+    }
+
+    public long getJobId() {
+        return jobId;
+    }
+
+    public Map<String, String> getJobProperties() {
+        return jobProperties;
+    }
+
+    public static AlterLoadJobOperationLog read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, AlterLoadJobOperationLog.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -773,6 +773,11 @@ public class EditLog {
                     globalStateMgr.getRoutineLoadManager().replayAlterRoutineLoadJob(log);
                     break;
                 }
+                case OperationType.OP_ALTER_LOAD_JOB: {
+                    AlterLoadJobOperationLog log = (AlterLoadJobOperationLog) journal.getData();
+                    globalStateMgr.getLoadManager().replayAlterLoadJob(log);
+                    break;
+                }
                 case OperationType.OP_GLOBAL_VARIABLE_V2: {
                     GlobalVarPersistInfo info = (GlobalVarPersistInfo) journal.getData();
                     globalStateMgr.replayGlobalVariableV2(info);
@@ -1430,6 +1435,10 @@ public class EditLog {
 
     public void logAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log) {
         logEdit(OperationType.OP_ALTER_ROUTINE_LOAD_JOB, log);
+    }
+
+    public void logAlterLoadJob(AlterLoadJobOperationLog log) {
+        logEdit(OperationType.OP_ALTER_LOAD_JOB, log);
     }
 
     public void logGlobalVariableV2(GlobalVarPersistInfo info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -266,4 +266,8 @@ public class OperationType {
 
     // integrate with starmgr
     public static final short OP_STARMGR = 11000;
+
+    // alter load
+    public static final short OP_ALTER_LOAD_JOB = 11100;
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.BackupStmt;
 import com.starrocks.analysis.CancelAlterSystemStmt;
@@ -358,6 +359,14 @@ public class DDLStmtExecutor {
         public ShowResultSet visitAlterRoutineLoadStatement(AlterRoutineLoadStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getRoutineLoadManager().alterRoutineLoadJob(stmt);
+            });
+            return null;
+        }
+
+        @Override
+        public ShowResultSet visitAlterLoadStatement(AlterLoadStmt stmt, ConnectContext context) {
+            ErrorReport.wrapWithRuntimeException(() -> {
+                context.getGlobalStateMgr().getLoadManager().alterLoadJob(stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterLoadAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterLoadAnalyzer.java
@@ -1,0 +1,44 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.sql.analyzer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.starrocks.analysis.AlterLoadStmt;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeNameFormat;
+import com.starrocks.common.UserException;
+import com.starrocks.qe.ConnectContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AlterLoadAnalyzer {
+
+    private static final Logger LOG = LogManager.getLogger(AlterLoadAnalyzer.class);
+
+    private AlterLoadAnalyzer() {
+        throw new IllegalStateException("creating an instance is illegal");
+    }
+
+    public static void analyze(AlterLoadStmt statement, ConnectContext context) {
+        String dbName = statement.getDbName();
+        if (Strings.isNullOrEmpty(dbName)) {
+            dbName = context.getDatabase();
+            if (Strings.isNullOrEmpty(dbName)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
+            }
+        }
+        Preconditions.checkArgument(context.getDatabase().equalsIgnoreCase(dbName)
+                        || context.getDatabase().equalsIgnoreCase(""),
+                "session's dbname not equal lable's dbname", context.getDatabase(), dbName);
+        statement.setDbName(dbName);
+        try {
+            FeNameFormat.checkLabel(statement.getLabel());
+            statement.checkJobProperties();
+        } catch (UserException e) {
+            LOG.error(e);
+            throw new SemanticException(e.getMessage());
+        }
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -2,6 +2,7 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.AddSqlBlackListStmt;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.BackupStmt;
 import com.starrocks.analysis.CreateRepositoryStmt;
@@ -504,6 +505,12 @@ public class Analyzer {
 
         public Void visitAlterRoutineLoadStatement(AlterRoutineLoadStmt statement, ConnectContext session) {
             AlterRoutineLoadAnalyzer.analyze(statement, session);
+            return null;
+        }
+
+        @Override
+        public Void visitAlterLoadStatement(AlterLoadStmt statement, ConnectContext session) {
+            AlterLoadAnalyzer.analyze(statement, session);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -2,6 +2,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.AddSqlBlackListStmt;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.ArithmeticExpr;
@@ -379,6 +380,10 @@ public abstract class AstVisitor<R, C> {
     }
 
     public R visitAlterRoutineLoadStatement(AlterRoutineLoadStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    public R visitAlterLoadStatement(AlterLoadStmt statement, C context) {
         return visitStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.AddSqlBlackListStmt;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.AnalyticWindow;
@@ -1800,6 +1801,20 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
         return new AlterRoutineLoadStmt(new LabelName(dbName == null ? null : dbName.toString(), name),
                 loadPropertyList, jobProperties, new RoutineLoadDataSourceProperties());
+    }
+
+    @Override
+    public ParseNode visitAlterLoadStatement(StarRocksParser.AlterLoadStatementContext context) {
+        QualifiedName dbName = null;
+        if (context.db != null) {
+            dbName = getQualifiedName(context.db);
+        }
+
+        String name = ((Identifier) visit(context.name)).getValue();
+        Map<String, String> jobProperties = getJobProperties(context.jobProperties());
+
+        return new AlterLoadStmt(new LabelName(dbName == null ? null : dbName.toString(), name),
+                jobProperties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -136,6 +136,7 @@ statement
     | showLoadStatement
     | showLoadWarningsStatement
     | cancelLoadStatement
+    | alterLoadStatement
 
     //Show Statement
     | showAuthorStatement
@@ -956,6 +957,11 @@ showLoadWarningsStatement
 
 cancelLoadStatement
     : CANCEL LOAD (FROM identifier)? (WHERE expression)?
+    ;
+
+alterLoadStatement
+    : ALTER LOAD FOR (db=qualifiedName '.')? name=identifier
+        jobProperties?
     ;
 
 // ------------------------------------------- Show Statement ----------------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -49,7 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-public class ExportExportingTask extends LeaderTask {
+public class ExportExportingTask extends PriorityLeaderTask {
     private static final Logger LOG = LogManager.getLogger(ExportExportingTask.class);
     private static final int RETRY_NUM = 2;
 
@@ -278,7 +278,7 @@ public class ExportExportingTask extends LeaderTask {
         return Status.OK;
     }
 
-    private class ExportExportingSubTask extends LeaderTask {
+    private class ExportExportingSubTask extends PriorityLeaderTask {
         private final Coordinator coord;
         private final int taskIdx;
         private final int coordSize;

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
@@ -45,7 +45,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public class ExportPendingTask extends LeaderTask {
+public class ExportPendingTask extends PriorityLeaderTask {
     private static final Logger LOG = LogManager.getLogger(ExportPendingTask.class);
 
     protected final ExportJob job;

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTask.java
@@ -20,7 +20,7 @@ package com.starrocks.task;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public abstract class LeaderTask implements Runnable {
+public abstract class LeaderTask extends PriorityLeaderTask {
     private static final Logger LOG = LogManager.getLogger(LeaderTask.class);
 
     protected long signature;

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -71,7 +71,7 @@ public class LeaderTaskExecutor {
      * @return true if submit success
      * false if task exists
      */
-    public boolean submit(LeaderTask task) {
+    public boolean submit(PriorityLeaderTask task) {
         long signature = task.getSignature();
         synchronized (runningTasks) {
             if (runningTasks.containsKey(signature)) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTask.java
@@ -1,0 +1,40 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.task;
+
+import com.starrocks.common.PriorityRunnable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class PriorityLeaderTask extends PriorityRunnable {
+    private static final Logger LOG = LogManager.getLogger(PriorityLeaderTask.class);
+
+    protected long signature;
+
+    public PriorityLeaderTask() {
+        super(0);
+    }
+
+    public PriorityLeaderTask(int priority) {
+        super(priority);
+    }
+
+    @Override
+    public void run() {
+        try {
+            exec();
+        } catch (Exception e) {
+            LOG.error("task exec error ", e);
+        }
+    }
+
+    public long getSignature() {
+        return signature;
+    }
+
+    /**
+     * implement in child
+     */
+    protected abstract void exec();
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -1,0 +1,115 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.task;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.PriorityFutureTask;
+import com.starrocks.common.PriorityThreadPoolExecutor;
+import com.starrocks.common.ThreadPoolManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityLeaderTaskExecutor {
+    private static final Logger LOG = LogManager.getLogger(PriorityLeaderTaskExecutor.class);
+
+    private PriorityThreadPoolExecutor executor;
+    private Map<Long, PriorityFutureTask<?>> runningTasks;
+    public ScheduledThreadPoolExecutor scheduledThreadPool;
+
+    public PriorityLeaderTaskExecutor(String name, int threadNum, int queueSize, boolean needRegisterMetric) {
+        executor = ThreadPoolManager.newDaemonFixedPriorityThreadPool(threadNum, queueSize, name + "_priority_pool",
+                needRegisterMetric);
+        runningTasks = Maps.newHashMap();
+        scheduledThreadPool = ThreadPoolManager.newDaemonScheduledThreadPool(1,
+                name + "_scheduler_priority_thread_pool", needRegisterMetric);
+    }
+
+    public void start() {
+        scheduledThreadPool.scheduleAtFixedRate(new TaskChecker(), 0L, 1000L, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * submit task to task executor
+     * Notice:
+     * If the queue is full, this function will be blocked until the pool enqueue task succeed or timeout (60s default),
+     * so this function should be used outside any lock to prevent holding lock for long time.
+     *
+     * @param task
+     * @return true if submit success
+     * false if task exists
+     */
+    public boolean submit(PriorityLeaderTask task) {
+        long signature = task.getSignature();
+        synchronized (runningTasks) {
+            if (runningTasks.containsKey(signature)) {
+                return false;
+            }
+
+            try {
+                PriorityFutureTask<?> future = executor.submit(task);
+                runningTasks.put(signature, future);
+                return true;
+            } catch (RejectedExecutionException e) {
+                LOG.warn("submit task {} failed.", task.getSignature(), e);
+                return false;
+            }
+        }
+    }
+
+    /**
+     * update task prirority still in queue, no effect if task already executed
+     * @param signature
+     * @param priority
+     * @return trun if update task priority success, false if update fail which
+     *         means task not exists or already executed
+     */
+    public boolean updatePriority(long signature, int priority) {
+        synchronized (runningTasks) {
+            PriorityFutureTask<?> task = runningTasks.get(signature);
+            if (task == null) {
+                return false;
+            }
+
+            return executor.updatePriority(task, priority);
+        }
+    }
+
+    public void close() {
+        scheduledThreadPool.shutdown();
+        executor.shutdown();
+        runningTasks.clear();
+    }
+
+    public int getTaskNum() {
+        synchronized (runningTasks) {
+            return runningTasks.size();
+        }
+    }
+
+    private class TaskChecker implements Runnable {
+        @Override
+        public void run() {
+            try {
+                synchronized (runningTasks) {
+                    Iterator<Entry<Long, PriorityFutureTask<?>>> iterator = runningTasks.entrySet().iterator();
+                    while (iterator.hasNext()) {
+                        Entry<Long, PriorityFutureTask<?>> entry = iterator.next();
+                        PriorityFutureTask<?> future = entry.getValue();
+                        if (future.isDone()) {
+                            iterator.remove();
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("check task error", e);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterLoadStmtTest.java
@@ -1,0 +1,165 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.analysis;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.UserException;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class AlterLoadStmtTest {
+
+    private Analyzer analyzer;
+
+    @Mocked
+    private Auth auth;
+
+    @Before
+    public void setUp() {
+        analyzer = AccessTestUtil.fetchAdminAnalyzer();
+
+        new Expectations() {
+            {
+                auth.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
+                minTimes = 0;
+                result = true;
+
+                auth.checkDbPriv((ConnectContext) any, anyString, (PrivPredicate) any);
+                minTimes = 0;
+                result = true;
+
+                auth.checkTblPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
+                minTimes = 0;
+                result = true;
+            }
+        };
+    }
+
+    @Test
+    public void testNormal() {
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "NORMAL");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+            } catch (UserException e) {
+                Assert.fail();
+            }
+
+            Assert.assertEquals(1, stmt.getAnalyzedJobProperties().size());
+            Assert.assertTrue(
+                    stmt.getAnalyzedJobProperties().containsKey(LoadStmt.PRIORITY));
+        }
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "HIGH");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+            } catch (UserException e) {
+                Assert.fail();
+            }
+
+            Assert.assertEquals(1, stmt.getAnalyzedJobProperties().size());
+            Assert.assertTrue(
+                    stmt.getAnalyzedJobProperties().containsKey(LoadStmt.PRIORITY));
+        }
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "HIGHEST");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+            } catch (UserException e) {
+                Assert.fail();
+            }
+
+            Assert.assertEquals(1, stmt.getAnalyzedJobProperties().size());
+            Assert.assertTrue(
+                    stmt.getAnalyzedJobProperties().containsKey(LoadStmt.PRIORITY));
+        }
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "LOW");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+            } catch (UserException e) {
+                Assert.fail();
+            }
+
+            Assert.assertEquals(1, stmt.getAnalyzedJobProperties().size());
+            Assert.assertTrue(
+                    stmt.getAnalyzedJobProperties().containsKey(LoadStmt.PRIORITY));
+        }
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "LOWEST");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+            } catch (UserException e) {
+                Assert.fail();
+            }
+
+            Assert.assertEquals(1, stmt.getAnalyzedJobProperties().size());
+            Assert.assertTrue(
+                    stmt.getAnalyzedJobProperties().containsKey(LoadStmt.PRIORITY));
+        }
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testNoPproperties() throws AnalysisException, UserException {
+        AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"), null);
+        stmt.analyze(analyzer);
+    }
+
+    @Test
+    public void testUnsupportedProperties() {
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(CreateRoutineLoadStmt.FORMAT, "csv");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+            try {
+                stmt.analyze(analyzer);
+                Assert.fail();
+            } catch (AnalysisException e) {
+                Assert.assertTrue(e.getMessage().contains("format is invalid property"));
+            } catch (UserException e) {
+                Assert.fail();
+            }
+        }
+
+        {
+            Map<String, String> jobProperties = Maps.newHashMap();
+            jobProperties.put(LoadStmt.PRIORITY, "abc");
+            AlterLoadStmt stmt = new AlterLoadStmt(new LabelName("db1", "label1"),
+                    jobProperties);
+
+            try {
+                stmt.analyze(analyzer);
+                Assert.fail();
+            } catch (AnalysisException e) {
+                Assert.assertTrue(e.getMessage().contains("priority"));
+            } catch (UserException e) {
+                Assert.fail();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
@@ -47,22 +47,23 @@ public class ShowLoadStmtTest {
         ShowLoadStmt stmt = (ShowLoadStmt) analyzeSuccess("SHOW LOAD FROM test");
         ShowResultSetMetaData metaData = stmt.getMetaData();
         Assert.assertNotNull(metaData);
-        Assert.assertEquals(15, metaData.getColumnCount());
+        Assert.assertEquals(16, metaData.getColumnCount());
         Assert.assertEquals("JobId", metaData.getColumn(0).getName());
         Assert.assertEquals("Label", metaData.getColumn(1).getName());
         Assert.assertEquals("State", metaData.getColumn(2).getName());
         Assert.assertEquals("Progress", metaData.getColumn(3).getName());
         Assert.assertEquals("Type", metaData.getColumn(4).getName());
-        Assert.assertEquals("EtlInfo", metaData.getColumn(5).getName());
-        Assert.assertEquals("TaskInfo", metaData.getColumn(6).getName());
-        Assert.assertEquals("ErrorMsg", metaData.getColumn(7).getName());
-        Assert.assertEquals("CreateTime", metaData.getColumn(8).getName());
-        Assert.assertEquals("EtlStartTime", metaData.getColumn(9).getName());
-        Assert.assertEquals("EtlFinishTime", metaData.getColumn(10).getName());
-        Assert.assertEquals("LoadStartTime", metaData.getColumn(11).getName());
-        Assert.assertEquals("LoadFinishTime", metaData.getColumn(12).getName());
-        Assert.assertEquals("URL", metaData.getColumn(13).getName());
-        Assert.assertEquals("JobDetails", metaData.getColumn(14).getName());
+        Assert.assertEquals("Priority", metaData.getColumn(5).getName());
+        Assert.assertEquals("EtlInfo", metaData.getColumn(6).getName());
+        Assert.assertEquals("TaskInfo", metaData.getColumn(7).getName());
+        Assert.assertEquals("ErrorMsg", metaData.getColumn(8).getName());
+        Assert.assertEquals("CreateTime", metaData.getColumn(9).getName());
+        Assert.assertEquals("EtlStartTime", metaData.getColumn(10).getName());
+        Assert.assertEquals("EtlFinishTime", metaData.getColumn(11).getName());
+        Assert.assertEquals("LoadStartTime", metaData.getColumn(12).getName());
+        Assert.assertEquals("LoadFinishTime", metaData.getColumn(13).getName());
+        Assert.assertEquals("URL", metaData.getColumn(14).getName());
+        Assert.assertEquals("JobDetails", metaData.getColumn(15).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/PriorityThreadPoolExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PriorityThreadPoolExecutorTest.java
@@ -1,0 +1,140 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PriorityThreadPoolExecutorTest {
+
+    @Test
+    public void testDefault() throws InterruptedException, ExecutionException {
+        PriorityBlockingQueue<Runnable> workQueue = new PriorityBlockingQueue<Runnable>(1000);
+        PriorityThreadPoolExecutor pool = new PriorityThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, workQueue);
+
+        Future[] futures = new Future[20];
+        StringBuffer buffer = new StringBuffer();
+        for (int i = 0; i < futures.length; i++) {
+            int index = i;
+            futures[i] = pool.submit(new PriorityRunnable(0) {
+
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    buffer.append(index + ", ");
+                }
+            });
+        }
+        for (int i = 0; i < futures.length; i++) {
+            futures[i].get();
+        }
+        assertEquals("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ", buffer.toString());
+    }
+
+    @Test
+    public void testSamePriority() throws InterruptedException, ExecutionException {
+        PriorityBlockingQueue<Runnable> workQueue = new PriorityBlockingQueue<Runnable>(1000);
+        PriorityThreadPoolExecutor pool = new PriorityThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, workQueue);
+
+        Future[] futures = new Future[10];
+        StringBuffer buffer = new StringBuffer();
+        for (int i = 0; i < futures.length; i++) {
+            futures[i] = pool.submit(new TenSecondTask(i, 1, buffer));
+        }
+        for (int i = 0; i < futures.length; i++) {
+            futures[i].get();
+        }
+        assertEquals("01@00, 01@01, 01@02, 01@03, 01@04, 01@05, 01@06, 01@07, 01@08, 01@09, ", buffer.toString());
+    }
+
+    @Test
+    public void testRandomPriority() throws InterruptedException, ExecutionException {
+        PriorityBlockingQueue<Runnable> workQueue = new PriorityBlockingQueue<Runnable>(1000);
+        PriorityThreadPoolExecutor pool = new PriorityThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, workQueue);
+
+        Future[] futures = new Future[20];
+        StringBuffer buffer = new StringBuffer();
+        for (int i = 0; i < futures.length; i++) {
+            int r = (int) (Math.random() * 100);
+            futures[i] = pool.submit(new TenSecondTask(i, r, buffer));
+        }
+        for (int i = 0; i < futures.length; i++) {
+            futures[i].get();
+        }
+
+        buffer.append("01@00");
+        String[] split = buffer.toString().split(", ");
+        for (int i = 2; i < split.length - 1; i++) {
+            String s = split[i].split("@")[0];
+            assertTrue(Integer.valueOf(s) >= Integer.valueOf(split[i + 1].split("@")[0]));
+        }
+    }
+
+    @Test
+    public void testDynamicPriority() throws InterruptedException, ExecutionException {
+        PriorityBlockingQueue<Runnable> workQueue = new PriorityBlockingQueue<Runnable>(1000);
+        PriorityThreadPoolExecutor pool = new PriorityThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, workQueue);
+
+        PriorityFutureTask<Void>[] futures = new PriorityFutureTask[20];
+        StringBuffer buffer = new StringBuffer();
+        for (int i = 0; i < futures.length; i++) {
+            futures[i] = pool.submit(new TenSecondTask(i, i, buffer));
+        }
+        for (int i = 10; i < futures.length; i++) {
+            assertTrue(pool.updatePriority(futures[i], i - 10));
+        }
+
+        flag = 1;
+
+        for (int i = 0; i < futures.length; i++) {
+            futures[i].get();
+        }
+
+        for (int i = 0; i < futures.length; i++) {
+            assertFalse(pool.updatePriority(futures[i], i + 20));
+        }
+
+        assertEquals(
+                "00@00, 09@09, 09@19, 08@08, 08@18, 07@07, 07@17, 06@06, 06@16, " +
+                        "05@05, 05@15, 04@04, 04@14, 03@03, 03@13, 02@02, 02@12, 01@01, 01@11, 00@10, ",
+                buffer.toString());
+    }
+
+    public static int flag = 0;
+
+    public static class TenSecondTask extends PriorityRunnable {
+        private StringBuffer buffer;
+        int index;
+
+        public TenSecondTask(int index, int priority, StringBuffer buffer) {
+            super(priority);
+            this.index = index;
+            this.buffer = buffer;
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (flag == 0) {
+                    Thread.sleep(1000);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            buffer.append(String.format("%02d@%02d", getPriority(), index)).append(", ");
+            //System.out.println(buffer);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -24,6 +24,7 @@ package com.starrocks.load.loadv2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.AlterLoadStmt;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.LoadStmt;
@@ -52,6 +53,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,6 +174,78 @@ public class BrokerLoadJobTest {
 
     }
 
+    @Test
+    public void testAlterLoad(@Injectable LoadStmt loadStmt,
+            @Injectable AlterLoadStmt alterLoadStmt,
+            @Injectable DataDescription dataDescription,
+            @Injectable LabelName labelName,
+            @Injectable Database database,
+            @Injectable OlapTable olapTable,
+            @Mocked GlobalStateMgr globalStateMgr) {
+
+        String label = "label";
+        long dbId = 1;
+        String tableName = "table";
+        String databaseName = "database";
+        List<DataDescription> dataDescriptionList = Lists.newArrayList();
+        dataDescriptionList.add(dataDescription);
+        BrokerDesc brokerDesc = new BrokerDesc("broker0", Maps.newHashMap());
+        Map<String, String> properties = new HashMap<>();
+        properties.put(LoadStmt.PRIORITY, "HIGH");
+
+        new Expectations() {
+            {
+                loadStmt.getLabel();
+                minTimes = 0;
+                result = labelName;
+                labelName.getDbName();
+                minTimes = 0;
+                result = databaseName;
+                labelName.getLabelName();
+                minTimes = 0;
+                result = label;
+                globalStateMgr.getDb(databaseName);
+                minTimes = 0;
+                result = database;
+                loadStmt.getDataDescriptions();
+                minTimes = 0;
+                result = dataDescriptionList;
+                dataDescription.getTableName();
+                minTimes = 0;
+                result = tableName;
+                database.getTable(tableName);
+                minTimes = 0;
+                result = olapTable;
+                dataDescription.getPartitionNames();
+                minTimes = 0;
+                result = null;
+                database.getId();
+                minTimes = 0;
+                result = dbId;
+                loadStmt.getBrokerDesc();
+                minTimes = 0;
+                result = brokerDesc;
+                loadStmt.getEtlJobType();
+                minTimes = 0;
+                result = EtlJobType.BROKER;
+                alterLoadStmt.getAnalyzedJobProperties();
+                minTimes = 0;
+                result = properties;
+            }
+        };
+
+        try {
+            BrokerLoadJob brokerLoadJob = (BrokerLoadJob) BulkLoadJob.fromLoadStmt(loadStmt, null);
+            Assert.assertEquals(Long.valueOf(dbId), Deencapsulation.getField(brokerLoadJob, "dbId"));
+            Assert.assertEquals(label, Deencapsulation.getField(brokerLoadJob, "label"));
+            Assert.assertEquals(JobState.PENDING, Deencapsulation.getField(brokerLoadJob, "state"));
+            Assert.assertEquals(EtlJobType.BROKER, Deencapsulation.getField(brokerLoadJob, "jobType"));
+            brokerLoadJob.alterJob(alterLoadStmt);
+        } catch (DdlException e) {
+            Assert.fail(e.getMessage());
+        }
+
+    }
     @Test
     public void testGetTableNames(@Injectable BrokerFileGroupAggInfo fileGroupAggInfo,
                                   @Injectable BrokerFileGroup brokerFileGroup,

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterLoadOperationLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterLoadOperationLogTest.java
@@ -1,0 +1,69 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/AlterRoutineLoadOperationLogTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.persist;
+
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.LoadStmt;
+import com.starrocks.common.AnalysisException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+public class AlterLoadOperationLogTest {
+    private static String fileName = "./AlterLoadOperationLogTest";
+
+    @Test
+    public void testSerialzeAlterViewInfo() throws IOException, AnalysisException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        file.deleteOnExit();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        long jobId = 1000;
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(LoadStmt.PRIORITY, "NORMAL");
+
+        AlterLoadJobOperationLog log = new AlterLoadJobOperationLog(jobId,
+                        jobProperties);
+        log.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+
+        AlterLoadJobOperationLog log2 = AlterLoadJobOperationLog.read(in);
+        Assert.assertEquals(1, log2.getJobProperties().size());
+        Assert.assertEquals("NORMAL", log2.getJobProperties().get(LoadStmt.PRIORITY));
+
+        in.close();
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterRoutineLoadOperationLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterRoutineLoadOperationLogTest.java
@@ -1,23 +1,4 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/persist/AlterRoutineLoadOperationLogTest.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
 package com.starrocks.persist;
 

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -1,0 +1,102 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.task;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PriorityLeaderTaskExecutorTest {
+    private static final Logger LOG = LoggerFactory.getLogger(PriorityLeaderTaskExecutorTest.class);
+    private static final int THREAD_NUM = 1;
+    private static final long SLEEP_MS = 200L;
+
+    private static List<Long> SEQ = new ArrayList<>();
+
+    private PriorityLeaderTaskExecutor executor;
+
+    @Before
+    public void setUp() {
+        executor = new PriorityLeaderTaskExecutor("priority_task_executor_test", THREAD_NUM, 100, false);
+        executor.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (executor != null) {
+            executor.close();
+        }
+    }
+
+    @Test
+    public void testSubmit() {
+        // submit task
+        PriorityLeaderTask task1 = new TestLeaderTask(1L);
+        Assert.assertTrue(executor.submit(task1));
+        Assert.assertEquals(1, executor.getTaskNum());
+        // submit same running task error
+        Assert.assertFalse(executor.submit(task1));
+        Assert.assertEquals(1, executor.getTaskNum());
+
+        // submit another task
+        PriorityLeaderTask task2 = new TestLeaderTask(2L);
+        Assert.assertTrue(executor.submit(task2));
+        Assert.assertEquals(2, executor.getTaskNum());
+
+        // submit priority task
+        PriorityLeaderTask task3 = new TestLeaderTask(3L, 1);
+        Assert.assertTrue(executor.submit(task3));
+        Assert.assertEquals(3, executor.getTaskNum());
+
+        // submit priority task
+        PriorityLeaderTask task4 = new TestLeaderTask(4L);
+        Assert.assertTrue(executor.submit(task4));
+        Assert.assertEquals(4, executor.getTaskNum());
+
+        Assert.assertTrue(executor.updatePriority(4L, 5));
+
+        // wait for tasks run to end
+        try {
+            Thread.sleep(2000);
+            Assert.assertEquals(0, executor.getTaskNum());
+        } catch (InterruptedException e) {
+            LOG.error("error", e);
+        }
+
+        Assert.assertEquals(4, SEQ.size());
+        Assert.assertEquals(1L, SEQ.get(0).longValue());
+        Assert.assertEquals(4L, SEQ.get(1).longValue());
+        Assert.assertEquals(3L, SEQ.get(2).longValue());
+        Assert.assertEquals(2L, SEQ.get(3).longValue());
+    }
+
+    private class TestLeaderTask extends PriorityLeaderTask {
+
+        public TestLeaderTask(long signature) {
+            this.signature = signature;
+        }
+
+        public TestLeaderTask(long signature, int priority) {
+            super(priority);
+            this.signature = signature;
+        }
+
+        @Override
+        protected void exec() {
+            LOG.info("run exec. signature: {}, priority: {}", signature, getPriority());
+            SEQ.add(signature);
+            try {
+                Thread.sleep(SLEEP_MS);
+            } catch (InterruptedException e) {
+                LOG.error("error", e);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11120

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
FE config `async_load_task_pool_size` determines the maximum number of BrokerLoad tasks that can be executed in parallel in the cluster. When the number of Broker Loads submitted at the same time exceeds this limit, the excess tasks will be queued. 
In the past, they were queued according to the `submission time`. Now we support queuing according to the specified `priority`.
Supports specifying the priority `LOWEST/LOW/NORMAL/HIGH/HIGHEST` when creating a broker load job. the default priority is `NORMAL`
```
LOAD LABEL test_db.label1
(
    DATA INFILE("hdfs://<hdfs_host>:<hdfs_port>/user/starrocks/file1.csv")
    INTO TABLE table1
    COLUMNS TERMINATED BY ","
    (id, city)
)
WITH BROKER "mybroker"
(
    "username" = "hdfs_username",
    "password" = "hdfs_password"
)
PROPERTIES
(
    "priority" = "HIGH"
);
```
show load can see the broker load job's priority
```
mysql> show load;
+-------+-----------+-----------+---------------------+--------+----------+------------------------------------------------------------+------------------------------------------------------+-----------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| JobId | Label     | State     | Progress            | Type   | Priority | EtlInfo                                                    | TaskInfo                                             | ErrorMsg                                                        | CreateTime          | EtlStartTime        | EtlFinishTime       | LoadStartTime       | LoadFinishTime      | URL  | JobDetails                                                                                                                                                                                                                                                                                                             |
+-------+-----------+-----------+---------------------+--------+----------+------------------------------------------------------------+------------------------------------------------------+-----------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 21025 | hj2155441 | LOADING   | ETL:100%; LOAD:0%   | BROKER | NORMAL   | NULL                                                       | resource:N/A; timeout(s):36000; max_filter_ratio:0.1 | NULL                                                            | 2022-09-22 15:54:41 | 2022-09-22 15:54:42 | 2022-09-22 15:54:42 | 2022-09-22 15:54:42 | NULL                | NULL | {"All backends":{"3d380558-2b8d-4470-aaa6-9e79502691c3":[10004,10003,10002]},"FileNumber":1,"FileSize":16093067793,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"3d380558-2b8d-4470-aaa6-9e79502691c3":[10004,10003,10002]}}                  |
| 21028 | hj2155442 | QUEUEING  | ETL:100%; LOAD:0%   | BROKER | NORMAL   | NULL                                                       | resource:N/A; timeout(s):36000; max_filter_ratio:0.1 | NULL                                                            | 2022-09-22 15:54:42 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | NULL                | NULL | {"All backends":{},"FileNumber":1,"FileSize":16093067793,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":0,"Unfinished backends":{}}                                                                                                                                      |
| 21029 | hj2155444 | QUEUEING  | ETL:100%; LOAD:0%   | BROKER | NORMAL   | NULL                                                       | resource:N/A; timeout(s):36000; max_filter_ratio:0.1 | NULL                                                            | 2022-09-22 15:54:44 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | NULL                | NULL | {"All backends":{},"FileNumber":1,"FileSize":16093067793,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":0,"Unfinished backends":{}}                                                                                                                                      |
| 21030 | hj2155445 | QUEUEING  | ETL:100%; LOAD:0%   | BROKER | NORMAL   | NULL                                                       | resource:N/A; timeout(s):36000; max_filter_ratio:0.1 | NULL                                                            | 2022-09-22 15:54:45 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | 2022-09-22 15:54:47 | NULL                | NULL | {"All backends":{},"FileNumber":1,"FileSize":16093067793,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":0,"Unfinished backends":{}}                                                                                                                                      |
+-------+-----------+-----------+---------------------+--------+----------+------------------------------------------------------------+------------------------------------------------------+-----------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
and supports modifying the priority of the `QUEUEING` broker load job. 
```
alter load for test_db.label1 properties('priority'='LOW');
```
> modify job's priority which already in `LOADING` has no effect. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
