### PR TITLE
[UT] fix sleep negative for BDB UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -114,8 +114,8 @@ public class BDBEnvironmentTest {
                 return;
             } catch (Exception e) {
                 // sleep 5 ~ 15 seconds
-                int sleepSeconds = new Random().nextInt() % 10 + 5;
-                LOG.warn("failed to initClusterMasterFollower! will sleep {} seconds and retry", sleepSeconds);
+                int sleepSeconds = ThreadLocalRandom.current().nextInt(5, 15);
+                LOG.warn("failed to initClusterMasterFollower! will sleep {} seconds and retry", sleepSeconds, e);
                 Thread.sleep(sleepSeconds * 1000L);
             }
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix a bug that may pass negative number to `Thread.sleep`.

```
java.lang.IllegalArgumentException: timeout value is negative
	at java.lang.Thread.sleep(Native Method)
	at com.starrocks.journal.bdbje.BDBEnvironmentTest.initClusterMasterFollower(BDBEnvironmentTest.java:119)
```

Already fixed in #9227, but after I reverted the retry PR and then commited again later, I forgot to add this patch. My mistake.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
