### PR TITLE
[Enhancement] Add rate limit macro to limit too much log print

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -48,6 +48,7 @@
 #include "storage/tablet_updates.h"
 #include "storage/update_manager.h"
 #include "util/defer_op.h"
+#include "util/ratelimit.h"
 #include "util/time.h"
 
 namespace starrocks {
@@ -502,8 +503,8 @@ Status Tablet::capture_consistent_versions(const Version& spec_version, std::vec
         } else {
             auto msg = fmt::format("version not found. tablet_id: {}, version: {}", _tablet_meta->tablet_id(),
                                    spec_version.second);
-            LOG(WARNING) << msg;
-            _print_missed_versions(missed_versions);
+            RATE_LIMIT_BY_TAG(tablet_id(), LOG(WARNING) << msg, 1000);
+            RATE_LIMIT_BY_TAG(tablet_id(), _print_missed_versions(missed_versions), 1000);
             return Status::NotFound(msg);
         }
     }

--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -93,6 +93,9 @@ private:
     // [0-5] [6-10] 11 12
     // minReadableVersion will be updated to 10
     int64_t _min_readable_version{-1};
+
+    // print log rate limit by tablet id
+    int64_t _tablet_id{0};
 };
 
 /// TimestampedVersion class which is implemented to maintain multi-version path of rowsets.

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -74,7 +74,7 @@ StatusOr<bool> success_once(OnceFlag& once, Callable&& f, Args&&... args) {
             } else {
                 once.flag.store(0, std::memory_order_release);
                 (void)bthread::futex_wake_private(&once.flag, 1);
-                return st;
+                return std::move(st);
             }
         }
         if (curr_flag == 1) {

--- a/be/src/util/ratelimit.h
+++ b/be/src/util/ratelimit.h
@@ -1,0 +1,31 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <atomic>
+
+#include "util/time.h"
+
+#define RATE_LIMIT(func, interval_ms)           \
+    {                                           \
+        static std::atomic<int64_t> last;       \
+        static int64_t RATE_LIMIT_SKIP_CNT = 0; \
+        int64_t now = starrocks::UnixMillis();  \
+        if (now > last.load() + interval_ms) {  \
+            func;                               \
+            RATE_LIMIT_SKIP_CNT = 0;            \
+            last.store(now);                    \
+        } else {                                \
+            RATE_LIMIT_SKIP_CNT++;              \
+        }                                       \
+    }
+
+#define RATE_LIMIT_BY_TAG(tag, func, interval_ms)        \
+    {                                                    \
+        static std::atomic<int64_t> last[64];            \
+        int64_t now = starrocks::UnixMillis();           \
+        if (now > last[tag & 63].load() + interval_ms) { \
+            func;                                        \
+            last[tag & 63].store(now);                   \
+        }                                                \
+    }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -300,6 +300,7 @@ set(EXEC_FILES
         ./util/arrow/starrocks_column_to_arrow_test.cpp
         ./util/starrocks_metrics_test.cpp
         ./util/system_metrics_test.cpp
+        ./util/ratelimit_test.cpp
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
         )

--- a/be/test/util/ratelimit_test.cpp
+++ b/be/test/util/ratelimit_test.cpp
@@ -1,0 +1,36 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "util/ratelimit.h"
+
+#include <gtest/gtest.h>
+
+#include "common/logging.h"
+
+namespace starrocks {
+
+class RateLimitTest : public testing::Test {
+public:
+    RateLimitTest() {}
+    virtual ~RateLimitTest() {}
+};
+
+TEST_F(RateLimitTest, rate_limit) {
+    int count = 0;
+    for (int i = 0; i < 100; i++) {
+        RATE_LIMIT(count++, 100); // inc each 0.1s
+        RATE_LIMIT(std::cout << "skip log cnt: " << RATE_LIMIT_SKIP_CNT << std::endl, 100);
+        usleep(10000); // execute inc each 10ms
+    }
+    ASSERT_TRUE(count <= 10);
+}
+
+TEST_F(RateLimitTest, rate_limit_by_tag) {
+    int count = 0;
+    for (int i = 0; i < 100; i++) {
+        RATE_LIMIT_BY_TAG(i % 2, count++, 100); // inc each 0.1s
+        usleep(10000);                          // execute inc each 10ms
+    }
+    ASSERT_TRUE(count <= 20);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #11754

## Problem Summary(Required) ：
Too much log print when required version not exist in version graph, this log is useful so we can't just remove it, but too much print will cause performance issue. So I add a macro `RATE_LIMIT`，that we can use it to limit the log print rate.
Usage, e.g 
```
// limit that do_something() can only be called one time per second max.
RATE_LIMIT(do_something(), 1000); 
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
