### PR TITLE
[Bugfix] ConnectorChunkSource uses different scan_sched_entity

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -81,7 +81,7 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
         }
 
         if (running_wg != nullptr && time_spent_ns >= YIELD_PREEMPT_MAX_TIME_SPENT &&
-            running_wg->scan_sched_entity()->in_queue()->should_yield(running_wg, time_spent_ns)) {
+            _scan_sched_entity(running_wg)->in_queue()->should_yield(running_wg, time_spent_ns)) {
             break;
         }
     }

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -57,6 +57,8 @@ public:
 protected:
     // MUST be implemented by different ChunkSource
     virtual Status _read_chunk(RuntimeState* state, vectorized::ChunkPtr* chunk) = 0;
+    // The schedule entity of this workgroup for resource group.
+    virtual const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const = 0;
 
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -198,4 +198,10 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, vectorized::ChunkP
     return Status::OK();
 }
 
+const workgroup::WorkGroupScanSchedEntity* ConnectorChunkSource::_scan_sched_entity(
+        const workgroup::WorkGroup* wg) const {
+    DCHECK(wg != nullptr);
+    return wg->connector_scan_sched_entity();
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -76,6 +76,8 @@ public:
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 
+    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
+
     connector::DataSourcePtr _data_source;
     vectorized::ConnectorScanNode* _scan_node;
     const int64_t _limit; // -1: no limit

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -280,6 +280,11 @@ Status OlapChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     return _read_chunk_from_storage(_runtime_state, (*chunk).get());
 }
 
+const workgroup::WorkGroupScanSchedEntity* OlapChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
+    DCHECK(wg != nullptr);
+    return wg->scan_sched_entity();
+}
+
 // mapping a slot-column-id to schema-columnid
 Status OlapChunkSource::_init_global_dicts(vectorized::TabletReaderParams* params) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -41,6 +41,8 @@ private:
 
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 
+    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
+
     Status _get_tablet(const TInternalScanRange* scan_range);
     Status _init_reader_params(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges,
                                const std::vector<uint32_t>& scanner_columns, std::vector<uint32_t>& reader_columns);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -240,6 +240,11 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
         bool scan_ratio_registered = StarRocksMetrics::instance()->metrics()->register_metric(
                 "resource_group_scan_use_ratio", MetricLabels().add("name", wg->name()),
                 resource_group_scan_use_ratio.get());
+        // connector scan use ratio.
+        auto resource_group_connector_scan_use_ratio = std::make_unique<starrocks::DoubleGauge>(MetricUnit::PERCENT);
+        bool connector_scan_ratio_registered = StarRocksMetrics::instance()->metrics()->register_metric(
+                "resource_group_connector_scan_use_ratio", MetricLabels().add("name", wg->name()),
+                resource_group_connector_scan_use_ratio.get());
         // mem limit.
         auto resource_group_mem_limit_bytes = std::make_unique<starrocks::IntGauge>(MetricUnit::BYTES);
         bool mem_limit_registered = StarRocksMetrics::instance()->metrics()->register_metric(
@@ -278,6 +283,8 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
         if (cpu_limit_registered) _wg_cpu_limit_metrics.emplace(wg->name(), std::move(resource_group_cpu_limit_ratio));
         if (cpu_ratio_registered) _wg_cpu_metrics.emplace(wg->name(), std::move(resource_group_cpu_use_ratio));
         if (scan_ratio_registered) _wg_scan_metrics.emplace(wg->name(), std::move(resource_group_scan_use_ratio));
+        if (connector_scan_ratio_registered)
+            _wg_connector_scan_metrics.emplace(wg->name(), std::move(resource_group_connector_scan_use_ratio));
         if (mem_limit_registered) _wg_mem_limit_metrics.emplace(wg->name(), std::move(resource_group_mem_limit_bytes));
         if (mem_inuse_registered) _wg_mem_metrics.emplace(wg->name(), std::move(resource_group_mem_allocated_bytes));
         if (running_registered) _wg_running_queries.emplace(wg->name(), std::move(resource_group_running_queries));
@@ -292,9 +299,11 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
 void WorkGroupManager::update_metrics_unlocked() {
     int64_t sum_cpu_runtime_ns = 0;
     int64_t sum_scan_runtime_ns = 0;
+    int64_t sum_connector_scan_runtime_ns = 0;
     for (const auto& [_, wg] : _workgroups) {
         sum_cpu_runtime_ns += wg->driver_sched_entity()->runtime_ns();
         sum_scan_runtime_ns += wg->scan_sched_entity()->runtime_ns();
+        sum_connector_scan_runtime_ns += wg->connector_scan_sched_entity()->runtime_ns();
     }
 
     for (const auto& [name, wg_id] : _wg_metrics) {
@@ -308,10 +317,15 @@ void WorkGroupManager::update_metrics_unlocked() {
                     sum_cpu_runtime_ns <= 0 ? 0 : double(wg->driver_sched_entity()->runtime_ns()) / sum_cpu_runtime_ns;
             double scan_use_ratio =
                     sum_scan_runtime_ns <= 0 ? 0 : double(wg->scan_sched_entity()->runtime_ns()) / sum_scan_runtime_ns;
+            double connector_scan_use_ratio =
+                    sum_connector_scan_runtime_ns <= 0
+                            ? 0
+                            : double(wg->connector_scan_sched_entity()->runtime_ns()) / sum_connector_scan_runtime_ns;
 
             _wg_cpu_limit_metrics[name]->set_value(cpu_expected_use_ratio);
             _wg_cpu_metrics[name]->set_value(cpu_use_ratio);
             _wg_scan_metrics[name]->set_value(scan_use_ratio);
+            _wg_connector_scan_metrics[name]->set_value(connector_scan_use_ratio);
             _wg_mem_limit_metrics[name]->set_value(wg->mem_limit_bytes());
             _wg_mem_metrics[name]->set_value(wg->mem_tracker()->consumption());
             _wg_running_queries[name]->set_value(wg->num_running_queries());
@@ -324,6 +338,7 @@ void WorkGroupManager::update_metrics_unlocked() {
             _wg_cpu_limit_metrics[name]->set_value(0);
             _wg_cpu_metrics[name]->set_value(0);
             _wg_scan_metrics[name]->set_value(0);
+            _wg_connector_scan_metrics[name]->set_value(0);
             _wg_mem_limit_metrics[name]->set_value(0);
             _wg_mem_metrics[name]->set_value(0);
             _wg_running_queries[name]->set_value(0);

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -247,6 +247,7 @@ private:
     std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_cpu_limit_metrics;
     std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_cpu_metrics;
     std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_scan_metrics;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_connector_scan_metrics;
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_mem_limit_metrics;
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_mem_metrics;
     std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_running_queries;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1072.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`ChunkSource::buffer_next_batch_chunks_blocking` uses `running_wg->scan_sched_entity()->in_queue()->should_yield` to decide whether it should yield, but `ConnectorChunkSource` should uses `connector_scan_sched_entity` not `scan_sched_entity`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
