### PR TITLE
[BugFix] Adding '-j' to run build.sh causes the compilation run on empty

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -119,7 +119,7 @@ fi
 USE_JEMALLOC=ON
 
 HELP=0
-if [ $# == 1 ] ; then
+if [[ $OPTS =~ "-j" ]] && [ $# == 3 ] || [ $# == 1 ] ; then
     # default
     BUILD_BE=1
     BUILD_FE=1


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11597

## Problem Summary(Required) ：
Adding '-j' to run build.sh causes the compilation run on empty. `BE`, `FE`, and `SPARK_DPP` are not compiled at all. See the issue #11597.
