### PR TITLE
[Enhancement] Support runtime filter storage layer range prune

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -146,7 +146,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
-    _params.runtime_ranger_ctx =
+    _params.runtime_range_pruner =
             OlapRuntimeScanRangePruner(parser, _scan_ctx->conjuncts_manager().unarrived_runtime_filters());
     _morsel->init_tablet_reader_params(&_params);
     _decide_chunk_size();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -7,7 +7,6 @@
 #include "exec/vectorized/olap_scan_node.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "exec/workgroup/work_group.h"
-#include "exprs/vectorized/olap_runtime_ranger.hpp"
 #include "gutil/map_util.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
@@ -15,6 +14,7 @@
 #include "runtime/primitive_type.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
+#include "storage/olap_runtime_range_pruner.hpp"
 #include "storage/predicate_parser.h"
 #include "storage/projection_iterator.h"
 #include "storage/storage_engine.h"
@@ -146,7 +146,8 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
-    _params.runtime_ranger_ctx = RuntimeRangerContext(_scan_ctx->conjuncts_manager().runtime_ranger_params(), parser);
+    _params.runtime_ranger_ctx =
+            OlapRuntimeScanRangePruner(parser, _scan_ctx->conjuncts_manager().unarrived_runtime_filters());
     _morsel->init_tablet_reader_params(&_params);
     _decide_chunk_size();
     std::vector<PredicatePtr> preds;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -7,6 +7,7 @@
 #include "exec/vectorized/olap_scan_node.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "exec/workgroup/work_group.h"
+#include "exprs/vectorized/olap_runtime_ranger.hpp"
 #include "gutil/map_util.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
@@ -90,6 +91,8 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
+    _seg_rt_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _zm_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
@@ -136,20 +139,20 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
                                             std::vector<uint32_t>& reader_columns) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     bool skip_aggregation = thrift_olap_scan_node.is_preaggregation;
+    auto parser = _obj_pool.add(new PredicateParser(_tablet->tablet_schema()));
     _params.is_pipeline = true;
     _params.reader_type = READER_QUERY;
     _params.skip_aggregation = skip_aggregation;
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.runtime_ranger_ctx = RuntimeRangerContext(_scan_ctx->conjuncts_manager().runtime_ranger_params(), parser);
     _morsel->init_tablet_reader_params(&_params);
     _decide_chunk_size();
