### PR TITLE
[Enhancement] Insert local shuffle only for enable tablet internal parallel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2018,7 +2018,9 @@ public class Coordinator {
      * @return Whether using the strategy of assigning scanRanges to each driver sequence.
      */
     private <T> boolean enableAssignScanRangesPerDriverSeq(List<T> scanRanges, int pipelineDop) {
-        return scanRanges.size() > pipelineDop / 2;
+        boolean enableTabletInternalParallel =
+                connectContext != null && connectContext.getSessionVariable().isEnableTabletInternalParallel();
+        return !enableTabletInternalParallel || scanRanges.size() > pipelineDop / 2;
     }
 
     public void computeColocatedJoinInstanceParam(Map<Integer, TNetworkAddress> bucketSeqToAddress,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -990,6 +990,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enablePipelineEngine = enablePipelineEngine;
     }
 
+    public boolean isEnableTabletInternalParallel() {
+        return enableTabletInternalParallel;
+    }
+
     public boolean isEnableResourceGroup() {
         return enableResourceGroup;
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for one-phase-local-agg, we insert a local shuffle between ScanNode and AggNode to make it possible parallel scan on the single tablet.
However, when disabling tablet internal parallel, this local shuffle is useless.

Therefore, only insert local shuffle when enable tablet internal parallel.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
