### PR TITLE
[Refactor] Remove useless config cumulative_compaction_skip_window_seconds

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -277,10 +277,6 @@ CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, "1000");
 // -1 means no limit if enable event_based_compaction_framework, and the max concurrency will be:
 CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
 // CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
-// cumulative compaction skips recently published deltas in order to prevent
-// compacting a version that might be queried (in case the query planning phase took some time).
-// the following config set the window size
-CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 
 CONF_mInt32(update_compaction_check_interval_seconds, "60");
 CONF_Int32(update_compaction_num_threads_per_disk, "1");

--- a/be/src/storage/cumulative_compaction.cpp
+++ b/be/src/storage/cumulative_compaction.cpp
@@ -57,8 +57,7 @@ Status CumulativeCompaction::compact() {
 
 Status CumulativeCompaction::pick_rowsets_to_compact() {
     std::vector<RowsetSharedPtr> candidate_rowsets;
-    _tablet->pick_candicate_rowsets_to_cumulative_compaction(config::cumulative_compaction_skip_window_seconds,
-                                                             &candidate_rowsets);
+    _tablet->pick_candicate_rowsets_to_cumulative_compaction(&candidate_rowsets);
 
     if (candidate_rowsets.empty()) {
         return Status::NotFound("cumulative compaction no suitable version error.");

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -838,12 +838,10 @@ TabletInfo Tablet::get_tablet_info() const {
     return TabletInfo(tablet_id(), schema_hash(), tablet_uid());
 }
 
-void Tablet::pick_candicate_rowsets_to_cumulative_compaction(int64_t skip_window_sec,
-                                                             std::vector<RowsetSharedPtr>* candidate_rowsets) {
-    int64_t now = UnixSeconds();
+void Tablet::pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets) {
     std::shared_lock rdlock(_meta_lock);
     for (auto& it : _rs_version_map) {
-        if (it.first.first >= _cumulative_point && (it.second->creation_time() + skip_window_sec < now)) {
+        if (it.first.first >= _cumulative_point) {
             candidate_rowsets->push_back(it.second);
         }
     }

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -200,8 +200,7 @@ public:
 
     TabletInfo get_tablet_info() const;
 
-    void pick_candicate_rowsets_to_cumulative_compaction(int64_t skip_window_sec,
-                                                         std::vector<RowsetSharedPtr>* candidate_rowsets);
+    void pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
     void pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
 
     void calculate_cumulative_point();

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -168,8 +168,6 @@ public:
                 Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
         tablet->init();
 
-        config::cumulative_compaction_skip_window_seconds = -2;
-
         CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
 
         ASSERT_TRUE(cumulative_compaction.compact().ok());


### PR DESCRIPTION
TabletReader can acquire version from _stale_rs_version_map after cumulative compaction, no need to skip compaction

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`cumulative_compaction_skip_window_seconds ` introduced by https://github.com/apache/doris/pull/3271. At that time, it can not acquire rowset version after compaction, but now we can acquire from _stale_rs_version_map.
so that this config is useless now.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
