### PR TITLE
[Enhancement] support table name with one leading underscore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -29,7 +29,7 @@ import com.starrocks.system.SystemInfoService;
 public class FeNameFormat {
     private FeNameFormat() {}
 
-    private static final String LABEL_REGEX = "^\\w{1,128}$";
+    private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name
     // so it can not distinguish whether it is an operator or a column name

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -27,15 +27,17 @@ import com.starrocks.mysql.privilege.Role;
 import com.starrocks.system.SystemInfoService;
 
 public class FeNameFormat {
-    private static final String LABEL_REGEX = "^[-_A-Za-z0-9]{1,128}$";
-    public static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,63}$|^_[a-zA-Z0-9][a-zA-Z0-9_]{0,62}$";
+    private FeNameFormat() {}
+
+    private static final String LABEL_REGEX = "^\\w{1,128}$";
+    public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,1023}$";
 
     // The user name  by kerberos authentication may include the host name, so additional adaptation is required.
-    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z0-9_]{1,64}/?[.a-zA-Z0-9_-]{0,63}$";
+    private static final String MYSQL_USER_NAME_REGEX = "^\\w{1,64}/?[.\\w-]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -28,7 +28,7 @@ import com.starrocks.system.SystemInfoService;
 
 public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-_A-Za-z0-9]{1,128}$";
-    public static final String COMMON_NAME_REGEX = "^([a-zA-Z][a-zA-Z0-9_]{0,63})|(_[a-zA-Z0-9][a-zA-Z0-9_]{0,62})$";
+    public static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,63}$|^_[a-zA-Z0-9][a-zA-Z0-9_]{0,62}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -28,7 +28,7 @@ import com.starrocks.system.SystemInfoService;
 
 public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-_A-Za-z0-9]{1,128}$";
-    public static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,63}$";
+    public static final String COMMON_NAME_REGEX = "^([a-zA-Z][a-zA-Z0-9_]{0,63})|(_[a-zA-Z0-9][a-zA-Z0-9_]{0,62})$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -51,7 +51,7 @@ public class AnalyzeAlterTableStatementTest {
 
     @Test(expected = SemanticException.class)
     public void testIllegalNewTableName() {
-        TableRenameClause clause = new TableRenameClause("_newName");
+        TableRenameClause clause = new TableRenameClause("__newName");
         clauseAnalyzerVisitor.analyze(clause, connectContext);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11640 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Modify the regular expression of the table name so that table name with one underscore is considered legal and table name with more than one consecutive underscores is not.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
