### PR TITLE
[Enhancement] support creating lake statistic tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -106,7 +106,10 @@ public class StatisticUtils {
             if (table == null) {
                 return false;
             }
-
+            if (table.isLakeTable()) {
+                continue;
+            }
+            
             // check replicate miss
             for (Partition partition : table.getPartitions()) {
                 if (partition.getBaseIndex().getTablets().stream()

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -190,7 +190,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
         stmt = new CreateTableStmt(false, false,
                 tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
                 engine,
                 new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
                 null,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -123,11 +123,12 @@ public class StatisticsMetaManager extends LeaderDaemon {
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
         String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        KeysType keysType = KeysType.UNIQUE_KEYS;
         CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
                 engine,
-                new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
+                new KeysDesc(keysType, KEY_COLUMN_NAMES),
                 null,
                 new HashDistributionDesc(10, KEY_COLUMN_NAMES),
                 properties,
@@ -153,30 +154,18 @@ public class StatisticsMetaManager extends LeaderDaemon {
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table, which not support primary key
-        CreateTableStmt stmt = null;
-        if (Config.use_staros) {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                    CreateTableStmt.LAKE_ENGINE_NAME,
-                    new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        } else {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        }
+        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        KeysType keysType = Config.use_staros ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                engine,
+                new KeysDesc(keysType, FULL_STATISTICS_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                properties,
+                null,
+                "");
    
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
@@ -198,30 +187,18 @@ public class StatisticsMetaManager extends LeaderDaemon {
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table, which not support primary key
-        CreateTableStmt stmt = null;
-        if (Config.use_staros) {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                    CreateTableStmt.LAKE_ENGINE_NAME,
-                    new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        } else {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        }
+        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        KeysType keysType = Config.use_staros ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                engine,
+                new KeysDesc(keysType, HISTOGRAM_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                properties,
+                null,
+                "");
         
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -122,9 +122,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
-        CreateTableStmt stmt = null;
         String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
-        stmt = new CreateTableStmt(false, false,
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
                 engine,
@@ -154,9 +153,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
-        CreateTableStmt stmt = null;
         String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
-        stmt = new CreateTableStmt(false, false,
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
                 engine,
@@ -186,9 +184,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
-        CreateTableStmt stmt = null;
         String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
-        stmt = new CreateTableStmt(false, false,
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
                 engine,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -152,18 +152,32 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
-        // if use_staros, create lake table
-        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
-        CreateTableStmt stmt = new CreateTableStmt(false, false,
+        // if use_staros, create lake table, which not support primary key
+        CreateTableStmt stmt = null;
+        if (Config.use_staros) {
+            stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                engine,
+                CreateTableStmt.LAKE_ENGINE_NAME,
                 new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
                 null,
                 new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
                 properties,
                 null,
                 "");
+        } else {
+            stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                "olap",
+                new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                properties,
+                null,
+                "");
+        }
+   
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
@@ -183,18 +197,32 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
-        // if use_staros, create lake table
-        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
-        CreateTableStmt stmt = new CreateTableStmt(false, false,
+        // if use_staros, create lake table, which not support primary key
+        CreateTableStmt stmt = null;
+        if (Config.use_staros) {
+            stmt = new CreateTableStmt(false, false,
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                engine,
+                CreateTableStmt.LAKE_ENGINE_NAME,
                 new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
                 null,
                 new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
                 properties,
                 null,
                 "");
+        } else {
+            stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                "olap",
+                new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                properties,
+                null,
+                "");
+        }
+        
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -123,30 +123,17 @@ public class StatisticsMetaManager extends LeaderDaemon {
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
         CreateTableStmt stmt = null;
-        if (Config.use_staros) {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
-                    null,
-                    new HashDistributionDesc(10, KEY_COLUMN_NAMES),
-                    properties,
-                    null,
-                    "");
-        } else {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
-                    null,
-                    new HashDistributionDesc(10, KEY_COLUMN_NAMES),
-                    properties,
-                    null,
-                    "");
-        }
-
+        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
+                engine,
+                new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
+                null,
+                new HashDistributionDesc(10, KEY_COLUMN_NAMES),
+                properties,
+                null,
+                "");
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
@@ -168,29 +155,17 @@ public class StatisticsMetaManager extends LeaderDaemon {
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
         CreateTableStmt stmt = null;
-        if (Config.use_staros) {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                    "starrocks",
-                    new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        } else {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        }
+        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                engine,
+                new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                properties,
+                null,
+                "");
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
@@ -212,29 +187,17 @@ public class StatisticsMetaManager extends LeaderDaemon {
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         // if use_staros, create lake table
         CreateTableStmt stmt = null;
-        if (Config.use_staros) {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                    "starrocks",
-                    new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        } else {
-            stmt = new CreateTableStmt(false, false,
-                    tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                    "olap",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
-                    null,
-                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                    properties,
-                    null,
-                    "");
-        }
+        String engine = Config.use_staros ? CreateTableStmt.LAKE_ENGINE_NAME : "olap";
+        stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                engine,
+                new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                properties,
+                null,
+                "");
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -192,9 +192,9 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 tableName,
                 StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
                 engine,
-                new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
                 null,
-                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
                 properties,
                 null,
                 "");

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -156,26 +156,26 @@ public class StatisticsMetaManager extends LeaderDaemon {
         CreateTableStmt stmt = null;
         if (Config.use_staros) {
             stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                CreateTableStmt.LAKE_ENGINE_NAME,
-                new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                    CreateTableStmt.LAKE_ENGINE_NAME,
+                    new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
         } else {
             stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                "olap",
-                new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
         }
    
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
@@ -201,26 +201,26 @@ public class StatisticsMetaManager extends LeaderDaemon {
         CreateTableStmt stmt = null;
         if (Config.use_staros) {
             stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                CreateTableStmt.LAKE_ENGINE_NAME,
-                new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                    CreateTableStmt.LAKE_ENGINE_NAME,
+                    new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
         } else {
             stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                "olap",
-                new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
         }
         
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -79,6 +79,9 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Preconditions.checkState(db != null);
         OlapTable table = (OlapTable) db.getTable(tableName);
         Preconditions.checkState(table != null);
+        if (table.isLakeTable()) {
+            return true;
+        }
 
         boolean check = true;
         for (Partition partition : table.getPartitions()) {
@@ -170,7 +173,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                     tableName,
                     StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
                     "starrocks",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                    new KeysDesc(KeysType.UNIQUE_KEYS, FULL_STATISTICS_KEY_COLUMNS),
                     null,
                     new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
                     properties,
@@ -214,7 +217,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                     tableName,
                     StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
                     "starrocks",
-                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
+                    new KeysDesc(KeysType.UNIQUE_KEYS, HISTOGRAM_KEY_COLUMNS),
                     null,
                     new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
                     properties,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -118,16 +118,32 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
-        CreateTableStmt stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
-                "olap",
-                new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
-                null,
-                new HashDistributionDesc(10, KEY_COLUMN_NAMES),
-                properties,
-                null,
-                "");
+        // if use_staros, create lake table
+        CreateTableStmt stmt = null;
+        if (Config.use_staros) {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
+                    null,
+                    new HashDistributionDesc(10, KEY_COLUMN_NAMES),
+                    properties,
+                    null,
+                    "");
+        } else {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.UNIQUE_KEYS, KEY_COLUMN_NAMES),
+                    null,
+                    new HashDistributionDesc(10, KEY_COLUMN_NAMES),
+                    properties,
+                    null,
+                    "");
+        }
+
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
@@ -147,16 +163,31 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
-        CreateTableStmt stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
-                "olap",
-                new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+        // if use_staros, create lake table
+        CreateTableStmt stmt = null;
+        if (Config.use_staros) {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                    "starrocks",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
+        } else {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, FULL_STATISTICS_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, FULL_STATISTICS_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
+        }
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
@@ -176,16 +207,31 @@ public class StatisticsMetaManager extends LeaderDaemon {
         Map<String, String> properties = Maps.newHashMap();
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
-        CreateTableStmt stmt = new CreateTableStmt(false, false,
-                tableName,
-                StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
-                "olap",
-                new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
-                null,
-                new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
-                properties,
-                null,
-                "");
+        // if use_staros, create lake table
+        CreateTableStmt stmt = null;
+        if (Config.use_staros) {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                    "starrocks",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
+        } else {
+            stmt = new CreateTableStmt(false, false,
+                    tableName,
+                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                    "olap",
+                    new KeysDesc(KeysType.PRIMARY_KEYS, HISTOGRAM_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, HISTOGRAM_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
+        }
         Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Because statistics tables are built on local. If there are only lake tables in a cluster, after you put all BE down and get some new BE up, the statistics tables will not exist and the query plan would change. So this pr fix this bug.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
