### PR TITLE
[cherry-pick][branch-2.2][Bugfix] Fix wrong result when process 'is null' in condition expr in dictionary optimization (#8869)

### DIFF
--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -275,9 +275,9 @@ Status DictOptimizeParser::_rewrite_expr_ctxs(std::vector<ExprContext*>* pexpr_c
     for (int i = 0; i < expr_ctxs.size(); ++i) {
         auto& expr_ctx = expr_ctxs[i];
         DictOptimizeContext dict_ctx;
-        _check_could_apply_dict_optimize(expr_ctx, &dict_ctx);
+        RETURN_IF_ERROR(_check_could_apply_dict_optimize(expr_ctx, &dict_ctx));
         if (dict_ctx.could_apply_dict_optimize) {
-            eval_expression(expr_ctx, &dict_ctx, slot_ids[i]);
+            RETURN_IF_ERROR(eval_expression(expr_ctx, &dict_ctx, slot_ids[i]));
             auto* dict_ctx_handle = _free_pool.add(new DictOptimizeContext(std::move(dict_ctx)));
             Expr* replaced_expr = _free_pool.add(new DictFuncExpr(*expr_ctx->root(), dict_ctx_handle));
 

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -161,7 +161,7 @@ public:
     // dictionary codes from the column |codes|.
     // |codes| must be of type `FixedLengthColumn<int32_t>` or `NullableColumn<FixedLengthColumn<int32_t>`
     // and assume no `null` value in |codes|.
-    Status decode_dict_codes(const vectorized::Column& codes, vectorized::Column* words);
+    virtual Status decode_dict_codes(const vectorized::Column& codes, vectorized::Column* words);
 
     // given a list of ordinals, fetch corresponding values.
     // |ordinals| must be ascending sorted.

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -125,39 +125,10 @@ public:
         return Status::NotSupported("GlobalDictCodeColumnIterator does not support next_dict_codes");
     }
 
+    Status decode_dict_codes(const vectorized::Column& codes, vectorized::Column* words) override;
+
     Status decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) override {
-        LowCardDictColumn::Container* container = nullptr;
-        bool output_nullable = words->is_nullable();
-
-        if (output_nullable) {
-            vectorized::ColumnPtr& data_column = down_cast<vectorized::NullableColumn*>(words)->data_column();
-            container = &down_cast<LowCardDictColumn*>(data_column.get())->get_data();
-        } else {
-            container = &down_cast<LowCardDictColumn*>(words)->get_data();
-        }
-
-        auto& res_data = *container;
-        res_data.resize(size);
-#ifndef NDEBUG
-        for (size_t i = 0; i < size; ++i) {
-            DCHECK(codes[i] <= vectorized::DICT_DECODE_MAX_SIZE);
-            if (codes[i] < 0) {
-                DCHECK(output_nullable);
-            }
-        }
-#endif
-        {
-            using namespace vectorized;
-            // res_data[i] = _local_to_global[codes[i]];
-            SIMDGather::gather(res_data.data(), _local_to_global, codes, DICT_DECODE_MAX_SIZE, size);
-        }
-
-        if (output_nullable) {
-            auto& null_data = down_cast<vectorized::NullableColumn*>(words)->null_column_data();
-            null_data.resize(size);
-        }
-
-        return Status::OK();
+        return Status::NotSupported("unsupport decode_dict_codes in GlobalDictCodeColumnIterator");
     }
 
     Status get_row_ranges_by_zone_map(const std::vector<const vectorized::ColumnPredicate*>& predicates,

--- a/be/src/storage/vectorized/column_predicate_dict_conjuct.cpp
+++ b/be/src/storage/vectorized/column_predicate_dict_conjuct.cpp
@@ -14,13 +14,17 @@ namespace starrocks::vectorized {
 
 // DictConjuctPredicateOperator for global dictionary optimization.
 // It converts all predicates into code mappings.
+// the null input will deal with 0
 // eg: where key = 'SR' will convert to
-// [0] "SR" -> true
-// [1] "RK" -> false
+// [0] NULL -> false
+// [1] "SR" -> true
+// [2] "RK" -> false
 //
+
 template <FieldType field_type>
 class DictConjuctPredicateOperator {
 public:
+    static constexpr bool skip_null = false;
     DictConjuctPredicateOperator(std::vector<uint8_t> code_mapping) : _code_mapping(std::move(code_mapping)) {}
 
     uint8_t eval_at(const LowCardDictColumn* lowcard_column, int idx) const {


### PR DESCRIPTION
cherry-pick #8869