### PR TITLE
[BugFix] avoid translate into cross join when conjunct is not empty (backport #10986)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -109,7 +109,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         OptExpression root;
         if (joinEqPredicate == null) {
             JoinOperator joinType =
-                    (join.getOnPredicate() == null || join.getJoinType().isCrossJoin() || conjunctList.isEmpty()) ?
+                    (join.getOnPredicate() == null || join.getJoinType().isCrossJoin()) ?
                             JoinOperator.CROSS_JOIN : join.getJoinType();
             LogicalJoinOperator nestLoop = new LogicalJoinOperator.Builder().withOperator(join)
                     .setJoinType(joinType)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -105,7 +105,7 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan,
                 plan.contains("  3:NESTLOOP JOIN\n" +
-                        "  |  join op: CROSS JOIN\n" +
+                        "  |  join op: INNER JOIN\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  \n" +
                         "  |----2:EXCHANGE\n" +
@@ -643,7 +643,7 @@ public class JoinTest extends PlanTestBase {
         String sql = "select * from t0 as x0 join t1 as x1 on (1 = 2) is not null;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "3:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN\n" +
+                "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -32,6 +32,16 @@ public class NestLoopJoinTest extends PlanTestBase {
         String sql = "SELECT * from t0 join test_all_type where t0.v1 = 2;";
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment, planFragment.contains("NESTLOOP JOIN"));
+
+        // Outer join
+        PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
+        sql = "SELECT * from t0 left join test_all_type t1 on 2 = t1.t1c";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment, planFragment.contains("LEFT OUTER JOIN"));
+
+        sql = "SELECT * from t0 left join test_all_type t1 on 2 = t0.v1";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment, planFragment.contains("LEFT OUTER JOIN"));
     }
 
     private void assertNestloopJoin(String sql, String joinType, String onPredicate) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -471,4 +471,5 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  group by: 5: v4");
         }
     }
+
 }

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/join.sql
@@ -226,7 +226,7 @@ RIGHT SEMI JOIN (join-predicate [5: v5 = 1: v1] post-join-predicate [null])
 [sql]
 select v1,v2,v3,v4 from t0 inner join t1 on v1=v5 and 1>2
 [result]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
+INNER JOIN (join-predicate [null] post-join-predicate [null])
     VALUES
     EXCHANGE BROADCAST
         VALUES

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
@@ -28,7 +28,7 @@ INNER JOIN (join-predicate [2: v2 = 5: v5 AND 1: v1 > 4: v4] post-join-predicate
 [sql]
 select v1 from t0 inner join t1 on v1 = v2
 [result]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
+INNER JOIN (join-predicate [null] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[1: v1 = 2: v2])
     EXCHANGE BROADCAST
         SCAN (columns[4: v4] predicate[null])


### PR DESCRIPTION
backport #10986