### PR TITLE
[Enhancement] optimize colocate balancing when replication_num is 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -342,8 +342,8 @@ public class ColocateTableBalancer extends LeaderDaemon {
             // update backends and hosts at each round
             backendsPerBucketSeq = Lists.partition(flatBackendsPerBucketSeq, replicationNum);
             List<List<String>> hostsPerBucketSeq = getHostsPerBucketSeq(backendsPerBucketSeq, infoService);
-            Preconditions
-                    .checkState(hostsPerBucketSeq != null && backendsPerBucketSeq.size() == hostsPerBucketSeq.size());
+            Preconditions.checkState(hostsPerBucketSeq != null &&
+                    backendsPerBucketSeq.size() == hostsPerBucketSeq.size());
 
             long srcBeId = -1;
             List<Integer> srcBeSeqIndexes = null;
@@ -357,30 +357,34 @@ public class ColocateTableBalancer extends LeaderDaemon {
                     break;
                 }
             }
-            // sort backends with replica num in desc order
+
+            // Sort backends with replica num in desc order, the list contains only all the *available* backends.
             List<Map.Entry<Long, Long>> backendWithReplicaNum =
                     getSortedBackendReplicaNumPairs(availableBeIds, unavailableBeIds, statistic,
                             flatBackendsPerBucketSeq);
