### PR TITLE
[Feature] Implement HudiRemoteFileIO

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/RemotePathKey.java
@@ -3,18 +3,27 @@
 package com.starrocks.external;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class RemotePathKey {
     private final String path;
     private final boolean isRecursive;
 
+    // The table location must exist in HudiTable
+    private final Optional<String> hudiTableLocation;
+
     public static RemotePathKey of(String path, boolean isRecursive) {
-        return new RemotePathKey(path, isRecursive);
+        return new RemotePathKey(path, isRecursive, Optional.empty());
     }
 
-    public RemotePathKey(String path, boolean isRecursive) {
+    public static RemotePathKey of(String path, boolean isRecursive, Optional<String> hudiTableLocation) {
+        return new RemotePathKey(path, isRecursive, hudiTableLocation);
+    }
+
+    public RemotePathKey(String path, boolean isRecursive, Optional<String> hudiTableLocation) {
         this.path = path;
         this.isRecursive = isRecursive;
+        this.hudiTableLocation = hudiTableLocation;
     }
 
     public String getPath() {
@@ -25,6 +34,10 @@ public class RemotePathKey {
         return isRecursive;
     }
 
+    public Optional<String> getHudiTableLocation() {
+        return hudiTableLocation;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -33,20 +46,23 @@ public class RemotePathKey {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RemotePathKey that = (RemotePathKey) o;
-        return isRecursive == that.isRecursive && Objects.equals(path, that.path);
+        RemotePathKey pathKey = (RemotePathKey) o;
+        return isRecursive == pathKey.isRecursive &&
+                Objects.equals(path, pathKey.path) &&
+                Objects.equals(hudiTableLocation, pathKey.hudiTableLocation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, isRecursive);
+        return Objects.hash(path, isRecursive, hudiTableLocation);
     }
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("RemotePathKey{");
+        final StringBuilder sb = new StringBuilder("RemotePathKey{");
         sb.append("path='").append(path).append('\'');
         sb.append(", isRecursive=").append(isRecursive);
+        sb.append(", hudiTableLocation=").append(hudiTableLocation);
         sb.append('}');
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -205,7 +205,6 @@ public class CachingHiveMetastore implements IHiveMetastore {
                 Streams.stream(partitionNames).map(partitionName -> partitionName.getPartitionNames().get())
                         .collect(Collectors.toList()));
 
-
         ImmutableMap.Builder<NewHivePartitionName, Partition> partitions = ImmutableMap.builder();
         for (NewHivePartitionName partitionName : partitionNames) {
             partitions.put(partitionName, partitionsByNames.get(partitionName.getPartitionNames().get()));

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
@@ -66,7 +66,6 @@ public class HiveMetastoreApiConverter {
         return tableBuilder.build();
     }
 
-
     public static Partition toPartition(StorageDescriptor sd, Map<String, String> params) {
         requireNonNull(sd, "StorageDescriptor is null");
         Partition.Builder partitionBuilder = Partition.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
@@ -76,7 +76,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                         ImmutableList.copyOf(fileBlockDescs), ImmutableList.of()));
             }
         } catch (Exception e) {
-            throw new StarRocksConnectorException("Failed to get remote file's metadata on path: %s", pathKey);
+            throw new StarRocksConnectorException("Failed to get hive remote file's metadata on path: %s", pathKey);
         }
 
         return resultPartitions.put(pathKey, fileDescs).build();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
@@ -1,0 +1,81 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hudi;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.external.ObjectStorageUtils;
+import com.starrocks.external.RemoteFileDesc;
+import com.starrocks.external.RemoteFileIO;
+import com.starrocks.external.RemotePathKey;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.BaseFile;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class HudiRemoteFileIO implements RemoteFileIO {
+    private final Configuration configuration;
+
+    // table location -> HoodieTableMetaClient
+    private final Map<String, HoodieTableMetaClient> hudiClients = new ConcurrentHashMap<>();
+
+    public HudiRemoteFileIO(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
+        String tableLocation = pathKey.getHudiTableLocation().orElseThrow(() ->
+                new StarRocksConnectorException("Missing hudi table base location on %s", pathKey));
+
+        String partitionPath = ObjectStorageUtils.formatObjectStoragePath(pathKey.getPath());
+        String partitionName =  FSUtils.getRelativePartitionPath(new Path(tableLocation), new Path(partitionPath));
+
+        ImmutableMap.Builder<RemotePathKey, List<RemoteFileDesc>> resultPartitions = ImmutableMap.builder();
+        List<RemoteFileDesc> fileDescs = Lists.newArrayList();
+
+        HoodieTableMetaClient metaClient = hudiClients.computeIfAbsent(tableLocation, ignored ->
+                HoodieTableMetaClient.builder().setConf(configuration).setBasePath(tableLocation).build()
+        );
+
+        HoodieTimeline timeline = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants();
+        String globPath = String.format("%s/%s/*", metaClient.getBasePath(), partitionName);
+        try {
+            List<FileStatus> statuses = FSUtils.getGlobStatusExcludingMetaFolder(metaClient.getRawFs(), new Path(globPath));
+            HoodieTableFileSystemView fileSystemView = new HoodieTableFileSystemView(metaClient,
+                    timeline, statuses.toArray(new FileStatus[0]));
+            String queryInstant = timeline.lastInstant().get().getTimestamp();
+            Iterator<FileSlice> hoodieFileSliceIterator = fileSystemView
+                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, queryInstant).iterator();
+            while (hoodieFileSliceIterator.hasNext()) {
+                FileSlice fileSlice = hoodieFileSliceIterator.next();
+                Optional<HoodieBaseFile> baseFile = fileSlice.getBaseFile().toJavaOptional();
+                String fileName = baseFile.map(BaseFile::getFileName).orElse("");
+                long fileLength = baseFile.map(BaseFile::getFileLen).orElse(-1L);
+                List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
+                fileDescs.add(new RemoteFileDesc(fileName, "", fileLength,
+                        ImmutableList.of(), ImmutableList.copyOf(logs)));
+            }
+        } catch (Exception e) {
+            throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s", pathKey);
+        }
+        return resultPartitions.put(pathKey, fileDescs).build();
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Construct `HoodieTableMetaClient` need to use the table location. So each hudi table need to have  a `HoodieTableMetaClient` instance to pull remote file's metadata. If we want to pre-init and reuse the instance, we should cache `HoodieTableMetaClient` instance for each hudi table. So we add Optional\<String\> hudi table location to RemotePathKey.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
