### PR TITLE
[Cherry-pick 2.4][Feature] Support all-digit user name (#9715)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -35,7 +35,7 @@ public class FeNameFormat {
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
 
     // The user name  by kerberos authentication may include the host name, so additional adaptation is required.
-    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{1,63}/?[.a-zA-Z0-9_-]{0,63}$";
+    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z0-9_]{1,64}/?[.a-zA-Z0-9_-]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -2279,4 +2279,12 @@ public class AuthTest {
         newAuth.replayRevokeImpersonate(infos.get(0));
         Assert.assertFalse(newAuth.canImpersonate(harry, gregory));
     }
+
+    @Test
+    public void testUserNamePureDigit() throws Exception {
+        String sql = "CREATE USER '12345' IDENTIFIED BY '12345'";
+        CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        auth.createUser(createUserStmt);
+        Assert.assertNotNull(auth.getUserProperties("default_cluster:'12345'@'%'"));
+    }
 }


### PR DESCRIPTION
Allow all-digit user name, such as create user '12345';.

manually cherrypick from f62b50193.