### PR TITLE
[Feature] Add new classes for Hive metastore statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStatistics.java
@@ -1,0 +1,262 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
+import org.apache.hadoop.hive.metastore.api.Date;
+import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.Decimal;
+import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.round;
+
+public class HiveColumnStatistics {
+    private static final Logger LOG = LogManager.getLogger(HiveColumnStatistics.class);
+
+    private enum StatisticType {
+        UNKNOWN,
+        ESTIMATE
+    }
+
+    private long totalSizeBytes;
+    private long numNulls;
+    private long ndv;
+    private double min;
+    private double max;
+    private StatisticType type;
+
+    public HiveColumnStatistics() {
+    }
+
+    public HiveColumnStatistics(long totalSizeBytes, long numNulls, long ndv, double min, double max, StatisticType type) {
+        this.totalSizeBytes = totalSizeBytes;
+        this.numNulls = numNulls;
+        this.ndv = ndv;
+        this.min = min;
+        this.max = max;
+        this.type = type;
+    }
+
+    public static HiveColumnStats fromString(String columnStats) {
+        String[] columnStatsArray = columnStats.split(",");
+        Preconditions.checkState(columnStatsArray.length == 6);
+
+        List<String> columnStatsList = Arrays.stream(columnStatsArray).map(s -> s.substring(s.indexOf(":") + 2)).
+                collect(Collectors.toList());
+        return new HiveColumnStats(Double.parseDouble(columnStatsList.get(3)), Double.parseDouble(columnStatsList.get(4)),
+                Long.parseLong(columnStatsList.get(1)), Double.parseDouble(columnStatsList.get(0)),
+                Long.parseLong(columnStatsList.get(2)), HiveColumnStats.StatisticType.valueOf(columnStatsList.get(5)));
+    }
+
+    private void initBoolColumnStats(BooleanColumnStatsData boolStats) {
+        numNulls = getNumNulls(boolStats.getNumNulls());
+        // If we have numNulls, we can infer NDV from that.
+        if (numNulls > 0) {
+            ndv = 3;
+        } else if (numNulls == 0) {
+            ndv = 2;
+        } else {
+            ndv = -1;
+        }
+        type = StatisticType.ESTIMATE;
+    }
+
+    private void initLongColumnStats(LongColumnStatsData longStats, long rowNums) {
+        numNulls = getNumNulls(longStats.getNumNulls());
+        min = longStats.isSetLowValue() ? longStats.getLowValue() : -1;
+        max = longStats.isSetHighValue() ? longStats.getHighValue() : -1;
+        ndv = longStats.isSetNumDVs() ? getNdvValue(longStats.getNumDVs(), rowNums) : -1;
+        type = StatisticType.ESTIMATE;
+    }
+
+    private void initDoubleColumnStats(DoubleColumnStatsData doubleStats, long rowNums) {
+        numNulls = getNumNulls(doubleStats.getNumNulls());
+        min = doubleStats.isSetLowValue() ? doubleStats.getLowValue() : -1;
+        max = doubleStats.isSetHighValue() ? doubleStats.getHighValue() : -1;
+        ndv = doubleStats.isSetNumDVs() ? getNdvValue(doubleStats.getNumDVs(), rowNums) : -1;
+        type = StatisticType.ESTIMATE;
+    }
+
+    private void initDateColumnStats(DateColumnStatsData dateStats, long rowNums) {
+        numNulls = getNumNulls(dateStats.getNumNulls());
+        min = dateStats.isSetLowValue() ? getDateValue(dateStats.getLowValue()) : -1;
+        max = dateStats.isSetHighValue() ? getDateValue(dateStats.getHighValue()) : -1;
+        ndv = dateStats.isSetNumDVs() ? getNdvValue(dateStats.getNumDVs(), rowNums) : -1;
+        type = StatisticType.ESTIMATE;
+    }
+
+    private void initDecimalColumnStats(DecimalColumnStatsData decimalStats, long rowNums) {
+        numNulls = getNumNulls(decimalStats.getNumNulls());
+        min = decimalStats.isSetLowValue() ? getDecimalValue(decimalStats.getLowValue()) : -1;
+        max = decimalStats.isSetHighValue() ? getDecimalValue(decimalStats.getHighValue()) : -1;
+        ndv = decimalStats.isSetNumDVs() ? getNdvValue(decimalStats.getNumDVs(), rowNums) : -1;
+        type = StatisticType.ESTIMATE;
+    }
+
+    private void initStringColumnStats(StringColumnStatsData stringStats, long rowNums) {
+        numNulls = getNumNulls(stringStats.getNumNulls());
+        ndv = stringStats.isSetNumDVs() ? getNdvValue(stringStats.getNumDVs(), rowNums) : -1;
+        double avgColLen = stringStats.isSetAvgColLen() ? stringStats.getAvgColLen() : -1;
+        totalSizeBytes = getStringColumnTotalSizeBytes(avgColLen, rowNums);
+        type = StatisticType.ESTIMATE;
+    }
+
+    public void initialize(ColumnStatisticsData statisticsData, long rowNums) {
+        if (statisticsData.isSetBooleanStats()) {
+            initBoolColumnStats(statisticsData.getBooleanStats());
+        } else if (statisticsData.isSetLongStats()) {
+            initLongColumnStats(statisticsData.getLongStats(), rowNums);
+        } else if (statisticsData.isSetDoubleStats()) {
+            initDoubleColumnStats(statisticsData.getDoubleStats(), rowNums);
+        } else if (statisticsData.isSetDecimalStats()) {
+            initDecimalColumnStats(statisticsData.getDecimalStats(), rowNums);
+        } else if (statisticsData.isSetDateStats()) {
+            initDateColumnStats(statisticsData.getDateStats(), rowNums);
+        } else if (statisticsData.isSetStringStats()) {
+            initStringColumnStats(statisticsData.getStringStats(), rowNums);
+        } else {
+            type = StatisticType.UNKNOWN;
+            LOG.warn("Unexpected column statistics data: {}", statisticsData);
+        }
+    }
+
+    public long getTotalSizeBytes() {
+        return totalSizeBytes;
+    }
+
+    public long getNumNulls() {
+        return numNulls;
+    }
+
+    public long getNdv() {
+        return ndv;
+    }
+
+    public double getMin() {
+        return min;
+    }
+
+    public double getMax() {
+        return max;
+    }
+
+    public StatisticType getType() {
+        return type;
+    }
+
+    private double getDecimalValue(Decimal decimal) {
+        if (decimal == null) {
+            return -1;
+        }
+        return new BigDecimal(new BigInteger(decimal.getUnscaled()), decimal.getScale()).doubleValue();
+    }
+
+    private double getDateValue(Date date) {
+        return date.getDaysSinceEpoch() * 24.0 * 3600L;
+    }
+
+    private long getNdvValue(long ndv, long rowNums) {
+        if (ndv != -1 && numNulls != -1 && rowNums != -1) {
+            long nonNullsNum = rowNums - numNulls;
+            if (numNulls > 0 && ndv > 0) {
+                ndv--;
+            }
+
+            if (nonNullsNum > 0 && ndv == 0) {
+                ndv = 1;
+            }
+
+            if (ndv > nonNullsNum) {
+                return nonNullsNum;
+            }
+
+            return ndv;
+        }
+        return -1;
+    }
+
+    private long getNumNulls(long numNulls) {
+        if (numNulls >= 0L) {
+            return numNulls;
+        }
+        return -1L;
+    }
+
+    public long getStringColumnTotalSizeBytes(double avgColLen, long rowNums) {
+        if (avgColLen != -1 && rowNums != -1 && numNulls != -1) {
+            long nonNullsNums = rowNums - numNulls;
+            if (nonNullsNums < 0) {
+                return -1;
+            }
+            return round(avgColLen * nonNullsNums);
+        }
+        return -1;
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format("ndv: %d, min: %.2f, max: %.2f, totalSizeBytes: %.2d, numNulls: %d, type: %s",
+                ndv, min, max, totalSizeBytes, numNulls, type);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long totalSizeBytes = -1L;
+        private long numNulls = -1L;
+        private long ndv = -1L;
+        private double min = Double.NEGATIVE_INFINITY;
+        private double max = Double.POSITIVE_INFINITY;
+        private StatisticType type = StatisticType.UNKNOWN;
+
+        public Builder setTotalSizeBytes(long totalSizeBytes) {
+            this.totalSizeBytes = totalSizeBytes;
+            return this;
+        }
+
+        public Builder setNumNulls(long numNulls) {
+            this.numNulls = numNulls;
+            return this;
+        }
+
+        public Builder setNdv(long ndv) {
+            this.ndv = ndv;
+            return this;
+        }
+
+        public Builder setMin(double min) {
+            this.min = min;
+            return this;
+        }
+
+        public Builder setMax(double max) {
+            this.max = max;
+            return this;
+        }
+
+        public Builder setType(StatisticType type) {
+            this.type = type;
+            return this;
+        }
+
+        public HiveColumnStatistics build() {
+            return new HiveColumnStatistics(totalSizeBytes, numNulls, ndv, min, max, type);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveCommonStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveCommonStats.java
@@ -1,0 +1,43 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+public class HiveCommonStats {
+    private static HiveCommonStats EMPTY = new HiveCommonStats(-1, -1);
+
+    // Row num is first obtained from the table or partition's parameters.
+    // If the num is null or -1, it will be estimated from total size of the partition or table's files.
+    private long rowNums;
+
+    private long totalFileBytes;
+
+    public HiveCommonStats(long rowNums, long totalSize) {
+        this.rowNums = rowNums;
+        this.totalFileBytes = totalSize;
+    }
+
+    public static HiveCommonStats empty() {
+        return EMPTY;
+    }
+
+    public void setTotalFileBytes(long totalFileBytes) {
+        this.totalFileBytes = totalFileBytes;
+    }
+
+    public long getRowNums() {
+        return rowNums;
+    }
+
+    public long getTotalFileBytes() {
+        return totalFileBytes;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("HiveCommonStats{");
+        sb.append("rowNums=").append(rowNums);
+        sb.append(", totalFileBytes=").append(totalFileBytes);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStatistics.java
@@ -1,0 +1,40 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class HivePartitionStatistics {
+    private static final HivePartitionStatistics EMPTY = new HivePartitionStatistics(HiveCommonStats.empty(), ImmutableMap.of());
+
+    private final HiveCommonStats commonStats;
+    private final Map<String, HiveColumnStatistics> columnStats;
+
+    public static HivePartitionStatistics empty() {
+        return EMPTY;
+    }
+
+    public HivePartitionStatistics(HiveCommonStats commonStats, Map<String, HiveColumnStatistics> columnStats) {
+        this.commonStats = commonStats;
+        this.columnStats = columnStats;
+    }
+
+    public HiveCommonStats getCommonStats() {
+        return commonStats;
+    }
+
+    public Map<String, HiveColumnStatistics> getColumnStats() {
+        return columnStats;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("HivePartitionStatistics{");
+        sb.append("commonStats=").append(commonStats);
+        sb.append(", columnStats=").append(columnStats);
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add some new classes for hive statistics. the `HiveColumnStatistics` and `HivePartitionStatistics` will be rename to `HiveColumnStats` and `HivePartitionStats` when the latter two are removed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
