### PR TITLE
[Refactor] Refactor HivePartitionKey

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HivePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HivePartitionKey.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.catalog;
+
+import com.starrocks.external.hive.HiveMetaClient;
+
+public class HivePartitionKey extends PartitionKey implements NullablePartitionKey {
+    public HivePartitionKey() {
+        super();
+    }
+
+    @Override
+    public String nullPartitionValue() {
+        return HiveMetaClient.PARTITION_NULL_VALUE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiPartitionKey.java
@@ -1,0 +1,16 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.catalog;
+
+import com.starrocks.external.hive.HiveMetaClient;
+
+public class HudiPartitionKey extends PartitionKey implements NullablePartitionKey {
+    public HudiPartitionKey() {
+        super();
+    }
+
+    @Override
+    public String nullPartitionValue() {
+        return HiveMetaClient.HUDI_PARTITION_NULL_VALUE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/NullablePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/NullablePartitionKey.java
@@ -1,0 +1,9 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.catalog;
+
+public interface NullablePartitionKey {
+    default String nullPartitionValue() {
+        return "";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -51,14 +51,14 @@ public class HiveMetaCache {
     // HivePartitionKeysKey => ImmutableMap<PartitionKey -> PartitionId>
     // for unPartitioned table, partition map is: ImmutableMap<>.of(new PartitionKey(), PartitionId)
     LoadingCache<HivePartitionKeysKey, ImmutableMap<PartitionKey, Long>> partitionKeysCache;
-    // HivePartitionKey => Partitions
-    LoadingCache<HivePartitionKey, HivePartition> partitionsCache;
+    // HivePartitionName => Partitions
+    LoadingCache<HivePartitionName, HivePartition> partitionsCache;
 
     // statistic cache
     // HiveTableKey => HiveTableStatistic
     LoadingCache<HiveTableKey, HiveTableStats> tableStatsCache;
-    // HivePartitionKey => PartitionStatistic
-    LoadingCache<HivePartitionKey, HivePartitionStats> partitionStatsCache;
+    // HivePartitionName => PartitionStatistic
+    LoadingCache<HivePartitionName, HivePartitionStats> partitionStatsCache;
 
     // HiveTableColumnsKey => ImmutableMap<ColumnName -> HiveColumnStats>
     LoadingCache<HiveTableColumnsKey, ImmutableMap<String, HiveColumnStats>> tableColumnStatsCache;
@@ -91,9 +91,9 @@ public class HiveMetaCache {
                 }, executor));
 
         partitionsCache = newCacheBuilder(MAX_PARTITION_CACHE_SIZE)
-                .build(asyncReloading(new CacheLoader<HivePartitionKey, HivePartition>() {
+                .build(asyncReloading(new CacheLoader<HivePartitionName, HivePartition>() {
                     @Override
-                    public HivePartition load(HivePartitionKey key) throws Exception {
+                    public HivePartition load(HivePartitionName key) throws Exception {
                         return loadPartition(key);
                     }
                 }, executor));
@@ -107,9 +107,9 @@ public class HiveMetaCache {
                 }, executor));
 
         partitionStatsCache = newCacheBuilder(MAX_PARTITION_CACHE_SIZE)
-                .build(asyncReloading(new CacheLoader<HivePartitionKey, HivePartitionStats>() {
+                .build(asyncReloading(new CacheLoader<HivePartitionName, HivePartitionStats>() {
                     @Override
-                    public HivePartitionStats load(HivePartitionKey key) throws Exception {
+                    public HivePartitionStats load(HivePartitionName key) throws Exception {
                         return loadPartitionStats(key);
                     }
                 }, executor));
@@ -177,7 +177,7 @@ public class HiveMetaCache {
         return ImmutableMap.copyOf(partitionKeys);
     }
 
-    private HivePartition loadPartition(HivePartitionKey key) throws DdlException {
+    private HivePartition loadPartition(HivePartitionName key) throws DdlException {
         if (key.getTableType() == Table.TableType.HUDI) {
             return client.getHudiPartition(key.getDatabaseName(), key.getTableName(), key.getPartitionValues());
         } else {
@@ -189,7 +189,7 @@ public class HiveMetaCache {
         return client.getTableStats(key.getDatabaseName(), key.getTableName());
     }
 
-    private HivePartitionStats loadPartitionStats(HivePartitionKey key) throws Exception {
+    private HivePartitionStats loadPartitionStats(HivePartitionName key) throws Exception {
         HivePartitionStats partitionStats =
                 client.getPartitionStats(key.getDatabaseName(), key.getTableName(), key.getPartitionValues());
         HivePartition partition = partitionsCache.get(key);
@@ -237,7 +237,7 @@ public class HiveMetaCache {
         List<String> partitionValues = Utils.getPartitionValues(partitionKey,
                 hmsTable.getTableType() == Table.TableType.HUDI);
         try {
-            return partitionsCache.get(new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
+            return partitionsCache.get(new HivePartitionName(hmsTable.getDb(), hmsTable.getTable(),
                     hmsTable.getTableType(), partitionValues));
         } catch (ExecutionException e) {
             throw new DdlException("get partition detail failed: " + e.getMessage());
@@ -256,8 +256,8 @@ public class HiveMetaCache {
                                                 PartitionKey partitionKey) throws DdlException {
         List<String> partValues =
                 Utils.getPartitionValues(partitionKey, hmsTable.getTableType() == Table.TableType.HUDI);
-        HivePartitionKey key =
-                new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(), hmsTable.getTableType(), partValues);
+        HivePartitionName key =
+                new HivePartitionName(hmsTable.getDb(), hmsTable.getTable(), hmsTable.getTableType(), partValues);
         try {
             return partitionStatsCache.get(key);
         } catch (ExecutionException e) {
@@ -352,7 +352,7 @@ public class HiveMetaCache {
         return HiveMetaStoreTableUtils.convertToSRDatabase(dbName);
     }
 
-    public void alterTableByEvent(HiveTableKey tableKey, HivePartitionKey hivePartitionKey,
+    public void alterTableByEvent(HiveTableKey tableKey, HivePartitionName hivePartitionKey,
                                   StorageDescriptor sd, Map<String, String> params) throws Exception {
         HiveTableStats tableStats = new HiveTableStats(Utils.getRowCount(params), Utils.getTotalSize(params));
         tableStatsCache.put(tableKey, tableStats);
@@ -360,7 +360,7 @@ public class HiveMetaCache {
     }
 
     public synchronized void addPartitionKeyByEvent(HivePartitionKeysKey hivePartitionKeysKey,
-                                                    PartitionKey partitionKey, HivePartitionKey hivePartitionKey) {
+                                                    PartitionKey partitionKey, HivePartitionName hivePartitionKey) {
         ImmutableMap<PartitionKey, Long> cachedPartitions = partitionKeysCache.getIfPresent(hivePartitionKeysKey);
         if (cachedPartitions == null) {
             return;
@@ -381,7 +381,7 @@ public class HiveMetaCache {
         return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
     }
 
-    public void alterPartitionByEvent(HivePartitionKey hivePartitionKey,
+    public void alterPartitionByEvent(HivePartitionName hivePartitionKey,
                                       StorageDescriptor sd, Map<String, String> params) throws Exception {
         HivePartition updatedHivePartition = getPartitionByEvent(sd);
         partitionsCache.put(hivePartitionKey, updatedHivePartition);
@@ -396,7 +396,7 @@ public class HiveMetaCache {
     }
 
     public synchronized void dropPartitionKeyByEvent(HivePartitionKeysKey hivePartitionKeysKey,
-                                                     PartitionKey partitionKey, HivePartitionKey hivePartitionKey) {
+                                                     PartitionKey partitionKey, HivePartitionName hivePartitionKey) {
         ImmutableMap<PartitionKey, Long> cachedPartitions = partitionKeysCache.getIfPresent(hivePartitionKeysKey);
         if (cachedPartitions == null) {
             return;
@@ -419,7 +419,7 @@ public class HiveMetaCache {
         return exist;
     }
 
-    public boolean partitionExistInCache(HivePartitionKey partitionKey) {
+    public boolean partitionExistInCache(HivePartitionName partitionKey) {
         boolean exist = partitionsCache.getIfPresent(partitionKey) != null;
         if (!HiveMetaStoreTableUtils.isInternalCatalog(resourceName)) {
             boolean connectorTableExist = getTableFromCache(
@@ -465,8 +465,8 @@ public class HiveMetaCache {
 
             // for unpartition table, refresh the partition info, because there is only one partition
             if (partColumns.size() <= 0) {
-                HivePartitionKey hivePartitionKey =
-                        new HivePartitionKey(dbName, tableName, tableType, new ArrayList<>());
+                HivePartitionName hivePartitionKey =
+                        new HivePartitionName(dbName, tableName, tableType, new ArrayList<>());
                 partitionsCache.put(hivePartitionKey, loadPartition(hivePartitionKey));
                 partitionStatsCache.put(hivePartitionKey, loadPartitionStats(hivePartitionKey));
             }
@@ -483,7 +483,7 @@ public class HiveMetaCache {
         try {
             for (String partName : partNames) {
                 List<String> partValues = client.partitionNameToVals(partName);
-                HivePartitionKey key = new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
+                HivePartitionName key = new HivePartitionName(hmsTable.getDb(), hmsTable.getTable(),
                         hmsTable.getTableType(), partValues);
                 partitionsCache.put(key, loadPartition(key));
                 partitionStatsCache.put(key, loadPartitionStats(key));
@@ -522,8 +522,8 @@ public class HiveMetaCache {
         tableColumnStatsCache.invalidate(new HiveTableColumnsKey(dbName, tableName, null, null, tableType));
         if (partitionKeys != null) {
             for (Map.Entry<PartitionKey, Long> entry : partitionKeys.entrySet()) {
-                HivePartitionKey pKey =
-                        new HivePartitionKey(dbName, tableName, tableType,
+                HivePartitionName pKey =
+                        new HivePartitionName(dbName, tableName, tableType,
                                 Utils.getPartitionValues(entry.getKey(), tableType == Table.TableType.HUDI));
                 partitionsCache.invalidate(pKey);
                 partitionStatsCache.invalidate(pKey);
@@ -532,7 +532,7 @@ public class HiveMetaCache {
 
         if (!HiveMetaStoreTableUtils.isInternalCatalog(resourceName)) {
             if (partitionKeys != null) {
-                List<HivePartitionKey> residualToRemove = partitionsCache.asMap().keySet().stream()
+                List<HivePartitionName> residualToRemove = partitionsCache.asMap().keySet().stream()
                         .filter(key -> key.approximateMatchTable(dbName, tableName))
                         .collect(Collectors.toList());
                 partitionsCache.invalidateAll(residualToRemove);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionName.java
@@ -7,13 +7,13 @@ import com.starrocks.catalog.Table.TableType;
 import java.util.List;
 import java.util.Objects;
 
-public class HivePartitionKey {
+public class HivePartitionName {
     private final String databaseName;
     private final String tableName;
     private final List<String> partitionValues;
     private final TableType tableType;
 
-    public HivePartitionKey(String databaseName, String tableName, TableType tableType, List<String> partitionValues) {
+    public HivePartitionName(String databaseName, String tableName, TableType tableType, List<String> partitionValues) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionValues = partitionValues;
@@ -49,7 +49,7 @@ public class HivePartitionKey {
             return false;
         }
 
-        HivePartitionKey other = (HivePartitionKey) o;
+        HivePartitionName other = (HivePartitionName) o;
         return Objects.equals(databaseName, other.databaseName) &&
                 Objects.equals(tableName, other.tableName) &&
                 Objects.equals(partitionValues, other.partitionValues) &&

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/AddPartitionEvent.java
@@ -8,8 +8,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
 import com.starrocks.external.hive.HivePartitionKeysKey;
+import com.starrocks.external.hive.HivePartitionName;
 import com.starrocks.external.hive.HiveTableKey;
 import com.starrocks.external.hive.Utils;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
@@ -52,7 +52,7 @@ public class AddPartitionEvent extends MetastoreTableEvent {
             hmsTbl = addPartitionMessage.getTableObj();
             hivePartitionKeys.clear();
             hivePartitionKeys.add(
-                    new HivePartitionKey(dbName, tblName, Table.TableType.HIVE, addedPartition.getValues()));
+                    new HivePartitionName(dbName, tblName, Table.TableType.HIVE, addedPartition.getValues()));
         } catch (Exception ex) {
             throw new MetastoreNotificationException(ex);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/AlterPartitionEvent.java
@@ -6,7 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
+import com.starrocks.external.hive.HivePartitionName;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.messaging.AlterPartitionMessage;
@@ -40,7 +40,7 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
             hmsTbl = alterPartitionMessage.getTableObj();
             hivePartitionKeys.clear();
             hivePartitionKeys.add(
-                    new HivePartitionKey(dbName, tblName, Table.TableType.HIVE, partitionAfter.getValues()));
+                    new HivePartitionName(dbName, tblName, Table.TableType.HIVE, partitionAfter.getValues()));
         } catch (Exception e) {
             throw new MetastoreNotificationException(
                     debugString("Unable to parse the alter partition message"), e);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/DropPartitionEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/DropPartitionEvent.java
@@ -8,8 +8,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
 import com.starrocks.external.hive.HivePartitionKeysKey;
+import com.starrocks.external.hive.HivePartitionName;
 import com.starrocks.external.hive.Utils;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.messaging.DropPartitionMessage;
@@ -47,7 +47,7 @@ public class DropPartitionEvent extends MetastoreTableEvent {
             Preconditions.checkState(!partCols.isEmpty());
             this.partCols = partCols;
             hivePartitionKeys.clear();
-            hivePartitionKeys.add(new HivePartitionKey(dbName, tblName, Table.TableType.HIVE,
+            hivePartitionKeys.add(new HivePartitionName(dbName, tblName, Table.TableType.HIVE,
                     Lists.newArrayList(droppedPartition.values())));
         } catch (Exception ex) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/InsertEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/InsertEvent.java
@@ -6,7 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
+import com.starrocks.external.hive.HivePartitionName;
 import com.starrocks.external.hive.HiveTableKey;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -39,7 +39,7 @@ public class InsertEvent extends MetastoreTableEvent {
             if (insertPartition != null) {
                 hivePartitionKeys.clear();
                 hivePartitionKeys.add(
-                        new HivePartitionKey(dbName, tblName, Table.TableType.HIVE, insertPartition.getValues()));
+                        new HivePartitionName(dbName, tblName, Table.TableType.HIVE, insertPartition.getValues()));
             }
         } catch (Exception e) {
             LOG.warn("The InsertEvent of the current hive version cannot be parsed, " +
@@ -75,7 +75,7 @@ public class InsertEvent extends MetastoreTableEvent {
     protected boolean existInCache() {
         if (isPartitionTbl()) {
             List<String> partVals = insertPartition.getValues();
-            HivePartitionKey partitionKey = new HivePartitionKey(dbName, tblName, Table.TableType.HIVE, partVals);
+            HivePartitionName partitionKey = new HivePartitionName(dbName, tblName, Table.TableType.HIVE, partVals);
             return cache.partitionExistInCache(partitionKey);
         } else {
             HiveTableKey tableKey = HiveTableKey.gen(dbName, tblName);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/MetastoreEventFactory.java
@@ -9,7 +9,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.external.HiveMetaStoreTableUtils;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
+import com.starrocks.external.hive.HivePartitionName;
 import com.starrocks.external.hive.HiveTableName;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
@@ -104,15 +104,15 @@ public class MetastoreEventFactory implements EventFactory {
     }
 
     /**
-     * Create batch event tasks according to HivePartitionKey to facilitate subsequent parallel processing.
+     * Create batch event tasks according to HivePartitionName to facilitate subsequent parallel processing.
      * For ADD_PARTITION and DROP_PARTITION, we directly override any events before that partition.
      * For a partition, it is meaningless to process any events before the drop partition.
      */
     List<MetastoreEvent> createBatchEvents(List<MetastoreEvent> events) {
-        Map<HivePartitionKey, MetastoreEvent> batchEvents = Maps.newHashMap();
+        Map<HivePartitionName, MetastoreEvent> batchEvents = Maps.newHashMap();
         for (MetastoreEvent event : events) {
             MetastoreTableEvent metastoreTableEvent = (MetastoreTableEvent) event;
-            HivePartitionKey hivePartitionKey = metastoreTableEvent.getHivePartitionKey();
+            HivePartitionName hivePartitionKey = metastoreTableEvent.getHivePartitionKey();
             switch (event.getEventType()) {
                 case ADD_PARTITION:
                 case DROP_PARTITION:

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/events/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/events/MetastoreTableEvent.java
@@ -7,7 +7,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.external.hive.HiveMetaCache;
-import com.starrocks.external.hive.HivePartitionKey;
+import com.starrocks.external.hive.HivePartitionName;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.Table;
 
@@ -25,14 +25,14 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
     protected Table hmsTbl;
 
     // HivePartitionKeys of each event to process. for unpartition table, the partition values are empty.
-    protected List<HivePartitionKey> hivePartitionKeys = Lists.newArrayList();
+    protected List<HivePartitionName> hivePartitionKeys = Lists.newArrayList();
 
     protected MetastoreTableEvent(NotificationEvent event, HiveMetaCache metaCache) {
         super(event, metaCache);
         Preconditions.checkNotNull(dbName, "Database name cannot be null");
         tblName = Preconditions.checkNotNull(event.getTableName());
 
-        HivePartitionKey hivePartitionKey = new HivePartitionKey(dbName, tblName, TableType.HIVE, Lists.newArrayList());
+        HivePartitionName hivePartitionKey = new HivePartitionName(dbName, tblName, TableType.HIVE, Lists.newArrayList());
         hivePartitionKeys.add(hivePartitionKey);
     }
 
@@ -62,14 +62,14 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
         }
     }
 
-    protected List<HivePartitionKey> getHivePartitionKeys() {
+    protected List<HivePartitionName> getHivePartitionKeys() {
         return hivePartitionKeys;
     }
 
     /**
-     * According to the current processing method, each event only needs to process one {@link HivePartitionKey}.
+     * According to the current processing method, each event only needs to process one {@link HivePartitionName}.
      */
-    protected HivePartitionKey getHivePartitionKey() {
+    protected HivePartitionName getHivePartitionKey() {
         return hivePartitionKeys.get(0);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -145,7 +145,7 @@ public class HiveMetaCacheTest {
                 new HivePartitionKeysKey("db", "tbl", Table.TableType.HIVE, partColumns);
         List<String> partValues = Lists.newArrayList("11", "22", "33");
         PartitionKey newPartitionKey = Utils.createPartitionKey(partValues, partColumns);
-        HivePartitionKey newHivePartitionKey = new HivePartitionKey("db", "tbl", Table.TableType.HIVE, partValues);
+        HivePartitionName newHivePartitionKey = new HivePartitionName("db", "tbl", Table.TableType.HIVE, partValues);
         metaCache.addPartitionKeyByEvent(newPartitionKeysKey, newPartitionKey, newHivePartitionKey);
         partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(4, partitionKeys.size());
@@ -177,7 +177,7 @@ public class HiveMetaCacheTest {
         Map<String, String> params = Maps.newHashMap();
         params.put("numRows", "5");
         List<String> partValues = Lists.newArrayList("1", "2", "3");
-        HivePartitionKey partitionKey = new HivePartitionKey("db", "tbl", Table.TableType.HIVE, partValues);
+        HivePartitionName partitionKey = new HivePartitionName("db", "tbl", Table.TableType.HIVE, partValues);
         StorageDescriptor sd = new StorageDescriptor();
         sd.setInputFormat("org.apache.hadoop.mapred.TextInputFormat");
         SerDeInfo serDeInfo = new SerDeInfo();
@@ -216,7 +216,7 @@ public class HiveMetaCacheTest {
                 new HivePartitionKeysKey("db", "tbl", Table.TableType.HIVE, partColumns);
         List<String> partValues = Lists.newArrayList("1", "2", "3");
         PartitionKey dropPartitionKey = Utils.createPartitionKey(partValues, partColumns);
-        HivePartitionKey dropHivePartitionKey = new HivePartitionKey("db", "tbl", Table.TableType.HIVE, partValues);
+        HivePartitionName dropHivePartitionKey = new HivePartitionName("db", "tbl", Table.TableType.HIVE, partValues);
         metaCache.dropPartitionKeyByEvent(dropPartitionKeysKey, dropPartitionKey, dropHivePartitionKey);
         partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(2, partitionKeys.size());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- extensive use of `isHudiTable` in fe is not clear.  HiveTable and HudiTable have different null values. So `isHudiTable` is used to determine which null value to use.
- port HivePartitionKey to HivePartitionName. the implement of HivePartitionName will be commited in next patchs.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
