### PR TITLE
[BugFix] Check the correctness of `UDF_RUNTIME_DIR` before removing it, avoid removing the system files in root directory

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -100,7 +100,9 @@ if [ ! -d $UDF_RUNTIME_DIR ]; then
     mkdir -p ${UDF_RUNTIME_DIR}
 fi
 
-rm -f ${UDF_RUNTIME_DIR}/*
+if [ ! -z ${UDF_RUNTIME_DIR} ]; then
+    rm -f ${UDF_RUNTIME_DIR}/*
+fi
 
 pidfile=$PID_DIR/be.pid
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
It is dangerous to execute `rm -f ${UDF_RUNTIME_DIR}/*` without any check in our start_be.sh.
If some unexpected error happend before this line, the `${UDF_RUNTIME_DIR}` may not be assigned as expected and it wil keep an empty string. As we don't exit the script now for any error, the `rm -f ${UDF_RUNTIME_DIR}/*` will continue to execute as `rm -f /*`, which will remove system files in root directory. It will make users crazy.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
