### PR TITLE
[Cherry-pick] [BugFix] When the status of HeartBeat is not ok, it also need to be synced to follower(#8265)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -82,10 +82,15 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
             } else {
                 if (isAlive) {
                     isAlive = false;
-                    isChanged = true;
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            // When the leader receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
+            isChanged = true;
         }
 
         return isChanged;

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -667,13 +667,17 @@ public class Backend implements Writable {
                 this.heartbeatRetryTimes++;
             } else {
                 if (isAlive.compareAndSet(true, false)) {
-                    isChanged = true;
                     LOG.info("{} is dead,", this.toString());
                 }
-
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
                 lastMissingHeartbeatTime = System.currentTimeMillis();
             }
+            // When the leader receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
+            isChanged = true;
         }
 
         return isChanged;

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -142,10 +142,15 @@ public class Frontend implements Writable {
             } else {
                 if (isAlive) {
                     isAlive = false;
-                    isChanged = true;
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
             }
+            // When the leader receives an error heartbeat info which status not ok, 
+            // this heartbeat info also need to be synced to follower.
+            // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
+            // if this heartbeat is not synchronized to the follower, 
+            // that will cause the Follower and master’s memory to be inconsistent
+            isChanged = true;
         }
         return isChanged;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8259

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When master the received heartbeat status is not ok, the heartbeat info also need to be synced to follower. 
Otherwise, the failed heartbeat information will not be synchronized to the follower.
Since the failed heartbeat info also modifies fe's memory, `this.heartbeatRetryTimes++;` 
if it is not synchronized to the follower, this will cause the master and follower's metadata to be inconsistent