### PR TITLE
[Enhancement] Support cumulative compaction on the tablet with missing version

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -287,6 +287,9 @@ CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 // if compaction of a tablet failed, this tablet should not be chosen to
 // compaction until this interval passes.
 CONF_mInt64(min_compaction_failure_interval_sec, "120"); // 2 min
+
+CONF_mInt64(min_cmumulative_compaction_failure_interval_sec, "30"); // 30s
+
 // Too many compaction tasks may run out of memory.
 // This config is to limit the max concurrency of running compaction tasks.
 // -1 means no limit, and the max concurrency will be:

--- a/be/src/storage/cumulative_compaction.cpp
+++ b/be/src/storage/cumulative_compaction.cpp
@@ -45,7 +45,9 @@ Status CumulativeCompaction::compact() {
     _state = CompactionState::SUCCESS;
 
     // 5. set cumulative point
-    _tablet->set_cumulative_layer_point(_input_rowsets.back()->end_version() + 1);
+    if (_tablet->cumulative_layer_point() == _input_rowsets.front()->start_version()) {
+        _tablet->set_cumulative_layer_point(_input_rowsets.back()->end_version() + 1);
+    }
 
     // 6. add metric to cumulative compaction
     StarRocksMetrics::instance()->cumulative_compaction_deltas_total.increment(_input_rowsets.size());
@@ -53,6 +55,20 @@ Status CumulativeCompaction::compact() {
     TRACE("save cumulative compaction metrics");
 
     return Status::OK();
+}
+
+bool CumulativeCompaction::fit_compaction_condition(const std::vector<RowsetSharedPtr>& rowsets,
+                                                    int64_t compaction_score) {
+    if (!rowsets.empty()) {
+        if (compaction_score >= config::min_cumulative_compaction_num_singleton_deltas) {
+            return true;
+        }
+        if (rowsets.front()->start_version() == _tablet->cumulative_layer_point()) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 Status CumulativeCompaction::pick_rowsets_to_compact() {
@@ -65,62 +81,92 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
 
     std::sort(candidate_rowsets.begin(), candidate_rowsets.end(), Rowset::comparator);
 
-    RETURN_IF_ERROR(check_version_continuity_with_cumulative_point(candidate_rowsets));
-    RETURN_IF_ERROR(check_version_continuity(candidate_rowsets));
-
     std::vector<RowsetSharedPtr> transient_rowsets;
     size_t compaction_score = 0;
     // the last delete version we meet when traversing candidate_rowsets
     Version last_delete_version{-1, -1};
 
+    // | means cumulative point
+    // 6 means version 6 is singleton version
+    // 1-2 means version 1-2 is non singleton version
+    // (5) means version 5 is delete version
+    // <4,5> means version 4,5 selected for cumulative compaction
+    int64_t prev_end_version = _tablet->cumulative_layer_point() - 1;
     for (auto rowset : candidate_rowsets) {
+        // meet missed version
+        if (rowset->start_version() != prev_end_version + 1) {
+            if (!transient_rowsets.empty() &&
+                compaction_score >= config::min_cumulative_compaction_num_singleton_deltas) {
+                // min_cumulative_compaction_num_singleton_deltas = 2
+                // 7,6,<4,3>|2-1 -> <4,3>
+                _input_rowsets = transient_rowsets;
+                break;
+            } else {
+                // 7,6,<3>|2-1
+                compaction_score = 0;
+                transient_rowsets.clear();
+            }
+        }
+        // meet a delete version
         if (_tablet->version_for_delete_predicate(rowset->version())) {
             last_delete_version = rowset->version();
-            if (!transient_rowsets.empty()) {
+            if (fit_compaction_condition(transient_rowsets, compaction_score)) {
+                // 7,6,(5),<4,3>|2-1 -> <4,3>
                 // we meet a delete version, and there were other versions before.
                 // we should compact those version before handling them over to base compaction
                 _input_rowsets = transient_rowsets;
                 break;
+            } else {
+                // 7,6,5,4,(3)|2-1 -> 7,6,5,4|(3),2-1
+                // we meet a delete version, and there were no other versions before.
+                // we can increase the cumulative point when delete version next to cumulative_layer_point
+                // NOTICE: after that, the cumulative point may be larger than max version of this tablet, but it doen't matter.
+                if (_tablet->cumulative_layer_point() == last_delete_version.first) {
+                    _tablet->set_cumulative_layer_point(last_delete_version.first + 1);
+                }
+                compaction_score = 0;
+                transient_rowsets.clear();
+                prev_end_version = rowset->end_version();
+                continue;
             }
-
-            // we meet a delete version, and no other versions before, skip it and continue
-            transient_rowsets.clear();
-            compaction_score = 0;
-            continue;
+        }
+        // meet already compaction rowset
+        if (!rowset->rowset_meta()->is_singleton_delta()) {
+            // 6-5,<4,3>|2-1 -> <4,3>
+            if (fit_compaction_condition(transient_rowsets, compaction_score)) {
+                _input_rowsets = transient_rowsets;
+                break;
+            } else {
+                // 6,5,4-3|2-1 -> 6,5|4-3,2-1
+                if (_tablet->cumulative_layer_point() == rowset->start_version()) {
+                    _tablet->set_cumulative_layer_point(rowset->end_version() + 1);
+                }
+                // 9-8,<7>|2-1
+                compaction_score = 0;
+                transient_rowsets.clear();
+                prev_end_version = rowset->end_version();
+                continue;
+            }
         }
 
         if (compaction_score >= config::max_cumulative_compaction_num_singleton_deltas) {
             // got enough segments
+            _input_rowsets = transient_rowsets;
             break;
         }
 
         compaction_score += rowset->rowset_meta()->get_compaction_score();
         transient_rowsets.push_back(rowset);
+        prev_end_version = rowset->end_version();
     }
 
-    // if we have a sufficient number of segments,
-    // or have other versions before encountering the delete version, we should process the compaction.
-    if (compaction_score >= config::min_cumulative_compaction_num_singleton_deltas ||
-        (last_delete_version.first != -1 && !transient_rowsets.empty())) {
+    if (_input_rowsets.empty() && transient_rowsets.size() >= config::min_cumulative_compaction_num_singleton_deltas) {
         _input_rowsets = transient_rowsets;
     }
 
     // Cumulative compaction will process with at least 1 rowset.
     // So when there is no rowset being chosen, we should return Status::NotFound("cumulative compaction no suitable version error.");
     if (_input_rowsets.empty()) {
-        if (last_delete_version.first != -1) {
-            // we meet a delete version, should increase the cumulative point to let base compaction handle the delete version.
-            // plus 1 to skip the delete version.
-            // NOTICE: after that, the cumulative point may be larger than max version of this tablet, but it doen't matter.
-            _tablet->set_cumulative_layer_point(last_delete_version.first + 1);
-            return Status::NotFound("cumulative compaction no suitable version error.");
-        }
-
-        // we did not meet any delete version. which means compaction_score is not enough to do cumulative compaction.
-        // We should wait until there are more rowsets to come, and keep the cumulative point unchanged.
-        // But in order to avoid the stall of compaction because no new rowset arrives later, we should increase
-        // the cumulative point after waiting for a long time, to ensure that the base compaction can continue.
-
         // check both last success time of base and cumulative compaction
         int64_t now = UnixMillis();
         int64_t last_cumu = _tablet->last_cumu_compaction_success_time();
@@ -130,20 +176,20 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
             int64_t cumu_interval = now - last_cumu;
             int64_t base_interval = now - last_base;
             if (cumu_interval > interval_threshold && base_interval > interval_threshold) {
-                // before increasing cumulative point, we should make sure all rowsets are non-overlapping.
-                // if at least one rowset is overlapping, we should compact them first.
-                CHECK(candidate_rowsets.size() == transient_rowsets.size())
-                        << "tablet: " << _tablet->full_name() << ", " << candidate_rowsets.size() << " vs. "
-                        << transient_rowsets.size();
-                for (auto& rs : candidate_rowsets) {
-                    if (rs->rowset_meta()->is_segments_overlapping()) {
-                        _input_rowsets = candidate_rowsets;
-                        return Status::OK();
+                if (check_version_continuity_with_cumulative_point(candidate_rowsets).ok() &&
+                    check_version_continuity(candidate_rowsets).ok()) {
+                    // before increasing cumulative point, we should make sure all rowsets are non-overlapping.
+                    // if at least one rowset is overlapping, we should compact them first.
+                    for (auto& rs : candidate_rowsets) {
+                        if (rs->rowset_meta()->is_segments_overlapping()) {
+                            _input_rowsets = candidate_rowsets;
+                            return Status::OK();
+                        }
                     }
-                }
 
-                // all candicate rowsets are non-overlapping, increase the cumulative point
-                _tablet->set_cumulative_layer_point(candidate_rowsets.back()->start_version() + 1);
+                    // all candicate rowsets are non-overlapping, increase the cumulative point
+                    _tablet->set_cumulative_layer_point(candidate_rowsets.back()->start_version() + 1);
+                }
             }
         } else {
             // init the compaction success time for first time
@@ -158,6 +204,11 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
 
         return Status::NotFound("cumulative compaction no suitable version error.");
     }
+
+    RETURN_IF_ERROR(check_version_continuity(_input_rowsets));
+
+    LOG(INFO) << "pick cumulative compaction rowset version=" << _input_rowsets.front()->start_version() << "-"
+              << _input_rowsets.back()->end_version() << " score=" << compaction_score;
 
     return Status::OK();
 }

--- a/be/src/storage/cumulative_compaction.h
+++ b/be/src/storage/cumulative_compaction.h
@@ -24,6 +24,8 @@ protected:
     // check_version_continuity_with_cumulative_point checks whether the input rowsets is continuous with cumulative point.
     Status check_version_continuity_with_cumulative_point(const std::vector<RowsetSharedPtr>& rowsets);
 
+    bool fit_compaction_condition(const std::vector<RowsetSharedPtr>& rowsets, int64_t compaction_score);
+
     std::string compaction_name() const override { return "cumulative compaction"; }
 
     ReaderType compaction_type() const override { return ReaderType::READER_CUMULATIVE_COMPACTION; }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -650,6 +650,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     if (!res.ok()) {
         if (!res.is_mem_limit_exceeded()) {
             best_tablet->set_last_cumu_compaction_failure_time(UnixMillis());
+            best_tablet->set_last_cumu_compaction_failure_status(res.code());
         }
         if (!res.is_not_found()) {
             StarRocksMetrics::instance()->cumulative_compaction_request_failed.increment(1);
@@ -660,6 +661,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     }
 
     best_tablet->set_last_cumu_compaction_failure_time(0);
+    best_tablet->set_last_cumu_compaction_failure_status(TStatusCode::OK);
     return Status::OK();
 }
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -169,7 +169,6 @@ public:
     static bool check_migrate(const TabletSharedPtr& tablet);
 
     // operation for compaction
-    bool can_do_compaction();
     const uint32_t calc_cumulative_compaction_score() const;
     const uint32_t calc_base_compaction_score() const;
 
@@ -182,6 +181,9 @@ public:
 
     int64_t last_cumu_compaction_failure_time() { return _last_cumu_compaction_failure_millis; }
     void set_last_cumu_compaction_failure_time(int64_t millis) { _last_cumu_compaction_failure_millis = millis; }
+
+    TStatusCode::type last_cumu_compaction_failure_status() { return _last_cumu_compaction_failure_status; }
+    void set_last_cumu_compaction_failure_status(TStatusCode::type st) { _last_cumu_compaction_failure_status = st; }
 
     int64_t last_base_compaction_failure_time() { return _last_base_compaction_failure_millis; }
     void set_last_base_compaction_failure_time(int64_t millis) { _last_base_compaction_failure_millis = millis; }
@@ -329,6 +331,8 @@ private:
     std::atomic<int64_t> _last_cumu_compaction_success_millis{0};
     // timestamp of last base compaction success
     std::atomic<int64_t> _last_base_compaction_success_millis{0};
+
+    TStatusCode::type _last_cumu_compaction_failure_status = TStatusCode::OK;
 
     std::atomic<int64_t> _cumulative_point{0};
     std::atomic<int32_t> _newly_created_rowset_num{0};

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -32,9 +32,63 @@ public:
             _engine = nullptr;
         }
     }
-    void create_rowset_writer_context(RowsetWriterContext* rowset_writer_context) {
+    void write_new_version(TabletMetaSharedPtr tablet_meta) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, _version);
+        _version++;
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer_add_rows(rowset_writer);
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        ASSERT_EQ(1024, src_rowset->num_rows());
+
+        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+    }
+
+    void write_specify_version(TabletSharedPtr tablet, int64_t version) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, version);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer_add_rows(rowset_writer);
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        ASSERT_EQ(1024, src_rowset->num_rows());
+
+        ASSERT_TRUE(tablet->add_rowset(src_rowset).ok());
+    }
+
+    void write_delete_version(TabletMetaSharedPtr tablet_meta, int64_t version) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, version);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        ASSERT_EQ(0, src_rowset->num_rows());
+
+        auto* delete_predicate = src_rowset->rowset_meta()->mutable_delete_predicate();
+        delete_predicate->set_version(version);
+        auto* in_pred = delete_predicate->add_in_predicates();
+        in_pred->set_column_name("k1");
+        in_pred->set_is_not_in(false);
+        in_pred->add_values("0");
+
+        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+    }
+
+    void create_rowset_writer_context(RowsetWriterContext* rowset_writer_context, int64_t version) {
         RowsetId rowset_id;
-        rowset_id.init(10000);
+        rowset_id.init(_rowset_id++);
         rowset_writer_context->rowset_id = rowset_id;
         rowset_writer_context->tablet_id = 12345;
         rowset_writer_context->tablet_schema_hash = 1111;
@@ -42,8 +96,8 @@ public:
         rowset_writer_context->rowset_path_prefix = config::storage_root_path + "/data/0/12345/1111";
         rowset_writer_context->rowset_state = VISIBLE;
         rowset_writer_context->tablet_schema = _tablet_schema.get();
-        rowset_writer_context->version.first = 0;
-        rowset_writer_context->version.second = 0;
+        rowset_writer_context->version.first = version;
+        rowset_writer_context->version.second = version;
     }
 
     void create_tablet_schema(KeysType keys_type) {
@@ -124,44 +178,11 @@ public:
     void do_compaction() {
         create_tablet_schema(UNIQUE_KEYS);
 
-        RowsetWriterContext rowset_writer_context;
-        create_rowset_writer_context(&rowset_writer_context);
-        std::unique_ptr<RowsetWriter> _rowset_writer;
-        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &_rowset_writer).ok());
-
-        rowset_writer_add_rows(_rowset_writer);
-
-        _rowset_writer->flush();
-        RowsetSharedPtr src_rowset = *_rowset_writer->build();
-        ASSERT_TRUE(src_rowset != nullptr);
-        RowsetId src_rowset_id;
-        src_rowset_id.init(10000);
-        ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
-        ASSERT_EQ(1024, src_rowset->num_rows());
-
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         create_tablet_meta(tablet_meta.get());
-        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
 
