### PR TITLE
[Enhancement] support to set file size in advance to avoid rpc `get_size`

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -252,6 +252,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.scan_ranges = {&scan_range};
     scanner_params.fs = _pool.add(fs.release());
     scanner_params.path = native_file_path;
+    scanner_params.file_size = _scan_range.file_length;
     scanner_params.tuple_desc = _tuple_desc;
     scanner_params.materialize_slots = _materialize_slots;
     scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -194,6 +194,7 @@ Status HdfsScanner::open_random_access_file() {
                 std::make_shared<io::CompressedSeekableInputStream>(compressed_input_stream);
         _file = std::make_unique<RandomAccessFile>(compressed_seekable_input_stream, _raw_file->filename());
     }
+    _file->set_size(_scanner_params.file_size);
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -89,8 +89,8 @@ struct HdfsScannerParams {
     FileSystem* fs = nullptr;
     // The file to scan
     std::string path;
-    // The file size
-    int64_t file_size;
+    // The file size. -1 means unknown.
+    int64_t file_size = -1;
 
     const TupleDescriptor* tuple_desc = nullptr;
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -89,6 +89,8 @@ struct HdfsScannerParams {
     FileSystem* fs = nullptr;
     // The file to scan
     std::string path;
+    // The file size
+    int64_t file_size;
 
     const TupleDescriptor* tuple_desc = nullptr;
 

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -34,6 +34,7 @@ public:
     StatusOr<int64_t> position() override { return _offset; }
     StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override;
     Status seek(int64_t offset) override;
+    void set_size(int64_t size) override;
 
 private:
     hdfsFS _fs;
@@ -89,6 +90,10 @@ StatusOr<int64_t> HdfsInputStream::get_size() {
         if (!st.ok()) return st;
     }
     return _file_size;
+}
+
+void HdfsInputStream::set_size(int64_t value) {
+    _file_size = value;
 }
 
 StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_statistics() {

--- a/be/src/io/s3_input_stream.cpp
+++ b/be/src/io/s3_input_stream.cpp
@@ -64,4 +64,8 @@ StatusOr<int64_t> S3InputStream::get_size() {
     return _size;
 }
 
+void S3InputStream::set_size(int64_t value) {
+    _size = value;
+}
+
 } // namespace starrocks::io

--- a/be/src/io/s3_input_stream.h
+++ b/be/src/io/s3_input_stream.h
@@ -40,6 +40,8 @@ public:
 
     StatusOr<int64_t> get_size() override;
 
+    void set_size(int64_t size) override;
+
 private:
     std::shared_ptr<Aws::S3::S3Client> _s3client;
     std::string _bucket;

--- a/be/src/io/seekable_input_stream.cpp
+++ b/be/src/io/seekable_input_stream.cpp
@@ -21,4 +21,6 @@ Status SeekableInputStream::skip(int64_t count) {
     return seek(pos + count);
 }
 
+void SeekableInputStream::set_size(int64_t count) {}
+
 } // namespace starrocks::io

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -54,6 +54,8 @@ public:
     //    return seek(pos + count);
     // ```
     Status skip(int64_t count) override;
+
+    virtual void set_size(int64_t);
 };
 
 class SeekableInputStreamWrapper : public SeekableInputStream {
@@ -101,6 +103,8 @@ public:
     StatusOr<int64_t> get_size() override { return _impl->get_size(); }
 
     Status seek(int64_t offset) override { return _impl->seek(offset); }
+
+    void set_size(int64_t value) override { return _impl->set_size(value); }
 
 private:
     SeekableInputStream* _impl;

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -82,6 +82,7 @@ HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfs
     auto* param = _pool.add(new HdfsScannerParams());
     param->fs = FileSystem::Default();
     param->path = file;
+    param->file_size = range->file_length;
     param->scan_ranges.emplace_back(range);
     param->tuple_desc = tuple_desc;
     std::vector<int> materialize_index_in_chunk;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

File size has been fetched in FE side, so we don't need to call `get_size` to get remote file(object) size any more. This could save amount of rpc calls when handling excessive small files.

in our case, 10 partitions, each partition has 100000  small files, we could save 10seconds(total time is 100 seconds)

<img width="1087" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/1081215/190350883-8c99124f-3c14-4a35-8d2e-670133575b70.png">

<img width="1155" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/1081215/190350863-0a4978ce-bd31-40dc-8231-6cfb41d38340.png">

----

We can see from flamegraph that `get_size` has been removed.

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/1081215/190351047-cd1ea764-4dfb-4d04-833b-b2cd1c3e79aa.png">

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/1081215/190351110-d69068b0-5ec4-4b58-b6db-f7a8fb5a76a3.png">


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
