### PR TITLE
[Enhancement] Allow one-phase local aggregate in the single BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -53,6 +53,8 @@ public class AggregationNode extends PlanNode {
 
     private String streamingPreaggregationMode = "auto";
 
+    private boolean withLocalShuffle = false;
+
     /**
      * Create an agg node that is not an intermediate node.
      * isIntermediate is true if it is a slave node in a 2-part agg plan.
@@ -91,6 +93,10 @@ public class AggregationNode extends PlanNode {
         Preconditions.checkState(tupleIds.get(0).equals(aggInfo.getOutputTupleId()));
         tupleIds.clear();
         tupleIds.add(aggInfo.getIntermediateTupleId());
+    }
+
+    public void setWithLocalShuffle(boolean withLocalShuffle) {
+        this.withLocalShuffle = withLocalShuffle;
     }
 
     @Override
@@ -212,10 +218,14 @@ public class AggregationNode extends PlanNode {
                     getVerboseExplain(aggInfo.getGroupingExprs(), detailLevel)).append("\n");
         }
 
-
         if (!conjuncts.isEmpty()) {
             output.append(detailPrefix).append("having: ").append(getVerboseExplain(conjuncts, detailLevel)).append("\n");
         }
+
+        if (withLocalShuffle) {
+            output.append(detailPrefix).append("withLocalShuffle: true\n");
+        }
+
         return output.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -150,6 +150,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
+    public static final String ENABLE_LOCAL_SHUFFLE_AGG = "enable_local_shuffle_agg";
+
     public static final String ENABLE_DELIVER_BATCH_FRAGMENTS = "enable_deliver_batch_fragments";
 
     // Use resource group. It will influence the CPU schedule, I/O scheduler, and
@@ -286,6 +288,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_LOCAL_SHUFFLE_AGG)
+    private boolean enableLocalShuffleAgg = true;
 
     @VariableMgr.VarAttr(name = USE_COMPUTE_NODES)
     private int useComputeNodes = -1;
@@ -1000,6 +1005,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {
         this.enablePipelineEngine = enablePipelineEngine;
+    }
+
+    public void setEnableLocalShuffleAgg(boolean enableLocalShuffleAgg) {
+        this.enableLocalShuffleAgg = enableLocalShuffleAgg;
+    }
+
+    public boolean isEnableLocalShuffleAgg() {
+        return enableLocalShuffleAgg;
     }
 
     public boolean isEnableTabletInternalParallel() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -150,6 +150,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
+    /**
+     * Whether to allow the generation of one-phase local aggregation with the local shuffle operator
+     * (ScanNode->LocalShuffleNode->OnePhaseAggNode) regardless of the differences between grouping keys
+     * and scan distribution keys, when there is only one BE.
+     */
     public static final String ENABLE_LOCAL_SHUFFLE_AGG = "enable_local_shuffle_agg";
 
     public static final String ENABLE_DELIVER_BATCH_FRAGMENTS = "enable_deliver_batch_fragments";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2,6 +2,7 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.AggregateInfo;
@@ -58,6 +59,7 @@ import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
 import com.starrocks.planner.RepeatNode;
 import com.starrocks.planner.RuntimeFilterId;
+import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.planner.SelectNode;
 import com.starrocks.planner.SetOperationNode;
@@ -65,6 +67,7 @@ import com.starrocks.planner.SortNode;
 import com.starrocks.planner.TableFunctionNode;
 import com.starrocks.planner.UnionNode;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
@@ -1082,10 +1085,97 @@ public class PlanFragmentBuilder {
             return true;
         }
 
+        /**
+         * Whether all the nodes of the plan tree only contain the specific node types.
+         *
+         * @param root              The plan tree root.
+         * @param requiredNodeTypes The specific node type.
+         * @return true if all the nodes belong to the node types, otherwise false.
+         */
+        private boolean onlyContainNodeTypes(PlanNode root, List<Class<? extends PlanNode>> requiredNodeTypes) {
+            boolean rootMatched = requiredNodeTypes.stream().anyMatch(type -> type.isInstance(root));
+            if (!rootMatched) {
+                return false;
+            }
+
+            for (PlanNode child : root.getChildren()) {
+                if (!onlyContainNodeTypes(child, requiredNodeTypes)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /**
+         * Remove ExchangeNode between AggNode and ScanNode for the single backend.
+         *
+         * This is used to generate "ScanNode->LocalShuffle->OnePhaseLocalAgg" for the single backend,
+         * which contains two steps:
+         * 1. Ignore the network cost for ExchangeNode when estimating cost model.
+         * 2. Remove ExchangeNode between AggNode and ScanNode when building fragments.
+         *
+         * Specifically, transfer
+         * (AggNode->ExchangeNode)->([ProjectNode->]ScanNode)
+         * -      *inputFragment         sourceFragment
+         * to
+         * (AggNode->[ProjectNode->]ScanNode)
+         * -      *sourceFragment
+         * That is, when matching this fragment pattern, remove inputFragment and return sourceFragment.
+         *
+         * @param inputFragment The input fragment to match the above pattern.
+         * @param context The context of building fragment, which contains all the fragments.
+         * @return SourceFragment if it matches th pattern, otherwise the original inputFragment.
+         */
+        private PlanFragment removeExchangeNodeForLocalShuffleAgg(PlanFragment inputFragment, ExecPlan context) {
+            if (ConnectContext.get() == null) {
+                return inputFragment;
+            }
+            SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+            boolean enableLocalShuffleAgg = sessionVariable.isEnableLocalShuffleAgg()
+                    && sessionVariable.isEnablePipelineEngine()
+                    && GlobalStateMgr.getCurrentSystemInfo().isSingleBackendAndComputeNode();
+            if (!enableLocalShuffleAgg) {
+                return inputFragment;
+            }
+
+            // InputFragment should match "AggNode->ExchangeNode" pattern, where AggNode is the caller of this method.
+            if (!(inputFragment.getPlanRoot() instanceof ExchangeNode)) {
+                return inputFragment;
+            }
+
+            // SourceFragment should match "[ProjectNode->]ScanNode" pattern.
+            PlanNode sourceFragmentRoot = inputFragment.getPlanRoot().getChild(0);
+            if (!onlyContainNodeTypes(sourceFragmentRoot, ImmutableList.of(ScanNode.class, ProjectNode.class))) {
+                return inputFragment;
+            }
+
+            // If ExchangeSink is CTE MultiCastPlanFragment, we cannot remove this ExchangeNode.
+            PlanFragment sourceFragment = sourceFragmentRoot.getFragment();
+            if (sourceFragment instanceof MultiCastPlanFragment) {
+                return inputFragment;
+            }
+
+            // Traverse fragment in reverse to delete inputFragment,
+            // because the last fragment is inputFragment for the most cases.
+            ArrayList<PlanFragment> fragments = context.getFragments();
+            for (int i = fragments.size() - 1; i >= 0; --i) {
+                if (fragments.get(i).equals(inputFragment)) {
+                    fragments.remove(i);
+                    break;
+                }
+            }
+
+            return sourceFragment;
+        }
+
         @Override
         public PlanFragment visitPhysicalHashAggregate(OptExpression optExpr, ExecPlan context) {
             PhysicalHashAggregateOperator node = (PhysicalHashAggregateOperator) optExpr.getOp();
-            PlanFragment inputFragment = visit(optExpr.inputAt(0), context);
+            PlanFragment originalInputFragment = visit(optExpr.inputAt(0), context);
+
+            PlanFragment inputFragment = removeExchangeNodeForLocalShuffleAgg(originalInputFragment, context);
+            boolean withLocalShuffle = inputFragment != originalInputFragment;
 
             /*
              * Create aggregate TupleDescriptor
@@ -1250,8 +1340,10 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             if ((node.isOnePhaseAgg() || node.getType().isDistinct())) {
-                inputFragment.setEnableSharedScan(false);
-                inputFragment.setAssignScanRangesPerDriverSeq(true);
+                // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
+                inputFragment.setAssignScanRangesPerDriverSeq(!withLocalShuffle);
+                inputFragment.setEnableSharedScan(withLocalShuffle);
+                aggregationNode.setWithLocalShuffle(withLocalShuffle);
             }
 
             inputFragment.setPlanRoot(aggregationNode);
@@ -1602,7 +1694,8 @@ public class PlanFragmentBuilder {
             return planFragment;
         }
 
-        private List<Expr> getHashDistributionSpecPartitionByExprs(HashDistributionSpec hashDistributionSpec, ExecPlan context) {
+        private List<Expr> getHashDistributionSpecPartitionByExprs(HashDistributionSpec hashDistributionSpec,
+                                                                   ExecPlan context) {
             List<Integer> columnRefSet = hashDistributionSpec.getHashDistributionDesc().getColumns();
             Preconditions.checkState(!columnRefSet.isEmpty());
             List<ColumnRefOperator> partitionColumns = new ArrayList<>();
@@ -1626,7 +1719,8 @@ public class PlanFragmentBuilder {
                     leftChildColumns, rightChildColumns, onPredicates);
 
             Preconditions.checkState(!node.getJoinType().isCrossJoin(), "should not be cross join");
-            Preconditions.checkState(!(node.getJoinType().isInnerJoin() && eqOnPredicates.isEmpty()), "should has eq conjuncts");
+            Preconditions.checkState(!(node.getJoinType().isInnerJoin() && eqOnPredicates.isEmpty()),
+                    "should has eq conjuncts");
 
             JoinOperator joinOperator = node.getJoinType();
 
@@ -1654,8 +1748,9 @@ public class PlanFragmentBuilder {
                     optExpr.getRequiredProperties().get(1).getDistributionProperty().getSpec();
             if (leftDistributionSpec instanceof HashDistributionSpec &&
                     rightDistributionSpec instanceof HashDistributionSpec) {
-                probePartitionByExprs = getHashDistributionSpecPartitionByExprs((HashDistributionSpec) leftDistributionSpec,
-                        context);
+                probePartitionByExprs =
+                        getHashDistributionSpecPartitionByExprs((HashDistributionSpec) leftDistributionSpec,
+                                context);
             }
 
             JoinNode.DistributionMode distributionMode;

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -151,6 +151,10 @@ public class SystemInfoService {
         computeNode.setBackendState(BackendState.using);
     }
 
+    public boolean isSingleBackendAndComputeNode() {
+        return idToBackendRef.size() + idToComputeNodeRef.size() == 1;
+    }
+
     /**
      * @param hostPortPairs : backend's host and port
      * @throws DdlException

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -22,8 +22,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlanFragmentWithCostTest extends PlanTestBase {
+    private static final int NUM_TABLE2_ROWS = 10000;
+    private static final int NUM_TABLE0_ROWS = 10000;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -33,10 +36,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
-        setTableStatistics(table2, 10000);
+        setTableStatistics(table2, NUM_TABLE2_ROWS);
 
         OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
-        setTableStatistics(t0, 10000);
+        setTableStatistics(t0, NUM_TABLE0_ROWS);
 
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withTable("CREATE TABLE test_mv\n" +
@@ -1471,5 +1474,100 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "  |  group by: 3: v3, 2: v2, 6: GROUPING_ID\n" +
                 "  |  \n" +
                 "  7:EXCHANGE");
+    }
+
+
+    @Test
+    public void testOnePhaseAggWithLocalShuffle(@Mocked MockTpchStatisticStorage mockedStatisticStorage) throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo().isSingleBackendAndComputeNode();
+                returns(true, true, true, false, true);
+            }
+
+            final List<ColumnStatistic> avgHighCardinality = ImmutableList.of(
+                    new ColumnStatistic(0.0, NUM_TABLE0_ROWS, 0.0, 10, NUM_TABLE0_ROWS));
+            final List<ColumnStatistic> avgLowCardinality = ImmutableList.of(
+                    new ColumnStatistic(0.0, NUM_TABLE0_ROWS, 0.0, 10, 100));
+            {
+                mockedStatisticStorage.getColumnStatistics((Table) any, Lists.newArrayList("v2"));
+                returns(avgHighCardinality, avgHighCardinality, avgHighCardinality, avgHighCardinality, avgLowCardinality);
+            }
+
+            {
+                mockedStatisticStorage.getColumnStatistics((Table) any, Lists.newArrayList("v1"));
+                result = avgLowCardinality;
+            }
+        };
+
+        boolean prevEnableLocalShuffleAgg = connectContext.getSessionVariable().isEnableLocalShuffleAgg();
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
+
+        try {
+            // case 1: use one-phase local aggregation with local shuffle for high-cardinality agg and single BE.
+            String sql = "select sum(v2) from t0 group by v2";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                    "  |  output: sum(2: v2)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  withLocalShuffle: true\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            // case 2: use one-phase local aggregation without local shuffle for high-cardinality agg and single BE.
+            sql = "select sum(v1) from t0 group by v1";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                    "  |  output: sum(1: v1)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            // case 3: use two-phase aggregation for non-grouping agg.
+            sql = "select sum(v2) from t0";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "1:AGGREGATE (update serialize)\n" +
+                    "  |  output: sum(2: v2)\n" +
+                    "  |  group by: \n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+            assertContains(plan, "3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(4: sum)\n" +
+                    "  |  group by: \n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE");
+
+            // case 4: use two-phase aggregation for multiple BEs.
+            sql = "select sum(v2) from t0 group by v2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(2: v2)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+            assertContains(plan, "3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(4: sum)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE");
+
+            // case 5: use two-phase aggregation for low-cardinality agg.
+            sql = "select sum(v2) from t0 group by v2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(2: v2)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+            assertContains(plan, "3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(4: sum)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE");
+        } finally {
+            connectContext.getSessionVariable().setEnableLocalShuffleAgg(prevEnableLocalShuffleAgg);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -69,6 +69,7 @@ public class PlanTestBase {
         connectContext.getSessionVariable().setMaxTransformReorderJoins(8);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         connectContext.getSessionVariable().setEnableReplicationJoin(false);
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(false);
 
         starRocksAssert.withTable("CREATE TABLE `t0` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +
@@ -1052,6 +1053,7 @@ public class PlanTestBase {
     @AfterClass
     public static void afterClass() {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
     }
 
     public static void assertContains(String text, String... pattern) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -19,6 +19,7 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -47,6 +48,7 @@ public class ReplayFromDumpTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         connectContext.getSessionVariable().setJoinImplementationMode("auto");
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(false);
         starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
     }
@@ -54,6 +56,11 @@ public class ReplayFromDumpTest {
     @Before
     public void before() {
         BackendCoreStat.reset();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
     }
 
     public String getModelContent(String filename, String model) {
@@ -141,6 +148,7 @@ public class ReplayFromDumpTest {
             queryDumpInfo.setSessionVariable(sessionVariable);
         }
         queryDumpInfo.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        queryDumpInfo.getSessionVariable().setEnableLocalShuffleAgg(false);
         return new Pair<>(queryDumpInfo,
                 UtFrameUtils.getNewPlanAndFragmentFromDump(connectContext, queryDumpInfo).second.
                         getExplainString(level));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Generating "ScanNode->LocalShuffle->OnePhaseLocalAgg" for the single backend, contains two steps:
1. Ignore the network cost for ExchangeNode when estimating cost model.
2. Remove ExchangeNode between AggNode and ScanNode when building 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
