### PR TITLE
[Enhancement] optimize lambda functions by rewriting replicate() and splitting large chunks 

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -104,6 +104,7 @@ void ArrayColumn::append_selective(const Column& src, const uint32_t* indexes, u
     }
 }
 
+// TODO(fzh): directly copy elements for un-nested arrays
 void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -111,7 +111,7 @@ ColumnPtr BinaryColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
     auto dest = std::dynamic_pointer_cast<BinaryColumnBase<T>>(BinaryColumnBase<T>::create());
     auto& dest_offsets = dest->get_offset();
     auto& dest_bytes = dest->get_bytes();
-    auto src_size = this->size();
+    auto src_size = offsets.size() - 1; // this->size() may be large than offsets->size() -1
     size_t total_size = 0; // total size to copy
     for (auto i = 0; i < src_size; ++i) {
         auto bytes_size = _offsets[i + 1] - _offsets[i];

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -112,7 +112,7 @@ ColumnPtr BinaryColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
     auto& dest_offsets = dest->get_offset();
     auto& dest_bytes = dest->get_bytes();
     auto src_size = offsets.size() - 1; // this->size() may be large than offsets->size() -1
-    size_t total_size = 0; // total size to copy
+    size_t total_size = 0;              // total size to copy
     for (auto i = 0; i < src_size; ++i) {
         auto bytes_size = _offsets[i + 1] - _offsets[i];
         total_size += bytes_size * (offsets[i + 1] - offsets[i]);

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -129,6 +129,7 @@ ColumnPtr BinaryColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
             dest_offsets[j + 1] = pos;
         }
     }
+    return dest;
 }
 
 template <typename T>

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -182,6 +182,8 @@ public:
         _slices_cache = false;
     }
 
+    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+
     void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -152,6 +152,17 @@ public:
 
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
+    // TODO(fzh): optimize replicate() for specific columns, such as array_column, object_column.
+    virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) {
+        auto dest = this->clone_empty();
+        auto dest_size = offsets.size() - 1;
+        DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
+        dest->reserve(offsets.back());
+        for (int i = 0; i < offsets.size() - 1; ++i) {
+            dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i]);
+        }
+        return dest;
+    }
     // Update elements to default value which hit by the filter
     virtual void fill_default(const Filter& filter) = 0;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -153,9 +153,9 @@ public:
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
     // replicate a column to align with an array's offset, used for captured columns in lambda functions
-    // for example: column(1,2)->replicate({0,2,3}) = column(1,1,2,2,2)
+    // for example: column(1,2)->replicate({0,2,5}) = column(1,1,2,2,2)
     // FixedLengthColumn, BinaryColumn and ConstColumn override this function for better performance.
-    // TODO(fzh): optimize replicate() for specific columns, such as ArrayColumn, ObjectColumn.
+    // TODO(fzh): optimize replicate() for ArrayColumn, ObjectColumn and others.
     virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) {
         auto dest = this->clone_empty();
         auto dest_size = offsets.size() - 1;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -161,7 +161,7 @@ public:
         auto dest_size = offsets.size() - 1;
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
         dest->reserve(offsets.back());
-        for (int i = 0; i < offsets.size() - 1; ++i) {
+        for (int i = 0; i < dest_size; ++i) {
             dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i]);
         }
         return dest;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -152,7 +152,10 @@ public:
 
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
-    // TODO(fzh): optimize replicate() for specific columns, such as array_column, object_column.
+    // replicate a column to align with an array's offset, used for captured columns in lambda functions
+    // for example: column(1,2)->replicate({0,2,3}) = column(1,1,2,2,2)
+    // FixedLengthColumn, BinaryColumn and ConstColumn override this function for better performance.
+    // TODO(fzh): optimize replicate() for specific columns, such as ArrayColumn, ObjectColumn.
     virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) {
         auto dest = this->clone_empty();
         auto dest_size = offsets.size() - 1;

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -132,14 +132,6 @@ public:
 
         return dst_column;
     }
