### PR TITLE
[Feature] Implement HiveMetastoreOperations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/Utils.java
@@ -19,6 +19,8 @@ import org.apache.hadoop.hive.common.StatsSetupConst;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
 
 import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
@@ -157,5 +159,13 @@ public class Utils {
             // ignore
         }
         return -1;
+    }
+
+    public static <T> void executeInNewThread(String threadName, Callable<T> callable) {
+        FutureTask<T> task = new FutureTask<>(callable);
+        Thread thread = new Thread(task);
+        thread.setName(threadName);
+        thread.setDaemon(true);
+        thread.start();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -221,7 +221,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     @Override
-    public Map<String, HivePartitionStatistics> getPartitionsStatistics(Table table, List<String> partitionNames) {
+    public Map<String, HivePartitionStatistics> getPartitionStatistics(Table table, List<String> partitionNames) {
         String dbName = ((HiveMetaStoreTable) table).getDbName();
         String tblName = ((HiveMetaStoreTable) table).getTableName();
 
@@ -246,7 +246,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         Table table = getTable(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
         Preconditions.checkState(hivePartitionName.getPartitionNames().isPresent(), "hive partition name is missing");
         Map<String, HivePartitionStatistics> partitionsStatistics = metastore
-                .getPartitionsStatistics(table, Lists.newArrayList(hivePartitionName.getPartitionNames().get()));
+                .getPartitionStatistics(table, Lists.newArrayList(hivePartitionName.getPartitionNames().get()));
 
         return partitionsStatistics.get(hivePartitionName.getPartitionNames().get());
     }
@@ -256,7 +256,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         NewHivePartitionName hivePartitionName = Iterables.get(partitionNames, 0);
         Table table = getTable(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
 
-        Map<String, HivePartitionStatistics> partitionsStatistics =  metastore.getPartitionsStatistics(table,
+        Map<String, HivePartitionStatistics> partitionsStatistics =  metastore.getPartitionStatistics(table,
                 Streams.stream(partitionNames).map(partitionName -> partitionName.getPartitionNames().get())
                         .collect(Collectors.toList()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
@@ -107,7 +107,7 @@ public class HiveMetastore implements IHiveMetastore {
         return new HivePartitionStatistics(commonStats, columnStatistics);
     }
 
-    public Map<String, HivePartitionStatistics> getPartitionsStatistics(Table table, List<String> partitionNames) {
+    public Map<String, HivePartitionStatistics> getPartitionStatistics(Table table, List<String> partitionNames) {
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
         String dbName = hmsTbl.getDbName();
         String tblName = hmsTbl.getTableName();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreOperations.java
@@ -1,0 +1,88 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveMetaStoreTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.external.Utils;
+import org.apache.hadoop.hive.common.FileUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class HiveMetastoreOperations {
+    private final CachingHiveMetastore metastore;
+
+    public HiveMetastoreOperations(CachingHiveMetastore cachingHiveMetastore) {
+        this.metastore = cachingHiveMetastore;
+    }
+
+    public List<String> getAllDatabaseNames() {
+        return metastore.getAllDatabaseNames();
+    }
+
+    public List<String> getAllTableNames(String dbName) {
+        return metastore.getAllTableNames(dbName);
+    }
+
+    public List<String> getPartitionKeys(String dbName, String tableName) {
+        return metastore.getPartitionKeys(dbName, tableName);
+    }
+
+    public Database getDb(String dbName) {
+        return metastore.getDb(dbName);
+    }
+
+    public Table getTable(String dbName, String tableName) {
+        return metastore.getTable(dbName, tableName);
+    }
+
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        return metastore.getPartition(dbName, tableName, partitionValues);
+    }
+
+    public Map<String, Partition> getPartitionsByNames(Table table, List<PartitionKey> partitionKeys) {
+        String dbName = ((HiveMetaStoreTable) table).getDbName();
+        String tblName = ((HiveMetaStoreTable) table).getTableName();
+        List<String> partitionColumnNames = ((HiveMetaStoreTable) table).getPartitionColumnNames();
+        List<String> partitionNames = partitionKeys.stream()
+                .map(partitionKey ->
+                        FileUtils.makePartName(partitionColumnNames, Utils.getPartitionValues(partitionKey)))
+                .collect(Collectors.toList());
+
+        return metastore.getPartitionsByNames(dbName, tblName, partitionNames);
+    }
+
+    public HivePartitionStatistics getTableStatistics(String dbName, String tblName) {
+        return metastore.getTableStatistics(dbName, tblName);
+    }
+
+    public Map<String, HivePartitionStatistics> getPartitionStatistics(Table table, List<String> partitionNames) {
+        String catalogName = ((HiveMetaStoreTable) table).getCatalogName();
+        String dbName = ((HiveMetaStoreTable) table).getDbName();
+        String tblName = ((HiveMetaStoreTable) table).getTableName();
+        List<NewHivePartitionName> hivePartitionNames = partitionNames.stream()
+                .map(partitionName -> NewHivePartitionName.of(dbName, tblName, partitionName))
+                .peek(hivePartitionName -> checkState(hivePartitionName.getPartitionNames().isPresent(),
+                        "partition name is missing"))
+                .collect(Collectors.toList());
+
+        Map<String, HivePartitionStatistics> presentPartitionStatsInCache =
+                metastore.getPresentPartitionsStatistics(hivePartitionNames);
+
+        if (presentPartitionStatsInCache.size() == partitionNames.size()) {
+            return presentPartitionStatsInCache;
+        }
+
+        String backgroundThreadName = String.format("background-get-partitions-statistics-%s-%s-%s",
+                catalogName, dbName, tblName);
+        Utils.executeInNewThread(backgroundThreadName, () -> metastore.getPartitionStatistics(table, partitionNames));
+
+        return presentPartitionStatsInCache;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/IHiveMetastore.java
@@ -26,5 +26,5 @@ public interface IHiveMetastore {
 
     HivePartitionStatistics getTableStatistics(String dbName, String tblName);
 
-    Map<String, HivePartitionStatistics> getPartitionsStatistics(Table table, List<String> partitions);
+    Map<String, HivePartitionStatistics> getPartitionStatistics(Table table, List<String> partitions);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
@@ -137,7 +137,7 @@ public class HiveMetastoreTest {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog");
         com.starrocks.catalog.Table hiveTable = metastore.getTable("db1", "table1");
-        Map<String, HivePartitionStatistics> statistics = metastore.getPartitionsStatistics(
+        Map<String, HivePartitionStatistics> statistics = metastore.getPartitionStatistics(
                 hiveTable, Lists.newArrayList("col1=1", "col1=2"));
 
         HivePartitionStatistics stats1 = statistics.get("col1=1");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- HiveMetastoreOperations is the query-level instance. 
- It include query-level's `CachingHiveMetastore` instance and use it to get hive metastore metadata.
- It will only get present partition statistics in cache to prevent the timeout of cbo. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
