### PR TITLE
[Cherry-pick 2.2][BugFix] Add predicate on database for `SHOW TABLES WHERE` (#11411)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
@@ -91,8 +91,18 @@ public class ShowTableStmt extends ShowStmt {
             aliasMap.put(new SlotRef(null, TYPE_COL), item.getExpr().clone(null));
         }
         where = where.substitute(aliasMap);
+        // where databases_name = currentdb
+        Expr whereDbEQ = new BinaryPredicate(
+                BinaryPredicate.Operator.EQ,
+                new SlotRef(TABLE_NAME, "TABLE_SCHEMA"),
+                new StringLiteral(ClusterNamespace.getNameFromFullName(db)));
+        // old where + and + db where
+        Expr finalWhere = new CompoundPredicate(
+                CompoundPredicate.Operator.AND,
+                whereDbEQ,
+                where);
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                where, null, null));
+                finalWhere, null, null));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
@@ -22,7 +22,9 @@
 package com.starrocks.analysis;
 
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AST2SQL;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,6 +67,14 @@ public class ShowTableStmtTest {
         Assert.assertEquals(2, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Tables_in_abc", stmt.getMetaData().getColumn(0).getName());
         Assert.assertEquals("Table_type", stmt.getMetaData().getColumn(1).getName());
+        Assert.assertEquals("bcd", stmt.getPattern());
+
+        String sql = "show full tables where table_type !='VIEW'";
+        stmt = (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        QueryStatement queryStatement = stmt.toSelectStmt();
+        String expect = "SELECT TABLE_NAME AS Tables_in_testDb, TABLE_TYPE AS Table_type FROM information_schema.tables"
+                + " WHERE (TABLE_SCHEMA = 'testDb') AND (TABLE_TYPE != 'VIEW')";
+        Assert.assertEquals(expect, AST2SQL.toString(queryStatement));
     }
 
     @Test(expected = SemanticException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -57,7 +57,9 @@ public class AnalyzeShowTest {
     public void testShowTables() throws AnalysisException {
         analyzeSuccess("show tables;");
         ShowStmt statement = (ShowStmt) analyzeSuccess("show tables where table_name = 't1';");
-        Assert.assertEquals("SELECT TABLE_NAME AS Tables_in_test FROM information_schema.tables WHERE table_name = 't1'",
+        Assert.assertEquals(
+                "SELECT TABLE_NAME AS Tables_in_test FROM information_schema.tables"
+                        + " WHERE (TABLE_SCHEMA = 'test') AND (table_name = 't1')",
                 AST2SQL.toString(statement.toSelectStmt()));
         analyzeSuccess("show tables from `test` like 'test'");
     }


### PR DESCRIPTION
Many show statements support predicates by rewriting SQL to a query statement on a certain table in `infomation_schema` database. However, the result of the query on tables in `infomation_schema` is of all databases. Thus we should always add a predicate `database = xxx` when rewriting.

Fixes #11126

Manually cherry-pick from 46e3aa7aca327578b3ca76b4399606a3832698db