-            if (srcBeSeqIndexes == null || srcBeSeqIndexes.size() <= 0) {
-                // there is only one available backend and no unavailable bucketId to relocate, end the outer loop
-                if (backendWithReplicaNum.size() <= 1) {
-                    break;
-                }
-
-                // there is no unavailable bucketId to relocate, choose max bucketId num be as src be
-                srcBeId = backendWithReplicaNum.get(0).getKey();
-                srcBeSeqIndexes = getBeSeqIndexes(flatBackendsPerBucketSeq, srcBeId);
-            } else if (backendWithReplicaNum.size() <= 0) {
-                // there is unavailable bucketId to relocate, but no available backend, end the outer loop
+            if (backendWithReplicaNum.size() <= 1) {
+                // There is not enough replicas for us to do relocation or balance, because in this case we
+                // can not choose a valid backend to migrate replica to, end the outer loop.
                 break;
             }
 
             int leftBound;
-            if (hasUnavailableBe) {
-                leftBound = -1;
-            } else {
+            if (!hasUnavailableBe || replicationNum == 1) {
+                // There are two cases:
+                // 1. there is no unavailable bucketId to relocate
+                // 2. there is unavailable bucketId to relocate, but the number of replica is one, we can do
+                //    nothing but wait for the dead BE to come alive, in this case we shouldn't change the bucket
+                //    sequence which will cause a lot of wasted colocate balancing work and further more make the
+                //    colocate group unstable for longer time, but we can still do the balance work.
+                //
+                // In both cases, we change the src be to which that have the most replicas.
+                srcBeId = backendWithReplicaNum.get(0).getKey();
+                srcBeSeqIndexes = getBeSeqIndexes(flatBackendsPerBucketSeq, srcBeId);
                 leftBound = 0;
+            } else {
+                leftBound = -1;
             }
+
             int j = backendWithReplicaNum.size() - 1;
             boolean isThisRoundChanged = false;
             INNER:
@@ -388,7 +392,9 @@ public class ColocateTableBalancer extends LeaderDaemon {
                 // we try to use a low backend to replace the src backend.
                 // if replace failed(eg: both backends are on same host), select next low backend and try(j--)
                 Map.Entry<Long, Long> lowBackend = backendWithReplicaNum.get(j);
-                if ((!hasUnavailableBe) && (srcBeSeqIndexes.size() - lowBackend.getValue()) <= 1) {
+                // leftBound == 0 indicates that we don't need to consider the unavailable backends and only do
+                // balance work.
+                if (leftBound == 0 && (srcBeSeqIndexes.size() - lowBackend.getValue()) <= 1) {
                     // balanced
                     break OUT;
                 }
@@ -410,7 +416,9 @@ public class ColocateTableBalancer extends LeaderDaemon {
                     if (!backendsSet.contains(destBeId) && !hostsSet.contains(destBe.getHost())) {
                         Preconditions.checkState(backendsSet.contains(srcBeId), srcBeId);
                         flatBackendsPerBucketSeq.set(seqIndex, destBeId);
-                        LOG.info("replace backend {} with backend {} in colocate group {}", srcBeId, destBeId, groupId);
+                        LOG.info("replace backend {} with backend {} in colocate group {}, src be seq index: {}" +
+                                        ", bucket index: {}, original backend list: {}",
+                                srcBeId, destBeId, groupId, seqIndex, bucketIndex, backendsSet);
                         // just replace one backend at a time, src and dest BE id should be recalculated because
                         // flatBackendsPerBucketSeq is changed.
                         isChanged = true;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -107,9 +107,8 @@ public class ColocateTableBalancerTest {
         mixLoadScores.put(9L, 0.9);
     }
 
-    private ColocateTableIndex createColocateIndex(GroupId groupId, List<Long> flatList) {
+    private ColocateTableIndex createColocateIndex(GroupId groupId, List<Long> flatList, int replicationNum) {
         ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
-        int replicationNum = 3;
         List<List<Long>> backendsPerBucketSeq = Lists.partition(flatList, replicationNum);
         colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
         return colocateTableIndex;
@@ -172,10 +171,10 @@ public class ColocateTableBalancerTest {
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
 
-        // 1. balance a imbalance group
+        // 1. balance an imbalanced group
         // [[1, 2, 3], [4, 1, 2], [3, 4, 1], [2, 3, 4], [1, 2, 3]]
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L));
+                Lists.newArrayList(1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
@@ -188,9 +187,9 @@ public class ColocateTableBalancerTest {
         Assert.assertTrue(changed);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
 
-        // 2. balance a already balanced group
+        // 2. balance an already balanced group
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L));
+                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         balancedBackendsPerBucketSeq.clear();
         changed = (Boolean) Deencapsulation
@@ -199,6 +198,162 @@ public class ColocateTableBalancerTest {
         System.out.println(balancedBackendsPerBucketSeq);
         Assert.assertFalse(changed);
         Assert.assertTrue(balancedBackendsPerBucketSeq.isEmpty());
+    }
+
+    private void setGroup2Schema(GroupId groupId, ColocateTableIndex colocateTableIndex,
+                                 int bucketNum, short replicationNum) {
+        List<Column> distributionCols = Lists.newArrayList();
+        distributionCols.add(new Column("k1", Type.INT));
+        ColocateGroupSchema groupSchema =
+                new ColocateGroupSchema(groupId, distributionCols, bucketNum, replicationNum);
+        Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
+        group2Schema.put(groupId, groupSchema);
+        Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
+    }
+
+    @Test
+    public void testBalanceWithOnlyOneAvailableBackend(@Mocked SystemInfoService infoService,
+                                                       @Mocked ClusterLoadStatistic statistic,
+                                                       @Mocked Backend myBackend2,
+                                                       @Mocked Backend myBackend3,
+                                                       @Mocked Backend myBackend4) {
+        new Expectations() {
+            {
+                // backend2 is available
+                infoService.getBackend(2L);
+                result = myBackend2;
+                minTimes = 0;
+                myBackend2.isAvailable();
+                result = true;
+                minTimes = 0;
+
+                // backend3 not available, and dead for a long time
+                infoService.getBackend(3L);
+                result = myBackend3;
+                minTimes = 0;
+                myBackend3.isAvailable();
+                result = false;
+                minTimes = 0;
+                myBackend3.isAlive();
+                result = false;
+                minTimes = 0;
+                myBackend3.getLastUpdateMs();
+                result = System.currentTimeMillis() - Config.tablet_sched_repair_delay_factor_second * 1000 * 20;
+                minTimes = 0;
+
+                // backend4 not available, and dead for a short time
+                infoService.getBackend(4L);
+                result = myBackend4;
+                minTimes = 0;
+                myBackend4.isAvailable();
+                result = false;
+                minTimes = 0;
+                myBackend4.isAlive();
+                result = false;
+                minTimes = 0;
+                myBackend4.getLastUpdateMs();
+                result = System.currentTimeMillis();
+                minTimes = 0;
+            }
+        };
+
+        // To avoid "missing x invocation to..." error
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
+        GroupId groupId = new GroupId(10000, 10001);
+        ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
+                Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 3);
+        setGroup2Schema(groupId, colocateTableIndex, 3, (short) 3);
+
+        Set<Long> unavailableBeIds = Sets.newHashSet(3L, 4L);
+        List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
+        List<Long> availBackendIds = Lists.newArrayList(2L);
+
+        boolean changed = (Boolean) Deencapsulation
+                .invoke(balancer, "relocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+        // in this case, there is only on available backend, no need to make balancing decision.
+        Assert.assertFalse(changed);
+    }
+
+    @Test
+    public void testBalanceWithSingleReplica(@Mocked SystemInfoService infoService,
+                                             @Mocked ClusterLoadStatistic statistic,
+                                             @Mocked Backend myBackend2,
+                                             @Mocked Backend myBackend3,
+                                             @Mocked Backend myBackend4) {
+        new Expectations() {
+            {
+                // backend2 is available
+                infoService.getBackend(2L);
+                result = myBackend2;
+                minTimes = 0;
+                myBackend2.isAvailable();
+                result = true;
+                minTimes = 0;
+                myBackend2.getHost();
+                result = "192.168.0.112";
+                minTimes = 0;
+
+                // backend3 is available
+                infoService.getBackend(3L);
+                result = myBackend3;
+                minTimes = 0;
+                myBackend3.isAvailable();
+                result = true;
+                minTimes = 0;
+                myBackend3.getHost();
+                result = "192.168.0.113";
+                minTimes = 0;
+
+                // backend4 not available, and dead for a short time
+                infoService.getBackend(4L);
+                result = myBackend4;
+                minTimes = 0;
+                myBackend4.isAvailable();
+                result = false;
+                minTimes = 0;
+                myBackend4.isAlive();
+                result = false;
+                minTimes = 0;
+                myBackend4.getLastUpdateMs();
+                result = System.currentTimeMillis();
+                minTimes = 0;
+                myBackend4.getHost();
+                result = "192.168.0.114";
+                minTimes = 0;
+            }
+        };
+
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
+        GroupId groupId = new GroupId(10000, 10001);
+        ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
+                Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 1);
+        setGroup2Schema(groupId, colocateTableIndex, 9, (short) 1);
+
+        Set<Long> unavailableBeIds = Sets.newHashSet(3L);
+        List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
+        List<Long> availBackendIds = Lists.newArrayList(2L, 4L);
+
+        boolean changed = (Boolean) Deencapsulation
+                .invoke(balancer, "relocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+        // there is unavailable backend, but the replication number is 1 and replicas on available backends are
+        // already balanced, so the bucket sequence will remain unchanged.
+        Assert.assertFalse(changed);
+
+        colocateTableIndex = createColocateIndex(groupId,
+                Lists.newArrayList(2L, 2L, 3L, 2L, 2L, 3L, 4L, 2L, 3L), 1);
+        setGroup2Schema(groupId, colocateTableIndex, 9, (short) 1);
+        changed = (Boolean) Deencapsulation
+                .invoke(balancer, "relocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+        Assert.assertTrue(changed);
+        System.out.println(balancedBackendsPerBucketSeq);
+        List<List<Long>> expected = Lists.partition(
+                Lists.newArrayList(4L, 4L, 3L, 2L, 2L, 3L, 4L, 2L, 3L), 1);
+        // there is unavailable backend, but the replication number is 1 and replicas on available backends are
+        // not balanced, check the balancer actually working.
+        Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
     }
 
     @Test
@@ -247,7 +402,7 @@ public class ColocateTableBalancerTest {
 
         // 1. only one available backend
         // [[7], [7], [7], [7], [7]]
-        ColocateTableIndex colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L));
+        ColocateTableIndex colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
@@ -260,7 +415,7 @@ public class ColocateTableBalancerTest {
         // 2. all backends are checked but this round is not changed
         // [[7], [7], [7], [7], [7]]
         // and add new backends 8, 9 that are on the same host with 7
-        colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L));
+        colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         balancedBackendsPerBucketSeq = Lists.newArrayList();
@@ -271,7 +426,7 @@ public class ColocateTableBalancerTest {
         Assert.assertFalse(changed);
 
         // 3. all backends are not available
-        colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L));
+        colocateTableIndex = createColocateIndex(groupId, Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         balancedBackendsPerBucketSeq = Lists.newArrayList();
         allAvailBackendIds = Lists.newArrayList();
@@ -537,7 +692,7 @@ public class ColocateTableBalancerTest {
 
         // group is balanced before backend 9 is dropped
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L));
+                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
         Set<Long> unavailableBeIds = Sets.newHashSet(9L);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10619

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If there is unavailable bucketId to relocate, but the number of replica is one, we can do
nothing but wait for the dead BE to come alive, in this case we shouldn't change the bucket
sequence which will cause a lot of wasted colocate relocation work and further more make the
colocate group unstable for longer time, but we can still do the balance work.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
