### PR TITLE
[cherry-pick] [branch-2.4] [Enhancement] Add mem statistics for tablet (#10998)

### DIFF
--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -57,7 +57,7 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
         return Status::InternalError("no tablet exist");
     }
-    auto tablet_meta = TabletMeta::create(StorageEngine::instance()->metadata_mem_tracker());
+    auto tablet_meta = TabletMeta::create();
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -226,8 +226,6 @@ int main(int argc, char** argv) {
     starrocks::EngineOptions options;
     options.store_paths = paths;
     options.backend_uid = starrocks::UniqueId::gen_uid();
-    options.metadata_mem_tracker = exec_env->metadata_mem_tracker();
-    options.schema_change_mem_tracker = exec_env->schema_change_mem_tracker();
     options.compaction_mem_tracker = exec_env->compaction_mem_tracker();
     options.update_mem_tracker = exec_env->update_mem_tracker();
     options.conf_path = string(getenv("STARROCKS_HOME")) + "/conf/";

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -49,9 +49,7 @@ struct EngineOptions {
     std::vector<StorePath> store_paths;
     // BE's UUID. It will be reset every time BE restarts.
     UniqueId backend_uid{0, 0};
-    MemTracker* metadata_mem_tracker = nullptr;
     MemTracker* compaction_mem_tracker = nullptr;
-    MemTracker* schema_change_mem_tracker = nullptr;
     MemTracker* update_mem_tracker = nullptr;
     // config path to store cluster_id, used by DummyStorageEngine
     std::string conf_path;

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -26,7 +26,6 @@ public:
     using segment_rowid_t = uint32_t;
     using DeletesMap = std::unordered_map<uint32_t, vector<segment_rowid_t>>;
     using tablet_rowid_t = uint64_t;
-    using TabletRowidColumn = vectorized::UInt64Column;
 
     PrimaryIndex();
     PrimaryIndex(const vectorized::Schema& pk_schema);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -210,7 +210,6 @@ private:
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;
     PagePointer _short_key_index_page;
-    MemTracker* _mem_tracker;
 
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,
     // This means that this segment has no data for that column, which may be added

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -24,7 +24,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <csignal>
 #include <cstring>
 #include <filesystem>
 #include <memory>
@@ -84,7 +83,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _options(options),
           _available_storage_medium_type_count(0),
           _is_all_cluster_id_exist(true),
-          _tablet_manager(new TabletManager(options.metadata_mem_tracker, config::tablet_map_shard_size)),
+          _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size)),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -179,8 +179,6 @@ public:
 
     bool bg_worker_stopped() { return _bg_worker_stopped.load(std::memory_order_consume); }
 
