### PR TITLE
[Enhancement] CostModel not depends the pipeline dop

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -194,13 +194,12 @@ public class CostModel {
                     result = CostEstimate.ofCpu(statistics.getOutputSize(outputColumns));
                     break;
                 case BROADCAST:
-                    int parallelExecInstanceNum = Math.max(1, getParallelExecInstanceNum(context));
                     // beNum is the number of right table should broadcast, now use alive backends
                     int aliveBackendNumber = ctx.getAliveBackendNumber();
                     int beNum = Math.max(1, aliveBackendNumber);
                     result = CostEstimate.of(statistics.getOutputSize(outputColumns) * aliveBackendNumber,
-                            statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum,
-                            Math.max(statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum, 1));
+                            statistics.getOutputSize(outputColumns) * beNum,
+                            Math.max(statistics.getOutputSize(outputColumns) * beNum, 1));
                     if (statistics.getOutputSize(outputColumns) > sessionVariable.getMaxExecMemByte()) {
                         return CostEstimate.of(result.getCpuCost() * StatsConstants.BROADCAST_JOIN_MEM_EXCEED_PENALTY,
                                 result.getMemoryCost() * StatsConstants.BROADCAST_JOIN_MEM_EXCEED_PENALTY,
@@ -218,11 +217,6 @@ public class CostModel {
                             ErrorType.UNSUPPORTED);
             }
             return result;
-        }
-
-        private int getParallelExecInstanceNum(ExpressionContext context) {
-            return Math.min(ConnectContext.get().getSessionVariable().getDegreeOfParallelism(),
-                    context.getRootProperty().getLeftMostScanTabletsNum());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -282,7 +282,8 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         double leftOutputSize = leftChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex - 1));
         double rightOutputSize = rightChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex));
 
-        int parallelExecInstance = CostModel.getParallelExecInstanceNum();
+        int parallelExecInstance = CostModel.getParallelExecInstanceNum(
+                groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum());
         if (leftOutputSize < rightOutputSize * parallelExecInstance * beNum * sv.getBroadcastRightTableScaleFactor()
                 && rightChildStats.getOutputRowCount() >
                 sv.getBroadcastRowCountLimit()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -273,9 +273,6 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         // shuffling large left-hand table data
         ConnectContext ctx = ConnectContext.get();
         SessionVariable sv = ConnectContext.get().getSessionVariable();
-        int parallelExecInstance = Math.max(1,
-                Math.min(groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum(),
-                        sv.getDegreeOfParallelism()));
         int beNum = Math.max(1, ctx.getAliveBackendNumber());
         Statistics leftChildStats = groupExpression.getInputs().get(curChildIndex - 1).getStatistics();
         Statistics rightChildStats = groupExpression.getInputs().get(curChildIndex).getStatistics();
@@ -285,6 +282,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         double leftOutputSize = leftChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex - 1));
         double rightOutputSize = rightChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex));
 
+        int parallelExecInstance = CostModel.getParallelExecInstanceNum();
         if (leftOutputSize < rightOutputSize * parallelExecInstance * beNum * sv.getBroadcastRightTableScaleFactor()
                 && rightChildStats.getOutputRowCount() >
                 sv.getBroadcastRowCountLimit()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -168,8 +168,8 @@ public class ReplayFromDumpTest {
         sessionVariable.setNewPlanerAggStage(2);
         Pair<QueryDumpInfo, String> replayPair =
                 getCostPlanFragment(getDumpInfoFromFile("query_dump/tpch17"), sessionVariable);
-        Assert.assertTrue(replayPair.second.contains("1:AGGREGATE (update serialize)"));
-        Assert.assertTrue(replayPair.second.contains("3:AGGREGATE (merge finalize)"));
+        Assert.assertTrue(replayPair.second.contains("2:AGGREGATE (update serialize)"));
+        Assert.assertTrue(replayPair.second.contains("4:AGGREGATE (merge finalize)"));
     }
 
     @Test
@@ -422,8 +422,10 @@ public class ReplayFromDumpTest {
     public void testJoinWithPipelineDop() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/join_pipeline_dop"), null, TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second.contains("25:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)"));
+        Assert.assertTrue(replayPair.second.contains("24:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: ss_customer_sk = 52: c_customer_sk"));
     }
 
     @Test
