### PR TITLE
[Feature] Support database level Backup and Restore(#11619)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -416,7 +416,11 @@ public class BackupHandler extends LeaderDaemon implements Writable {
         // Also remove all unrelated objs
         Preconditions.checkState(infos.size() == 1);
         BackupJobInfo jobInfo = infos.get(0);
-        checkAndFilterRestoreObjsExistInSnapshot(jobInfo, stmt.getTableRefs());
+        // If TableRefs is empty, it means that we do not specify any table in Restore stmt.
+        // So, we should restore all table in current database.
+        if (stmt.getTableRefs().size() != 0) {
+            checkAndFilterRestoreObjsExistInSnapshot(jobInfo, stmt.getTableRefs());
+        }
 
         TableType t = TableType.OLAP;
         BackupMeta backupMeta = downloadAndDeserializeMetaInfo(jobInfo, repository, stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -61,6 +61,15 @@ public class BackupRestoreAnalyzer {
             analyzeLabelAndRepo(backupStmt.getLabel(), backupStmt.getRepoName());
             Map<String, TableRef> tblPartsMap = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
             List<TableRef> tableRefs = backupStmt.getTableRefs();
+            // If TableRefs is empty, it means that we do not specify any table in Backup stmt.
+            // We should backup all table in current database.
+            if (tableRefs.size() == 0) {
+                for (Table tbl : database.getTables()) {
+                    TableName tableName = new TableName(dbName, tbl.getName());
+                    TableRef tableRef = new TableRef(tableName, null, null);
+                    tableRefs.add(tableRef);
+                }
+            }
             for (TableRef tableRef : tableRefs) {
                 analyzeTableRef(tableRef, dbName, database, tblPartsMap, context.getCurrentCatalog());
                 if (tableRef.hasExplicitAlias()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1375,7 +1375,7 @@ tabletList
 backupStatement
     : BACKUP SNAPSHOT qualifiedName
     TO identifier
-    ON '(' tableDesc (',' tableDesc) * ')'
+    (ON '(' tableDesc (',' tableDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
@@ -1386,7 +1386,7 @@ showBackupStatement
 restoreStatement
     : RESTORE SNAPSHOT qualifiedName
     FROM identifier
-    ON '(' restoreTableDesc (',' restoreTableDesc) * ')'
+    (ON '(' restoreTableDesc (',' restoreTableDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -50,6 +50,8 @@ public class AnalyzeBackupRestoreTest {
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP SNAPSHOT snapshot_label2 TO `repo` ON ( t0, t1 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT snapshot_label2 TO `repo` " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t0 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t1 ) " +
@@ -81,6 +83,10 @@ public class AnalyzeBackupRestoreTest {
     @Test
     public void testRestore() {
         analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` ON ( `t0` , `t1` AS `new_tbl` ) " +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
+                "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
+                "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
+        analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` " +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11619

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Problem:
Currently starrocks does not support database-level backup and restore.This feature adds a new syntax to support this scenario.

Solution:
Parser:Modify the grammar rules to make "ON ..." optional. 
Analyzer: When the tableRefs is empty, we backup all table in the current database. 
Execute: When the tableRefs is empty, we don't check table list in the meta info of fe. This will restore all table in current database.

Usage:
BACKUP SNAPSHOT test.testbackup TO test_repo PROPERTIES ("type" = "full"); RESTORE SNAPSHOT test.testbackup FROM test_repo PROPERTIES("backup_timestamp" = "xxx", "replication_num" = "1");
