### PR TITLE
[Cherry-pick 2.3][BugFix] Add predicate on database for `SHOW TABLES WHERE` (#11411)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowTableStmt.java
@@ -95,7 +95,7 @@ public class ShowTableStmt extends ShowStmt {
         Expr whereDbEQ = new BinaryPredicate(
                 BinaryPredicate.Operator.EQ,
                 new SlotRef(TABLE_NAME, "TABLE_SCHEMA"),
-                new StringLiteral(db));
+                new StringLiteral((ClusterNamespace.getNameFromFullName(db))));
         // old where + and + db where
         Expr finalWhere = new CompoundPredicate(
                 CompoundPredicate.Operator.AND,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
@@ -73,7 +73,7 @@ public class ShowTableStmtTest {
         stmt = (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         QueryStatement queryStatement = stmt.toSelectStmt();
         String expect = "SELECT TABLE_NAME AS Tables_in_testDb, TABLE_TYPE AS Table_type FROM information_schema.tables"
-                + " WHERE (TABLE_SCHEMA = 'testCluster:testDb') AND (TABLE_TYPE != 'VIEW')";
+                + " WHERE (TABLE_SCHEMA = 'testDb') AND (TABLE_TYPE != 'VIEW')";
         Assert.assertEquals(expect, AST2SQL.toString(queryStatement));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -69,7 +69,7 @@ public class AnalyzeShowTest {
         ShowTableStmt statement = (ShowTableStmt) analyzeSuccess("show tables where table_name = 't1';");
         Assert.assertEquals(
                 "SELECT TABLE_NAME AS Tables_in_test FROM information_schema.tables"
-                        + " WHERE (TABLE_SCHEMA = 'default_cluster:test') AND (table_name = 't1')",
+                        + " WHERE (TABLE_SCHEMA = 'test') AND (table_name = 't1')",
                 AST2SQL.toString(statement.toSelectStmt()));
 
         statement = (ShowTableStmt) analyzeSuccess("show tables from `test`");


### PR DESCRIPTION
Many show statements support predicates by rewriting SQL to a query statement on a certain table in `information_schema` database. However, the result of the query on tables in `information_schema` is of all databases. Thus we should always add a predicate `database = xxx` when rewriting.

Fixes #11126

Manually cherry-pick from 46e3aa7aca327578b3ca76b4399606a3832698db

fix a bug in #11411