-    static ColumnPtr duplicate_column(ColumnPtr src, MutableColumnPtr desc, UInt32Column::Ptr offsets) {
-        auto desc_size = offsets->size() - 1;
-        DCHECK(src->size() >= desc_size) << "The size of the source column is less when duplicating it.";
-        for (int i = 0; i < offsets->size() - 1; ++i) {
-            desc->append_value_multiple_times(*src, i, offsets->get_data()[i + 1] - offsets->get_data()[i]);
-        }
-        return desc;
-    }
 
     // Update column according to whether the dest column and source column are nullable or not.
     static ColumnPtr update_column_nullable(const TypeDescriptor& dst_type_desc, bool dst_nullable,

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -33,6 +33,10 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
+ColumnPtr ConstColumn::replicate(const std::vector<uint32_t>& offsets) {
+    return ConstColumn::create(this->_data->clone_shared(), offsets.back());
+}
+
 void ConstColumn::fill_default(const Filter& filter) {
     CHECK(false) << "ConstColumn does not support update";
 }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -89,6 +89,8 @@ public:
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
+    virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+
     bool append_nulls(size_t count) override {
         if (_data->is_nullable()) {
             bool ok = true;

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -52,7 +52,7 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 
 //TODO(fzh): optimize copy using SIMD
 template <typename T>
-ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offsets){
+ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
     auto dest = this->clone_empty();
     auto& dest_data = down_cast<FixedLengthColumnBase<T>&>(*dest);
     dest_data._data.resize(offsets.back());

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -56,7 +56,7 @@ ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offse
     auto dest = this->clone_empty();
     auto& dest_data = down_cast<FixedLengthColumnBase<T>&>(*dest);
     dest_data._data.resize(offsets.back());
-    size_t orig_size = _data.size();
+    size_t orig_size = offsets.size() - 1; // this->size() may be large than offsets->size() -1
     for (auto i = 0; i < orig_size; ++i) {
         for (auto j = offsets[i]; j < offsets[i + 1]; ++j) {
             dest_data._data[j] = _data[i];

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -50,6 +50,21 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
     }
 }
 
+//TODO(fzh): optimize copy using SIMD
+template <typename T>
+ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offsets){
+    auto dest = this->clone_empty();
+    auto& dest_data = down_cast<FixedLengthColumnBase<T>&>(*dest);
+    dest_data._data.resize(offsets.back());
+    size_t orig_size = _data.size();
+    for (auto i = 0; i < orig_size; ++i) {
+        for (auto j = offsets[i]; j < offsets[i + 1]; ++j) {
+            dest_data._data[j] = _data[i];
+        }
+    }
+    return dest;
+}
+
 template <typename T>
 void FixedLengthColumnBase<T>::fill_default(const Filter& filter) {
     T val = DefaultValueGenerator<T>::next_value();

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -131,6 +131,8 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
+    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+
     void fill_default(const Filter& filter) override;
 
     Status update_rows(const Column& src, const uint32_t* indexes) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -107,6 +107,11 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
+ColumnPtr NullableColumn::replicate(const std::vector<uint32_t>& offsets) {
+    return NullableColumn::create(this->_data_column->replicate(offsets),
+                                  std::dynamic_pointer_cast<NullColumn>(this->_null_column->replicate(offsets)));
+}
+
 bool NullableColumn::append_nulls(size_t count) {
     DCHECK_GT(count, 0u);
     _data_column->append_default(count);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -225,6 +225,7 @@ public:
         _has_null = true;
         return true;
     }
+    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
 
     size_t memory_usage() const override {
         return _data_column->memory_usage() + _null_column->memory_usage() + sizeof(bool);

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -105,7 +105,7 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
         }
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {
             column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
-        } else {
+        } else { // split large chunks into small ones to avoid too large or various batch_size
             ChunkAccumulator accumulator(DEFAULT_CHUNK_SIZE);
             accumulator.push(std::move(cur_chunk));
             accumulator.finalize();

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -97,9 +97,9 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
         for (auto id : slot_ids) {
             DCHECK(id > 0);
             auto captured = chunk->get_column_by_slot_id(id);
-            if (captured->size() != input_array->size()) {
-                throw std::runtime_error(fmt::format(
-                        "The size of the captured column {} does not equal to array's size.", captured->get_name()));
+            if (captured->size() < input_array->size()) {
+                throw std::runtime_error(fmt::format("The size of the captured column {} is less than array's size.",
+                                                     captured->get_name()));
             }
             cur_chunk->append_column(captured->replicate(input_array->offsets_column()->get_data()), id);
         }

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -15,6 +15,7 @@
 #include "exprs/vectorized/function_helper.h"
 #include "exprs/vectorized/lambda_function.h"
 #include "runtime/user_function_cache.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks::vectorized {
 ArrayMapExpr::ArrayMapExpr(const TExprNode& node) : Expr(node, false) {}
@@ -76,7 +77,7 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
         inputs.push_back(cur_array->elements_column());
     }
 
-    ColumnPtr column;
+    ColumnPtr column = nullptr;
     if (input_array->elements_column()->size() == 0) { // arrays may be null or empty
         column = input_array->elements_column();
     } else {
@@ -97,13 +98,27 @@ ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
             DCHECK(id > 0);
             auto captured = chunk->get_column_by_slot_id(id);
             if (captured->size() != input_array->size()) {
-                throw std::runtime_error(
-                        fmt::format("The size of the captured column {} does not equal to array's size"),
-                        captured->get_name());
+                throw std::runtime_error(fmt::format(
+                        "The size of the captured column {} does not equal to array's size.", captured->get_name()));
             }
             cur_chunk->append_column(captured->replicate(input_array->offsets_column()->get_data()), id);
         }
-        column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
+        if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {
+            column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
+        } else {
+            ChunkAccumulator accumulator(DEFAULT_CHUNK_SIZE);
+            accumulator.push(std::move(cur_chunk));
+            accumulator.finalize();
+            while (auto tmp_chunk = accumulator.pull()) {
+                auto tmp_col = EVALUATE_NULL_IF_ERROR(context, _children[0], tmp_chunk.get());
+                if (column == nullptr) {
+                    column = tmp_col;
+                } else {
+                    column->append(*tmp_col);
+                }
+            }
+        }
+
         // construct the result array
         DCHECK(column != nullptr);
         // the elements of the new array should be nullable and not const.

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1106,13 +1106,13 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
 
     auto res = column->replicate(off);
 
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(1));
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(2));
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(3));
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(4));
-    ASSERT_EQ("[]", column->debug_item(5));
-    ASSERT_EQ("[]", column->debug_item(6));
+    ASSERT_EQ("[1, 2, 3]", res->debug_item(0));
+    ASSERT_EQ("[1, 2, 3]", res->debug_item(1));
+    ASSERT_EQ("[1, 2, 3]", res->debug_item(2));
+    ASSERT_EQ("[4, 5, 6]", res->debug_item(3));
+    ASSERT_EQ("[4, 5, 6]", res->debug_item(4));
+    ASSERT_EQ("[]", res->debug_item(5));
+    ASSERT_EQ("[]", res->debug_item(6));
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1081,4 +1081,38 @@ PARALLEL_TEST(ArrayColumnTest, test_empty_null_array) {
     ASSERT_EQ("[]", column->debug_item(1));
 }
 
