### PR TITLE
[Cherry-pick][Branch-2.4][Enhancement] Remove final merge in load of PrimaryKey table

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -123,7 +123,9 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
     // updatable tablet require extra processing
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         _rowset_meta_pb->set_num_delete_files(_num_delfile);
-        _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        if (_num_segment <= 1) {
+            _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        }
         // if load only has delete, we can skip the partial update logic
         if (_context.partial_update_tablet_schema && _flush_chunk_state != FlushChunkState::DELETE) {
             DCHECK(_context.referenced_column_ids.size() == _context.partial_update_tablet_schema->columns().size());
@@ -220,9 +222,7 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
 StatusOr<std::unique_ptr<SegmentWriter>> HorizontalBetaRowsetWriter::_create_segment_writer() {
     std::lock_guard<std::mutex> l(_lock);
     std::string path;
-    if ((_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
-         _context.segments_overlap != NONOVERLAPPING) ||
-        _context.schema_change_sorting) {
+    if (_context.schema_change_sorting) {
         path = Rowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_segment);
         _tmp_segment_files.emplace_back(path);
     } else {
@@ -385,19 +385,10 @@ StatusOr<RowsetSharedPtr> HorizontalBetaRowsetWriter::build() {
     }
 }
 
-// why: when the data is large, multi segment files created, may be OVERLAPPINGed.
-// what: do final merge for NONOVERLAPPING state among segment files
-// when: segment files number larger than one, no delete files(for now, ignore it when just one segment)
-// how: for final merge scenario, temporary files created at first, merge them, create final segment files.
+// final merge is still used for sorting schema change right now, so we keep the logic in RowsetWriter
+// we may move this logic to `schema change` in near future, we can remove the following logic at that time
 Status HorizontalBetaRowsetWriter::_final_merge() {
-    if (_num_segment == 1) {
-        RETURN_IF_ERROR_WITH_WARN(
-                _fs->rename_file(Rowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, 0),
-                                 Rowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, 0)),
-                "Fail to rename file");
-        return Status::OK();
-    }
-
+    DCHECK(_context.schema_change_sorting);
     auto span = Tracer::Instance().start_trace_txn_tablet("final_merge", _context.txn_id, _context.tablet_id);
     auto scoped = trace::Scope(span);
     MonotonicStopWatch timer;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/10953

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PrimaryKey table will write data into temp files first, then read and merge temp files in data load. So PrimaryKey table needs to read and write all data twice in data load, which causes the load time to be twice as long as other types of tables.

The final merge of the PrimaryKey table is unnecessary; we can remove the final merge to speed up the data load.

In my test environment, the load cost time is shown as below:

| branch | load_type | num_rows | format | file size | key type | cost time | final merge time | 
| ------- | ---------- | ---------- | ------- | -------  | -------- | ---------  | ---------------- |
|   main   | stream load | 20000000 | CSV | 7.6G | PrimaryKey | 205668ms |      102151ms  |
| remove_final_merge| stream load | 20000000 | CSV | 7.6G | PrimaryKey| 97577ms | |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
