### PR TITLE
[Feature] Add RemoteFileIO interface for dla connector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileIO.java
@@ -2,5 +2,10 @@
 
 package com.starrocks.external;
 
-public abstract class RemoteFileIO {
+import java.util.List;
+import java.util.Map;
+
+public interface RemoteFileIO {
+
+    Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey);
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
RemoteFileIO provides `getRemoteFiles()` mainly used to generate scan range

- RmoteFileIO declares getRemoteFiles function.
- The class that currently implements it has `HiveRemoteFileIO` and `HudiRemoteFileIO` and `CachingRemoteFileIO` 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
