### PR TITLE
[Enhancement] use mem_limit to initialize page cache and calc max consistency mem

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -107,11 +107,7 @@ static int64_t calc_max_compaction_memory(int64_t process_mem_limit) {
 }
 
 static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
-    int64_t max_mem = MemInfo::physical_mem();
-    if (_mem_tracker->has_limit()) {
-        max_mem = _mem_tracker->limit();
-    }
-    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, max_mem);
+    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, process_mem_limit);
     int64_t percent = config::consistency_max_memory_limit_percent;
 
     if (process_mem_limit < 0) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -107,7 +107,7 @@ static int64_t calc_max_compaction_memory(int64_t process_mem_limit) {
 }
 
 static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
-    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit);
+    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, MemInfo::physical_mem());
     int64_t percent = config::consistency_max_memory_limit_percent;
 
     if (process_mem_limit < 0) {
@@ -320,7 +320,7 @@ Status ExecEnv::init_mem_tracker() {
     int64_t bytes_limit = 0;
     std::stringstream ss;
     // --mem_limit="" means no memory limit
-    bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit);
+    bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
     // use 90% of mem_limit as the soft mem limit of BE
     bytes_limit = bytes_limit * 0.9;
     if (bytes_limit <= 0) {
@@ -382,7 +382,11 @@ Status ExecEnv::init_mem_tracker() {
 }
 
 Status ExecEnv::_init_storage_page_cache() {
-    int64_t storage_cache_limit = ParseUtil::parse_mem_spec(config::storage_page_cache_limit);
+    int64_t mem_limit = MemInfo::physical_mem();
+    if (_mem_tracker->has_limit()) {
+        mem_limit = _mem_tracker->limit();
+    }
+    int64_t storage_cache_limit = ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
     if (storage_cache_limit > MemInfo::physical_mem()) {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
                      << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -107,7 +107,11 @@ static int64_t calc_max_compaction_memory(int64_t process_mem_limit) {
 }
 
 static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
-    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, MemInfo::physical_mem());
+    int64_t max_mem = MemInfo::physical_mem();
+    if (_mem_tracker->has_limit()) {
+        max_mem = _mem_tracker->limit();
+    }
+    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, max_mem);
     int64_t percent = config::consistency_max_memory_limit_percent;
 
     if (process_mem_limit < 0) {

--- a/be/src/util/parse_util.cpp
+++ b/be/src/util/parse_util.cpp
@@ -26,7 +26,7 @@
 
 namespace starrocks {
 
-int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str) {
+int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str, const int64_t memory_limit) {
     bool is_percent = false;
     if (mem_spec_str.empty()) {
         return 0;
@@ -91,7 +91,7 @@ int64_t ParseUtil::parse_mem_spec(const std::string& mem_spec_str) {
         }
 
         if (is_percent) {
-            bytes = (static_cast<double>(limit_val) / 100.0) * MemInfo::physical_mem();
+            bytes = (static_cast<double>(limit_val) / 100.0) * memory_limit;
         } else {
             bytes = limit_val;
         }

--- a/be/src/util/parse_util.h
+++ b/be/src/util/parse_util.h
@@ -34,11 +34,10 @@ public:
     // '<int>[bB]?'  -> bytes (default if no unit given)
     // '<float>[mM]' -> megabytes
     // '<float>[gG]' -> in gigabytes
-    // '<int>%'      -> in percent of MemInfo::physical_mem()
-    // Requires MemInfo to be initialized for the '%' spec to work.
+    // '<int>%'      -> in percent of memory_limit
     // Returns 0 if mem_spec_str is empty or '-1'.
     // Returns -1 if parsing failed.
-    static int64_t parse_mem_spec(const std::string& mem_spec_str);
+    static int64_t parse_mem_spec(const std::string& mem_spec_str, const int64_t memory_limit);
 };
 
 } // namespace starrocks

--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -27,8 +27,10 @@
 
 namespace starrocks {
 
+const static int64_t test_memory_limit = 10000;
+
 static void test_parse_mem_spec(const std::string& mem_spec_str, int64_t result) {
-    int64_t bytes = ParseUtil::parse_mem_spec(mem_spec_str);
+    int64_t bytes = ParseUtil::parse_mem_spec(mem_spec_str, test_memory_limit);
     ASSERT_EQ(result, bytes);
 }
 
@@ -50,8 +52,8 @@ TEST(TestParseMemSpec, Normal) {
     test_parse_mem_spec("8t", 8L * 1024 * 1024 * 1024 * 1024L);
     test_parse_mem_spec("128T", 128L * 1024 * 1024 * 1024 * 1024L);
 
-    int64_t bytes = ParseUtil::parse_mem_spec("20%");
-    ASSERT_GT(bytes, 0);
+    int64_t bytes = ParseUtil::parse_mem_spec("20%", test_memory_limit);
+    ASSERT_EQ(bytes, test_memory_limit * 0.2);
 }
 
 TEST(TestParseMemSpec, Bad) {
@@ -70,7 +72,7 @@ TEST(TestParseMemSpec, Bad) {
     bad_values.push_back("1eb");
     bad_values.push_back("%");
     for (const auto& value : bad_values) {
-        int64_t bytes = ParseUtil::parse_mem_spec(value);
+        int64_t bytes = ParseUtil::parse_mem_spec(value, test_memory_limit);
         ASSERT_EQ(-1, bytes);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
use mem_limit to initialize page cache and calc max consistency mem.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