-
-    PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;
-    RETURN_IF_ERROR(_scan_ctx->conjuncts_manager().get_column_predicates(&parser, &preds));
+    RETURN_IF_ERROR(_scan_ctx->conjuncts_manager().get_column_predicates(parser, &preds));
     for (auto& p : preds) {
-        if (parser.can_pushdown(p.get())) {
+        if (parser->can_pushdown(p.get())) {
             _params.predicates.push_back(p.get());
         } else {
             _not_push_down_predicates.add(p.get());
@@ -406,6 +409,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
+    COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
     COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);
     COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -118,6 +118,7 @@ private:
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -484,6 +484,8 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _bi_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BitmapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
+    _seg_rt_filtered_counter =
+            ADD_CHILD_COUNTER(_scan_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _sk_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -202,6 +202,7 @@ private:
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -8,11 +8,11 @@
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/dictmapping_expr.h"
 #include "exprs/vectorized/in_const_predicate.hpp"
-#include "exprs/vectorized/olap_runtime_ranger.hpp"
 #include "gutil/map_util.h"
 #include "runtime/descriptors.h"
 #include "runtime/primitive_type.h"
 #include "runtime/primitive_type_infra.h"
+#include "storage/olap_runtime_range_pruner.h"
 #include "storage/predicate_parser.h"
 #include "storage/vectorized_column_predicate.h"
 #include "types/date_value.hpp"
@@ -384,7 +384,7 @@ void OlapScanConjunctsManager::normalize_join_runtime_filter(const SlotDescripto
 
         // runtime filter existed and does not have null.
         if (rf == nullptr) {
-            rt_ranger_params.add_unreached_rf(desc, &slot);
+            rt_ranger_params.add_unarrived_rf(desc, &slot);
             continue;
         }
 

--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -6,6 +6,7 @@
 #include "exec/olap_common.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "exprs/vectorized/olap_runtime_ranger.h"
 
 namespace starrocks {
 class RuntimeState;
@@ -35,6 +36,9 @@ private:
     std::vector<TCondition> is_null_vector;                           // from conjunct_ctxs
     std::map<int, std::vector<ExprContext*>> slot_index_to_expr_ctxs; // from conjunct_ctxs
 
+    // unreached runtime filter and they can push down to storage engine
+    RuntimeRangerParams rt_ranger_params;
+
 public:
     static Status eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
 
@@ -46,6 +50,8 @@ public:
 
     Status parse_conjuncts(bool scan_keys_unlimited, int32_t max_scan_key_num,
                            bool enable_column_expr_predicate = false);
+
+    const RuntimeRangerParams& runtime_ranger_params() { return rt_ranger_params; }
 
 private:
     friend struct ColumnRangeBuilder;

--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -6,7 +6,7 @@
 #include "exec/olap_common.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
-#include "exprs/vectorized/olap_runtime_ranger.h"
+#include "storage/olap_runtime_range_pruner.h"
 
 namespace starrocks {
 class RuntimeState;
@@ -37,7 +37,7 @@ private:
     std::map<int, std::vector<ExprContext*>> slot_index_to_expr_ctxs; // from conjunct_ctxs
 
     // unreached runtime filter and they can push down to storage engine
-    RuntimeRangerParams rt_ranger_params;
+    UnarrivedRuntimeFilterList rt_ranger_params;
 
 public:
     static Status eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
@@ -51,7 +51,7 @@ public:
     Status parse_conjuncts(bool scan_keys_unlimited, int32_t max_scan_key_num,
                            bool enable_column_expr_predicate = false);
 
-    const RuntimeRangerParams& runtime_ranger_params() { return rt_ranger_params; }
+    const UnarrivedRuntimeFilterList& unarrived_runtime_filters() { return rt_ranger_params; }
 
 private:
     friend struct ColumnRangeBuilder;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -133,11 +133,11 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
         _params.chunk_size = runtime_state()->chunk_size();
     }
 
-    PredicateParser parser(_tablet->tablet_schema());
+    auto parser = _pool.add(new PredicateParser(_tablet->tablet_schema()));
     std::vector<PredicatePtr> preds;
-    RETURN_IF_ERROR(_parent->_conjuncts_manager.get_column_predicates(&parser, &preds));
+    RETURN_IF_ERROR(_parent->_conjuncts_manager.get_column_predicates(parser, &preds));
     for (auto& p : preds) {
-        if (parser.can_pushdown(p.get())) {
+        if (parser->can_pushdown(p.get())) {
             _params.predicates.push_back(p.get());
         } else {
             _predicates.add(p.get());
@@ -335,6 +335,8 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_pred_filter_counter, _reader->stats().rows_vec_cond_filtered);
     COUNTER_UPDATE(_parent->_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
     COUNTER_UPDATE(_parent->_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
+    COUNTER_UPDATE(_parent->_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
+
     COUNTER_UPDATE(_parent->_zm_filtered_counter, _reader->stats().rows_stats_filtered);
     COUNTER_UPDATE(_parent->_bf_filtered_counter, _reader->stats().rows_bf_filtered);
     COUNTER_UPDATE(_parent->_sk_filtered_counter, _reader->stats().rows_key_range_filtered);

--- a/be/src/exprs/vectorized/olap_runtime_ranger.h
+++ b/be/src/exprs/vectorized/olap_runtime_ranger.h
@@ -1,0 +1,64 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "common/status.h"
+
+namespace starrocks {
+class SlotDescriptor;
+namespace vectorized {
+class RuntimeFilterProbeDescriptor;
+class PredicateParser;
+class ColumnPredicate;
+class SparseRange;
+
+struct RuntimeRangerParams {
+    std::vector<const RuntimeFilterProbeDescriptor*> unreached_runtime_filters;
+    std::vector<const SlotDescriptor*> slot_descs;
+    void add_unreached_rf(const RuntimeFilterProbeDescriptor* desc, const SlotDescriptor* slot_desc) {
+        unreached_runtime_filters.push_back(desc);
+        slot_descs.push_back(slot_desc);
+    }
+};
+
+class RuntimeRangerContext {
+public:
+    RuntimeRangerContext() = default;
+    RuntimeRangerContext(const RuntimeRangerParams& params, PredicateParser* parser) {
+        _parser = parser;
+        DCHECK_EQ(_unreached_runtime_filters.size(), _slot_descs.size());
+        _init(params);
+    }
+
+    void set_predicate_parser(PredicateParser* parser) { _parser = parser; }
+
+    template <class Updater>
+    Status update_range_if_arrived(Updater&& updater) {
+        if (_arrived_runtime_filters.empty()) return Status::OK();
+        return _update<Updater>(std::move(updater));
+    }
+
+private:
+    using PredicatesPtrs = std::vector<std::unique_ptr<ColumnPredicate>>;
+    using PredicatesRawPtrs = std::vector<const ColumnPredicate*>;
+
+    std::vector<const RuntimeFilterProbeDescriptor*> _unreached_runtime_filters;
+    std::vector<const SlotDescriptor*> _slot_descs;
+    std::vector<bool> _arrived_runtime_filters;
+    PredicateParser* _parser = nullptr;
+
+    // get predicate
+    StatusOr<PredicatesPtrs> _get_predicates(size_t idx);
+
+    PredicatesRawPtrs _as_raw_predicates(const std::vector<std::unique_ptr<ColumnPredicate>>& predicates);
+
+    template <class Updater>
+    Status _update(Updater&& updater);
+
+    void _init(const RuntimeRangerParams& params);
+};
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/exprs/vectorized/olap_runtime_ranger.hpp
+++ b/be/src/exprs/vectorized/olap_runtime_ranger.hpp
@@ -1,0 +1,124 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <memory>
+
+#include "exec/olap_common.h"
+#include "exprs/vectorized/olap_runtime_ranger.h"
+#include "exprs/vectorized/runtime_filter_bank.h"
+#include "storage/predicate_parser.h"
+#include "storage/vectorized_column_predicate.h"
+
+namespace starrocks::vectorized {
+namespace ranger::detail {
+struct RuntimeColumnPredicateBuilder {
+    template <PrimitiveType ptype>
+    StatusOr<std::vector<std::unique_ptr<ColumnPredicate>>> operator()(PredicateParser* parser,
+                                                                       const RuntimeFilterProbeDescriptor* desc,
+                                                                       const SlotDescriptor* slot) {
+        if constexpr (ptype == TYPE_TIME || ptype == TYPE_NULL || ptype == TYPE_JSON || pt_is_float<ptype>) {
+            CHECK(false) << "unreachable path";
+            return Status::NotSupported("unreachable path");
+        } else {
+            std::vector<std::unique_ptr<ColumnPredicate>> preds;
+
+            // Treat tinyint and boolean as int
+            constexpr PrimitiveType limit_type = ptype == TYPE_TINYINT || ptype == TYPE_BOOLEAN ? TYPE_INT : ptype;
+            // Map TYPE_CHAR to TYPE_VARCHAR
+            constexpr PrimitiveType mapping_type = ptype == TYPE_CHAR ? TYPE_VARCHAR : ptype;
+
+            using value_type = typename RunTimeTypeLimits<limit_type>::value_type;
+            using RangeType = ColumnValueRange<value_type>;
+
+            const std::string& col_name = slot->col_name();
+            RangeType full_range(col_name, ptype, RunTimeTypeLimits<ptype>::min_value(),
+                                 RunTimeTypeLimits<ptype>::max_value());
+            if constexpr (pt_is_decimal<limit_type>) {
+                full_range.set_precision(slot->type().precision);
+                full_range.set_scale(slot->type().scale);
+            }
+
+            RangeType& range = full_range;
+            range.set_index_filter_only(true);
+
+            const JoinRuntimeFilter* rf = desc->runtime_filter();
+
+            const RuntimeBloomFilter<mapping_type>* filter = down_cast<const RuntimeBloomFilter<mapping_type>*>(rf);
+
+            using ValueType = typename vectorized::RunTimeTypeTraits<mapping_type>::CppType;
+            SQLFilterOp min_op = to_olap_filter_type(TExprOpcode::GE, false);
+            ValueType min_value = filter->min_value();
+            range.add_range(min_op, static_cast<value_type>(min_value));
+
+            SQLFilterOp max_op = to_olap_filter_type(TExprOpcode::LE, false);
+            ValueType max_value = filter->max_value();
+            range.add_range(max_op, static_cast<value_type>(max_value));
+
+            std::vector<TCondition> filters;
+            range.to_olap_filter(filters);
+
+            for (auto& f : filters) {
+                std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
+                p->set_index_filter_only(f.is_index_filter_only);
+                preds.emplace_back(std::move(p));
+            }
+
+            return preds;
+        }
+    }
+};
+} // namespace ranger::detail
+
+template <class Updater>
+Status RuntimeRangerContext::_update(Updater&& updater) {
+    size_t cnt = 0;
+    for (size_t i = 0; i < _arrived_runtime_filters.size(); ++i) {
+        if (_arrived_runtime_filters[i] == 0 && _unreached_runtime_filters[i]->runtime_filter()) {
+            ASSIGN_OR_RETURN(auto predicates, _get_predicates(i));
+            auto raw_predicates = _as_raw_predicates(predicates);
+            if (!raw_predicates.empty()) {
+                RETURN_IF_ERROR(updater(raw_predicates.front()->column_id(), raw_predicates));
+            }
+            _arrived_runtime_filters[i] = true;
+        }
+        cnt += _arrived_runtime_filters[i];
+    }
+
+    // all filters arrived
+    if (cnt == _arrived_runtime_filters.size()) {
+        _arrived_runtime_filters.clear();
+    }
+    return Status::OK();
+}
+
+inline auto RuntimeRangerContext::_get_predicates(size_t idx) -> StatusOr<PredicatesPtrs> {
+    auto rf = _unreached_runtime_filters[idx]->runtime_filter();
+    if (rf->has_null()) return PredicatesPtrs{};
+    // convert to olap filter
+    auto slot_desc = _slot_descs[idx];
+    return type_dispatch_predicate<StatusOr<PredicatesPtrs>>(slot_desc->type().type, false,
+                                                             ranger::detail::RuntimeColumnPredicateBuilder(), _parser,
+                                                             _unreached_runtime_filters[idx], slot_desc);
+}
+
+inline auto RuntimeRangerContext::_as_raw_predicates(const std::vector<std::unique_ptr<ColumnPredicate>>& predicates)
+        -> PredicatesRawPtrs {
+    PredicatesRawPtrs res;
+    for (auto& predicate : predicates) {
+        res.push_back(predicate.get());
+    }
+    return res;
+}
+
+inline void RuntimeRangerContext::_init(const RuntimeRangerParams& params) {
+    for (size_t i = 0; i < params.slot_descs.size(); ++i) {
+        if (_parser->can_pushdown(params.slot_descs[i])) {
+            _unreached_runtime_filters.emplace_back(params.unreached_runtime_filters[i]);
+            _slot_descs.emplace_back(params.slot_descs[i]);
+            _arrived_runtime_filters.emplace_back();
+        }
+    }
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -606,6 +606,7 @@ void RuntimeFilterProbeDescriptor::set_runtime_filter(const JoinRuntimeFilter* r
         _latency_timer->set((_ready_timestamp - _open_timestamp) * 1000);
     }
 }
+
 void RuntimeFilterProbeDescriptor::set_shared_runtime_filter(const std::shared_ptr<const JoinRuntimeFilter>& rf) {
     std::shared_ptr<const JoinRuntimeFilter> old_value = nullptr;
     if (std::atomic_compare_exchange_strong(&_shared_runtime_filter, &old_value, rf)) {

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -453,6 +453,8 @@ struct OlapReaderStatistics {
     int64_t rowsets_read_count = 0;
     int64_t segments_read_count = 0;
     int64_t total_columns_data_page_count = 0;
+
+    int64_t runtime_stats_filtered = 0;
 };
 
 typedef uint32_t ColumnId;

--- a/be/src/storage/olap_runtime_range_pruner.h
+++ b/be/src/storage/olap_runtime_range_pruner.h
@@ -9,27 +9,28 @@
 
 namespace starrocks {
 class SlotDescriptor;
+
 namespace vectorized {
 class RuntimeFilterProbeDescriptor;
 class PredicateParser;
 class ColumnPredicate;
 class SparseRange;
 
-struct RuntimeRangerParams {
-    std::vector<const RuntimeFilterProbeDescriptor*> unreached_runtime_filters;
+struct UnarrivedRuntimeFilterList {
+    std::vector<const RuntimeFilterProbeDescriptor*> unarrived_runtime_filters;
     std::vector<const SlotDescriptor*> slot_descs;
-    void add_unreached_rf(const RuntimeFilterProbeDescriptor* desc, const SlotDescriptor* slot_desc) {
-        unreached_runtime_filters.push_back(desc);
+    void add_unarrived_rf(const RuntimeFilterProbeDescriptor* desc, const SlotDescriptor* slot_desc) {
+        unarrived_runtime_filters.push_back(desc);
         slot_descs.push_back(slot_desc);
     }
 };
 
-class RuntimeRangerContext {
+class OlapRuntimeScanRangePruner {
 public:
-    RuntimeRangerContext() = default;
-    RuntimeRangerContext(const RuntimeRangerParams& params, PredicateParser* parser) {
+    OlapRuntimeScanRangePruner() = default;
+    OlapRuntimeScanRangePruner(PredicateParser* parser, const UnarrivedRuntimeFilterList& params) {
         _parser = parser;
-        DCHECK_EQ(_unreached_runtime_filters.size(), _slot_descs.size());
+        DCHECK_EQ(_unarrived_runtime_filters.size(), _slot_descs.size());
         _init(params);
     }
 
@@ -37,7 +38,7 @@ public:
 
     template <class Updater>
     Status update_range_if_arrived(Updater&& updater) {
-        if (_arrived_runtime_filters.empty()) return Status::OK();
+        if (_arrived_runtime_filters_masks.empty()) return Status::OK();
         return _update<Updater>(std::move(updater));
     }
 
@@ -45,9 +46,9 @@ private:
     using PredicatesPtrs = std::vector<std::unique_ptr<ColumnPredicate>>;
     using PredicatesRawPtrs = std::vector<const ColumnPredicate*>;
 
-    std::vector<const RuntimeFilterProbeDescriptor*> _unreached_runtime_filters;
+    std::vector<const RuntimeFilterProbeDescriptor*> _unarrived_runtime_filters;
     std::vector<const SlotDescriptor*> _slot_descs;
-    std::vector<bool> _arrived_runtime_filters;
+    std::vector<bool> _arrived_runtime_filters_masks;
     PredicateParser* _parser = nullptr;
 
     // get predicate
@@ -58,7 +59,7 @@ private:
     template <class Updater>
     Status _update(Updater&& updater);
 
-    void _init(const RuntimeRangerParams& params);
+    void _init(const UnarrivedRuntimeFilterList& params);
 };
 } // namespace vectorized
 } // namespace starrocks

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -70,8 +70,10 @@ struct RuntimeColumnPredicateBuilder {
 };
 } // namespace detail
 
-template <class Updater>
-Status OlapRuntimeScanRangePruner::_update(Updater&& updater) {
+inline Status OlapRuntimeScanRangePruner::_update(RuntimeFilterArrivedCallBack&& updater) {
+    if (_arrived_runtime_filters_masks.empty()) {
+        return Status::OK();
+    }
     size_t cnt = 0;
     for (size_t i = 0; i < _arrived_runtime_filters_masks.size(); ++i) {
         if (_arrived_runtime_filters_masks[i] == 0 && _unarrived_runtime_filters[i]->runtime_filter()) {

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -17,6 +17,7 @@ struct RuntimeColumnPredicateBuilder {
     StatusOr<std::vector<std::unique_ptr<ColumnPredicate>>> operator()(PredicateParser* parser,
                                                                        const RuntimeFilterProbeDescriptor* desc,
                                                                        const SlotDescriptor* slot) {
+        // keep consistent with ColumnRangeBuilder
         if constexpr (ptype == TYPE_TIME || ptype == TYPE_NULL || ptype == TYPE_JSON || pt_is_float<ptype>) {
             CHECK(false) << "unreachable path";
             return Status::NotSupported("unreachable path");

--- a/be/src/storage/predicate_parser.cpp
+++ b/be/src/storage/predicate_parser.cpp
@@ -21,6 +21,14 @@ bool PredicateParser::can_pushdown(const ColumnPredicate* predicate) const {
            column.aggregation() == FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE;
 }
 
+bool PredicateParser::can_pushdown(const SlotDescriptor* slot_desc) const {
+    const size_t index = _schema.field_index(slot_desc->col_name());
+    CHECK(index <= _schema.num_columns());
+    const TabletColumn& column = _schema.column(index);
+    return _schema.keys_type() == KeysType::PRIMARY_KEYS ||
+           column.aggregation() == FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE;
+}
+
 ColumnPredicate* PredicateParser::parse_thrift_cond(const TCondition& condition) const {
     const size_t index = _schema.field_index(condition.column_name);
     RETURN_IF(index >= _schema.num_columns(), nullptr);

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -20,6 +20,7 @@ class PredicateParser {
 public:
     explicit PredicateParser(const TabletSchema& schema) : _schema(schema) {}
 
+    // check if an expression can be pushed down to the storage level
     bool can_pushdown(const ColumnPredicate* predicate) const;
 
     bool can_pushdown(const SlotDescriptor* slot_desc) const;

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -1,5 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
+#pragma once
+
 #include <string>
 
 namespace starrocks {
@@ -19,6 +21,8 @@ public:
     explicit PredicateParser(const TabletSchema& schema) : _schema(schema) {}
 
     bool can_pushdown(const ColumnPredicate* predicate) const;
+
+    bool can_pushdown(const SlotDescriptor* slot_desc) const;
 
     // Parse |condition| into a predicate that can be pushed down.
     // return nullptr if parse failed.

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <initializer_list>
 #include <sstream>
 #include <string>
@@ -110,6 +111,7 @@ public:
     // Return the next discontiguous range contains at most |size| rows
     void next_range(size_t size, SparseRange* range);
 
+    // rhs should be a ordered sparse range
     SparseRangeIterator intersection(const SparseRange& rhs, SparseRange* result) const;
 
     void set_range(SparseRange* range) { _range = range; }
@@ -328,9 +330,14 @@ inline void SparseRangeIterator::next_range(size_t size, SparseRange* range) {
 }
 
 inline SparseRangeIterator SparseRangeIterator::intersection(const SparseRange& rhs, SparseRange* result) const {
+    DCHECK(std::is_sorted(rhs._ranges.begin(), rhs._ranges.end(),
+                          [](const auto& l, const auto& r) { return l.begin() < r.begin(); }));
     for (size_t i = _index; i < _range->_ranges.size(); ++i) {
         const auto& r1 = _range->_ranges[i];
         for (const auto& r2 : rhs._ranges) {
+            if (r1.end() < r2.begin()) {
+                break;
+            }
             if (r1.has_intersection(r2)) {
                 result->_add_uncheck(r1.intersection(r2));
             }

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -340,8 +340,8 @@ inline SparseRangeIterator SparseRangeIterator::intersection(const SparseRange& 
     if (res.has_more()) {
         for (size_t i = 0; i < res._range->size(); ++i) {
             // set idx and next rowid
-            if (_next_rowid < res._range[i].end()) {
-                res._next_rowid = res._range[i].begin();
+            if (_next_rowid < res._range->_ranges[i].end()) {
+                res._next_rowid = std::max(res._range->_ranges[i].begin(), _next_rowid);
                 res._index = i;
                 break;
             }

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -346,6 +346,7 @@ Status Rowset::get_segment_iterators(const vectorized::Schema& schema, const Row
     seg_options.chunk_size = options.chunk_size;
     seg_options.global_dictmaps = options.global_dictmaps;
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
+    seg_options.runtime_ranger_ctx = options.runtime_ranger_ctx;
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());
     }

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -346,7 +346,7 @@ Status Rowset::get_segment_iterators(const vectorized::Schema& schema, const Row
     seg_options.chunk_size = options.chunk_size;
     seg_options.global_dictmaps = options.global_dictmaps;
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
-    seg_options.runtime_ranger_ctx = options.runtime_ranger_ctx;
+    seg_options.runtime_range_pruner = options.runtime_range_pruner;
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());
     }

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -6,9 +6,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "runtime/global_dict/types.h"
 #include "storage/olap_common.h"
+#include "storage/olap_runtime_range_pruner.h"
 #include "storage/seek_range.h"
 
 namespace starrocks {
@@ -65,7 +65,7 @@ public:
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
-    vectorized::RuntimeRangerContext runtime_ranger_ctx;
+    vectorized::OlapRuntimeScanRangePruner runtime_range_pruner;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "runtime/global_dict/types.h"
 #include "storage/olap_common.h"
 #include "storage/seek_range.h"
@@ -13,7 +14,7 @@
 namespace starrocks {
 class Conditions;
 class KVStore;
-class OlapReaderStatistics;
+struct OlapReaderStatistics;
 class RuntimeProfile;
 class RowCursor;
 class RuntimeState;
@@ -63,6 +64,8 @@ public:
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+
+    vectorized::RuntimeRangerContext runtime_ranger_ctx;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "column/datum.h"
+#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "fs/fs.h"
 #include "runtime/global_dict/types.h"
 #include "storage/disjunctive_predicates.h"
@@ -64,6 +65,8 @@ public:
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+
+    RuntimeRangerContext runtime_ranger_ctx;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -6,10 +6,10 @@
 #include <vector>
 
 #include "column/datum.h"
-#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "fs/fs.h"
 #include "runtime/global_dict/types.h"
 #include "storage/disjunctive_predicates.h"
+#include "storage/olap_runtime_range_pruner.h"
 #include "storage/seek_range.h"
 
 namespace starrocks {
@@ -66,7 +66,7 @@ public:
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
-    RuntimeRangerContext runtime_ranger_ctx;
+    OlapRuntimeScanRangePruner runtime_range_pruner;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<FieldType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -114,6 +114,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.tablet_schema = &_tablet->tablet_schema();
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
+    rs_opts.runtime_ranger_ctx = params.runtime_ranger_ctx;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -114,7 +114,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.tablet_schema = &_tablet->tablet_schema();
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
-    rs_opts.runtime_range_pruner = params.runtime_ranger_ctx;
+    rs_opts.runtime_range_pruner = params.runtime_range_pruner;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -114,7 +114,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.tablet_schema = &_tablet->tablet_schema();
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
-    rs_opts.runtime_ranger_ctx = params.runtime_ranger_ctx;
+    rs_opts.runtime_range_pruner = params.runtime_ranger_ctx;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -64,7 +64,7 @@ struct TabletReaderParams {
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
-    OlapRuntimeScanRangePruner runtime_ranger_ctx;
+    OlapRuntimeScanRangePruner runtime_range_pruner;
 
 public:
     std::string to_string() const;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "runtime/global_dict/types.h"
 #include "storage/chunk_iterator.h"
 #include "storage/olap_common.h"
@@ -62,6 +63,8 @@ struct TabletReaderParams {
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+
+    RuntimeRangerContext runtime_ranger_ctx;
 
 public:
     std::string to_string() const;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -6,10 +6,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "exprs/vectorized/olap_runtime_ranger.h"
 #include "runtime/global_dict/types.h"
 #include "storage/chunk_iterator.h"
 #include "storage/olap_common.h"
+#include "storage/olap_runtime_range_pruner.h"
 #include "storage/tuple.h"
 
 namespace starrocks {
@@ -64,7 +64,7 @@ struct TabletReaderParams {
     RowidRangeOptionPtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
-    RuntimeRangerContext runtime_ranger_ctx;
+    OlapRuntimeScanRangePruner runtime_ranger_ctx;
 
 public:
     std::string to_string() const;

--- a/be/test/storage/range_test.cpp
+++ b/be/test/storage/range_test.cpp
@@ -181,6 +181,15 @@ TEST(SparseRangeIteratorTest, intersect_test) {
         auto iter2 = iter.intersection(r2, &r3);
         EXPECT_STREQ(dump_range_iter(iter2).data(), "[1000,1500],[2000,4096]");
     }
+    {
+        SparseRange r1(0, 100);
+        SparseRangeIterator iter = r1.new_iterator();
+        iter.skip(30);
+        SparseRange r2({{10, 200}, {2000, 25000}, {3000, 7000}});
+        SparseRange r3;
+        auto iter2 = iter.intersection(r2, &r3);
+        EXPECT_STREQ(dump_range_iter(iter2).data(), "[30,100]");
+    }
 }
 
 TEST(SparseRangeIteratorTest, convert_to_bitmap) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

Fixes #

## Problem Summary(Required) ：
Our global runtime filter retains min/max information. We can use this information to determine the scan range when we are within the scan wait. And this patch provides the ability to prune some scan range by zone map after the scan wait time.

case:
16c 4BE
TPCDS-1T-Q80
| iterator | patched | baseline |
| -------- | ------- | -------- |
| 1 |4s484ms|4s662ms|
| 2 |4s294ms|4s418ms|
| 3 |4s130ms|11s49ms|
| 4 |3s940ms|4s491ms|
| 5 |4s145ms|7s345ms|
| 6 |3s962ms|5s94ms|
| 7 |4s79ms| 4s717ms|

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