-    MemTracker* metadata_mem_tracker() { return _options.metadata_mem_tracker; }
-
     void compaction_check();
 
     // submit repair compaction tasks

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -52,15 +52,11 @@
 
 namespace starrocks {
 
-TabletSharedPtr Tablet::create_tablet_from_meta(MemTracker* mem_tracker, const TabletMetaSharedPtr& tablet_meta,
-                                                DataDir* data_dir) {
-    auto tablet =
-            std::shared_ptr<Tablet>(new Tablet(tablet_meta, data_dir), DeleterWithMemTracker<Tablet>(mem_tracker));
-    mem_tracker->consume(tablet->mem_usage());
-    return tablet;
+TabletSharedPtr Tablet::create_tablet_from_meta(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir) {
+    return std::make_shared<Tablet>(tablet_meta, data_dir);
 }
 
-Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
+Tablet::Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
         : BaseTablet(tablet_meta, data_dir),
           _last_cumu_compaction_failure_millis(0),
           _last_base_compaction_failure_millis(0),
@@ -69,9 +65,16 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
           _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _timestamped_version_tracker
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
-Tablet::~Tablet() {}
+Tablet::Tablet() {
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+}
+
+Tablet::~Tablet() {
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+}
 
 Status Tablet::_init_once_action() {
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
@@ -123,7 +126,7 @@ void Tablet::save_meta() {
     CHECK(st.ok()) << "fail to save tablet_meta: " << st;
 }
 
-Status Tablet::revise_tablet_meta(MemTracker* mem_tracker, const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
+Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
                                   const std::vector<Version>& versions_to_delete) {
     LOG(INFO) << "begin to clone data to tablet. tablet=" << full_name()
               << ", rowsets_to_clone=" << rowsets_to_clone.size()
@@ -136,7 +139,7 @@ Status Tablet::revise_tablet_meta(MemTracker* mem_tracker, const std::vector<Row
     Status st;
     do {
         // load new local tablet_meta to operate on
-        auto new_tablet_meta = TabletMeta::create(mem_tracker);
+        auto new_tablet_meta = TabletMeta::create();
 
         generate_tablet_meta_copy_unlocked(new_tablet_meta);
         // Segment store the pointer of TabletSchema, so don't release the TabletSchema of old TabletMeta
@@ -512,16 +515,6 @@ Status Tablet::check_version_integrity(const Version& version) {
     return capture_consistent_versions(version, nullptr);
 }
 
-// If any rowset contains the specific version, it means the version already exist
-bool Tablet::check_version_exist(const Version& version) const {
-    for (auto& it : _rs_version_map) {
-        if (it.first.contains(version)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void Tablet::list_versions(vector<Version>* versions) const {
     DCHECK(versions != nullptr && versions->empty());
 
@@ -572,11 +565,6 @@ Status Tablet::_capture_consistent_rowsets_unlocked(const std::vector<Version>& 
         }
     }
     return Status::OK();
-}
-
-void Tablet::add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version) {
-    CHECK(!_updates) << "updatable tablet should not call add_delete_predicate";
-    _tablet_meta->add_delete_predicate(delete_predicate, version);
 }
 
 // TODO(lingbin): what is the difference between version_for_delete_predicate() and
@@ -722,11 +710,6 @@ void Tablet::calc_missed_versions_unlocked(int64_t spec_version, std::vector<Ver
     for (int64_t i = last_version + 1; i <= spec_version; ++i) {
         missed_versions->emplace_back(Version(i, i));
     }
-}
-
-Version Tablet::max_continuous_version_from_beginning() const {
-    std::shared_lock rdlock(_meta_lock);
-    return _max_continuous_version_from_beginning_unlocked();
 }
 
 Version Tablet::_max_continuous_version_from_beginning_unlocked() const {
@@ -1200,11 +1183,6 @@ void Tablet::_update_tablet_compaction_context() {
     } else {
         _compaction_context.reset();
     }
-}
-
-bool Tablet::_is_compacted_singleton(Rowset* rowset) {
-    DCHECK(rowset) << "invalid rowset";
-    return rowset->num_segments() > 1 && rowset->rowset_meta()->segments_overlap() == NONOVERLAPPING;
 }
 
 // protected by meta lock

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -65,13 +65,15 @@ using ChunkIteratorPtr = std::shared_ptr<vectorized::ChunkIterator>;
 
 class Tablet : public BaseTablet {
 public:
-    static TabletSharedPtr create_tablet_from_meta(MemTracker* mem_tracker, const TabletMetaSharedPtr& tablet_meta,
-                                                   DataDir* data_dir = nullptr);
+    static TabletSharedPtr create_tablet_from_meta(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir = nullptr);
 
-    Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir);
+    Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir);
+
+    Tablet(const Tablet&) = delete;
+    const Tablet& operator=(const Tablet&) = delete;
 
     // for ut
-    Tablet() = default;
+    Tablet();
 
     ~Tablet() override;
 
@@ -85,7 +87,7 @@ public:
 
     void save_meta();
     // Used in clone task, to update local meta when finishing a clone job
-    Status revise_tablet_meta(MemTracker* mem_tracker, const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
+    Status revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
                               const std::vector<Version>& versions_to_delete);
 
     const int64_t cumulative_layer_point() const;
@@ -102,9 +104,7 @@ public:
     size_t num_key_columns() const;
     size_t num_short_key_columns() const;
     size_t num_rows_per_row_block() const;
-    CompressKind compress_kind() const;
     size_t next_unique_id() const;
-    size_t row_size() const;
     size_t field_index(const string& field_name) const;
 
     // operation in rowsets
@@ -129,16 +129,12 @@ public:
 
     Status capture_consistent_versions(const Version& spec_version, vector<Version>* version_path) const;
     Status check_version_integrity(const Version& version);
-    bool check_version_exist(const Version& version) const;
     void list_versions(std::vector<Version>* versions) const;
 
     // REQUIRE: `obtain_header_rdlock()`ed
     Status capture_consistent_rowsets(const Version& spec_version, vector<RowsetSharedPtr>* rowsets) const;
 
-    using IteratorList = std::vector<ChunkIteratorPtr>;
-
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
-    void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     bool version_for_delete_predicate(const Version& version);
 
     // message for alter task
@@ -189,10 +185,6 @@ public:
     void calc_missed_versions(int64_t spec_version, vector<Version>* missed_versions);
     void calc_missed_versions_unlocked(int64_t spec_version, vector<Version>* missed_versions) const;
 
-    // This function to find max continuous version from the beginning.
-    // For example: If there are 1, 2, 3, 5, 6, 7 versions belongs tablet, then 3 is target.
-    Version max_continuous_version_from_beginning() const;
-
     // Same as max_continuous_version_from_beginning, only return end version, using a more efficient implementation
     int64_t max_continuous_version() const;
 
@@ -221,13 +213,6 @@ public:
     void pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
 
     void calculate_cumulative_point();
-    // TODO(ygl):
-    bool is_primary_replica() { return false; }
-
-    // TODO(ygl):
-    // eco mode means power saving in new energy car
-    // eco mode also means save money in starrocks
-    bool in_eco_mode() { return false; }
 
     void do_tablet_meta_checkpoint();
 
@@ -245,8 +230,6 @@ public:
     // updatable tablet specific operations
     TabletUpdates* updates() { return _updates.get(); }
     Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
-
-    int64_t mem_usage() { return sizeof(Tablet); }
 
     // if there is _compaction_task running
     // do not do compaction
@@ -278,6 +261,8 @@ protected:
     void on_shutdown() override;
 
 private:
+    int64_t _mem_usage() { return sizeof(Tablet); }
+
     Status _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
     bool _contains_rowset(const RowsetId rowset_id);
@@ -293,8 +278,6 @@ private:
     bool _check_versions_completeness();
 
     std::unique_ptr<CompactionContext> _get_compaction_context();
-
-    bool _is_compacted_singleton(Rowset* rowset);
 
     // protected by _meta_lock
     void _update_tablet_compaction_context();
@@ -359,9 +342,6 @@ private:
     std::atomic<int64_t> _cumulative_point{0};
     std::atomic<int32_t> _newly_created_rowset_num{0};
     std::atomic<int64_t> _last_checkpoint_time{0};
-
-    Tablet(const Tablet&) = delete;
-    const Tablet& operator=(const Tablet&) = delete;
 };
 
 inline bool Tablet::init_succeeded() {
@@ -408,20 +388,12 @@ inline size_t Tablet::num_rows_per_row_block() const {
     return _tablet_meta->tablet_schema().num_rows_per_row_block();
 }
 
-inline CompressKind Tablet::compress_kind() const {
-    return _tablet_meta->tablet_schema().compress_kind();
-}
-
 inline size_t Tablet::next_unique_id() const {
     return _tablet_meta->tablet_schema().next_column_unique_id();
 }
 
 inline size_t Tablet::field_index(const string& field_name) const {
     return _tablet_meta->tablet_schema().field_index(field_name);
-}
-
-inline size_t Tablet::row_size() const {
-    return _tablet_meta->tablet_schema().row_size();
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -69,9 +69,8 @@ static void get_shutdown_tablets(std::ostream& os, void*) {
 
 bvar::PassiveStatus<std::string> g_shutdown_tablets("starrocks_shutdown_tablets", get_shutdown_tablets, nullptr);
 
-TabletManager::TabletManager(MemTracker* mem_tracker, int32_t tablet_map_lock_shard_size)
-        : _mem_tracker(mem_tracker),
-          _tablets_shards(tablet_map_lock_shard_size),
+TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
+        : _tablets_shards(tablet_map_lock_shard_size),
           _tablets_shards_mask(tablet_map_lock_shard_size - 1),
           _last_update_stat_ms(0),
           _cur_shard(0) {
@@ -329,7 +328,7 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreat
             continue;
         }
 
-        TabletSharedPtr new_tablet = Tablet::create_tablet_from_meta(_mem_tracker, tablet_meta, data_dir);
+        TabletSharedPtr new_tablet = Tablet::create_tablet_from_meta(tablet_meta, data_dir);
         st = fs::create_directories(new_tablet->schema_hash_path());
         if (!st.ok()) {
             LOG(WARNING) << "Fail to create " << new_tablet->schema_hash_path() << ": " << st.to_string();
@@ -659,7 +658,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         tablet_meta->set_tablet_state(TABLET_RUNNING);
     }
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_mem_tracker, tablet_meta, data_dir);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, data_dir);
     if (tablet == nullptr) {
         LOG(WARNING) << "Fail to load tablet_id=" << tablet_id;
         return Status::InternalError("Fail to create tablet");
@@ -728,7 +727,7 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id, 
         return Status::NotFound("header file not exist");
     }
 
-    auto tablet_meta = TabletMeta::create(_mem_tracker);
+    auto tablet_meta = TabletMeta::create();
     if (!tablet_meta->create_from_file(meta_path).ok()) {
         LOG(WARNING) << "Fail to load tablet_meta. file_path=" << meta_path;
         return Status::InternalError("fail to create tablet meta from file");
@@ -1159,8 +1158,8 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
         return Status::InternalError("fail to get root path shard");
     }
     // We generate a new tablet_uid for this new tablet.
-    return TabletMeta::create(_mem_tracker, normal_request, TabletUid::gen_uid(), shard_id, next_unique_id,
-                              col_idx_to_unique_id, tablet_meta);
+    return TabletMeta::create(normal_request, TabletUid::gen_uid(), shard_id, next_unique_id, col_idx_to_unique_id,
+                              tablet_meta);
 }
 
 Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag) {
@@ -1324,7 +1323,7 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
         return Status::InternalError("tablet state is shutdown");
     }
     // DO NOT access tablet->updates() until tablet has been init()-ed.
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_mem_tracker, tablet_meta, store);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, store);
     if (tablet == nullptr) {
         LOG(WARNING) << "Fail to load tablet " << tablet_id;
         return Status::InternalError("Fail to create tablet");

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -58,7 +58,7 @@ enum TabletDropFlag {
 // please uniformly name the method in "xxx_unlocked()" mode
 class TabletManager {
 public:
-    explicit TabletManager(MemTracker* mem_tracker, int32_t tablet_map_lock_shard_size);
+    explicit TabletManager(int32_t tablet_map_lock_shard_size);
     ~TabletManager() = default;
 
     // The param stores holds all candidate data_dirs for this tablet.
@@ -142,8 +142,6 @@ public:
 
     Status delete_shutdown_tablet(int64_t tablet_id);
 
-    MemTracker* metadata_mem_tracker() { return _mem_tracker; }
-
     // return true if all tablets visited
     bool get_next_batch_tablets(size_t batch_size, std::vector<TabletSharedPtr>* tablets);
 
@@ -222,8 +220,6 @@ private:
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
-
-    MemTracker* _mem_tracker = nullptr;
 
     std::vector<TabletsShard> _tablets_shards;
     const int32_t _tablets_shards_mask;

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -110,20 +110,20 @@ using AlterTabletTaskSharedPtr = std::shared_ptr<AlterTabletTask>;
 // The concurrency control is handled in Tablet Class, not in this class.
 class TabletMeta {
 public:
-    static Status create(MemTracker* mem_tracker, const TCreateTabletReq& request, const TabletUid& tablet_uid,
-                         uint64_t shard_id, uint32_t next_unique_id,
+    static Status create(const TCreateTabletReq& request, const TabletUid& tablet_uid, uint64_t shard_id,
+                         uint32_t next_unique_id,
                          const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                          TabletMetaSharedPtr* tablet_meta);
 
-    static TabletMetaSharedPtr create(MemTracker* mem_tracker);
+    static TabletMetaSharedPtr create();
 
-    explicit TabletMeta() : _tablet_uid(0, 0) {}
+    explicit TabletMeta();
     TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash, uint64_t shard_id,
                const TTabletSchema& tablet_schema, uint32_t next_unique_id, bool enable_persistent_index,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,
                TTabletType::type tabletType);
 
-    virtual ~TabletMeta() {}
+    virtual ~TabletMeta();
 
     // Function create_from_file is used to be compatible with previous tablet_meta.
     // Previous tablet_meta is a physical file in tablet dir, which is not stored in rocksdb.
@@ -211,8 +211,6 @@ public:
         return _updatesPB.release();
     }
 
-    int64_t mem_usage() const { return sizeof(TabletMeta); }
-
     bool get_enable_persistent_index() const { return _enable_persistent_index; }
 
     void set_enable_persistent_index(bool enable_persistent_index) {
@@ -220,6 +218,8 @@ public:
     }
 
 private:
+    int64_t _mem_usage() const { return sizeof(TabletMeta); }
+
     Status _save_meta(DataDir* data_dir);
 
     static int64_t calc_mem_usage_of_rs_metas(const std::vector<RowsetMetaSharedPtr>& rs_metas) {

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -781,8 +781,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
     }
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
-                                           rowsets_to_clone, versions_to_delete);
+    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " status=" << st << "]";
     return st;
 }
@@ -862,8 +861,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     // 2. local tablet has error in push
     // 3. local tablet cloned rowset from other nodes
     // 4. if cleared alter task info, then push will not write to new tablet, the report info is error
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
-                                           rowsets_to_clone, versions_to_delete);
+    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << st;
     // in previous step, copy all files from CLONE_DIR to tablet dir
     // but some rowset is useless, so that remove them here

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -1030,5 +1030,4 @@ TEST_F(JsonScannerTest, test_illegal_input_with_jsonpath) {
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
 }
 
-
 } // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -774,7 +774,8 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STATUS(Status::NotFound(""),
                   test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[3].key", &output));
 
-    EXPECT_STATUS(Status::DataQualityError(""), test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
+    EXPECT_STATUS(Status::DataQualityError(""),
+                  test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
 }
 
 class JsonLengthTestFixture : public ::testing::TestWithParam<std::tuple<std::string, std::string, int>> {};

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -179,9 +179,8 @@ public:
             tablet_meta->add_rs_meta(src_rowset->rowset_meta());
         }
 
-        TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta,
-                                                starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
+        TabletSharedPtr tablet = Tablet::create_tablet_from_meta(
+                tablet_meta, starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
         tablet->init();
         tablet->calculate_cumulative_point();
 
@@ -234,7 +233,7 @@ protected:
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
 }
@@ -246,7 +245,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
@@ -295,7 +294,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     tablet->calculate_cumulative_point();
 

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -159,9 +159,8 @@ public:
 
             tablet_meta->add_rs_meta(src_rowset->rowset_meta());
         }
