### PR TITLE
[BugFix] Record query result if forward to leader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -489,9 +489,10 @@ public class ConnectProcessor {
                 // ShowResultSet is null means this is not ShowStmt, use remote packet(executor.getOutputPacket())
                 // or use local packet (getResultPacket())
                 if (resultSet == null) {
-                    if (executor.forwardResultToChannel(ctx.getMysqlChannel())) {  // query statement result
+                    if (executor.sendResultToChannel(ctx.getMysqlChannel())) {  // query statement result
                         packet = getResultPacket();
                         if (packet == null) {
+                            LOG.debug("packet == null");
                             return;
                         }
                     } else { // for lower version, in consideration of compatibility

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -491,10 +491,6 @@ public class ConnectProcessor {
                 if (resultSet == null) {
                     if (executor.sendResultToChannel(ctx.getMysqlChannel())) {  // query statement result
                         packet = getResultPacket();
-                        if (packet == null) {
-                            LOG.debug("packet == null");
-                            return;
-                        }
                     } else { // for lower version, in consideration of compatibility
                         packet = executor.getOutputPacket();
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -489,8 +489,15 @@ public class ConnectProcessor {
                 // ShowResultSet is null means this is not ShowStmt, use remote packet(executor.getOutputPacket())
                 // or use local packet (getResultPacket())
                 if (resultSet == null) {
-                    packet = executor.getOutputPacket();
-                } else {
+                    if (executor.forwardResultToChannel(ctx.getMysqlChannel())) {  // query statement result
+                        packet = getResultPacket();
+                        if (packet == null) {
+                            return;
+                        }
+                    } else { // for lower version, in consideration of compatibility
+                        packet = executor.getOutputPacket();
+                    }
+                } else { // show statement result
                     executor.sendShowResult(resultSet);
                     packet = getResultPacket();
                     if (packet == null) {
@@ -635,8 +642,12 @@ public class ConnectProcessor {
         }
         result.setPacket(getResultPacket());
         result.setState(ctx.getState().getStateType().toString());
-        if (executor != null && executor.getProxyResultSet() != null) {
-            result.setResultSet(executor.getProxyResultSet().tothrift());
+        if (executor != null) {
+            if (executor.getProxyResultSet() != null) {  // show statement
+                result.setResultSet(executor.getProxyResultSet().tothrift());
+            } else if (executor.getProxyResultBuffer() != null) {  // query statement
+                result.setChannelBufferList(executor.getProxyResultBuffer());
+            }
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -166,7 +166,7 @@ public class LeaderOpExecutor {
     }
 
     /**
-     * if a query statement is forwarded to the master, or if a show statement is automatically rewrote,
+     * if a query statement is forwarded to the leader, or if a show statement is automatically rewrote,
      * the result of the query will be returned in thrift body and should write into mysql channel.
      **/
     public boolean sendResultToChannel(MysqlChannel channel) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -169,7 +169,7 @@ public class LeaderOpExecutor {
      * if a query statement is forwarded to the master, or if a show statement is automatically rewrote,
      * the result of the query will be returned in thrift body and should write into mysql channel.
      **/
-    public boolean forwardResultToChannel(MysqlChannel channel) throws IOException {
+    public boolean sendResultToChannel(MysqlChannel channel) throws IOException {
         if (!result.isSetChannelBufferList() || result.channelBufferList.isEmpty()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -27,6 +27,7 @@ import com.starrocks.analysis.StatementBase;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.sql.analyzer.AST2SQL;
@@ -38,6 +39,7 @@ import com.starrocks.thrift.TQueryOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class LeaderOpExecutor {
@@ -161,6 +163,20 @@ public class LeaderOpExecutor {
         } else {
             return null;
         }
+    }
+
+    /**
+     * if a query statement is forwarded to the master, or if a show statement is automatically rewrote,
+     * the result of the query will be returned in thrift body and should write into mysql channel.
+     **/
+    public boolean forwardResultToChannel(MysqlChannel channel) throws IOException {
+        if (!result.isSetChannelBufferList() || result.channelBufferList.isEmpty()) {
+            return false;
+        }
+        for (ByteBuffer byteBuffer : result.channelBufferList) {
+            channel.sendOnePacket(byteBuffer);
+        }
+        return true;
     }
 
     public void setResult(TMasterOpResult result) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -139,6 +139,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,6 +167,7 @@ public class StmtExecutor {
     private LeaderOpExecutor leaderOpExecutor = null;
     private RedirectStatus redirectStatus = null;
     private final boolean isProxy;
+    private List<ByteBuffer> proxyResultBuffer = null;
     private ShowResultSet proxyResultSet = null;
     private PQueryStatistics statisticsForAuditLog;
 
@@ -175,6 +177,9 @@ public class StmtExecutor {
         this.originStmt = originStmt;
         this.serializer = context.getSerializer();
         this.isProxy = isProxy;
+        if (isProxy) {
+            proxyResultBuffer = new ArrayList<>();
+        }
     }
 
     // this constructor is only for test now.
@@ -282,6 +287,14 @@ public class StmtExecutor {
             return null;
         } else {
             return leaderOpExecutor.getProxyResultSet();
+        }
+    }
+
+    public boolean forwardResultToChannel(MysqlChannel channel) throws IOException {
+        if (leaderOpExecutor == null) {
+            return false;
+        } else {
+            return leaderOpExecutor.forwardResultToChannel(channel);
         }
     }
 
@@ -733,7 +746,7 @@ public class StmtExecutor {
                     sendFields(colNames, outputExprs);
                     isSendFields = true;
                 }
-                if (channel.isSendBufferNull()) {
+                if (!isProxy && channel.isSendBufferNull()) {
                     int bufferSize = 0;
                     for (ByteBuffer row : batch.getBatch().getRows()) {
                         bufferSize += (row.position() - row.limit());
@@ -743,7 +756,11 @@ public class StmtExecutor {
                 }
 
                 for (ByteBuffer row : batch.getBatch().getRows()) {
-                    channel.sendOnePacket(row);
+                    if (isProxy) {
+                        proxyResultBuffer.add(row);
+                    } else {
+                        channel.sendOnePacket(row);
+                    }
                 }
                 context.updateReturnRows(batch.getBatch().getRows().size());
             }
@@ -945,18 +962,30 @@ public class StmtExecutor {
         // sends how many columns
         serializer.reset();
         serializer.writeVInt(colNames.size());
-        context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+        if (isProxy) {
+            proxyResultBuffer.add(serializer.toByteBuffer());
+        } else {
+            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+        }
         // send field one by one
         for (int i = 0; i < colNames.size(); ++i) {
             serializer.reset();
             serializer.writeField(colNames.get(i), exprs.get(i).getOriginType());
-            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+            if (isProxy) {
+                proxyResultBuffer.add(serializer.toByteBuffer());
+            } else {
+                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+            }
         }
         // send EOF
         serializer.reset();
         MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
         eofPacket.writeTo(serializer);
-        context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+        if (isProxy) {
+            proxyResultBuffer.add(serializer.toByteBuffer());
+        } else {
+            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+        }
     }
 
     public void sendShowResult(ShowResultSet resultSet) throws IOException {
@@ -1487,5 +1516,9 @@ public class StmtExecutor {
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
         }
         return Pair.create(sqlResult, coord.getExecStatus());
+    }
+
+    public List<ByteBuffer> getProxyResultBuffer() {
+        return proxyResultBuffer;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -290,11 +290,11 @@ public class StmtExecutor {
         }
     }
 
-    public boolean forwardResultToChannel(MysqlChannel channel) throws IOException {
+    public boolean sendResultToChannel(MysqlChannel channel) throws IOException {
         if (leaderOpExecutor == null) {
             return false;
         } else {
-            return leaderOpExecutor.forwardResultToChannel(channel);
+            return leaderOpExecutor.sendResultToChannel(channel);
         }
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -503,8 +503,11 @@ struct TShowResultSet {
 struct TMasterOpResult {
     1: required i64 maxJournalId;
     2: required binary packet;
+    // for show statement
     3: optional TShowResultSet resultSet;
     4: optional string state;
+    // for query statement
+    5: optional list<binary> channelBufferList;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1081](https://github.com/StarRocks/StarRocksTest/issues/1081)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fixed a legacy bug that existed long before I joined the company.

Sometimes a SQL received by a follower FE may end up forwarding to the leader. The leader will process the statement and send the result back to the follower FE. The result will be stored in the `ShowResultSet` field of the thrift response message sent from the master to the follower. 

However, if the forwarded statement is a query statement, the query result has no place to store in the response and will be directly written to the send buffer of the leader MySQL channel. After the follower receives the response message from the leader, it will find out that the `ShowResultSet` field is empty and will regard the master as a lower version of FE; thus, it will send a simple EOF to the MySQL client. The MySQL client receives an unexpected EOF and will report a `malformated packet` error.

This bug is seldom triggered because we never forward a query statement unless when the progress of the follower is far behind the leader. Even in that scenario, we would try to fix the FE so that the follower can catch up with the leader. As a result, this bug is ignored.

Luckily, in developing materialized view, we rewrite the `show materialized` statement to a query in the `information_schema.materialized_views` table. This bug has finally revealed its veil.

To fix this bug, we need to add a list of Bytebuffer in the thrift response message from the leader to the master. All the packets that are supposed to send to the MySQL channel of the leader will be stored in this list so that they can send to the MySQL client after the follower receives the response.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
