### PR TITLE
[BugFix] upgrade librdkafka to v1.9.2

### DIFF
--- a/thirdparty/patches/librdkafka.patch
+++ b/thirdparty/patches/librdkafka.patch
@@ -1,8 +1,8 @@
 --- src/rdkafka_broker.c
 +++ src/rdkafka_broker.c
-@@ -5467,7 +5467,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
+@@ -5388,7 +5388,7 @@ static int rd_kafka_broker_thread_main(void *arg) {
   */
- void rd_kafka_broker_destroy_final (rd_kafka_broker_t *rkb) {
+ void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
  
 -        rd_assert(thrd_is_current(rkb->rkb_thread));
 +        //rd_assert(thrd_is_current(rkb->rkb_thread));

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -185,10 +185,10 @@ ROCKSDB_SOURCE=rocksdb-6.22.1
 ROCKSDB_MD5SUM="02727e52cdb94fa6a9dbbd68d157e619"
 
 # librdkafka
-LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.8.2.tar.gz"
-LIBRDKAFKA_NAME=librdkafka-1.8.2.tar.gz
-LIBRDKAFKA_SOURCE=librdkafka-1.8.2
-LIBRDKAFKA_MD5SUM="0abec0888d10c9553cdcbcbf9172d558"
+LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
+LIBRDKAFKA_NAME=librdkafka-1.9.2.tar.gz
+LIBRDKAFKA_SOURCE=librdkafka-1.9.2
+LIBRDKAFKA_MD5SUM="fe9624e905abbf8324b0f6be520d9c24"
 
 # zstd
 ZSTD_DOWNLOAD="https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/edenhill/librdkafka/pull/3639

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
[librdkafka v1.9.0 release note](https://github.com/edenhill/librdkafka/releases)
```
A ERR_MSG_SIZE_TOO_LARGE consumer error would previously be raised
if the consumer received a maximum sized FetchResponse only containing
(transaction) aborted messages with no control messages. The fetching did
not stop, but some applications would terminate upon receiving this error.
No error is now raised in this case. (https://github.com/edenhill/librdkafka/issues/2993)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