-        {
-            RowsetId src_rowset_id;
-            src_rowset_id.init(10001);
-            rowset_writer_context.rowset_id = src_rowset_id;
-            rowset_writer_context.version =
-                    Version(rowset_writer_context.version.second + 1, rowset_writer_context.version.second + 1);
-
-            std::unique_ptr<RowsetWriter> _rowset_writer;
-            ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &_rowset_writer).ok());
-
-            rowset_writer_add_rows(_rowset_writer);
-
-            _rowset_writer->flush();
-            RowsetSharedPtr src_rowset = *_rowset_writer->build();
-            ASSERT_TRUE(src_rowset != nullptr);
-            ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
-            ASSERT_EQ(1024, src_rowset->num_rows());
-
-            tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+        for (int i = 0; i < 2; ++i) {
+            write_new_version(tablet_meta);
         }
 
         TabletSharedPtr tablet =
@@ -169,12 +190,16 @@ public:
         tablet->init();
 
         CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
 
-        ASSERT_TRUE(cumulative_compaction.compact().ok());
+        ASSERT_EQ(1, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
     }
 
     void SetUp() override {
         config::min_cumulative_compaction_num_singleton_deltas = 2;
+        config::max_cumulative_compaction_num_singleton_deltas = 5;
         config::max_compaction_concurrency = 1;
         Compaction::init(config::max_compaction_concurrency);
 
@@ -199,6 +224,9 @@ public:
         _mem_pool = std::make_unique<MemPool>();
 
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+
+        _rowset_id = 10000;
+        _version = 0;
     }
 
     void TearDown() override {
@@ -214,6 +242,9 @@ protected:
     std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
+
+    int64_t _rowset_id;
+    int64_t _version;
 };
 
 TEST_F(CumulativeCompactionTest, test_init_succeeded) {
@@ -238,13 +269,564 @@ TEST_F(CumulativeCompactionTest, test_candidate_rowsets_empty) {
 }
 
 TEST_F(CumulativeCompactionTest, test_horizontal_compact_succeed) {
+    LOG(INFO) << "test_horizontal_compact_succeed";
     config::vertical_compaction_max_columns_per_group = 5;
     do_compaction();
 }
 
 TEST_F(CumulativeCompactionTest, test_vertical_compact_succeed) {
+    LOG(INFO) << "test_vertical_compact_succeed";
     config::vertical_compaction_max_columns_per_group = 1;
     do_compaction();
+}
+
+TEST_F(CumulativeCompactionTest, test_min_cumulative_compaction) {
+    LOG(INFO) << "test_min_cumulative_compaction";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+    auto res = cumulative_compaction.compact();
+    ASSERT_FALSE(res.ok());
+
+    ASSERT_EQ(1, tablet->version_count());
+    ASSERT_EQ(0, tablet->cumulative_layer_point());
+    std::vector<Version> versions;
+    tablet->list_versions(&versions);
+    ASSERT_EQ(1, versions.size());
+    ASSERT_EQ(0, versions[0].first);
+    ASSERT_EQ(0, versions[0].second);
+}
+
+TEST_F(CumulativeCompactionTest, test_max_cumulative_compaction) {
+    LOG(INFO) << "test_max_cumulative_compaction";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 6; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+    auto res = cumulative_compaction.compact();
+    ASSERT_TRUE(res.ok());
+
+    ASSERT_EQ(2, tablet->version_count());
+    ASSERT_EQ(5, tablet->cumulative_layer_point());
+    std::vector<Version> versions;
+    tablet->list_versions(&versions);
+    ASSERT_EQ(2, versions.size());
+    ASSERT_EQ(0, versions[0].first);
+    ASSERT_EQ(4, versions[0].second);
+    ASSERT_EQ(5, versions[1].first);
+    ASSERT_EQ(5, versions[1].second);
+}
+
+TEST_F(CumulativeCompactionTest, test_missed_first_version) {
+    LOG(INFO) << "test_missed_first_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        ASSERT_EQ(0, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+    }
+}
+
+TEST_F(CumulativeCompactionTest, test_missed_version_after_cumulative_point) {
+    LOG(INFO) << "test_missed_version_after_cumulative_point";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version++;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    // compaction 0-1
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    // compaction 3-4
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(4, versions[1].second);
+    }
+
+    // write 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    // compaction 2
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(3, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    // move cumulative point
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(5, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+
+    }
+}
+
+TEST_F(CumulativeCompactionTest, test_missed_two_version) {
+    LOG(INFO) << "test_missed_two_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version += 2;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    // compaction 0-1
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(4, versions[1].first);
+        ASSERT_EQ(4, versions[1].second);
+        ASSERT_EQ(5, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // compaction 4-5
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(4, versions[1].first);
+        ASSERT_EQ(5, versions[1].second);
+    }
+
+    // write version 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // won't compaction since only less that min_cumulative_compaction_num_singleton_deltas
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // write version 3
+    {
+        write_specify_version(tablet, 3);
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(4, versions[3].first);
+        ASSERT_EQ(5, versions[3].second);
+    }
+
+    // compaction 2-3
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(4, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // move cumulative point
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(6, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+}
+
+TEST_F(CumulativeCompactionTest, test_delete_version) {
+    LOG(INFO) << "test_missed_first_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    write_delete_version(tablet_meta, 1);
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    ASSERT_EQ(3, tablet->version_count());
+    ASSERT_EQ(-1, tablet->cumulative_layer_point());
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(1, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+    }
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+    }
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+    }
+}
+
+TEST_F(CumulativeCompactionTest, test_missed_and_delete_version) {
+    LOG(INFO) << "test_missed_two_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version += 2;
+    write_delete_version(tablet_meta, 3);
+
+    _version += 2;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+
+    ASSERT_EQ(5, tablet->version_count());
+
+    // compaction 0-1
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(6, versions[2].first);
+        ASSERT_EQ(6, versions[2].second);
+        ASSERT_EQ(7, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
+
+    // compaction 6-7
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(6, versions[2].first);
+        ASSERT_EQ(7, versions[2].second);
+    }
+
+    // write version 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(2, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(6, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
+
+    // compaction 2
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(3, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(6, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
+
+    // move cumulative point
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(4, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(6, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
 }
 
 TEST_F(CumulativeCompactionTest, test_read_chunk_size) {

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -89,5 +89,7 @@ int main(int argc, char** argv) {
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     starrocks::ExecEnv::destroy(exec_env);
 
+    starrocks::shutdown_logging();
+
     return r;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, StarRocks does not support cumulative compaction on missing versions of tablets. The number of versions backlog on the tablet may exceed `tablet_max_versions` before the missing version is fixed by clone. Therefore, we need to support cumulative compaction on tablets with missing versions.
As shown in the figure below, assuming `min_cumulative_compaction_num_singleton_deltas`=2

![compaction-第 2 页 drawio (1)](https://user-images.githubusercontent.com/1292236/192288682-85e0a749-9dce-405d-b6a4-bf4476445151.png)


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
