### PR TITLE
[Feature] support single file external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1994,7 +1994,16 @@ public class GlobalStateMgr {
         if (table.isLakeTable()) {
             sb.append(CreateTableStmt.LAKE_ENGINE_NAME.toUpperCase()).append(" ");
         } else {
-            sb.append(table.getType().name()).append(" ");
+            if (table.getType() == TableType.HIVE) {
+                HiveTable hiveTable = (HiveTable) table;
+                if (hiveTable.isFileEngine()) {
+                    sb.append("FILE").append(" ");
+                } else {
+                    sb.append(table.getType().name()).append(" ");
+                }
+            } else {
+                sb.append(table.getType().name()).append(" ");
+            }
         }
 
         if (table.isOlapOrLakeTable() || table.getType() == TableType.OLAP_EXTERNAL) {
@@ -2215,11 +2224,13 @@ public class GlobalStateMgr {
 
             // properties
             sb.append("\nPROPERTIES (\n");
-            sb.append("\"database\" = \"").append(hiveTable.getDbName()).append("\",\n");
-            sb.append("\"table\" = \"").append(hiveTable.getTableName()).append("\",\n");
-            sb.append("\"resource\" = \"").append(hiveTable.getResourceName()).append("\"");
-            if (!hiveTable.getHiveProperties().isEmpty()) {
-                sb.append(",\n");
+            if (!hiveTable.isFileEngine()) {
+                sb.append("\"database\" = \"").append(hiveTable.getDbName()).append("\",\n");
+                sb.append("\"table\" = \"").append(hiveTable.getTableName()).append("\",\n");
+                sb.append("\"resource\" = \"").append(hiveTable.getResourceName()).append("\"");
+                if (!hiveTable.getHiveProperties().isEmpty()) {
+                    sb.append(",\n");
+                }
             }
             sb.append(new PrintableMap<>(hiveTable.getHiveProperties(), " = ", true, true, false).toString());
             sb.append("\n)");

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -771,7 +771,7 @@ public class LocalMetastore implements ConnectorMetadata {
         } else if (engineName.equalsIgnoreCase("elasticsearch") || engineName.equalsIgnoreCase("es")) {
             createEsTable(db, stmt);
             return;
-        } else if (engineName.equalsIgnoreCase("hive")) {
+        } else if (engineName.equalsIgnoreCase("hive") || engineName.equalsIgnoreCase("file")) {
             createHiveTable(db, stmt);
             return;
         } else if (engineName.equalsIgnoreCase("iceberg")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -62,7 +62,8 @@ public class CreateTableAnalyzer {
         ICEBERG,
         HUDI,
         JDBC,
-        STARROCKS
+        STARROCKS,
+        FILE
     }
 
     public enum CharsetType {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
@@ -57,6 +57,7 @@ public class CreateTableStmt extends DdlStmt {
         engineNames.add("broker");
         engineNames.add("elasticsearch");
         engineNames.add("hive");
+        engineNames.add("file");
         engineNames.add("iceberg");
         engineNames.add("hudi");
         engineNames.add("jdbc");


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`CREATE EXTERNAL TABLE `hive_0` (
  `c1` int NULL, 
  `c2` array<array<int>> NULL
) ENGINE=FILE
PROPERTIES (
  "path"="hdfs://172.17.0.3/user/hive/warehouse/array2d_parq",
  "format"="parquet"
);`

the path can be a dir or a file,
the table name and type must be same with the file in the directory or the file itself.
support orc and parquet.

then can query the hive_0:
`select * from hive_0`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
