### PR TITLE
[cherry-pick] [branch-2.2] [BugFix] fix the mem leak of MysqlResultWriter (#11472)

### DIFF
--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -82,8 +82,8 @@ Status MysqlResultWriter::append_chunk(vectorized::Chunk* chunk) {
     // Note: this method will delete result pointer if status is OK
     // TODO(kks): use std::unique_ptr instead of raw pointer
     auto add_status = _sinker->add_batch(fetch_data);
-    if (status.ok()) {
-        _written_rows += num_rows;
+    if (add_status.ok()) {
+        _written_rows += static_cast<int64_t>(num_rows);
         return add_status;
     } else {
         LOG(WARNING) << "append result batch to sink failed.";


### PR DESCRIPTION
```
Fail to open fragment d7feedb4-3652-11ed-a0b3-00163e0d9975: Cancelled: Cancelled BufferControlBlock::add_batch
```

the `fetch_data` is not delete when `add_batch` failed
