### PR TITLE
[BugFix] fix the mem statistics bug of column zone map

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -117,12 +117,14 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
                 break;
             case ZONE_MAP_INDEX:
                 _zonemap_index_meta.reset(index_meta->release_zone_map_index());
-                MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->column_zonemap_index_mem_tracker(),
-                                         _zonemap_index_meta->SpaceUsedLong());
-                _zonemap_index = std::make_unique<ZoneMapIndexReader>();
                 _segment_zone_map.reset(_zonemap_index_meta->release_segment_zone_map());
+                MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->column_zonemap_index_mem_tracker(),
+                                         _zonemap_index_meta->SpaceUsedLong())
+                // the segment zone map will release from zonemap_index_map,
+                // so we should calc mem usage after release.
                 MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->segment_zonemap_mem_tracker(),
-                                         _segment_zone_map->SpaceUsedLong());
+                                         _segment_zone_map->SpaceUsedLong())
+                _zonemap_index = std::make_unique<ZoneMapIndexReader>();
                 break;
             case BITMAP_INDEX:
                 _bitmap_index_meta.reset(index_meta->release_bitmap_index());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the segment zone map will release from zonemap_index_map, so we should calc mem usage after release.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