-        TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta,
-                                                starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
+        TabletSharedPtr tablet = Tablet::create_tablet_from_meta(
+                tablet_meta, starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
         tablet->init();
 
         config::cumulative_compaction_skip_window_seconds = -2;
@@ -184,7 +183,6 @@ public:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.metadata_mem_tracker = _metadata_mem_tracker.get();
         options.compaction_mem_tracker = _compaction_mem_tracker.get();
         if (k_engine == nullptr) {
             Status s = starrocks::StorageEngine::open(options, &k_engine);
@@ -219,7 +217,7 @@ protected:
 
 TEST_F(CumulativeCompactionTest, test_init_succeeded) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());
 }
@@ -232,7 +230,7 @@ TEST_F(CumulativeCompactionTest, test_candidate_rowsets_empty) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -65,8 +65,6 @@ void set_up() {
     k_schema_change_mem_tracker = new MemTracker();
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.metadata_mem_tracker = k_metadata_mem_tracker;
-    options.schema_change_mem_tracker = k_schema_change_mem_tracker;
     Status s = starrocks::StorageEngine::open(options, &k_engine);
     ASSERT_TRUE(s.ok()) << s.to_string();
 }

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -132,8 +132,10 @@ TEST_F(DuplicateTabletWriterTest, test_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, fmt::format("{}/{}", kTestGroupPath, files[0]), 0, _tablet_schema.get()));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, fmt::format("{}/{}", kTestGroupPath, files[1]), 1, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg0,
+                    Segment::open(fs, fmt::format("{}/{}", kTestGroupPath, files[0]), 0, _tablet_schema.get()));
+    ASSIGN_OR_ABORT(auto seg1,
+                    Segment::open(fs, fmt::format("{}/{}", kTestGroupPath, files[1]), 1, _tablet_schema.get()));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -33,7 +33,6 @@
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
-#include "storage/data_dir.h"
 #include "storage/empty_iterator.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_options.h"
