### PR TITLE
[Feature] Implement CachingRemoteFileIO

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
@@ -1,0 +1,76 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class CachingRemoteFileIO implements RemoteFileIO {
+    public static final long NEVER_EVICT = -1;
+    public static final long NEVER_REFRESH = -1;
+    private final RemoteFileIO fileIO;
+    private final LoadingCache<RemotePathKey, List<RemoteFileDesc>> cache;
+
+    public CachingRemoteFileIO(RemoteFileIO fileIO,
+                               Executor executor,
+                               long expireAfterWriteSec,
+                               long refreshIntervalSec,
+                               long maxSize) {
+        this.fileIO = fileIO;
+        this.cache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadRemoteFiles), executor));
+    }
+
+    public static CachingRemoteFileIO reuseRemoteFileIO(RemoteFileIO fileIO, long maxSize) {
+        return new CachingRemoteFileIO(
+                fileIO,
+                newDirectExecutorService(),
+                NEVER_EVICT,
+                NEVER_REFRESH,
+                maxSize);
+    }
+
+    public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
+        try {
+            return ImmutableMap.of(pathKey, cache.getUnchecked(pathKey));
+        } catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), StarRocksConnectorException.class);
+            throw e;
+        }
+    }
+
+    public Map<RemotePathKey, List<RemoteFileDesc>> getPresentRemoteFiles(List<RemotePathKey> paths) {
+        return cache.getAllPresent(paths);
+    }
+
+    private List<RemoteFileDesc> loadRemoteFiles(RemotePathKey pathKey) {
+        return fileIO.getRemoteFiles(pathKey).get(pathKey);
+    }
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteSec >= 0) {
+            cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
+        }
+
+        if (refreshSec > 0 && expiresAfterWriteSec > refreshSec) {
+            cacheBuilder.refreshAfterWrite(refreshSec, SECONDS);
+        }
+
+        cacheBuilder.maximumSize(maximumSize);
+        return cacheBuilder;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/external/CachingRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/CachingRemoteFileIOTest.java
@@ -1,0 +1,60 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.external.hive.HiveRemoteFileIO;
+import com.starrocks.external.hive.MockedRemoteFileSystem;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.starrocks.external.hive.MockedRemoteFileSystem.TEST_FILES;
+
+public class CachingRemoteFileIOTest {
+
+    @Test
+    public void testGetHiveRemoteFiles() {
+        HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
+        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        hiveRemoteFileIO.setFileSystem(fs);
+        FeConstants.runningUnitTest = true;
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executor, 10, 10, 10);
+
+        String tableLocation = "hdfs://fake:9000/db_name/table_name";
+        RemotePathKey pathKey = RemotePathKey.of(tableLocation, false);
+        Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = cachingFileIO.getRemoteFiles(pathKey);
+        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);
+        Assert.assertNotNull(fileDescs);
+        Assert.assertEquals(1, fileDescs.size());
+        RemoteFileDesc fileDesc = fileDescs.get(0);
+        Assert.assertNotNull(fileDesc);
+        Assert.assertEquals("000000_0", fileDesc.getFileName());
+        Assert.assertEquals("", fileDesc.getCompression());
+        Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertFalse(fileDesc.isSplittable());
+        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+
+        List<RemoteFileBlockDesc> blockDescs = fileDesc.getBlockDescs();
+        Assert.assertEquals(1, blockDescs.size());
+        RemoteFileBlockDesc blockDesc = blockDescs.get(0);
+        Assert.assertEquals(0, blockDesc.getOffset());
+        Assert.assertEquals(20, blockDesc.getLength());
+        Assert.assertEquals(2, blockDesc.getReplicaHostIds().length);
+
+        CachingRemoteFileIO queryLevelCache = CachingRemoteFileIO.reuseRemoteFileIO(cachingFileIO, 5);
+        Assert.assertEquals(1, queryLevelCache.getRemoteFiles(pathKey).size());
+
+        Map<RemotePathKey, List<RemoteFileDesc>> presentRemoteFileInfos =
+                cachingFileIO.getPresentRemoteFiles(Lists.newArrayList(pathKey));
+        Assert.assertEquals(1, presentRemoteFileInfos.size());
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`CahcingRemoteFileIO` mainly to use `HiveRemoteFileIO` or `HudiRemoteFileIO` to pull remote file's metadata from hdfs or s3. The `CachingRemoteFileIO#getRemoteFiles(RemotePathKey pathKey)` can be used in parallel.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