@@ -613,7 +615,7 @@ public class ReplayFromDumpTest {
     public void testHiveTPCH08UsingResource() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch08_resource"), null, TExplainLevel.COSTS);
-        Assert.assertTrue(replayPair.second.contains("33:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second.contains("30:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  equal join conjunct: [33: o_orderkey, INT, true] = [17: l_orderkey, INT, true]\n" +
                 "  |  build runtime filters:\n" +
@@ -663,7 +665,7 @@ public class ReplayFromDumpTest {
     public void testParHiveTPCH08UsingCatalog() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch08_catalog"), null, TExplainLevel.COSTS);
-        Assert.assertTrue(replayPair.second.contains("21:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second.contains("18:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [18: l_partkey, INT, true] = [1: p_partkey, INT, true]\n" +
                 "  |  build runtime filters:\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #




## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


QO's costmodel should  not depend pipeline's dop right now because BE's hash table can be reused for broadcast-join.
```
    after	   before
query01.sql	0.512	0.527
query02.sql	0.689	0.684
query03.sql	0.167	0.174
query04.sql	8.826	6.656
query05.sql	1.045	1.057
query06.sql	0.407	0.52
query07.sql	0.398	0.486
query08.sql	0.328	0.344
query09.sql	1.564	1.571
query10.sql	0.556	0.561
query11.sql	5.823	2.824
query12.sql	0.33	0.332
query13.sql	0.308	0.38
query14.sql	6.729	8.318
query15.sql	0.406	0.414
query16.sql	0.666	0.876
query17.sql	0.712	0.704
query18.sql	0.565	0.838
query19.sql	0.467	0.478
query20.sql	0.331	0.334
query21.sql	0.152	0.152
query22.sql	2.536	2.596
query23.sql	8.16	8.541
query24.sql	1.04	1.095
query25.sql	0.663	0.755
query26.sql	0.4	0.395
query27.sql	0.376	0.379
query28.sql	1.258	1.289
query29.sql	0.579	0.928
query30.sql	0.511	0.536
query31.sql	0.721	0.906
query32.sql	0.171	0.176
query33.sql	0.774	1.267
query34.sql	0.337	0.338
query35.sql	0.976	0.985
query36.sql	0.277	0.356
query37.sql	0.114	0.108
query38.sql	1.521	1.405
query39.sql	1.403	1.62
query40.sql	0.464	0.458
query41.sql	0.069	0.067
query42.sql	0.134	0.136
query43.sql	0.33	0.327
query44.sql	0.433	0.434
query45.sql	0.377	0.484
query46.sql	0.439	0.521
query47.sql	1.275	1.26
query48.sql	0.274	0.367
query49.sql	0.625	0.632
query50.sql	0.463	0.512
query51.sql	1.815	1.711
query52.sql	0.217	0.217
query53.sql	0.371	0.373
query54.sql	0.657	0.87
query55.sql	0.207	0.203
query56.sql	0.618	1.071
query57.sql	1.039	1.04
query58.sql	0.536	0.541
query59.sql	1.517	1.557
query60.sql	0.694	1.37
query61.sql	0.596	0.645
query62.sql	0.294	0.287
query63.sql	0.351	0.348
query64.sql	8.891	8.676
query65.sql	1.099	1.178
query66.sql	0.514	0.527
query67.sql	6.905	6.786
query68.sql	0.506	0.514
query69.sql	0.796	0.787
query70.sql	0.662	0.682
query71.sql	0.514	0.504
query72.sql	1.664	1.667
query73.sql	0.299	0.302
query74.sql	3.148	2.747
query75.sql	1.616	1.608
query76.sql	0.386	0.594
query77.sql	0.699	0.696
query78.sql	1.972	1.967
query79.sql	0.431	0.526
query80.sql	0.989	1.081
query81.sql	0.47	0.563
query82.sql	0.121	0.125
query83.sql	0.302	0.461
query84.sql	0.181	0.181
query85.sql	0.562	0.561
query86.sql	0.274	0.365
query87.sql	1.586	1.445
query88.sql	1.182	1.181
query89.sql	0.409	0.401
query90.sql	0.147	0.28
query91.sql	0.297	0.299
query92.sql	0.222	0.227
query93.sql	0.393	0.397
query94.sql	0.581	0.663
query95.sql	1.37	1.416
query96.sql	0.129	0.123
query97.sql	0.782	0.794
query98.sql	0.333	0.404
query99.sql	0.364	0.359
	107.389	108.423
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
