### PR TITLE
[Cherry-pick 2.2][BugFix] Allow select from view when user is only granted on view (#10508)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -11,19 +11,36 @@ import com.starrocks.analysis.ShowTableStatusStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Catalog;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
-
-import java.util.Map;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.ViewRelation;
 
 public class PrivilegeChecker {
     public static void check(StatementBase statement, ConnectContext session) {
         new PrivilegeCheckerVisitor().check(statement, session);
+    }
+
+    public static boolean checkTblPriv(ConnectContext context,
+                                       TableName tableName,
+                                       PrivPredicate predicate) {
+        return checkTblPriv(context, tableName.getDb(), tableName.getTbl(), predicate);
+    }
+    public static boolean checkTblPriv(ConnectContext context,
+                                       String dbName,
+                                       String tableName,
+                                       PrivPredicate predicate) {
+        return context.getCatalog().getAuth().checkTblPriv(
+                        context, dbName, tableName, predicate);
     }
 
     private static class PrivilegeCheckerVisitor extends AstVisitor<Void, ConnectContext> {
@@ -93,15 +110,7 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitQueryStatement(QueryStatement stmt, ConnectContext session) {
-            Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(stmt);
-            for (Map.Entry<TableName, Table> table : tables.entrySet()) {
-                TableName tableName = table.getKey();
-                if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(session, tableName.getDb(),
-                        tableName.getTbl(), PrivPredicate.SELECT)) {
-                    ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
-                            session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
-                }
-            }
+            new TablePrivilegeChecker(session).visit(stmt);
             return null;
         }
 
@@ -114,4 +123,69 @@ public class PrivilegeChecker {
             return null;
         }
     }
+
+    private static class TablePrivilegeChecker extends AstVisitor<Void, Void> {
+        private ConnectContext session;
+        public TablePrivilegeChecker(ConnectContext session) {
+            this.session = session;
+        }
+        @Override
+        public Void visitQueryStatement(QueryStatement node, Void context) {
+            return visit(node.getQueryRelation());
+        }
+
+        @Override
+        public Void visitSubquery(SubqueryRelation node, Void context) {
+            return visit(node.getQueryStatement());
+        }
+
+        @Override
+        public Void visitView(ViewRelation node, Void context) {
+            // if user has select privilege for the view, then there's no need to check base table
+            if (checkTblPriv(session, node.getName(), PrivPredicate.SELECT)) {
+                return null;
+            }
+            return visit(node.getQueryStatement());
+        }
+
+        @Override
+        public Void visitSelect(SelectRelation node, Void context) {
+            if (node.hasWithClause()) {
+                node.getCteRelations().forEach(this::visit);
+            }
+
+            return visit(node.getRelation());
+        }
+
+        @Override
+        public Void visitSetOp(SetOperationRelation node, Void context) {
+            if (node.hasWithClause()) {
+                node.getRelations().forEach(this::visit);
+            }
+            node.getRelations().forEach(this::visit);
+            return null;
+        }
+
+        @Override
+        public Void visitJoin(JoinRelation node, Void context) {
+            visit(node.getLeft());
+            visit(node.getRight());
+            return null;
+        }
+
+        @Override
+        public Void visitCTE(CTERelation node, Void context) {
+            return visit(node.getCteQueryStatement());
+        }
+
+        @Override
+        public Void visitTable(TableRelation node, Void context) {
+            if (!checkTblPriv(session, node.getName(), PrivPredicate.SELECT)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
+                        session.getQualifiedUser(), session.getRemoteIP(), node.getTable());
+            }
+            return null;
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -149,4 +149,48 @@ public class PrivilegeCheckerTest {
         Assert.assertThrows(SemanticException.class,
                 () -> PrivilegeChecker.check(statementBase, starRocksAssert.getCtx()));
     }
+
+    @Test
+    public void testSelectView() throws Exception {
+        auth = starRocksAssert.getCtx().getCatalog().getAuth();
+        starRocksAssert.getCtx().setQualifiedUser("test");
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
+        starRocksAssert.getCtx().setRemoteIP("%");
+
+        // create view
+        TablePattern tablePattern = new TablePattern("db1", "tbl1");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        tablePattern = new TablePattern("db1", "*");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.CREATE_PRIV), false);
+        String sql = "create view db1.view1 as select k1 from db1.tbl1;";
+        starRocksAssert.withView(sql);
+
+        // select privilege on base table
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(
+                "select * from db1.view1", starRocksAssert.getCtx());
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+        // revoke select privilege on base table
+        tablePattern = new TablePattern("db1", "tbl1");
+        tablePattern.analyze("default_cluster");
+        auth.revokePrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        // grant select privilege on view
+        tablePattern = new TablePattern("db1", "view1");
+        tablePattern.analyze("default_cluster");
+        auth.grantPrivs(testUser, tablePattern, PrivBitSet.of(Privilege.SELECT_PRIV), false);
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+        // no select privilege on neither the base table nor the view
+        UserIdentity testUser2 = new UserIdentity("test2", "%");
+        testUser2.analyze("default_cluster");
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser2);
+        try {
+            PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+            Assert.fail();
+        } catch (SemanticException e) {
+            Assert.assertTrue(e.getMessage().contains("SELECT command denied to user"));
+        }
+    }
 }


### PR DESCRIPTION
When checking the privileges of a query statement, instead of checking the select privileges of all the relative tables, we traversal all nodes and handle them separately. As to view, the operation will be allowed when the user has the privilege to the view itself, otherwise, it will keep looking for select privileges on all the base tables as it used to be.

manually cherry-pick from efaba04f2

Fixes #10472