### PR TITLE
[Feature] Implement CachingHiveMetastore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -1,0 +1,287 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveMetaStoreTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class CachingHiveMetastore implements IHiveMetastore {
+    public static final long NEVER_CACHE = 0;
+    public static final long NEVER_EVICT = -1;
+    public static final long NEVER_REFRESH = -1;
+    protected final IHiveMetastore metastore;
+
+    protected LoadingCache<String, List<String>> databaseNamesCache;
+    protected LoadingCache<String, List<String>> tableNamesCache;
+    protected LoadingCache<HiveTableName, List<String>> partitionKeysCache;
+
+    protected LoadingCache<String, Database> databaseCache;
+    protected LoadingCache<HiveTableName, Table> tableCache;
+
+    protected LoadingCache<NewHivePartitionName, Partition> partitionCache;
+    protected LoadingCache<HiveTableName, HivePartitionStatistics> tableStatsCache;
+    protected LoadingCache<NewHivePartitionName, HivePartitionStatistics> partitionStatsCache;
+
+    public static CachingHiveMetastore reuseMetastore(IHiveMetastore metastore, long perQueryCacheMaxSize) {
+        return new CachingHiveMetastore(
+                metastore,
+                newDirectExecutorService(),
+                NEVER_EVICT,
+                NEVER_REFRESH,
+                perQueryCacheMaxSize,
+                true);
+    }
+
+    protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, long expireAfterWriteSec,
+                                   long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
+        this.metastore = metastore;
+
+        if (enableListNamesCache) {
+            databaseNamesCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                    .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
+            tableNamesCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                    .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
+            partitionKeysCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                    .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
+        } else {
+            databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                    .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
+            tableNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                    .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
+            partitionKeysCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                    .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
+        }
+
+        databaseCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadDb), executor));
+
+        tableCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTable), executor));
+
+        partitionCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize)
+                .build(asyncReloading(new CacheLoader<NewHivePartitionName, Partition>() {
+                    @Override
+                    public Partition load(@NotNull NewHivePartitionName key) {
+                        return loadPartition(key);
+                    }
+
+                    @Override
+                    public Map<NewHivePartitionName, Partition> loadAll(
+                            @NotNull Iterable<? extends NewHivePartitionName> partitionKeys) {
+                        return loadPartitionsByNames(partitionKeys);
+                    }
+                }, executor));
+
+        tableStatsCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTableStatistics), executor));
+
+        partitionStatsCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize)
+                .build(asyncReloading(new CacheLoader<NewHivePartitionName, HivePartitionStatistics>() {
+                    @Override
+                    public HivePartitionStatistics load(@NotNull NewHivePartitionName key) {
+                        return loadPartitionStatistics(key);
+                    }
+
+                    @Override
+                    public Map<NewHivePartitionName, HivePartitionStatistics> loadAll(
+                            @NotNull Iterable<? extends NewHivePartitionName> partitionKeys) {
+                        return loadPartitionsStatistics(partitionKeys);
+                    }
+                }, executor));
+    }
+
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteSec >= 0) {
+            cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
+        }
+
+        if (refreshSec > 0 && expiresAfterWriteSec > refreshSec) {
+            cacheBuilder.refreshAfterWrite(refreshSec, SECONDS);
+        }
+
+        cacheBuilder.maximumSize(maximumSize);
+        return cacheBuilder;
+    }
+
+    public List<String> getAllDatabaseNames() {
+        return get(databaseNamesCache, "");
+    }
+
+    private List<String> loadAllDatabaseNames() {
+        return metastore.getAllDatabaseNames();
+    }
+
+    public List<String> getAllTableNames(String dbName) {
+        return get(tableNamesCache, dbName);
+    }
+
+    private List<String> loadAllTableNames(String dbName) {
+        return metastore.getAllTableNames(dbName);
+    }
+
+    public List<String> getPartitionKeys(String dbName, String tableName) {
+        return get(partitionKeysCache, HiveTableName.of(dbName, tableName));
+    }
+
+    private List<String> loadPartitionKeys(HiveTableName hiveTableName) {
+        return metastore.getPartitionKeys(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+    }
+
+    public Database getDb(String dbName) {
+        return get(databaseCache, dbName);
+    }
+
+    private Database loadDb(String dbName) {
+        return metastore.getDb(dbName);
+    }
+
+    public Table getTable(String dbName, String tableName) {
+        return get(tableCache, HiveTableName.of(dbName, tableName));
+    }
+
+    private Table loadTable(HiveTableName hiveTableName) {
+        return metastore.getTable(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+    }
+
+    public Partition getPartition(String dbName, String tblName, List<String> partitionValues) {
+        return get(partitionCache, NewHivePartitionName.of(dbName, tblName, partitionValues));
+    }
+
+    public Partition loadPartition(NewHivePartitionName key) {
+        return metastore.getPartition(key.getDatabaseName(), key.getTableName(), key.getPartitionValues());
+    }
+
+    public Map<String, Partition> getPartitionsByNames(String dbName, String tblName, List<String> partitionNames) {
+        List<NewHivePartitionName> hivePartitionNames = partitionNames.stream()
+                .map(partitionName -> NewHivePartitionName.of(dbName, tblName, partitionName))
+                .peek(hivePartitionName -> checkState(hivePartitionName.getPartitionNames().isPresent(),
+                        "partition name is missing"))
+                .collect(Collectors.toList());
+
+        Map<NewHivePartitionName, Partition> all = getAll(partitionCache, hivePartitionNames);
+        ImmutableMap.Builder<String, Partition> partitionsByName = ImmutableMap.builder();
+        for (Map.Entry<NewHivePartitionName, Partition> entry : all.entrySet()) {
+            partitionsByName.put(entry.getKey().getPartitionNames().get(), entry.getValue());
+        }
+        return partitionsByName.build();
+    }
+
+    private Map<NewHivePartitionName, Partition> loadPartitionsByNames(Iterable<? extends NewHivePartitionName> partitionNames) {
+        NewHivePartitionName hivePartitionName = Iterables.get(partitionNames, 0);
+        Map<String, Partition> partitionsByNames =  metastore.getPartitionsByNames(
+                hivePartitionName.getDatabaseName(),
+                hivePartitionName.getTableName(),
+                Streams.stream(partitionNames).map(partitionName -> partitionName.getPartitionNames().get())
+                        .collect(Collectors.toList()));
+
+
+        ImmutableMap.Builder<NewHivePartitionName, Partition> partitions = ImmutableMap.builder();
+        for (NewHivePartitionName partitionName : partitionNames) {
+            partitions.put(partitionName, partitionsByNames.get(partitionName.getPartitionNames().get()));
+        }
+        return partitions.build();
+    }
+
+    public HivePartitionStatistics getTableStatistics(String dbName, String tblName) {
+        return get(tableStatsCache, HiveTableName.of(dbName, tblName));
+    }
+
+    private HivePartitionStatistics loadTableStatistics(HiveTableName hiveTableName) {
+        return metastore.getTableStatistics(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+    }
+
+    @Override
+    public Map<String, HivePartitionStatistics> getPartitionsStatistics(Table table, List<String> partitionNames) {
+        String dbName = ((HiveMetaStoreTable) table).getDbName();
+        String tblName = ((HiveMetaStoreTable) table).getTableName();
+
+        List<NewHivePartitionName> hivePartitionNames = partitionNames.stream()
+                .map(partitionName -> NewHivePartitionName.of(dbName, tblName, partitionName))
+                .collect(Collectors.toList());
+
+        Map<NewHivePartitionName, HivePartitionStatistics> statistics = getAll(partitionStatsCache, hivePartitionNames);
+
+        return statistics.entrySet()
+                .stream()
+                .collect(toImmutableMap(entry -> entry.getKey().getPartitionNames().get(), Map.Entry::getValue));
+    }
+
+    public Map<String, HivePartitionStatistics> getPresentPartitionsStatistics(List<NewHivePartitionName> partitions) {
+        return partitionStatsCache.getAllPresent(partitions).entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().getPartitionNames().get(), Map.Entry::getValue));
+
+    }
+
+    private HivePartitionStatistics loadPartitionStatistics(NewHivePartitionName hivePartitionName) {
+        Table table = getTable(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
+        Preconditions.checkState(hivePartitionName.getPartitionNames().isPresent(), "hive partition name is missing");
+        Map<String, HivePartitionStatistics> partitionsStatistics = metastore
+                .getPartitionsStatistics(table, Lists.newArrayList(hivePartitionName.getPartitionNames().get()));
+
+        return partitionsStatistics.get(hivePartitionName.getPartitionNames().get());
+    }
+
+    private Map<NewHivePartitionName, HivePartitionStatistics> loadPartitionsStatistics(
+            Iterable<? extends NewHivePartitionName> partitionNames) {
+        NewHivePartitionName hivePartitionName = Iterables.get(partitionNames, 0);
+        Table table = getTable(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
+
+        Map<String, HivePartitionStatistics> partitionsStatistics =  metastore.getPartitionsStatistics(table,
+                Streams.stream(partitionNames).map(partitionName -> partitionName.getPartitionNames().get())
+                        .collect(Collectors.toList()));
+
+        return partitionsStatistics.entrySet().stream().collect(Collectors.toMap(
+                entry -> NewHivePartitionName.of(
+                        hivePartitionName.getDatabaseName(), hivePartitionName.getTableName(), entry.getKey()),
+                Map.Entry::getValue
+        ));
+    }
+
+    private static <K, V> V get(LoadingCache<K, V> cache, K key) {
+        try {
+            return cache.getUnchecked(key);
+        } catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), StarRocksConnectorException.class);
+            throw e;
+        }
+    }
+
+    private static <K, V> Map<K, V> getAll(LoadingCache<K, V> cache, Iterable<K> keys) {
+        try {
+            return cache.getAll(keys);
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), StarRocksConnectorException.class);
+            throwIfUnchecked(e);
+            throw new UncheckedExecutionException(e);
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -62,6 +62,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
                                    long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
         this.metastore = metastore;
 