+PARALLEL_TEST(ArrayColumnTest, test_replicate) {
+    auto offsets = UInt32Column::create();
+    auto elements = Int32Column::create();
+    auto column = ArrayColumn::create(elements, offsets);
+
+    // insert [1, 2, 3], [4, 5, 6],[]
+    elements->append(1);
+    elements->append(2);
+    elements->append(3);
+    offsets->append(3);
+
+    elements->append(4);
+    elements->append(5);
+    elements->append(6);
+    offsets->append(6);
+    offsets->append(6);
+
+    Offsets off;
+    off.push_back(0);
+    off.push_back(3);
+    off.push_back(5);
+    off.push_back(7);
+
+    auto res = column->replicate(off);
+
+    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
+    ASSERT_EQ("[1, 2, 3]", column->debug_item(1));
+    ASSERT_EQ("[1, 2, 3]", column->debug_item(2));
+    ASSERT_EQ("[4, 5, 6]", column->debug_item(3));
+    ASSERT_EQ("[4, 5, 6]", column->debug_item(4));
+    ASSERT_EQ("[]", column->debug_item(5));
+    ASSERT_EQ("[]", column->debug_item(6));
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -620,4 +620,26 @@ PARALLEL_TEST(BinaryColumnTest, test_xor_checksum) {
     ASSERT_EQ(checksum, expected_checksum);
 }
 
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_replicate) {
+    auto c1 = BinaryColumn::create();
+    c1->append_datum("abc");
+    c1->append_datum("def");
+
+    Offsets offsets;
+    offsets.push_back(0);
+    offsets.push_back(3);
+    offsets.push_back(5);
+
+    auto c2 = c1->replicate(offsets);
+
+    slices = down_cast<BinaryColumn*>(c2.get())->get_data();
+    ASSERT_EQ(5, c2->size());
+    ASSERT_EQ("abc", slices[0]);
+    ASSERT_EQ("abc", slices[1]);
+    ASSERT_EQ("abc", slices[2]);
+    ASSERT_EQ("def", slices[3]);
+    ASSERT_EQ("def", slices[4]);
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -633,7 +633,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
 
     auto c2 = c1->replicate(offsets);
 
-    slices = down_cast<BinaryColumn*>(c2.get())->get_data();
+    auto slices = down_cast<BinaryColumn*>(c2.get())->get_data();
     ASSERT_EQ(5, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("abc", slices[1]);

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -339,7 +339,7 @@ PARALLEL_TEST(ConstColumnTest, test_replicate) {
     auto c2 = c1->replicate(offsets);
 
     ASSERT_EQ(7, c2->size());
-    ASSERT_EQ(1, c2->get(6));
+    ASSERT_EQ(1, c2->get(6).get_int32());
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -318,4 +318,28 @@ PARALLEL_TEST(ConstColumnTest, test_clone_empty) {
     ASSERT_TRUE(c2->data_column().unique());
 }
 
+// NOLINTNEXTLINE
+PARALLEL_TEST(ConstColumnTest, test_replicate) {
+    auto create_const_column = [](int32_t value, size_t size) {
+        auto c = Int32Column::create();
+        c->append_numbers(&value, sizeof(value));
+        return ConstColumn::create(c, size);
+    };
+
+    auto c1 = create_const_column(1, 3);
+
+    ASSERT_EQ(3, c1->size());
+
+    Offsets offsets;
+    offsets.push_back(0);
+    offsets.push_back(2);
+    offsets.push_back(5);
+    offsets.push_back(7);
+
+    auto c2 = c1->replicate(offsets);
+
+    ASSERT_EQ(7, c2->size());
+    ASSERT_EQ(1, c2->get(6));
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -590,4 +590,24 @@ TEST(FixedLengthColumnTest, test_fixed_length_column_downgrade) {
     ASSERT_FALSE(column->has_large_column());
 }
 
+// NOLINTNEXTLINE
+TEST(FixedLengthColumnTest, test_replicate) {
+    auto column = FixedLengthColumn<int32_t>::create();
+    column->append(7);
+    column->append(3);
+
+    Offsets offsets;
+    offsets.push_back(0);
+    offsets.push_back(3);
+    offsets.push_back(5);
+
+    auto c2 = column->replicate(offsets);
+    ASSERT_EQ(5, c2->size());
+    ASSERT_EQ(c2->get(0).get_int32(), 7);
+    ASSERT_EQ(c2->get(1).get_int32(), 7);
+    ASSERT_EQ(c2->get(2).get_int32(), 7);
+    ASSERT_EQ(c2->get(3).get_int32(), 3);
+    ASSERT_EQ(c2->get(4).get_int32(), 3);
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -339,4 +339,26 @@ PARALLEL_TEST(NullableColumnTest, test_compare_row) {
     }
 }
 
+PARALLEL_TEST(NullableColumnTest, test_replicate) {
+    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    column->append_datum((int32_t)1);
+    column->append_datum({});
+    column->append_datum((int32_t)4);
+
+    Offsets offsets;
+    offsets.push_back(0);
+    offsets.push_back(2);
+    offsets.push_back(4);
+    offsets.push_back(7);
+    auto c2 = column->replicate(offsets);
+
+    ASSERT_EQ(1, c2->get(0).get_int32());
+    ASSERT_EQ(1, c2->get(1).get_int32());
+    ASSERT_TRUE(c2->get(2).is_null());
+    ASSERT_TRUE(c2->get(3).is_null());
+    ASSERT_EQ(4, c2->get(4).get_int32());
+    ASSERT_EQ(4, c2->get(5).get_int32());
+    ASSERT_EQ(4, c2->get(6).get_int32());
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
### problem1:
align captured column with array's offsets, which copy one captured value mulitple times  equalling to array's, for example: 
captuerd value =1, array=['a','b','c'], then captured value 1 is replicated 3 times to [1,1,1], aligning to array's size.

this replicate takes too much time, so we optimized it to write specific replicat() for FixedLengthColumn, BinaryColumn and ConstColumn.

### problem2:

as lambda functions adopt array->elements to compute, but array->elements's szie may be vary large and various during executing, so split the array->elements into small chunks to evaluate, however which induces too much copy cost. we should to avoid the expensive copy cost later. 


<byte-sheet-html-origin data-id="RKqHJKmRoO-1663660075844" data-version="3" data-is-embed="false" data-importRangeRawData-spreadSource="https://starrocks.feishu.cn/sheets/shtcndJJCISGcsb70prBNBOt37c" data-importRangeRawData-range="&#39;Sheet6&#39;!C2:E3">

 sql |  before | after
-- | -- | --
SELECT max(g), max(g0), max(g1), max(g2), max(g3), max(g4), max(g5), max(g6), max(g7), max(g8), max(g9) FROM(SELECT array_sum(array_map(x->x * x + x*b, a)) g, array_sum(array_map((x, y)->x * x + x*b - b * y + 10, a, a)) g0, array_sum(array_map((x, y)->x * x + x*b - b * y + 11, a, a)) g1, array_sum(array_map((x, y)->x * x + x*b - b * y + 12, a, a)) g2, array_sum(array_map((x, y)->x*x + x*b - b * y + 13, a, a)) g3, array_sum(array_map((x, y)->x * x + x*b - b * y + 14, a, a)) g4, array_sum(array_map((x, y)->x*x + x*b - b * y + 15, a, a)) g5, array_sum(array_map((x, y)->x * x + x*b - b * y + 16, a, a)) g6, array_sum(array_map((x, y)->x*x + x*b - b * y + 17, a, a)) g7, array_sum(array_map((x, y)->x * x + x*b - b * y + 18, a, a)) g8, array_sum(array_map((x, y)->x*x + x*b - b * y + 19, a, a)) g9 FROM (SELECT aint a, lo_custkey b FROM tarray)A)B; | 17.95 | 13.36

</byte-sheet-html-origin>

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
