### PR TITLE
[Enhancement] optimize merge/serialize/finalize stage in UDAF

### DIFF
--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -16,7 +16,7 @@ namespace starrocks::vectorized {
 const int DEFAULT_UDAF_BUFFER_SIZE = 1024;
 
 const AggregateFunction* getJavaUDAFFunction(bool input_nullable) {
-    static JavaUDAFAggregateFunction<false> no_nullable_udaf_func;
+    static JavaUDAFAggregateFunction no_nullable_udaf_func;
     return &no_nullable_udaf_func;
 }
 
@@ -74,8 +74,10 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
     ASSIGN_OR_RETURN(auto get_func, analyzer->get_method_object(state_clazz.clazz(), "get"));
+    ASSIGN_OR_RETURN(auto batch_get_func, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
     ASSIGN_OR_RETURN(auto add_func, analyzer->get_method_object(state_clazz.clazz(), "add"));
-    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), std::move(get_func), std::move(add_func));
+    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), std::move(get_func),
+                                                       std::move(batch_get_func), std::move(add_func));
     udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
 
     return Status::OK();

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -9,96 +9,52 @@
 #include <vector>
 
 #include "column/binary_column.h"
+#include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "gutil/casts.h"
-#include "jni.h"
 #include "runtime/primitive_type.h"
 #include "udf/java/java_data_converter.h"
 #include "udf/java/java_udf.h"
 #include "udf/udf.h"
 #include "udf/udf_internal.h"
+#include "util/defer_op.h"
 
 namespace starrocks::vectorized {
 
-template <bool handle_null = true>
 class JavaUDAFAggregateFunction : public AggregateFunction {
 public:
     using State = JavaUDAFState;
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
-                size_t row_num) const override final {}
+                size_t row_num) const override final {
+        CHECK(false) << "unreadable path";
+    }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
                size_t row_num) const override final {
-        // TODO merge
-        const BinaryColumn* input_column = nullptr;
-        if (column->is_nullable()) {
-            auto* null_column = down_cast<const NullableColumn*>(column);
-            input_column = down_cast<const BinaryColumn*>(null_column->data_column().get());
-        } else {
-            input_column = down_cast<const BinaryColumn*>(column);
-        }
-        Slice slice = input_column->get_slice(row_num);
-        auto* udaf_ctx = ctx->impl()->udaf_ctxs();
-
-        if (udaf_ctx->buffer->capacity() < slice.get_size()) {
-            udaf_ctx->buffer_data.resize(slice.get_size());
-            udaf_ctx->buffer =
-                    std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
-        }
-        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get(), ctx);
-        memcpy(udaf_ctx->buffer_data.data(), slice.get_data(), slice.get_size());
-        udaf_ctx->_func->merge(this->data(state).handle, udaf_ctx->buffer->handle());
+        CHECK(false) << "unreadable path";
     }
 
     void serialize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
                              Column* to) const override final {
-        BinaryColumn* column = nullptr;
-        // TODO serialize
-        if (to->is_nullable()) {
-            auto* null_column = down_cast<NullableColumn*>(to);
-            null_column->null_column()->append(DATUM_NOT_NULL);
-            column = down_cast<BinaryColumn*>(null_column->data_column().get());
-        } else {
-            DCHECK(to->is_binary());
-            column = down_cast<BinaryColumn*>(to);
-        }
-
-        size_t old_size = column->get_bytes().size();
-        auto* udaf_ctx = ctx->impl()->udaf_ctxs();
-        int serialize_size = udaf_ctx->_func->serialize_size(this->data(state).handle);
-        if (udaf_ctx->buffer->capacity() < serialize_size) {
-            udaf_ctx->buffer_data.resize(serialize_size);
-            udaf_ctx->buffer =
-                    std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
-        }
-        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get(), ctx);
-
-        udaf_ctx->_func->serialize(this->data(state).handle, udaf_ctx->buffer->handle());
-        size_t new_size = old_size + serialize_size;
-        column->get_bytes().resize(new_size);
-        column->get_offset().emplace_back(new_size);
-        memcpy(column->get_bytes().data() + old_size, udaf_ctx->buffer_data.data(), serialize_size);
+        CHECK(false) << "unreadable path";
     }
 
     void finalize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
                             Column* to) const override final {
-        auto* udaf_ctx = ctx->impl()->udaf_ctxs();
-        jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
-        append_jvalue(udaf_ctx->finalize->method_desc[0], to, val);
-        release_jvalue(udaf_ctx->finalize->method_desc[0].is_box, val);
+        CHECK(false) << "unreadable path";
     }
 