@@ -47,9 +46,7 @@
 #include "storage/tablet_schema_helper.h"
 #include "storage/union_iterator.h"
 #include "storage/update_manager.h"
-#include "storage/vectorized_column_predicate.h"
 #include "testutil/assert.h"
-#include "util/defer_op.h"
 
 using std::string;
 
@@ -62,8 +59,6 @@ protected:
     OlapReaderStatistics _stats;
 
     void SetUp() override {
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
-        _schema_change_mem_tracker = std::make_unique<MemTracker>();
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
         config::tablet_map_shard_size = 1;
         config::txn_map_shard_size = 1;
@@ -80,8 +75,6 @@ protected:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.metadata_mem_tracker = _metadata_mem_tracker.get();
-        options.schema_change_mem_tracker = _schema_change_mem_tracker.get();
         Status s = starrocks::StorageEngine::open(options, &k_engine);
         ASSERT_TRUE(s.ok()) << s.to_string();
 
@@ -227,8 +220,6 @@ protected:
     }
 
 private:
-    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _schema_change_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
 };
 
@@ -492,7 +483,7 @@ static ssize_t read_and_compare(const vectorized::ChunkIteratorPtr& iter, int64_
 
 static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, std::shared_ptr<TabletSchema> partial_schema,
                                        int64_t version, int64_t nkeys) {
-    vectorized::Schema schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema.get());
+    vectorized::Schema schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema);
     vectorized::TabletReader reader(tablet, Version(0, version), schema);
     auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
