### PR TITLE
[cherry-pick][branch-2.4][Enhancement] open the page cache by default (#10482)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -248,10 +248,10 @@ CONF_Int32(min_file_descriptor_number, "60000");
 CONF_Int64(index_stream_cache_capacity, "10737418240");
 // CONF_Int64(max_packed_row_block_size, "20971520");
 
-// Cache for stoage page size
-CONF_String(storage_page_cache_limit, "0");
+// Cache for storage page size
+CONF_String(storage_page_cache_limit, "20%");
 // whether to disable page cache feature in storage
-CONF_Bool(disable_storage_page_cache, "true");
+CONF_Bool(disable_storage_page_cache, "false");
 // whether to disable column pool
 CONF_Bool(disable_column_pool, "false");
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -376,6 +376,15 @@ Status ExecEnv::_init_storage_page_cache() {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
                      << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
     }
+    if (!config::disable_storage_page_cache) {
+        if (storage_cache_limit < kcacheMinSize) {
+            LOG(WARNING) << "Storage cache limit is too small, give up using page cache.";
+            config::disable_storage_page_cache = true;
+            storage_cache_limit = 0;
+        } else {
+            LOG(INFO) << "Set storage page cache size " << storage_cache_limit;
+        }
+    }
     StoragePageCache::create_global_cache(_page_cache_mem_tracker, storage_cache_limit);
 
     // TODO(zc): The current memory usage configuration is a bit confusing,

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -36,6 +36,9 @@ namespace starrocks {
 class PageCacheHandle;
 class MemTracker;
 
+// Page cache min size is 512MB
+static constexpr int64_t kcacheMinSize = 536870912;
+
 // Warpper around Cache, and used for cache page of column datas
 // in Segment.
 // TODO(zc): We should add some metric to see cache hit/miss rate.

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -69,6 +69,11 @@ int main(int argc, char** argv) {
         return -1;
     }
     auto* exec_env = starrocks::ExecEnv::GetInstance();
+    // Pagecache is turned on by default, and some test cases require cache to be turned on,
+    // and some test cases do not. For easy management, we turn cache off during unit test
+    // initialization. If there are test cases that require Pagecache, it must be responsible
+    // for managing it.
+    starrocks::config::disable_storage_page_cache = true;
     exec_env->init_mem_tracker();
     starrocks::ExecEnv::init(exec_env, paths);
 


### PR DESCRIPTION
Open the page cache by default. In general, page cache default size is 20% * os memory.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
