### PR TITLE
[Refactor]Rename HdfsFileFormat to RemoteFileInputFormat

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -373,10 +373,10 @@ public class HiveMetaCache {
     }
 
     private HivePartition getPartitionByEvent(StorageDescriptor sd) throws Exception {
-        HdfsFileFormat format = HdfsFileFormat.fromHdfsInputFormatClass(sd.getInputFormat());
+        RemoteFileInputFormat format = RemoteFileInputFormat.fromHdfsInputFormatClass(sd.getInputFormat());
         String path = ObjectStorageUtils.formatObjectStoragePath(sd.getLocation());
         boolean isSplittable = ObjectStorageUtils.isObjectStorage(path) ||
-                HdfsFileFormat.isSplittable(sd.getInputFormat());
+                RemoteFileInputFormat.isSplittable(sd.getInputFormat());
         List<HdfsFileDesc> fileDescs = client.getHdfsFileDescs(path, isSplittable, sd);
         return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -254,14 +254,14 @@ public class HiveMetaClient {
                 Table table = client.hiveClient.getTable(dbName, tableName);
                 sd = table.getSd();
             }
-            HdfsFileFormat format = HdfsFileFormat.fromHdfsInputFormatClass(sd.getInputFormat());
+            RemoteFileInputFormat format = RemoteFileInputFormat.fromHdfsInputFormatClass(sd.getInputFormat());
             if (format == null) {
                 throw new DdlException("unsupported file format [" + sd.getInputFormat() + "]");
             }
 
             String path = ObjectStorageUtils.formatObjectStoragePath(sd.getLocation());
             List<HdfsFileDesc> fileDescs = getHdfsFileDescs(path,
-                    ObjectStorageUtils.isObjectStorage(path) || HdfsFileFormat.isSplittable(sd.getInputFormat()),
+                    ObjectStorageUtils.isObjectStorage(path) || RemoteFileInputFormat.isSplittable(sd.getInputFormat()),
                     sd);
             return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
         } catch (NoSuchObjectException e) {
@@ -291,13 +291,13 @@ public class HiveMetaClient {
                     HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
             HoodieFileFormat hudiBaseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
 
-            HdfsFileFormat format;
+            RemoteFileInputFormat format;
             switch (hudiBaseFileFormat) {
                 case PARQUET:
-                    format = HdfsFileFormat.PARQUET;
+                    format = RemoteFileInputFormat.PARQUET;
                     break;
                 case ORC:
-                    format = HdfsFileFormat.ORC;
+                    format = RemoteFileInputFormat.ORC;
                     break;
                 default:
                     throw new DdlException("unsupported file format [" + hudiBaseFileFormat.name() + "]");
@@ -333,7 +333,7 @@ public class HiveMetaClient {
             long fileLength = baseFile.map(BaseFile::getFileLen).orElse(-1L);
             List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
             fileDescs.add(new HdfsFileDesc(fileName, "", fileLength,
-                    ImmutableList.of(), ImmutableList.copyOf(logs), HdfsFileFormat.isSplittable(sd.getInputFormat()),
+                    ImmutableList.of(), ImmutableList.copyOf(logs), RemoteFileInputFormat.isSplittable(sd.getInputFormat()),
                     getTextFileFormatDesc(sd)));
         }
         return fileDescs;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
@@ -7,19 +7,19 @@ import com.google.gson.annotations.SerializedName;
 
 public class HivePartition {
     @SerializedName(value = "format")
-    private HdfsFileFormat format;
+    private RemoteFileInputFormat format;
     @SerializedName(value = "files")
     private ImmutableList<HdfsFileDesc> files;
     @SerializedName(value = "fullPath")
     private String fullPath;
 
-    public HivePartition(HdfsFileFormat format, ImmutableList<HdfsFileDesc> files, String fullPath) {
+    public HivePartition(RemoteFileInputFormat format, ImmutableList<HdfsFileDesc> files, String fullPath) {
         this.format = format;
         this.files = files;
         this.fullPath = fullPath;
     }
 
-    public HdfsFileFormat getFormat() {
+    public RemoteFileInputFormat getFormat() {
         return format;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/RemoteFileInputFormat.java
@@ -5,14 +5,14 @@ package com.starrocks.external.hive;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.thrift.THdfsFileFormat;
 
-public enum HdfsFileFormat {
+public enum RemoteFileInputFormat {
     UNKNOWN,
     PARQUET,
     ORC,
     TEXT;
 
-    private static final ImmutableMap<String, HdfsFileFormat> VALID_INPUT_FORMATS =
-            new ImmutableMap.Builder<String, HdfsFileFormat>()
+    private static final ImmutableMap<String, RemoteFileInputFormat> VALID_INPUT_FORMATS =
+            new ImmutableMap.Builder<String, RemoteFileInputFormat>()
                     .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", PARQUET)
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", ORC)
                     .put("org.apache.hadoop.mapred.TextInputFormat", TEXT)
@@ -25,7 +25,7 @@ public enum HdfsFileFormat {
                     .put("org.apache.hadoop.mapred.TextInputFormat", true)
                     .build();
 
-    public static HdfsFileFormat fromHdfsInputFormatClass(String className) {
+    public static RemoteFileInputFormat fromHdfsInputFormatClass(String className) {
         return VALID_INPUT_FORMATS.get(className);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -11,7 +11,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
-import com.starrocks.external.hive.HdfsFileFormat;
+import com.starrocks.external.hive.RemoteFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
@@ -89,14 +89,14 @@ public class IcebergUtil {
      * Get hdfs file format in StarRocks use iceberg file format.
      *
      * @param format
-     * @return HdfsFileFormat
+     * @return RemoteFileInputFormat
      */
-    public static HdfsFileFormat getHdfsFileFormat(FileFormat format) {
+    public static RemoteFileInputFormat getHdfsFileFormat(FileFormat format) {
         switch (format) {
             case ORC:
-                return HdfsFileFormat.ORC;
+                return RemoteFileInputFormat.ORC;
             case PARQUET:
-                return HdfsFileFormat.PARQUET;
+                return RemoteFileInputFormat.PARQUET;
             default:
                 throw new StarRocksIcebergException(
                         "Unexpected file format: " + format.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/HiveTableDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/HiveTableDumpInfo.java
@@ -16,11 +16,11 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.external.hive.HdfsFileDesc;
-import com.starrocks.external.hive.HdfsFileFormat;
 import com.starrocks.external.hive.HiveColumnStats;
 import com.starrocks.external.hive.HivePartition;
 import com.starrocks.external.hive.HivePartitionStats;
 import com.starrocks.external.hive.HiveTableStats;
+import com.starrocks.external.hive.RemoteFileInputFormat;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.lang.reflect.Type;
@@ -220,7 +220,7 @@ public class HiveTableDumpInfo implements HiveMetaStoreTableDumpInfo {
             Map<PartitionKey, HivePartition> hivePartitions = Maps.newHashMap();
             for (Map.Entry<String, JsonElement> entry : partitionsObject.entrySet()) {
                 JsonObject partition = entry.getValue().getAsJsonObject();
-                HdfsFileFormat format = HdfsFileFormat.valueOf(partition.get("format").getAsString());
+                RemoteFileInputFormat format = RemoteFileInputFormat.valueOf(partition.get("format").getAsString());
                 String fullPath = partition.get("fullPath").getAsString();
                 List<HdfsFileDesc> fileDescs = Lists.newArrayList();
                 for (JsonElement file : partition.get("files").getAsJsonArray()) {

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -82,13 +82,13 @@ public class HiveMetaCacheTest {
         HivePartition partition = metaCache.getPartition(hmsTable,
                 Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(1, partition.getFiles().size());
-        Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
+        Assert.assertEquals(RemoteFileInputFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
 
         partition = metaCache.getPartition(hmsTable,
                 Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(1, partition.getFiles().size());
-        Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
+        Assert.assertEquals(RemoteFileInputFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
 
         Assert.assertEquals(1, clientMethodGetPartitionCalledTimes);
@@ -192,7 +192,7 @@ public class HiveMetaCacheTest {
                 Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertTrue(metaCache.partitionExistInCache(partitionKey));
         Assert.assertEquals(5, partitionStats.getNumRows());
-        Assert.assertSame(partition.getFormat(), HdfsFileFormat.TEXT);
+        Assert.assertSame(partition.getFormat(), RemoteFileInputFormat.TEXT);
         long totalSize = partition.getFiles().stream().mapToLong(HdfsFileDesc::getLength).sum();
         Assert.assertEquals(partitionStats.getTotalFileBytes(), totalSize);
         file.delete();
@@ -287,7 +287,7 @@ public class HiveMetaCacheTest {
         public HivePartition getPartition(String dbName, String tableName, List<String> partValues)
                 throws DdlException {
             clientMethodGetPartitionCalledTimes++;
-            return new HivePartition(HdfsFileFormat.PARQUET,
+            return new HivePartition(RemoteFileInputFormat.PARQUET,
                     ImmutableList.of(new HdfsFileDesc("file1",
                             "",
                             10000L,

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/RemoteFileInputFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/RemoteFileInputFormatTest.java
@@ -5,12 +5,12 @@ package com.starrocks.external.hive;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class HdfsFileFormatTest {
+public class RemoteFileInputFormatTest {
     @Test
     public void testParquetFormat() {
-        Assert.assertSame(HdfsFileFormat.PARQUET, HdfsFileFormat
+        Assert.assertSame(RemoteFileInputFormat.PARQUET, RemoteFileInputFormat
                 .fromHdfsInputFormatClass("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"));
-        Assert.assertSame(HdfsFileFormat.ORC,
-                HdfsFileFormat.fromHdfsInputFormatClass("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"));
+        Assert.assertSame(RemoteFileInputFormat.ORC,
+                RemoteFileInputFormat.fromHdfsInputFormatClass("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
@@ -5,7 +5,7 @@ package com.starrocks.external.iceberg;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
-import com.starrocks.external.hive.HdfsFileFormat;
+import com.starrocks.external.hive.RemoteFileInputFormat;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
@@ -28,8 +28,8 @@ public class IcebergUtilTest {
 
     @Test
     public void testGetHdfsFileFormat() {
-        HdfsFileFormat fileFormat = IcebergUtil.getHdfsFileFormat(FileFormat.PARQUET);
-        Assert.assertTrue(fileFormat.equals(HdfsFileFormat.PARQUET));
+        RemoteFileInputFormat fileFormat = IcebergUtil.getHdfsFileFormat(FileFormat.PARQUET);
+        Assert.assertTrue(fileFormat.equals(RemoteFileInputFormat.PARQUET));
         Assert.assertThrows("Unexpected file format: %s", StarRocksIcebergException.class, () -> {
             IcebergUtil.getHdfsFileFormat(FileFormat.AVRO);
         });


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fe need to process remote files from hdfs or s3. not just hdfs.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
