### PR TITLE
[Feature] Implement RemoteFileOperations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
@@ -52,12 +52,12 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         }
     }
 
-    public Map<RemotePathKey, List<RemoteFileDesc>> getPresentRemoteFiles(List<RemotePathKey> paths) {
-        return cache.getAllPresent(paths);
-    }
-
     private List<RemoteFileDesc> loadRemoteFiles(RemotePathKey pathKey) {
         return fileIO.getRemoteFiles(pathKey).get(pathKey);
+    }
+
+    public Map<RemotePathKey, List<RemoteFileDesc>> getPresentRemoteFiles(List<RemotePathKey> paths) {
+        return cache.getAllPresent(paths);
     }
 
     private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileInfo.java
@@ -2,5 +2,67 @@
 
 package com.starrocks.external;
 
+import com.starrocks.external.hive.RemoteFileInputFormat;
+
+import java.util.List;
+
 public class RemoteFileInfo {
+    private RemoteFileInputFormat format;
+    private List<RemoteFileDesc> files;
+    private final String fullPath;
+
+    public RemoteFileInfo(RemoteFileInputFormat format, List<RemoteFileDesc> files, String fullPath) {
+        this.format = format;
+        this.files = files;
+        this.fullPath = fullPath;
+    }
+
+    public RemoteFileInputFormat getFormat() {
+        return format;
+    }
+
+    public void setFormat(RemoteFileInputFormat format) {
+        this.format = format;
+    }
+
+    public List<RemoteFileDesc> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<RemoteFileDesc> files) {
+        this.files = files;
+    }
+
+    public String getFullPath() {
+        return fullPath;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private RemoteFileInputFormat format;
+        private List<RemoteFileDesc> files;
+        private String fullPath;
+
+        public Builder setFormat(RemoteFileInputFormat format) {
+            this.format = format;
+            return this;
+        }
+
+        public Builder setFiles(List<RemoteFileDesc> files) {
+            this.files = files;
+            return this;
+        }
+
+        public Builder setFullPath(String fullPath) {
+            this.fullPath = fullPath;
+            return this;
+        }
+
+        public RemoteFileInfo build() {
+            return new RemoteFileInfo(format, files, fullPath);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileOperations.java
@@ -1,0 +1,106 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external;
+
+import com.google.common.collect.Lists;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.external.hive.Partition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class RemoteFileOperations {
+    protected CachingRemoteFileIO remoteFileIO;
+    private final ExecutorService executor;
+    private final boolean isRecursive;
+
+    public RemoteFileOperations(CachingRemoteFileIO remoteFileIO, ExecutorService executor, boolean isRecursive) {
+        this.remoteFileIO = remoteFileIO;
+        this.executor = executor;
+        this.isRecursive = isRecursive;
+    }
+
+    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions) {
+        return getRemoteFiles(partitions, Optional.empty());
+    }
+
+    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Optional<String> hudiTableLocation) {
+        Map<RemotePathKey, Partition> pathKeyToPartition = partitions.stream()
+                .collect(Collectors.toMap(
+                        partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation),
+                        Function.identity()));
+
+        List<RemoteFileInfo> resultRemoteFiles = Lists.newArrayList();
+        List<Future<Map<RemotePathKey, List<RemoteFileDesc>>>> futures = Lists.newArrayList();
+        for (Partition partition : partitions) {
+            RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
+            Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = executor.submit(() -> remoteFileIO.getRemoteFiles(pathKey));
+            futures.add(future);
+        }
+
+        List<Map<RemotePathKey, List<RemoteFileDesc>>> result = Lists.newArrayList();
+        for (Future<Map<RemotePathKey, List<RemoteFileDesc>>> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                throw new StarRocksConnectorException("Failed to get remote files, msg: %s", e.getMessage());
+            }
+        }
+
+        for (Map<RemotePathKey, List<RemoteFileDesc>> pathToDesc : result) {
+            resultRemoteFiles.addAll(fillFileInfo(pathToDesc, pathKeyToPartition));
+        }
+
+        return resultRemoteFiles;
+    }
+
+    public List<RemoteFileInfo> getPresentFilesInCache(Collection<Partition> partitions) {
+        return getPresentFilesInCache(partitions, Optional.empty());
+    }
+
+    public List<RemoteFileInfo> getPresentFilesInCache(Collection<Partition> partitions, Optional<String> hudiTableLocation) {
+        Map<RemotePathKey, Partition> pathKeyToPartition = partitions.stream()
+                .collect(Collectors.toMap(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation),
+                        Function.identity()));
+
+        List<RemotePathKey> paths = partitions.stream()
+                .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation))
+                .collect(Collectors.toList());
+
+        Map<RemotePathKey, List<RemoteFileDesc>> presentFiles = remoteFileIO.getPresentRemoteFiles(paths);
+        return fillFileInfo(presentFiles, pathKeyToPartition);
+    }
+
+    private List<RemoteFileInfo> fillFileInfo(
+            Map<RemotePathKey, List<RemoteFileDesc>> files,
+            Map<RemotePathKey, Partition> partitions) {
+        List<RemoteFileInfo> result = Lists.newArrayList();
+        for (Map.Entry<RemotePathKey, List<RemoteFileDesc>> entry : files.entrySet()) {
+            RemotePathKey key = entry.getKey();
+            List<RemoteFileDesc> remoteFileDescs = entry.getValue();
+            Partition partition = partitions.get(key);
+            result.add(buildRemoteFileInfo(partition, remoteFileDescs));
+        }
+
+        return result;
+    }
+
+    private RemoteFileInfo buildRemoteFileInfo(Partition partition, List<RemoteFileDesc> fileDescs) {
+        RemoteFileInfo.Builder builder = RemoteFileInfo.builder()
+                .setFormat(partition.getInputFormat())
+                .setFullPath(partition.getFullPath())
+                .setFiles(fileDescs.stream()
+                        .map(desc -> desc.setTextFileFormatDesc(partition.getTextFileFormatDesc()))
+                        .map(desc -> desc.setSplittable(partition.isSplittable()))
+                        .collect(Collectors.toList()));
+
+        return builder.build();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/Utils.java
@@ -12,6 +12,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.external.hive.HiveMetaClient;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -122,8 +123,10 @@ public class Utils {
     }
 
     public static String getSuffixName(String dirPath, String filePath) {
-        Preconditions.checkArgument(filePath.startsWith(dirPath),
-                "dirPath " + dirPath + " should be prefix of filePath " + filePath);
+        if (!FeConstants.runningUnitTest) {
+            Preconditions.checkArgument(filePath.startsWith(dirPath),
+                    "dirPath " + dirPath + " should be prefix of filePath " + filePath);
+        }
 
         String name = filePath.replaceFirst(dirPath, "");
         if (name.startsWith("/")) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,6 +31,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class HiveRemoteFileIO implements RemoteFileIO {
+    private static final Logger LOG = LogManager.getLogger(HiveRemoteFileIO.class);
+
     private final Configuration configuration;
 
     // only used for ut.
@@ -76,6 +80,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                         ImmutableList.copyOf(fileBlockDescs), ImmutableList.of()));
             }
         } catch (Exception e) {
+            LOG.error("Failed to get hive remote file's metadata on path: {}", path, e);
             throw new StarRocksConnectorException("Failed to get hive remote file's metadata on path: %s", pathKey);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/RemoteFileOperationsTest.java
@@ -4,8 +4,13 @@ package com.starrocks.external;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
+import com.starrocks.external.hive.HiveMetaClient;
+import com.starrocks.external.hive.HiveMetastore;
+import com.starrocks.external.hive.HiveMetastoreTest;
 import com.starrocks.external.hive.HiveRemoteFileIO;
 import com.starrocks.external.hive.MockedRemoteFileSystem;
+import com.starrocks.external.hive.Partition;
+import com.starrocks.external.hive.RemoteFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Assert;
@@ -18,30 +23,44 @@ import java.util.concurrent.Executors;
 
 import static com.starrocks.external.hive.MockedRemoteFileSystem.TEST_FILES;
 
-public class CachingRemoteFileIOTest {
-
+public class RemoteFileOperationsTest {
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
         FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
-        ExecutorService executor = Executors.newFixedThreadPool(5);
-        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executor, 10, 10, 10);
+        ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
+        ExecutorService executorToLoad = Executors.newFixedThreadPool(5);
+
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
+        RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, false);
 
         String tableLocation = "hdfs://127.0.0.1:10000/hive.db/hive_tbl";
         RemotePathKey pathKey = RemotePathKey.of(tableLocation, false);
-        Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = cachingFileIO.getRemoteFiles(pathKey);
-        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);
+
+        HiveMetaClient client = new HiveMetastoreTest.MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog");
+        List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
+        Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
+
+        List<RemoteFileInfo> remoteFileInfos = ops.getRemoteFiles(Lists.newArrayList(partitions.values()));
+        Assert.assertEquals(2, remoteFileInfos.size());
+
+        RemoteFileInfo fileInfo = remoteFileInfos.get(0);
+        Assert.assertEquals(RemoteFileInputFormat.PARQUET, fileInfo.getFormat());
+        Assert.assertEquals("hdfs://127.0.0.1:10000/hive.db/hive_tbl/col1=1", fileInfo.getFullPath());
+
+        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(0).getFiles();
         Assert.assertNotNull(fileDescs);
         Assert.assertEquals(1, fileDescs.size());
