### PR TITLE
[BugFix] fix null aware anti join in not in subquery

### DIFF
--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -619,6 +619,11 @@ private:
     void _probe_from_ht_for_left_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
+    // for null aware anti join with other join conjunct
+    template <bool first_probe>
+    void _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
+                                                               const Buffer<CppType>& probe_data);
+
     // for one key right outer join with other conjunct
     template <bool first_probe>
     void _probe_from_ht_for_right_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -621,8 +621,9 @@ private:
 
     // for null aware anti join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
-                                                               const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_null_aware_anti_join_with_other_conjunct(RuntimeState* state,
+                                                                     const Buffer<CppType>& build_data,
+                                                                     const Buffer<CppType>& probe_data);
 
     // for one key right outer join with other conjunct
     template <bool first_probe>

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1468,6 +1468,8 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
     for (; i < probe_row_count; i++) {
         size_t build_index = _probe_state->next[i];
         if (build_index == 0) {
+            _probe_state->probe_index[match_count] = i;
+            _probe_state->build_index[match_count] = 0;
             if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
                 // when left table col value is null needs match all rows in right table
                 for (size_t j = 1; j < _table_items->row_count + 1; j++) {
@@ -1485,6 +1487,11 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
                     }
                 }
             }
+
+            if (match_count == 0) {
+                match_count++;
+            }
+
             continue;
         } else {
             // left table col value hits in hash table, we also need match null values firstly then match hit rows.

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1493,8 +1493,8 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = 0;
                 match_count++;
+                RETURN_IF_CHUNK_FULL()
             }
-            RETURN_IF_CHUNK_FULL()
             continue;
         } else {
             // left table col value hits in hash table, we also need match null values firstly then match hit rows.

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1432,6 +1432,22 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_wi
                 RETURN_IF_CHUNK_FULL()
             }
             continue;
+        } else {
+            // values hit in hash table, we also need match null values
+            if (_table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
+                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
+                auto& null_array = nullable_column->null_column()->get_data();
+                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
+                    if (null_array[j] == 1) {
+                        _probe_state->probe_index[match_count] = i;
+                        _probe_state->build_index[match_count] = j;
+                        _probe_state->probe_match_index[i]++;
+                        match_count++;
+                        _probe_state->cur_row_match_count++;
+                        RETURN_IF_CHUNK_FULL()
+                    }
+                }
+            }
         }
 
         while (build_index != 0) {

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1399,11 +1399,38 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_wi
     for (; i < probe_row_count; i++) {
         size_t build_index = _probe_state->next[i];
         if (build_index == 0) {
-            _probe_state->probe_index[match_count] = i;
-            _probe_state->build_index[match_count] = 0;
-            match_count++;
-
-            RETURN_IF_CHUNK_FULL()
+            if (_table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
+                if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
+                    // when probe value is null needs match all rows in right table
+                    for (size_t j = 1; j < _table_items->row_count + 1; j++) {
+                        _probe_state->probe_index[match_count] = i;
+                        _probe_state->build_index[match_count] = j;
+                        _probe_state->probe_match_index[i]++;
+                        match_count++;
+                        _probe_state->cur_row_match_count++;
+                        RETURN_IF_CHUNK_FULL()
+                    }
+                } else {
+                    // match all null value rows in right table
+                    auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
+                    auto& null_array = nullable_column->null_column()->get_data();
+                    for (size_t j = 1; j < _table_items->row_count + 1; j++) {
+                        if (null_array[j] == 1) {
+                            _probe_state->probe_index[match_count] = i;
+                            _probe_state->build_index[match_count] = j;
+                            _probe_state->probe_match_index[i]++;
+                            match_count++;
+                            _probe_state->cur_row_match_count++;
+                            RETURN_IF_CHUNK_FULL()
+                        }
+                    }
+                }
+            } else {
+                _probe_state->probe_index[match_count] = i;
+                _probe_state->build_index[match_count] = 0;
+                match_count++;
+                RETURN_IF_CHUNK_FULL()
+            }
             continue;
         }
 
@@ -1419,6 +1446,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_wi
             }
             build_index = _table_items->next[build_index];
         }
+
         if (_probe_state->cur_row_match_count <= 0) {
             _probe_state->probe_index[match_count] = i;
             _probe_state->build_index[match_count] = 0;

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1489,7 +1489,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
                 }
             }
 
