### PR TITLE
[Feature] Support write quorum property for table

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -674,6 +674,8 @@ void run_update_meta_info_task(std::shared_ptr<UpdateTabletMetaInfoAgentTaskRequ
             case TTabletMetaType::INMEMORY:
                 // This property is no longer supported.
                 break;
+            case TTabletMetaType::WRITE_QUORUM:
+                break;
             case TTabletMetaType::ENABLE_PERSISTENT_INDEX:
                 LOG(INFO) << "update tablet:" << tablet->tablet_id()
                           << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -197,6 +197,8 @@ private:
     RuntimeState* _runtime_state = nullptr;
 
     bool _enable_colocate_mv_index = config::enable_load_colocate_mv;
+
+    WriteQuorumTypePB _write_quorum_type = WriteQuorumTypePB::MAJORITY;
 };
 
 class IndexChannel {
@@ -231,6 +233,8 @@ private:
     std::unordered_map<int64_t, int64_t> _be_to_tablet_num;
     // BeId
     std::set<int64_t> _failed_channels;
+
+    TWriteQuorumType::type _write_quorum_type = TWriteQuorumType::MAJORITY;
 };
 
 // Write data to Olap Table.
@@ -305,7 +309,15 @@ private:
 
     void mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
     bool is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }
-    bool has_intolerable_failure() { return _failed_channels.size() >= ((_num_repicas + 1) / 2); }
+    bool has_intolerable_failure() {
+        if (_write_quorum_type == TWriteQuorumType::ALL) {
+            return _failed_channels.size() > 0;
+        } else if (_write_quorum_type == TWriteQuorumType::ONE) {
+            return _failed_channels.size() >= _num_repicas;
+        } else {
+            return _failed_channels.size() >= ((_num_repicas + 1) / 2);
+        }
+    }
 
     void for_each_node_channel(const std::function<void(NodeChannel*)>& func) {
         for (auto& it : _node_channels) {
@@ -416,6 +428,8 @@ private:
     bool _colocate_mv_index = config::enable_load_colocate_mv;
 
     bool _enable_replicated_storage = false;
+
+    TWriteQuorumType::type _write_quorum_type = TWriteQuorumType::MAJORITY;
 };
 
 } // namespace stream_load

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -384,6 +384,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.node_id = _node_id;
         options.timeout_ms = params.timeout_ms();
         options.is_replicated_storage = params.is_replicated_storage();
+        options.write_quorum = params.write_quorum();
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -41,6 +41,7 @@ struct DeltaWriterOptions {
     bool is_replicated_storage = false;
     std::vector<PNetworkAddress> replicas;
     int64_t timeout_ms;
+    WriteQuorumTypePB write_quorum;
 };
 
 enum ReplicaState {

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -193,8 +193,13 @@ ReplicateToken::ReplicateToken(std::unique_ptr<ThreadPoolToken> replicate_pool_t
         _replicate_channels.emplace_back(std::move(std::make_unique<ReplicateChannel>(
                 opt, opt->replicas[i].host(), opt->replicas[i].port(), opt->replicas[i].node_id())));
     }
-    // default quorom policy
-    _max_fail_replica_num = opt->replicas.size() - (opt->replicas.size() / 2 + 1);
+    if (opt->write_quorum == WriteQuorumTypePB::ONE) {
+        _max_fail_replica_num = opt->replicas.size();
+    } else if (opt->write_quorum == WriteQuorumTypePB::ALL) {
+        _max_fail_replica_num = 0;
+    } else {
+        _max_fail_replica_num = opt->replicas.size() - (opt->replicas.size() / 2 + 1);
+    }
 }
 
 Status ReplicateToken::submit(std::unique_ptr<SegmentPB> segment, bool eos) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -506,21 +506,24 @@ public class Alter {
                 }
             } else if (alterClause instanceof ModifyTablePropertiesClause) {
                 Map<String, String> properties = alterClause.getProperties();
-                // currently, only in memory property and enable persistent index property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY) ||
-                        properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX));
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX) ||
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM));
 
                 OlapTable olapTable = (OlapTable) db.getTable(tableName);
                 if (olapTable.isLakeTable()) {
-                    throw new DdlException("Lake table not support alter in_memory or enable_persistent_index");
+                    throw new DdlException("Lake table not support alter in_memory or enable_persistent_index or write_quorum");
                 }
 
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName,
                             properties, TTabletMetaType.INMEMORY);
