### PR TITLE
[BugFix] Make The column TABLE_TYPE of information_schema.tables match the mysql definition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -233,7 +233,7 @@ public class InformationSchemaDataSource {
                         info.setTable_catalog(DEF);
                         info.setTable_schema(dbName);
                         info.setTable_name(table.getName());
-                        info.setTable_type(table.getType().toString());
+                        info.setTable_type(transferTableTypeToAdaptMysql(table.getType()));
                         info.setEngine(table.getEngine());
                         info.setVersion(DEF_NULL_NUM);
                         info.setRow_format(DEF_NULL);
@@ -277,6 +277,32 @@ public class InformationSchemaDataSource {
         });    
         response.setTables_infos(infos);
         return response;
+    }
+
+    private static String transferTableTypeToAdaptMysql(TableType tableType) {
+        // 'BASE TABLE','SYSTEM VERSIONED','PARTITIONED TABLE','VIEW','FOREIGN TABLE','MATERIALIZED VIEW','EXTERNAL TABLE'
+        switch (tableType) {
+            case MYSQL:
+            case HIVE:
+            case ICEBERG:
+            case HUDI:
+            case LAKE:
+            case ELASTICSEARCH:
+            case JDBC:
+                return "EXTERNAL TABLE";
+            case OLAP:
+            case OLAP_EXTERNAL:
+                return "BASE TABLE";
+            case MATERIALIZED_VIEW:
+                return "MATERIALIZED VIEW";
+            case VIEW:
+                return "VIEW";
+            default:
+                // SCHEMA
+                // INLINE_VIEW
+                // BROKER
+                return "BASE TABLE";
+        }
     }
 
     private static TTableInfo genNormalTableInfo(Table table, TTableInfo info) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -12,6 +12,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Table.TableType;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
@@ -32,6 +33,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -181,5 +184,46 @@ public class InformationSchemaDataSourceTest {
                 Assert.assertTrue(info.getUpdate_time() == -1L);
             }
         });
+    }
+
+    @Test
+    public void testTransferTableTypeToAdaptMysql() throws NoSuchMethodException, 
+                                                            SecurityException, 
+                                                            IllegalAccessException,
+                                                            IllegalArgumentException, 
+                                                            InvocationTargetException, 
+                                                            ClassNotFoundException {
+
+        Class<?> clazz = Class.forName(InformationSchemaDataSource.class.getName());
+        Method m = clazz.getDeclaredMethod("transferTableTypeToAdaptMysql", TableType.class);
+        m.setAccessible(true);
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.MYSQL)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.HIVE)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.ICEBERG)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.HUDI)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.LAKE)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.ELASTICSEARCH)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.JDBC)).
+                equals("EXTERNAL TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.OLAP)).
+                equals("BASE TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.OLAP_EXTERNAL)).
+                equals("BASE TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.MATERIALIZED_VIEW)).
+                equals("MATERIALIZED VIEW"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.VIEW)).
+                equals("VIEW"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.SCHEMA)).
+                equals("BASE TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.INLINE_VIEW)).
+                equals("BASE TABLE"));
+        Assert.assertTrue(((String) m.invoke(InformationSchemaDataSource.class, TableType.BROKER)).
+                equals("BASE TABLE"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -154,7 +154,7 @@ public class InformationSchemaDataSourceTest {
                 Assert.assertTrue(info.getTable_catalog().equals("def"));
                 Assert.assertTrue(info.getTable_schema().equals("test_db"));
                 Assert.assertTrue(info.getTable_name().equals("test_table_pk"));
-                Assert.assertTrue(info.getTable_type().equals("OLAP"));
+                Assert.assertTrue(info.getTable_type().equals("BASE TABLE"));
                 Assert.assertTrue(info.getEngine().equals("StarRocks"));
                 Assert.assertTrue(info.getVersion() == -1L);
                 Assert.assertTrue(info.getRow_format().equals("NULL"));
@@ -174,6 +174,7 @@ public class InformationSchemaDataSourceTest {
                 Assert.assertTrue(info.getTable_comment().equals("test_comment"));
             } 
             if (info.getTable_name().equals("test_view")) {
+                Assert.assertTrue(info.getTable_type().equals("VIEW"));
                 Assert.assertTrue(info.getTable_rows() == -1L);
                 Assert.assertTrue(info.getAvg_row_length() == -1L);
                 Assert.assertTrue(info.getData_length() == -1L);


### PR DESCRIPTION
…ql definition

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11506

Make The column TABLE_TYPE of information_schema.tables match the mysql definition
This issue  just introduced in main
Maybe it is not a bug, SR has some custom table types, but in order to adapt to some more BI tools, table type must correspond to the definition of mysql

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