@@ -515,7 +506,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    auto schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema.get());
+    auto schema = ChunkHelper::convert_schema_to_format_v2(*partial_schema);
 
     {
         auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -26,7 +26,6 @@
 #include <string>
 
 #include "runtime/decimalv2_value.h"
-#include "runtime/mem_tracker.h"
 
 namespace starrocks {
 
@@ -105,10 +104,9 @@ TEST(TabletMetaTest, test_create) {
     col_ordinal_to_unique_id[2] = 10002;
     col_ordinal_to_unique_id[3] = 10003;
 
-    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(-1);
     TabletMetaSharedPtr tablet_meta;
-    Status st = TabletMeta::create(mem_tracker.get(), request, TabletUid(321, 456), 987 /*shared_id*/,
-                                   20000 /*next_unique_id*/, col_ordinal_to_unique_id, &tablet_meta);
+    Status st = TabletMeta::create(request, TabletUid(321, 456), 987 /*shared_id*/, 20000 /*next_unique_id*/,
+                                   col_ordinal_to_unique_id, &tablet_meta);
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(tablet_meta != nullptr);
 

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -24,7 +24,6 @@
 
 #include "fs/fs_util.h"
 #include "gtest/gtest.h"
-#include "runtime/mem_tracker.h"
 #include "storage/kv_store.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
@@ -44,7 +43,6 @@ static StorageEngine* k_engine = nullptr;
 class TabletMgrTest : public testing::Test {
 public:
     virtual void SetUp() {
-        _mem_tracker = std::make_unique<MemTracker>();
         config::tablet_map_shard_size = 1;
         config::txn_map_shard_size = 1;
         config::txn_shard_size = 1;
@@ -74,7 +72,7 @@ public:
         _schema_hash = 368169781;
         _tablet_data_path = tmp_data_path + "/" + std::to_string(0) + "/" + std::to_string(_tablet_id) + "/" +
                             std::to_string(_schema_hash);
-        _tablet_mgr.reset(new TabletManager(_mem_tracker.get(), 1));
+        _tablet_mgr.reset(new TabletManager(1));
     }
 
     virtual void TearDown() {
@@ -108,7 +106,6 @@ public:
     }
 
 protected:
-    std::unique_ptr<MemTracker> _mem_tracker = nullptr;
     DataDir* _data_dir;
     std::string _engine_data_path;
     int64_t _tablet_id;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -288,10 +288,7 @@ public:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    void SetUp() override {
-        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
-        _metadata_mem_tracker = std::make_unique<MemTracker>();
-    }
+    void SetUp() override { _compaction_mem_tracker = std::make_unique<MemTracker>(-1); }
 
     void TearDown() override {
         if (_tablet2) {
@@ -449,10 +446,9 @@ protected:
     TabletSharedPtr _tablet;
     TabletSharedPtr _tablet2;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
-    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
-static TabletSharedPtr load_same_tablet_from_store(MemTracker* mem_tracker, const TabletSharedPtr& tablet) {
+static TabletSharedPtr load_same_tablet_from_store(const TabletSharedPtr& tablet) {
     auto data_dir = tablet->data_dir();
     auto tablet_id = tablet->tablet_id();
     auto schema_hash = tablet->schema_hash();
@@ -468,7 +464,7 @@ static TabletSharedPtr load_same_tablet_from_store(MemTracker* mem_tracker, cons
     CHECK(tablet_meta->deserialize(serialized_meta).ok());
 
     // Create a new tablet instance from the latest snapshot.
-    auto tablet1 = Tablet::create_tablet_from_meta(mem_tracker, tablet_meta, data_dir);
+    auto tablet1 = Tablet::create_tablet_from_meta(tablet_meta, data_dir);
     CHECK(tablet1 != nullptr);
     CHECK(tablet1->init().ok());
     CHECK(tablet1->init_succeeded());
@@ -761,7 +757,7 @@ void TabletUpdatesTest::test_noncontinous_meta_save_load(bool enable_persistent_
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     _tablet->save_meta();
 
-    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_tablet);
 
     ASSERT_EQ(2, tablet1->updates()->num_pending());
     ASSERT_EQ(2, tablet1->updates()->max_version());
@@ -799,7 +795,7 @@ void TabletUpdatesTest::test_save_meta(bool enable_persistent_index) {
 
     _tablet->save_meta();
 
-    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_tablet);
     ASSERT_EQ(31, tablet1->updates()->version_history_count());
     ASSERT_EQ(31, tablet1->updates()->max_version());
 
@@ -877,7 +873,7 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     EXPECT_EQ(-1, read_tablet(_tablet, 2));
     EXPECT_EQ(-1, read_tablet(_tablet, 1));
 
-    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_tablet);
     EXPECT_EQ(1, tablet1->updates()->version_history_count());
     EXPECT_EQ(4, tablet1->updates()->max_version());
     EXPECT_EQ(N, read_tablet(tablet1, 4));
@@ -924,7 +920,7 @@ void TabletUpdatesTest::test_apply(bool enable_persistent_index) {
 
     // Ensure the persistent meta is correct.
     auto max_version = rowsets.size() + 1;
-    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_tablet);
     // `enable_persistent_index` is not persistent in this case
     // so we reset the `enable_persistent_index` after load
     tablet1->set_enable_persistent_index(enable_persistent_index);
@@ -1008,7 +1004,7 @@ void TabletUpdatesTest::test_concurrent_write_read_and_gc(bool enable_persistent
     EXPECT_EQ(version.load(), _tablet->updates()->max_version());
 
     // Ensure the persistent meta is correct.
-    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_tablet);
     EXPECT_EQ(1, tablet1->updates()->version_history_count());
     EXPECT_EQ(version.load(), tablet1->updates()->max_version());
     EXPECT_EQ(N, read_tablet(tablet1, version.load()));
@@ -1444,7 +1440,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental(bool enable_persistent_in
     ASSERT_EQ(6, tablet1->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet1, 6));
 
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(6, tablet2->updates()->max_version());
     ASSERT_EQ(6, tablet2->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet2, 6));
@@ -1518,7 +1514,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_ignore_already_committed_
     ASSERT_EQ(6, tablet1->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet1, 6));
 
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(6, tablet2->updates()->max_version());
     ASSERT_EQ(6, tablet2->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet2, 6));
@@ -2050,7 +2046,7 @@ void TabletUpdatesTest::test_load_snapshot_full(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(11, tablet2->updates()->max_version());
     ASSERT_EQ(1, tablet2->updates()->version_history_count());
     EXPECT_EQ(keys0.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
@@ -2120,7 +2116,7 @@ void TabletUpdatesTest::test_load_snapshot_full_file_not_exist(bool enable_persi
     EXPECT_EQ(keys1.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the persistent meta is still valid.
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(3, tablet2->updates()->max_version());
     ASSERT_EQ(3, tablet2->updates()->version_history_count());
     EXPECT_EQ(keys1.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
@@ -2234,7 +2230,7 @@ void TabletUpdatesTest::test_issue_4193(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size() + keys1.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(13, tablet2->updates()->max_version());
     EXPECT_EQ(keys0.size() + keys1.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
 }
@@ -2287,7 +2283,7 @@ void TabletUpdatesTest::test_issue_4181(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(tablet1);
     ASSERT_EQ(11, tablet2->updates()->max_version());
     EXPECT_EQ(keys0.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
 }

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -341,15 +341,11 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    std::unique_ptr<starrocks::MemTracker> metadata_mem_tracker = std::make_unique<starrocks::MemTracker>();
-    std::unique_ptr<starrocks::MemTracker> schema_change_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.metadata_mem_tracker = metadata_mem_tracker.get();
-    options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();
     starrocks::Status s = starrocks::StorageEngine::open(options, &engine);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -59,8 +59,6 @@ int main(int argc, char** argv) {
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.metadata_mem_tracker = metadata_mem_tracker.get();
-    options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();
     starrocks::Status s = starrocks::StorageEngine::open(options, &engine);


### PR DESCRIPTION
Currently it is too hard to troubleshoot metadata memory problem, and more detailed statistics are required. Add mem statistics for segment for tablet metadata.