### PR TITLE
[Cherry-pick 2.3][BugFix] Record query result if forward to leader (#11339)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -501,8 +501,12 @@ public class ConnectProcessor {
                 // ShowResultSet is null means this is not ShowStmt, use remote packet(executor.getOutputPacket())
                 // or use local packet (getResultPacket())
                 if (resultSet == null) {
-                    packet = executor.getOutputPacket();
-                } else {
+                    if (executor.sendResultToChannel(ctx.getMysqlChannel())) {  // query statement result
+                        packet = getResultPacket();
+                    } else { // for lower version, in consideration of compatibility
+                        packet = executor.getOutputPacket();
+                    }
+                } else { // show statement result
                     executor.sendShowResult(resultSet);
                     packet = getResultPacket();
                     if (packet == null) {
@@ -645,8 +649,12 @@ public class ConnectProcessor {
         }
         result.setPacket(getResultPacket());
         result.setState(ctx.getState().getStateType().toString());
-        if (executor != null && executor.getProxyResultSet() != null) {
-            result.setResultSet(executor.getProxyResultSet().tothrift());
+        if (executor != null) {
+            if (executor.getProxyResultSet() != null) {  // show statement
+                result.setResultSet(executor.getProxyResultSet().tothrift());
+            } else if (executor.getProxyResultBuffer() != null) {  // query statement
+                result.setChannelBufferList(executor.getProxyResultBuffer());
+            }
         }
         return result;
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -487,8 +487,11 @@ struct TShowResultSet {
 struct TMasterOpResult {
     1: required i64 maxJournalId;
     2: required binary packet;
+    // for show statement
     3: optional TShowResultSet resultSet;
     4: optional string state;
+    // for query statement
+    5: optional list<binary> channelBufferList;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
Fixed a legacy bug that existed long before I joined the company.

Sometimes a SQL received by a follower FE may end up forwarding to the leader. The leader will process the statement and send the result back to the follower FE. The result will be stored in the ShowResultSet field of the thrift response message sent from the master to the follower.

However, if the forwarded statement is a query statement, the query result has no place to store in the response and will be directly written to the send buffer of the leader MySQL channel. After the follower receives the response message from the leader, it will find out that the ShowResultSet field is empty and will regard the master as a lower version of FE; thus, it will send a simple EOF to the MySQL client. The MySQL client receives an unexpected EOF and will report a malformated packet error.

This bug is seldom triggered because we never forward a query statement unless when the progress of the follower is far behind the leader. Even in that scenario, we would try to fix the FE so that the follower can catch up with the leader. As a result, this bug is ignored.

Luckily, in developing materialized view, we rewrite the show materialized statement to a query in the information_schema.materialized_views table. This bug has finally revealed its veil.

To fix this bug, we need to add a list of Bytebuffer in the thrift response message from the leader to the master. All the packets that are supposed to send to the MySQL channel of the leader will be stored in this list so that they can send to the MySQL client after the follower receives the response.

Fixes [#1081](https://github.com/StarRocks/StarRocksTest/issues/1081)

Manually cherry-picked from 243952ca39de7b127bde069ef5b648c83f20fd15
