### PR TITLE
[Feature] Provide Reentrant executor for lazy refresh of loading cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/BoundedExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/BoundedExecutor.java
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.connector;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Stolen from io.airlift.concurrent.
+ * Guarantees that no more than maxThreads will be used to execute tasks submitted
+ * through {@link #execute(Runnable) execute()}.
+ */
+public class BoundedExecutor implements Executor {
+    private static final Logger LOG = LogManager.getLogger(BoundedExecutor.class);
+
+    private final Queue<Runnable> queue = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger queueSize = new AtomicInteger(0);
+    private final AtomicBoolean failed = new AtomicBoolean();
+
+    private final Executor coreExecutor;
+    private final int maxThreads;
+
+    public BoundedExecutor(Executor coreExecutor, int maxThreads) {
+        requireNonNull(coreExecutor, "coreExecutor is null");
+        checkArgument(maxThreads > 0, "maxThreads must be greater than zero");
+        this.coreExecutor = coreExecutor;
+        this.maxThreads = maxThreads;
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        if (failed.get()) {
+            throw new RejectedExecutionException("BoundedExecutor is in a failed state");
+        }
+
+        queue.add(task);
+
+        int size = queueSize.incrementAndGet();
+        if (size <= maxThreads) {
+            try {
+                coreExecutor.execute(this::releaseQueue);
+            } catch (Throwable e) {
+                failed.set(true);
+                LOG.error("BoundedExecutor state corrupted due to underlying executor failure");
+                throw e;
+            }
+        }
+    }
+
+    private void releaseQueue() {
+        do {
+            try {
+                requireNonNull(queue.poll()).run();
+            } catch (Throwable e) {
+                LOG.error("Task failed", e);
+            }
+        } while (queueSize.getAndDecrement() > maxThreads);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ReentrantExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ReentrantExecutor.java
@@ -1,0 +1,39 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.connector;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+// Loading cache in CachingHiveMetastore may trigger loading of another cache entry for different key type.
+// If there are no empty executor slots, such operation would deadlock. ReentrantExecutor is necessary.
+public class ReentrantExecutor implements Executor {
+    private final ThreadLocal<Boolean> executorMarker = ThreadLocal.withInitial(() -> false);
+    private final Executor boundedExecutor;
+    private final Executor coreExecutor;
+
+    public ReentrantExecutor(Executor coreExecutor, int maxThreads) {
+        this.boundedExecutor = new BoundedExecutor(requireNonNull(coreExecutor, "coreExecutor is null"), maxThreads);
+        this.coreExecutor = coreExecutor;
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        if (executorMarker.get()) {
+            coreExecutor.execute(task);
+            return;
+        }
+
+        boundedExecutor.execute(() -> {
+            executorMarker.set(true);
+            try {
+                task.run();
+            } finally {
+                executorMarker.remove();
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/TestReentrantExecutor.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/TestReentrantExecutor.java
@@ -1,0 +1,47 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.starrocks.connector.ReentrantExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.Executors.newCachedThreadPool;
+
+public class TestReentrantExecutor {
+    @Test
+    public void testReentrantExecutor() throws ExecutionException, InterruptedException {
+        AtomicInteger callCounter = new AtomicInteger();
+        SettableFuture<Object> future = SettableFuture.create();
+        ExecutorService executor = newCachedThreadPool();
+        try {
+            Executor reentrantExecutor = new ReentrantExecutor(executor, 1);
+            reentrantExecutor.execute(() -> {
+                callCounter.incrementAndGet();
+                reentrantExecutor.execute(() -> {
+                    callCounter.incrementAndGet();
+                    future.set(null);
+                });
+                try {
+                    future.get();
+                } catch (Exception ignored) {
+                }
+            });
+            future.get();
+
+            SettableFuture<Object> secondFuture = SettableFuture.create();
+            reentrantExecutor.execute(() -> secondFuture.set(null));
+            secondFuture.get();
+
+            Assert.assertEquals(2, callCounter.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/5836
https://github.com/StarRocks/starrocks/issues/11349
https://github.com/StarRocks/starrocks/pull/10109
https://github.com/StarRocks/starrocks/issues/10103
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Loading cache in CachingHiveMetastore may trigger loading of another cache entry for different key type. If there are no empty executor slots, such operation would deadlock. ReentrantExecutor is necessary.  Reentrant executor needs to be used that might trigger loading action directly if it is triggered from executor thread context.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