+        // The list names interface of hive metastore latency is very low, so we default to pull the latest every time.
         if (enableListNamesCache) {
             databaseNamesCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                     .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
@@ -115,7 +116,6 @@ public class CachingHiveMetastore implements IHiveMetastore {
                     }
                 }, executor));
     }
-
 
     private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -46,7 +46,6 @@ public class CachingHiveMetastore implements IHiveMetastore {
     protected LoadingCache<String, Database> databaseCache;
     protected LoadingCache<HiveTableName, Table> tableCache;
 
-    // Partition stores some necessary information used in the planner phase
     protected LoadingCache<NewHivePartitionName, Partition> partitionCache;
     protected LoadingCache<HiveTableName, HivePartitionStatistics> tableStatsCache;
     protected LoadingCache<NewHivePartitionName, HivePartitionStatistics> partitionStatsCache;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -39,6 +39,8 @@ public class CachingHiveMetastore implements IHiveMetastore {
 
     protected LoadingCache<String, List<String>> databaseNamesCache;
     protected LoadingCache<String, List<String>> tableNamesCache;
+
+    // HiveTableName -> List("year=2022/month=10", "year=2022/month=11")
     protected LoadingCache<HiveTableName, List<String>> partitionKeysCache;
 
     protected LoadingCache<String, Database> databaseCache;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -46,6 +46,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
     protected LoadingCache<String, Database> databaseCache;
     protected LoadingCache<HiveTableName, Table> tableCache;
 
+    // eg: "year=2022/month=10" -> Partition
     protected LoadingCache<NewHivePartitionName, Partition> partitionCache;
     protected LoadingCache<HiveTableName, HivePartitionStatistics> tableStatsCache;
     protected LoadingCache<NewHivePartitionName, HivePartitionStatistics> partitionStatsCache;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -40,12 +40,13 @@ public class CachingHiveMetastore implements IHiveMetastore {
     protected LoadingCache<String, List<String>> databaseNamesCache;
     protected LoadingCache<String, List<String>> tableNamesCache;
 
-    // HiveTableName -> List("year=2022/month=10", "year=2022/month=11")
+    // eg: HiveTableName -> List("year=2022/month=10", "year=2022/month=11")
     protected LoadingCache<HiveTableName, List<String>> partitionKeysCache;
 
     protected LoadingCache<String, Database> databaseCache;
     protected LoadingCache<HiveTableName, Table> tableCache;
 
+    // Partition stores some necessary information used in the planner phase
     protected LoadingCache<NewHivePartitionName, Partition> partitionCache;
     protected LoadingCache<HiveTableName, HivePartitionStatistics> tableStatsCache;
     protected LoadingCache<NewHivePartitionName, HivePartitionStatistics> partitionStatsCache;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/NewHivePartitionName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/NewHivePartitionName.java
@@ -1,0 +1,116 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.starrocks.analysis.BoolLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.NullLiteral;
+import com.starrocks.catalog.NullablePartitionKey;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.external.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+// TODO(stephen): rename NewHivePartitionName to HivePartitionName and remove original HivePartitionName
+//  After refactoring others related codes
+public class NewHivePartitionName {
+    private final String databaseName;
+    private final String tableName;
+    private final List<String> partitionValues;
+
+    // partition name eg: "year=2020/month=10/day=10"
+    private final Optional<String> partitionNames;
+
+    public NewHivePartitionName(String dbName, String tableName, List<String> partitionValues) {
+        this(dbName, tableName, partitionValues, Optional.empty());
+    }
+
+    public NewHivePartitionName(String databaseName,
+                                String tableName,
+                                List<String> partitionValues,
+                                Optional<String> partitionNames) {
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.partitionValues = partitionValues;
+        this.partitionNames = partitionNames;
+    }
+
+    public static NewHivePartitionName of(String dbName, String tblName, List<String> partitionValues) {
+        return new NewHivePartitionName(dbName, tblName, partitionValues);
+    }
+
+    public static NewHivePartitionName of(String dbName, String tblName, String partitionNames) {
+        return new NewHivePartitionName(dbName, tblName, Utils.toPartitionValues(partitionNames), Optional.of(partitionNames));
+    }
+
+    public static List<String> fromPartitionKey(PartitionKey key) {
+        // get string value from partitionKey
+        List<LiteralExpr> literalValues = key.getKeys();
+        List<String> values = new ArrayList<>(literalValues.size());
+        for (LiteralExpr value : literalValues) {
+            if (value instanceof NullLiteral) {
+                values.add(((NullablePartitionKey) key).nullPartitionValue());
+            } else if (value instanceof BoolLiteral) {
+                BoolLiteral boolValue = ((BoolLiteral) value);
+                values.add(String.valueOf(boolValue.getValue()));
+            } else {
+                values.add(value.getStringValue());
+            }
+        }
+        return values;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public List<String> getPartitionValues() {
+        return partitionValues;
+    }
+
+    public Optional<String> getPartitionNames() {
+        return partitionNames;
+    }
+
+    public boolean approximateMatchTable(String db, String tblName) {
+        return this.databaseName.equals(db) && this.tableName.equals(tblName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NewHivePartitionName other = (NewHivePartitionName) o;
+        return Objects.equals(databaseName, other.databaseName) &&
+                Objects.equals(tableName, other.tableName) &&
+                Objects.equals(partitionValues, other.partitionValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseName, tableName, partitionValues);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("NewHivePartitionName{");
+        sb.append("databaseName='").append(databaseName).append('\'');
+        sb.append(", tableName='").append(tableName).append('\'');
+        sb.append(", partitionValues=").append(partitionValues);
+        sb.append(", partitionNames=").append(partitionNames);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 /**
  * Partition stores some necessary information used in the planner stage
- * such as in the cbo and build scan range stage. The purpose of caching partition instance
+ * such as in the cbo and building scan range stage. The purpose of caching partition instance
  * is to reduce repeated calls to the hive metastore rpc interface at each stage.
  */
 public class Partition {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
@@ -7,6 +7,7 @@ import com.starrocks.external.hive.text.TextFileFormatDesc;
 import java.util.Map;
 import java.util.Objects;
 
+// Partition stores some necessary information used in the planner phase
 public class Partition {
     private final Map<String, String> parameters;
     private final RemoteFileInputFormat inputFormat;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Partition.java
@@ -7,7 +7,11 @@ import com.starrocks.external.hive.text.TextFileFormatDesc;
 import java.util.Map;
 import java.util.Objects;
 
-// Partition stores some necessary information used in the planner phase
+/**
+ * Partition stores some necessary information used in the planner stage
+ * such as in the cbo and build scan range stage. The purpose of caching partition instance
+ * is to reduce repeated calls to the hive metastore rpc interface at each stage.
+ */
 public class Partition {
     private final Map<String, String> parameters;
     private final RemoteFileInputFormat inputFormat;

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/CachingHiveMetastoreTest.java
@@ -1,0 +1,189 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HivePartitionKey;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.starrocks.external.hive.RemoteFileInputFormat.PARQUET;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
+
+public class CachingHiveMetastoreTest {
+    private HiveMetaClient client;
+    private HiveMetastore metastore;
+    private ExecutorService executor;
+    private long expireAfterWriteSec = 10;
+    private long refreshAfterWriteSec = -1;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new HiveMetastoreTest.MockedHiveMetaClient();
+        metastore = new HiveMetastore(client, "hive_catalog");
+        executor = Executors.newFixedThreadPool(5);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdown();
+    }
+
+    @Test
+    public void testGetAllDatabaseNames() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        List<String> databaseNames = cachingHiveMetastore.getAllDatabaseNames();
+        Assert.assertEquals(Lists.newArrayList("db1", "db2"), databaseNames);
+        CachingHiveMetastore queryLevelCache = CachingHiveMetastore.reuseMetastore(cachingHiveMetastore, 100);
+        Assert.assertEquals(Lists.newArrayList("db1", "db2"), queryLevelCache.getAllDatabaseNames());
+    }
+
+    @Test
+    public void testGetAllTableNames() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        List<String> databaseNames = cachingHiveMetastore.getAllTableNames("xxx");
+        Assert.assertEquals(Lists.newArrayList("table1", "table2"), databaseNames);
+    }
+
+    @Test
+    public void testGetDb() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        Database database = cachingHiveMetastore.getDb("db1");
+        Assert.assertEquals("db1", database.getFullName());
+
+        try {
+            metastore.getDb("db2");
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof StarRocksConnectorException);
+        }
+    }
+
+    @Test
+    public void testGetTable() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        com.starrocks.catalog.Table table = cachingHiveMetastore.getTable("db1", "tbl1");
+        HiveTable hiveTable = (HiveTable) table;
+        Assert.assertEquals("db1", hiveTable.getDbName());
+        Assert.assertEquals("tbl1", hiveTable.getTableName());
+        Assert.assertEquals(Lists.newArrayList("col1"), hiveTable.getPartitionColumnNames());
+        Assert.assertEquals(Lists.newArrayList("col2"), hiveTable.getDataColumnNames());
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive", hiveTable.getHdfsPath());
+        Assert.assertEquals(ScalarType.INT, hiveTable.getPartitionColumns().get(0).getType());
+        Assert.assertEquals(ScalarType.INT, hiveTable.getBaseSchema().get(0).getType());
+        Assert.assertEquals("hive_catalog", hiveTable.getCatalogName());
+    }
+
+    @Test
+    public void testGetPartitionKeys() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        Assert.assertEquals(Lists.newArrayList("col1"), cachingHiveMetastore.getPartitionKeys("db1", "tbl1"));
+    }
+
+    @Test
+    public void testGetPartition() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        com.starrocks.external.hive.Partition partition = cachingHiveMetastore.getPartition(
+                "db1", "tbl1", Lists.newArrayList("par1"));
+        Assert.assertEquals(PARQUET, partition.getInputFormat());
+        Assert.assertEquals("100", partition.getParameters().get(TOTAL_SIZE));
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive", partition.getFullPath());
+
+        partition = metastore.getPartition("db1", "tbl1", Lists.newArrayList());
+        Assert.assertEquals("100", partition.getParameters().get(TOTAL_SIZE));
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive", partition.getFullPath());
+    }
+
+    @Test
+    public void testGetPartitionByNames() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        List<String> partitionNames = Lists.newArrayList("part1=1/part2=2", "part1=3/part2=4");
+        Map<String, Partition> partitions =
+                cachingHiveMetastore.getPartitionsByNames("db1", "table1", partitionNames);
+
+        com.starrocks.external.hive.Partition partition1 = partitions.get("part1=1/part2=2");
+        Assert.assertEquals(PARQUET, partition1.getInputFormat());
+        Assert.assertEquals("100", partition1.getParameters().get(TOTAL_SIZE));
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive.db/hive_tbl/part1=1/part2=2", partition1.getFullPath());
+
+        com.starrocks.external.hive.Partition partition2 = partitions.get("part1=3/part2=4");
+        Assert.assertEquals(PARQUET, partition2.getInputFormat());
+        Assert.assertEquals("100", partition2.getParameters().get(TOTAL_SIZE));
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive.db/hive_tbl/part1=3/part2=4", partition2.getFullPath());
+    }
+
+    @Test
+    public void testGetTableStatistics() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        HivePartitionStatistics statistics = cachingHiveMetastore.getTableStatistics("db1", "table1");
+        HiveCommonStats commonStats = statistics.getCommonStats();
+        Assert.assertEquals(50, commonStats.getRowNums());
+        Assert.assertEquals(100, commonStats.getTotalFileBytes());
+        HiveColumnStatistics columnStatistics = statistics.getColumnStats().get("col1");
+        Assert.assertEquals(0, columnStatistics.getTotalSizeBytes());
+        Assert.assertEquals(1, columnStatistics.getNumNulls());
+        Assert.assertEquals(2, columnStatistics.getNdv());
+    }
+
+    @Test
+    public void testGetPartitionStatistics() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        com.starrocks.catalog.Table hiveTable = cachingHiveMetastore.getTable("db1", "table1");
+        Map<String, HivePartitionStatistics> statistics = cachingHiveMetastore.getPartitionsStatistics(
+                hiveTable, Lists.newArrayList("col1=1", "col1=2"));
+
+        HivePartitionStatistics stats1 = statistics.get("col1=1");
+        HiveCommonStats commonStats1 = stats1.getCommonStats();
+        Assert.assertEquals(50, commonStats1.getRowNums());
+        Assert.assertEquals(100, commonStats1.getTotalFileBytes());
+        HiveColumnStatistics columnStatistics1 = stats1.getColumnStats().get("col2");
+        Assert.assertEquals(0, columnStatistics1.getTotalSizeBytes());
+        Assert.assertEquals(1, columnStatistics1.getNumNulls());
+        Assert.assertEquals(2, columnStatistics1.getNdv());
+
+        HivePartitionStatistics stats2 = statistics.get("col1=2");
+        HiveCommonStats commonStats2 = stats2.getCommonStats();
+        Assert.assertEquals(50, commonStats2.getRowNums());
+        Assert.assertEquals(100, commonStats2.getTotalFileBytes());
+        HiveColumnStatistics columnStatistics2 = stats2.getColumnStats().get("col2");
+        Assert.assertEquals(0, columnStatistics2.getTotalSizeBytes());
+        Assert.assertEquals(1, columnStatistics2.getNumNulls());
+        Assert.assertEquals(5, columnStatistics2.getNdv());
+
+        List<NewHivePartitionName> partitionNames = Lists.newArrayList(
+                NewHivePartitionName.of("db1", "table1", "col1=1"),
+                NewHivePartitionName.of("db1", "table1", "col1=2"));
+
+        Assert.assertEquals(2, cachingHiveMetastore.getPresentPartitionsStatistics(partitionNames).size());
+    }
+
+    @Test
+    public void testPartitionNames() {
+        HivePartitionKey hivePartitionKey = new HivePartitionKey();
+        hivePartitionKey.pushColumn(new StringLiteral(HiveMetaClient.PARTITION_NULL_VALUE), PrimitiveType.NULL_TYPE);
+        List<String> value = NewHivePartitionName.fromPartitionKey(hivePartitionKey);
+        Assert.assertEquals(HiveMetaClient.PARTITION_NULL_VALUE, value.get(0));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
@@ -159,7 +159,7 @@ public class HiveMetastoreTest {
         Assert.assertEquals(5, columnStatistics2.getNdv());
     }
 
-    private static class MockedHiveMetaClient extends HiveMetaClient {
+    public static class MockedHiveMetaClient extends HiveMetaClient {
 
         public MockedHiveMetaClient() {
             super(new HiveConf());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- We use guava loading cache as cache structure.
- CachingHiveMetastore could cache any hive metadata used in planner.
- Both Catalog-level and Query-level cache use CachingMetastore as instance. The `expireAfterWrite` and `refreshAfterWrite` of the two is different.
- Query-level cache instance need to reuse catalog-level cache instance to access user's hive metastore.
- I'll rename NewHivePartitionName to HivePartitionName and remove original HivePartitionName After refactoring others related codes

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
