### PR TITLE
[BugFix] Fix potential data error in vertical compaction of PrimaryKeyTable

### DIFF
--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -140,9 +140,6 @@ public:
 protected:
     Status init();
     void close_child(size_t child);
-    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override {
-        return Status::NotSupported("merge iterator get chunk with sources not supported");
-    }
 
     virtual Status fill(size_t child) = 0;
 
@@ -200,7 +197,6 @@ private:
 };
 
 inline Status HeapMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) {
-    LOG(WARNING) << "do get next in heap merge iterator";
     if (!_inited) {
         RETURN_IF_ERROR(init());
     }
@@ -304,7 +300,6 @@ inline Status HeapMergeIterator::fill(size_t child) {
 ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& children) {
     DCHECK(!children.empty());
     if (children.size() == 1) {
-        LOG(WARNING) << "segment iterator num is 1";
         return children[0];
     }
 
@@ -313,7 +308,6 @@ ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& ch
     const static size_t kMaxChildrenSize = std::numeric_limits<uint16_t>::max();
 
     if (children.size() <= kMaxChildrenSize) {
-        LOG(WARNING) << "return heap merge iterator";
         return std::make_shared<HeapMergeIterator>(children);
     }
     std::vector<ChunkIteratorPtr> sub_merge_iterators;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -95,6 +95,7 @@ public:
 protected:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, vector<uint32_t>* rowid) override;
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override { return do_get_next(chunk); }
 
 private:
     struct ScanContext {

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -42,6 +42,7 @@ struct MergeEntry {
     // set |encode_schema| if require encode chunk pk columns
     const vectorized::Schema* encode_schema = nullptr;
     uint16_t order;
+    std::vector<vectorized::RowSourceMask>* source_masks = nullptr;
 
     MergeEntry() = default;
     ~MergeEntry() { close(); }
@@ -80,7 +81,7 @@ struct MergeEntry {
         DCHECK(pk_cur == nullptr || pk_cur > pk_last);
         chunk->reset();
         while (true) {
-            auto st = segment_itr->get_next(chunk.get());
+            auto st = segment_itr->get_next(chunk.get(), source_masks);
             if (st.ok()) {
                 // 1. setup chunk_pk_column
                 if (encode_schema != nullptr) {
@@ -248,7 +249,8 @@ private:
     Status _do_merge_horizontally(Tablet& tablet, int64_t version, const Schema& schema,
                                   const vector<RowsetSharedPtr>& rowsets, RowsetWriter* writer, const MergeConfig& cfg,
                                   size_t* total_input_size, size_t* total_rows, size_t* total_chunk,
-                                  OlapReaderStatistics* stats, RowSourceMaskBuffer* mask_buffer = nullptr) {
+                                  OlapReaderStatistics* stats, RowSourceMaskBuffer* mask_buffer = nullptr,
+                                  std::vector<std::unique_ptr<RowSourceMaskBuffer>>* rowsets_mask_buffer = nullptr) {
         std::unique_ptr<vectorized::Column> pk_column;
         if (schema.num_key_fields() > 1) {
             if (!PrimaryKeyEncoder::create_column(schema, &pk_column).ok()) {
@@ -256,6 +258,7 @@ private:
             }
         }
 
+        std::vector<std::unique_ptr<vector<RowSourceMask>>> rowsets_source_masks;
         uint16_t order = 0;
         for (const auto& rowset : rowsets) {
             *total_input_size += rowset->data_disk_size();
@@ -271,12 +274,17 @@ private:
             if (res.value().empty()) {
                 entry.segment_itr = new_empty_iterator(schema, _chunk_size);
             } else {
-                entry.segment_itr = new_heap_merge_iterator(res.value());
+                entry.segment_itr = std::move(new_heap_merge_iterator(res.value()));
             }
             if (pk_column) {
                 entry.encode_schema = &schema;
                 entry.chunk_pk_column = pk_column->clone_shared();
                 entry.chunk_pk_column->reserve(_chunk_size);
+            }
+            if (rowsets_mask_buffer) {
+                std::unique_ptr<vector<RowSourceMask>> rowset_source_masks = std::make_unique<vector<RowSourceMask>>();
+                rowsets_source_masks.emplace_back(std::move(rowset_source_masks));
+                entry.source_masks = rowsets_source_masks[order].get();
             }
             entry.order = order++;
             auto st = entry.init();
@@ -338,6 +346,15 @@ private:
                     return st;
                 }
             }
+
+            if (rowsets_mask_buffer) {
+                for (size_t i = 0; i < rowsets_source_masks.size(); ++i) {
+                    if (!rowsets_source_masks[i]->empty()) {
+                        RETURN_IF_ERROR((*rowsets_mask_buffer)[i]->write(*(rowsets_source_masks[i])));
+                        rowsets_source_masks[i]->clear();
+                    }
+                }
+            }
         }
 
         if (mask_buffer) {
@@ -353,6 +370,12 @@ private:
                 LOG(WARNING) << "failed to flush rowset when merging rowsets of tablet " << tablet.tablet_id()
                              << ", err=" << st;
                 return st;
+            }
+        }
+
+        if (rowsets_mask_buffer) {
+            for (size_t i = 0; i < rowsets_mask_buffer->size(); ++i) {
+                RETURN_IF_ERROR((*rowsets_mask_buffer)[i]->flush());
             }
         }
 
@@ -373,10 +396,17 @@ private:
         DCHECK_GT(column_groups.size(), 1);
         // merge key columns
         auto mask_buffer = std::make_unique<RowSourceMaskBuffer>(tablet.tablet_id(), tablet.data_dir()->path());
+        std::vector<std::unique_ptr<RowSourceMaskBuffer>> rowsets_mask_buffer;
+        for (size_t i = 0; i < rowsets.size(); ++i) {
+            auto rowset_mask_buffer =
+                    std::make_unique<RowSourceMaskBuffer>(tablet.tablet_id(), tablet.data_dir()->path());
+            rowsets_mask_buffer.emplace_back(std::move(rowset_mask_buffer));
+        }
         {
             Schema schema = ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema(), column_groups[0]);
             RETURN_IF_ERROR(_do_merge_horizontally(tablet, version, schema, rowsets, writer, cfg, total_input_size,
-                                                   total_rows, total_chunk, stats, mask_buffer.get()));
+                                                   total_rows, total_chunk, stats, mask_buffer.get(),
+                                                   &rowsets_mask_buffer));
         }
 
         // merge non key columns
@@ -391,7 +421,9 @@ private:
             iterators.reserve(rowsets.size());
             OlapReaderStatistics non_key_stats;
             Schema schema = ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema(), column_groups[i]);
-            for (const auto& rowset : rowsets) {
+            for (size_t j = 0; j < rowsets.size(); j++) {
+                const auto& rowset = rowsets[j];
+                rowsets_mask_buffer[j]->flip_to_read();
                 _entries.emplace_back(new MergeEntry<T>());
                 MergeEntry<T>& entry = *_entries.back();
                 entry.rowset_release_guard = std::make_unique<RowsetReleaseGuard>(rowset);
@@ -409,7 +441,7 @@ private:
                 if (segment_iters.empty()) {
                     iterators.emplace_back(new_empty_iterator(schema, _chunk_size));
                 } else {
-                    iterators.emplace_back(new_union_iterator(std::move(segment_iters)));
+                    iterators.emplace_back(new_mask_merge_iterator(segment_iters, rowsets_mask_buffer[j].get()));
                 }
             }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We remove the `final merge` phase of the PrimaryKey table import process, so the data among segments may be OVERLAPPING, so we need to sort data in compaction.

In vertical compaction, we use `heap_merge_iterator` to generate `row_source_mask` of the Key column group, and we should use `mask_merge_iterator` to read data of value columns but not `union_iterator`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
