### PR TITLE
[Cherry-pick 2.4][BugFix] Fix checking the existance of domained users fails (#10999)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowGrantsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowGrantsStmt.java
@@ -75,7 +75,7 @@ public class ShowGrantsStmt extends ShowStmt {
                 throw new AnalysisException("Can not specified keyword ALL when specified user");
             }
             userIdent.analyze();
-            if (!GlobalStateMgr.getCurrentState().getAuth().getUserPrivTable().doesUserExist(userIdent)) {
+            if (!GlobalStateMgr.getCurrentState().getAuth().doesUserExist(userIdent)) {
                 throw new AnalysisException("user " + userIdent + " not exist!");
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1097,7 +1097,7 @@ public class Auth implements Writable {
     }
 
     // return true if user ident exist
-    private boolean doesUserExist(UserIdentity userIdent) {
+    public boolean doesUserExist(UserIdentity userIdent) {
         if (userIdent.isDomain()) {
             return propertyMgr.doesUserExist(userIdent);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -50,7 +50,7 @@ public class PrivilegeStmtAnalyzer {
 
             if (checkExist) {
                 // check if user exists
-                if (!session.getGlobalStateMgr().getAuth().getUserPrivTable().doesUserExist(userIdent)) {
+                if (!session.getGlobalStateMgr().getAuth().doesUserExist(userIdent)) {
                     throw new SemanticException("user " + userIdent + " not exist!");
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
@@ -33,7 +33,7 @@ public class AlterUserStmtTest {
 
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };
@@ -117,7 +117,7 @@ public class AlterUserStmtTest {
     public void testBadPass(@Mocked Auth auth) throws Exception {
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };
@@ -130,7 +130,7 @@ public class AlterUserStmtTest {
     public void testInvalidAuthPlugin(@Mocked Auth auth) throws Exception {
         new Expectations() {
             {
-                auth.getUserPrivTable().doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 result = true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
@@ -6,7 +6,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
 import com.starrocks.mysql.privilege.PrivPredicate;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
@@ -23,8 +22,6 @@ public class ShowGrantsStmtTest {
     private GlobalStateMgr globalStateMgr;
     @Mocked
     private Auth auth;
-    @Mocked
-    private UserPrivTable userPrivTable;
     @Mocked
     private ConnectContext ctx;
 
@@ -47,10 +44,6 @@ public class ShowGrantsStmtTest {
         };
         new Expectations(auth) {
             {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
-
                 auth.checkGlobalPriv(ctx, PrivPredicate.GRANT);
                 minTimes = 0;
                 result = true;
@@ -61,9 +54,9 @@ public class ShowGrantsStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity)any);
                 minTimes = 0;
                 result = true;
             }
@@ -75,9 +68,9 @@ public class ShowGrantsStmtTest {
     @Test(expected = AnalysisException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity)any);
                 minTimes = 0;
                 result = false;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class ExecuteAsStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -34,13 +31,6 @@ public class ExecuteAsStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
-            }
-        };
-        new Expectations(auth) {
-            {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
             }
         };
 
@@ -56,9 +46,9 @@ public class ExecuteAsStmtTest {
     @Test
     public void testWithNoRevert() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -76,9 +66,9 @@ public class ExecuteAsStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = false;
             }
@@ -92,9 +82,9 @@ public class ExecuteAsStmtTest {
     @Test(expected = SemanticException.class)
     public void testAllowRevert() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeImpersonateStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class GrantRevokeImpersonateStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -38,10 +35,6 @@ public class GrantRevokeImpersonateStmtTest {
         };
         new Expectations(auth) {
             {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
-
                 auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = true;
@@ -60,9 +53,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -95,9 +88,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity)any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = false;
             }
@@ -111,9 +104,9 @@ public class GrantRevokeImpersonateStmtTest {
     @Test(expected = SemanticException.class)
     public void testRoleNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
+        new Expectations(auth) {
             {
-                userPrivTable.doesUserExist((UserIdentity) any);
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
-import com.starrocks.mysql.privilege.UserPrivTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -22,8 +21,6 @@ public class GrantRevokeRoleStmtTest {
     @Mocked
     private Auth auth;
     @Mocked
-    private UserPrivTable userPrivTable;
-    @Mocked
     private ConnectContext ctx;
 
     @Before
@@ -34,13 +31,6 @@ public class GrantRevokeRoleStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
-            }
-        };
-        new Expectations(auth) {
-            {
-                auth.getUserPrivTable();
-                minTimes = 0;
-                result = userPrivTable;
             }
         };
 
@@ -56,18 +46,14 @@ public class GrantRevokeRoleStmtTest {
     @Test
     public void testNormal() throws Exception {
         // suppose current user exists
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity)any);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
         // suppose current role exists and has GRANT privilege
         new Expectations(auth) {
             {
                 auth.doesRoleExist((String)any);
+                minTimes = 0;
+                result = true;
+
+                auth.doesUserExist((UserIdentity) any);
                 minTimes = 0;
                 result = true;
             }
@@ -99,17 +85,14 @@ public class GrantRevokeRoleStmtTest {
     @Test(expected = SemanticException.class)
     public void testUserNotExist() throws Exception {
         // suppose current user doesn't exist, check for exception
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity)any);
-                minTimes = 0;
-                result = false;
-            }
-        };
         // suppose current role exists
         new Expectations(auth) {
             {
-                auth.doesRoleExist((String)any);
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = false;
+
+                auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = true;
             }
@@ -122,17 +105,14 @@ public class GrantRevokeRoleStmtTest {
     @Test(expected = SemanticException.class)
     public void testRoleNotExist() throws Exception {
         // suppose current exists
-        new Expectations(userPrivTable) {
-            {
-                userPrivTable.doesUserExist((UserIdentity)any);
-                minTimes = 0;
-                result = true;
-            }
-        };
         // suppose current role doesn't exist, check for exception
         new Expectations(auth) {
             {
-                auth.doesRoleExist((String)any);
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = true;
+
+                auth.doesRoleExist((String) any);
                 minTimes = 0;
                 result = false;
             }


### PR DESCRIPTION
My original code checks if a user exits by looking through all the `GlobalPrivEntry` in `UserPrivTable`. But domained user won't store in `UserPrivTable`, it should be checked through `PropertyManager`. Luckily, there is already a function called `Auth.doesUserExist` that has done this job. I'm replacing `Auth.userPrivTable.doesUserExist` with `Auth.doesUserExist` to fix this bug.

Fixes #10997 

Manually cherry-pick from 82db084e8a46123a9b5bd44865a0910e5560b610