-    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t batch_size,
                                      ColumnPtr* dst) const override final {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
         auto* udf_ctxs = ctx->impl()->udaf_ctxs();
         // 1 convert input as state
         // 1.1 create state list
-        auto rets = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->create->method.handle(), chunk_size);
+        auto rets = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->create->method.handle(), batch_size);
         // 1.2 convert input as input array
         int num_cols = ctx->get_num_args();
         std::vector<DirectByteBuffer> buffers;
@@ -108,14 +64,15 @@ public:
         for (int i = 0; i < src.size(); ++i) {
             raw_input_ptrs[i] = src[i].get();
         }
-        JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, raw_input_ptrs.data(), num_cols, chunk_size,
+        JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, raw_input_ptrs.data(), num_cols, batch_size,
                                                       &args);
         // 2 batch call update
         helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                   ctx->impl()->udaf_ctxs()->update->method.handle(), args.data(), args.size());
         // 3 get serialize size
         jintArray serialize_szs = (jintArray)helper.int_batch_call(
-                ctx, rets, ctx->impl()->udaf_ctxs()->serialize_size->method.handle(), chunk_size);
+                ctx, rets, ctx->impl()->udaf_ctxs()->serialize_size->method.handle(), batch_size);
+        LOCAL_REF_GUARD_ENV(env, serialize_szs);
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
         helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
@@ -125,26 +82,24 @@ public:
         udf_ctxs->buffer =
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
         // chunk size
-        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), chunk_size);
+        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {rets, buffer_array};
         helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                   ctx->impl()->udaf_ctxs()->serialize->method.handle(), state_and_buffer, 2);
-        std::vector<Slice> slices(chunk_size);
+        std::vector<Slice> slices(batch_size);
         // 5 ready
         int offsets = 0;
-        for (int i = 0; i < chunk_size; ++i) {
+        for (int i = 0; i < batch_size; ++i) {
             slices[i] = Slice(udf_ctxs->buffer_data.data() + offsets, slice_sz[i]);
             offsets += slice_sz[i];
         }
         // append result to dst column
         CHECK((*dst)->append_strings(slices));
         // 6 clean up arrays
-        env->DeleteLocalRef(buffer_array);
-        env->DeleteLocalRef(serialize_szs);
         for (int i = 0; i < args.size(); ++i) {
             env->DeleteLocalRef(args[i]);
         }
-        env->DeleteLocalRef(rets);
     }
 
     // State Data
@@ -222,40 +177,152 @@ public:
         env->PopLocalFrame(nullptr);
     }
 
+    template <class StatesProvider, class MergeCaller>
+    void _merge_batch_process(StatesProvider&& states_provider, MergeCaller&& caller, const Column* column,
+                              int batch_size) const {
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = helper.getEnv();
+        // get state lists
+        auto state_array = states_provider();
+        LOCAL_REF_GUARD_ENV(env, state_array);
+
+        // prepare buffer
+        DCHECK(column->is_binary());
+        auto serialized_column =
+                ColumnHelper::get_binary_column(const_cast<Column*>(ColumnHelper::get_data_column(column)));
+
+        auto& serialized_bytes = serialized_column->get_bytes();
+        auto buffer = std::make_unique<DirectByteBuffer>(serialized_bytes.data(), serialized_bytes.size());
+        auto buffer_array = helper.create_object_array(buffer->handle(), batch_size);
+        LOCAL_REF_GUARD_ENV(env, buffer_array);
+
+        // batch call merge
+        caller(state_array, buffer_array);
+    }
+
     void merge_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
                      AggDataPtr* states) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
-            this->merge(ctx, column, states[i] + state_offset, i);
-        }
+        // batch merge
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = helper.getEnv();
+
+        auto provider = [&]() {
+            auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+            LOCAL_REF_GUARD_ENV(env, state_id_list);
+            auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
+            return state_array;
+        };
+        auto merger = [&](jobject state_array, jobject buffer_array) {
+            jobject state_and_buffer[2] = {state_array, buffer_array};
+            helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
+                                      ctx->impl()->udaf_ctxs()->merge->method.handle(), state_and_buffer, 2);
+        };
+        _merge_batch_process(std::move(provider), std::move(merger), column, batch_size);
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
-        for (size_t i = 0; i < batch_size; i++) {
-            if (filter[i] == 0) {
-                this->merge(ctx, column, states[i] + state_offset, i);
-            }
-        }
+        // batch merge
+        auto& helper = JVMFunctionHelper::getInstance();
+
+        auto provider = [&]() {
+            auto state_id_list = JavaDataTypeConverter::convert_to_states_with_filter(states, state_offset,
+                                                                                      filter.data(), batch_size);
+            return state_id_list;
+        };
+        auto merger = [&](jobject state_array, jobject buffer_array) {
+            jobject state_and_buffer[] = {buffer_array};
+            helper.batch_update_if_not_null(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
+                                            ctx->impl()->udaf_ctxs()->merge->method.handle(), state_array,
+                                            state_and_buffer, 1);
+        };
+        _merge_batch_process(std::move(provider), std::move(merger), column, batch_size);
     }
 
     void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
                                   AggDataPtr __restrict state) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
