### PR TITLE
[Feature] add md5sum_numeric function

### DIFF
--- a/be/src/exprs/vectorized/encryption_functions.h
+++ b/be/src/exprs/vectorized/encryption_functions.h
@@ -47,6 +47,7 @@ public:
      * @return: Int32Column
      */
     DEFINE_VECTORIZED_FN(md5sum);
+    DEFINE_VECTORIZED_FN(md5sum_numeric);
 
     /**
      * @param: [json_string, tagged_value]

--- a/be/src/runtime/large_int_value.h
+++ b/be/src/runtime/large_int_value.h
@@ -33,6 +33,7 @@
 
 #include "runtime/decimal_value.h"
 #include "util/hash_util.hpp"
+#include "util/integer_util.h"
 
 namespace starrocks {
 
@@ -55,12 +56,7 @@ public:
         return d;
     }
 
-    static std::string to_string(__int128 value) {
-        char buf[64] = {0};
-        auto end = fmt::format_to(buf, "{}", value);
-        int len = end - buf;
-        return std::string(buf, len);
-    }
+    static std::string to_string(__int128 value) { return integer_to_string<__int128>(value); }
 };
 
 std::ostream& operator<<(std::ostream& os, __int128 const& value);

--- a/be/src/util/integer_util.h
+++ b/be/src/util/integer_util.h
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <fmt/format.h>
+
+namespace starrocks {
+template <class T>
+inline std::string integer_to_string(T value) {
+    char buf[64] = {0};
+    auto end = fmt::format_to(buf, "{}", value);
+    int len = end - buf;
+    return std::string(buf, len);
+}
+} // namespace starrocks

--- a/be/test/exprs/vectorized/encryption_functions_test.cpp
+++ b/be/test/exprs/vectorized/encryption_functions_test.cpp
@@ -734,6 +734,58 @@ TEST_F(EncryptionFunctionsTest, md5sumNullTest) {
     }
 }
 
+TEST_F(EncryptionFunctionsTest, md5sum_numericTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+
+    std::string plains[] = {"dorisqq", "1", "324", "2111"};
+    std::string results[] = {"313541553194712735798834777371609380343"};
+
+    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+        auto plain = BinaryColumn::create();
+        plain->append(plains[j]);
+        columns.emplace_back(plain);
+    }
+
+    ColumnPtr result = EncryptionFunctions::md5sum_numeric(ctx.get(), columns);
+
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    }
+}
+
+TEST_F(EncryptionFunctionsTest, md5sum_numericNullTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+
+    std::string plains[] = {"dorisqq", "1", "324", "2111"};
+    std::string results[] = {"313541553194712735798834777371609380343"};
+
+    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+        auto plain = BinaryColumn::create();
+        plain->append(plains[j]);
+        columns.emplace_back(plain);
+    }
+
+    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+        auto plain = BinaryColumn::create();
+        plain->append(plains[j]);
+        auto plain_null = NullColumn::create();
+        plain_null->append(1);
+        columns.emplace_back(NullableColumn::create(plain, plain_null));
+    }
+
+    ColumnPtr result = EncryptionFunctions::md5sum_numeric(ctx.get(), columns);
+
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    }
+}
+
 class ShaTestFixture : public ::testing::TestWithParam<std::tuple<std::string, int, std::string>> {};
 
 TEST_P(ShaTestFixture, test_sha2) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -117,6 +117,7 @@ public class FunctionSet {
     public static final String TO_BASE64 = "to_base64";
     public static final String MD5 = "md5";
     public static final String MD5_SUM = "md5sum";
+    public static final String MD5_SUM_NUMERIC = "md5sum_numeric";
     public static final String SHA2 = "sha2";
     public static final String SM3 = "sm3";
 
@@ -469,6 +470,7 @@ public class FunctionSet {
                     .add(FunctionSet.NOW)
                     .add(FunctionSet.UTC_TIMESTAMP)
                     .add(FunctionSet.MD5_SUM)
+                    .add(FunctionSet.MD5_SUM_NUMERIC)
                     .build();
 
     public static final Set<String> decimalRoundFunctions =

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -531,6 +531,7 @@ vectorized_functions = [
     [120130, "to_base64", "VARCHAR", ["VARCHAR"], "EncryptionFunctions::to_base64", False],
     [120140, "md5", "VARCHAR", ["VARCHAR"], "EncryptionFunctions::md5", False],
     [120150, "md5sum", "VARCHAR", ["VARCHAR", "..."], "EncryptionFunctions::md5sum", False],
+    [120151, "md5sum_numeric", "VARCHAR", ["VARCHAR", "..."], "EncryptionFunctions::md5sum_numeric", False],
     [120160, "sha2", "VARCHAR", ["VARCHAR", "INT"], "EncryptionFunctions::sha2", "EncryptionFunctions::sha2_prepare", "EncryptionFunctions::sha2_close", False],
 
       # geo function


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add a new function `md5sum_numeric`, which is similar in function to `md5sum`. It accepts multiple parameters as input and returns the decimal representation of the md5sum value of the input parameters.

Here is an example:
```sql
mysql> select md5sum_numeric(null);
+-----------------------------------------+
| md5sum_numeric(NULL)                    |
+-----------------------------------------+
| 281949768489412648962353822266799178366 |
+-----------------------------------------+
1 row in set (0.01 sec)

mysql> select md5sum_numeric('');
+-----------------------------------------+
| md5sum_numeric('')                      |
+-----------------------------------------+
| 281949768489412648962353822266799178366 |
+-----------------------------------------+
1 row in set (0.00 sec)

mysql> select md5sum_numeric('star');
+-----------------------------------------+
| md5sum_numeric('star')                  |
+-----------------------------------------+
| 191374186311408650337359893478819208715 |
+-----------------------------------------+
1 row in set (0.01 sec)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
