### PR TITLE
[Enhancement][POC] optimize windows sort property when single tablet mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -219,7 +219,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
     public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
-    public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL = "enable_rewrite_groupingsets_to_union_all";
+    public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
+            "enable_rewrite_groupingsets_to_union_all";
 
     // --------  New planner session variables end --------
 
@@ -249,7 +250,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
-    public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER = "enable_multicolumn_global_runtime_filter";
+    public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
+            "enable_multicolumn_global_runtime_filter";
     public static final String ENABLE_OPTIMIZER_TRACE_LOG = "enable_optimizer_trace_log";
     public static final String JOIN_IMPLEMENTATION_MODE = "join_implementation_mode";
     public static final String JOIN_IMPLEMENTATION_MODE_V2 = "join_implementation_mode_v2";
@@ -261,6 +263,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_QUERY_DEBUG_TRACE = "enable_query_debug_trace";
 
     public static final String PARSE_TOKENS_LIMIT = "parse_tokens_limit";
+
+    public static final String SINGLE_TABLET_MODE = "single_tablet_mode";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -633,12 +637,27 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
 
+    @VarAttr(name = SINGLE_TABLET_MODE)
+    private boolean singleTabletMode = false;
+
+    public boolean isSingleTabletMode() {
+        return singleTabletMode;
+    }
+
     public void setCboCTEMaxLimit(int cboCTEMaxLimit) {
         this.cboCTEMaxLimit = cboCTEMaxLimit;
     }
 
     public int getCboCTEMaxLimit() {
         return cboCTEMaxLimit;
+    }
+
+    public boolean isEnableTabletInternalParallel() {
+        return enableTabletInternalParallel;
+    }
+
+    public void setEnableTabletInternalParallel(boolean enableTabletInternalParallel) {
+        this.enableTabletInternalParallel = enableTabletInternalParallel;
     }
 
     public double getCboPruneShuffleColumnRate() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -270,7 +270,7 @@ public class WindowTransformer {
             // Each LogicalWindowOperator will belong to a SortGroup,
             // so we need to record sortProperty to ensure that only one SortNode is enforced
             List<Ordering> sortEnforceProperty = new ArrayList<>();
-            partitions.forEach(p -> sortEnforceProperty.add(new Ordering((ColumnRefOperator) p, true, true)));
+            partitions.forEach(p -> sortEnforceProperty.add(new Ordering((ColumnRefOperator) p, true, false)));
             for (Ordering ordering : orderings) {
                 if (sortEnforceProperty.stream().noneMatch(sp -> sp.getColumnRef().equals(ordering.getColumnRef()))) {
                     sortEnforceProperty.add(ordering);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Optimize window required sort property,  scan node can support sort property when only one tablet



### how to enable this feature?
```
set enable_tablet_internal_parallel=false;
set single_tablet_mode=true;
set pipeline_dop=96; -- greate than tablet number
```
this PR doesn't support serial read tablets on scan node, so needs to set the DOP greate than the tablet number when test

## some performance test result:
### env
1FE 4BE SSB-100G
### table
```
CREATE TABLE `lineorder_uniq` (
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` int(11) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderdate` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
  `lo_shippriority` int(11) NOT NULL COMMENT "",
  `lo_quantity` int(11) NOT NULL COMMENT "",
  `lo_extendedprice` int(11) NOT NULL COMMENT "",
  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
  `lo_discount` int(11) NOT NULL COMMENT "",
  `lo_revenue` int(11) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` int(11) NOT NULL COMMENT "",
  `lo_commitdate` int(11) NOT NULL COMMENT "",
  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
) ENGINE=OLAP 
UNIQUE KEY(`lo_orderkey`, `lo_linenumber`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
PROPERTIES (
"replication_num" = "1",
"colocate_with" = "groupa1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false",
"compression" = "LZ4"
);

insert into lineorder_uniq select * from lineorder;
```

baseline:
```
MySQL ssb_100g_performance> set pipeline_dop=96
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance> set single_tablet_mode=false;
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance> set enable_tablet_internal_parallel=false;
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance>   select sum(lo_extendedprice) over (partition by lo_orderkey order by lo_orderkey) t from lineorder_uniq order by t limit 1;

+-------+
| t     |
+-------+
| 90099 |
+-------+
1 row in set
Time: 2.790s
MySQL ssb_100g_performance>
```

explain
```
MySQL ssb_100g_performance> explain select sum(lo_extendedprice) over (partition by lo_orderkey order by lo_orderkey) t from li
neorder_uniq order by t limit 1;
+-------------------------------------------------------------------------------------------+
| Explain String                                                                            |
+-------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                           |
|  OUTPUT EXPRS:18: sum(10: lo_extendedprice)                                               |
|   PARTITION: UNPARTITIONED                                                                |
|                                                                                           |
|   RESULT SINK                                                                             |
|                                                                                           |
|   5:MERGING-EXCHANGE                                                                      |
|      limit: 1                                                                             |
|                                                                                           |
| PLAN FRAGMENT 1                                                                           |
|  OUTPUT EXPRS:                                                                            |
|   PARTITION: RANDOM                                                                       |
|                                                                                           |
|   STREAM DATA SINK                                                                        |
|     EXCHANGE ID: 05                                                                       |
|     UNPARTITIONED                                                                         |
|                                                                                           |
|   4:TOP-N                                                                                 |
|   |  order by: <slot 18> 18: sum(10: lo_extendedprice) ASC                                |
|   |  offset: 0                                                                            |
|   |  limit: 1                                                                             |
|   |                                                                                       |
|   3:Project                                                                               |
|   |  <slot 18> : 18: sum(10: lo_extendedprice)                                            |
|   |                                                                                       |
|   2:ANALYTIC                                                                              |
|   |  functions: [, sum(10: lo_extendedprice), ]                                           |
|   |  partition by: 1: lo_orderkey                                                         |
|   |  order by: 1: lo_orderkey ASC                                                         |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                            |
|   |                                                                                       |
|   1:SORT                                                                                  |
|   |  order by: <slot 1> 1: lo_orderkey ASC                                                |
|   |  offset: 0                                                                            |
|   |                                                                                       |
|   0:OlapScanNode                                                                          |
|      TABLE: lineorder_uniq                                                                |
|      PREAGGREGATION: OFF. Reason: None aggregate function                                 |
|      partitions=1/1                                                                       |
|      rollup: lineorder_uniq                                                               |
|      tabletRatio=48/48                                                                    |
|      tabletList=241057,241059,241061,241063,241065,241067,241069,241071,241073,241075 ... |
|      cardinality=600037902                                                                |
|      avgRowSize=5.0                                                                       |
|      numNodes=0                                                                           |
+-------------------------------------------------------------------------------------------+
45 rows in set
Time: 0.014s
```


enable this feature
```
MySQL ssb_100g_performance> set pipeline_dop=96
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance> set single_tablet_mode=true;
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance> set enable_tablet_internal_parallel=false;
Query OK, 0 rows affected
Time: 0.002s
MySQL ssb_100g_performance>  select sum(lo_extendedprice) over (partition by lo_orderkey order by lo_orderkey) t from lineorder_uniq order by t limit 1;
+-------+
| t     |
+-------+
| 90099 |
+-------+
1 row in set
Time: 1.136s
```

explain:
```
MySQL ssb_100g_performance> explain select sum(lo_extendedprice) over (partition by lo_orderkey order by lo_orderkey) t from li
neorder_uniq order by t limit 1;
+-------------------------------------------------------------------------------------------+
| Explain String                                                                            |
+-------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                           |
|  OUTPUT EXPRS:18: sum(10: lo_extendedprice)                                               |
|   PARTITION: UNPARTITIONED                                                                |
|                                                                                           |
|   RESULT SINK                                                                             |
|                                                                                           |
|   4:MERGING-EXCHANGE                                                                      |
|      limit: 1                                                                             |
|                                                                                           |
| PLAN FRAGMENT 1                                                                           |
|  OUTPUT EXPRS:                                                                            |
|   PARTITION: RANDOM                                                                       |
|                                                                                           |
|   STREAM DATA SINK                                                                        |
|     EXCHANGE ID: 04                                                                       |
|     UNPARTITIONED                                                                         |
|                                                                                           |
|   3:TOP-N                                                                                 |
|   |  order by: <slot 18> 18: sum(10: lo_extendedprice) ASC                                |
|   |  offset: 0                                                                            |
|   |  limit: 1                                                                             |
|   |                                                                                       |
|   2:Project                                                                               |
|   |  <slot 18> : 18: sum(10: lo_extendedprice)                                            |
|   |                                                                                       |
|   1:ANALYTIC                                                                              |
|   |  functions: [, sum(10: lo_extendedprice), ]                                           |
|   |  partition by: 1: lo_orderkey                                                         |
|   |  order by: 1: lo_orderkey ASC                                                         |
|   |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW                            |
|   |                                                                                       |
|   0:OlapScanNode                                                                          |
|      TABLE: lineorder_uniq                                                                |
|      PREAGGREGATION: OFF. Reason: None aggregate function                                 |
|      partitions=1/1                                                                       |
|      rollup: lineorder_uniq                                                               |
|      tabletRatio=48/48                                                                    |
|      tabletList=241057,241059,241061,241063,241065,241067,241069,241071,241073,241075 ... |
|      cardinality=600037902                                                                |
|      avgRowSize=5.0                                                                       |
|      numNodes=0                                                                           |
+-------------------------------------------------------------------------------------------+
41 rows in set
Time: 0.014s
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
