### PR TITLE
[Enhancement] Support use local file to accelerate the broker load

### DIFF
--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -285,7 +285,8 @@ std::string FileScanner::create_tmp_file_path() {
 
     auto stores = StorageEngine::instance()->get_stores();
     std::stringstream ss;
-    ss << stores[cur_sec % stores.size()]->path() << TMP_PREFIX << "/" << buf << "." << generate_uuid_string() << ".tmp";
+    ss << stores[cur_sec % stores.size()]->path() << TMP_PREFIX << "/" << buf << "." << generate_uuid_string()
+       << ".tmp";
     return ss.str();
 }
 

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -20,6 +20,7 @@
 #include "storage/olap_define.h"
 #include "storage/storage_engine.h"
 #include "util/compression/stream_compression.h"
+#include "util/uid_util.h"
 
 namespace starrocks::vectorized {
 
@@ -284,8 +285,7 @@ std::string FileScanner::create_tmp_file_path() {
 
     auto stores = StorageEngine::instance()->get_stores();
     std::stringstream ss;
-    gettimeofday(&tv, nullptr); // for ensuring file path random
-    ss << stores[cur_sec % stores.size()]->path() << TMP_PREFIX << "/" << buf << "." << tv.tv_usec << ".tmp";
+    ss << stores[cur_sec % stores.size()]->path() << TMP_PREFIX << "/" << buf << "." << generate_uuid_string() << ".tmp";
     return ss.str();
 }
 

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -289,7 +289,8 @@ std::string FileScanner::create_tmp_file_path() {
     return ss.str();
 }
 
-StatusOr<std::shared_ptr<TempRandomAccessFile>> FileScanner::create_tmp_file(std::unique_ptr<SequentialFile> broker_file) {
+StatusOr<std::shared_ptr<TempRandomAccessFile>> FileScanner::create_tmp_file(
+        std::unique_ptr<SequentialFile> broker_file) {
     std::string tmp_file_path = create_tmp_file_path();
     LOG(INFO) << "broker load cache file: " << tmp_file_path;
 

--- a/be/src/exec/vectorized/file_scanner.h
+++ b/be/src/exec/vectorized/file_scanner.h
@@ -9,6 +9,7 @@
 namespace starrocks {
 class SequentialFile;
 class RandomAccessFile;
+class TempRandomAccessFile;
 } // namespace starrocks
 
 namespace starrocks::vectorized {
@@ -58,6 +59,8 @@ protected:
     // materialize is used to transform source chunk depicted by src_slot_descriptors into destination
     // chunk depicted by dest_slot_descriptors
     StatusOr<ChunkPtr> materialize(const starrocks::vectorized::ChunkPtr& src, starrocks::vectorized::ChunkPtr& cast);
+    std::string create_tmp_file_path();
+    StatusOr<std::shared_ptr<TempRandomAccessFile>> create_tmp_file(std::unique_ptr<SequentialFile> broker_file);
 
 protected:
     RuntimeState* _state;

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -272,7 +272,7 @@ private:
 // Wrap `RandomAccessFile`
 class TempRandomAccessFile : public RandomAccessFile {
 public:
-    TempRandomAccessFile(std::string filename, std::shared_ptr<RandomAccessFile> file)
+    TempRandomAccessFile(const std::string& filename, std::shared_ptr<RandomAccessFile> file)
             : RandomAccessFile(file->stream(), filename), _filename(filename), _file(std::move(file)) {}
     ~TempRandomAccessFile() { FileSystem::Default()->delete_file(_filename); }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
@@ -75,6 +75,7 @@ public class LoadStmt extends DdlStmt {
     public static final String TIMEZONE = "timezone";
     public static final String PARTIAL_UPDATE = "partial_update";
     public static final String PRIORITY = "priority";
+    public static final String USE_LOCAL_CACHE = "use_local_cache";
 
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
@@ -112,6 +113,7 @@ public class LoadStmt extends DdlStmt {
             .add(TIMEZONE)
             .add(PARTIAL_UPDATE)
             .add(PRIORITY)
+            .add(USE_LOCAL_CACHE)
             .build();
 
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions,
@@ -254,6 +256,15 @@ public class LoadStmt extends DdlStmt {
         if (priorityProperty != null) {
             if (LoadPriority.priorityByName(priorityProperty) == null) {
                 throw new DdlException(PRIORITY + " should in HIGHEST/HIGH/NORMAL/LOW/LOWEST");
+            }
+        }
+
+        // local cache
+        final String useLocalCache = properties.get(USE_LOCAL_CACHE);
+        if (useLocalCache != null) {
+            if (!useLocalCache.equalsIgnoreCase("true")
+                    && !useLocalCache.equalsIgnoreCase("false")) {
+                throw new DdlException(USE_LOCAL_CACHE + " is not a boolean");
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -230,7 +230,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 LoadLoadingTask task = new LoadLoadingTask(db, table, brokerDesc,
                         brokerFileGroups, getDeadlineMs(), loadMemLimit,
                         strictMode, transactionId, this, timezone, timeoutSecond, createTimestamp, partialUpdate,
-                        sessionVariables, context, TLoadJobType.Broker, priority);
+                        sessionVariables, context, TLoadJobType.Broker, priority, useLocalCache);
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 task.init(loadId, attachment.getFileStatusByTable(aggKey), attachment.getFileNumByTable(aggKey));

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -114,6 +114,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // reuse deleteFlag as partialUpdate
     // @Deprecated
     // protected boolean deleteFlag = false;
+    protected boolean useLocalCache = false; // default is false
 
     protected long createTimestamp = -1;
     protected long loadStartTimestamp = -1;
@@ -230,7 +231,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     public void updateProgess(Long beId, TUniqueId loadId, TUniqueId fragmentId, 
             long sinkRows, long sinkBytes, long sourceRows, long sourceBytes, boolean isDone) {
-        loadingStatus.getLoadStatistic().updateLoadProgress(beId, loadId, fragmentId, sinkRows, 
+        loadingStatus.getLoadStatistic().updateLoadProgress(beId, loadId, fragmentId, sinkRows,
                 sinkBytes, sourceRows, sourceBytes, isDone);
     }
 
@@ -322,6 +323,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
             if (properties.containsKey(LoadStmt.PRIORITY)) {
                 priority = LoadPriority.priorityByName(properties.get(LoadStmt.PRIORITY));
+            }
+
+            if (properties.containsKey(LoadStmt.USE_LOCAL_CACHE)) {
+                useLocalCache = Boolean.parseBoolean(properties.get(LoadStmt.USE_LOCAL_CACHE));
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -70,6 +70,7 @@ public class LoadLoadingTask extends LoadTask {
     private final long timeoutS;
     private final Map<String, String> sessionVariables;
     private final TLoadJobType loadJobType;
+    private boolean useLocalCache;
 
     private LoadingTaskPlanner planner;
     private ConnectContext context;
@@ -78,7 +79,7 @@ public class LoadLoadingTask extends LoadTask {
             long jobDeadlineMs, long execMemLimit, boolean strictMode,
             long txnId, LoadTaskCallback callback, String timezone,
             long timeoutS, long createTimestamp, boolean partialUpdate, Map<String, String> sessionVariables, 
-            ConnectContext context, TLoadJobType loadJobType, int priority) {
+            ConnectContext context, TLoadJobType loadJobType, int priority, boolean useLocalCache) {
         super(callback, TaskType.LOADING, priority);
         this.db = db;
         this.table = table;
@@ -97,12 +98,13 @@ public class LoadLoadingTask extends LoadTask {
         this.sessionVariables = sessionVariables;
         this.context = context;
         this.loadJobType = loadJobType;
+        this.useLocalCache = useLocalCache;
     }
 
     public void init(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
         this.loadId = loadId;
         planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups,
-                strictMode, timezone, timeoutS, createTimestamp, partialUpdate);
+                strictMode, timezone, timeoutS, createTimestamp, partialUpdate, useLocalCache);
         planner.plan(loadId, fileStatusList, fileNum);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -85,6 +85,7 @@ public class LoadingTaskPlanner {
     private final boolean partialUpdate;
     private final int parallelInstanceNum;
     private final long startTime;
+    private final boolean useLocalCache;
 
     // Something useful
     // ConnectContext here is just a dummy object to avoid some NPE problem, like ctx.getDatabase()
@@ -103,7 +104,7 @@ public class LoadingTaskPlanner {
     public LoadingTaskPlanner(Long loadJobId, long txnId, long dbId, OlapTable table,
                               BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
                               boolean strictMode, String timezone, long timeoutS,
-                              long startTime, boolean partialUpdate) {
+                              long startTime, boolean partialUpdate, boolean useLocalCache) {
         this.loadJobId = loadJobId;
         this.txnId = txnId;
         this.dbId = dbId;
@@ -116,6 +117,7 @@ public class LoadingTaskPlanner {
         this.partialUpdate = partialUpdate;
         this.parallelInstanceNum = Config.load_parallel_instance_num;
         this.startTime = startTime;
+        this.useLocalCache = useLocalCache;
     }
 
     public void plan(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusesList, int filesAdded)
@@ -175,6 +177,7 @@ public class LoadingTaskPlanner {
                 fileStatusesList, filesAdded);
         scanNode.setLoadInfo(loadJobId, txnId, table, brokerDesc, fileGroups, strictMode, parallelInstanceNum);
         scanNode.setUseVectorizedLoad(true);
+        scanNode.setUseLocalCache(useLocalCache);
         scanNode.init(analyzer);
         scanNode.finalizeStats(analyzer);
         scanNodes.add(scanNode);
@@ -217,6 +220,7 @@ public class LoadingTaskPlanner {
                 fileStatusesList, filesAdded);
         scanNode.setLoadInfo(loadJobId, txnId, table, brokerDesc, fileGroups, strictMode, parallelInstanceNum);
         scanNode.setUseVectorizedLoad(true);
+        scanNode.setUseLocalCache(useLocalCache);
         scanNode.init(analyzer);
         scanNode.finalizeStats(analyzer);
         scanNodes.add(scanNode);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -142,6 +142,8 @@ public class FileScanNode extends LoadScanNode {
     // 3. use vectorized engine
     private boolean useVectorizedLoad;
 
+    private boolean useLocalCache;
+
     private static class ParamCreateContext {
         public BrokerFileGroup fileGroup;
         public TBrokerScanRangeParams params;
@@ -160,6 +162,7 @@ public class FileScanNode extends LoadScanNode {
         this.filesAdded = filesAdded;
         this.parallelInstanceNum = 1;
         this.useVectorizedLoad = false;
+        this.useLocalCache = false;
     }
 
     @Override
@@ -229,6 +232,10 @@ public class FileScanNode extends LoadScanNode {
         this.useVectorizedLoad = useVectorizedLoad;
     }
 
+    public void setUseLocalCache(boolean useLocalCache) {
+        this.useLocalCache = useLocalCache;
+    }
+
     // Called from init, construct source tuple information
     private void initParams(ParamCreateContext context)
             throws UserException {
@@ -266,6 +273,7 @@ public class FileScanNode extends LoadScanNode {
         params.setStrict_mode(strictMode);
         params.setProperties(brokerDesc.getProperties());
         params.setUse_broker(brokerDesc.hasBroker());
+        params.setUse_local_cache(useLocalCache);
         initColumns(context);
         initWhereExpr(fileGroup.getWhereExpr(), analyzer);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
@@ -183,7 +183,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 1;
         long startTime = System.currentTimeMillis();
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, false);
         planner.plan(loadId, fileStatusesList, 2);
         Assert.assertEquals(1, planner.getScanNodes().size());
         FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
@@ -193,7 +193,7 @@ public class LoadingTaskPlannerTest {
         // load_parallel_instance_num: 2
         Config.load_parallel_instance_num = 2;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, false);
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -203,7 +203,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 2;
         Config.max_broker_concurrency = 3;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, false);
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -285,7 +285,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -423,7 +423,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -506,7 +506,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -593,7 +593,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -699,7 +699,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -795,7 +795,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -899,7 +899,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment
@@ -1000,7 +1000,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, false);
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -218,6 +218,8 @@ struct TBrokerScanRangeParams {
     15: optional i32 hdfs_read_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties
     16: THdfsProperties hdfs_properties
+    // If use_local_cache is set, we will use local file for broker random access
+    17: optional bool use_local_cache = false
 }
 
 // Broker scan range


### PR DESCRIPTION
## What type of PR is this：
- [x] Enhancement

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When there is obvious network latency(e.g. ping command cost time greater than 40ms) between BE and broker file(such as in different idc), broker load ran into slow.

This PR set `use_local_cache` in broker load option to accelerate it.
```
LOAD LABEL test_db.label1
(
    xxx
)
WITH BROKER "mybroker"
(
    xxx
)
PROPERTIES
(
    "timeout" = "3600"
    "use_local_cache" = "true"
);
```
test result:

orc broker load（file count：101，total data size：13GB，table field count:25）

| BE&broker file in different idc  | use [Optimize orc load random I/O](https://github.com/StarRocks/starrocks/pull/11328) | use local cache | elapsed time
| ------------- | ------------- |------------- |------------- |
| NO | NO | NO  | 7min |
| NO | YES | NO  | 6.5min |
| NO | NO | YES  | 6.5min |
| NO | YES | YES  | 6.5min |
| YES | NO | NO  | 30min timeoute |
| YES | YES | NO  | 30min timeoute |
| YES | NO | YES  | 11min |
| YES | YES | YES  | 11min |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
