### PR TITLE
[cherry-pick 2.2] [Enhancement] speed up trash sweep

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -265,8 +265,22 @@ void* StorageEngine::_garbage_sweeper_thread_callback(void* arg) {
         // when usage < 60%,curr_interval is about max_interval,
         // when usage > 80%, curr_interval is close to min_interval
         curr_interval = curr_interval > min_interval ? curr_interval : min_interval;
-        SLEEP_IN_BG_WORKER(curr_interval);
 
+        // For shutdown gracefully
+        std::cv_status cv_status = std::cv_status::no_timeout;
+        int64_t left_seconds = curr_interval;
+        while (!_bg_worker_stopped.load(std::memory_order_consume) && left_seconds > 0) {
+            std::unique_lock<std::mutex> lk(_trash_sweeper_mutex);
+            cv_status = _trash_sweeper_cv.wait_for(lk, std::chrono::seconds(1));
+            if (cv_status == std::cv_status::no_timeout) {
+                LOG(INFO) << "trash sweeper has been notified";
+                break;
+            }
+            --left_seconds;
+        }
+        if (_bg_worker_stopped.load(std::memory_order_consume)) {
+            break;
+        }
         // start sweep, and get usage after sweep
         Status res = _start_trash_sweep(&usage);
         if (!res.ok()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -340,6 +340,19 @@ void StorageEngine::_start_disk_stat_monitor() {
     if (some_tablets_were_dropped) {
         trigger_report();
     }
+
+    // Once sweep operation can lower the disk water level by removing data, so it doesn't make sense
+    // to wake up the sweeper thread multiple times in a short period of time. To avoid multiple
+    // disk scans, set an valid disk scan interval.
+    static time_t last_sweep_time = 0;
+    static const int32_t valid_sweep_interval = 30;
+    for (auto& it : _store_map) {
+        if (difftime(time(NULL), last_sweep_time) > valid_sweep_interval && it.second->reach_capacity_limit(0)) {
+            std::unique_lock<std::mutex> lk(_trash_sweeper_mutex);
+            _trash_sweeper_cv.notify_one();
+            last_sweep_time = time(NULL);
+        }
+    }
 }
 
 // TODO(lingbin): Should be in EnvPosix?
@@ -704,6 +717,7 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
 }
 
 Status StorageEngine::_start_trash_sweep(double* usage) {
+    LOG(INFO) << "start to sweep trash";
     Status res = Status::OK();
 
     const int32_t snapshot_expire = config::snapshot_expire_time_sec;

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -315,6 +315,9 @@ private:
     // threads to run tablet checkpoint
     std::vector<std::thread> _tablet_checkpoint_threads;
 
+    std::mutex _trash_sweeper_mutex;
+    std::condition_variable _trash_sweeper_cv;
+
     // For tablet and disk-stat report
     std::mutex _report_mtx;
     std::condition_variable _report_cv;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, when the disk water level is high, the sweeper thread removes the trash directory files to reclaim disk space, but the sweeper thread sleeps too long, the default value ranges from 3 minutes to 1 hour, which could cause data GC to be delayed when the critical water level is reached.
This PR ensures that the sweeper thread is awakened in time when the critical disk water level is reached. At the same time the original behavior of the sweeper thread is preserved.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
