### PR TITLE
[Enhancement] Optimize orc load random I/O

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -718,6 +718,8 @@ CONF_Bool(enable_orc_late_materialization, "true");
 CONF_Int32(orc_file_cache_max_size, "8388608");
 CONF_Int32(orc_natural_read_size, "8388608");
 CONF_mBool(orc_coalesce_read_enable, "true");
+CONF_mBool(enable_orc_load_prefetch, "true");
+CONF_Int32(orc_load_prefetch_size, "16777216");
 
 // parquet reader, each column will reserve X bytes for read
 // but with coalesce read enabled, this value is not used.

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -220,6 +220,7 @@ Status ORCScanner::_open_next_orc_reader() {
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
         st = _orc_reader->init(std::move(inStream));
+        _orc_reader->enable_sequential_read();
         if (st.is_end_of_file()) {
             LOG(WARNING) << "Failed to init orc reader. filename: " << file_name << ", status: " << st.to_string();
             continue;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/MemoryPool.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/MemoryPool.hh
@@ -47,6 +47,7 @@ private:
     uint64_t currentSize;
     // maximal capacity (actual allocated memory)
     uint64_t currentCapacity;
+    bool manageByPool;
 
     // not implemented
     DataBuffer(DataBuffer& buffer) = delete;
@@ -56,6 +57,11 @@ public:
     DataBuffer(MemoryPool& pool, uint64_t _size = 0);
 
     DataBuffer(DataBuffer<T>&& buffer) ORC_NOEXCEPT;
+
+    // optimize for creating a data buffer in the middle of another data buffer,
+    // should perform reserve or resize on such data buffer,
+    // also ~DataBuffer will not release the memory as its memory is managed by another data buffer
+    DataBuffer(MemoryPool& pool, T* _buf, uint64_t _size) ORC_NOEXCEPT;
 
     virtual ~DataBuffer();
 

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -312,6 +312,9 @@ public:
     bool getUseWriterTimezone() const;
     RowReaderOptions& includeLazyLoadColumnNames(const std::list<std::string>& include);
     const std::list<std::string>& getLazyLoadColumnNames() const;
+
+    void setSequentialRead();
+    bool getSequentialRead() const;
 };
 
 class RowReader;

--- a/be/src/formats/orc/apache-orc/c++/src/Options.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Options.hh
@@ -146,6 +146,9 @@ struct RowReaderOptionsPrivate {
     std::shared_ptr<RowReaderFilter> filter;
     std::string readerTimezone;
     bool useWriterTimezone;
+    // if sequentialRead is true, which means we will sequential read
+    // all data from orc file, to avoid many random io, we will enable prefetch
+    bool sequentialRead;
 
     RowReaderOptionsPrivate() {
         selection = ColumnSelection_NONE;
@@ -156,6 +159,7 @@ struct RowReaderOptionsPrivate {
         enableLazyDecoding = false;
         readerTimezone = "GMT";
         useWriterTimezone = false;
+        sequentialRead = false;
     }
 };
 
@@ -283,6 +287,14 @@ RowReaderOptions& RowReaderOptions::searchArgument(std::unique_ptr<SearchArgumen
 
 std::shared_ptr<SearchArgument> RowReaderOptions::getSearchArgument() const {
     return privateBits->sargs;
+}
+
+void RowReaderOptions::setSequentialRead() {
+    privateBits->sequentialRead = true;
+}
+
+bool RowReaderOptions::getSequentialRead() const {
+    return privateBits->sequentialRead;
 }
 
 RowReaderOptions& RowReaderOptions::rowReaderFilter(std::shared_ptr<RowReaderFilter> filter) {

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -230,7 +230,8 @@ RowReaderImpl::RowReaderImpl(const std::shared_ptr<FileContents>& _contents, con
           enableEncodedBlock(opts.getEnableLazyDecoding()),
           readerTimezone(getTimezoneByName(opts.getTimezoneName())),
           useWriterTimezone(opts.getUseWriterTimezone()),
-          sharedBuffer(*contents->pool, 0) {
+          sharedBuffer(*contents->pool, 0),
+          sequentialRead(opts.getSequentialRead()) {
     uint64_t numberOfStripes;
     numberOfStripes = static_cast<uint64_t>(footer->stripes_size());
     currentStripe = numberOfStripes;
@@ -1083,7 +1084,7 @@ void RowReaderImpl::startNextStripe() {
 
             StripeStreamsImpl stripeStreams(*this, currentStripe, currentStripeInfo, currentStripeFooter,
                                             currentStripeInfo.offset(), *contents->stream, writerTimezone,
-                                            readerTimezone);
+                                            readerTimezone, sequentialRead);
             reader = buildReader(*contents->schema, stripeStreams);
 
             if (sargsApplier) {

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -169,6 +169,10 @@ private:
 
     mutable DataBuffer<char> sharedBuffer;
 
+    // if sequentialRead is true, which means we will sequential read
+    // all data from orc file, to avoid many random io, we will enable prefetch
+    bool sequentialRead;
+
     // load stripe index if not done so
     void loadStripeIndex();
 

--- a/be/src/formats/orc/apache-orc/c++/src/StripeStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/StripeStream.hh
@@ -46,11 +46,13 @@ private:
     InputStream& input;
     const Timezone& writerTimezone;
     const Timezone& readerTimezone;
+    bool sequentialRead;
+    mutable std::shared_ptr<FileInputStreamLoadPrefetchIndex> loadPrefetchIndex;
 
 public:
     StripeStreamsImpl(const RowReaderImpl& reader, uint64_t index, const proto::StripeInformation& stripeInfo,
                       const proto::StripeFooter& footer, uint64_t stripeStart, InputStream& input,
-                      const Timezone& writerTimezone, const Timezone& readerTimezone);
+                      const Timezone& writerTimezone, const Timezone& readerTimezone, bool sequentialRead = false);
 
     ~StripeStreamsImpl() override;
 

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
@@ -196,8 +196,7 @@ bool SeekableFileInputStream::tryFillBuffer(DataBuffer<char>* prefetchBuffer, ui
     if (!(start >= bufferStartOffset && start + length < bufferEndOffset)) {
         return false;
     }
-    buffer.reset(new DataBuffer<char>(pool, length));
-    memcpy(buffer->data(), prefetchBuffer->data() + start - bufferStartOffset, length);
+    buffer.reset(new DataBuffer<char>(pool, prefetchBuffer->data() + start - bufferStartOffset, length));
     pushBack = length;
     return true;
 }

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
@@ -131,12 +131,16 @@ public:
                                         uint64_t bufferStartOffset, uint64_t bufferEndOffset) {
         last_max_read_offset = std::max(last_max_read_offset, curStreamStartOffset);
         auto iter = index.find(curStreamStartOffset);
+        if (iter == index.end()) {
+            return;
+        }
+        iter++;
         while (iter != index.end()) {
-            iter++;
             if (!(iter->second->tryFillBuffer(buffer, bufferStartOffset, bufferEndOffset))) {
                 break;
             }
             last_max_read_offset = std::max(last_max_read_offset, iter->first);
+            iter++;
         }
     }
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1144,6 +1144,9 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader) {
         builder->literal(orc::TruthValue::YES_NO_NULL);
         _row_reader_options.searchArgument(builder->build());
     }
+    if (_enable_sequential_read) {
+        _row_reader_options.setSequentialRead();
+    }
     RETURN_IF_ERROR(_init_include_columns());
     try {
         _row_reader = _reader->createRowReader(_row_reader_options);

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -84,6 +84,7 @@ public:
     bool get_broker_load_mode() const { return _broker_load_mode; }
     bool get_strict_mode() const { return _strict_mode; }
     std::shared_ptr<Column::Filter> get_broker_load_fiter() { return _broker_load_filter; }
+    void enable_sequential_read() { _enable_sequential_read = true; }
 
     void set_hive_column_names(const std::vector<std::string>* v) {
         if (v != nullptr && v->size() != 0) {
@@ -171,6 +172,7 @@ private:
     std::string _current_file_name;
     int _error_message_counter;
     LazyLoadContext* _lazy_load_ctx;
+    bool _enable_sequential_read;
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11329

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

In current implementation, broker load for orc will initiate a large number of random io, each strip stream is an independent io.

For example, if the table's column number is 590, and all the column types are varchar, and the orc file has 3 stripes (total 20000 number of rows), then the entire broker load will initiate 7080 random io, 590 * 2 (1180) io for meta data, 590 * 2 * 2(2360) io for each stripe(data).

In this pr, we optimize random io for stripe, we will prefetch orc_load_prefetch_size data in each io and set these prefetch data to other SeekableFileInputStream.

In our test, this optimization can improve broker load for orc's speed 7x in the best case.