### PR TITLE
[Cherry-pick 2.4][BugFix] fix sleep negative for BDB UT (#11347)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -127,8 +127,8 @@ public class BDBEnvironmentTest {
                 return;
             } catch (Exception e) {
                 // sleep 5 ~ 15 seconds
-               int sleepSeconds = new Random().nextInt() % 10 + 5;
-                LOG.warn("failed to initClusterMasterFollower! will sleep {} seconds and retry", sleepSeconds);
+                int sleepSeconds = ThreadLocalRandom.current().nextInt(5, 15);
+                LOG.warn("failed to initClusterMasterFollower! will sleep {} seconds and retry", sleepSeconds, e);
                 Thread.sleep(sleepSeconds * 1000L);
             }
         }


### PR DESCRIPTION
Fix a bug that may pass negative number to Thread.sleep.

```
java.lang.IllegalArgumentException: timeout value is negative
	at java.lang.Thread.sleep(Native Method)
	at com.starrocks.journal.bdbje.BDBEnvironmentTest.initClusterMasterFollower(BDBEnvironmentTest.java:119)
```

Already fixed in #9227, but after I reverted the retry PR and then commited again later, I forgot to add this patch. My mistake.

Manually cherry-picked from 258165f165b211cd7c003ab9f204e3a36fc15611