### PR TITLE
[BugFix] Fix bug inconsistent metadata when out-of-order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -497,7 +497,23 @@ public class TaskManager {
                 return;
             }
 
-            TaskRun pendingTaskRun = taskRunQueue.poll();
+            // It is possible to update out of order for priority queue.
+            Map<String, TaskRun> pendingIndex = Maps.newHashMap();
+            while (!taskRunQueue.isEmpty()) {
+                TaskRun taskRun = taskRunQueue.poll();
+                pendingIndex.put(taskRun.getStatus().getQueryId(), taskRun);
+            }
+
+            TaskRun pendingTaskRun = pendingIndex.get(statusChange.getQueryId());
+            if (pendingTaskRun == null) {
+                LOG.warn("could not find query_id:{}, taskId:{}, when replay update pendingTaskRun",
+                        statusChange.getQueryId(), taskId);
+                taskRunQueue.addAll(pendingIndex.values());
+                return;
+            } else {
+                pendingIndex.remove(statusChange.getQueryId());
+                taskRunQueue.addAll(pendingIndex.values());
+            }
             TaskRunStatus status = pendingTaskRun.getStatus();
 
             if (toStatus == Constants.TaskRunState.RUNNING) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -498,21 +498,23 @@ public class TaskManager {
             }
 
             // It is possible to update out of order for priority queue.
-            Map<String, TaskRun> pendingIndex = Maps.newHashMap();
+            TaskRun pendingTaskRun = null;
+            List<TaskRun> tempQueue = Lists.newArrayList();
             while (!taskRunQueue.isEmpty()) {
                 TaskRun taskRun = taskRunQueue.poll();
-                pendingIndex.put(taskRun.getStatus().getQueryId(), taskRun);
+                if (taskRun.getStatus().getQueryId().equals(statusChange.getQueryId())) {
+                    pendingTaskRun = taskRun;
+                    break;
+                } else {
+                    tempQueue.add(taskRun);
+                }
             }
+            taskRunQueue.addAll(tempQueue);
 
-            TaskRun pendingTaskRun = pendingIndex.get(statusChange.getQueryId());
             if (pendingTaskRun == null) {
                 LOG.warn("could not find query_id:{}, taskId:{}, when replay update pendingTaskRun",
                         statusChange.getQueryId(), taskId);
-                taskRunQueue.addAll(pendingIndex.values());
                 return;
-            } else {
-                pendingIndex.remove(statusChange.getQueryId());
-                taskRunQueue.addAll(pendingIndex.values());
             }
             TaskRunStatus status = pendingTaskRun.getStatus();
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -12,6 +12,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.SubmitTaskStmt;
@@ -414,5 +415,33 @@ public class TaskManagerTest {
 
     }
 
+    @Test
+    public void testReplayUpdateTaskRunOutOfOrder() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("test");
+        taskManager.replayCreateTask(task);
+        long taskId = 1;
+
+        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        long now = System.currentTimeMillis();
+        taskRun1.setTaskId(taskId);
+        taskRun1.initStatus("1", now);
+        taskRun1.getStatus().setDefinition("select 1");
+
+        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        taskRun2.setTaskId(taskId);
+        taskRun2.initStatus("2", now);
+        taskRun2.getStatus().setDefinition("select 1");
+        taskManager.replayCreateTaskRun(taskRun2.getStatus());
+        taskManager.replayCreateTaskRun(taskRun1.getStatus());
+
+        TaskRunStatusChange change1 = new TaskRunStatusChange(task.getId(), taskRun2.getStatus(),
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        taskManager.replayUpdateTaskRun(change1);
+
+        Map<Long, TaskRun> runningTaskRunMap = taskManager.getTaskRunManager().getRunningTaskRunMap();
+        Assert.assertEquals(1, runningTaskRunMap.values().size());
+
+    }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11066

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is because Task scheduling may form 2 CREATEs followed by 4 updates. The update order of the master may be different from the update order of the follower, so the disorder should be dealt with during playback.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
