### PR TITLE
[Refactor] Refactor lake table storage cache info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
@@ -12,7 +12,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.thrift.TTabletType;
 
 import java.util.HashMap;
@@ -89,7 +89,7 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
     }
 
     @Override
-    public StorageInfo getStorageInfo() {
+    public StorageCacheInfo getStorageCacheInfo() {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/PartitionDesc.java
@@ -27,7 +27,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.thrift.TTabletType;
 import org.apache.commons.lang.NotImplementedException;
 
@@ -87,7 +87,7 @@ public class PartitionDesc implements ParseNode {
         throw new NotImplementedException();
     }
 
-    public StorageInfo getStorageInfo() throws NotImplementedException {
+    public StorageCacheInfo getStorageCacheInfo() throws NotImplementedException {
         throw new NotImplementedException();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
@@ -12,7 +12,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.thrift.TTabletType;
 
 import java.util.List;
@@ -89,7 +89,7 @@ public class SingleItemListPartitionDesc extends PartitionDesc {
     }
 
     @Override
-    public StorageInfo getStorageInfo() {
+    public StorageCacheInfo getStorageCacheInfo() {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.lake.StorageCacheInfo;
-import com.starrocks.lake.StorageInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -53,7 +52,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
     private boolean isInMemory = false;
     private TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
     private Long versionInfo;
-    private StorageInfo storageInfo;
+    private StorageCacheInfo storageCacheInfo;
 
     public SingleRangePartitionDesc(boolean ifNotExists, String partName, PartitionKeyDesc partitionKeyDesc,
                                     Map<String, String> properties) {
@@ -102,8 +101,8 @@ public class SingleRangePartitionDesc extends PartitionDesc {
     }
 
     @Override
-    public StorageInfo getStorageInfo() {
-        return storageInfo;
+    public StorageCacheInfo getStorageCacheInfo() {
+        return storageCacheInfo;
     }
 
     public Map<String, String> getProperties() {
@@ -174,8 +173,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         if (!enableStorageCache && allowAsyncWriteBack) {
             throw new AnalysisException("storage allow_async_write_back can't be enabled when cache is disabled");
         }
-        storageInfo =
-                new StorageInfo(null, new StorageCacheInfo(enableStorageCache, storageCacheTtlS, allowAsyncWriteBack));
+        storageCacheInfo = new StorageCacheInfo(enableStorageCache, storageCacheTtlS, allowAsyncWriteBack);
 
         if (otherProperties == null) {
             // check unknown properties

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -51,7 +51,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.Util;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.qe.OriginStatement;
@@ -762,7 +762,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
                         rangePartitionInfo.getDataProperty(partition.getId()),
                         rangePartitionInfo.getReplicationNum(partition.getId()),
                         rangePartitionInfo.getIsInMemory(partition.getId()),
-                        rangePartitionInfo.getStorageInfo(partition.getId()),
+                        rangePartitionInfo.getStorageCacheInfo(partition.getId()),
                         isLakeTable());
             } else if (!reserveTablets) {
                 tabletIds = GlobalStateMgr.getCurrentState().onErasePartition(partition);
@@ -1416,17 +1416,17 @@ public class OlapTable extends Table implements GsonPostProcessable {
         DataProperty dataProperty = partitionInfo.getDataProperty(oldPartition.getId());
         short replicationNum = partitionInfo.getReplicationNum(oldPartition.getId());
         boolean isInMemory = partitionInfo.getIsInMemory(oldPartition.getId());
-        StorageInfo storageInfo = partitionInfo.getStorageInfo(oldPartition.getId());
+        StorageCacheInfo storageCacheInfo = partitionInfo.getStorageCacheInfo(oldPartition.getId());
 
         if (partitionInfo.getType() == PartitionType.RANGE) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             Range<PartitionKey> range = rangePartitionInfo.getRange(oldPartition.getId());
             rangePartitionInfo.dropPartition(oldPartition.getId());
             rangePartitionInfo.addPartition(newPartition.getId(), false, range, dataProperty,
-                    replicationNum, isInMemory, storageInfo);
+                    replicationNum, isInMemory, storageCacheInfo);
         } else {
             partitionInfo.dropPartition(oldPartition.getId());
-            partitionInfo.addPartition(newPartition.getId(), dataProperty, replicationNum, isInMemory, storageInfo);
+            partitionInfo.addPartition(newPartition.getId(), dataProperty, replicationNum, isInMemory, storageCacheInfo);
         }
 
         return oldPartition;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -27,7 +27,7 @@ import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.server.GlobalStateMgr;
@@ -69,16 +69,18 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
     // so we defer adding meta serialization until memory engine feature is more complete.
     protected Map<Long, TTabletType> idToTabletType;
 
-    // for lake table storage cache and ttl
-    @SerializedName(value = "idToStorageInfo")
-    protected Map<Long, StorageInfo> idToStorageInfo;
+    // for lake table
+    // storage cache, ttl and allow_async_write_back
+    @SerializedName(value = "idToStorageCacheInfo")
+    protected Map<Long, StorageCacheInfo> idToStorageCacheInfo;
+
 
     public PartitionInfo() {
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStorageInfo = new HashMap<>();
+        this.idToStorageCacheInfo = new HashMap<>();
     }
 
     public PartitionInfo(PartitionType type) {
@@ -87,7 +89,7 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
         this.idToReplicationNum = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStorageInfo = new HashMap<>();
+        this.idToStorageCacheInfo = new HashMap<>();
     }
 
     public PartitionType getType() {
@@ -140,12 +142,12 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
         idToTabletType.put(partitionId, tabletType);
     }
 
-    public StorageInfo getStorageInfo(long partitionId) {
-        return idToStorageInfo.get(partitionId);
+    public StorageCacheInfo getStorageCacheInfo(long partitionId) {
+        return idToStorageCacheInfo.get(partitionId);
     }
 
-    public void setStorageInfo(long partitionId, StorageInfo storageInfo) {
-        idToStorageInfo.put(partitionId, storageInfo);
+    public void setStorageCacheInfo(long partitionId, StorageCacheInfo storageCacheInfo) {
+        idToStorageCacheInfo.put(partitionId, storageCacheInfo);
     }
 
     public void dropPartition(long partitionId) {
@@ -165,10 +167,10 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
     public void addPartition(long partitionId, DataProperty dataProperty,
                              short replicationNum,
                              boolean isInMemory,
-                             StorageInfo storageInfo) {
+                             StorageCacheInfo storageCacheInfo) {
         this.addPartition(partitionId, dataProperty, replicationNum, isInMemory);
-        if (storageInfo != null) {
-            idToStorageInfo.put(partitionId, storageInfo);
+        if (storageCacheInfo != null) {
+            idToStorageCacheInfo.put(partitionId, storageCacheInfo);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -34,7 +34,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.util.RangeUtils;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -100,8 +100,8 @@ public class RangePartitionInfo extends PartitionInfo {
     }
 
     public void addPartition(long partitionId, boolean isTemp, Range<PartitionKey> range, DataProperty dataProperty,
-                             short replicationNum, boolean isInMemory, StorageInfo storageInfo) {
-        addPartition(partitionId, dataProperty, replicationNum, isInMemory, storageInfo);
+                             short replicationNum, boolean isInMemory, StorageCacheInfo storageCacheInfo) {
+        addPartition(partitionId, dataProperty, replicationNum, isInMemory, storageCacheInfo);
         setRangeInternal(partitionId, isTemp, range);
     }
 
@@ -203,7 +203,7 @@ public class RangePartitionInfo extends PartitionInfo {
         idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
         idToReplicationNum.put(partitionId, desc.getReplicationNum());
         idToInMemory.put(partitionId, desc.isInMemory());
-        idToStorageInfo.put(partitionId, desc.getStorageInfo());
+        idToStorageCacheInfo.put(partitionId, desc.getStorageCacheInfo());
         return range;
     }
 
@@ -227,7 +227,7 @@ public class RangePartitionInfo extends PartitionInfo {
                 idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
                 idToReplicationNum.put(partitionId, desc.getReplicationNum());
                 idToInMemory.put(partitionId, desc.isInMemory());
-                idToStorageInfo.put(partitionId, desc.getStorageInfo());
+                idToStorageCacheInfo.put(partitionId, desc.getStorageCacheInfo());
             }
         }
     }
@@ -252,7 +252,7 @@ public class RangePartitionInfo extends PartitionInfo {
         idToDataProperty.put(partitionId, info.getDataProperty());
         idToReplicationNum.put(partitionId, info.getReplicationNum());
         idToInMemory.put(partitionId, info.isInMemory());
-        idToStorageInfo.put(partitionId, info.getStorageInfo());
+        idToStorageCacheInfo.put(partitionId, info.getStorageCacheInfo());
     }
 
     public void setRange(long partitionId, boolean isTemp, Range<PartitionKey> range) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -50,7 +50,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.OrderByPair;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.monitor.unit.ByteSizeValue;
 
 import java.util.ArrayList;
@@ -287,10 +287,10 @@ public class PartitionsProcDir implements ProcDirInterface {
                 long dataSize = partition.getDataSize();
                 ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
                 if (olapTable.isLakeTable()) {
-                    StorageInfo storageInfo = tblPartitionInfo.getStorageInfo(partitionId);
-                    partitionInfo.add(storageInfo.isEnableStorageCache());
-                    partitionInfo.add(storageInfo.getStorageCacheTtlS());
-                    partitionInfo.add(storageInfo.isAllowAsyncWriteBack());
+                    StorageCacheInfo storageCacheInfo = tblPartitionInfo.getStorageCacheInfo(partitionId);
+                    partitionInfo.add(storageCacheInfo.isEnableStorageCache());
+                    partitionInfo.add(storageCacheInfo.getStorageCacheTtlS());
+                    partitionInfo.add(storageCacheInfo.isAllowAsyncWriteBack());
                     partitionInfo.add(byteSizeValue);
                     partitionInfo.add(partition.getRowCount());
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -74,9 +74,7 @@ public class LakeTable extends OlapTable {
         } else {
             cacheInfo = storageCacheInfo.getCacheInfo();
         }
-        ShardStorageInfo shardStorageInfo =
-                ShardStorageInfo.newBuilder(getDefaultShardStorageInfo()).setCacheInfo(cacheInfo).build();
-        return shardStorageInfo;
+        return ShardStorageInfo.newBuilder(getDefaultShardStorageInfo()).setCacheInfo(cacheInfo).build();
     }
 
     public void setStorageInfo(ShardStorageInfo shardStorageInfo, boolean enableCache, long cacheTtlS,

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.lake;
 
+import com.staros.proto.CacheInfo;
 import com.staros.proto.ObjectStorageInfo;
 import com.staros.proto.ShardStorageInfo;
 import com.starrocks.alter.AlterJobV2Builder;
@@ -58,15 +59,28 @@ public class LakeTable extends OlapTable {
     }
 
     public String getStorageGroup() {
-        return getShardStorageInfo().getObjectStorageInfo().getObjectUri();
+        return getDefaultShardStorageInfo().getObjectStorageInfo().getObjectUri();
     }
 
-    public ShardStorageInfo getShardStorageInfo() {
+    public ShardStorageInfo getDefaultShardStorageInfo() {
         return tableProperty.getStorageInfo().getShardStorageInfo();
     }
 
+    public ShardStorageInfo getPartitionShardStorageInfo(long partitionId) {
+        CacheInfo cacheInfo = null;
+        StorageCacheInfo storageCacheInfo = partitionInfo.getStorageCacheInfo(partitionId);
+        if (storageCacheInfo == null) {
+            cacheInfo = getDefaultShardStorageInfo().getCacheInfo();
+        } else {
+            cacheInfo = storageCacheInfo.getCacheInfo();
+        }
+        ShardStorageInfo shardStorageInfo =
+                ShardStorageInfo.newBuilder(getDefaultShardStorageInfo()).setCacheInfo(cacheInfo).build();
+        return shardStorageInfo;
+    }
+
     public void setStorageInfo(ShardStorageInfo shardStorageInfo, boolean enableCache, long cacheTtlS,
-            boolean allowAsyncWriteBack) throws DdlException {
+                               boolean allowAsyncWriteBack) throws DdlException {
         String storageGroup;
         // s3://bucket/serviceId/tableId/
         String path = String.format("%s/%d/", shardStorageInfo.getObjectStorageInfo().getObjectUri(), id);
@@ -84,14 +98,16 @@ public class LakeTable extends OlapTable {
         ObjectStorageInfo objectStorageInfo =
                 ObjectStorageInfo.newBuilder(shardStorageInfo.getObjectStorageInfo()).setObjectUri(storageGroup)
                         .build();
+        CacheInfo cacheInfo = CacheInfo.newBuilder().setEnableCache(enableCache).setTtlSeconds(cacheTtlS)
+                .setAllowAsyncWriteBack(allowAsyncWriteBack).build();
         ShardStorageInfo newShardStorageInfo =
-                ShardStorageInfo.newBuilder(shardStorageInfo).setObjectStorageInfo(objectStorageInfo).build();
+                ShardStorageInfo.newBuilder(shardStorageInfo).setObjectStorageInfo(objectStorageInfo)
+                        .setCacheInfo(cacheInfo).build();
 
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());
         }
-        tableProperty.setStorageInfo(new StorageInfo(
-                newShardStorageInfo, new StorageCacheInfo(enableCache, cacheTtlS, allowAsyncWriteBack)));
+        tableProperty.setStorageInfo(new StorageInfo(newShardStorageInfo));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -3,46 +3,47 @@
 package com.starrocks.lake;
 
 import com.google.gson.annotations.SerializedName;
+import com.staros.proto.CacheInfo;
 import com.staros.proto.ShardStorageInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 
 import java.io.IOException;
 
+// Storage info for lake table, include object storage info and table default cache info.
+// Currently, storage group is table level.
 public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
     // "shardStorageInfoBytes" is used for serialization of "shardStorageInfo".
     @SerializedName(value = "shardStorageInfoBytes")
     private byte[] shardStorageInfoBytes;
-    // Currently, storage group is table level, so "shardStorageInfo" is null in partition property.
     private ShardStorageInfo shardStorageInfo;
 
-    // TODO: replace StorageCacheInfo with com.staros.proto.CacheInfo.
-    @SerializedName(value = "storageCacheInfo")
-    private StorageCacheInfo storageCacheInfo;
-
-    public StorageInfo(ShardStorageInfo shardStorageInfo, StorageCacheInfo storageCacheInfo) {
+    public StorageInfo(ShardStorageInfo shardStorageInfo) {
         this.shardStorageInfo = shardStorageInfo;
-        this.storageCacheInfo = storageCacheInfo;
     }
 
     public boolean isEnableStorageCache() {
-        return storageCacheInfo.isEnableCache();
+        return getCacheInfo().getEnableCache();
     }
 
     public long getStorageCacheTtlS() {
-        return storageCacheInfo.getCacheTtlS();
+        return getCacheInfo().getTtlSeconds();
     }
 
     public boolean isAllowAsyncWriteBack() {
-        return storageCacheInfo.isAllowAsyncWriteBack();
+        return getCacheInfo().getAllowAsyncWriteBack();
     }
 
     public ShardStorageInfo getShardStorageInfo() {
         return shardStorageInfo;
     }
 
+    public CacheInfo getCacheInfo() {
+        return shardStorageInfo.getCacheInfo();
+    }
+
     public StorageCacheInfo getStorageCacheInfo() {
-        return storageCacheInfo;
+        return new StorageCacheInfo(getCacheInfo());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/persist/PartitionPersistInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/PartitionPersistInfoV2.java
@@ -7,7 +7,7 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataInput;
@@ -30,12 +30,19 @@ public class PartitionPersistInfoV2 implements Writable {
     private boolean isInMemory;
     @SerializedName("isTempPartition")
     private boolean isTempPartition;
-    @SerializedName("StorageInfo")
-    private StorageInfo storageInfo;
+    @SerializedName("storageCacheInfo")
+    private StorageCacheInfo storageCacheInfo;
 
     public PartitionPersistInfoV2(Long dbId, Long tableId, Partition partition,
                                   DataProperty dataProperty, short replicationNum,
                                   boolean isInMemory, boolean isTempPartition) {
+        this(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition, null);
+    }
+
+    public PartitionPersistInfoV2(Long dbId, Long tableId, Partition partition,
+                                  DataProperty dataProperty, short replicationNum,
+                                  boolean isInMemory, boolean isTempPartition,
+                                  StorageCacheInfo storageCacheInfo) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partition = partition;
@@ -43,14 +50,7 @@ public class PartitionPersistInfoV2 implements Writable {
         this.replicationNum = replicationNum;
         this.isInMemory = isInMemory;
         this.isTempPartition = isTempPartition;
-    }
-
-    public PartitionPersistInfoV2(Long dbId, Long tableId, Partition partition,
-                                  DataProperty dataProperty, short replicationNum,
-                                  boolean isInMemory, boolean isTempPartition,
-                                  StorageInfo storageInfo) {
-        this(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition);
-        this.storageInfo = storageInfo;
+        this.storageCacheInfo = storageCacheInfo;
     }
 
     public final boolean isListPartitionPersistInfo() {
@@ -108,8 +108,8 @@ public class PartitionPersistInfoV2 implements Writable {
         return this.isTempPartition;
     }
 
-    public StorageInfo getStorageInfo() {
-        return this.storageInfo;
+    public StorageCacheInfo getStorageCacheInfo() {
+        return this.storageCacheInfo;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/RangePartitionPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/RangePartitionPersistInfo.java
@@ -8,7 +8,7 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.util.RangeUtils;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 
@@ -32,8 +32,8 @@ public class RangePartitionPersistInfo extends PartitionPersistInfoV2
                                      DataProperty dataProperty, short replicationNum,
                                      boolean isInMemory, boolean isTempPartition,
                                      Range<PartitionKey> range,
-                                     StorageInfo storageInfo) {
-        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition, storageInfo);
+                                     StorageCacheInfo storageCacheInfo) {
+        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, isTempPartition, storageCacheInfo);
         this.range = range;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.staros.proto.CacheInfo;
 import com.staros.proto.ShardStorageInfo;
 import com.starrocks.analysis.ColumnDef;
 import com.starrocks.analysis.CreateMaterializedViewStmt;
@@ -116,6 +115,7 @@ import com.starrocks.common.util.Util;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.persist.AddPartitionsInfo;
@@ -1008,7 +1008,7 @@ public class LocalMetastore implements ConnectorMetadata {
             copiedTable.getPartitionInfo().setTabletType(partitionId, partitionDesc.getTabletType());
             copiedTable.getPartitionInfo().setReplicationNum(partitionId, partitionDesc.getReplicationNum());
             copiedTable.getPartitionInfo().setIsInMemory(partitionId, partitionDesc.isInMemory());
-            copiedTable.getPartitionInfo().setStorageInfo(partitionId, partitionDesc.getStorageInfo());
+            copiedTable.getPartitionInfo().setStorageCacheInfo(partitionId, partitionDesc.getStorageCacheInfo());
 
             Partition partition =
                     createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet);
@@ -1100,7 +1100,7 @@ public class LocalMetastore implements ConnectorMetadata {
                         partitionDescs.get(0).getPartitionDataProperty(), partitionInfo.getReplicationNum(partition.getId()),
                         partitionInfo.getIsInMemory(partition.getId()), isTempPartition,
                         ((RangePartitionInfo) partitionInfo).getRange(partition.getId()),
-                        ((SingleRangePartitionDesc) partitionDescs.get(0)).getStorageInfo());
+                        ((SingleRangePartitionDesc) partitionDescs.get(0)).getStorageCacheInfo());
                 partitionInfoV2List.add(info);
                 AddPartitionsInfoV2 infos = new AddPartitionsInfoV2(partitionInfoV2List);
                 editLog.logAddPartitions(infos);
@@ -1127,7 +1127,7 @@ public class LocalMetastore implements ConnectorMetadata {
                                 partitionInfo.getReplicationNum(partition.getId()),
                                 partitionInfo.getIsInMemory(partition.getId()), isTempPartition,
                                 ((RangePartitionInfo) partitionInfo).getRange(partition.getId()),
-                                ((SingleRangePartitionDesc) partitionDescs.get(i)).getStorageInfo());
+                                ((SingleRangePartitionDesc) partitionDescs.get(i)).getStorageCacheInfo());
 
                         partitionInfoV2List.add(info);
                     } else {
@@ -2055,7 +2055,9 @@ public class LocalMetastore implements ConnectorMetadata {
             partitionInfo.setReplicationNum(partitionId, replicationNum);
             partitionInfo.setIsInMemory(partitionId, isInMemory);
             partitionInfo.setTabletType(partitionId, tabletType);
-            partitionInfo.setStorageInfo(partitionId, olapTable.getTableProperty().getStorageInfo());
+            StorageInfo storageInfo = olapTable.getTableProperty().getStorageInfo();
+            StorageCacheInfo storageCacheInfo = storageInfo == null ? null : storageInfo.getStorageCacheInfo();
+            partitionInfo.setStorageCacheInfo(partitionId, storageCacheInfo);
         }
 
         // check colocation properties
@@ -2574,16 +2576,9 @@ public class LocalMetastore implements ConnectorMetadata {
             throw new DdlException("Unknown distribution type: " + distributionInfoType);
         }
 
-        PartitionInfo partitionInfo = table.getPartitionInfo();
-        StorageInfo partitionStorageInfo = partitionInfo.getStorageInfo(partitionId);
-        CacheInfo cacheInfo = CacheInfo.newBuilder().setEnableCache(partitionStorageInfo.isEnableStorageCache())
-                .setTtlSeconds(partitionStorageInfo.getStorageCacheTtlS())
-                .setAllowAsyncWriteBack(partitionStorageInfo.isAllowAsyncWriteBack())
-                .build();
-        ShardStorageInfo shardStorageInfo = ShardStorageInfo.newBuilder(table.getShardStorageInfo())
-                .setCacheInfo(cacheInfo).build();
         int bucketNum = distributionInfo.getBucketNum();
-        List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum, shardStorageInfo);
+        List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
+                table.getPartitionShardStorageInfo(partitionId));
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
             index.addTablet(tablet, tabletMeta);
@@ -4162,7 +4157,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 partitionInfo.setDataProperty(newPartitionId, partitionInfo.getDataProperty(oldPartitionId));
 
                 if (copiedTbl.isLakeTable()) {
-                    partitionInfo.setStorageInfo(newPartitionId, partitionInfo.getStorageInfo(oldPartitionId));
+                    partitionInfo.setStorageCacheInfo(newPartitionId, partitionInfo.getStorageCacheInfo(oldPartitionId));
                 }
 
                 copiedTbl.setDefaultDistributionInfo(entry.getValue().getDistributionInfo());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -54,7 +54,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.StarOSAgent;
-import com.starrocks.lake.StorageInfo;
+import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.persist.ListPartitionPersistInfo;
 import com.starrocks.persist.PartitionPersistInfoV2;
@@ -1897,9 +1897,9 @@ public class AlterTest {
         boolean isInMemory = partitionInfo.getIsInMemory(partitionId);
         boolean isTempPartition = false;
         Range<PartitionKey> range = partitionInfo.getRange(partitionId);
-        StorageInfo storageInfo = partitionInfo.getStorageInfo(partitionId);
+        StorageCacheInfo storageCacheInfo = partitionInfo.getStorageCacheInfo(partitionId);
         RangePartitionPersistInfo partitionPersistInfoOut = new RangePartitionPersistInfo(dbId, tableId, partition,
-                dataProperty, replicationNum, isInMemory, isTempPartition, range, storageInfo);
+                dataProperty, replicationNum, isInMemory, isTempPartition, range, storageCacheInfo);
 
         // write log
         File file = new File("./test_serial.log");
@@ -1925,7 +1925,7 @@ public class AlterTest {
 
         // replay log
         GlobalStateMgr.getCurrentState().replayAddPartition(partitionPersistInfoIn);
-        Assert.assertNotNull(partitionInfo.getStorageInfo(partitionId));
+        Assert.assertNotNull(partitionInfo.getStorageCacheInfo(partitionId));
 
         String dropSQL = "drop table new_table";
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -29,7 +29,6 @@ import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StorageCacheInfo;
-import com.starrocks.lake.StorageInfo;
 import com.starrocks.lake.Utils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.RpcException;
@@ -116,12 +115,9 @@ public class LakeTableSchemaChangeJobTest {
         ObjectStorageInfo.Builder osib = builder.getObjectStorageInfoBuilder();
         ObjectStorageInfo osi = osib.setObjectUri("s3://test").setAccessKey("zzz").setAccessKeySecret("yyy").build();
         ShardStorageInfo shardStorageInfo = ShardStorageInfo.newBuilder().setObjectStorageInfo(osi).build();
-
-        StorageCacheInfo storageCacheInfo = new StorageCacheInfo(false, 0, false);
-
-        StorageInfo storageInfo = new StorageInfo(shardStorageInfo, storageCacheInfo);
         table.setStorageInfo(shardStorageInfo, false, 0, false);
-        partitionInfo.setStorageInfo(partitionId, storageInfo);
+        StorageCacheInfo storageCacheInfo = new StorageCacheInfo(false, 0, false);
+        partitionInfo.setStorageCacheInfo(partitionId, storageCacheInfo);
 
         db.createTable(table);
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -148,10 +148,10 @@ public class CreateLakeTableTest {
             Assert.assertEquals(3600, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partitionId = lakeTable.getPartition("single_partition_duplicate_key_cache").getId();
-            StorageInfo partitionStorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partitionId);
-            Assert.assertTrue(partitionStorageInfo.isEnableStorageCache());
-            Assert.assertEquals(3600, partitionStorageInfo.getStorageCacheTtlS());
-            Assert.assertEquals(false, partitionStorageInfo.isAllowAsyncWriteBack());
+            StorageCacheInfo partitionStorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partitionId);
+            Assert.assertTrue(partitionStorageCacheInfo.isEnableStorageCache());
+            Assert.assertEquals(3600, partitionStorageCacheInfo.getStorageCacheTtlS());
+            Assert.assertEquals(false, partitionStorageCacheInfo.isAllowAsyncWriteBack());
         }
 
         ExceptionChecker.expectThrowsNoException(() -> createTable(
@@ -171,14 +171,14 @@ public class CreateLakeTableTest {
             Assert.assertEquals(7200, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partition1Id = lakeTable.getPartition("p1").getId();
-            StorageInfo partition1StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition1Id);
-            Assert.assertTrue(partition1StorageInfo.isEnableStorageCache());
-            Assert.assertEquals(7200, partition1StorageInfo.getStorageCacheTtlS());
+            StorageCacheInfo partition1StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition1Id);
+            Assert.assertTrue(partition1StorageCacheInfo.isEnableStorageCache());
+            Assert.assertEquals(7200, partition1StorageCacheInfo.getStorageCacheTtlS());
             long partition2Id = lakeTable.getPartition("p2").getId();
-            StorageInfo partition2StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition2Id);
-            Assert.assertTrue(partition2StorageInfo.isEnableStorageCache());
-            Assert.assertEquals(7200, partition2StorageInfo.getStorageCacheTtlS());
-            Assert.assertEquals(true, partition2StorageInfo.isAllowAsyncWriteBack());
+            StorageCacheInfo partition2StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition2Id);
+            Assert.assertTrue(partition2StorageCacheInfo.isEnableStorageCache());
+            Assert.assertEquals(7200, partition2StorageCacheInfo.getStorageCacheTtlS());
+            Assert.assertEquals(true, partition2StorageCacheInfo.isAllowAsyncWriteBack());
         }
 
         ExceptionChecker.expectThrowsNoException(() -> createTable(
@@ -197,14 +197,14 @@ public class CreateLakeTableTest {
             Assert.assertEquals(0, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partition1Id = lakeTable.getPartition("p1").getId();
-            StorageInfo partition1StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition1Id);
-            Assert.assertFalse(partition1StorageInfo.isEnableStorageCache());
-            Assert.assertEquals(0, partition1StorageInfo.getStorageCacheTtlS());
+            StorageCacheInfo partition1StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition1Id);
+            Assert.assertFalse(partition1StorageCacheInfo.isEnableStorageCache());
+            Assert.assertEquals(0, partition1StorageCacheInfo.getStorageCacheTtlS());
             long partition2Id = lakeTable.getPartition("p2").getId();
-            StorageInfo partition2StorageInfo = lakeTable.getPartitionInfo().getStorageInfo(partition2Id);
-            Assert.assertTrue(partition2StorageInfo.isEnableStorageCache());
+            StorageCacheInfo partition2StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition2Id);
+            Assert.assertTrue(partition2StorageCacheInfo.isEnableStorageCache());
             Assert.assertEquals(Config.tablet_sched_storage_cooldown_second,
-                    partition2StorageInfo.getStorageCacheTtlS());
+                    partition2StorageCacheInfo.getStorageCacheTtlS());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
@@ -106,7 +106,7 @@ public class LakeTableTest {
         Assert.assertTrue(newTable.isLakeTable());
         LakeTable newLakeTable = (LakeTable) newTable;
         Assert.assertEquals(String.format("%s%d/", serviceStorageUri, tableId), newLakeTable.getStorageGroup());
-        ObjectStorageInfo newObjectStorageInfo = newLakeTable.getShardStorageInfo().getObjectStorageInfo();
+        ObjectStorageInfo newObjectStorageInfo = newLakeTable.getDefaultShardStorageInfo().getObjectStorageInfo();
         Assert.assertEquals(endpoint, newObjectStorageInfo.getEndpoint());
 
         Partition p1 = newLakeTable.getPartition(partitionId);


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Only save partition cache info in PartitionInfo.
2. Directly use ShardStorageInfo to save table storage group and default cache info.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