+
         RemoteFileDesc fileDesc = fileDescs.get(0);
         Assert.assertNotNull(fileDesc);
-        Assert.assertEquals("000000_0", fileDesc.getFileName());
+        Assert.assertNotNull(fileDesc.getTextFileFormatDesc());
         Assert.assertEquals("", fileDesc.getCompression());
         Assert.assertEquals(20, fileDesc.getLength());
-        Assert.assertFalse(fileDesc.isSplittable());
-        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+        Assert.assertTrue(fileDesc.isSplittable());
 
         List<RemoteFileBlockDesc> blockDescs = fileDesc.getBlockDescs();
         Assert.assertEquals(1, blockDescs.size());
@@ -56,5 +75,7 @@ public class CachingRemoteFileIOTest {
         Map<RemotePathKey, List<RemoteFileDesc>> presentRemoteFileInfos =
                 cachingFileIO.getPresentRemoteFiles(Lists.newArrayList(pathKey));
         Assert.assertEquals(1, presentRemoteFileInfos.size());
+
+        Assert.assertEquals(2, ops.getPresentFilesInCache(partitions.values()).size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetastoreTest.java
@@ -192,7 +192,7 @@ public class HiveMetastoreTest {
             StorageDescriptor sd = new StorageDescriptor();
             sd.setCols(unPartKeys);
             sd.setLocation(hdfsPath);
-            sd.setInputFormat("org.apache.hadoop.hive.ql.io.HiveInputFormat");
+            sd.setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
             SerDeInfo serDeInfo = new SerDeInfo();
             serDeInfo.setParameters(ImmutableMap.of());
             sd.setSerdeInfo(serDeInfo);
@@ -214,7 +214,7 @@ public class HiveMetastoreTest {
             StorageDescriptor sd = new StorageDescriptor();
             String hdfsPath = "hdfs://127.0.0.1:10000/hive";
             sd.setLocation(hdfsPath);
-            sd.setInputFormat("org.apache.hadoop.hive.ql.io.HiveInputFormat");
+            sd.setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
             SerDeInfo serDeInfo = new SerDeInfo();
             serDeInfo.setParameters(ImmutableMap.of());
             sd.setSerdeInfo(serDeInfo);
@@ -229,7 +229,7 @@ public class HiveMetastoreTest {
             List<Partition> res = Lists.newArrayList();
             for (String partitionName : partitionNames) {
                 StorageDescriptor sd = new StorageDescriptor();
-                sd.setInputFormat("org.apache.hadoop.hive.ql.io.HiveInputFormat");
+                sd.setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
                 SerDeInfo serDeInfo = new SerDeInfo();
                 serDeInfo.setParameters(ImmutableMap.of());
                 sd.setSerdeInfo(serDeInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveRemoteFileIOTest.java
@@ -23,7 +23,7 @@ public class HiveRemoteFileIOTest {
         HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
         fileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
-        String tableLocation = "hdfs://fake:9000/db_name/table_name";
+        String tableLocation = "hdfs://127.0.0.1:10000/hive.db/hive_tbl";
         RemotePathKey pathKey = RemotePathKey.of(tableLocation, false);
         Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = fileIO.getRemoteFiles(pathKey);
         List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/MockedRemoteFileSystem.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class MockedRemoteFileSystem extends FileSystem {
     private final List<LocatedFileStatus> files;
 
-    public static final String TEST_PATH_1_STR = "hdfs://fake:9000/db_name/table_name/000000_0";
+    public static final String TEST_PATH_1_STR = "hdfs://127.0.0.1:10000/hive.db/hive_tbl/000000_0";
     public static final Path TEST_PATH_1 = new Path(TEST_PATH_1_STR);
     public static final List<LocatedFileStatus> TEST_FILES = ImmutableList.of(locatedFileStatus(TEST_PATH_1));
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Use query-level `CachingRemoteFileIO` instance to get remote file's metadata from s3 or hdfs in parallel.
- Use `Partition` to fill the remote file metadata result. it's mainly use in the building scan range stage.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
