### PR TITLE
[Enhancement] support to set dop of second agg phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -262,6 +262,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PARSE_TOKENS_LIMIT = "parse_tokens_limit";
 
+    public static final String SECOND_AGG_PHASE_DOP = "second_agg_phase_dop";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(ENABLE_SPILLING)
@@ -632,6 +634,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
+
+    @VarAttr(name = SECOND_AGG_PHASE_DOP, flag = VariableMgr.INVISIBLE)
+    private int secondAggPhaseDop = -1;
 
     public void setCboCTEMaxLimit(int cboCTEMaxLimit) {
         this.cboCTEMaxLimit = cboCTEMaxLimit;
@@ -1163,6 +1168,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getEnableReplicatedStorage() {
         return enableReplicatedStorage;
+    }
+
+    public int getSecondAggPhaseDop() {
+        return secondAggPhaseDop;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1194,6 +1194,10 @@ public class PlanFragmentBuilder {
                     aggregationNode =
                             new AggregationNode(context.getNextNodeId(), inputFragment.getPlanRoot(),
                                     aggInfo);
+                    int secondAggPhaseDop = context.getConnectContext().getSessionVariable().getSecondAggPhaseDop();
+                    if (secondAggPhaseDop > 0) {
+                        inputFragment.setPipelineDop(secondAggPhaseDop);
+                    }
                 }
                 // set aggregate node can use local aggregate
                 if (hasColocateOlapScanChildInFragment(aggregationNode)) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In this PR, I add a session variable to support setting dop of the second agg phase. By setting `parallel_exchange_instance_num=1` and  `second_agg_phase_dop=1`, we can make the aggregation into a scatter-gather-like execution mode.

In some low-cardinality aggregation scenarios, changing the dop of second agg phase will effect the exchange operator. Because the downstream of exchange is more concentrated, compression will play a role ,resulting in less data being transmitted and the number of schedules of the exchange pipeline will also be reduced.

I conducted a concurrent query test on ssb-flat 100G data, after turning on the scatter-gather mode, the query throughput of most scenarios can be improved by more than 10% and some can be improved by more than 40~50%.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
