### PR TITLE
[Cherry-pick 2.3][Enhancement] support table name with one leading underscore (#11642)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -27,15 +27,17 @@ import com.starrocks.mysql.privilege.Role;
 import com.starrocks.system.SystemInfoService;
 
 public class FeNameFormat {
-    private static final String LABEL_REGEX = "^[-_A-Za-z0-9]{1,128}$";
-    public static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,63}$";
+    private FeNameFormat() {}
+
+    private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
+    public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
 
     // The user name  by kerberos authentication may include the host name, so additional adaptation is required.
-    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{1,63}/?[.a-zA-Z0-9_-]{0,63}$";
+    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z]\\w{1,63}/?[.\\w-]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -365,4 +365,22 @@ public class CreateTableTest {
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Data type of first column cannot be HLL",
                 () -> createTable("create table test.tmp3\n" + "(k1 hll, k2 float)\n"));
     }
+
+    @Test
+    public void testNameWithUnderscore() throws Exception {
+        // table name with one underscore is fine
+        String sql = "CREATE TABLE test._txx(_k1 VARCHAR(100)) DISTRIBUTED BY HASH(_k1) "
+                + "BUCKETS 8 PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(sql);
+
+        // table name with two underscore is not allowed
+        sql = "CREATE TABLE test.__txx(_k1 VARCHAR(100)) DISTRIBUTED BY HASH(_k1) "
+                + "BUCKETS 8 PROPERTIES(\"replication_num\" = \"1\");";
+        try {
+            createTable(sql);
+            Assert.fail();
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("Incorrect table name"));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -44,7 +44,7 @@ public class AnalyzeAlterTableStatementTest {
 
     @Test(expected = SemanticException.class)
     public void testIllegalNewTableName() {
-        TableRenameClause clause = new TableRenameClause("_newName");
+        TableRenameClause clause = new TableRenameClause("__newName");
         clauseAnalyzerVisitor.analyze(clause, connectContext);
     }
 


### PR DESCRIPTION
Modify the regular expression of the table name so that table name with one underscore is considered legal and table name with more than one consecutive underscores is not.
Fixes #11640
manually cherry-picked from 0e2f13a5bdaba68619d6a6867cdf464a0072dc4d