### PR TITLE
[BugFix] Fix ExprContext use-after-free when error happen in init stage

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -161,7 +161,7 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
     }
 
     std::vector<ExprContext*> cloned_conjunct_ctxs;
-    RETURN_IF_ERROR(Expr::clone_if_not_exists(_conjunct_ctxs, state, &cloned_conjunct_ctxs));
+    RETURN_IF_ERROR(Expr::clone_if_not_exists(state, &_pool, _conjunct_ctxs, &cloned_conjunct_ctxs));
 
     for (ExprContext* ctx : cloned_conjunct_ctxs) {
         const Expr* root_expr = ctx->root();

--- a/be/src/exec/sort_exec_exprs.cpp
+++ b/be/src/exec/sort_exec_exprs.cpp
@@ -32,6 +32,7 @@ Status SortExecExprs::init(const TSortInfo& sort_info, ObjectPool* pool) {
 
 Status SortExecExprs::init(const std::vector<TExpr>& ordering_exprs, const std::vector<TExpr>* sort_tuple_slot_exprs,
                            ObjectPool* pool) {
+    _pool = pool;
     RETURN_IF_ERROR(Expr::create_expr_trees(pool, ordering_exprs, &_lhs_ordering_expr_ctxs));
     for (auto& expr : _lhs_ordering_expr_ctxs) {
         auto& type_desc = expr->root()->type();
@@ -71,7 +72,7 @@ Status SortExecExprs::open(RuntimeState* state) {
         RETURN_IF_ERROR(Expr::open(_sort_tuple_slot_expr_ctxs, state));
     }
     RETURN_IF_ERROR(Expr::open(_lhs_ordering_expr_ctxs, state));
-    RETURN_IF_ERROR(Expr::clone_if_not_exists(_lhs_ordering_expr_ctxs, state, &_rhs_ordering_expr_ctxs));
+    RETURN_IF_ERROR(Expr::clone_if_not_exists(state, _pool, _lhs_ordering_expr_ctxs, &_rhs_ordering_expr_ctxs));
     return Status::OK();
 }
 

--- a/be/src/exec/sort_exec_exprs.h
+++ b/be/src/exec/sort_exec_exprs.h
@@ -62,6 +62,7 @@ public:
     const std::vector<ExprContext*>& rhs_ordering_expr_ctxs() const { return _rhs_ordering_expr_ctxs; }
 
 private:
+    ObjectPool* _pool = nullptr;
     // Create two ExprContexts for evaluating over the TupleRows.
     std::vector<ExprContext*> _lhs_ordering_expr_ctxs;
     std::vector<ExprContext*> _rhs_ordering_expr_ctxs;

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -281,7 +281,7 @@ void FileScanNode::_scanner_worker(int start_idx, int length) {
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
     DeferOp close_exprs([this, &scanner_expr_ctxs] { Expr::close(scanner_expr_ctxs, runtime_state()); });
-    auto status = Expr::clone_if_not_exists(_conjunct_ctxs, runtime_state(), &scanner_expr_ctxs);
+    auto status = Expr::clone_if_not_exists(runtime_state(), _pool, _conjunct_ctxs, &scanner_expr_ctxs);
 
     if (!status.ok()) {
         LOG(WARNING) << "Clone conjuncts failed.";

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -943,7 +943,7 @@ Status HashJoinNode::_create_implicit_local_join_runtime_filters(RuntimeState* s
     for (int i = 0; i < _probe_expr_ctxs.size(); i++) {
         auto* desc = _pool->add(new RuntimeFilterProbeDescriptor());
         desc->_filter_id = implicit_runtime_filter_id_offset + i;
-        RETURN_IF_ERROR(_probe_expr_ctxs[i]->clone(state, &desc->_probe_expr_ctx));
+        RETURN_IF_ERROR(_probe_expr_ctxs[i]->clone(state, _pool, &desc->_probe_expr_ctx));
         desc->_runtime_filter.store(nullptr);
         child(0)->register_runtime_filter_descriptor(state, desc);
     }

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -32,7 +32,7 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     _skip_aggregation = params.skip_aggregation;
     _need_agg_finalize = params.need_agg_finalize;
 
-    RETURN_IF_ERROR(Expr::clone_if_not_exists(*params.conjunct_ctxs, runtime_state, &_conjunct_ctxs));
+    RETURN_IF_ERROR(Expr::clone_if_not_exists(runtime_state, &_pool, *params.conjunct_ctxs, &_conjunct_ctxs));
     RETURN_IF_ERROR(_get_tablet(params.scan_range));
     RETURN_IF_ERROR(_init_unused_output_columns(*params.unused_output_columns));
     RETURN_IF_ERROR(_init_return_columns());

--- a/be/src/exec/vectorized/tablet_scanner.h
+++ b/be/src/exec/vectorized/tablet_scanner.h
@@ -70,7 +70,7 @@ private:
     OlapScanNode* _parent = nullptr;
 
     using PredicatePtr = std::unique_ptr<ColumnPredicate>;
-
+    ObjectPool _pool;
     std::vector<ExprContext*> _conjunct_ctxs;
     ConjunctivePredicates _predicates;
     std::vector<uint8_t> _selection;

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -434,7 +434,7 @@ void Expr::close(RuntimeState* state, ExprContext* context, FunctionContext::Fun
 #endif
 }
 
-Status Expr::clone_if_not_exists(const std::vector<ExprContext*>& ctxs, RuntimeState* state,
+Status Expr::clone_if_not_exists(RuntimeState* state, ObjectPool* pool, const std::vector<ExprContext*>& ctxs,
                                  std::vector<ExprContext*>* new_ctxs) {
     DCHECK(new_ctxs != nullptr);
     if (!new_ctxs->empty()) {
@@ -448,7 +448,7 @@ Status Expr::clone_if_not_exists(const std::vector<ExprContext*>& ctxs, RuntimeS
 
     new_ctxs->resize(ctxs.size());
     for (int i = 0; i < ctxs.size(); ++i) {
-        RETURN_IF_ERROR(ctxs[i]->clone(state, &(*new_ctxs)[i]));
+        RETURN_IF_ERROR(ctxs[i]->clone(state, pool, &(*new_ctxs)[i]));
     }
     return Status::OK();
 }

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -170,8 +170,8 @@ public:
     /// Clones each ExprContext for multiple expr trees. 'new_ctxs' must be non-NULL.
     /// Idempotent: if '*new_ctxs' is empty, a clone of each context in 'ctxs' will be added
     /// to it, and if non-empty, it is assumed CloneIfNotExists() was already called and the
-    /// call is a no-op. The new ExprContexts are created in state->obj_pool().
-    static Status clone_if_not_exists(const std::vector<ExprContext*>& ctxs, RuntimeState* state,
+    /// call is a no-op. The new ExprContexts are created in provided object pool.
+    static Status clone_if_not_exists(RuntimeState* state, ObjectPool* pool, const std::vector<ExprContext*>& ctxs,
                                       std::vector<ExprContext*>* new_ctxs);
 
     /// Convenience function for closing multiple expr trees.

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -109,12 +109,12 @@ int ExprContext::register_func(RuntimeState* state, const starrocks_udf::Functio
     return _fn_contexts.size() - 1;
 }
 
-Status ExprContext::clone(RuntimeState* state, ExprContext** new_ctx) {
+Status ExprContext::clone(RuntimeState* state, ObjectPool* pool, ExprContext** new_ctx) {
     DCHECK(_prepared);
     DCHECK(_opened);
     DCHECK(*new_ctx == nullptr);
 
-    *new_ctx = state->obj_pool()->add(new ExprContext(_root));
+    *new_ctx = pool->add(new ExprContext(_root));
     (*new_ctx)->_pool = std::make_unique<MemPool>();
     for (auto& _fn_context : _fn_contexts) {
         (*new_ctx)->_fn_contexts.push_back(_fn_context->impl()->clone((*new_ctx)->_pool.get()));
@@ -128,12 +128,12 @@ Status ExprContext::clone(RuntimeState* state, ExprContext** new_ctx) {
     return _root->open(state, *new_ctx, FunctionContext::THREAD_LOCAL);
 }
 
-Status ExprContext::clone(RuntimeState* state, ExprContext** new_ctx, Expr* root) {
+Status ExprContext::clone(RuntimeState* state, ObjectPool* pool, ExprContext** new_ctx, Expr* root) {
     DCHECK(_prepared);
     DCHECK(_opened);
     DCHECK(*new_ctx == nullptr);
 
-    *new_ctx = state->obj_pool()->add(new ExprContext(root));
+    *new_ctx = pool->add(new ExprContext(root));
     (*new_ctx)->_pool = std::make_unique<MemPool>();
     for (auto& _fn_context : _fn_contexts) {
         (*new_ctx)->_fn_contexts.push_back(_fn_context->impl()->clone((*new_ctx)->_pool.get()));

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -46,6 +46,7 @@ class Expr;
 class MemPool;
 class MemTracker;
 class RuntimeState;
+class ObjectPool;
 class TColumnValue;
 
 using vectorized::ColumnPtr;
@@ -77,9 +78,9 @@ public:
     /// to create an ExprContext for each execution thread that needs to evaluate
     /// 'root'. Note that clones are already opened. '*new_context' must be initialized by
     /// the caller to NULL.
-    Status clone(RuntimeState* state, ExprContext** new_context);
+    Status clone(RuntimeState* state, ObjectPool* pool, ExprContext** new_context);
 
-    Status clone(RuntimeState* state, ExprContext** new_ctx, Expr* root);
+    Status clone(RuntimeState* state, ObjectPool* pool, ExprContext** new_ctx, Expr* root);
 
     /// Closes all FunctionContexts. Must be called on every ExprContext, including clones.
     void close(RuntimeState* state);

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -42,7 +42,7 @@ void ColumnExprPredicate::_add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx) {
     if (expr_ctx != nullptr) {
         DCHECK(expr_ctx->opened());
         // Transfer the ownership to object pool
-        auto* ctx = _state->obj_pool()->add(expr_ctx.release());
+        auto* ctx = _pool.add(expr_ctx.release());
         _expr_ctxs.emplace_back(ctx);
         _monotonic &= ctx->root()->is_monotonic();
     }
@@ -52,7 +52,7 @@ void ColumnExprPredicate::_add_expr_ctx(ExprContext* expr_ctx) {
     if (expr_ctx != nullptr) {
         DCHECK(expr_ctx->opened());
         ExprContext* ctx = nullptr;
-        DCHECK_IF_ERROR(expr_ctx->clone(_state, &ctx));
+        DCHECK_IF_ERROR(expr_ctx->clone(_state, &_pool, &ctx));
         _expr_ctxs.emplace_back(ctx);
         _monotonic &= ctx->root()->is_monotonic();
     }

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -68,6 +68,7 @@ private:
     // Share the ownership, is necessary to clone it
     void _add_expr_ctx(ExprContext* expr_ctx);
 
+    ObjectPool _pool;
     RuntimeState* _state;
     std::vector<ExprContext*> _expr_ctxs;
     const SlotDescriptor* _slot_desc;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #11395

## Problem Summary(Required) ：
before call ExprContext::clone. the destruct order will be 
```
RuntimeState::pool<-ExecNode::pool<-Expr<-OlapScanNode::pool<-ExprContext
```
ExprContext::clone will create a new context and add it to RuntimeState::_obj_pool;

then the destruct order will be 
```
RuntimeState::pool<-ClonedExprContext<-ExecNode::pool<-Expr<-OlapScanNode::pool<-ExprContext
```

so when we call call close method in TabletScanner. use-after-free will happen

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
