### PR TITLE
[Cherry-pick 2.3][Feature] add separated authorized user in audit log. (#11099)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -55,8 +55,13 @@ public class AuditEvent {
     public long timestamp = -1;
     @AuditField(value = "Client")
     public String clientIp = "";
+    // The original login user
     @AuditField(value = "User")
     public String user = "";
+    // The user used to authorize
+    // `User` could be different from `AuthorizedUser` if impersonated
+    @AuditField(value = "AuthorizedUser")
+    public String authorizedUser = "";
     @AuditField(value = "ResourceGroup")
     public String resourceGroup = "default_wg";
     @AuditField(value = "Catalog")
@@ -124,6 +129,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setUser(String user) {
             auditEvent.user = user;
+            return this;
+        }
+
+        public AuditEventBuilder setAuthorizedUser(String authorizedUser) {
+            auditEvent.authorizedUser = authorizedUser;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -283,6 +283,7 @@ public class ConnectProcessor {
                 .setTimestamp(System.currentTimeMillis())
                 .setClientIp(ctx.getMysqlChannel().getRemoteHostPortString())
                 .setUser(ctx.getQualifiedUser())
+                .setAuthorizedUser(ctx.getCurrentUserIdentity().toString())
                 .setDb(ctx.getDatabase())
                 .setCatalog(ctx.getCurrentCatalog());
         ctx.getPlannerProfile().reset();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
@@ -46,6 +46,7 @@ public class AuditEventProcessorTest {
                 .setTimestamp(System.currentTimeMillis())
                 .setClientIp("127.0.0.1")
                 .setUser("user1")
+                .setAuthorizedUser("user2")
                 .setDb("db1")
                 .setState("EOF")
                 .setQueryTime(2000)
@@ -59,6 +60,7 @@ public class AuditEventProcessorTest {
         Assert.assertEquals("127.0.0.1", event.clientIp);
         Assert.assertEquals(200000, event.scanRows);
         Assert.assertEquals("catalog1", event.catalog);
+        Assert.assertEquals("user2", event.authorizedUser);
     }
 
     @Test
@@ -73,6 +75,7 @@ public class AuditEventProcessorTest {
                         .setTimestamp(System.currentTimeMillis())
                         .setClientIp("127.0.0.1")
                         .setUser("user1")
+                        .setAuthorizedUser("user2")
                         .setDb("db1")
                         .setState("EOF")
                         .setQueryTime(2000)
@@ -99,6 +102,7 @@ public class AuditEventProcessorTest {
                     .setTimestamp(System.currentTimeMillis())
                     .setClientIp("127.0.0.1")
                     .setUser("user1")
+                    .setAuthorizedUser("user2")
                     .setDb("db1")
                     .setState("EOF")
                     .setQueryTime(2000)

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -22,6 +22,7 @@
 package com.starrocks.qe;
 
 import com.starrocks.analysis.AccessTestUtil;
+import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.MysqlCapability;
@@ -257,6 +258,10 @@ public class ConnectProcessorTest {
                 context.getClusterName();
                 minTimes = 0;
                 result = "testCluster";
+
+                context.getCurrentUserIdentity();
+                minTimes = 0;
+                result = UserIdentity.ROOT;
 
                 context.getStartTime();
                 minTimes = 0;


### PR DESCRIPTION
"SQL statements after `execute as xxx` statement, audit log still shows old user id as the user executing SQL statement. So that there is no easy way to ensure StarRocks uses a new user id to execute the SQL statement. I hope the user in the audit log can change to a new user id. Please help. Thanks."

Add a new field called `AuthroizedUser` to record the user used to authorize. The original `User` field merely represents the login name of the login user.

manually cherry-pick from 95290745404aa8eb34cc403fd748fd6e1ef53748