-                } else {
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties,
                             TTabletMetaType.ENABLE_PERSISTENT_INDEX);
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)) {
+                    ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties,
+                            TTabletMetaType.WRITE_QUORUM);
                 }
             } else {
                 throw new DdlException("Invalid alter opertion: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -327,6 +327,7 @@ public class ExternalOlapTable extends OlapTable {
             tableProperty.buildStorageFormat();
             tableProperty.buildInMemory();
             tableProperty.buildDynamicProperty();
+            tableProperty.buildWriteQuorum();
 
             indexes = null;
             if (meta.isSetIndex_infos()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -69,6 +69,7 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
@@ -1631,6 +1632,23 @@ public class OlapTable extends Table implements GsonPostProcessable {
                 .modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                         Boolean.valueOf(enablePersistentIndex).toString());
         tableProperty.buildEnablePersistentIndex();
+    }
+
+    public TWriteQuorumType writeQuorum() {
+        if (tableProperty != null) {
+            return tableProperty.writeQuorum();
+        }
+        return TWriteQuorumType.MAJORITY;
+    }
+
+    public void setWriteQuorum(String writeQuorum) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty
+                .modifyTableProperties(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM,
+                        writeQuorum);
+        tableProperty.buildWriteQuorum();
     }
 
     public void setStorageMedium(TStorageMedium storageMedium) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -33,6 +33,7 @@ import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -104,8 +105,14 @@ public class PartitionInfo implements Writable, GsonPreProcessable, GsonPostProc
         idToDataProperty.put(partitionId, newDataProperty);
     }
 
