### PR TITLE
[Enhancement] Avoid using DeleteRange for delvec GC

### DIFF
--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -956,6 +956,62 @@ StatusOr<DeleteVectorList> TabletMetaManager::list_del_vector(KVStore* meta, TTa
     return std::move(ret);
 }
 
+StatusOr<size_t> TabletMetaManager::delete_del_vector_before_version(KVStore* meta, TTabletId tablet_id,
+                                                                     int64_t version) {
+    DeleteVectorList ret;
+    std::string lower = encode_del_vector_key(tablet_id, 0, INT64_MAX);
+    std::string upper = encode_del_vector_key(tablet_id, UINT32_MAX, 0);
+    std::map<uint32_t, std::vector<int64_t>> segments;
+    auto st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper,
+                                  [&](std::string_view key, std::string_view value) -> bool {
+                                      TTabletId dummy;
+                                      uint32_t segment_id;
+                                      int64_t version;
+                                      decode_del_vector_key(key, &dummy, &segment_id, &version);
+                                      DCHECK_EQ(tablet_id, dummy);
+                                      segments[segment_id].push_back(version);
+                                      return true;
+                                  });
+    if (!st.ok()) {
+        LOG(WARNING) << "fail to iterate rocksdb for delete_del_vector_before_version. tablet_id=" << tablet_id;
+        return st;
+    }
+    size_t num_delete = 0;
+    WriteBatch batch;
+    auto cf_handle = meta->handle(META_COLUMN_FAMILY_INDEX);
+    std::ostringstream vlog_delvec_maplist;
+    for (auto& segment : segments) {
+        auto& versions = segment.second;
+        bool del = false;
+        bool added = false;
+        for (size_t i = 0; i < versions.size(); i++) {
+            if (del == true) {
+                std::string key = encode_del_vector_key(tablet_id, segment.first, versions[i]);
+                rocksdb::Status st = batch.Delete(cf_handle, key);
+                if (!st.ok()) {
+                    return to_status(st);
+                }
+                num_delete++;
+                if (!added) {
+                    vlog_delvec_maplist << " " << segment.first << ":" << versions[i];
+                    added = true;
+                } else {
+                    vlog_delvec_maplist << "," << versions[i];
+                }
+            } else if (versions[i] <= version) {
+                // versions after this version can be deleted
+                del = true;
+            }
+        }
+    }
+    RETURN_IF_ERROR(meta->write_batch(&batch));
+    if (num_delete > 0) {
+        LOG(INFO) << "delete_del_vector_before_version version:" << version << " tablet:" << tablet_id
+                  << vlog_delvec_maplist.str();
+    }
+    return num_delete;
+}
+
 Status TabletMetaManager::delete_del_vector_range(KVStore* meta, TTabletId tablet_id, uint32_t segment_id,
                                                   int64_t start_version, int64_t end_version) {
     if (start_version == end_version) {

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -985,7 +985,7 @@ StatusOr<size_t> TabletMetaManager::delete_del_vector_before_version(KVStore* me
         bool del = false;
         bool added = false;
         for (size_t i = 0; i < versions.size(); i++) {
-            if (del == true) {
+            if (del) {
                 std::string key = encode_del_vector_key(tablet_id, segment.first, versions[i]);
                 rocksdb::Status st = batch.Delete(cf_handle, key);
                 if (!st.ok()) {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -168,6 +168,13 @@ public:
 
     static StatusOr<DeleteVectorList> list_del_vector(KVStore* meta, TTabletId tablet_id, int64_t max_version);
 
+    // delete all delete vectors of a tablet not useful anymore for query version < `version`, for example
+    // suppose we have delete vectors of version 1, 3, 5, 6, 7, 12, 16
+    // min queryable version is 10, which require delvector of version 7
+    // delvector of versin < 7 can be deleted, that is [1,3,5,6]
+    // return num of del vector deleted
+    static StatusOr<size_t> delete_del_vector_before_version(KVStore* meta, TTabletId tablet_id, int64_t version);
+
     static Status delete_del_vector_range(KVStore* meta, TTabletId tablet_id, uint32_t segment_id,
                                           int64_t start_version, int64_t end_version);
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1464,7 +1464,8 @@ void TabletUpdates::to_updates_pb(TabletUpdatesPB* updates_pb) const {
 }
 
 void TabletUpdates::_erase_expired_versions(int64_t expire_time,
-                                            std::vector<std::unique_ptr<EditVersionInfo>>* expire_list) {
+                                            std::vector<std::unique_ptr<EditVersionInfo>>* expire_list,
+                                            int64_t* min_readable_version) {
     DCHECK(expire_list->empty());
     std::lock_guard l(_lock);
     if (_edit_version_infos.empty()) {
@@ -1481,6 +1482,7 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
     auto n = expire_list->size();
     _edit_version_infos.erase(_edit_version_infos.begin(), _edit_version_infos.begin() + n);
     _apply_version_idx -= n;
+    *min_readable_version = _edit_version_infos[0]->version.major();
 }
 
 bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
@@ -1521,7 +1523,8 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
     }
     /// Remove expired versions from memory.
     std::vector<std::unique_ptr<EditVersionInfo>> expired_edit_version_infos;
-    _erase_expired_versions(expire_time, &expired_edit_version_infos);
+    int64_t min_readable_version = 0;
+    _erase_expired_versions(expire_time, &expired_edit_version_infos, &min_readable_version);
 
     if (!expired_edit_version_infos.empty()) {
         int64_t tablet_id = 0;
@@ -1553,29 +1556,21 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
             _rowset_stats.erase(id);
         }
 
-        /// Remove useless delete vectors.
-        auto max_expired_version = expired_edit_version_infos.back()->version.major();
+        // Remove useless delete vectors.
         auto meta_store = _tablet.data_dir()->get_meta();
-
-        size_t n_delvec_range = 0;
-        auto res = TabletMetaManager::list_del_vector(meta_store, tablet_id, max_expired_version + 1);
-        if (res.ok()) {
-            for (const auto& elem : *res) {
-                auto segment_id = elem.first;
-                auto end_version = elem.second;
-                (void)TabletMetaManager::delete_del_vector_range(meta_store, tablet_id, segment_id, 0, end_version);
-                VLOG(1) << "Removed delete vector tablet_id=" << tablet_id << " segment_id=" << segment_id
-                        << " start_version=0 end_version=" << end_version;
-            }
-            n_delvec_range = (*res).size();
+        auto res = TabletMetaManager::delete_del_vector_before_version(meta_store, tablet_id, min_readable_version);
+        size_t delvec_deleted = 0;
+        if (!res.ok()) {
+            LOG(WARNING) << "Fail to delete_del_vector_before_version tablet:" << tablet_id
+                         << " min_readable_version:" << min_readable_version << " msg:" << res.status();
         } else {
-            LOG(WARNING) << "Fail to list delete vector: " << res.status();
+            delvec_deleted = res.value();
         }
         LOG(INFO) << Substitute(
-                "remove_expired_versions $0 time:$1 max_expire_version:$2 deletes: #version:$3 #rowset:$4 "
-                "#delvecrange:$5",
-                _debug_version_info(true), expire_time, max_expired_version, expired_edit_version_infos.size(),
-                unused_rid.size(), n_delvec_range);
+                "remove_expired_versions $0 time:$1 min_readable_version:$2 deletes: #version:$3 #rowset:$4 "
+                "#delvec:$5",
+                _debug_version_info(true), expire_time, min_readable_version, expired_edit_version_infos.size(),
+                unused_rid.size(), delvec_deleted);
     }
     _remove_unused_rowsets();
 }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -293,7 +293,8 @@ private:
     // Find all but the latest already-applied versions whose creation time is less than or
     // equal to |expire_time|, then append them into |expire_list| and erase them from the
     // in-memory version list.
-    void _erase_expired_versions(int64_t expire_time, std::vector<std::unique_ptr<EditVersionInfo>>* expire_list);
+    void _erase_expired_versions(int64_t expire_time, std::vector<std::unique_ptr<EditVersionInfo>>* expire_list,
+                                 int64_t* min_readable_version);
 
     std::set<uint32_t> _active_rowsets();
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -849,10 +849,10 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     vectorized::TabletReader reader2(_tablet, Version(0, 2), schema);
     vectorized::TabletReader reader3(_tablet, Version(0, 3), schema);
     vectorized::TabletReader reader4(_tablet, Version(0, 4), schema);
-    auto iter_v0 = create_tablet_iterator(reader1, schema);
-    auto iter_v1 = create_tablet_iterator(reader2, schema);
-    auto iter_v2 = create_tablet_iterator(reader3, schema);
-    auto iter_v3 = create_tablet_iterator(reader4, schema);
+    auto iter_v1 = create_tablet_iterator(reader1, schema);
+    auto iter_v2 = create_tablet_iterator(reader2, schema);
+    auto iter_v3 = create_tablet_iterator(reader3, schema);
+    auto iter_v4 = create_tablet_iterator(reader4, schema);
 
     // Remove all but the last version.
     _tablet->updates()->remove_expired_versions(time(NULL));
@@ -860,12 +860,12 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     ASSERT_EQ(4, _tablet->updates()->max_version());
 
     EXPECT_EQ(N, read_tablet(_tablet, 4));
-    EXPECT_EQ(N, read_until_eof(iter_v3));
-    EXPECT_EQ(N, read_until_eof(iter_v2)); // delete vector v2 still valid.
-    EXPECT_EQ(0, read_until_eof(iter_v0)); // iter_v0 is empty iterator
+    EXPECT_EQ(N, read_until_eof(iter_v4));
+    EXPECT_EQ(0, read_until_eof(iter_v1)); // iter_v1 is empty iterator
 
     // Read expired versions should fail.
-    EXPECT_EQ(-1, read_until_eof(iter_v1));
+    EXPECT_EQ(-1, read_until_eof(iter_v3));
+    EXPECT_EQ(-1, read_until_eof(iter_v2));
     EXPECT_EQ(-1, read_tablet(_tablet, 3));
     EXPECT_EQ(-1, read_tablet(_tablet, 2));
     EXPECT_EQ(-1, read_tablet(_tablet, 1));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11405

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Rocksdb range deletes may cause range query to perform badly. Previously, delvec GC is performed by range delete delvecs of a segment of versions [0 to min_readable_version), this PR changes delvec GC logic to scan through all delvecs of a tablet, get all expired delvec keys, then perform a batch delete.  There is already a scan through delvecs before performing range delete, this PR just use the original scan, so it does not introduce any new overhead. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
