### PR TITLE
[Feature] Add new POJO for Hive metadata cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
@@ -1,0 +1,71 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.starrocks.external.hive.text.TextFileFormatDesc;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class Partition {
+    private final Map<String, String> parameters;
+    private final RemoteFileInputFormat inputFormat;
+    private final TextFileFormatDesc textFileFormatDesc;
+    private final String fullPath;
+    private final boolean isSplittable;
+
+    public Partition(Map<String, String> parameters,
+                     RemoteFileInputFormat inputFormat,
+                     TextFileFormatDesc textFileFormatDesc,
+                     String fullPath,
+                     boolean isSplittable) {
+        this.parameters = parameters;
+        this.inputFormat = inputFormat;
+        this.textFileFormatDesc = textFileFormatDesc;
+        this.fullPath = fullPath;
+        this.isSplittable = isSplittable;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public RemoteFileInputFormat getInputFormat() {
+        return inputFormat;
+    }
+
+    public TextFileFormatDesc getTextFileFormatDesc() {
+        return textFileFormatDesc;
+    }
+
+    public String getFullPath() {
+        return fullPath;
+    }
+
+    public boolean isSplittable() {
+        return isSplittable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Partition partition = (Partition) o;
+
+        return isSplittable == partition.isSplittable &&
+                Objects.equals(parameters, partition.parameters) &&
+                inputFormat == partition.inputFormat &&
+                Objects.equals(textFileFormatDesc, partition.textFileFormatDesc) &&
+                Objects.equals(fullPath, partition.fullPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parameters, inputFormat, textFileFormatDesc, fullPath, isSplittable);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add partition class to cache the important info of `org.apache.hadoop.hive.metastore.api` or `org.apache.hadoop.hive.metastore.api.Table`. It will be used on the stage of 'getStatistics' and 'getRemoteInfos' etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
