### PR TITLE
[Cherry-pick-2.2][BugFix] Fix load encrypted kms failed with error: KMS provider at xxx threw an IOException ... Failed to find any Kerberos tgt

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -144,7 +144,8 @@ public class FileSystemManager {
     
     private ConcurrentHashMap<FileSystemIdentity, BrokerFileSystem> cachedFileSystem;
     private ClientContextManager clientContextManager;
-    
+    private boolean hasSetGlobalUGI = false;
+
     public FileSystemManager() {
         cachedFileSystem = new ConcurrentHashMap<>();
         clientContextManager = new ClientContextManager(handleManagementPool);
@@ -329,6 +330,11 @@ public class FileSystemManager {
                     UserGroupInformation.setConfiguration(conf);
  
                     ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab);
+                    if (!hasSetGlobalUGI) {
+                        // set a global ugi so that other components(kms for example) can get the kerberos token.
+                        UserGroupInformation.setLoginUser(ugi);
+                        hasSetGlobalUGI = true;
+                    }
                     if (properties.containsKey(KERBEROS_KEYTAB_CONTENT)) {
                         try {
                             File file = new File(tmpFilePath);


### PR DESCRIPTION
This PR #8820 change the kerberos UGI (UserGroupInformation) to a private mode to support multi kerberos users. But for loading data from a kms encrypted path, calling kms server will fail because it cannot find a kerberos token. To fix this bug, set a kerberos ugi to the global context, so that kms client can use the kerberos token to interact with kms server.