### PR TITLE
[BugFix] Avoid limit push down of multi-distinct cases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -147,10 +147,16 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                 .filter(kv -> kv.getValue().isDistinct()).map(Map.Entry::getKey).collect(Collectors.toList());
         List<ColumnRefOperator> otherAggregate = aggregate.getAggregations().entrySet().stream()
                 .filter(kv -> !kv.getValue().isDistinct()).map(Map.Entry::getKey).collect(Collectors.toList());
+        List<ColumnRefOperator> groupingKeys = aggregate.getGroupingKeys();
+        boolean hasGroupBy = !groupingKeys.isEmpty();
 
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
         LinkedList<OptExpression> allCteConsumes = buildDistinctAggCTEConsume(aggregate, distinctAggList, cteProduce,
                 columnRefFactory, columnRefMap);
+        // For inner join(with group by), distinct aggregate cannot have limitation
+        if (hasGroupBy) {
+            allCteConsumes.forEach(opt -> opt.getOp().setLimit(Operator.DEFAULT_LIMIT));
+        }
 
         if (otherAggregate.size() > 0) {
             allCteConsumes.offer(
@@ -158,15 +164,14 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
                             columnRefMap));
         }
 
-        List<ColumnRefOperator> groupingKeys = aggregate.getGroupingKeys();
         // left deep join tree
         while (allCteConsumes.size() > 1) {
             OptExpression left = allCteConsumes.poll();
             OptExpression right = allCteConsumes.poll();
             OptExpression join;
-            if (groupingKeys.isEmpty()) {
-                join = OptExpression.create(new LogicalJoinOperator(JoinOperator.CROSS_JOIN, null), left,
-                        right);
+            if (!hasGroupBy) {
+                join = OptExpression.create(new LogicalJoinOperator(JoinOperator.CROSS_JOIN, null),
+                        left, right);
             } else {
                 // create inner join when aggregate has group by keys
                 join = buildInnerJoin(left, right);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -124,6 +124,10 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return false;
         }
 
+        if (agg.getLimit() >= 0) {
+            return false;
+        }
+
         List<CallOperator> distinctAggOperatorList = agg.getAggregations().values().stream()
                 .filter(CallOperator::isDistinct).collect(Collectors.toList());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -135,15 +135,19 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         OptExpression result;
         if (hasAvg) {
             OptExpression aggOpt = OptExpression
-                    .create(new LogicalAggregationOperator(AggType.GLOBAL, aggregationOperator.getGroupingKeys(),
-                                    newAggMapWithAvg),
+                    .create(new LogicalAggregationOperator.Builder().withOperator(aggregationOperator)
+                                    .setType(AggType.GLOBAL)
+                                    .setAggregations(newAggMapWithAvg)
+                                    .build(),
                             input.getInputs());
             aggregationOperator.getGroupingKeys().forEach(c -> projections.put(c, c));
             result = OptExpression.create(new LogicalProjectOperator(projections), Lists.newArrayList(aggOpt));
         } else {
             result = OptExpression
-                    .create(new LogicalAggregationOperator(AggType.GLOBAL, aggregationOperator.getGroupingKeys(),
-                                    newAggMap),
+                    .create(new LogicalAggregationOperator.Builder().withOperator(aggregationOperator)
+                                    .setType(AggType.GLOBAL)
+                                    .setAggregations(newAggMap)
+                                    .build(),
                             input.getInputs());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -641,10 +641,12 @@ public class CTEPlanTest extends PlanTestBase {
             assertContains(plan, "  2:Project\n" +
                     "  |  <slot 4> : 4: sum\n" +
                     "  |  <slot 5> : CAST(7: multi_distinct_sum AS DOUBLE) / CAST(6: multi_distinct_count AS DOUBLE)\n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: multi_distinct_sum(1: v1), multi_distinct_count(2: v2), multi_distinct_sum(2: v2)\n" +
                     "  |  group by: \n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  0:OlapScanNode\n" +
                     "     TABLE: t0");
@@ -655,10 +657,12 @@ public class CTEPlanTest extends PlanTestBase {
             assertContains(plan, "  2:Project\n" +
                     "  |  <slot 4> : 4: sum\n" +
                     "  |  <slot 5> : CAST(7: multi_distinct_sum AS DOUBLE) / CAST(6: multi_distinct_count AS DOUBLE)\n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: multi_distinct_sum(1: v1), multi_distinct_count(2: v2), multi_distinct_sum(2: v2)\n" +
                     "  |  group by: 3: v3\n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  0:OlapScanNode\n" +
                     "     TABLE: t0");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -638,31 +638,30 @@ public class CTEPlanTest extends PlanTestBase {
         {
             String sql = "select sum(distinct(v1)), avg(distinct(v2)) from t0 limit 1";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  8:AGGREGATE (merge finalize)\n" +
-                    "  |  output: sum(4: sum)\n" +
+            assertContains(plan, "  2:Project\n" +
+                    "  |  <slot 4> : 4: sum\n" +
+                    "  |  <slot 5> : CAST(7: multi_distinct_sum AS DOUBLE) / CAST(6: multi_distinct_count AS DOUBLE)\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: multi_distinct_sum(1: v1), multi_distinct_count(2: v2), multi_distinct_sum(2: v2)\n" +
                     "  |  group by: \n" +
-                    "  |  limit: 1");
-            assertContains(plan, "  26:AGGREGATE (merge finalize)\n" +
-                    "  |  output: count(9: count)\n" +
-                    "  |  group by: \n" +
-                    "  |  limit: 1");
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
         }
         {
             String sql = "select sum(distinct(v1)), avg(distinct(v2)) from t0 group by v3 limit 1";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  |    19:HASH JOIN\n" +
-                    "  |    |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                    "  |    |  colocate: false, reason: \n" +
-                    "  |    |  equal join conjunct: 7: v3 <=> 13: v3\n" +
-                    "  |    |  \n" +
-                    "  |    |----18:AGGREGATE (update finalize)\n" +
-                    "  |    |    |  output: count(12: v2)\n" +
-                    "  |    |    |  group by: 13: v3\n" +
-                    "  |    |    |  \n" +
-                    "  |    |    17:AGGREGATE (merge serialize)\n" +
-                    "  |    |    |  group by: 12: v2, 13: v3\n" +
-                    "  |    |    |  \n" +
-                    "  |    |    16:EXCHANGE");
+            assertContains(plan, "  2:Project\n" +
+                    "  |  <slot 4> : 4: sum\n" +
+                    "  |  <slot 5> : CAST(7: multi_distinct_sum AS DOUBLE) / CAST(6: multi_distinct_count AS DOUBLE)\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: multi_distinct_sum(1: v1), multi_distinct_count(2: v2), multi_distinct_sum(2: v2)\n" +
+                    "  |  group by: 3: v3\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11274

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For multi-distinct cases with group like `select sum(distinct(v1)), avg(distinct(v2)) from t3 group by v3 limit 1`, limit cannot be push down to the aggregate. But for cases without group by, it can.

## Test

And, I'm wondering which plan,with or without cte , is better in the case of limitation.

```sql
-- Q1, with low cardinality group by, without non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem group by L_TAX limit 1;

-- Q2, with high cardinality group by, without non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem group by L_ORDERKEY limit 1;

-- Q3, with low cardinality group by, with non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)), sum(L_LINENUMBER), avg(L_QUANTITY) from lineitem group by L_TAX limit 1;

-- Q4, with high cardinality group by, with non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)), sum(L_LINENUMBER), avg(L_QUANTITY) from lineitem group by L_ORDERKEY limit 1;

-- Q5 without group by, without non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem limit 1;

-- Q6 without group by, with non-distinct agg
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)), sum(L_LINENUMBER), avg(L_QUANTITY) from lineitem limit 1;

-- Q7
select sum(dis_sum), sum(dis_avg) from (
    select sum(distinct(L_LINENUMBER)) as dis_sum , avg(distinct(L_QUANTITY)) as dis_avg from lineitem group by L_TAX
)a

-- Q8
select sum(dis_sum), sum(dis_avg) from (
    select sum(distinct(L_LINENUMBER)) as dis_sum , avg(distinct(L_QUANTITY)) as dis_avg from lineitem group by L_ORDERKEY
)a

-- Q9
select sum(dis_sum), sum(dis_avg) from (
    select sum(distinct(L_ORDERKEY)) as dis_sum , avg(distinct(L_SUPPKEY)) as dis_avg from lineitem group by L_TAX
)a

-- Q10
select sum(dis_sum), sum(dis_avg) from (
    select sum(distinct(L_ORDERKEY)) as dis_sum , avg(distinct(L_SUPPKEY)) as dis_avg from lineitem group by L_ORDERKEY
)a
```

| Query | with cte(withouth limit push down) | without cte |
|:--|:--|:--|
| Q1 | 5.4s | 0.44s |
| Q2 | 17.5s | 0.82s |
| Q3 | 10.0s | 0.45s |
| Q4 | 15.6s | 0.78s |
| Q5 | 4.6s | 0.27s |
| Q6 | 8.8s | 0.31s |
| Q7 | 5.421s | 0.403s |
| Q8 | 18.658s | 3.659s |
| Q9 | 19.580s | 12.149s |
| Q10 | 15.426s | 2.931s |

**So, better to disable cte if multi-distinct-groupby with or without limitation.**

```sql
-- Q11 low cardinality distinct without group by
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem;

-- Q12 high cardinality distinct without group by
select sum(distinct(L_ORDERKEY)), avg(distinct(L_SUPPKEY)) from lineitem;

-- Q13, low cardinality distinct with low distinct group by
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem group by L_TAX;

-- Q14, low cardinality distinct with high distinct group by
select sum(distinct(L_LINENUMBER)), avg(distinct(L_QUANTITY)) from lineitem group by L_ORDERKEY;

-- Q15, high cardinality distinct with low distinct group by
select sum(distinct(L_ORDERKEY)), avg(distinct(L_SUPPKEY)) from lineitem group by L_TAX;

-- Q16, high cardinality distinct with low distinct group by
select sum(distinct(L_ORDERKEY)), avg(distinct(L_SUPPKEY)) from lineitem group by L_ORDERKEY;
```

| Query | with cte | without cte |
|:--|:--|:--|
| Q11 | 4.736s | 0.314s |
| Q12 | 5.746s | 15.055s |
| Q13 | 5.387s | 0.399s |
| Q14 | timeout | timeout |
| Q15 | 21.120s | 22.926s |
| Q16 | timeout | timeout |



**CTE optimization for multi-distinct has bad case when cardinality is low, which is beyond the scope of this pr. And it will be solved in another pr later.**

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
