### PR TITLE
[Feature] Support materialized view for external table (step 1/3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -168,6 +169,11 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     public String getHdfsPath() {
         return this.hdfsPath;
+    }
+
+    @Override
+    public String getTableIdentifier() {
+        return Joiner.on(":").join(name, createTime);
     }
 
     public Map<String, String> getHiveProperties() {
@@ -370,6 +376,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         if (hiveTable == null) {
             hiveTable = hiveRepository.getTable(resourceName, this.hiveDbName, this.hiveTableName);
         }
+        this.createTime = hiveTable.getCreateTime();
+
         String hiveTableType = hiveTable.getTableType();
         if (hiveTableType == null) {
             throw new DdlException("Unknown hive table type.");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -168,7 +168,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
     @Override
     public String getTableIdentifier() {
-        return Joiner.on(":").join(name, createTime);
+        return Joiner.on(":").join(table, createTime);
     }
 
     public static HudiTableType fromInputFormat(String inputFormat) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -165,6 +166,11 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         return dataColumnNames;
     }
 
+    @Override
+    public String getTableIdentifier() {
+        return Joiner.on(":").join(name, createTime);
+    }
+
     public static HudiTableType fromInputFormat(String inputFormat) {
         switch (inputFormat) {
             case COW_INPUT_FORMAT:
@@ -276,6 +282,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         org.apache.hadoop.hive.metastore.api.Table metastoreTable =
                 GlobalStateMgr.getCurrentState().getHiveRepository().getTable(resourceName, this.db, this.table);
         Schema tableSchema = HudiTable.loadHudiSchema(metastoreTable);
+        this.createTime = metastoreTable.getCreateTime();
 
         for (Column column : this.fullSchema) {
             if (!column.isAllowNull()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -22,6 +23,7 @@ import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TIcebergTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
@@ -98,6 +100,11 @@ public class IcebergTable extends Table {
 
     public String getResourceName() {
         return resourceName;
+    }
+
+    @Override
+    public String getTableIdentifier() {
+        return Joiner.on(":").join(table, ((BaseTable) getIcebergTable()).operations().current().uuid());
     }
 
     public IcebergCatalogType getCatalogType() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -175,10 +175,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
     @SerializedName(value = "tableProperty")
     protected TableProperty tableProperty;
 
-    // not serialized field
-    // record all materialized views based on this OlapTable
-    private Set<Long> relatedMaterializedViews;
-
     public OlapTable() {
         this(TableType.OLAP);
     }
@@ -197,7 +193,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
         this.indexes = null;
 
         this.tableProperty = null;
-        this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 
     public OlapTable(long id, String tableName, List<Column> baseSchema, KeysType keysType,
@@ -239,7 +234,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
         this.indexes = indexes;
 
         this.tableProperty = null;
-        this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 
     public void setTableProperty(TableProperty tableProperty) {
@@ -1333,8 +1327,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
         // So, here we need to rebuild the fullSchema to ensure the correctness of the properties.
         rebuildFullSchema();
 
-        this.relatedMaterializedViews = Sets.newConcurrentHashSet();
-
         // Recover nameToPartition from idToPartition
         nameToPartition = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         for (Partition partition : idToPartition.values()) {
@@ -1840,19 +1832,6 @@ public class OlapTable extends Table implements GsonPostProcessable {
         return tableProperty.getCompressionType();
     }
 
-    // should call this when create materialized view
-    public void addRelatedMaterializedView(long mvId) {
-        relatedMaterializedViews.add(mvId);
-    }
-
-    // should call this when drop materialized view
-    public void removeRelatedMaterializedView(long mvId) {
-        relatedMaterializedViews.remove(mvId);
-    }
-
-    public Set<Long> getRelatedMaterializedViews() {
-        return relatedMaterializedViews;
-    }
 
     @Override
     public void onCreate() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.common.FeMetaVersion;
@@ -121,10 +122,15 @@ public class Table extends MetaObject implements Writable {
     @SerializedName(value = "comment")
     protected String comment = "";
 
+    // not serialized field
+    // record all materialized views based on this Table
+    private Set<Long> relatedMaterializedViews;
+
     public Table(TableType type) {
         this.type = type;
         this.fullSchema = Lists.newArrayList();
         this.nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 
     public Table(long id, String tableName, TableType type, List<Column> fullSchema) {
@@ -145,6 +151,7 @@ public class Table extends MetaObject implements Writable {
             Preconditions.checkArgument(type == TableType.VIEW, "Table has no columns");
         }
         this.createTime = Instant.now().getEpochSecond();
+        this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 
     public boolean isTypeRead() {
@@ -160,6 +167,10 @@ public class Table extends MetaObject implements Writable {
     }
 
     public String getName() {
+        return name;
+    }
+
+    public String getTableIdentifier() {
         return name;
     }
 
@@ -485,4 +496,19 @@ public class Table extends MetaObject implements Writable {
     public Map<String, String> getProperties() {
         throw new NotImplementedException();
     }
+
+    // should call this when create materialized view
+    public void addRelatedMaterializedView(long mvId) {
+        relatedMaterializedViews.add(mvId);
+    }
+
+    // should call this when drop materialized view
+    public void removeRelatedMaterializedView(long mvId) {
+        relatedMaterializedViews.remove(mvId);
+    }
+
+    public Set<Long> getRelatedMaterializedViews() {
+        return relatedMaterializedViews;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -80,7 +80,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     private Database database;
     private MaterializedView materializedView;
     private MvTaskRunContext mvContext;
-    private Map<Long, OlapTable> snapshotBaseTables;
+    // table id -> <base table info, snapshot table>
+    private Map<Long, Pair<MaterializedView.BaseTableInfo, Table>> snapshotBaseTables;
 
     // Core logics:
     // 1. prepare to check some conditions
@@ -177,9 +178,12 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                 currentTablePartitionInfo.putAll(partitionInfoMap);
 
                 // remove partition info of not-exist partition for snapshot table from version map
-                OlapTable snapshotOlapTable = snapshotBaseTables.get(tableId);
-                currentTablePartitionInfo.keySet().removeIf(partitionName ->
-                        !snapshotOlapTable.getPartitionNames().contains(partitionName));
+                Table snapshotTable = snapshotBaseTables.get(tableId).second;
+                if (snapshotTable.isOlapTable()) {
+                    OlapTable snapshotOlapTable = (OlapTable) snapshotTable;
+                    currentTablePartitionInfo.keySet().removeIf(partitionName ->
+                            !snapshotOlapTable.getPartitionNames().contains(partitionName));
+                }
             }
             ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                     new ChangeMaterializedViewRefreshSchemeLog(materializedView);
@@ -214,7 +218,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     }
 
     private void syncPartitions() {
-        snapshotBaseTables = collectBaseTables(materializedView, database);
+        snapshotBaseTables = collectBaseTables(materializedView);
         PartitionInfo partitionInfo = materializedView.getPartitionInfo();
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             syncPartitionsForExpr();
@@ -229,16 +233,17 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         return materializedView.getPartitionRefTableExprs().get(0);
     }
 
-    private Pair<OlapTable, Column> getPartitionTableAndColumn(Map<Long, OlapTable> olapTables) {
+    private Pair<Table, Column> getPartitionTableAndColumn(Map<Long, Pair<MaterializedView.BaseTableInfo, Table>> tables) {
         List<SlotRef> slotRefs = Lists.newArrayList();
         Expr partitionExpr = getPartitionExpr();
         partitionExpr.collect(SlotRef.class, slotRefs);
         // if partitionExpr is FunctionCallExpr, get first SlotRef
         Preconditions.checkState(slotRefs.size() == 1);
         SlotRef slotRef = slotRefs.get(0);
-        for (OlapTable olapTable : olapTables.values()) {
-            if (slotRef.getTblNameWithoutAnalyzed().getTbl().equals(olapTable.getName())) {
-                return Pair.create(olapTable, olapTable.getColumn(slotRef.getColumnName()));
+        for (Pair<MaterializedView.BaseTableInfo, Table> tableInfo : tables.values()) {
+            Table table = tableInfo.second;
+            if (slotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
+                return Pair.create(table, table.getColumn(slotRef.getColumnName()));
             }
         }
         return Pair.create(null, null);
@@ -246,18 +251,20 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
 
     private void syncPartitionsForExpr() {
         Expr partitionExpr = getPartitionExpr();
-        Pair<OlapTable, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
-        OlapTable partitionBaseTable = partitionTableAndColumn.first;
+        Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
+        Table partitionBaseTable = partitionTableAndColumn.first;
         Preconditions.checkNotNull(partitionBaseTable);
         Column partitionColumn = partitionTableAndColumn.second;
         Preconditions.checkNotNull(partitionColumn);
 
         PartitionDiff partitionDiff = new PartitionDiff();
-        Map<String, Range<PartitionKey>> basePartitionMap;
+        Map<String, Range<PartitionKey>> basePartitionMap = Maps.newHashMap();
         Map<String, Range<PartitionKey>> mvPartitionMap;
         database.readLock();
         try {
-            basePartitionMap = partitionBaseTable.getRangePartitionMap();
+            if (partitionBaseTable.isOlapTable()) {
+                basePartitionMap = ((OlapTable) partitionBaseTable).getRangePartitionMap();
+            }
             mvPartitionMap = materializedView.getRangePartitionMap();
             if (partitionExpr instanceof SlotRef) {
                 partitionDiff = SyncPartitionUtils.calcSyncSamePartition(basePartitionMap, mvPartitionMap);
@@ -308,8 +315,12 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         return !materializedView.getNeedRefreshPartitionNames(olapTable).isEmpty();
     }
 
-    private boolean needToRefreshNonPartitionTable(OlapTable partitionTable) {
-        for (OlapTable olapTable : snapshotBaseTables.values()) {
+    private boolean needToRefreshNonPartitionTable(Table partitionTable) {
+        if (snapshotBaseTables.values().stream().anyMatch(tablePair -> !tablePair.second.isOlapTable())) {
+            return true;
+        }
+        for (Pair<MaterializedView.BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
+            OlapTable olapTable = (OlapTable) tablePair.second;
             if (olapTable.getId() == partitionTable.getId()) {
                 continue;
             }
@@ -321,7 +332,11 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     }
 
     private boolean needToRefreshNonPartitionTable() {
-        for (OlapTable olapTable : snapshotBaseTables.values()) {
+        if (snapshotBaseTables.values().stream().anyMatch(tablePair -> !tablePair.second.isOlapTable())) {
+            return true;
+        }
+        for (Pair<MaterializedView.BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
+            OlapTable olapTable = (OlapTable) tablePair.second;
             if (needToRefreshTable(olapTable)) {
                 return true;
             }
@@ -340,8 +355,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
             }
         } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             Expr partitionExpr = getPartitionExpr();
-            Pair<OlapTable, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
-            OlapTable partitionTable = partitionTableAndColumn.first;
+            Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
+            Table partitionTable = partitionTableAndColumn.first;
 
             if (needToRefreshNonPartitionTable(partitionTable)) {
                 // if non partition table changed, should refresh all partitions of materialized view
@@ -373,13 +388,19 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     }
 
     private Map<String, Set<String>> getSourceTablePartitions(Set<String> affectedMaterializedViewPartitions) {
-        OlapTable partitionTable = null;
+        Table partitionTable = null;
         if (materializedView.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
-            Pair<OlapTable, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
+            Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
             partitionTable = partitionTableAndColumn.first;
         }
         Map<String, Set<String>> tableNamePartitionNames = Maps.newHashMap();
-        for (OlapTable olapTable : snapshotBaseTables.values()) {
+        for (Pair<MaterializedView.BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
+            Table table = tablePair.second;
+            if (!table.isOlapTable()) {
+                // TODO(ywb) support external table refresh according to partition later
+                return tableNamePartitionNames;
+            }
+            OlapTable olapTable = (OlapTable) table;
             if (partitionTable != null && olapTable.getId() == partitionTable.getId()) {
                 Set<String> needRefreshTablePartitionNames = Sets.newHashSet();
                 Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvToBaseNameRef();
@@ -395,7 +416,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     }
 
     private ExecPlan generateRefreshPlan(ConnectContext ctx, InsertStmt insertStmt) throws AnalysisException {
-        return new StatementPlanner().plan(insertStmt, ctx);
+        return StatementPlanner.plan(insertStmt, ctx);
     }
 
     private InsertStmt generateInsertStmt(Set<String> materializedViewPartitions,
@@ -420,7 +441,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
             Set<String> tablePartitionNames = sourceTablePartitions.get(nameTableRelationEntry.getKey());
             TableRelation tableRelation = nameTableRelationEntry.getValue();
             tableRelation.setPartitionNames(
-                    new PartitionNames(false, new ArrayList<>(tablePartitionNames)));
+                    new PartitionNames(false, tablePartitionNames == null ?  null :
+                            new ArrayList<>(tablePartitionNames)));
         }
         // insert overwrite mv must set system = true
         insertStmt.setSystem(true);
@@ -430,21 +452,38 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
 
     private boolean checkBaseTablePartitionChange() {
         // check snapshotBaseTables and current tables in catalog
-        for (OlapTable snapshotTable : snapshotBaseTables.values()) {
-            if (snapshotTable.getPartitionInfo() instanceof SinglePartitionInfo) {
-                Set<String> partitionNames = ((OlapTable) database.getTable(snapshotTable.getId())).getPartitionNames();
-                if (!snapshotTable.getPartitionNames().equals(partitionNames)) {
-                    // there is partition rename
-                    return true;
+        for (Pair<MaterializedView.BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
+            MaterializedView.BaseTableInfo baseTableInfo = tablePair.first;
+            Table table = tablePair.second;
+            if (!table.isOlapTable()) {
+                // do not check other type table have changed now.
+                continue;
+            }
+            OlapTable snapshotTable = (OlapTable) table;
+            Database db = baseTableInfo.getDb();
+            if (db == null) {
+                return true;
+            }
+            db.readLock();
+            try {
+                if (snapshotTable.getPartitionInfo() instanceof SinglePartitionInfo) {
+                    Set<String> partitionNames =
+                            ((OlapTable) db.getTable(snapshotTable.getId())).getPartitionNames();
+                    if (!snapshotTable.getPartitionNames().equals(partitionNames)) {
+                        // there is partition rename
+                        return true;
+                    }
+                } else {
+                    Map<String, Range<PartitionKey>> snapshotPartitionMap = snapshotTable.getRangePartitionMap();
+                    Map<String, Range<PartitionKey>> currentPartitionMap =
+                            ((OlapTable) db.getTable(snapshotTable.getId())).getRangePartitionMap();
+                    boolean changed = SyncPartitionUtils.hasPartitionChange(snapshotPartitionMap, currentPartitionMap);
+                    if (changed) {
+                        return true;
+                    }
                 }
-            } else {
-                Map<String, Range<PartitionKey>> snapshotPartitionMap = snapshotTable.getRangePartitionMap();
-                Map<String, Range<PartitionKey>> currentPartitionMap =
-                        ((OlapTable) database.getTable(snapshotTable.getId())).getRangePartitionMap();
-                boolean changed = SyncPartitionUtils.hasPartitionChange(snapshotPartitionMap, currentPartitionMap);
-                if (changed) {
-                    return true;
-                }
+            } finally {
+                db.readUnlock();
             }
         }
         return false;
@@ -482,26 +521,42 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     }
 
     @VisibleForTesting
-    public Map<Long, OlapTable> collectBaseTables(MaterializedView materializedView, Database database) {
-        Map<Long, OlapTable> olapTables = Maps.newHashMap();
-        Set<Long> baseTableIds = materializedView.getBaseTableIds();
-        database.readLock();
-        try {
-            for (Long baseTableId : baseTableIds) {
-                OlapTable olapTable = (OlapTable) database.getTable(baseTableId);
-                if (olapTable == null) {
-                    throw new DmlException("Materialized view base table: %d not exist.", baseTableId);
-                }
-                OlapTable copied = new OlapTable();
-                if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
-                    throw new DmlException("Failed to copy olap table: %s", olapTable.getName());
-                }
-                olapTables.put(olapTable.getId(), copied);
+    public Map<Long, Pair<MaterializedView.BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
+        Map<Long, Pair<MaterializedView.BaseTableInfo, Table>> tables = Maps.newHashMap();
+        List<MaterializedView.BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+
+        for (MaterializedView.BaseTableInfo baseTableInfo : baseTableInfos) {
+            Database db = baseTableInfo.getDb();
+            if (db == null) {
+                LOG.warn("database {} do not exist when refreshing materialized view:{}",
+                        baseTableInfo.getDbInfoStr(), materializedView.getName());
+                throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");
             }
-        } finally {
-            database.readUnlock();
+
+            Table table = baseTableInfo.getTable();
+            if (table == null) {
+                LOG.warn("table {} do not exist when refreshing materialized view:{}",
+                        baseTableInfo.getTableInfoStr(), materializedView.getName());
+                throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
+            }
+
+            db.readLock();
+            try {
+                if (table.isOlapTable()) {
+                    Table copied = new OlapTable();
+                    if (!DeepCopy.copy(table, copied, OlapTable.class)) {
+                        throw new DmlException("Failed to copy olap table: %s", table.getName());
+                    }
+                    tables.put(table.getId(), Pair.create(baseTableInfo, copied));
+                } else {
+                    tables.put(table.getId(), Pair.create(baseTableInfo, table));
+                }
+            } finally {
+                db.readUnlock();
+            }
         }
-        return olapTables;
+
+        return tables;
     }
 
     private Map<String, String> getPartitionProperties(MaterializedView materializedView) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3177,7 +3177,7 @@ public class LocalMetastore implements ConnectorMetadata {
         // set comment
         materializedView.setComment(stmt.getComment());
         // set baseTableIds
-        materializedView.setBaseTableIds(stmt.getBaseTableIds());
+        materializedView.setBaseTableInfos(stmt.getBaseTableInfos());
         // set viewDefineSql
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         // set partitionRefTableExprs
@@ -3329,10 +3329,10 @@ public class LocalMetastore implements ConnectorMetadata {
         }
         if (table instanceof MaterializedView) {
             db.dropTable(table.getName(), stmt.isSetIfExists(), true);
-            Set<Long> baseTableIds = ((MaterializedView) table).getBaseTableIds();
-            if (baseTableIds != null) {
-                for (Long baseTableId : baseTableIds) {
-                    OlapTable baseTable = ((OlapTable) db.getTable(baseTableId));
+            List<MaterializedView.BaseTableInfo> baseTableInfos = ((MaterializedView) table).getBaseTableInfos();
+            if (baseTableInfos != null) {
+                for (MaterializedView.BaseTableInfo baseTableInfo : baseTableInfos) {
+                    Table baseTable = baseTableInfo.getTable();
                     if (baseTable != null) {
                         baseTable.removeRelatedMaterializedView(table.getId());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -36,6 +36,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterMaterializedViewStatement;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
@@ -55,6 +56,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.starrocks.server.CatalogMgr.isInternalCatalog;
 
 public class MaterializedViewAnalyzer {
 
@@ -114,8 +117,8 @@ public class MaterializedViewAnalyzer {
             // convert queryStatement to sql and set
             statement.setInlineViewDef(ViewDefBuilder.build(queryStatement));
             // collect table from query statement
-            Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllTableAndViewWithAlias(queryStatement);
-            Set<Long> baseTableIds = Sets.newHashSet();
+            Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllTable(queryStatement);
+            List<MaterializedView.BaseTableInfo> baseTableInfos = Lists.newArrayList();
             Database db = context.getGlobalStateMgr().getDb(statement.getTableName().getDb());
             if (db == null) {
                 throw new SemanticException("Can not find database:" + statement.getTableName().getDb());
@@ -123,26 +126,30 @@ public class MaterializedViewAnalyzer {
             if (tableNameTableMap.isEmpty()) {
                 throw new SemanticException("Can not find base table in query statement");
             }
-            tableNameTableMap.values().forEach(table -> {
-                if (db.getTable(table.getId()) == null) {
-                    throw new SemanticException(
-                            "Materialized view do not support table: " + table.getName() +
-                                    " do not exist in database: " + db.getOriginName());
-                }
-                if (!(table instanceof OlapTable)) {
-                    throw new SemanticException(
-                            "Materialized view only supports olap table, but the type of table: " +
-                                    table.getName() + " is: " + table.getType().name());
+            tableNameTableMap.forEach((tableNameInfo, table) -> {
+                if (table == null) {
+                    throw new SemanticException("Materialized view do not support table: " + tableNameInfo.getTbl() +
+                                    " do not exist in database: " + tableNameInfo.getCatalog() + ":" +
+                            tableNameInfo.getDb());
                 }
                 if (table instanceof MaterializedView) {
                     throw new SemanticException(
                             "Creating a materialized view from materialized view is not supported now. The type of table: " +
                                     table.getName() + " is: Materialized View");
                 }
-                baseTableIds.add(table.getId());
+                Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableNameInfo.getCatalog(),
+                        tableNameInfo.getDb());
+                if (isInternalCatalog(tableNameInfo.getCatalog())) {
+                    baseTableInfos.add(new MaterializedView.BaseTableInfo(database.getId(), table.getId()));
+                } else {
+                    baseTableInfos.add(new MaterializedView.BaseTableInfo(tableNameInfo.getCatalog(),
+                            tableNameInfo.getDb(), table.getTableIdentifier()));
+                }
             });
-            statement.setBaseTableIds(baseTableIds);
+            statement.setBaseTableInfos(baseTableInfos);
             Map<Column, Expr> columnExprMap = Maps.newHashMap();
+            Map<TableName, Table> aliasTableMap = AnalyzerUtils.collectAllTableAndViewWithAlias(queryStatement);
+
             // get outputExpressions and convert it to columns which in selectRelation
             // set the columns into createMaterializedViewStatement
             // record the relationship between columns and outputExpressions for next check
@@ -155,10 +162,10 @@ public class MaterializedViewAnalyzer {
                 // check whether partition expression functions are allowed if it exists
                 checkPartitionExpParams(statement);
                 // check partition column must be base table's partition column
-                checkPartitionColumnWithBaseTable(statement, tableNameTableMap);
+                checkPartitionColumnWithBaseTable(statement, aliasTableMap);
             }
             // check and analyze distribution
-            checkDistribution(statement, tableNameTableMap);
+            checkDistribution(statement, aliasTableMap);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -9,10 +9,10 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedView;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Materialized view is performed to materialize the results of query.
@@ -40,7 +40,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     protected String inlineViewDef;
     // for create column in mv
     private List<Column> mvColumnItems = Lists.newArrayList();
-    private Set<Long> baseTableIds;
+    private List<MaterializedView.BaseTableInfo> baseTableInfos;
     private Column partitionColumn;
     // record expression which related with partition by clause
     private Expr partitionRefTableExpr;
@@ -147,12 +147,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.mvColumnItems = mvColumnItems;
     }
 
-    public Set<Long> getBaseTableIds() {
-        return baseTableIds;
+    public List<MaterializedView.BaseTableInfo> getBaseTableInfos() {
+        return baseTableInfos;
     }
 
-    public void setBaseTableIds(Set<Long> baseTableIds) {
-        this.baseTableIds = baseTableIds;
+    public void setBaseTableInfos(List<MaterializedView.BaseTableInfo> baseTableInfos) {
+        this.baseTableInfos = baseTableInfos;
     }
 
     public Column getPartitionColumn() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -46,7 +46,6 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class CreateMaterializedViewTest {
 
@@ -309,8 +308,8 @@ public class CreateMaterializedViewTest {
             partitionFunctionCallExpr.collect(SlotRef.class, slotRefs);
             SlotRef partitionSlotRef = slotRefs.get(0);
             Assert.assertEquals("k1", partitionSlotRef.getColumnName());
-            Set<Long> baseTableIds = materializedView.getBaseTableIds();
-            Assert.assertEquals(1, baseTableIds.size());
+            List<MaterializedView.BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+            Assert.assertEquals(1, baseTableInfos.size());
             Expr partitionRefTableExpr = materializedView.getPartitionRefTableExprs().get(0);
             List<SlotRef> tableSlotRefs = Lists.newArrayList();
             partitionRefTableExpr.collect(SlotRef.class, tableSlotRefs);
@@ -319,7 +318,7 @@ public class CreateMaterializedViewTest {
             Assert.assertEquals(baseTableName.getDb(), testDb.getFullName());
             Table baseTable = testDb.getTable(baseTableName.getTbl());
             Assert.assertNotNull(baseTable);
-            Assert.assertTrue(baseTableIds.contains(baseTable.getId()));
+            Assert.assertEquals(baseTableInfos.get(0).getTableId(), baseTable.getId());
             Assert.assertEquals(1, ((OlapTable) baseTable).getRelatedMaterializedViews().size());
             Column baseColumn = baseTable.getColumn(slotRef.getColumnName());
             Assert.assertNotNull(baseColumn);
@@ -387,7 +386,6 @@ public class CreateMaterializedViewTest {
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
-
     }
 
     @Test
@@ -403,7 +401,6 @@ public class CreateMaterializedViewTest {
                 ")\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-
     }
 
     @Test
@@ -419,7 +416,6 @@ public class CreateMaterializedViewTest {
                 ")\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-
     }
 
     @Test
@@ -452,8 +448,8 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpr instanceof SlotRef);
             SlotRef partitionSlotRef = (SlotRef) partitionExpr;
             Assert.assertEquals("s1", partitionSlotRef.getColumnName());
-            Set<Long> baseTableIds = materializedView.getBaseTableIds();
-            Assert.assertEquals(2, baseTableIds.size());
+            List<MaterializedView.BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+            Assert.assertEquals(2, baseTableInfos.size());
             Expr partitionRefTableExpr = materializedView.getPartitionRefTableExprs().get(0);
             List<SlotRef> slotRefs = Lists.newArrayList();
             partitionRefTableExpr.collect(SlotRef.class, slotRefs);
@@ -462,8 +458,9 @@ public class CreateMaterializedViewTest {
             Assert.assertEquals(baseTableName.getDb(), testDb.getFullName());
             Table baseTable = testDb.getTable(baseTableName.getTbl());
             Assert.assertNotNull(baseTable);
-            Assert.assertTrue(baseTableIds.contains(baseTable.getId()));
-            Assert.assertEquals(1, ((OlapTable) baseTable).getRelatedMaterializedViews().size());
+            Assert.assertTrue(baseTableInfos.stream().anyMatch(baseTableInfo ->
+                    baseTableInfo.getTableId() == baseTable.getId()));
+            Assert.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
             Column baseColumn = baseTable.getColumn(slotRef.getColumnName());
             Assert.assertNotNull(baseColumn);
             Assert.assertEquals("k1", baseColumn.getName());
@@ -516,9 +513,9 @@ public class CreateMaterializedViewTest {
             Partition partition = materializedView.getPartitions().iterator().next();
             Assert.assertNotNull(partition);
             Assert.assertEquals("mv1", partition.getName());
-            Set<Long> baseTableIds = materializedView.getBaseTableIds();
-            Assert.assertEquals(1, baseTableIds.size());
-            Table baseTable = testDb.getTable(baseTableIds.iterator().next());
+            List<MaterializedView.BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+            Assert.assertEquals(1, baseTableInfos.size());
+            Table baseTable = testDb.getTable(baseTableInfos.iterator().next().getTableId());
             Assert.assertEquals(1, ((OlapTable) baseTable).getRelatedMaterializedViews().size());
             // test sql
             Assert.assertEquals("SELECT `test`.`tbl1`.`k1` AS `k1`, `test`.`tbl1`.`k2` " +
@@ -546,7 +543,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testPartitionByTableAlias() {
+    public void testPartitionByTableAlias() throws Exception {
         String sql = "create materialized view mv1 " +
                 "partition by k1 " +
                 "distributed by hash(k2) " +
@@ -829,8 +826,8 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement statementBase =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            Set<Long> baseTableIds = statementBase.getBaseTableIds();
-            Assert.assertEquals(1, baseTableIds.size());
+            List<MaterializedView.BaseTableInfo> baseTableInfos = statementBase.getBaseTableInfos();
+            Assert.assertEquals(1, baseTableInfos.size());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -1280,8 +1277,8 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals("Materialized view only supports olap table, " +
-                    "but the type of table: mysql_external_table is: MYSQL", e.getMessage());
+            // support partitioned mv for external table later
+            Assert.assertTrue(e.getMessage().contains("com.starrocks.catalog.MysqlTable cannot be cast to"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
@@ -115,7 +115,7 @@ public class UseMaterializedViewTest {
             Table table = database.getTable("mv_to_drop");
             Assert.assertTrue(table != null);
             MaterializedView materializedView = (MaterializedView) table;
-            long baseTableId = materializedView.getBaseTableIds().iterator().next();
+            long baseTableId = materializedView.getBaseTableInfos().iterator().next().getTableId();
             OlapTable baseTable = ((OlapTable) database.getTable(baseTableId));
             Assert.assertEquals(baseTable.getRelatedMaterializedViews().size(), 2);
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -3,7 +3,6 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.PartitionKeyDesc;
@@ -83,8 +82,17 @@ public class MaterializedViewTest {
         Assert.assertEquals(true, mv2.isActive());
         mv2.setActive(false);
         Assert.assertEquals(false, mv2.isActive());
-        mv2.setBaseTableIds(Sets.newHashSet(10L, 20L));
-        Assert.assertEquals(Sets.newHashSet(10L, 20L), mv2.getBaseTableIds());
+
+        List<MaterializedView.BaseTableInfo> baseTableInfos = Lists.newArrayList();
+        MaterializedView.BaseTableInfo baseTableInfo1 = new MaterializedView.BaseTableInfo(100L, 10L);
+        baseTableInfos.add(baseTableInfo1);
+        MaterializedView.BaseTableInfo baseTableInfo2 = new MaterializedView.BaseTableInfo(100L, 20L);
+        baseTableInfos.add(baseTableInfo2);
+        mv2.setBaseTableInfos(baseTableInfos);
+        List<MaterializedView.BaseTableInfo> baseTableInfosCheck = mv2.getBaseTableInfos();
+
+        Assert.assertEquals(10L, baseTableInfosCheck.get(0).getTableId());
+        Assert.assertEquals(20L, baseTableInfosCheck.get(1).getTableId());
 
         String mvDefinition = "create materialized view mv2 select col1, col2 from table1";
         mv2.setViewDefineSql(mvDefinition);
@@ -249,7 +257,16 @@ public class MaterializedViewTest {
         MaterializedIndex index = new MaterializedIndex(3, IndexState.NORMAL);
         Partition partition = new Partition(2, "mv_name", index, hashDistributionInfo);
         mv.addPartition(partition);
-        mv.setBaseTableIds(Sets.newHashSet(10L, 20L, 30L));
+
+        List<MaterializedView.BaseTableInfo> baseTableInfos = Lists.newArrayList();
+        MaterializedView.BaseTableInfo baseTableInfo1 = new MaterializedView.BaseTableInfo(100L, 10L);
+        baseTableInfos.add(baseTableInfo1);
+        MaterializedView.BaseTableInfo baseTableInfo2 = new MaterializedView.BaseTableInfo(100L, 20L);
+        baseTableInfos.add(baseTableInfo2);
+        MaterializedView.BaseTableInfo baseTableInfo3 = new MaterializedView.BaseTableInfo(100L, 30L);
+        baseTableInfos.add(baseTableInfo3);
+
+        mv.setBaseTableInfos(baseTableInfos);
 
         FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(byteArrayOutputStream);
@@ -347,7 +364,11 @@ public class MaterializedViewTest {
         MaterializedIndex index = new MaterializedIndex(3, MaterializedIndex.IndexState.NORMAL);
         Partition partition = new Partition(2, "mv_name", index, hashDistributionInfo);
         mv.addPartition(partition);
-        mv.setBaseTableIds(Sets.newHashSet(baseTable.getId()));
+
+        List<MaterializedView.BaseTableInfo> baseTableInfos = Lists.newArrayList();
+        MaterializedView.BaseTableInfo baseTableInfo = new MaterializedView.BaseTableInfo(100L, baseTable.getId());
+        baseTableInfos.add(baseTableInfo);
+        mv.setBaseTableInfos(baseTableInfos);
         mv.setViewDefineSql("select * from test.tbl1");
 
         FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#11116 
#9792

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In this PR, There are two main feature:
1. support create mv based on external (hive/hudi) **unpartitioned** table 
2. support create mv select data from different database

Major changes:
1. Use BaseTableInfo instead of baseTableIds to represent MV-dependent base tables
2. Where OlapTable is heavily dependent, use Table instead
3. Because dbId and tableId are not available for external table, use TableIdentifier to uniquely identify a table

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
