### PR TITLE
[Cherry-Pick-2.3][BugFix] Fix set replica status bug after changed to new parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AdminSetReplicaStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AdminSetReplicaStatusStmt.java
@@ -115,6 +115,18 @@ public class AdminSetReplicaStatusStmt extends DdlStmt {
         return status;
     }
 
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    public void setBackendId(long backendId) {
+        this.backendId = backendId;
+    }
+
+    public void setStatus(ReplicaStatus status) {
+        this.status = status;
+    }
+
     @Override
     public RedirectStatus getRedirectStatus() {
         return RedirectStatus.FORWARD_WITH_SYNC;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminSetReplicaStatusStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminSetReplicaStatusStmtAnalyzer.java
@@ -54,6 +54,9 @@ public class AdminSetReplicaStatusStmtAnalyzer {
             if (tabletId == -1 || backendId == -1 || status == null) {
                 throw new SemanticException("Should add following properties: TABLET_ID, BACKEND_ID and STATUS");
             }
+            adminSetReplicaStatusStmt.setTabletId(tabletId);
+            adminSetReplicaStatusStmt.setBackendId(backendId);
+            adminSetReplicaStatusStmt.setStatus(status);
             return null;
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Cherry-Pick the bug fix code from PR #8963.
Set the tabletId/backendId/status to AdminSetReplicaStatusStmt after visiting the properties

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
