### PR TITLE
[BugFix] Fix export close file fail bug

### DIFF
--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -174,9 +174,6 @@ Status HDFSWritableFile::close() {
         return Status::OK();
     }
     auto ret = call_hdfs_scan_function_in_pthread([this]() {
-        // If we open a file and close it immediately here (before this file is flushed to the disk),
-        // hdfs cannot find the file and will cause BE crash.
-        // To avoid this, before closing the file, we need to call file sync.
         int r = hdfsHSync(_fs, _file);
         if (r != 0) {
             return Status::IOError("sync error, file: {}"_format(_path));

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -45,7 +45,8 @@ ExportSink::ExportSink(ObjectPool* pool, const RowDescriptor& row_desc, const st
           _profile(nullptr),
           _bytes_written_counter(nullptr),
           _rows_written_counter(nullptr),
-          _write_timer(nullptr) {}
+          _write_timer(nullptr),
+          _closed(false) {}
 
 Status ExportSink::init(const TDataSink& t_sink) {
     RETURN_IF_ERROR(DataSink::init(t_sink));
@@ -89,12 +90,17 @@ Status ExportSink::open(RuntimeState* state) {
 }
 
 Status ExportSink::close(RuntimeState* state, Status exec_status) {
+    if (_closed) {
+        return Status::OK();
+    }
     Expr::close(_output_expr_ctxs, state);
     if (_file_builder != nullptr) {
         Status st = _file_builder->finish();
         _file_builder.reset();
+        _closed = true;
         return st;
     }
+    _closed = true;
     return Status::OK();
 }
 
@@ -150,8 +156,13 @@ Status ExportSink::gen_file_name(std::string* file_name) {
     return Status::OK();
 }
 
-Status ExportSink::send_chunk(RuntimeState*, vectorized::Chunk* chunk) {
-    return _file_builder->add_chunk(chunk);
+Status ExportSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) {
+    Status status = _file_builder->add_chunk(chunk);
+    if (!status.ok()) {
+        Status status;
+        close(state, status);
+    }
+    return status;
 }
 
 } // namespace starrocks

--- a/be/src/runtime/export_sink.h
+++ b/be/src/runtime/export_sink.h
@@ -82,6 +82,7 @@ private:
     RuntimeProfile::Counter* _write_timer;
 
     std::unique_ptr<FileBuilder> _file_builder;
+    bool _closed = false;
 };
 
 } // end namespace starrocks


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11183

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

If an error occurs in export, such as PlainTextBuilder init fail because of No CSV converter for type OBJECT, the export will return from BE to FE immediately, and FE will clean the temp dir. At the same time, BE will close the temp file in temp dir. if unfortunately, the temporary file to be closed has already been deleted, it will report that the close file is deleted error msgs.

In this pr, we will return to FE until we close all temp files.