### PR TITLE
[Enhancement] Use the max_data_size of last recent partitions instead of average size in the calAvgBucketNumOfRecentPartitions()

### DIFF
--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -1056,7 +1056,8 @@ TEST_F(JsonScannerTest, test_column_2x_than_columns_with_json_root) {
     range.__set_path("./be/test/exec/test_data/json_scanner/test_ndjson_expanded_array.json");
     ranges.emplace_back(range);
 
-    auto scanner = create_json_scanner(types, ranges, {"k1", "kind", "keyname", "null_col1", "null_col2", "null_col3", "null_col4"});
+    auto scanner = create_json_scanner(types, ranges,
+                                       {"k1", "kind", "keyname", "null_col1", "null_col2", "null_col3", "null_col4"});
 
     Status st;
     st = scanner->open();
@@ -1066,11 +1067,16 @@ TEST_F(JsonScannerTest, test_column_2x_than_columns_with_json_root) {
     EXPECT_EQ(7, chunk->num_columns());
     EXPECT_EQ(5, chunk->num_rows());
 
-    EXPECT_EQ("['v1', 'server', {\"ip\": \"10.10.0.1\", \"value\": \"10\"}, NULL, NULL, NULL, NULL]", chunk->debug_row(0));
-    EXPECT_EQ("['v2', 'server', {\"ip\": \"10.10.0.2\", \"value\": \"20\"}, NULL, NULL, NULL, NULL]", chunk->debug_row(1));
-    EXPECT_EQ("['v3', 'server', {\"ip\": \"10.10.0.3\", \"value\": \"30\"}, NULL, NULL, NULL, NULL]", chunk->debug_row(2));
-    EXPECT_EQ("['v4', 'server', {\"ip\": \"10.10.0.4\", \"value\": \"40\"}, NULL, NULL, NULL, NULL]", chunk->debug_row(3));
-    EXPECT_EQ("['v5', 'server', {\"ip\": \"10.10.0.5\", \"value\": \"50\"}, NULL, NULL, NULL, NULL]", chunk->debug_row(4));
+    EXPECT_EQ("['v1', 'server', {\"ip\": \"10.10.0.1\", \"value\": \"10\"}, NULL, NULL, NULL, NULL]",
+              chunk->debug_row(0));
+    EXPECT_EQ("['v2', 'server', {\"ip\": \"10.10.0.2\", \"value\": \"20\"}, NULL, NULL, NULL, NULL]",
+              chunk->debug_row(1));
+    EXPECT_EQ("['v3', 'server', {\"ip\": \"10.10.0.3\", \"value\": \"30\"}, NULL, NULL, NULL, NULL]",
+              chunk->debug_row(2));
+    EXPECT_EQ("['v4', 'server', {\"ip\": \"10.10.0.4\", \"value\": \"40\"}, NULL, NULL, NULL, NULL]",
+              chunk->debug_row(3));
+    EXPECT_EQ("['v5', 'server', {\"ip\": \"10.10.0.5\", \"value\": \"50\"}, NULL, NULL, NULL, NULL]",
+              chunk->debug_row(4));
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -821,7 +821,7 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
 TEST_F(FileReaderTest, TestReadArray2dColumn) {
     auto file = _create_file(_file5_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                std::filesystem::file_size(_file5_path));
+                                                    std::filesystem::file_size(_file5_path));
 
     //init
     auto* ctx = _create_file5_base_context();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -972,18 +972,19 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         }
 
+        bucketNum = calBucketNumAccordingToBackends();
         if (!dataImported) {
-            bucketNum = calBucketNumAccordingToBackends();
             return bucketNum;
         }
 
         // 3. Use the totalSize of recentPartitions to speculate the bucketNum
-        long totalDataSize = 0;
+        long maxDataSize = 0;
         for (Partition partition : partitions) {
-            totalDataSize += partition.getDataSize();
+            maxDataSize = Math.max(maxDataSize, partition.getDataSize());
         }
         // A tablet will be regarded using the 1GB size
-        bucketNum = (int) (totalDataSize / (1024 * 1024 * 1024L));
+        // And also the number will not be larger than the calBucketNumAccordingToBackends()
+        bucketNum = (int) Math.min(bucketNum, maxDataSize / (1024 * 1024 * 1024L));
         if (bucketNum == 0) {
             bucketNum = 1;
         }


### PR DESCRIPTION
1. To alleviate the small tablet, speculate the tablet num according to the max_data_size.
2. The max table num of the partition must be guarantee not to be larger than calBucketNumAccordingToBackends()

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