-            this->merge(ctx, column, state, i);
-        }
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = helper.getEnv();
+        auto provider = [&]() {
+            auto state_handle = reinterpret_cast<JavaUDAFState*>(state)->handle;
+            auto res = helper.convert_handle_to_jobject(ctx, state_handle);
+            LOCAL_REF_GUARD_ENV(env, res);
+            return helper.create_object_array(res, batch_size);
+        };
+        auto merger = [&](jobject state_array, jobject buffer_array) {
+            jobject state_and_buffer[2] = {state_array, buffer_array};
+            helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
+                                      ctx->impl()->udaf_ctxs()->merge->method.handle(), state_and_buffer, 2);
+        };
+        _merge_batch_process(std::move(provider), std::move(merger), column, batch_size);
     }
 
     void batch_serialize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                          size_t state_offset, Column* to) const override {
-        for (size_t i = 0; i < batch_size; i++) {
-            this->serialize_to_column(ctx, agg_states[i] + state_offset, to);
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = helper.getEnv();
+        auto* udf_ctxs = ctx->impl()->udaf_ctxs();
+
+        // step 1 get state lists
+        auto states = const_cast<AggDataPtr*>(agg_states.data());
+        auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+        LOCAL_REF_GUARD_ENV(env, state_id_list);
+        auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
+        LOCAL_REF_GUARD_ENV(env, state_array);
+        // step 2 serialize size
+        jintArray serialize_szs = (jintArray)helper.int_batch_call(
+                ctx, state_array, ctx->impl()->udaf_ctxs()->serialize_size->method.handle(), batch_size);
+        LOCAL_REF_GUARD_ENV(env, serialize_szs);
+        int length = env->GetArrayLength(serialize_szs);
+        std::vector<int> slice_sz(length);
+        helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
+        int totalLength = std::accumulate(slice_sz.begin(), slice_sz.end(), 0, [](auto l, auto r) { return l + r; });
+        // step 3 prepare serialize buffer
+        udf_ctxs->buffer_data.resize(totalLength);
+        udf_ctxs->buffer =
+                std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
+
+        // step 4 call serialize
+        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        LOCAL_REF_GUARD_ENV(env, buffer_array);
+        jobject state_and_buffer[2] = {state_array, buffer_array};
+        helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
+                                  ctx->impl()->udaf_ctxs()->serialize->method.handle(), state_and_buffer, 2);
+
+        int offsets = 0;
+        std::vector<Slice> slices(batch_size);
+        for (int i = 0; i < batch_size; ++i) {
+            slices[i] = Slice(udf_ctxs->buffer_data.data() + offsets, slice_sz[i]);
+            offsets += slice_sz[i];
         }
+        CHECK(to->append_strings(slices));
     }
 
     void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                         size_t state_offset, Column* to) const override {
-        for (size_t i = 0; i < batch_size; i++) {
-            this->finalize_to_column(ctx, agg_states[i] + state_offset, to);
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = helper.getEnv();
+        auto* udf_ctxs = ctx->impl()->udaf_ctxs();
+
+        // 1. get state list
+        auto states = const_cast<AggDataPtr*>(agg_states.data());
+        auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+        LOCAL_REF_GUARD_ENV(env, state_id_list);
+        auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
+        LOCAL_REF_GUARD_ENV(env, state_array);
+        // 2. batch call finalize
+        CHECK(to->empty());
+        // 3. get result from column
+        auto res = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->finalize->method.handle(), &state_array,
+                                     1, batch_size);
+        LOCAL_REF_GUARD_ENV(env, res);
+        PrimitiveType type = udf_ctxs->finalize->method_desc[0].type;
+        if (!to->is_nullable()) {
+            ColumnPtr wrapper(const_cast<Column*>(to), [](auto p) {});
+            auto output = NullableColumn::create(wrapper, NullColumn::create());
+            helper.get_result_from_boxed_array(ctx, type, output.get(), res, batch_size);
+        } else {
+            helper.get_result_from_boxed_array(ctx, type, to, res, batch_size);
         }
     }
 

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -51,8 +51,11 @@ Status window_init_jvm_context(int64_t fid, const std::string& url, const std::s
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
     ASSIGN_OR_RETURN(auto get_func, analyzer->get_method_object(state_clazz.clazz(), "get"));
+    ASSIGN_OR_RETURN(auto batch_get_func, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
     ASSIGN_OR_RETURN(auto add_func, analyzer->get_method_object(state_clazz.clazz(), "add"));
-    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), std::move(get_func), std::move(add_func));
+
+    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), std::move(get_func),
+                                                       std::move(batch_get_func), std::move(add_func));
     udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
 
     return Status::OK();

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -18,7 +18,7 @@
 namespace starrocks::vectorized {
 void assign_jvalue(MethodTypeDescriptor method_type_desc, Column* col, int row_num, jvalue val);
 
-class JavaWindowFunction final : public JavaUDAFAggregateFunction<true> {
+class JavaWindowFunction final : public JavaUDAFAggregateFunction {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         ctx->impl()->udaf_ctxs()->_func->reset(data(state).handle);

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -74,9 +74,11 @@ public:
     // only used for AGG streaming
     void batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input, int cols);
 
-    // batch call evalute
+    // batch call evalute by callstub
     jobject batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows);
-    // batch call no-args function
+    // batch call method by reflect
+    jobject batch_call(FunctionContext* ctx, jobject caller, jobject method, jobject* input, int cols, int rows);
+    // batch call no-args function by reflect
     jobject batch_call(FunctionContext* ctx, jobject caller, jobject method, int rows);
     // batch call int()
     // callers should be Object[]
@@ -93,6 +95,9 @@ public:
     // convert int handle to jobject
     // return a local ref
     jobject convert_handle_to_jobject(FunctionContext* ctx, int state);
+
+    // convert handle list to jobject array (Object[])
+    jobject convert_handles_to_jobjects(FunctionContext* ctx, jobject state_ids);
 
     // List methods
     jobject list_get(jobject obj, int idx);
@@ -346,12 +351,15 @@ private:
 class UDAFStateList {
 public:
     static inline const char* clazz_name = "com.starrocks.udf.FunctionStates";
-    UDAFStateList(JavaGlobalRef&& handle, JavaGlobalRef&& get, JavaGlobalRef&& add);
+    UDAFStateList(JavaGlobalRef&& handle, JavaGlobalRef&& get, JavaGlobalRef&& batch_get, JavaGlobalRef&& add);
 
     jobject handle() { return _handle.handle(); }
 
     // get state with index state
     jobject get_state(FunctionContext* ctx, JNIEnv* env, int state);
+
+    // batch get states
+    jobject get_state(FunctionContext* ctx, JNIEnv* env, jobject state_ids);
 
     // add a state to StateList
     int add_state(FunctionContext* ctx, JNIEnv* env, jobject state);
@@ -359,8 +367,10 @@ public:
 private:
     JavaGlobalRef _handle;
     JavaGlobalRef _get_method;
+    JavaGlobalRef _batch_get_method;
     JavaGlobalRef _add_method;
     jmethodID _get_method_id;
+    jmethodID _batch_get_method_id;
     jmethodID _add_method_id;
 };
 

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/FunctionStates.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/FunctionStates.java
@@ -12,6 +12,17 @@ public class FunctionStates<T> {
         return states.get(idx);
     }
 
+    Object[] batch_get(int[] idxs) {
+        Object[] res = new Object[idxs.length];
+        for(int i = 0;i < idxs.length; ++i) {
+            if (idxs[i] != -1) {
+                res[i] = states.get(idxs[i]);
+            }
+        }
+        return res;
+    }
+
+
     public int add(T state) throws Exception {
         states.add(state);
         return states.size() - 1;

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -617,7 +617,7 @@ public class UDFHelper {
     public static Object[] batchCall(Object o, Method method, int batchSize)
             throws Throwable {
         try {
-            Object[] res = new Object[batchSize];
+            Object[] res = (Object[]) Array.newInstance(method.getReturnType(), batchSize);
             for (int i = 0; i < batchSize; ++i) {
                 res[i] = method.invoke(o);
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
#5803

## Problem Summary(Required) ：
main optimize point is avoid call JNI function for each state
for some high cadinality case. merge/serialize/finalize may cost a lot of CPU.

case: 
1FE 4BE 16c TPCH-SF1

```
 select count(ct) from (select sum_int(L_ORDERKEY) ct from lineitem group by l_partkey) tb;
```

baseline: 30.47 sec patched: 6.75 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
