### PR TITLE
[Enhancement] disable pre-read when orc io coalesce read enabled

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -52,13 +52,6 @@ public:
         const size_t cache_max_size = config::orc_file_cache_max_size;
         if (length > cache_max_size) return;
         if (canUseCacheBuffer(offset, length)) return;
-
-        // If this stripe is small, probably other stripes are also small
-        // we combine those reads into one, and try to read several stripes in one shot.
-        if (scope == orc::InputStream::PrepareCacheScope::READ_FULL_STRIPE) {
-            length = std::min(_length - offset, cache_max_size);
-        }
-
         _cache_buffer.resize(length);
         _cache_offset = offset;
         doRead(_cache_buffer.data(), length, offset, true);

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -1033,11 +1033,13 @@ void RowReaderImpl::startNextStripe() {
             }
         }
 
-        contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_STRIPE, currentStripeInfo.offset(),
-                                       stripeSize);
         if (streamIORangesEnabled) {
             contents->stream->clearIORanges();
+        } else {
+            contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_STRIPE, currentStripeInfo.offset(),
+                                           stripeSize);
         }
+
         currentStripeFooter = getStripeFooter(currentStripeInfo, *contents);
         rowsInCurrentStripe = currentStripeInfo.numberofrows();
         if (streamIORangesEnabled) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Running time of following SQL can be cut down from 43s to 16s

> select max(lo_orderkey) from lineorder_flat_1000_10_orc;

```
MySQL [emr_test.dla_scan]> select max(lo_orderkey) from lineorder_flat_1000_10_orc;
+------------------+
| max(lo_orderkey) |
+------------------+
|        600000000 |
+------------------+
1 row in set (43.88 sec)

MySQL [emr_test.dla_scan]> select max(lo_orderkey) from lineorder_flat_1000_10_orc;
+------------------+
| max(lo_orderkey) |
+------------------+
|        600000000 |
+------------------+
1 row in set (16.18 sec)
```

---

The reason is there are lot of excessive reads caused by empty stripe. Looking at following output of `orc meta`


<img width="789" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/1081215/190961106-5e12b707-013b-4660-8024-513501ad3c09.png">

there is a gap between stripes:
- you can see stream 37 ends at 24818212 + 127 = 24818339
- next strip starts at 24818991

And this gap actually is a  very small stripe, and following code will make excessive reads.
```
-        // If this stripe is small, probably other stripes are also small
-        // we combine those reads into one, and try to read several stripes in one shot.
-        if (scope == orc::InputStream::PrepareCacheScope::READ_FULL_STRIPE) {
-            length = std::min(_length - offset, cache_max_size);
-        }
```
- the small strip is 127 bytes 
- but we will make it up to 8M bytes.

----

Another reason why it was slow, is because there are a lot of stripe whose size is actually around 8MB. So we have to read whole stripe up, but actually use a little bit. So for performance consideration, we disable pre-read stripe when we enable io coalesace read

```
  if (streamIORangesEnabled) {
      contents->stream->clearIORanges();
  } else {
      contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_STRIPE, currentStripeInfo.offset(),
                                     stripeSize);
  }
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
