### PR TITLE
[Enhancement] Support to specify aws cred provider in broker load

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -99,6 +99,7 @@ public class FileSystemManager {
     // which is not thread-safe and may cause 'Filesystem closed' exception when it is closed by other thread.
     private static final String FS_HDFS_IMPL_DISABLE_CACHE = "fs.hdfs.impl.disable.cache";
 
+    // https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html
     // arguments for s3a
     private static final String FS_S3A_ACCESS_KEY = "fs.s3a.access.key";
     private static final String FS_S3A_SECRET_KEY = "fs.s3a.secret.key";
@@ -106,6 +107,7 @@ public class FileSystemManager {
     // This property is used like 'fs.hdfs.impl.disable.cache'
     private static final String FS_S3A_IMPL_DISABLE_CACHE = "fs.s3a.impl.disable.cache";
     private static final String FS_S3A_CONNECTION_SSL_ENABLED = "fs.s3a.connection.ssl.enabled";
+    private static final String FS_S3A_AWS_CRED_PROVIDER = "fs.s3a.aws.credentials.provider";
 
     // arguments for ks3
     private static final String FS_KS3_ACCESS_KEY = "fs.ks3.AccessKey";
@@ -335,7 +337,7 @@ public class FileSystemManager {
                                 "keytab is required for kerberos authentication");
                     }
                     UserGroupInformation.setConfiguration(conf);
- 
+
                     ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab);
                     if (properties.containsKey(KERBEROS_KEYTAB_CONTENT)) {
                         try {
@@ -441,6 +443,7 @@ public class FileSystemManager {
         String endpoint = properties.getOrDefault(FS_S3A_ENDPOINT, "");
         String disableCache = properties.getOrDefault(FS_S3A_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = properties.getOrDefault(FS_S3A_CONNECTION_SSL_ENABLED, "true");
+        String awsCredProvider = properties.getOrDefault(FS_S3A_AWS_CRED_PROVIDER, null);
         // endpoint is the server host, pathUri.getUri().getHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
         String host = S3A_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
@@ -469,6 +472,9 @@ public class FileSystemManager {
                 conf.set(FS_S3A_ENDPOINT, endpoint);
                 conf.set(FS_S3A_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
+                if (awsCredProvider != null) {
+                    conf.set(FS_S3A_AWS_CRED_PROVIDER, awsCredProvider);
+                }
                 FileSystem s3AFileSystem = FileSystem.get(pathUri.getUri(), conf);
                 fileSystem.setFileSystem(s3AFileSystem);
             }
@@ -853,7 +859,8 @@ public class FileSystemManager {
                             "end of file reached");
                 }
                 if (logger.isDebugEnabled()) {
-                    logger.debug("read buffer from input stream, buffer size:" + buf.length + ", read length:" + readLength);
+                    logger.debug(
+                            "read buffer from input stream, buffer size:" + buf.length + ", read length:" + readLength);
                 }
                 return ByteBuffer.wrap(buf, 0, readLength);
             } catch (IOException e) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

To support to specify aws cred provider in broker load request. And according to doc link https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html,  several default providers are chained, it should suffice for most cases.

```
    <property>
        <name>fs.s3a.aws.credentials.provider</name>
        <value>
            org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider,
            org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider,
            org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider,
            com.amazonaws.auth.EnvironmentVariableCredentialsProvider,
            org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider
        </value>
    </property>
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