-    public int getQuorumNum(long partitionId) {
-        return getReplicationNum(partitionId) / 2 + 1;
+    public int getQuorumNum(long partitionId, TWriteQuorumType writeQuorum) {
+        if (writeQuorum == TWriteQuorumType.ALL) {
+            return getReplicationNum(partitionId);
+        } else if (writeQuorum == TWriteQuorumType.ONE) {
+            return 1;
+        } else {
+            return getReplicationNum(partitionId) / 2 + 1;
+        }
     }
 
     public short getReplicationNum(long partitionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -88,6 +88,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_PERSISTENT_INDEX = "enable_persistent_index";
 
+    public static final String PROPERTIES_WRITE_QUORUM = "write_quorum";
+
     public static final String PROPERTIES_TABLET_TYPE = "tablet_type";
 
     public static final String PROPERTIES_STRICT_RANGE = "strict_range";
@@ -444,6 +446,22 @@ public class PropertyAnalyzer {
             return CompressionUtils.getCompressTypeByName(compressionType);
         } else {
             throw new AnalysisException("unknown compression type: " + compressionType);
+        }
+    }
+
+    // analyzeWriteQuorum will parse the write quorum from properties
+    public static String analyzeWriteQuorum(Map<String, String> properties) throws AnalysisException {
+        String writeQuorum;
+        if (properties == null || !properties.containsKey(PROPERTIES_WRITE_QUORUM)) {
+            return WriteQuorum.MAJORITY;
+        }
+        writeQuorum = properties.get(PROPERTIES_WRITE_QUORUM);
+        properties.remove(PROPERTIES_WRITE_QUORUM);
+
+        if (WriteQuorum.findTWriteQuorumByName(writeQuorum) != null) {
+            return writeQuorum;
+        } else {
+            throw new AnalysisException("unknown write quorum: " + writeQuorum);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/WriteQuorum.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/WriteQuorum.java
@@ -1,0 +1,35 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.starrocks.thrift.TWriteQuorumType;
+
+public class WriteQuorum {
+    public static final String MAJORITY = "MAJORITY";
+    public static final String ALL = "ALL";
+    public static final String ONE = "ONE";
+
+    private static final ImmutableMap<String, TWriteQuorumType> T_WRITE_QUORUM_BY_NAME =
+            (new ImmutableSortedMap.Builder<String, TWriteQuorumType>(String.CASE_INSENSITIVE_ORDER))
+                    .put(MAJORITY, TWriteQuorumType.MAJORITY)
+                    .put(ONE, TWriteQuorumType.ONE)
+                    .put(ALL, TWriteQuorumType.ALL)
+                    .build();
+
+    private static final ImmutableMap<TWriteQuorumType, String> T_WRITE_QUORUM_TO_NAME =
+            (new ImmutableMap.Builder<TWriteQuorumType, String>())
+                    .put(TWriteQuorumType.MAJORITY, MAJORITY)
+                    .put(TWriteQuorumType.ONE, ONE)
+                    .put(TWriteQuorumType.ALL, ALL)
+                    .build();
+
+    public static TWriteQuorumType findTWriteQuorumByName(String name) {
+        return T_WRITE_QUORUM_BY_NAME.get(name);
+    }
+
+    public static String writeQuorumToName(TWriteQuorumType type) {
+        return T_WRITE_QUORUM_TO_NAME.get(type);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -573,6 +573,7 @@ public class JournalEntity implements Writable {
             case OperationType.OP_MODIFY_IN_MEMORY:
             case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
             case OperationType.OP_MODIFY_REPLICATION_NUM:
+            case OperationType.OP_MODIFY_WRITE_QUORUM:
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX: {
                 data = ModifyTablePropertyOperationLog.read(in);
                 isRead = true;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -102,7 +102,7 @@ public class LoadLoadingTask extends LoadTask {
     public void init(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusList, int fileNum) throws UserException {
         this.loadId = loadId;
         planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups,
-                strictMode, timezone, timeoutS, createTimestamp, partialUpdate);
+                strictMode, timezone, timeoutS, createTimestamp, partialUpdate, sessionVariables);
         planner.plan(loadId, fileStatusList, fileNum);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -466,7 +466,7 @@ public class SparkLoadJob extends BulkLoadJob {
                         }
 
                         hasLoadPartitions = true;
-                        int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partitionId);
+                        int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partitionId, table.writeQuorum());
 
                         List<MaterializedIndex> indexes = partition.getMaterializedIndices(IndexExtState.ALL);
                         for (MaterializedIndex index : indexes) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -729,6 +729,7 @@ public class EditLog {
                 case OperationType.OP_MODIFY_IN_MEMORY:
                 case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
                 case OperationType.OP_MODIFY_REPLICATION_NUM:
+                case OperationType.OP_MODIFY_WRITE_QUORUM:
                 case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
                             (ModifyTablePropertyOperationLog) journal.getData();
@@ -1450,6 +1451,10 @@ public class EditLog {
 
     public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info) {
         logEdit(OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX, info);
+    }
+
+    public void logModifyWriteQuorum(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_MODIFY_WRITE_QUORUM, info);
     }
 
     public void logReplaceTempPartition(ReplacePartitionOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -198,6 +198,7 @@ public class OperationType {
     public static final short OP_FINISH_MULTI_DELETE = 10003;
     public static final short OP_ERASE_MULTI_TABLES = 10004;
     public static final short OP_MODIFY_ENABLE_PERSISTENT_INDEX = 10005;
+    public static final short OP_MODIFY_WRITE_QUORUM = 10006;
 
     // statistic 10010 ~ 10020
     public static final short OP_ADD_ANALYZER_JOB = 10010;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -107,6 +107,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.QueryableReentrantLock;
 import com.starrocks.common.util.SmallFileMgr;
 import com.starrocks.common.util.Util;
+import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.consistency.ConsistencyChecker;
@@ -233,6 +234,7 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.thrift.TWriteQuorumType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.PublishVersionDaemon;
 import com.starrocks.transaction.UpdateDbUsedDataQuotaDaemon;
@@ -2126,6 +2128,13 @@ public class GlobalStateMgr {
             sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
                     .append("\" = \"");
             sb.append(olapTable.enablePersistentIndex()).append("\"");
+
+            // write quorum
+            if (olapTable.writeQuorum() != TWriteQuorumType.MAJORITY) {
+                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)
+                        .append("\" = \"");
+                sb.append(WriteQuorum.writeQuorumToName(olapTable.writeQuorum())).append("\"");
+            }
 
             // compression type
             sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_COMPRESSION)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.thrift.TWriteQuorumType;
 
 import java.util.List;
 
@@ -87,7 +88,8 @@ public class DeletePlanner {
             for (Partition partition : table.getPartitions()) {
                 partitionIds.add(partition.getId());
             }
-            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds);
+            TWriteQuorumType writeQuorum = table.writeQuorum();
+            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, writeQuorum);
             execPlan.getFragments().get(0).setSink(dataSink);
             // At present, we only support dop=1 for olap table sink.
             // because tablet writing needs to know the number of senders in advance

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.thrift.TWriteQuorumType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -155,8 +156,11 @@ public class InsertPlanner {
 
             DataSink dataSink;
             if (insertStmt.getTargetTable() instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) insertStmt.getTargetTable();
+                TWriteQuorumType writeQuorum = olapTable.writeQuorum();
+
                 dataSink = new OlapTableSink((OlapTable) insertStmt.getTargetTable(), olapTuple,
-                        insertStmt.getTargetPartitionIds(), canUsePipeline);
+                        insertStmt.getTargetPartitionIds(), canUsePipeline, writeQuorum);
                 // At present, we only support dop=1 for olap table sink.
                 // because tablet writing needs to know the number of senders in advance
                 // and guaranteed order of data writing

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.thrift.TWriteQuorumType;
 
 import java.util.List;
 import java.util.Optional;
@@ -81,7 +82,8 @@ public class UpdatePlanner {
             for (Partition partition : table.getPartitions()) {
                 partitionIds.add(partition.getId());
             }
-            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds);
+            TWriteQuorumType writeQuorum = table.writeQuorum();
+            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, writeQuorum);
             execPlan.getFragments().get(0).setSink(dataSink);
             // At present, we only support dop=1 for olap table sink.
             // because tablet writing needs to know the number of senders in advance

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -21,6 +21,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -134,6 +135,13 @@ public class AlterTableStatementAnalyzer {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                             "Property " + PropertyAnalyzer.PROPERTIES_STORAGE_FORMAT + " should be v2");
                 }
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)) {
+                if (WriteQuorum.findTWriteQuorumByName(properties.get(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)) == null) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_WRITE_QUORUM + " not valid");
+                }
+                clause.setNeedTableStable(false);
+                clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
             } else if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
                 // do nothing, dynamic properties will be analyzed in SchemaChangeHandler.process
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -784,7 +784,7 @@ public class DatabaseTransactionMgr {
                     }
 
                     List<MaterializedIndex> allIndices = txn.getPartitionLoadedTblIndexes(tableId, partition);
