### PR TITLE
[BugFix] support both inner and outer table column in one side of operator in correlated predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -13,7 +13,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
 
@@ -156,16 +155,4 @@ public class JoinHelper {
         return type.isCrossJoin() || JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN.equals(type) ||
                 (type.isInnerJoin() && equalOnPredicate.isEmpty()) || "BROADCAST".equalsIgnoreCase(hint);
     }
-
-    public static boolean isJoinConditionContainsEq(OptExpression joinOpt) {
-        LogicalJoinOperator joinOperator = (LogicalJoinOperator) joinOpt.getOp();
-        ScalarOperator predicate = joinOperator.getOnPredicate();
-        ColumnRefSet leftColumnSet = joinOpt.getInputs().get(0).getOutputColumns();
-        ColumnRefSet rightColumnSet = joinOpt.getInputs().get(1).getOutputColumns();
-        List<BinaryPredicateOperator> equalConjuncts = JoinHelper.
-                getEqualsPredicate(leftColumnSet, rightColumnSet, Utils.extractConjuncts(predicate));
-        return CollectionUtils.isNotEmpty(equalConjuncts);
-    }
-
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -311,7 +311,7 @@ public class Optimizer {
     private OptExpression extractBestPlan(PhysicalPropertySet requiredProperty,
                                           Group rootGroup) {
         GroupExpression groupExpression = rootGroup.getBestExpression(requiredProperty);
-        Preconditions.checkNotNull(groupExpression, "no plan this sql");
+        Preconditions.checkNotNull(groupExpression, "no executable plan for this sql");
         List<PhysicalPropertySet> inputProperties = groupExpression.getInputProperties(requiredProperty);
 
         List<OptExpression> childPlans = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -139,11 +140,11 @@ public class SubqueryUtils {
         return correlationPredicate.clone().accept(scalarOperatorShuttle, null);
     }
 
-    public static boolean containsExpr(Map<ColumnRefOperator, ScalarOperator> innerRefMap) {
-        return innerRefMap.values().stream().anyMatch(e -> !e.isColumnRef());
+    public static boolean existNonColumnRef(Collection<ScalarOperator> scalarOperators) {
+        return scalarOperators.stream().anyMatch(e -> !e.isColumnRef());
     }
 
-    public static Map<ColumnRefOperator, ScalarOperator> updateOutputColumns(
+    public static Map<ColumnRefOperator, ScalarOperator> generateChildOutColumns(
             OptExpression input, Map<ColumnRefOperator, ScalarOperator> columns, OptimizerContext context) {
         Map<ColumnRefOperator, ScalarOperator> outPutColumns = Maps.newHashMap();
         context.getColumnRefFactory().getColumnRefs(input.getOutputColumns()).stream()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -193,7 +193,7 @@ public class SubqueryUtils {
     }
 
 
-    public static ScalarOperator rewritePredicateAndExtractColumnRefs (
+    public static ScalarOperator rewritePredicateAndExtractColumnRefs(
             ScalarOperator correlationPredicate, BaseScalarOperatorShuttle scalarOperatorShuttle) {
         return correlationPredicate.accept(scalarOperatorShuttle, null);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -25,11 +25,11 @@ import java.util.Map;
 
 public class SubqueryUtils {
 
-    public static String EXIST_NON_EQ_PREDICATE = "Not support Non-EQ correlated predicate in correlated subquery";
+    public static final String EXIST_NON_EQ_PREDICATE = "Not support Non-EQ correlated predicate in correlated subquery";
 
-    public static String NONE_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
+    public static final String NONE_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
 
-    public static String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with a correlated subquery";
+    public static final String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with a correlated subquery";
 
     private static Function getAggregateFunction(String functionName, Type[] argTypes) {
         Function func = Expr.getBuiltinFunction(functionName, argTypes,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -44,34 +44,7 @@ public class SubqueryUtils {
     // ApplyNode doesn't need to check the number of subquery's return rows
     // when the correlation predicate meets these requirements:
     // 1. All predicate is Binary.EQ
-    // 2. Only a child contains outer table's column
     // @todo: only check contains, not all
-    public static boolean checkAllIsBinaryEQ(List<ScalarOperator> correlationPredicate,
-                                             List<ColumnRefOperator> correlationColumnRefs) {
-        for (ScalarOperator predicate : correlationPredicate) {
-            if (!OperatorType.BINARY.equals(predicate.getOpType())) {
-                return false;
-            }
-
-            BinaryPredicateOperator bpo = ((BinaryPredicateOperator) predicate);
-            if (!BinaryPredicateOperator.BinaryType.EQ.equals(bpo.getBinaryType())) {
-                return false;
-            }
-
-            ScalarOperator left = bpo.getChild(0);
-            ScalarOperator right = bpo.getChild(1);
-
-            boolean correlationLeft = Utils.containAnyColumnRefs(correlationColumnRefs, left);
-            boolean correlationRight = Utils.containAnyColumnRefs(correlationColumnRefs, right);
-
-            if (correlationLeft == correlationRight) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     public static boolean checkAllIsBinaryEQ(List<ScalarOperator> correlationPredicate) {
         for (ScalarOperator predicate : correlationPredicate) {
             if (!OperatorType.BINARY.equals(predicate.getOpType())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -184,7 +184,7 @@ public class SubqueryUtils {
 
         private final Set<ScalarOperator> innerTableExprSet;
 
-        private InnerTableExprExtractor (List<ColumnRefOperator> correlationCols) {
+        private InnerTableExprExtractor(List<ColumnRefOperator> correlationCols) {
             correlationColSet = new ColumnRefSet(correlationCols);
             innerTableExprSet = Sets.newHashSet();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -29,7 +29,8 @@ public class SubqueryUtils {
 
     public static final String NONE_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
 
-    public static final String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with a correlated subquery";
+    public static final String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with " +
+            "a correlated subquery";
 
     private static Function getAggregateFunction(String functionName, Type[] argTypes) {
         Function func = Expr.getBuiltinFunction(functionName, argTypes,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -28,7 +28,7 @@ public class SubqueryUtils {
 
     public static final String EXIST_NON_EQ_PREDICATE = "Not support Non-EQ correlated predicate in correlated subquery";
 
-    public static final String NONE_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
+    public static final String NOT_FOUND_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
 
     public static final String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with " +
             "a correlated subquery";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -25,9 +25,11 @@ import java.util.Map;
 
 public class SubqueryUtils {
 
-    public static String EXIST_NON_EQ_PREDICATE = "Not support Non-EQ correlation predicate in correlation subquery";
+    public static String EXIST_NON_EQ_PREDICATE = "Not support Non-EQ correlated predicate in correlated subquery";
 
-    public static String NONE_CORRELATED_PREDICATE = "Not support none correlation predicate in correlation subquery";
+    public static String NONE_CORRELATED_PREDICATE = "Not support without correlated predicate in correlated subquery";
+
+    public static String CONST_QUANTIFIED_COMPARISON = "Not support const value quantified comparison with a correlated subquery";
 
     private static Function getAggregateFunction(String functionName, Type[] argTypes) {
         Function func = Expr.getBuiltinFunction(functionName, argTypes,
@@ -41,10 +43,11 @@ public class SubqueryUtils {
         return func;
     }
 
-    // ApplyNode doesn't need to check the number of subquery's return rows
-    // when the correlation predicate meets these requirements:
-    // 1. All predicate is Binary.EQ
-    // @todo: only check contains, not all
+    /**
+     * ApplyNode doesn't need to check the number of subquery's return rows
+     * when the correlation predicate meets these requirements:
+     * 1. All predicate is Binary.EQ
+     */
     public static boolean checkAllIsBinaryEQ(List<ScalarOperator> correlationPredicate) {
         for (ScalarOperator predicate : correlationPredicate) {
             if (!OperatorType.BINARY.equals(predicate.getOpType())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -444,22 +444,6 @@ public class Utils {
         return true;
     }
 
-    public static boolean containsEqualBinaryPredicate(ScalarOperator predicate) {
-        if (predicate instanceof BinaryPredicateOperator) {
-            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;
-            return binaryPredicate.getBinaryType().isEquivalence();
-        }
-        if (predicate instanceof CompoundPredicateOperator) {
-            CompoundPredicateOperator compoundPredicate = (CompoundPredicateOperator) predicate;
-            if (compoundPredicate.isAnd()) {
-                return isEqualBinaryPredicate(compoundPredicate.getChild(0)) ||
-                        isEqualBinaryPredicate(compoundPredicate.getChild(1));
-            }
-            return false;
-        }
-        return false;
-    }
-
     public static boolean isEqualBinaryPredicate(ScalarOperator predicate) {
         if (predicate instanceof BinaryPredicateOperator) {
             BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -1,8 +1,10 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.sql.optimizer.base;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.CaseExpr;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
@@ -19,6 +21,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ColumnRefFactory {
     private int nextId = 1;
@@ -72,6 +75,17 @@ public class ColumnRefFactory {
     public ColumnRefOperator getColumnRef(int id) {
         return columnRefs.get(id - 1);
     }
+
+    public Set<ColumnRefOperator> getColumnRefs(ColumnRefSet columnRefSet) {
+        Preconditions.checkState(!columnRefSet.isEmpty());
+        Set<ColumnRefOperator> columnRefOperators = Sets.newHashSet();
+        for (int idx : columnRefSet.getColumnIds()) {
+            columnRefOperators.add(getColumnRef(idx));
+        }
+        return columnRefOperators;
+    }
+
+
 
     public void updateColumnRefToColumns(ColumnRefOperator columnRef, Column column, Table table) {
         columnRefToColumns.put(columnRef, column);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -1,7 +1,6 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.sql.optimizer.base;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -77,7 +76,6 @@ public class ColumnRefFactory {
     }
 
     public Set<ColumnRefOperator> getColumnRefs(ColumnRefSet columnRefSet) {
-        Preconditions.checkState(!columnRefSet.isEmpty());
         Set<ColumnRefOperator> columnRefOperators = Sets.newHashSet();
         for (int idx : columnRefSet.getColumnIds()) {
             columnRefOperators.add(getColumnRef(idx));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BetweenPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BetweenPredicateOperator.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.List;
 import java.util.Objects;
 
 public class BetweenPredicateOperator extends PredicateOperator {
@@ -14,6 +15,12 @@ public class BetweenPredicateOperator extends PredicateOperator {
         super(OperatorType.BETWEEN, arguments);
         this.notBetween = notBetween;
         Preconditions.checkState(arguments.length == 3);
+    }
+
+    public BetweenPredicateOperator(boolean notBetween, List<ScalarOperator> arguments) {
+        super(OperatorType.BETWEEN, arguments);
+        this.notBetween = notBetween;
+        Preconditions.checkState(arguments != null && arguments.size() == 3);
     }
 
     public boolean isNotBetween() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -18,6 +19,12 @@ public class CompoundPredicateOperator extends PredicateOperator {
         super(OperatorType.COMPOUND, arguments);
         this.type = compoundType;
         Preconditions.checkState(arguments.length >= 1);
+    }
+
+    public CompoundPredicateOperator(CompoundType compoundType, List<ScalarOperator> arguments) {
+        super(OperatorType.COMPOUND, arguments);
+        this.type = compoundType;
+        Preconditions.checkState(!CollectionUtils.isEmpty(arguments));
     }
 
     public CompoundType getCompoundType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LikePredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LikePredicateOperator.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.List;
 import java.util.Objects;
 
 public class LikePredicateOperator extends PredicateOperator {
@@ -19,6 +20,12 @@ public class LikePredicateOperator extends PredicateOperator {
         super(OperatorType.LIKE, arguments);
         this.likeType = likeType;
         Preconditions.checkState(arguments.length == 2);
+    }
+
+    public LikePredicateOperator(LikeType likeType, List<ScalarOperator> arguments) {
+        super(OperatorType.LIKE, arguments);
+        this.likeType = likeType;
+        Preconditions.checkState(arguments != null && arguments.size() == 2);
     }
 
     public enum LikeType {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -1,0 +1,216 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayElementOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArraySliceOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+
+import java.util.List;
+
+public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOperator, Void> {
+
+    public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {
+        return scalarOperator;
+    }
+
+    @Override
+    public ScalarOperator visitConstant(ConstantOperator literal, Void context) {
+        return literal;
+    }
+
+    @Override
+    public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+        return variable;
+    }
+
+    @Override
+    public ScalarOperator visitArray(ArrayOperator array, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(array.getChildren(), update);
+        if (update[0]) {
+            return new ArrayOperator(array.getType(), array.isNullable(), clonedOperators);
+        } else {
+            return array;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitArrayElement(ArrayElementOperator array, Void Context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(array.getChildren(), update);
+        if (update[0]) {
+            return new ArrayElementOperator(array.getType(), clonedOperators.get(0), clonedOperators.get(1));
+        }
+        return array;
+    }
+
+    @Override
+    public ScalarOperator visitArraySlice(ArraySliceOperator array, Void Context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(array.getChildren(), update);
+        if (update[0]) {
+            return new ArraySliceOperator(array.getType(), clonedOperators);
+        } else {
+            return array;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitCall(CallOperator call, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(call.getChildren(), update);
+        if (update[0]) {
+            return new CallOperator(call.getFnName(), call.getType(), clonedOperators,
+                    call.getFunction(), call.isDistinct());
+        } else {
+            return call;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitPredicate(PredicateOperator predicate, Void context) {
+        return predicate;
+    }
+
+    @Override
+    public ScalarOperator visitBetweenPredicate(BetweenPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new BetweenPredicateOperator(predicate.isNotBetween(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new BinaryPredicateOperator(predicate.getBinaryType(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+
+    @Override
+    public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new CompoundPredicateOperator(predicate.getCompoundType(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitExistsPredicate(ExistsPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new ExistsPredicateOperator(predicate.isNotExists(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitInPredicate(InPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new InPredicateOperator(predicate.isNotIn(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new IsNullPredicateOperator(predicate.isNotNull(), clonedOperators.get(0));
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitLikePredicateOperator(LikePredicateOperator predicate, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(predicate.getChildren(), update);
+        if (update[0]) {
+            return new LikePredicateOperator(predicate.getLikeType(), clonedOperators);
+        } else {
+            return predicate;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitCastOperator(CastOperator operator, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(operator.getChildren(), update);
+        if (update[0]) {
+            return new CastOperator(operator.getType(), clonedOperators.get(0), operator.isImplicit());
+        } else {
+            return operator;
+        }
+    }
+
+    @Override
+    public ScalarOperator visitCaseWhenOperator(CaseWhenOperator operator, Void context) {
+        boolean[] update = {false};
+        List<ScalarOperator> clonedOperators = visitList(operator.getChildren(), update);
+        if (update[0]) {
+            ScalarOperator clonedCaseClause = null;
+            ScalarOperator clonedElseClause = null;
+            List<ScalarOperator> clonedWhenThenClauses;
+            if (operator.getCaseClause() != null) {
+                clonedCaseClause = clonedOperators.get(0);
+            }
+            if (operator.getElseClause() != null) {
+                clonedElseClause = clonedOperators.get(clonedOperators.size() - 1);
+            }
+
+            int whenThenEndIdx = operator.getElseClause() == null ? clonedOperators.size() : clonedOperators.size() - 1;
+            clonedWhenThenClauses = clonedOperators.subList(operator.getWhenStart(), whenThenEndIdx);
+
+            return new CaseWhenOperator(operator.getType(), clonedCaseClause, clonedElseClause, clonedWhenThenClauses);
+        } else {
+             return operator;
+        }
+    }
+
+    protected List<ScalarOperator> visitList(List<ScalarOperator> operators, boolean[] update) {
+        List<ScalarOperator> clonedOperators = Lists.newArrayList();
+        for (ScalarOperator operator : operators) {
+            ScalarOperator clonedOperator = operator.accept(this, null);
+            if ((clonedOperator != operator) && (update != null)) {
+                update[0] = true;
+            }
+            clonedOperators.add(clonedOperator);
+        }
+        return clonedOperators;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -214,7 +214,7 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
 
         List<ScalarOperator> clonedOperators = Lists.newArrayList();
         for (ScalarOperator operator : operators) {
-            ScalarOperator clonedOperator = operator == null ? null :operator.accept(this, null);
+            ScalarOperator clonedOperator = operator == null ? null : operator.accept(this, null);
             if ((clonedOperator != operator) && (update != null)) {
                 update[0] = true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -52,7 +52,7 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
     }
 
     @Override
-    public ScalarOperator visitArrayElement(ArrayElementOperator array, Void Context) {
+    public ScalarOperator visitArrayElement(ArrayElementOperator array, Void context) {
         boolean[] update = {false};
         List<ScalarOperator> clonedOperators = visitList(array.getChildren(), update);
         if (update[0]) {
@@ -62,7 +62,7 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
     }
 
     @Override
-    public ScalarOperator visitArraySlice(ArraySliceOperator array, Void Context) {
+    public ScalarOperator visitArraySlice(ArraySliceOperator array, Void context) {
         boolean[] update = {false};
         List<ScalarOperator> clonedOperators = visitList(array.getChildren(), update);
         if (update[0]) {
@@ -198,7 +198,7 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
 
             return new CaseWhenOperator(operator.getType(), clonedCaseClause, clonedElseClause, clonedWhenThenClauses);
         } else {
-             return operator;
+            return operator;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -24,6 +24,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
 import java.util.List;
 
+/**
+ * When you want to replace some types of nodes in a scalarOperator tree, you can extend this class and
+ * override specific visit methods. It will return a new scalarOperator tree with specific nodes replaced.
+ * shuttle means a scalarOperator bus, it takes you traverse the scalarOperator tree.
+ */
 public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOperator, Void> {
 
     public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -208,9 +208,13 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
     }
 
     protected List<ScalarOperator> visitList(List<ScalarOperator> operators, boolean[] update) {
+        if (operators == null) {
+            return null;
+        }
+
         List<ScalarOperator> clonedOperators = Lists.newArrayList();
         for (ScalarOperator operator : operators) {
-            ScalarOperator clonedOperator = operator.accept(this, null);
+            ScalarOperator clonedOperator = operator == null ? null :operator.accept(this, null);
             if ((clonedOperator != operator) && (update != null)) {
                 update[0] = true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
@@ -14,6 +14,17 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * used to extract distinct expr which only contains inner table column and replace it with a new columnRef.
+ * e.g. t1 is inner table, t2 is outer table. correlated predicate is:
+ * t1.col1 + t2.col1 = abs(t1.col2) + t2.col1 + concat(t1.col1, t2.col1)
+ * The rewriter will extract abs(t1.col2), t2.col1 and build scalarOperator to new columnRef map like:
+ * t1.col1 : t1.col1
+ * abs(t1.col2) : columnRef1
+ *
+ * then and rewrite the predicate like:
+ * t1.col1 + t2.col1 = columnRef1 + t2.col1 + concat(t1.col1, t2.col1)
+ */
 public class CorrelatedPredicateRewriter extends BaseScalarOperatorShuttle {
 
     private final ColumnRefSet correlationColSet;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
@@ -94,13 +94,19 @@ public class CorrelatedPredicateRewriter extends BaseScalarOperatorShuttle {
         return super.visitCastOperator(operator, context);
     }
 
+    /**
+     * if exprToColumnRefMap doesn't contain operator means should create a new columnRef to replace this operator,
+     * otherwise replace this operator with exist columnRef.
+     * @param operator
+     * @return
+     */
     private ScalarOperator addExprToColumnRefMap(ScalarOperator operator) {
         if (!exprToColumnRefMap.containsKey(operator)) {
             ColumnRefOperator columnRefOperator = createColumnRefOperator(operator);
             exprToColumnRefMap.put(operator, columnRefOperator);
             return columnRefOperator;
         } else {
-            return operator;
+            return exprToColumnRefMap.get(operator);
         }
     }
     private ColumnRefOperator createColumnRefOperator(ScalarOperator operator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
@@ -1,0 +1,110 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.google.common.collect.Maps;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+
+import java.util.List;
+import java.util.Map;
+
+public class CorrelatedPredicateRewriter extends BaseScalarOperatorShuttle {
+
+    private final ColumnRefSet correlationColSet;
+
+    private final Map<ScalarOperator, ColumnRefOperator> exprToColumnRefMap;
+
+    private final OptimizerContext optimizerContext;
+
+    public Map<ColumnRefOperator, ScalarOperator> getColumnRefToExprMap() {
+        Map<ColumnRefOperator, ScalarOperator> columnRefToExprMap = Maps.newHashMap();
+        exprToColumnRefMap.entrySet().stream().forEach(e -> columnRefToExprMap.put(e.getValue(), e.getKey()));
+        return columnRefToExprMap;
+    }
+
+    public CorrelatedPredicateRewriter(List<ColumnRefOperator> correlationCols, OptimizerContext optimizerContext) {
+        correlationColSet = new ColumnRefSet(correlationCols);
+        this.optimizerContext = optimizerContext;
+        exprToColumnRefMap = Maps.newHashMap();
+    }
+
+    @Override
+    public ScalarOperator visit(ScalarOperator operator, Void context) {
+        return operator;
+    }
+
+    @Override
+    public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+        ColumnRefSet usedColumns = variable.getUsedColumns();
+
+        if (correlationColSet.containsAll(usedColumns)) {
+            return variable;
+        }
+        exprToColumnRefMap.putIfAbsent(variable, variable);
+        return variable;
+    }
+
+    @Override
+    public ScalarOperator visitCall(CallOperator call, Void context) {
+        ColumnRefSet usedColumns = call.getUsedColumns();
+
+        if (correlationColSet.containsAll(usedColumns)) {
+            return call;
+        }
+
+        if (!correlationColSet.isIntersect(usedColumns)) {
+            return addExprToColumnRefMap(call);
+        }
+
+        return super.visitCall(call, context);
+    }
+
+    @Override
+    public ScalarOperator visitCaseWhenOperator(CaseWhenOperator operator, Void context) {
+        ColumnRefSet usedColumns = operator.getUsedColumns();
+
+        if (correlationColSet.containsAll(usedColumns)) {
+            return operator;
+        }
+
+        if (!correlationColSet.isIntersect(usedColumns)) {
+            return addExprToColumnRefMap(operator);
+        }
+
+        return super.visitCaseWhenOperator(operator, context);
+    }
+
+    @Override
+    public ScalarOperator visitCastOperator(CastOperator operator, Void context) {
+        ColumnRefSet usedColumns = operator.getUsedColumns();
+
+        if (correlationColSet.containsAll(usedColumns)) {
+            return operator;
+        }
+
+        if (!correlationColSet.isIntersect(usedColumns)) {
+            return addExprToColumnRefMap(operator);
+        }
+        return super.visitCastOperator(operator, context);
+    }
+
+    private ScalarOperator addExprToColumnRefMap(ScalarOperator operator) {
+        if (!exprToColumnRefMap.containsKey(operator)) {
+            ColumnRefOperator columnRefOperator = createColumnRefOperator(operator);
+            exprToColumnRefMap.put(operator, columnRefOperator);
+            return columnRefOperator;
+        } else {
+            return operator;
+        }
+    }
+    private ColumnRefOperator createColumnRefOperator(ScalarOperator operator) {
+        return optimizerContext.getColumnRefFactory().create(operator, operator.getType(), operator.isNullable());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
@@ -11,7 +11,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-
 import java.util.List;
 import java.util.Map;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/CorrelatedPredicateRewriter.java
@@ -17,13 +17,14 @@ import java.util.Map;
 /**
  * used to extract distinct expr which only contains inner table column and replace it with a new columnRef.
  * e.g. t1 is inner table, t2 is outer table. correlated predicate is:
- * t1.col1 + t2.col1 = abs(t1.col2) + t2.col1 + concat(t1.col1, t2.col1)
- * The rewriter will extract abs(t1.col2), t2.col1 and build scalarOperator to new columnRef map like:
+ * t1.col1 + t2.col1 = abs(t1.col2) + t2.col1 + concat(t1.col3, t2.col1) + abs(t1.col2)
+ * The rewriter will extract abs(t1.col2), t1.col1, t1.col3 and build scalarOperator to new columnRef map like:
  * t1.col1 : t1.col1
+ * t1.col3 : t1.col3
  * abs(t1.col2) : columnRef1
  *
  * then and rewrite the predicate like:
- * t1.col1 + t2.col1 = columnRef1 + t2.col1 + concat(t1.col1, t2.col1)
+ * t1.col1 + t2.col1 = columnRef1 + t2.col1 + concat(t1.col3, t2.col1) + columnRef1
  */
 public class CorrelatedPredicateRewriter extends BaseScalarOperatorShuttle {
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
@@ -3,12 +3,11 @@
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
-import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMergeJoinOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -26,10 +25,7 @@ public class MergeJoinImplementationRule extends JoinImplementationRule {
 
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
-        LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
-        ScalarOperator predicate = joinOperator.getOnPredicate();
-        // TODO: support non-equal predicate
-        return Utils.containsEqualBinaryPredicate(predicate);
+        return JoinHelper.isJoinConditionContainsEq(input);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
@@ -3,12 +3,13 @@
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
-import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMergeJoinOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 
@@ -25,7 +26,8 @@ public class MergeJoinImplementationRule extends JoinImplementationRule {
 
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
-        return JoinHelper.isJoinConditionContainsEq(input);
+        List<BinaryPredicateOperator> eqPredicates = extractEqPredicate(input, context);
+        return CollectionUtils.isNotEmpty(eqPredicates);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -232,7 +232,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
                                                    List<ColumnRefOperator> correlationColumnRefs,
                                                    boolean isNot) {
         // check correlation filter
-        if (!SubqueryUtils.checkAllIsBinaryEQ(correlationPredicates, correlationColumnRefs)) {
+        if (!SubqueryUtils.checkAllIsBinaryEQ(correlationPredicates)) {
             // @Todo:
             // 1. require least a EQ predicate
             // 2. for other binary predicate rewrite rule

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -245,7 +245,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
         CorrelatedPredicateRewriter rewriter = new CorrelatedPredicateRewriter(
                 correlationColumnRefs, context);
         ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(
-                Utils.compoundAnd(correlationPredicates).clone(), rewriter);
+                Utils.compoundAnd(correlationPredicates), rewriter);
 
         Map<ColumnRefOperator, ScalarOperator> innerRefMap = rewriter.getColumnRefToExprMap();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -239,7 +239,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
             // 2. for other binary predicate rewrite rule
             //  a. outer-key < inner key -> outer-key < aggregate MAX(key)
             //  b. outer-key > inner key -> outer-key > aggregate MIN(key)
-            throw new SemanticException("Not support Non-EQ correlation predicate correlation subquery");
+            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
         }
 
         // extract join-key

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.JoinOperator;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -27,9 +26,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.CorrelatedPredicateRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -127,7 +126,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
                                                            ExistsPredicateOperator epo, OptimizerContext context) {
         if (null == apply.getCorrelationConjuncts()) {
             // If the correlation predicate doesn't appear in here,
-            // it's should not be a situation that we currently support.
+            // it should not be a situation that we currently support.
             throw new SemanticException("Not support none correlation predicate correlation subquery");
         }
 
@@ -239,41 +238,40 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
             // 2. for other binary predicate rewrite rule
             //  a. outer-key < inner key -> outer-key < aggregate MAX(key)
             //  b. outer-key > inner key -> outer-key > aggregate MIN(key)
-            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
+            throw new SemanticException(SubqueryUtils.EXIST_NON_EQ_PREDICATE);
         }
 
         // extract join-key
-        Pair<List<ScalarOperator>, Map<ColumnRefOperator, ScalarOperator>> pair =
-                SubqueryUtils.rewritePredicateAndExtractColumnRefs(correlationPredicates,
-                        correlationColumnRefs, context);
+        CorrelatedPredicateRewriter rewriter = new CorrelatedPredicateRewriter(
+                correlationColumnRefs, context);
+        ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(
+                Utils.compoundAnd(correlationPredicates).clone(), rewriter);
+
+        Map<ColumnRefOperator, ScalarOperator> innerRefMap = rewriter.getColumnRefToExprMap();
 
         // rootOptExpression
         OptExpression rootOptExpression;
 
         // aggregate
         LogicalAggregationOperator aggregate =
-                new LogicalAggregationOperator(AggType.GLOBAL, new ArrayList<>(pair.second.keySet()),
+                new LogicalAggregationOperator(AggType.GLOBAL, Lists.newArrayList(innerRefMap.keySet()),
                         Maps.newHashMap());
 
         OptExpression aggregateOptExpression = OptExpression.create(aggregate);
         rootOptExpression = aggregateOptExpression;
 
-        // aggregate project
-        if (pair.second.entrySet().stream().anyMatch(d -> !(d.getValue().isColumnRef()))) {
-            Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
-            pair.second.entrySet().stream().filter(d -> !(d.getValue().isColumnRef()))
-                    .forEach(d -> projectMap.put(d.getKey(), d.getValue()));
-
-            // project add all output
-            Arrays.stream(input.getInputs().get(1).getOutputColumns().getColumnIds())
-                    .mapToObj(context.getColumnRefFactory()::getColumnRef).forEach(d -> projectMap.put(d, d));
-
+        // aggregate project, agg -> project
+        if (SubqueryUtils.containsExpr(innerRefMap)) {
+            // exists expression, need put it in project node
+            OptExpression rightChild = input.getInputs().get(1);
+            Map<ColumnRefOperator, ScalarOperator> projectMap = SubqueryUtils.updateOutputColumns(
+                    rightChild, innerRefMap, context);
             OptExpression projectOptExpression = OptExpression.create(new LogicalProjectOperator(projectMap));
             rootOptExpression.getInputs().add(projectOptExpression);
             rootOptExpression = projectOptExpression;
         }
 
-        // filter(UnCorrelation)
+        // filter(UnCorrelation) agg -> project -> un-correlation filter
         if (null != apply.getPredicate()) {
             OptExpression filterOptExpression =
                     OptExpression.create(new LogicalFilterOperator(apply.getPredicate()), input.getInputs().get(1));
@@ -286,7 +284,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
 
         // left outer join
         LogicalJoinOperator joinOperator =
-                new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, Utils.compoundAnd(pair.first));
+                new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, newPredicate);
         OptExpression joinOptExpression =
                 OptExpression.create(joinOperator, input.getInputs().get(0), aggregateOptExpression);
 
@@ -298,7 +296,7 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
                 .mapToObj(context.getColumnRefFactory()::getColumnRef).forEach(d -> projectMap.put(d, d));
 
         ScalarOperator nullPredicate = Utils.compoundAnd(
-                pair.second.keySet().stream().map(d -> new IsNullPredicateOperator(!isNot, d))
+                innerRefMap.keySet().stream().map(d -> new IsNullPredicateOperator(!isNot, d))
                         .collect(Collectors.toList()));
         projectMap.put(apply.getOutput(), nullPredicate);
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(projectMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -261,10 +261,10 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
         rootOptExpression = aggregateOptExpression;
 
         // aggregate project, agg -> project
-        if (SubqueryUtils.containsExpr(innerRefMap)) {
+        if (SubqueryUtils.existNonColumnRef(innerRefMap.values())) {
             // exists expression, need put it in project node
             OptExpression rightChild = input.getInputs().get(1);
-            Map<ColumnRefOperator, ScalarOperator> projectMap = SubqueryUtils.updateOutputColumns(
+            Map<ColumnRefOperator, ScalarOperator> projectMap = SubqueryUtils.generateChildOutColumns(
                     rightChild, innerRefMap, context);
             OptExpression projectOptExpression = OptExpression.create(new LogicalProjectOperator(projectMap));
             rootOptExpression.getInputs().add(projectOptExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
@@ -139,8 +139,8 @@ public class PushDownApplyAggFilterRule extends TransformationRule {
         OptExpression childOptExpression = vectorAggregationOptExpression;
 
         // exists expression, add project node. agg -> project
-        if (SubqueryUtils.containsExpr(innerRefMap)) {
-            Map<ColumnRefOperator, ScalarOperator> projectMap = SubqueryUtils.updateOutputColumns(
+        if (SubqueryUtils.existNonColumnRef(innerRefMap.values())) {
+            Map<ColumnRefOperator, ScalarOperator> projectMap = SubqueryUtils.generateChildOutColumns(
                     filterOptExpression, innerRefMap, context);
             OptExpression projectOptExpression = new OptExpression(new LogicalProjectOperator(projectMap));
             childOptExpression.getInputs().add(projectOptExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
@@ -119,7 +119,7 @@ public class PushDownApplyAggFilterRule extends TransformationRule {
                 apply.getCorrelationColumnRefs(), context);
 
         ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(
-                Utils.compoundAnd(correlationPredicate).clone(), rewriter);
+                Utils.compoundAnd(correlationPredicate), rewriter);
 
         Map<ColumnRefOperator, ScalarOperator> innerRefMap = rewriter.getColumnRefToExprMap();
         // create new trees

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
@@ -105,7 +105,7 @@ public class PushDownApplyAggFilterRule extends TransformationRule {
         if (correlationPredicate.isEmpty()) {
             // If the correlation predicate doesn't appear in here,
             // it should not be a situation that we currently support.
-            throw new SemanticException(SubqueryUtils.NONE_CORRELATED_PREDICATE);
+            throw new SemanticException(SubqueryUtils.NOT_FOUND_CORRELATED_PREDICATE);
         }
 
         // @Todo: Can be support contain one EQ predicate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
@@ -28,41 +28,39 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-// Push down ApplyNode and AggregationNode as a whole
-// Pattern:
-//      ApplyNode
-//      /      \
-//  LEFT     Aggregation(scalar aggregation)
-//               \
-//               Filter
-//                 \
-//                 ....
-//
-// Before:
-//      ApplyNode
-//      /      \
-//  LEFT     Aggregate(scalar aggregation)
-//               \
-//               Filter
-//                 \
-//                 ....
-//
-// After:
-//      ApplyNode
-//      /      \
-//  LEFT      Filter(correlation)
-//               \
-//            Aggregate(vector aggregation, group by correlation columns)
-//                 \
-//              Project(correlation columns: expression)[optional]
-//                   \
-//               Filter(un-correlation)[optional]
-//                     \
-//                      ....
-//
-// Requirements:
-// 1. All predicate is Binary.EQ in correlation filter
-//
+/**
+ * Push down ApplyNode and AggregationNode as a whole
+ * Pattern:
+ *      ApplyNode
+ *      /      \
+ *  LEFT     Aggregation(scalar aggregation)
+ *               \
+ *               Filter
+ *                 \
+ *                 ....
+ * Before:
+ *      ApplyNode
+ *      /      \
+ *  LEFT     Aggregate(scalar aggregation)
+ *               \
+ *               Filter
+ *                 \
+ *                 ....
+ * After:
+ *      ApplyNode
+ *      /      \
+ *  LEFT      Filter(correlation)
+ *               \
+ *            Aggregate(vector aggregation, group by correlation columns)
+ *                 \
+ *              Project(correlation columns: expression)[optional]
+ *                   \
+ *               Filter(un-correlation)[optional]
+ *                     \
+ *                      ....
+ * Requirements:
+ * 1. All predicate is Binary.EQ in correlation filter
+ */
 public class PushDownApplyAggFilterRule extends TransformationRule {
     public PushDownApplyAggFilterRule() {
         super(RuleType.TF_PUSH_DOWN_APPLY_AGG, Pattern.create(OperatorType.LOGICAL_APPLY).addChildren(
@@ -115,7 +113,7 @@ public class PushDownApplyAggFilterRule extends TransformationRule {
         // @Todo: Can be support contain one EQ predicate
         // check correlation filter
         if (!SubqueryUtils.checkAllIsBinaryEQ(correlationPredicate, apply.getCorrelationColumnRefs())) {
-            throw new SemanticException("Not support Non-EQ correlation predicate correlation subquery");
+            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
         }
 
         // extract group columns

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
@@ -265,13 +265,13 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
             }
 
             // CTE produce project
-            if (SubqueryUtils.containsExpr(corPredRewriter.getColumnRefToExprMap()) ||
-                    SubqueryUtils.containsExpr(inPredRewriter.getColumnRefToExprMap())) {
+            if (SubqueryUtils.existNonColumnRef(corPredRewriter.getColumnRefToExprMap().values()) ||
+                    SubqueryUtils.existNonColumnRef(inPredRewriter.getColumnRefToExprMap().values())) {
                 // has function, need project node
                 Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
                 projectMap.putAll(corPredRewriter.getColumnRefToExprMap());
                 projectMap.putAll(inPredRewriter.getColumnRefToExprMap());
-                projectMap = SubqueryUtils.updateOutputColumns(cteProduceChild, projectMap, context);
+                projectMap = SubqueryUtils.generateChildOutColumns(cteProduceChild, projectMap, context);
 
                 cteProduceChild = OptExpression.create(new LogicalProjectOperator(projectMap), cteProduceChild);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
@@ -91,7 +91,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
         correlationColumnRefs.addAll(apply.getCorrelationColumnRefs());
 
         // check correlation filter
-        if (!SubqueryUtils.checkAllIsBinaryEQ(joinOnPredicate, correlationColumnRefs)) {
+        if (!SubqueryUtils.checkAllIsBinaryEQ(joinOnPredicate)) {
             // @Todo:
             // 1. require least a EQ predicate
             // 2. for other binary predicate rewrite rule

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
@@ -57,8 +57,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
                 && !SubqueryUtils.containsCorrelationSubquery(input);
     }
 
-    /*
-     *
+    /**
      * @todo: support constant in sub-query
      * e.g.
      *   select v0, 1 in (select v0 from t0) from t1
@@ -98,7 +97,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
             // 2. for other binary predicate rewrite rule
             //  a. outer-key < inner key -> outer-key < aggregate MAX(key)
             //  b. outer-key > inner key -> outer-key > aggregate MIN(key)
-            throw new SemanticException("Not support Non-EQ correlation predicate correlation in sub-query");
+            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
         }
 
         CorrelationOuterJoinTransformer transformer = new CorrelationOuterJoinTransformer(input, context);
@@ -153,7 +152,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
             this.distinctAggregateOutputs = Lists.newArrayList();
         }
 
-        /*
+        /**
          * In:
          * before: select t0.v1, t0.v2 in (select t1.v2 from t1 where t0.v3 = t1.v3) from t0;
          * after: with xx as (select t1.v2, t1.v3 from t1)
@@ -189,7 +188,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
          *                               t1            t0     Agg(distinct)  CTEConsume
          *                                                         \
          *                                                        CTEConsume
-         * */
+         */
         public OptExpression transform() {
             check();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
@@ -97,7 +97,7 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
             // 2. for other binary predicate rewrite rule
             //  a. outer-key < inner key -> outer-key < aggregate MAX(key)
             //  b. outer-key > inner key -> outer-key > aggregate MIN(key)
-            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
+            throw new SemanticException(SubqueryUtils.EXIST_NON_EQ_PREDICATE);
         }
 
         CorrelationOuterJoinTransformer transformer = new CorrelationOuterJoinTransformer(input, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -71,7 +71,7 @@ public class ScalarApply2JoinRule extends TransformationRule {
         // check correlation filter
         if (!SubqueryUtils.checkAllIsBinaryEQ(Utils.extractConjuncts(apply.getCorrelationConjuncts()),
                 apply.getCorrelationColumnRefs())) {
-            throw new SemanticException("Not support Non-EQ correlation predicate correlation scalar-subquery");
+            throw new SemanticException(SubqueryUtils.UNSUPPORTED_CORRELATED_PREDICATE);
         }
 
         if (apply.isNeedCheckMaxRows()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -15,7 +15,6 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.SubqueryUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
@@ -110,8 +109,6 @@ public class ScalarApply2JoinRule extends TransformationRule {
         ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(correlationPredicate, rewriter);
 
         Map<ColumnRefOperator, ScalarOperator> innerRefMap = rewriter.getColumnRefToExprMap();
-        // t1.v1
-        ColumnRefSet correlationPredicateInnerRefs = new ColumnRefSet(innerRefMap.keySet());
 
         OptExpression rightChild = input.inputAt(1);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -107,7 +107,7 @@ public class ScalarApply2JoinRule extends TransformationRule {
         CorrelatedPredicateRewriter rewriter = new CorrelatedPredicateRewriter(
                 apply.getCorrelationColumnRefs(), context);
 
-        ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(correlationPredicate.clone(), rewriter);
+        ScalarOperator newPredicate = SubqueryUtils.rewritePredicateAndExtractColumnRefs(correlationPredicate, rewriter);
 
         Map<ColumnRefOperator, ScalarOperator> innerRefMap = rewriter.getColumnRefToExprMap();
         // t1.v1

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ScalarApply2JoinRule.java
@@ -112,10 +112,10 @@ public class ScalarApply2JoinRule extends TransformationRule {
 
         OptExpression rightChild = input.inputAt(1);
 
-        if (SubqueryUtils.containsExpr(innerRefMap)) {
+        if (SubqueryUtils.existNonColumnRef(innerRefMap.values())) {
             // exists expression, need put it in project node
             rightChild = OptExpression.create(new LogicalProjectOperator(
-                    SubqueryUtils.updateOutputColumns(rightChild, innerRefMap, context)), rightChild);
+                    SubqueryUtils.generateChildOutColumns(rightChild, innerRefMap, context)), rightChild);
         }
 
         // Non-correlated predicates

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -182,7 +182,7 @@ public class PlanFragmentBuilder {
 
         // Single tablet direct output
         // Note: If the fragment has right or full join and the join is local bucket shuffle join,
-        // We shouldn't set result sink directly to top fragment, because we will hash multi reslt sink.
+        // We shouldn't set result sink directly to top fragment, because we will hash multi result sink.
         if (!inputFragment.hashLocalBucketShuffleRightOrFullJoin(inputFragment.getPlanRoot())
                 && execPlan.getScanNodes().stream().allMatch(d -> d instanceof OlapScanNode)
                 && execPlan.getScanNodes().stream().map(d -> ((OlapScanNode) d).getScanTabletIds().size())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.ImmutableList;
@@ -51,7 +53,7 @@ class BaseScalarOperatorShuttleTest {
     @Test
     void visitBetweenPredicate() {
         BetweenPredicateOperator operator = new BetweenPredicateOperator(true,
-                new ColumnRefOperator(1, INT, "id", true ),
+                new ColumnRefOperator(1, INT, "id", true),
                 ConstantOperator.TRUE, ConstantOperator.TRUE);
         ScalarOperator newOperator = shuttle.visitBetweenPredicate(operator, null);
         assertEquals(operator, newOperator);
@@ -82,7 +84,7 @@ class BaseScalarOperatorShuttleTest {
     @Test
     void visitLikePredicateOperator() {
         LikePredicateOperator operator = new LikePredicateOperator(
-                new ColumnRefOperator(1, INT, "id", true ),
+                new ColumnRefOperator(1, INT, "id", true),
                 ConstantOperator.TRUE);
         ScalarOperator newOperator = shuttle.visitLikePredicateOperator(operator, null);
         assertEquals(operator, newOperator);
@@ -90,7 +92,7 @@ class BaseScalarOperatorShuttleTest {
 
     @Test
     void visitCastOperator() {
-        CastOperator operator = new CastOperator(INT, new ColumnRefOperator(1, INT, "id", true ));
+        CastOperator operator = new CastOperator(INT, new ColumnRefOperator(1, INT, "id", true));
         ScalarOperator newOperator = shuttle.visitCastOperator(operator, null);
         assertEquals(operator, newOperator);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -1,0 +1,105 @@
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayElementOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArraySliceOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.catalog.Type.ARRAY_TINYINT;
+import static com.starrocks.catalog.Type.INT;
+import static com.starrocks.catalog.Type.STRING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BaseScalarOperatorShuttleTest {
+
+    private final BaseScalarOperatorShuttle shuttle = new BaseScalarOperatorShuttle();
+
+
+    @Test
+    void visitArray() {
+        ArrayOperator operator = new ArrayOperator(ARRAY_TINYINT, true, null);
+        ScalarOperator newOperator = shuttle.visitArray(operator, null);
+        assertEquals(operator, newOperator);
+
+    }
+
+    @Test
+    void visitArrayElement() {
+        ArrayElementOperator operator = new ArrayElementOperator(STRING, null, null);
+        ScalarOperator newOperator = shuttle.visitArrayElement(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitArraySlice() {
+        ArraySliceOperator operator = new ArraySliceOperator(STRING, null);
+        ScalarOperator newOperator = shuttle.visitArraySlice(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitBetweenPredicate() {
+        BetweenPredicateOperator operator = new BetweenPredicateOperator(true,
+                new ColumnRefOperator(1, INT, "id", true ),
+                ConstantOperator.TRUE, ConstantOperator.TRUE);
+        ScalarOperator newOperator = shuttle.visitBetweenPredicate(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+
+    @Test
+    void visitExistsPredicate() {
+        ExistsPredicateOperator operator = new ExistsPredicateOperator(true, ImmutableList.of());
+        ScalarOperator newOperator = shuttle.visitExistsPredicate(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitInPredicate() {
+        InPredicateOperator operator = new InPredicateOperator(true, ImmutableList.of());
+        ScalarOperator newOperator = shuttle.visitInPredicate(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitIsNullPredicate() {
+        IsNullPredicateOperator operator = new IsNullPredicateOperator(true, null);
+        ScalarOperator newOperator = shuttle.visitIsNullPredicate(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitLikePredicateOperator() {
+        LikePredicateOperator operator = new LikePredicateOperator(
+                new ColumnRefOperator(1, INT, "id", true ),
+                ConstantOperator.TRUE);
+        ScalarOperator newOperator = shuttle.visitLikePredicateOperator(operator, null);
+        assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitCastOperator() {
+        CastOperator operator = new CastOperator(INT, new ColumnRefOperator(1, INT, "id", true ));
+        ScalarOperator newOperator = shuttle.visitCastOperator(operator, null);
+        assertEquals(operator, newOperator);
+
+    }
+
+    @Test
+    void visitCaseWhenOperator() {
+        CaseWhenOperator operator = new CaseWhenOperator(INT, null, null, ImmutableList.of());
+        ScalarOperator newOperator = shuttle.visitCaseWhenOperator(operator, null);
+        assertEquals(operator, newOperator);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -1338,7 +1338,7 @@ public class PlanTestBase {
                 writer.append(dump.trim());
             }
 
-            // writer.append("\n[end]\n\n");
+            writer.append("\n[end]\n\n");
             writer.flush();
         } catch (IOException e) {
             e.printStackTrace();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -575,15 +575,15 @@ public class ReplayFromDumpTest {
         Assert.assertTrue(replayPair.second, replayPair.second.contains(" 21:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: if(22: c_0_0 != 1: c_0_0, 4: c_0_3, 23: c_0_3) = 21: expr, " +
-                "CASE WHEN (24: countRows IS NULL) OR (24: countRows = 0) THEN FALSE WHEN 1: c_0_0 IS NULL " +
-                "THEN NULL WHEN 17: c_0_0 IS NOT NULL THEN TRUE WHEN 25: countNotNulls < 24: countRows " +
-                "THEN NULL ELSE FALSE END IS NULL"));
+                "  |  other join predicates: if(20: c_0_0 != 1: c_0_0, 4: c_0_3, 21: c_0_3) = '1969-12-28', " +
+                "CASE WHEN (22: countRows IS NULL) OR (22: countRows = 0) THEN FALSE " +
+                "WHEN 1: c_0_0 IS NULL THEN NULL WHEN 16: c_0_0 IS NOT NULL THEN TRUE " +
+                "WHEN 23: countNotNulls < 22: countRows THEN NULL ELSE FALSE END IS NULL"));
         Assert.assertTrue(replayPair.second.contains("14:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 1: c_0_0 = 17: c_0_0\n" +
-                "  |  other join predicates: if(17: c_0_0 != 1: c_0_0, 4: c_0_3, 19: c_0_3) = 18: expr"));
+                "  |  equal join conjunct: 1: c_0_0 = 16: c_0_0\n" +
+                "  |  other join predicates: if(16: c_0_0 != 1: c_0_0, 4: c_0_3, 18: c_0_3) = '1969-12-28'"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -98,9 +98,7 @@ public class SubqueryTest extends PlanTestBase {
     @Test
     public void testSubqueryLimit() throws Exception {
         String sql = "select * from t0 where 2 = (select v4 from t1 limit 1);";
-        sql = "select v1, v2 in (select v4 from t1 where t0.v1 + t1.v6 = t1.v4 + t1.v5) from t0;";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "4:SELECT\n" +
                 "  |  predicates: 4: v4 = 2\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -98,7 +98,9 @@ public class SubqueryTest extends PlanTestBase {
     @Test
     public void testSubqueryLimit() throws Exception {
         String sql = "select * from t0 where 2 = (select v4 from t1 limit 1);";
+        sql = "select v1, v2 in (select v4 from t1 where t0.v1 + t1.v6 = t1.v4 + t1.v5) from t0;";
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         assertContains(plan, "4:SELECT\n" +
                 "  |  predicates: 4: v4 = 2\n" +
                 "  |  \n" +
@@ -563,13 +565,12 @@ public class SubqueryTest extends PlanTestBase {
                 "      ) >= 1\n" +
                 "  ) subt0;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, " 2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
                 "  |  output: count(1), any_value(4: v7)\n" +
-                "  |  group by: 8: expr\n" +
+                "  |  group by: \n" +
                 "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 4> : 4: v7\n" +
-                "  |  <slot 8> : 284082749");
+                "  1:OlapScanNode\n" +
+                "     TABLE: t2");
         sql = "SELECT \n" +
                 "  subt0.v1 \n" +
                 "FROM \n" +

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -390,8 +390,7 @@ LEFT OUTER JOIN (join-predicate [2: v2 = 6: v8] post-join-predicate [null])
                 SCAN (columns[6: v8] predicate[null])
 [end]
 
-
-/*test ExistentialApply2OuterJoinRule*/
+/* test ExistentialApply2OuterJoinRule */
 
 [sql]
 select v1, exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6) from t0;
@@ -435,7 +434,7 @@ select t0.v1, exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 an
 from t0 left join t1 on true;
 [result]
 LEFT OUTER JOIN (join-predicate [21: add = 19: cast AND add(20: add, 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])
@@ -503,7 +502,7 @@ LEFT OUTER JOIN (join-predicate [add(19: cast, cast(1: v1 as double)) = cast(add
 select t0.v1, not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5) from t0 left join t1 on true;
 [result]
 LEFT OUTER JOIN (join-predicate [21: add = 19: cast AND add(20: add, 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])
@@ -542,7 +541,7 @@ RIGHT SEMI JOIN (join-predicate [4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] po
 select t0.v1 from t0 left join t1 on true where exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
 [result]
 LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])
@@ -563,7 +562,7 @@ RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v
 select t0.v1 from t0 left join t1 on true where not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
 [result]
 LEFT ANTI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])
@@ -571,7 +570,7 @@ LEFT ANTI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d
         SCAN (columns[7: t1a, 9: t1c, 10: t1d] predicate[7: t1a = a])
 [end]
 
-/*test ExistentialApply2JoinRule*/
+/* test ExistentialApply2JoinRule */
 
 [sql]
 select v1 from t0 where exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
@@ -586,7 +585,7 @@ RIGHT SEMI JOIN (join-predicate [4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] po
 select t0.v1 from t0 left join t1 on true where exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
 [result]
 LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])
@@ -607,7 +606,7 @@ RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v
 select t0.v1 from t0 left join t1 on true where not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
 [result]
 LEFT ANTI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
-    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [null] post-join-predicate [null])
         SCAN (columns[1: v1] predicate[null])
         EXCHANGE BROADCAST
             SCAN (columns[5: v5] predicate[null])

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -389,3 +389,228 @@ LEFT OUTER JOIN (join-predicate [2: v2 = 6: v8] post-join-predicate [null])
             AGGREGATE ([LOCAL] aggregate [{}] group by [[6: v8]] having [null]
                 SCAN (columns[6: v8] predicate[null])
 [end]
+
+
+/*test ExistentialApply2OuterJoinRule*/
+
+[sql]
+select v1, exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [1: v1 = 5: v4 AND 1: v1 = 1 AND add(2: v2, 6: v5) = 7: v6] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE SHUFFLE[5]
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 = 1])
+[end]
+
+[sql]
+select v1, exists (select v5 + v4 from t1 where v4 = 1 and abs(v1 + v4) = v1 + v5 and v2 + v5 = v6) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [abs(add(1: v1, 5: v4)) = cast(add(1: v1, 6: v5) as largeint(40)) AND add(2: v2, 6: v5) = 7: v6] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 = 1])
+[end]
+
+[sql]
+select v1, exists (select t1a from test_all_type where t1a + v1 = v4 + t1c and v2 = 1 and v5 = 1) from t0, t1;
+[result]
+LEFT OUTER JOIN (join-predicate [add(19: cast, cast(1: v1 as double)) = cast(add(4: v4, 20: cast) as double) AND 2: v2 = 1 AND 5: v5 = 1] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[4: v4, 5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[19: cast, 20: cast]] having [null]
+            EXCHANGE SHUFFLE[19, 20]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[19: cast, 20: cast]] having [null]
+                    SCAN (columns[8: t1a, 10: t1c] predicate[null])
+[end]
+
+[sql]
+select t0.v1, exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5)
+from t0 left join t1 on true;
+[result]
+LEFT OUTER JOIN (join-predicate [21: add = 19: cast AND add(20: add, 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[19: cast, 20: add]] having [null]
+            EXCHANGE SHUFFLE[19, 20]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[19: cast, 20: add]] having [null]
+                    SCAN (columns[8: t1a, 10: t1c, 11: t1d] predicate[8: t1a = a])
+[end]
+
+[sql]
+select t0.v1, exists (select abs(t1a) from test_all_type where t1c + t0.v3 = t1d - t1.v6) from  t0 left join t1 on t0.v3 = t1.
+v6;
+[result]
+LEFT OUTER JOIN (join-predicate [add(20: cast, 3: v3) = subtract(11: t1d, 6: v6)] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+        SCAN (columns[1: v1, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[6: v6] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[20: cast, 11: t1d]] having [null]
+            EXCHANGE SHUFFLE[20, 11]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[20: cast, 11: t1d]] having [null]
+                    SCAN (columns[10: t1c, 11: t1d] predicate[null])
+[end]
+
+[sql]
+select v1, not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [1: v1 = 5: v4 AND 1: v1 = 1 AND add(2: v2, 6: v5) = 7: v6] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE SHUFFLE[5]
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 = 1])
+[end]
+
+[sql]
+select v1, not exists (select v5 + v4 from t1 where v4 = 1 and abs(v1 + v4) = v1 + v5 and v2 + v5 = v6) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [abs(add(1: v1, 5: v4)) = cast(add(1: v1, 6: v5) as largeint(40)) AND add(2: v2, 6: v5) = 7: v6] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{}] group by [[5: v4, 6: v5, 7: v6]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[5: v4 = 1])
+[end]
+
+[sql]
+select v1, not exists (select t1a from test_all_type where t1a + v1 = v4 + t1c and v2 = 1 and v5 = 1) from t0, t1;
+[result]
+LEFT OUTER JOIN (join-predicate [add(19: cast, cast(1: v1 as double)) = cast(add(4: v4, 20: cast) as double) AND 2: v2 = 1 AND 5: v5 = 1] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[4: v4, 5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[19: cast, 20: cast]] having [null]
+            EXCHANGE SHUFFLE[19, 20]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[19: cast, 20: cast]] having [null]
+                    SCAN (columns[8: t1a, 10: t1c] predicate[null])
+[end]
+
+[sql]
+select t0.v1, not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5) from t0 left join t1 on true;
+[result]
+LEFT OUTER JOIN (join-predicate [21: add = 19: cast AND add(20: add, 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[19: cast, 20: add]] having [null]
+            EXCHANGE SHUFFLE[19, 20]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[19: cast, 20: add]] having [null]
+                    SCAN (columns[8: t1a, 10: t1c, 11: t1d] predicate[8: t1a = a])
+[end]
+
+[sql]
+select t0.v1, not exists (select abs(t1a) from test_all_type where t1c + t0.v3 = t1d - t1.v6) from  t0 left join t1 on t0.v3 = t1.v6;
+[result]
+LEFT OUTER JOIN (join-predicate [add(20: cast, 3: v3) = subtract(11: t1d, 6: v6)] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [3: v3 = 6: v6] post-join-predicate [null])
+        SCAN (columns[1: v1, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[6: v6] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[20: cast, 11: t1d]] having [null]
+            EXCHANGE SHUFFLE[20, 11]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[20: cast, 11: t1d]] having [null]
+                    SCAN (columns[10: t1c, 11: t1d] predicate[null])
+[end]
+
+[sql]
+select v1 from t0 where exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
+[result]
+RIGHT SEMI JOIN (join-predicate [4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 = 1])
+    EXCHANGE SHUFFLE[1]
+        SCAN (columns[1: v1, 2: v2] predicate[1: v1 = 1])
+[end]
+
+[sql]
+select t0.v1 from t0 left join t1 on true where exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
+[result]
+LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[7: t1a, 9: t1c, 10: t1d] predicate[7: t1a = a])
+[end]
+
+[sql]
+select v1 from t0 where not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
+[result]
+RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE SHUFFLE[1]
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select t0.v1 from t0 left join t1 on true where not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
+[result]
+LEFT ANTI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[7: t1a, 9: t1c, 10: t1d] predicate[7: t1a = a])
+[end]
+
+/*test ExistentialApply2JoinRule*/
+
+[sql]
+select v1 from t0 where exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
+[result]
+RIGHT SEMI JOIN (join-predicate [4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 = 1])
+    EXCHANGE SHUFFLE[1]
+        SCAN (columns[1: v1, 2: v2] predicate[1: v1 = 1])
+[end]
+
+[sql]
+select t0.v1 from t0 left join t1 on true where exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
+[result]
+LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[7: t1a, 9: t1c, 10: t1d] predicate[7: t1a = a])
+[end]
+
+[sql]
+select v1 from t0 where not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
+[result]
+RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE SHUFFLE[1]
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select t0.v1 from t0 left join t1 on true where not exists (select t1a from test_all_type where t1c = t0.v1 + t1.v5 and t1a = 'a' and t1c + t1d + t0.v1 = t1.v5);
+[result]
+LEFT ANTI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d), 1: v1) = 5: v5] post-join-predicate [null])
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        SCAN (columns[1: v1] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[5: v5] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[7: t1a, 9: t1c, 10: t1d] predicate[7: t1a = a])
+[end]

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -517,3 +517,443 @@ INNER JOIN (join-predicate [2: v2 = 7: v4] post-join-predicate [null])
                             TOP-N (order by [[8: v5 ASC NULLS FIRST]])
                                 SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
+
+/*test PushDownApplyAggFilterRule*/
+
+[sql]
+select * from t0 where v1 = (select max(v5 + 1) from t1 where t0.v2 = t1.v4);
+[result]
+INNER JOIN (join-predicate [2: v2 = 4: v4 AND 1: v1 = 8: max] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IS NOT NULL AND 1: v1 IS NOT NULL])
+    EXCHANGE SHUFFLE[8]
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[4: v4]] having [8: max IS NOT NULL]
+            AGGREGATE ([LOCAL] aggregate [{8: max=max(7: expr)}] group by [[4: v4]] having [null]
+                SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select * from t0 where v1 = (select avg(v5 + 1) from t1 where t0.v2 + 1 = 1);
+[result]
+INNER JOIN (join-predicate [10: cast = 8: avg] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 = 0])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{8: avg=avg(8: avg)}] group by [[]] having [8: avg IS NOT NULL]
+            EXCHANGE GATHER
+                AGGREGATE ([LOCAL] aggregate [{8: avg=avg(7: expr)}] group by [[]] having [null]
+                    SCAN (columns[5: v5] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select min(v5 + 1) from t1 where t0.v2 + 1  = t1.v4 + t1.v5);
+[result]
+INNER JOIN (join-predicate [11: add = 10: add AND 1: v1 = 8: min] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[add(2: v2, 1) IS NOT NULL AND 1: v1 IS NOT NULL])
+    EXCHANGE SHUFFLE[8]
+        AGGREGATE ([GLOBAL] aggregate [{8: min=min(8: min)}] group by [[10: add]] having [8: min IS NOT NULL]
+            EXCHANGE SHUFFLE[10]
+                AGGREGATE ([LOCAL] aggregate [{8: min=min(7: expr)}] group by [[10: add]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[add(4: v4, 5: v5) IS NOT NULL])
+[end]
+
+[sql]
+select * from t0 where v1 = (select max(v4 + v5 + v6) from t1 where abs(t0.v2 + t1.v4) = t1.v4);
+[result]
+INNER JOIN (join-predicate [1: v1 = 8: max AND abs(add(2: v2, 4: v4)) = 10: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+    EXCHANGE SHUFFLE[8]
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[4: v4, 10: cast]] having [8: max IS NOT NULL]
+            AGGREGATE ([LOCAL] aggregate [{8: max=max(7: expr)}] group by [[4: v4, 10: cast]] having [null]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select max(v4 + v5 + v6) from t1 where abs(t0.v2 + t1.v4) = abs(t1.v4));
+[result]
+INNER JOIN (join-predicate [1: v1 = 8: max AND abs(add(2: v2, 4: v4)) = 10: abs] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+    EXCHANGE SHUFFLE[8]
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[4: v4, 10: abs]] having [8: max IS NOT NULL]
+            AGGREGATE ([LOCAL] aggregate [{8: max=max(7: expr)}] group by [[4: v4, 10: abs]] having [null]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select max(v4 + v5 + v6) from t1 where abs(t0.v2 + t1.v4) = t1.v5);
+[result]
+INNER JOIN (join-predicate [1: v1 = 8: max AND abs(add(2: v2, 4: v4)) = 10: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+    EXCHANGE SHUFFLE[8]
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[4: v4, 10: cast]] having [8: max IS NOT NULL]
+            AGGREGATE ([LOCAL] aggregate [{8: max=max(7: expr)}] group by [[4: v4, 10: cast]] having [null]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where case when v1 = (select max(v4 + v5 + v6) from t1 where abs(t0.v2 + t1.v4) = t1.v5) then true else false end;
+[result]
+INNER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 10: cast AND if(1: v1 = 8: max, true, false)] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[4: v4, 10: cast]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{8: max=max(7: expr)}] group by [[4: v4, 10: cast]] having [null]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select v1, (select max(v5 + 1) from t1 where t0.v2 = t1.v4 and t0.v2 + 1 = 1 and t0.v2 + 1  = t1.v4 + t1.v5) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [2: v2 = 5: v4 AND 12: add = 11: add AND 2: v2 = 0] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{9: max=max(9: max)}] group by [[5: v4, 11: add]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{9: max=max(8: expr)}] group by [[5: v4, 11: add]] having [null]
+                SCAN (columns[5: v4, 6: v5] predicate[5: v4 = 0 AND add(5: v4, 6: v5) = 1])
+[end]
+
+[sql]
+select v1, (select max(v4 + v5 + v6) from t1 where abs(t0.v2 + t1.v4) = abs(t1.v4) and abs(t0.v2 + t1.v4) = abs(t1.v4) and abs(t0.v2 + t1.v4) = t1.v5) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 5: v4)) = 11: abs AND abs(add(2: v2, 5: v4)) = 12: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{9: max=max(9: max)}] group by [[5: v4, 11: abs, 12: cast]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{9: max=max(8: expr)}] group by [[5: v4, 11: abs, 12: cast]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select min(t1c )from test_all_type where t1d = (select max(v4 + v5) from t1 where t1a = v4 and v4 = 2));
+[result]
+INNER JOIN (join-predicate [1: v1 = 23: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+    EXCHANGE BROADCAST
+        PREDICATE cast(20: min as bigint(20)) IS NOT NULL
+            ASSERT LE 1
+                AGGREGATE ([GLOBAL] aggregate [{20: min=min(20: min)}] group by [[]] having [null]
+                    EXCHANGE GATHER
+                        AGGREGATE ([LOCAL] aggregate [{20: min=min(6: t1c)}] group by [[]] having [null]
+                            INNER JOIN (join-predicate [4: t1a = 22: cast AND 7: t1d = 18: max] post-join-predicate [null])
+                                SCAN (columns[4: t1a, 6: t1c, 7: t1d] predicate[4: t1a IS NOT NULL AND 7: t1d IS NOT NULL])
+                                EXCHANGE SHUFFLE[22]
+                                    AGGREGATE ([GLOBAL] aggregate [{18: max=max(18: max)}] group by [[22: cast]] having [18: max IS NOT NULL]
+                                        EXCHANGE SHUFFLE[22]
+                                            AGGREGATE ([LOCAL] aggregate [{18: max=max(17: expr)}] group by [[22: cast]] having [null]
+                                                SCAN (columns[14: v4, 15: v5] predicate[cast(14: v4 as varchar(1048576)) IS NOT NULL AND 14: v4 = 2])
+[end]
+
+[sql]
+select v1, (select min(t1c) from test_all_type where t1d = (select max(v4 + v5) from t1 where t1a = v4 and v4 = 2)) from t0;
+[result]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    SCAN (columns[1: v1] predicate[null])
+    EXCHANGE BROADCAST
+        ASSERT LE 1
+            AGGREGATE ([GLOBAL] aggregate [{21: min=min(21: min)}] group by [[]] having [null]
+                EXCHANGE GATHER
+                    AGGREGATE ([LOCAL] aggregate [{21: min=min(7: t1c)}] group by [[]] having [null]
+                        INNER JOIN (join-predicate [5: t1a = 23: cast AND 8: t1d = 19: max] post-join-predicate [null])
+                            SCAN (columns[5: t1a, 7: t1c, 8: t1d] predicate[5: t1a IS NOT NULL AND 8: t1d IS NOT NULL])
+                            EXCHANGE SHUFFLE[23]
+                                AGGREGATE ([GLOBAL] aggregate [{19: max=max(19: max)}] group by [[23: cast]] having [19: max IS NOT NULL]
+                                    EXCHANGE SHUFFLE[23]
+                                        AGGREGATE ([LOCAL] aggregate [{19: max=max(18: expr)}] group by [[23: cast]] having [null]
+                                            SCAN (columns[15: v4, 16: v5] predicate[cast(15: v4 as varchar(1048576)) IS NOT NULL AND 15: v4 = 2])
+[end]
+
+[sql]
+select * from t0 join t1 where v1 + v4 = (select max(t1d) from test_all_type where t1c = 1 and t1c + t0.v2 = t0.v1 + t1c and t1d + t0.v3 = t1.v5 + t1d)
+[result]
+INNER JOIN (join-predicate [20: add = 17: max AND add(19: cast, 2: v2) = add(1: v1, 19: cast) AND add(10: t1d, 3: v3) = add(5: v5, 10: t1d)] post-join-predicate [null])
+    CROSS JOIN (join-predicate [add(1: v1, 4: v4) IS NOT NULL] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{17: max=max(17: max)}] group by [[19: cast, 10: t1d]] having [17: max IS NOT NULL]
+            EXCHANGE SHUFFLE[19, 10]
+                AGGREGATE ([LOCAL] aggregate [{17: max=max(10: t1d)}] group by [[19: cast, 10: t1d]] having [null]
+                    SCAN (columns[9: t1c, 10: t1d] predicate[9: t1c = 1])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t1.v5 <=> (select max(t1d - 1) from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(12: t1c = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [5: v5 <=> 21: max])
+    LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+        LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{21: max=max(21: max)}] group by [[12: t1c]] having [null]
+            EXCHANGE SHUFFLE[12]
+                AGGREGATE ([LOCAL] aggregate [{21: max=max(20: expr)}] group by [[12: t1c]] having [null]
+                    SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t1.v5 = (select max(t1d - 1) from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c + t1.v5 = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+INNER JOIN (join-predicate [5: v5 = 21: max AND add(add(1: v1, 4: v4), 9: v9) = if(add(23: cast, 5: v5) = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [null])
+    LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
+        EXCHANGE BROADCAST
+            SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{21: max=max(21: max)}] group by [[23: cast]] having [21: max IS NOT NULL]
+            EXCHANGE SHUFFLE[23]
+                AGGREGATE ([LOCAL] aggregate [{21: max=max(20: expr)}] group by [[23: cast]] having [null]
+                    SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t0.v1 + t1.v5 <=> (select max(t1d - 1) from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(12: t1c = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [add(1: v1, 5: v5) <=> 21: max])
+    LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+        LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{21: max=max(21: max)}] group by [[12: t1c]] having [null]
+            EXCHANGE SHUFFLE[12]
+                AGGREGATE ([LOCAL] aggregate [{21: max=max(20: expr)}] group by [[12: t1c]] having [null]
+                    SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]
+
+
+/*test ScalarApply2JoinRule*/
+
+[sql]
+select * from t0 where 1 = (select v5 + 1 from t1 where t0.v2 = t1.v4);
+[result]
+PREDICATE 8: expr = 1
+    LEFT OUTER JOIN (join-predicate [2: v2 = 4: v4] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{9: countRows=count(9: countRows), 10: anyValue=any_value(10: anyValue)}] group by [[4: v4]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{9: countRows=count(1), 10: anyValue=any_value(add(5: v5, 1))}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+[end]
+
+[sql]
+select * from t0 where 1 = (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = t1.v5);
+[result]
+PREDICATE 8: expr = 1
+    LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 9: cast] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[4: v4, 9: cast]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(add(4: v4, 5: v5), 6: v6))}] group by [[4: v4, 9: cast]] having [null]
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v5 + 1 from t1 where t0.v2 = t1.v4);
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [2: v2 = 4: v4] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{9: countRows=count(9: countRows), 10: anyValue=any_value(10: anyValue)}] group by [[4: v4]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{9: countRows=count(1), 10: anyValue=any_value(add(5: v5, 1))}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v5 + 1 from t1 where t0.v2 + 1 = 1);
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [2: v2 = 0] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{9: countRows=count(9: countRows), 10: anyValue=any_value(10: anyValue)}] group by [[]] having [null]
+                EXCHANGE GATHER
+                    AGGREGATE ([LOCAL] aggregate [{9: countRows=count(1), 10: anyValue=any_value(add(5: v5, 1))}] group by [[]] having [null]
+                        SCAN (columns[5: v5] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v5 + 1 from t1 where t0.v2 + 1  = t1.v4 + t1.v5);
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [13: add = 9: add] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[9: add]] having [null]
+                EXCHANGE SHUFFLE[9]
+                    AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(5: v5, 1))}] group by [[9: add]] having [null]
+                        SCAN (columns[4: v4, 5: v5] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = t1.v4);
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 9: cast] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[4: v4, 9: cast]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(add(4: v4, 5: v5), 6: v6))}] group by [[4: v4, 9: cast]] having [null]
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = abs(t1.v4));
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 9: abs] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[4: v4, 9: abs]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(add(4: v4, 5: v5), 6: v6))}] group by [[4: v4, 9: abs]] having [null]
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = t1.v5);
+[result]
+PREDICATE 1: v1 = 8: expr
+    LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 9: cast] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[4: v4, 9: cast]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(add(4: v4, 5: v5), 6: v6))}] group by [[4: v4, 9: cast]] having [null]
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where case when v1 = (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = t1.v5) then true else false end;
+[result]
+PREDICATE if(1: v1 = 8: expr, true, false)
+    LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 4: v4)) = 9: cast] post-join-predicate [null])
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{10: countRows=count(10: countRows), 11: anyValue=any_value(11: anyValue)}] group by [[4: v4, 9: cast]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{10: countRows=count(1), 11: anyValue=any_value(add(add(4: v4, 5: v5), 6: v6))}] group by [[4: v4, 9: cast]] having [null]
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+[end]
+
+[sql]
+select v1, (select v5 + 1 from t1 where t0.v2 = t1.v4 and t0.v2 + 1 = 1 and t0.v2 + 1  = t1.v4 + t1.v5) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [2: v2 = 5: v4 AND 14: add = 10: add AND 2: v2 = 0] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{11: countRows=count(11: countRows), 12: anyValue=any_value(12: anyValue)}] group by [[5: v4, 10: add]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{11: countRows=count(1), 12: anyValue=any_value(add(6: v5, 1))}] group by [[5: v4, 10: add]] having [null]
+                SCAN (columns[5: v4, 6: v5] predicate[5: v4 = 0 AND add(5: v4, 6: v5) = 1])
+[end]
+
+[sql]
+select v1, (select v4 + v5 + v6 from t1 where abs(t0.v2 + t1.v4) = abs(t1.v4) and abs(t0.v2 + t1.v4) = abs(t1.v4) and abs(t0.v2 + t1.v4) = t1.v5) from t0;
+[result]
+LEFT OUTER JOIN (join-predicate [abs(add(2: v2, 5: v4)) = 10: abs AND abs(add(2: v2, 5: v4)) = 11: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE BROADCAST
+        AGGREGATE ([GLOBAL] aggregate [{12: countRows=count(12: countRows), 13: anyValue=any_value(13: anyValue)}] group by [[5: v4, 10: abs, 11: cast]] having [null]
+            AGGREGATE ([LOCAL] aggregate [{12: countRows=count(1), 13: anyValue=any_value(add(add(5: v4, 6: v5), 7: v6))}] group by [[5: v4, 10: abs, 11: cast]] having [null]
+                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[null])
+[end]
+
+[sql]
+select * from t0 where v1 = (select t1c from test_all_type where t1d = (select v4 + v5 from t1 where t1a = v4 and v4 = 2));
+[result]
+INNER JOIN (join-predicate [1: v1 = 24: cast] post-join-predicate [null])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+    EXCHANGE BROADCAST
+        PREDICATE cast(6: t1c as bigint(20)) IS NOT NULL
+            ASSERT LE 1
+                EXCHANGE GATHER
+                    PREDICATE 7: t1d = 18: expr
+                        LEFT OUTER JOIN (join-predicate [4: t1a = 20: cast] post-join-predicate [null])
+                            SCAN (columns[4: t1a, 6: t1c, 7: t1d] predicate[null])
+                            EXCHANGE SHUFFLE[20]
+                                AGGREGATE ([GLOBAL] aggregate [{21: countRows=count(21: countRows), 22: anyValue=any_value(22: anyValue)}] group by [[20: cast]] having [null]
+                                    EXCHANGE SHUFFLE[20]
+                                        AGGREGATE ([LOCAL] aggregate [{21: countRows=count(1), 22: anyValue=any_value(add(14: v4, 15: v5))}] group by [[20: cast]] having [null]
+                                            SCAN (columns[14: v4, 15: v5] predicate[14: v4 = 2])
+[end]
+
+[sql]
+select v1, (select t1c from test_all_type where t1d = (select v4 + v5 from t1 where t1a = v4 and v4 = 2)) from t0;
+[result]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    SCAN (columns[1: v1] predicate[null])
+    EXCHANGE BROADCAST
+        ASSERT LE 1
+            EXCHANGE GATHER
+                PREDICATE 8: t1d = 19: expr
+                    LEFT OUTER JOIN (join-predicate [5: t1a = 21: cast] post-join-predicate [null])
+                        SCAN (columns[5: t1a, 7: t1c, 8: t1d] predicate[null])
+                        EXCHANGE SHUFFLE[21]
+                            AGGREGATE ([GLOBAL] aggregate [{22: countRows=count(22: countRows), 23: anyValue=any_value(23: anyValue)}] group by [[21: cast]] having [null]
+                                EXCHANGE SHUFFLE[21]
+                                    AGGREGATE ([LOCAL] aggregate [{22: countRows=count(1), 23: anyValue=any_value(add(15: v4, 16: v5))}] group by [[21: cast]] having [null]
+                                        SCAN (columns[15: v4, 16: v5] predicate[15: v4 = 2])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t1.v5 <=> (select t1d - 1 from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+PREDICATE 5: v5 <=> 21: expr
+    LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(12: t1c = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [null])
+        LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+            LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                SCAN (columns[1: v1, 2: v2] predicate[null])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE BROADCAST
+                SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{22: countRows=count(22: countRows), 23: anyValue=any_value(23: anyValue)}] group by [[12: t1c]] having [null]
+                EXCHANGE SHUFFLE[12]
+                    AGGREGATE ([LOCAL] aggregate [{22: countRows=count(1), 23: anyValue=any_value(subtract(13: t1d, 1))}] group by [[12: t1c]] having [null]
+                        SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t1.v5 = (select t1d - 1 from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c + t1.v5 = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+PREDICATE 5: v5 = 21: expr
+    LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(add(22: cast, 5: v5) = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [null])
+        LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+            LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                SCAN (columns[1: v1, 2: v2] predicate[null])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE BROADCAST
+                SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{23: countRows=count(23: countRows), 24: anyValue=any_value(24: anyValue)}] group by [[22: cast]] having [null]
+                EXCHANGE SHUFFLE[22]
+                    AGGREGATE ([LOCAL] aggregate [{23: countRows=count(1), 24: anyValue=any_value(subtract(13: t1d, 1))}] group by [[22: cast]] having [null]
+                        SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]
+
+[sql]
+select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t0.v1 + t1.v5 <=> (select t1d - 1 from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
+[result]
+PREDICATE add(1: v1, 5: v5) <=> 21: expr
+    LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(12: t1c = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [null])
+        LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
+            LEFT OUTER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                SCAN (columns[1: v1, 2: v2] predicate[null])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE BROADCAST
+                SCAN (columns[7: v7, 8: v8, 9: v9] predicate[null])
+        EXCHANGE BROADCAST
+            AGGREGATE ([GLOBAL] aggregate [{22: countRows=count(22: countRows), 23: anyValue=any_value(23: anyValue)}] group by [[12: t1c]] having [null]
+                EXCHANGE SHUFFLE[12]
+                    AGGREGATE ([LOCAL] aggregate [{22: countRows=count(1), 23: anyValue=any_value(subtract(13: t1d, 1))}] group by [[12: t1c]] having [null]
+                        SCAN (columns[12: t1c, 13: t1d] predicate[null])
+[end]

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -518,8 +518,7 @@ INNER JOIN (join-predicate [2: v2 = 7: v4] post-join-predicate [null])
                                 SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
-/*test PushDownApplyAggFilterRule*/
-
+/* test PushDownApplyAggFilterRule */
 [sql]
 select * from t0 where v1 = (select max(v5 + 1) from t1 where t0.v2 = t1.v4);
 [result]
@@ -730,8 +729,7 @@ LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(12: t1c = 1,
 [end]
 
 
-/*test ScalarApply2JoinRule*/
-
+/* test ScalarApply2JoinRule */
 [sql]
 select * from t0 where 1 = (select v5 + 1 from t1 where t0.v2 = t1.v4);
 [result]


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#10815](https://github.com/StarRocks/starrocks/issues/10815)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This pr helps to solve the problem when correlated predicate contains both inner table column and outer table column in one side of eq operator. For example, this sql `select t1.a from t1 where t1.b < (select t2.d  from 
t2 where t1.b+abs(t2.a) = t2.c)`, we should extract `abs(t2.a)`, `t2.c` from the correlated predicate `t1.b+abs(t2.a) = t2.c` and add them into the inner table output.

To solve the bug, I did things as below:
1. add CorrelatedPredicateRewriter to rewrite the correlated predicate. In the rewrite, we only extract distinct expr which only contains inner table column and replace it with a new columnRef. This helps to avoid extract const value and duplicate expr which add extra cost to the child input process. In the future, we could enhance the ability of this rewriter to support more correlated predicate in subquery.
2. extract common logic from four subqueryToJoin rules to `SubqueryUtils` to simplify the code.
3. modify the check() method in  `HashJoinImplementationRule` and `NestloopJoinImplementationRule` . Only contains eq conditon and operands in each side of equal operator belongs to one child input  can implement to hash join.




## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