-            if (change_flag) {
+            if (!change_flag) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = 0;
                 match_count++;

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -2401,9 +2401,9 @@ TEST_F(JoinHashMapTest, NullAwareAntiJoinTest) {
     table_items.first.resize(build_row_count + 1, 0);
     table_items.next.resize(build_row_count + 1);
     table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
-    auto build_col_nulls = create_bools(build_row_count, 3);
+    auto build_col_nulls = create_bools(build_row_count + 1, 3);
     auto column_1 = create_nullable_column(TYPE_INT);
-    column_1->append(*create_nullable_column(TYPE_INT, build_col_nulls, 0, build_row_count));
+    column_1->append(*create_nullable_column(TYPE_INT, build_col_nulls, 0, build_row_count + 1));
     table_items.key_columns.emplace_back(column_1);
     table_items.join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
     table_items.row_count = build_row_count;

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -115,7 +115,7 @@ Buffer<uint8_t> JoinHashMapTest::create_bools(uint32_t count, int32_t flag) {
     }
 
     if (flag == 1) {
-        // all 0
+        // all 1
         for (uint32_t i = 0; i < count; i++) {
             nulls[i] = 1;
         }
@@ -2388,6 +2388,48 @@ TEST_F(JoinHashMapTest, EmptyHashMapTest) {
     check_empty_hash_map(TJoinOp::RIGHT_OUTER_JOIN, 5, 0, 0);
     check_empty_hash_map(TJoinOp::RIGHT_ANTI_JOIN, 5, 0, 0);
     check_empty_hash_map(TJoinOp::CROSS_JOIN, 5, 0, 0);
+}
+
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, NullAwareAntiJoinTest) {
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    uint32_t build_row_count = 4;
+    uint32_t probe_row_count = 3;
+
+    table_items.first.resize(build_row_count + 1, 0);
+    table_items.next.resize(build_row_count + 1);
+    table_items.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
+    auto build_col_nulls = create_bools(build_row_count, 3);
+    auto column_1 = create_nullable_column(TYPE_INT);
+    column_1->append(*create_nullable_column(TYPE_INT, build_col_nulls, 0, build_row_count));
+    table_items.key_columns.emplace_back(column_1);
+    table_items.join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
+    table_items.row_count = build_row_count;
+
+    auto probe_col_nulls = create_bools(build_row_count, 3);
+
+    probe_state.null_array = &probe_col_nulls;
+    prepare_probe_state(&probe_state, probe_row_count);
+    for (size_t i = 0; i < probe_row_count; i++) {
+        probe_state.next[i] = 0;
+    }
+
+    Buffer<int32_t> build_data;
+    Buffer<int32_t> probe_data;
+    this->prepare_probe_data(&build_data, build_row_count);
+    this->prepare_probe_data(&probe_data, probe_row_count);
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+    join_hash_map->_probe_from_ht_for_null_aware_anti_join_with_other_conjunct<true>(
+            _runtime_state.get(), build_data,probe_data);
+
+    // null in probe table match all build table rows
+    ASSERT_EQ(probe_state.probe_match_index[0], build_row_count);
+    // value in probe table not hit hash table match all null value rows in build table
+    ASSERT_EQ(probe_state.probe_match_index[1], 1);
+
 }
 
 } // namespace starrocks::vectorized

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -15,6 +15,14 @@ public class SubqueryTest extends PlanTestBase {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Test
+    public void test() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        String sql = "select v1 from t0 left join t1 on (v1 = v4)   left join t2 on (v2 = v8)";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+    }
+
+    @Test
     public void testCorrelatedSubqueryWithEqualsExpressions() throws Exception {
         String sql = "select t0.v1 from t0 where (t0.v2 in (select t1.v4 from t1 where t0.v3 + t1.v5 = 1)) is NULL";
         String plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -15,14 +15,6 @@ public class SubqueryTest extends PlanTestBase {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Test
-    public void test() throws Exception {
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
-        String sql = "select v1 from t0 left join t1 on (v1 = v4)   left join t2 on (v2 = v8)";
-        String plan = getFragmentPlan(sql);
-        System.out.println(plan);
-    }
-
-    @Test
     public void testCorrelatedSubqueryWithEqualsExpressions() throws Exception {
         String sql = "select t0.v1 from t0 where (t0.v2 in (select t1.v4 from t1 where t0.v3 + t1.v5 = 1)) is NULL";
         String plan = getFragmentPlan(sql);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#7043](https://github.com/StarRocks/starrocks/issues/7043)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This pr fix null aware anti join (NAAJ) in not in correlated subquery.
Firstly, let us review the steps in processing NAAJ. We use the below sql for example.
```
select * from t1 where t1.c not in (select t2.c from t2 where t1.x + t2.y = 10)
```
1. If `t1.x + t2.y = 10` is false or unknown, the subquery returns empty set, then return all the rows of t1.
2. If `t1.x + t2.y = 10` is true and `t2.c` contains null value, then return no rows of t1.
3. If `t1.c` is null,  then do not return this row in t1.
The above three rules priority from high to low.


In the previous version, we don't process rows in t1 with`t1.c is null` and rows in t2 with `t2.c is null` correctly. We always return `t1.c is null` rows even when subquery returns rows and not discard t1 rows when subquery query return rows with `t2.c is null`. It this pr, we consider the null value. When `t1.c is null` we combine this row with all rows in t2. When `t1.c is not null` when combine this row with all `t2.c is null` rows and `t2.c = t1.c` rows.

Some examples for explanation:
```
mysql> select * from t0;
+------+------+------+
| v1   | v2   | v3   |
+------+------+------+
|    3 |    1 |    1 |
| NULL |    1 |    1 |
|    1 |    1 |    1 |
+------+------+------+
3 rows in set (0.03 sec)

mysql> select * from t1;
+------+------+------+
| v4   | v5   | v6   |
+------+------+------+
| NULL |    4 | NULL |
|    2 |    2 |    2 |
|    1 |    3 | NULL |
|    1 |    2 |    1 |
+------+------+------+
4 rows in set (0.02 sec)

# (null, 1, 1) in t0 should not return, because subquery returns (2,1) when t0.v2 = 1.
mysql> select * from t0 where v1 not in (select v4 from t1 where v2 + v5 = 3 );
+------+------+------+
| v1   | v2   | v3   |
+------+------+------+
|    3 |    1 |    1 |
+------+------+------+
1 row in set (0.05 sec)

# (1, 1, 1) in t0 should not return , because subquery returns (null) when t0.v2 = 1
mysql> select * from t0 where v1 not in (select v4 from t1 where v2 + v5 = 5 );
Empty set (0.05 sec)
```




## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