-                    int quorumNum = partitionInfo.getQuorumNum(partitionId);
+                    int quorumNum = partitionInfo.getQuorumNum(partitionId, table.writeQuorum());
                     int replicaNum = partitionInfo.getReplicationNum(partitionId);
                     for (MaterializedIndex index : allIndices) {
                         for (Tablet tablet : index.getTablets()) {
@@ -918,7 +918,7 @@ public class DatabaseTransactionMgr {
                         continue;
                     }
 
-                    int quorumReplicaNum = partitionInfo.getQuorumNum(partitionId);
+                    int quorumReplicaNum = partitionInfo.getQuorumNum(partitionId, table.writeQuorum());
 
                     List<MaterializedIndex> allIndices =
                             transactionState.getPartitionLoadedTblIndexes(tableId, partition);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -108,7 +108,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
             }
 
             List<MaterializedIndex> allIndices = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
-            int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partition.getId());
+            int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partition.getId(), table.writeQuorum());
             for (MaterializedIndex index : allIndices) {
                 for (Tablet tablet : index.getTablets()) {
                     long tabletId = tablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
@@ -73,7 +73,7 @@ public class TransactionChecker {
                     continue;
                 }
                 PartitionChecker partitionChecker = new PartitionChecker(partitionId, partitionCommitInfo.getVersion(),
-                        table.getPartitionInfo().getQuorumNum(partitionId));
+                        table.getPartitionInfo().getQuorumNum(partitionId, table.writeQuorum()));
                 List<MaterializedIndex> allIndices = txn.getPartitionLoadedTblIndexes(tableCommitInfo.getTableId(), partition);
                 for (MaterializedIndex index : allIndices) {
                     for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
@@ -183,7 +183,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 1;
         long startTime = System.currentTimeMillis();
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 2);
         Assert.assertEquals(1, planner.getScanNodes().size());
         FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
@@ -193,7 +193,7 @@ public class LoadingTaskPlannerTest {
         // load_parallel_instance_num: 2
         Config.load_parallel_instance_num = 2;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -203,7 +203,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 2;
         Config.max_broker_concurrency = 3;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -285,7 +285,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -423,7 +423,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -506,7 +506,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -593,7 +593,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -699,7 +699,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -795,7 +795,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -899,7 +899,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment
@@ -1000,7 +1000,7 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false);
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap());
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -54,6 +54,7 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWriteQuorumType;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -123,7 +124,7 @@ public class OlapTableSinkTest {
             result = partition;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L), TWriteQuorumType.MAJORITY);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -160,7 +161,7 @@ public class OlapTableSinkTest {
             result = p1;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), TWriteQuorumType.MAJORITY);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         try {
             sink.complete();
@@ -183,7 +184,7 @@ public class OlapTableSinkTest {
             result = null;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId));
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId), TWriteQuorumType.MAJORITY);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -256,7 +257,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId));
+        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY);
         TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
         System.out.println(param);
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -338,6 +338,7 @@ public class PseudoCluster {
         private String tableName = "test_table";
         private int buckets = 3;
         private int replication = 3;
+        private String quorum = "MAJORITY";
 
         private boolean ssd = true;
 
@@ -361,11 +362,17 @@ public class PseudoCluster {
             return this;
         }
 
+        public CreateTableSqlBuilder setWriteQuorum(String quorum) {
+            this.quorum = quorum;
+            return this;
+        }
+
         public String build() {
             return String.format("create table %s (id bigint not null, name varchar(64) not null, age int null) " +
-                            "primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS %d " +
-                            "PROPERTIES(\"replication_num\" = \"%d\", \"storage_medium\" = \"%s\")", tableName,
-                    buckets, replication,
+                    "primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS %d " +
+                    "PROPERTIES(\"write_quorum\" = \"%s\", \"replication_num\" = \"%d\", \"storage_medium\" = \"%s\")",
+                    tableName,
+                    buckets, quorum, replication,
                     ssd ? "SSD" : "HDD");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/WriteQuorumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/WriteQuorumTest.java
@@ -1,0 +1,109 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.transaction;
+
+import com.starrocks.common.Config;
+import com.starrocks.pseudocluster.PseudoCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+public class WriteQuorumTest {
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Config.enable_new_publish_mechanism = true;
+        PseudoCluster.getOrCreateWithRandomPort(true, 3);
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql(null, "create database test");
+        cluster.runSql("test",
+                "create table test_default ( pk bigint NOT NULL, v0 string not null, v1 int not null ) " +
+                        "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 3 " +
+                        "PROPERTIES(\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\");");
+        cluster.runSql("test",
+                "create table test_all ( pk bigint NOT NULL, v0 string not null, v1 int not null ) " +
+                        "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 3 " +
+                        "PROPERTIES(\"write_quorum\" = \"all\", \"replication_num\" = \"3\", \"storage_medium\" = \"SSD\");");
+        cluster.runSql("test",
+                "create table test_one ( pk bigint NOT NULL, v0 string not null, v1 int not null ) " +
+                        "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 3 " +
+                        "PROPERTIES(\"write_quorum\" = \"one\", \"replication_num\" = \"3\", \"storage_medium\" = \"SSD\");");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        PseudoCluster.getInstance().shutdown(true);
+    }
+
+    @Test
+    public void test3Replica0FailInsertSuccess() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        int numLoad = 10;
+        long startTs = System.nanoTime();
+        for (int i = 0; i < numLoad; i++) {
+            cluster.runSql("test", "insert into test_default values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+            cluster.runSql("test", "insert into test_all values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+            cluster.runSql("test", "insert into test_one values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+        }
+        double t = (System.nanoTime() - startTs) / 1e9;
+        System.out.printf("numLoad:%d Time: %.2fs, %.2f tps\n", numLoad, t, numLoad / t);
+    }
+
+    @Test
+    public void test3Replica1FailInsertSuccess() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.getBackend(10001).setWriteFailureRate(1.0f);
+        try {
+            int numLoad = 10;
+            long startTs = System.nanoTime();
+            for (int i = 0; i < numLoad; i++) {
+                cluster.runSql("test", "insert into test_default values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+                cluster.runSql("test", "insert into test_one values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+            }
+            double t = (System.nanoTime() - startTs) / 1e9;
+            System.out.printf("numLoad:%d Time: %.2fs, %.2f tps\n", numLoad, t, numLoad / t);
+        } finally {
+            cluster.getBackend(10001).setWriteFailureRate(0.0f);
+        }
+    }
+
+    @Test(expected = SQLException.class)
+    public void test3Replica2FailInsertFail() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.getBackend(10001).setWriteFailureRate(1.0f);
+        cluster.getBackend(10002).setWriteFailureRate(1.0f);
+        try {
+            cluster.runSql("test", "insert into test_default values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+        } finally {
+            cluster.getBackend(10001).setWriteFailureRate(0.0f);
+            cluster.getBackend(10002).setWriteFailureRate(0.0f);
+        }
+    }
+
+    @Test(expected = SQLException.class)
+    public void test3Replica1FailInsertAllFail() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.getBackend(10001).setWriteFailureRate(1.0f);
+        try {
+            cluster.runSql("test", "insert into test_all values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+        } finally {
+            cluster.getBackend(10001).setWriteFailureRate(0.0f);
+        }
+    }
+
+    @Test(expected = SQLException.class)
+    public void test3Replica3FailInsertFail() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.getBackend(10001).setWriteFailureRate(1.0f);
+        cluster.getBackend(10002).setWriteFailureRate(1.0f);
+        cluster.getBackend(10003).setWriteFailureRate(1.0f);
+        try {
+            cluster.runSql("test", "insert into test_one values (1,\"1\", 1), (2,\"2\",2), (3,\"3\",3);");
+        } finally {
+            cluster.getBackend(10001).setWriteFailureRate(0.0f);
+            cluster.getBackend(10002).setWriteFailureRate(0.0f);
+            cluster.getBackend(10003).setWriteFailureRate(0.0f);
+        }
+    }
+
+}

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -149,6 +149,7 @@ message PTabletWriterOpenRequest {
     optional string txn_trace_parent = 22;
     optional bool is_replicated_storage = 23;
     optional int64 timeout_ms = 24;
+    optional WriteQuorumTypePB write_quorum = 25;
 };
 
 message PTabletWriterOpenResult {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -84,6 +84,12 @@ enum CompressionTypePB {
     LZ4_HADOOP = 13;
 }
 
+enum WriteQuorumTypePB {
+    ONE = 0;
+    MAJORITY = 1;
+    ALL = 2;
+}
+
 // Used to store additional information about a txn when it is finished/visible
 // It will be serialized with TransactionState
 message TxnFinishStatePB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -274,7 +274,8 @@ struct TRecoverTabletReq {
 enum TTabletMetaType {
     PARTITIONID,
     INMEMORY,
-    ENABLE_PERSISTENT_INDEX
+    ENABLE_PERSISTENT_INDEX,
+    WRITE_QUORUM
 }
 
 struct TTabletMetaInfo {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -166,6 +166,7 @@ struct TOlapTableSink {
     15: optional bool is_lake_table
     16: optional string txn_trace_parent
     17: optional Types.TKeysType keys_type
+    18: optional Types.TWriteQuorumType write_quorum_type
 }
 
 struct TDataSink {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -447,3 +447,9 @@ enum TCompressionType {
     BZIP2 = 10;
     LZO = 11; // Deprecated
 }
+
+enum TWriteQuorumType {
+    ONE = 0;
+    MAJORITY = 1;
+    ALL = 2;
+}


### PR DESCRIPTION
1. MAJORITY: write majority replica successfully returns success, default option
2. ONE: write one replica successfully returns success
3. ALL: write all replica successfully returns success

## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11613

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
User can set `write_quorum` to specify replica write strategy when create/alter table.

**MAJORITY**: write majority replica successfully returns success, default option
**ONE**: write one replica successfully returns success
**ALL**: write all replica successfully returns success

> Note: The write will only return after all replicas have determined the state, not if the write to some replicas is successful and the state of other replicas is unknown

### CREATE TABLE
```sql
CREATE TABLE my_table
(
    k1 TINYINT,
    k2 DECIMAL(10, 2) DEFAULT "10.5",
    v1 CHAR(10) REPLACE,
    v2 INT SUM
)
ENGINE = olap
AGGREGATE KEY(k1, k2)
DISTRIBUTED BY HASH(k1) BUCKETS 10
PROPERTIES ("write_quorum" = "one");
```
### ALTER TABLE
```sql
ALTER TABLE my_table
SET ("write_quorum" = "ALL");
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
