### PR TITLE
[BugFix] check canUsePipeline before optimizing and building fragment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -22,8 +22,10 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.MysqlTable;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TExplainLevel;
 
@@ -70,6 +72,13 @@ public abstract class DataSink {
         } else {
             throw new AnalysisException("Unknown table type " + table.getType());
         }
+    }
+
+    public static boolean canTableSinkUsePipeline(Table table) {
+        if (table instanceof OlapTable) {
+            return Config.enable_pipeline_load;
+        }
+        return false;
     }
 
     public boolean canUsePipeLine() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -102,6 +102,10 @@ public class ResultSink extends DataSink {
 
     @Override
     public boolean canUsePipeLine() {
+        return canUsePipeLine(sinkType);
+    }
+
+    public static boolean canUsePipeLine(TResultSinkType sinkType) {
         return sinkType == TResultSinkType.MYSQL_PROTOCAL || sinkType == TResultSinkType.STATISTIC;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -225,6 +225,8 @@ public class Coordinator {
     private final Set<Integer> bucketShuffleFragmentIds = new HashSet<>();
     private final Set<Integer> rightOrFullBucketShuffleFragmentIds = new HashSet<>();
 
+    private final boolean usePipeline;
+
     // Resource group
     ResourceGroup resourceGroup = null;
 
@@ -269,6 +271,8 @@ public class Coordinator {
         nextInstanceId.setHi(queryId.hi);
         nextInstanceId.setLo(queryId.lo + 1);
         this.forceScheduleLocal = context.getSessionVariable().isForceScheduleLocal();
+
+        this.usePipeline = canUsePipeline(this.connectContext, this.fragments);
     }
 
     // Used for broker export task coordinator
@@ -301,6 +305,8 @@ public class Coordinator {
         this.nextInstanceId = new TUniqueId();
         nextInstanceId.setHi(queryId.hi);
         nextInstanceId.setLo(queryId.lo + 1);
+
+        this.usePipeline = canUsePipeline(this.connectContext, this.fragments);
     }
 
     // Used for broker load task coordinator
@@ -337,6 +343,8 @@ public class Coordinator {
         this.nextInstanceId = new TUniqueId();
         nextInstanceId.setHi(queryId.hi);
         nextInstanceId.setLo(queryId.lo + 1);
+
+        this.usePipeline = canUsePipeline(this.connectContext, this.fragments);
     }
 
     public long getJobId() {
@@ -644,19 +652,14 @@ public class Coordinator {
     }
 
     private void deliverExecFragments() throws Exception {
-        // Disable pipeline engine for `INSERT INTO`.
-        // TODO: remove this when load supports pipeline engine.
-        boolean enablePipelineEngine = connectContext != null &&
-                connectContext.getSessionVariable().isEnablePipelineEngine() &&
-                fragments.stream().allMatch(PlanFragment::canUsePipeline);
         // Only pipeline uses deliver_batch_fragments.
-        boolean enableDeliverBatchFragments = enablePipelineEngine
-                && connectContext.getSessionVariable().isEnableDeliverBatchFragments();
+        boolean enableDeliverBatchFragments =
+                usePipeline && connectContext.getSessionVariable().isEnableDeliverBatchFragments();
 
         if (enableDeliverBatchFragments) {
-            deliverExecBatchFragmentsRequests(enablePipelineEngine);
+            deliverExecBatchFragmentsRequests(usePipeline);
         } else {
-            deliverExecFragmentRequests(enablePipelineEngine);
+            deliverExecFragmentRequests(usePipeline);
         }
     }
 
@@ -1124,8 +1127,6 @@ public class Coordinator {
 
     private void setGlobalRuntimeFilterParams(FragmentExecParams topParams, TNetworkAddress mergeHost)
             throws Exception {
-        boolean enablePipelineEngine = connectContext != null &&
-                connectContext.getSessionVariable().isEnablePipelineEngine();
 
         Map<Integer, List<TRuntimeFilterProberParams>> broadcastGRFProbersMap = Maps.newHashMap();
         List<RuntimeFilterDescription> broadcastGRFList = Lists.newArrayList();
@@ -1134,7 +1135,6 @@ public class Coordinator {
         for (PlanFragment fragment : fragments) {
             fragment.collectBuildRuntimeFilters(fragment.getPlanRoot());
             fragment.collectProbeRuntimeFilters(fragment.getPlanRoot());
-            boolean usePipeline = enablePipelineEngine && fragment.canUsePipeline();
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
             for (Map.Entry<Integer, RuntimeFilterDescription> kv : fragment.getProbeRuntimeFilters().entrySet()) {
                 List<TRuntimeFilterProberParams> probeParamList = Lists.newArrayList();
@@ -1641,10 +1641,7 @@ public class Coordinator {
             PlanFragment fragment = fragments.get(i);
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
 
-            boolean enablePipeline = connectContext != null &&
-                    connectContext.getSessionVariable().isEnablePipelineEngine() &&
-                    fragment.getPlanRoot().canUsePipeLine();
-            boolean dopAdaptionEnabled = enablePipeline &&
+            boolean dopAdaptionEnabled = usePipeline &&
                     connectContext.getSessionVariable().isPipelineDopAdaptionEnabled();
 
             // If left child is MultiCastDataFragment(only support left now), will keep same instance with child.
@@ -1793,10 +1790,10 @@ public class Coordinator {
             if (hasColocate || hasBucketShuffle) {
                 computeColocatedJoinInstanceParam(fragmentIdToSeqToAddressMap.get(fragment.getFragmentId()),
                         fragmentIdBucketSeqToScanRangeMap.get(fragment.getFragmentId()),
-                        parallelExecInstanceNum, pipelineDop, enablePipeline, params);
+                        parallelExecInstanceNum, pipelineDop, usePipeline, params);
                 computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
             } else {
-                boolean assignScanRangesPerDriverSeq = enablePipeline && fragment.isAssignScanRangesPerDriverSeq();
+                boolean assignScanRangesPerDriverSeq = usePipeline && fragment.isAssignScanRangesPerDriverSeq();
                 for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> tNetworkAddressMapEntry :
                         fragmentExecParamsMap.get(fragment.getFragmentId()).scanRangeAssignment.entrySet()) {
                     TNetworkAddress key = tNetworkAddressMapEntry.getKey();
@@ -2299,7 +2296,7 @@ public class Coordinator {
             return;
         }
 
-        if (!sessionVariable.isEnablePipelineEngine()) {
+        if (!usePipeline) {
             return;
         }
 
@@ -3325,5 +3322,18 @@ public class Coordinator {
     private void recordUsedBackend(TNetworkAddress addr, Long backendID) {
         usedBackendIDs.add(backendID);
         addressToBackendID.put(addr, backendID);
+    }
+
+    /**
+     * Whether it can use pipeline engine.
+     * @param connectContext It is null for broker broker export.
+     * @param fragments All the fragments need to execute.
+     * @return true if enabling pipeline in the session variable and all the fragments can use pipeline,
+     * otherwise false.
+     */
+    private boolean canUsePipeline(ConnectContext connectContext, List<PlanFragment> fragments) {
+        return connectContext != null &&
+                connectContext.getSessionVariable().isEnablePipelineEngine() &&
+                fragments.stream().allMatch(PlanFragment::canUsePipeline);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -39,49 +39,66 @@ public class DeletePlanner {
         List<String> colNames = query.getColumnOutputNames();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
-        Optimizer optimizer = new Optimizer();
-        OptExpression optimizedPlan = optimizer.optimize(
-                session,
-                logicalPlan.getRoot(),
-                new PhysicalPropertySet(),
-                new ColumnRefSet(logicalPlan.getOutputColumn()),
-                columnRefFactory);
-        ExecPlan execPlan = new PlanFragmentBuilder().createPhysicalPlan(optimizedPlan, session,
-                logicalPlan.getOutputColumn(), columnRefFactory,
-                colNames, TResultSinkType.MYSQL_PROTOCAL, false);
-        DescriptorTable descriptorTable = execPlan.getDescTbl();
-        TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
 
-        OlapTable table = (OlapTable) deleteStatement.getTable();
-        for (Column column : table.getBaseSchema()) {
-            if (column.isKey()) {
-                SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-                slotDescriptor.setIsMaterialized(true);
-                slotDescriptor.setType(column.getType());
-                slotDescriptor.setColumn(column);
-                slotDescriptor.setIsNullable(column.isAllowNull());
-            } else {
-                continue;
+        // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
+        boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
+        boolean canUsePipeline =
+                isEnablePipeline && DataSink.canTableSinkUsePipeline(deleteStatement.getTable()) &&
+                        logicalPlan.canUsePipeline();
+        boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
+        try {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(false);
+            }
+
+            Optimizer optimizer = new Optimizer();
+            OptExpression optimizedPlan = optimizer.optimize(
+                    session,
+                    logicalPlan.getRoot(),
+                    new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()),
+                    columnRefFactory);
+            ExecPlan execPlan = new PlanFragmentBuilder().createPhysicalPlan(optimizedPlan, session,
+                    logicalPlan.getOutputColumn(), columnRefFactory,
+                    colNames, TResultSinkType.MYSQL_PROTOCAL, false);
+            DescriptorTable descriptorTable = execPlan.getDescTbl();
+            TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+
+            OlapTable table = (OlapTable) deleteStatement.getTable();
+            for (Column column : table.getBaseSchema()) {
+                if (column.isKey()) {
+                    SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+                    slotDescriptor.setIsMaterialized(true);
+                    slotDescriptor.setType(column.getType());
+                    slotDescriptor.setColumn(column);
+                    slotDescriptor.setIsNullable(column.isAllowNull());
+                } else {
+                    continue;
+                }
+            }
+            SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+            slotDescriptor.setIsMaterialized(true);
+            slotDescriptor.setType(Type.TINYINT);
+            slotDescriptor.setColumn(new Column(Load.LOAD_OP_COLUMN, Type.TINYINT));
+            slotDescriptor.setIsNullable(false);
+            olapTuple.computeMemLayout();
+
+            List<Long> partitionIds = Lists.newArrayList();
+            for (Partition partition : table.getPartitions()) {
+                partitionIds.add(partition.getId());
+            }
+            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds);
+            execPlan.getFragments().get(0).setSink(dataSink);
+            // At present, we only support dop=1 for olap table sink.
+            // because tablet writing needs to know the number of senders in advance
+            // and guaranteed order of data writing
+            // It can be parallel only in some scenes, for easy use 1 dop now.
+            execPlan.getFragments().get(0).setPipelineDop(1);
+            return execPlan;
+        } finally {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(true);
             }
         }
-        SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-        slotDescriptor.setIsMaterialized(true);
-        slotDescriptor.setType(Type.TINYINT);
-        slotDescriptor.setColumn(new Column(Load.LOAD_OP_COLUMN, Type.TINYINT));
-        slotDescriptor.setIsNullable(false);
-        olapTuple.computeMemLayout();
-
-        List<Long> partitionIds = Lists.newArrayList();
-        for (Partition partition : table.getPartitions()) {
-            partitionIds.add(partition.getId());
-        }
-        DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds);
-        execPlan.getFragments().get(0).setSink(dataSink);
-        // At present, we only support dop=1 for olap table sink.
-        // because tablet writing needs to know the number of senders in advance
-        // and guaranteed order of data writing
-        // It can be parallel only in some scenes, for easy use 1 dop now.
-        execPlan.getFragments().get(0).setPipelineDop(1);
-        return execPlan;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -101,57 +101,75 @@ public class InsertPlanner {
         //6. Optimize logical plan and build physical plan
         logicalPlan = new LogicalPlan(optExprBuilder, outputColumns, logicalPlan.getCorrelation());
 
-        Optimizer optimizer = new Optimizer();
-        PhysicalPropertySet requiredPropertySet = createPhysicalPropertySet(insertStmt, outputColumns);
-        OptExpression optimizedPlan = optimizer.optimize(
-                session,
-                logicalPlan.getRoot(),
-                requiredPropertySet,
-                new ColumnRefSet(logicalPlan.getOutputColumn()),
-                columnRefFactory);
+        // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
+        boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
+        boolean canUsePipeline =
+                isEnablePipeline && DataSink.canTableSinkUsePipeline(insertStmt.getTargetTable()) &&
+                        logicalPlan.canUsePipeline();
+        boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
+        try {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(false);
+            }
 
-        //7. Build fragment exec plan
-        boolean hasOutputFragment = ((queryRelation instanceof SelectRelation && queryRelation.hasLimit())
-                || insertStmt.getTargetTable() instanceof MysqlTable);
-        ExecPlan execPlan = new PlanFragmentBuilder().createPhysicalPlan(
-                optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
-                queryRelation.getColumnOutputNames(), TResultSinkType.MYSQL_PROTOCAL, hasOutputFragment);
+            Optimizer optimizer = new Optimizer();
+            PhysicalPropertySet requiredPropertySet = createPhysicalPropertySet(insertStmt, outputColumns);
+            OptExpression optimizedPlan = optimizer.optimize(
+                    session,
+                    logicalPlan.getRoot(),
+                    requiredPropertySet,
+                    new ColumnRefSet(logicalPlan.getOutputColumn()),
+                    columnRefFactory);
 
-        DescriptorTable descriptorTable = execPlan.getDescTbl();
-        TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+            //7. Build fragment exec plan
+            boolean hasOutputFragment = ((queryRelation instanceof SelectRelation && queryRelation.hasLimit())
+                    || insertStmt.getTargetTable() instanceof MysqlTable);
+            ExecPlan execPlan = new PlanFragmentBuilder().createPhysicalPlan(
+                    optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
+                    queryRelation.getColumnOutputNames(), TResultSinkType.MYSQL_PROTOCAL, hasOutputFragment);
 
-        List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        long tableId = insertStmt.getTargetTable().getId();
-        for (Column column : insertStmt.getTargetTable().getFullSchema()) {
-            SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-            slotDescriptor.setIsMaterialized(true);
-            slotDescriptor.setType(column.getType());
-            slotDescriptor.setColumn(column);
-            slotDescriptor.setIsNullable(column.isAllowNull());
-            if (column.getType().isVarchar() && IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
-                dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
+            DescriptorTable descriptorTable = execPlan.getDescTbl();
+            TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+
+            List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
+            long tableId = insertStmt.getTargetTable().getId();
+            for (Column column : insertStmt.getTargetTable().getFullSchema()) {
+                SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+                slotDescriptor.setIsMaterialized(true);
+                slotDescriptor.setType(column.getType());
+                slotDescriptor.setColumn(column);
+                slotDescriptor.setIsNullable(column.isAllowNull());
+                if (column.getType().isVarchar() &&
+                        IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
+                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
+                    dict.ifPresent(
+                            columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
+                }
+            }
+            olapTuple.computeMemLayout();
+
+            DataSink dataSink;
+            if (insertStmt.getTargetTable() instanceof OlapTable) {
+                dataSink = new OlapTableSink((OlapTable) insertStmt.getTargetTable(), olapTuple,
+                        insertStmt.getTargetPartitionIds());
+                // At present, we only support dop=1 for olap table sink.
+                // because tablet writing needs to know the number of senders in advance
+                // and guaranteed order of data writing
+                // It can be parallel only in some scenes, for easy use 1 dop now.
+                execPlan.getFragments().get(0).setPipelineDop(1);
+            } else if (insertStmt.getTargetTable() instanceof MysqlTable) {
+                dataSink = new MysqlTableSink((MysqlTable) insertStmt.getTargetTable());
+            } else {
+                throw new SemanticException("Unknown table type " + insertStmt.getTargetTable().getType());
+            }
+            execPlan.getFragments().get(0).setSink(dataSink);
+            execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
+            return execPlan;
+        } finally {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(true);
             }
         }
-        olapTuple.computeMemLayout();
-
-        DataSink dataSink;
-        if (insertStmt.getTargetTable() instanceof OlapTable) {
-            dataSink = new OlapTableSink((OlapTable) insertStmt.getTargetTable(), olapTuple,
-                    insertStmt.getTargetPartitionIds());
-            // At present, we only support dop=1 for olap table sink.
-            // because tablet writing needs to know the number of senders in advance
-            // and guaranteed order of data writing
-            // It can be parallel only in some scenes, for easy use 1 dop now.
-            execPlan.getFragments().get(0).setPipelineDop(1);
-        } else if (insertStmt.getTargetTable() instanceof MysqlTable) {
-            dataSink = new MysqlTableSink((MysqlTable) insertStmt.getTargetTable());
-        } else {
-            throw new SemanticException("Unknown table type " + insertStmt.getTargetTable().getType());
-        }
-        execPlan.getFragments().get(0).setSink(dataSink);
-        execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
-        return execPlan;
     }
 
     private void castLiteralToTargetColumnsType(InsertStmt insertStatement) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -37,7 +37,8 @@ public class StatementPlanner {
         return plan(stmt, session, true, TResultSinkType.MYSQL_PROTOCAL);
     }
 
-    public static ExecPlan plan(StatementBase stmt, ConnectContext session, boolean lockDb, TResultSinkType resultSinkType) {
+    public static ExecPlan plan(StatementBase stmt, ConnectContext session, boolean lockDb,
+                                TResultSinkType resultSinkType) {
         if (stmt instanceof QueryStatement) {
             OptimizerTraceUtil.logQueryStatement(session, "after parse:\n%s", (QueryStatement) stmt);
         }
@@ -56,9 +57,11 @@ public class StatementPlanner {
             }
 
             if (stmt instanceof QueryStatement) {
+                QueryStatement queryStmt = (QueryStatement) stmt;
                 session.setCurrentSqlDbIds(dbs.values().stream().map(Database::getId).collect(Collectors.toSet()));
-                ExecPlan plan = createQueryPlan(((QueryStatement) stmt).getQueryRelation(), session, resultSinkType);
-                setOutfileSink((QueryStatement) stmt, plan);
+                resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+                ExecPlan plan = createQueryPlan(queryStmt.getQueryRelation(), session, resultSinkType);
+                setOutfileSink(queryStmt, plan);
 
                 return plan;
             } else if (stmt instanceof InsertStmt) {
@@ -74,7 +77,6 @@ public class StatementPlanner {
         return null;
     }
 
-
     public static ExecPlan createQueryPlan(Relation relation, ConnectContext session, TResultSinkType resultSinkType) {
         QueryRelation query = (QueryRelation) relation;
         List<String> colNames = query.getColumnOutputNames();
@@ -83,25 +85,41 @@ public class StatementPlanner {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
 
-        //2. Optimize logical plan and build physical plan
-        Optimizer optimizer = new Optimizer();
-        OptExpression optimizedPlan = optimizer.optimize(
-                session,
-                logicalPlan.getRoot(),
-                new PhysicalPropertySet(),
-                new ColumnRefSet(logicalPlan.getOutputColumn()),
-                columnRefFactory);
+        // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
+        boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
+        boolean canUsePipeline =
+                isEnablePipeline && ResultSink.canUsePipeLine(resultSinkType) && logicalPlan.canUsePipeline();
+        boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
+        try {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(false);
+            }
 
-        //3. Build fragment exec plan
-        /*
-         * SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
-         * currently only used in Spark/Flink Connector
-         * Because the connector sends only simple queries, it only needs to remove the output fragment
-         */
-        return new PlanFragmentBuilder().createPhysicalPlan(
-                optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
-                resultSinkType,
-                !session.getSessionVariable().isSingleNodeExecPlan());
+            //2. Optimize logical plan and build physical plan
+            Optimizer optimizer = new Optimizer();
+            OptExpression optimizedPlan = optimizer.optimize(
+                    session,
+                    logicalPlan.getRoot(),
+                    new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()),
+                    columnRefFactory);
+
+            //3. Build fragment exec plan
+            /*
+             * SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
+             * currently only used in Spark/Flink Connector
+             * Because the connector sends only simple queries, it only needs to remove the output fragment
+             */
+            return new PlanFragmentBuilder().createPhysicalPlan(
+                    optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
+                    resultSinkType,
+                    !session.getSessionVariable().isSingleNodeExecPlan());
+        } finally {
+            if (forceDisablePipeline) {
+                session.getSessionVariable().setEnablePipelineEngine(true);
+            }
+        }
+
     }
 
     // Lock all database before analyze

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -171,4 +171,8 @@ public class OptExpression {
         }
         return sb.toString();
     }
+
+    public boolean canUsePipeLine() {
+        return op.canUsePipeLine() && inputs.stream().allMatch(OptExpression::canUsePipeLine);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -112,6 +112,10 @@ public abstract class Operator {
         return Objects.hash(opType.ordinal(), limit, predicate, projection);
     }
 
+    public boolean canUsePipeLine() {
+        return true;
+    }
+
     public abstract static class Builder<O extends Operator, B extends Builder> {
         protected OperatorType opType;
         protected long limit = DEFAULT_LIMIT;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -73,6 +73,11 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         return Objects.hash(super.hashCode(), aggColumnIdToNames);
     }
 
+    @Override
+    public boolean canUsePipeLine() {
+        return false;
+    }
+
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalMetaScanOperator, LogicalMetaScanOperator.Builder> {
         private Map<Integer, String> aggColumnIdToNames;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSchemaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSchemaScanOperator.java
@@ -46,6 +46,11 @@ public class LogicalSchemaScanOperator extends LogicalScanOperator {
         return visitor.visitLogicalSchemaScan(this, context);
     }
 
+    @Override
+    public boolean canUsePipeLine() {
+        return false;
+    }
+
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalSchemaScanOperator, LogicalSchemaScanOperator.Builder> {
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -62,4 +62,9 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), aggColumnIdToNames);
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSchemaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSchemaScanOperator.java
@@ -32,4 +32,9 @@ public class PhysicalSchemaScanOperator extends PhysicalScanOperator {
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalSchemaScan(optExpression, context);
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
@@ -33,4 +33,8 @@ public class LogicalPlan {
     public List<ColumnRefOperator> getCorrelation() {
         return correlation;
     }
+
+    public boolean canUsePipeline() {
+        return root.getRoot().canUsePipeLine();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -4,6 +4,7 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
+import com.starrocks.planner.PlanFragment;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
@@ -25,9 +26,10 @@ public class CoordinatorMonitorTest {
             // Prepare coordinators.
             ConnectContext connCtx = new ConnectContext();
             connCtx.setExecutionId(new TUniqueId(0, 0));
-            Coordinator coord1 = new Coordinator(connCtx, null, null, null);
-            Coordinator coord2 = new Coordinator(connCtx, null, null, null);
-            Coordinator coord3 = new Coordinator(connCtx, null, null, null);
+            List<PlanFragment> fragments = ImmutableList.of();
+            Coordinator coord1 = new Coordinator(connCtx, fragments, null, null);
+            Coordinator coord2 = new Coordinator(connCtx, fragments, null, null);
+            Coordinator coord3 = new Coordinator(connCtx, fragments, null, null);
             List<Coordinator> coordinators = ImmutableList.of(coord1, coord2, coord3);
 
             final QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -6,14 +6,10 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
-import com.starrocks.planner.PlanFragment;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
-import com.starrocks.system.BackendCoreStat;
-import com.starrocks.thrift.TExplainLevel;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -2137,80 +2133,6 @@ public class JoinTest extends PlanTestBase {
                 "  |  equal join conjunct: 1: t1a = 21: cast\n" +
                 "  |  equal join conjunct: 22: cast = 11: t1a");
         FeConstants.runningUnitTest = false;
-    }
-
-    private void testParallelismHelper(int expectedParallelism) throws Exception {
-        // Case 1: local bucket shuffle join should use fragment instance parallel.
-        String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
-        ExecPlan plan = getExecPlan(sql);
-        PlanFragment fragment = plan.getFragments().get(1);
-        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
-        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-        Assert.assertEquals(1, fragment.getParallelExecNum());
-
-        // Case 2: colocate join should use pipeline instance parallel.
-        sql = "select * from colocate1 left join colocate2 " +
-                "on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
-        plan = getExecPlan(sql);
-        fragment = plan.getFragments().get(1);
-        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
-        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-        Assert.assertEquals(1, fragment.getParallelExecNum());
-
-        // Case 3: broadcast join should use pipeline parallel.
-        sql = "select a.v1 from t0 a join [broadcast] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
-        plan = getExecPlan(sql);
-        fragment = plan.getFragments().get(1);
-        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BROADCAST)");
-        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-        Assert.assertEquals(1, fragment.getParallelExecNum());
-
-        // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
-        sql = "select a.v1 from t0 a " +
-                "join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 " +
-                "join [broadcast] t0 c on a.v1 = c.v2";
-        plan = getExecPlan(sql);
-        fragment = plan.getFragments().get(1);
-        String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);
-        assertContains(fragmentString, "join op: INNER JOIN (BROADCAST)");
-        assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
-        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
-        Assert.assertEquals(1, fragment.getParallelExecNum());
-    }
-
-    @Test
-    public void testParallelism() throws Exception {
-        int numCores = 8;
-        new MockUp<BackendCoreStat>() {
-            @Mock
-            public int getAvgNumOfHardwareCoresOfBe() {
-                return numCores;
-            }
-        };
-
-        SessionVariable sessionVariable = connectContext.getSessionVariable();
-        boolean enablePipeline = sessionVariable.isEnablePipelineEngine();
-        int pipelineDop = sessionVariable.getPipelineDop();
-        int parallelExecInstanceNum = sessionVariable.getParallelExecInstanceNum();
-
-        try {
-            FeConstants.runningUnitTest = true;
-            sessionVariable.setEnablePipelineEngine(true);
-
-            sessionVariable.setPipelineDop(0);
-            sessionVariable.setParallelExecInstanceNum(1);
-            testParallelismHelper(numCores / 2);
-
-            sessionVariable.setPipelineDop(4);
-            sessionVariable.setParallelExecInstanceNum(8);
-            testParallelismHelper(4);
-
-        } finally {
-            sessionVariable.setEnablePipelineEngine(enablePipeline);
-            sessionVariable.setPipelineDop(pipelineDop);
-            sessionVariable.setParallelExecInstanceNum(parallelExecInstanceNum);
-            FeConstants.runningUnitTest = false;
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -2,12 +2,7 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.system.BackendCoreStat;
-import com.starrocks.thrift.TExplainLevel;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -80,39 +75,6 @@ public class OrderByTest extends PlanTestBase {
         String sql = "select * from t0 union all select * from t1 order by v1, v2, v1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 7> 7: v1 ASC, <slot 8> 8: v2 ASC");
-    }
-
-    @Test
-    public void testParallelism() throws Exception {
-        int numCores = 8;
-        int expectDop = numCores / 2;
-        new MockUp<BackendCoreStat>() {
-            @Mock
-            public int getAvgNumOfHardwareCoresOfBe() {
-                return 8;
-            }
-        };
-
-        boolean enablePipeline = true;
-        int pipelineDop = 0;
-        try {
-            enablePipeline = connectContext.getSessionVariable().isEnablePipelineEngine();
-            pipelineDop = connectContext.getSessionVariable().getPipelineDop();
-
-            connectContext.getSessionVariable().setEnablePipelineEngine(true);
-            connectContext.getSessionVariable().setPipelineDop(0);
-
-            String sql = "select * from t0 order by v1 limit 100";
-            ExecPlan plan = getExecPlan(sql);
-            PlanFragment fragment1 = plan.getFragments().get(1);
-            assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "TOP-N");
-            Assert.assertEquals(1, fragment1.getParallelExecNum());
-            Assert.assertEquals(expectDop, fragment1.getPipelineDop());
-        } finally {
-            connectContext.getSessionVariable().setEnablePipelineEngine(enablePipeline);
-            connectContext.getSessionVariable().setPipelineDop(pipelineDop);
-        }
-
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -1,0 +1,233 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.system.BackendCoreStat;
+import com.starrocks.thrift.TExplainLevel;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PipelineParallelismTest extends PlanTestBase {
+    private MockUp<BackendCoreStat> mockedBackendCoreStat = null;
+    private final int parallelExecInstanceNum = 16;
+    private final int numHardwareCores = 8;
+    private int prevParallelExecInstanceNum = 0;
+    private boolean prevEnablePipelineEngine = true;
+    private int prevPipelineDop = 0;
+
+    @Before
+    public void setUp() {
+        mockedBackendCoreStat = new MockUp<BackendCoreStat>() {
+            @Mock
+            public int getAvgNumOfHardwareCoresOfBe() {
+                return numHardwareCores;
+            }
+        };
+
+        prevParallelExecInstanceNum = connectContext.getSessionVariable().getParallelExecInstanceNum();
+        prevEnablePipelineEngine = connectContext.getSessionVariable().isEnablePipelineEngine();
+        prevPipelineDop = connectContext.getSessionVariable().getPipelineDop();
+
+        connectContext.getSessionVariable().setParallelExecInstanceNum(parallelExecInstanceNum);
+        connectContext.getSessionVariable().setEnablePipelineEngine(true);
+        connectContext.getSessionVariable().setPipelineDop(0);
+    }
+
+    @After
+    public void tearDown() {
+        mockedBackendCoreStat = null;
+
+        connectContext.getSessionVariable().setParallelExecInstanceNum(prevParallelExecInstanceNum);
+        connectContext.getSessionVariable().setEnablePipelineEngine(prevEnablePipelineEngine);
+        connectContext.getSessionVariable().setPipelineDop(prevPipelineDop);
+    }
+
+    @Test
+    public void testSchemaScan() throws Exception {
+        ExecPlan plan = getExecPlan("select * from information_schema.columns");
+        PlanFragment fragment0 = plan.getFragments().get(0);
+        assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "SCAN SCHEMA");
+        // SchemaScanNode doesn't support pipeline, so ParallelExecNum of fragment is 
+        // equal to the corresponding session variables.
+        Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
+        Assert.assertEquals(1, fragment0.getPipelineDop());
+    }
+
+    @Test
+    public void testMetaScan() throws Exception {
+        ExecPlan plan = getExecPlan("select * from t0 [_META_]");
+        PlanFragment fragment1 = plan.getFragments().get(1);
+        assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "MetaScan");
+        // MetaScanNode doesn't support pipeline, so ParallelExecNum of fragment is 
+        // equal to the corresponding session variables.
+        Assert.assertEquals(parallelExecInstanceNum, fragment1.getParallelExecNum());
+        Assert.assertEquals(1, fragment1.getPipelineDop());
+    }
+
+    @Test
+    public void testOutfile() throws Exception {
+        ExecPlan plan = getExecPlan("SELECT v1,v2,v3 FROM t0  INTO OUTFILE \"hdfs://path/to/result_\""
+                + "FORMAT AS CSV PROPERTIES" +
+                "(\"broker.name\" = \"my_broker\"," +
+                "\"broker.hadoop.security.authentication\" = \"kerberos\"," +
+                "\"line_delimiter\" = \"\n\", \"max_file_size\" = \"100MB\");");
+        System.out.println(plan.getExplainString(StatementBase.ExplainLevel.COST));
+        PlanFragment fragment0 = plan.getFragments().get(0);
+        assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "RESULT SINK");
+        // Outfile ResultSink doesn't support pipeline, so ParallelExecNum of fragment is 
+        // equal to the corresponding session variables.
+        Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
+        Assert.assertEquals(1, fragment0.getPipelineDop());
+    }
+
+    @Test
+    public void testInsert() throws Exception {
+        boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
+        try {
+            Config.enable_pipeline_load = false;
+            ExecPlan plan = getExecPlan("insert into t0 select * from t0");
+            PlanFragment fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
+            // equal to the corresponding session variables.
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("insert into t0 select * from t0");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+        } finally {
+            Config.enable_pipeline_load = prevEnablePipelineLoad;
+        }
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
+        try {
+            Config.enable_pipeline_load = false;
+            ExecPlan plan = getExecPlan("delete from tprimary where pk = 1");
+            System.out.println(plan.getExplainString(TExplainLevel.NORMAL));
+            PlanFragment fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
+            // equal to the corresponding session variables.
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("delete from tprimary where pk = 1");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+        } finally {
+            Config.enable_pipeline_load = prevEnablePipelineLoad;
+        }
+    }
+
+    @Test
+    public void tesUpdate() throws Exception {
+        boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
+        try {
+            Config.enable_pipeline_load = false;
+            ExecPlan plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
+            System.out.println(plan.getExplainString(TExplainLevel.NORMAL));
+            PlanFragment fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
+            // equal to the corresponding session variables.
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(1, fragment0.getPipelineDop());
+        } finally {
+            Config.enable_pipeline_load = prevEnablePipelineLoad;
+        }
+    }
+
+    @Test
+    public void testOrderBy() throws Exception {
+        String sql = "select * from t0 order by v1 limit 100";
+        ExecPlan plan = getExecPlan(sql);
+        PlanFragment fragment1 = plan.getFragments().get(1);
+        assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "TOP-N");
+        Assert.assertEquals(1, fragment1.getParallelExecNum());
+        Assert.assertEquals(numHardwareCores / 2, fragment1.getPipelineDop());
+    }
+
+    private void testJoinHelper(int expectedParallelism) throws Exception {
+        // Case 1: local bucket shuffle join should use fragment instance parallel.
+        String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
+        ExecPlan plan = getExecPlan(sql);
+        PlanFragment fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 2: colocate join should use pipeline instance parallel.
+        sql = "select * from colocate1 left join colocate2 " +
+                "on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 3: broadcast join should use pipeline parallel.
+        sql = "select a.v1 from t0 a join [broadcast] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BROADCAST)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+
+        // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
+        sql = "select a.v1 from t0 a " +
+                "join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 " +
+                "join [broadcast] t0 c on a.v1 = c.v2";
+        plan = getExecPlan(sql);
+        fragment = plan.getFragments().get(1);
+        String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);
+        assertContains(fragmentString, "join op: INNER JOIN (BROADCAST)");
+        assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
+        Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
+        Assert.assertEquals(1, fragment.getParallelExecNum());
+    }
+
+    @Test
+    public void testJoin() throws Exception {
+        try {
+            FeConstants.runningUnitTest = true;
+
+            connectContext.getSessionVariable().setPipelineDop(0);
+            connectContext.getSessionVariable().setParallelExecInstanceNum(1);
+            testJoinHelper(numHardwareCores / 2);
+
+            connectContext.getSessionVariable().setPipelineDop(4);
+            connectContext.getSessionVariable().setParallelExecInstanceNum(8);
+            testJoinHelper(4);
+        } finally {
+            FeConstants.runningUnitTest = false;
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11451.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For pipeline engine, there are some features different from non-pipeline:
- Adjust `pipeline_dop` and set `parallel_fragment_exec_instance_num` to 1.
- Generate some operators which are only support by pipeline.

We can apply this features, only when the SQL is executed by pipeline. However, we only check `sessionVariable.isEnablePipelineEngine()`, but ignore whether some operators haven't  implement in pipeline.

Therefore, we should check canUsePipeline before optimizing and building fragment.

## Modifications
- Add a method `canUsePipeline` to `LogicalOperator`.
- After generating the original logical plan, check whether the `LogicalOperator` tree and the data sink can use pipeline.
- If it cannot use pipeline, set the session variable `enablePipelineEngine` to `false` temporarily, when optimizing query and building fragment.
- Replace all the invocations `sessionVariable.isEnablePipelineEngine()` with the final `usePipeline` in  `Coordinator` as follows.

```java
        boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
        boolean canUsePipeline =
                isEnablePipeline && DataSink.canTableSinkUsePipeline(insertStmt.getTargetTable()) &&
                        logicalPlan.canUsePipeline();
        boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
        try {
            if (forceDisablePipeline) {
                session.getSessionVariable().setEnablePipelineEngine(false);
            }

            // optimizing query and building fragment
   
        } finally {
            if (forceDisablePipeline) {
                session.getSessionVariable().setEnablePipelineEngine(true);
            }
        }
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
