### PR TITLE
[Feature] Support sort key, add ORDER BY grammar to assign sort key.

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -145,7 +145,7 @@ void Chunk::remove_column_by_index(size_t idx) {
     }
 }
 
-void Chunk::remove_columns_by_index(const std::vector<size_t>& indexes) {
+[[maybe_unused]] void Chunk::remove_columns_by_index(const std::vector<size_t>& indexes) {
     DCHECK(std::is_sorted(indexes.begin(), indexes.end()));
     for (int i = indexes.size(); i > 0; i--) {
         _columns.erase(_columns.begin() + indexes[i - 1]);

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -90,7 +90,7 @@ public:
     // For simplicity and better performance, we are assuming |indexes| all all valid
     // and is sorted in ascending order, if it's not, unexpected columns may be removed (silently).
     // |indexes| can be empty and no column will be removed in this case.
-    void remove_columns_by_index(const std::vector<size_t>& indexes);
+    [[maybe_unused]] void remove_columns_by_index(const std::vector<size_t>& indexes);
 
     // schema must exists.
     const ColumnPtr& get_column_by_name(const std::string& column_name) const;

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -8,11 +8,11 @@ namespace starrocks::vectorized {
 
 #ifdef BE_TEST
 
-Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, std::vector<ColumnId>{}) {}
+Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, {}) {}
 
 #endif
 
-Schema::Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key_idxes)
+Schema::Schema(Fields fields, KeysType keys_type, const std::vector<ColumnId>& sort_key_idxes)
         : _fields(std::move(fields)),
           _sort_key_idxes(sort_key_idxes),
           _name_to_index_append_buffer(nullptr),
@@ -116,6 +116,7 @@ void Schema::append(const FieldPtr& field) {
     }
 }
 
+// it's not being used, especially in sort key scenario, so do not handle this case
 void Schema::insert(size_t idx, const FieldPtr& field) {
     DCHECK_LT(idx, _fields.size());
 
@@ -132,6 +133,7 @@ void Schema::insert(size_t idx, const FieldPtr& field) {
     _build_index_map(_fields);
 }
 
+// it's not being used, especially in sort key scenario, so do not handle this case
 void Schema::remove(size_t idx) {
     DCHECK_LT(idx, _fields.size());
     _num_keys -= _fields[idx]->is_key();
@@ -157,9 +159,7 @@ void Schema::remove(size_t idx) {
 
 const FieldPtr& Schema::field(size_t idx) const {
     DCHECK_GE(idx, 0);
-    if (_sort_key_idxes.empty()) {
-        DCHECK_LT(idx, _fields.size());
-    }
+    DCHECK_LT(idx, _fields.size());
     return _fields[idx];
 }
 

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -22,7 +22,7 @@ public:
     explicit Schema(Fields fields);
 #endif
 
-    explicit Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key_idxes);
+    explicit Schema(Fields fields, KeysType keys_type, const std::vector<ColumnId>& sort_key_idxes);
 
     // if we use this constructor and share the name_to_index with another schema,
     // we must make sure another shema is read only!!!

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -22,7 +22,7 @@ public:
     explicit Schema(Fields fields);
 #endif
 
-    explicit Schema(Fields fields, KeysType keys_type);
+    explicit Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key_idxes);
 
     // if we use this constructor and share the name_to_index with another schema,
     // we must make sure another shema is read only!!!
@@ -41,6 +41,8 @@ public:
     size_t num_fields() const { return _fields.size(); }
 
     size_t num_key_fields() const { return _num_keys; }
+
+    const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
 
     void reserve(size_t size) { _fields.reserve(size); }
 
@@ -75,6 +77,7 @@ private:
 
     Fields _fields;
     size_t _num_keys = 0;
+    std::vector<ColumnId> _sort_key_idxes;
     std::shared_ptr<std::unordered_map<std::string_view, size_t>> _name_to_index;
 
     // If we share the same _name_to_index with another vectorized schema,

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -98,7 +98,7 @@ vectorized::Schema ChunkHelper::convert_schema(const starrocks::TabletSchema& sc
         auto f = convert_field(cid, schema.column(cid));
         fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
     }
-    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
+    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type(), schema.sort_key_idxes());
 }
 
 starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id, const TabletColumn& c) {
@@ -148,8 +148,15 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
 
 starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {
     std::vector<ColumnId> short_key_cids;
-    for (ColumnId cid = 0; cid < schema.num_short_key_columns(); ++cid) {
-        short_key_cids.push_back(cid);
+    const auto& sort_key_idxes = schema.sort_key_idxes();
+    if (!sort_key_idxes.empty()) {
+        for (auto i = 0; i < schema.num_short_key_columns() && i < sort_key_idxes.size(); ++i) {
+            short_key_cids.push_back(sort_key_idxes[i]);
+        }
+    } else {
+        for (ColumnId cid = 0; cid < schema.num_short_key_columns(); ++cid) {
+            short_key_cids.push_back(cid);
+        }
     }
     return starrocks::vectorized::Schema(schema.schema(), short_key_cids);
 }

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -150,7 +150,7 @@ starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(c
     std::vector<ColumnId> short_key_cids;
     const auto& sort_key_idxes = schema.sort_key_idxes();
     if (!sort_key_idxes.empty()) {
-        for (auto i = 0; i < schema.num_short_key_columns() && i < sort_key_idxes.size(); ++i) {
+        for (auto i = 0; i < schema.num_short_key_columns(); ++i) {
             short_key_cids.push_back(sort_key_idxes[i]);
         }
     } else {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -149,14 +149,8 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
 starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {
     std::vector<ColumnId> short_key_cids;
     const auto& sort_key_idxes = schema.sort_key_idxes();
-    if (!sort_key_idxes.empty()) {
-        for (auto i = 0; i < schema.num_short_key_columns(); ++i) {
-            short_key_cids.push_back(sort_key_idxes[i]);
-        }
-    } else {
-        for (ColumnId cid = 0; cid < schema.num_short_key_columns(); ++cid) {
-            short_key_cids.push_back(cid);
-        }
+    for (auto i = 0; i < schema.num_short_key_columns(); ++i) {
+        short_key_cids.push_back(sort_key_idxes[i]);
     }
     return starrocks::vectorized::Schema(schema.schema(), short_key_cids);
 }

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -35,7 +35,7 @@ public:
                                                           const std::vector<ColumnId>& cids);
 
     // Get schema with format v2 type containing short key columns from TabletSchema.
-    static vectorized::Schema get_short_key_schema_with_format_v2(const TabletSchema& schema);
+    static vectorized::Schema get_short_key_schema_with_format_v2(const TabletSchema& tablet_schema);
 
     static ColumnId max_column_id(const vectorized::Schema& schema);
 

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -72,7 +72,7 @@ Status Compaction::do_compaction_impl() {
     CompactionAlgorithm algorithm = CompactionUtils::choose_compaction_algorithm(
             _tablet->num_columns(), config::vertical_compaction_max_columns_per_group, segment_iterator_num);
     if (algorithm == VERTICAL_COMPACTION) {
-        CompactionUtils::split_column_into_groups(_tablet->num_columns(), _tablet->num_key_columns(),
+        CompactionUtils::split_column_into_groups(_tablet->num_columns(), _tablet->tablet_schema().sort_key_idxes(),
                                                   config::vertical_compaction_max_columns_per_group, &_column_groups);
     }
 

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -78,25 +78,9 @@ uint32_t CompactionUtils::get_segment_max_rows(int64_t max_segment_file_size, in
     return max_segment_rows;
 }
 
-void CompactionUtils::split_column_into_groups(size_t num_columns, size_t num_key_columns,
+void CompactionUtils::split_column_into_groups(size_t num_columns, const std::vector<ColumnId>& sort_key_idxes,
                                                int64_t max_columns_per_group,
                                                std::vector<std::vector<uint32_t>>* column_groups) {
-    std::vector<uint32_t> key_columns;
-    for (size_t i = 0; i < num_key_columns; ++i) {
-        key_columns.emplace_back(i);
-    }
-    column_groups->emplace_back(std::move(key_columns));
-    for (size_t i = num_key_columns; i < num_columns; ++i) {
-        if ((i - num_key_columns) % max_columns_per_group == 0) {
-            column_groups->emplace_back();
-        }
-        column_groups->back().emplace_back(i);
-    }
-}
-
-void CompactionUtils::split_column_into_groups_sort_key(size_t num_columns, const std::vector<ColumnId> sort_key_idxes,
-                                                        int64_t max_columns_per_group,
-                                                        std::vector<std::vector<uint32_t>>* column_groups) {
     column_groups->emplace_back(sort_key_idxes);
     std::vector<ColumnId> all_columns;
     for (ColumnId i = 0; i < num_columns; ++i) {

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -86,12 +86,30 @@ void CompactionUtils::split_column_into_groups(size_t num_columns, size_t num_ke
         key_columns.emplace_back(i);
     }
     column_groups->emplace_back(std::move(key_columns));
-
     for (size_t i = num_key_columns; i < num_columns; ++i) {
         if ((i - num_key_columns) % max_columns_per_group == 0) {
             column_groups->emplace_back();
         }
         column_groups->back().emplace_back(i);
+    }
+}
+
+void CompactionUtils::split_column_into_groups_sort_key(size_t num_columns, const std::vector<ColumnId> sort_key_idxes,
+                                                        int64_t max_columns_per_group,
+                                                        std::vector<std::vector<uint32_t>>* column_groups) {
+    column_groups->emplace_back(sort_key_idxes);
+    std::vector<ColumnId> all_columns;
+    for (ColumnId i = 0; i < num_columns; ++i) {
+        all_columns.push_back(i);
+    }
+    std::vector<ColumnId> value_columns;
+    std::set_difference(all_columns.begin(), all_columns.end(), sort_key_idxes.begin(), sort_key_idxes.end(),
+                        std::back_inserter(value_columns));
+    for (auto i = 0; i < value_columns.size(); ++i) {
+        if (i % max_columns_per_group == 0) {
+            column_groups->emplace_back();
+        }
+        column_groups->back().emplace_back(value_columns[i]);
     }
 }
 

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -102,14 +102,14 @@ void CompactionUtils::split_column_into_groups_sort_key(size_t num_columns, cons
     for (ColumnId i = 0; i < num_columns; ++i) {
         all_columns.push_back(i);
     }
-    std::vector<ColumnId> value_columns;
+    std::vector<ColumnId> non_sort_columns;
     std::set_difference(all_columns.begin(), all_columns.end(), sort_key_idxes.begin(), sort_key_idxes.end(),
-                        std::back_inserter(value_columns));
-    for (auto i = 0; i < value_columns.size(); ++i) {
+                        std::back_inserter(non_sort_columns));
+    for (auto i = 0; i < non_sort_columns.size(); ++i) {
         if (i % max_columns_per_group == 0) {
             column_groups->emplace_back();
         }
-        column_groups->back().emplace_back(value_columns[i]);
+        column_groups->back().emplace_back(non_sort_columns[i]);
     }
 }
 

--- a/be/src/storage/compaction_utils.h
+++ b/be/src/storage/compaction_utils.h
@@ -46,6 +46,10 @@ public:
     static void split_column_into_groups(size_t num_columns, size_t num_key_columns, int64_t max_columns_per_group,
                                          std::vector<std::vector<uint32_t>>* column_groups);
 
+    static void split_column_into_groups_sort_key(size_t num_columns, const std::vector<ColumnId> sort_key_idxes,
+                                                  int64_t max_columns_per_group,
+                                                  std::vector<std::vector<uint32_t>>* column_groups);
+
     // choose compaction algorithm according to tablet schema, max columns per group and segment iterator num.
     // 1. if the number of columns in the schema is less than or equal to max_columns_per_group, use HORIZONTAL_COMPACTION.
     // 2. if source_num is less than or equal to 1, or is more than MAX_SOURCES, use HORIZONTAL_COMPACTION.

--- a/be/src/storage/compaction_utils.h
+++ b/be/src/storage/compaction_utils.h
@@ -43,12 +43,9 @@ public:
 
     static uint32_t get_segment_max_rows(int64_t max_segment_file_size, int64_t input_row_num, int64_t input_size);
 
-    static void split_column_into_groups(size_t num_columns, size_t num_key_columns, int64_t max_columns_per_group,
+    static void split_column_into_groups(size_t num_columns, const std::vector<ColumnId>& sort_key_idxes,
+                                         int64_t max_columns_per_group,
                                          std::vector<std::vector<uint32_t>>* column_groups);
-
-    static void split_column_into_groups_sort_key(size_t num_columns, const std::vector<ColumnId> sort_key_idxes,
-                                                  int64_t max_columns_per_group,
-                                                  std::vector<std::vector<uint32_t>>* column_groups);
 
     // choose compaction algorithm according to tablet schema, max columns per group and segment iterator num.
     // 1. if the number of columns in the schema is less than or equal to max_columns_per_group, use HORIZONTAL_COMPACTION.

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -183,7 +183,10 @@ Status DeltaWriter::_init() {
         }
         writer_context.partial_update_tablet_schema =
                 TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
-        if (!_tablet->tablet_schema().sort_key_idxes().empty()) {
+        auto sort_key_idxes = _tablet->tablet_schema().sort_key_idxes();
+        std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
+        if (!std::includes(writer_context.referenced_column_ids.begin(), writer_context.referenced_column_ids.end(),
+                           sort_key_idxes.begin(), sort_key_idxes.end())) {
             LOG(WARNING) << "table with sort key do not support partial update";
             return Status::NotSupported("table with sort key do not support partial update");
         }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -183,6 +183,10 @@ Status DeltaWriter::_init() {
         }
         writer_context.partial_update_tablet_schema =
                 TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
+        if (!_tablet->tablet_schema().sort_key_idxes().empty()) {
+            LOG(WARNING) << "table with sort key do not support partial update";
+            return Status::NotSupported("table with sort key do not support partial update");
+        }
         writer_context.tablet_schema = writer_context.partial_update_tablet_schema.get();
     } else {
         writer_context.tablet_schema = &_tablet->tablet_schema();

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -206,7 +206,7 @@ Status MemTable::finalize() {
                     _result_chunk = upserts;
                 }
             }
-            if (_keys_type == KeysType::PRIMARY_KEYS && !_vectorized_schema->sort_key_idxes().empty()) {
+            if (_keys_type == KeysType::PRIMARY_KEYS) {
                 std::vector<ColumnId> primary_key_idxes(_vectorized_schema->num_key_fields());
                 for (ColumnId i = 0; i < _vectorized_schema->num_key_fields(); ++i) {
                     primary_key_idxes[i] = i;

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -207,13 +207,13 @@ Status MemTable::finalize() {
                 }
             }
             if (_keys_type == KeysType::PRIMARY_KEYS && !_vectorized_schema->sort_key_idxes().empty()) {
-                std::vector<ColumnId> primary_key_idxes;
+                std::vector<ColumnId> primary_key_idxes(_vectorized_schema->num_key_fields());
                 for (ColumnId i = 0; i < _vectorized_schema->num_key_fields(); ++i) {
-                    primary_key_idxes.push_back(i);
+                    primary_key_idxes[i] = i;
                 }
                 const auto& sort_key_idxes = _vectorized_schema->sort_key_idxes();
-                if (!std::includes(primary_key_idxes.begin(), primary_key_idxes.end(), sort_key_idxes.begin(),
-                                   sort_key_idxes.end())) {
+                if (std::mismatch(sort_key_idxes.begin(), sort_key_idxes.end(), primary_key_idxes.begin()).first !=
+                    sort_key_idxes.end()) {
                     _chunk = _result_chunk;
                     _sort(true, true);
                 }

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -53,8 +53,8 @@ public:
 private:
     void _merge();
 
-    void _sort(bool is_final);
-    void _sort_column_inc();
+    void _sort(bool is_final, bool by_sort_key = false);
+    void _sort_column_inc(bool by_sort_key = false);
     void _append_to_sorted_chunk(Chunk* src, Chunk* dest, bool is_final);
 
     void _init_aggregator_if_needed();

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -274,7 +274,9 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
             }
         }
     }
-
+    for (const auto idx : tablet_schema.sort_key_idxes) {
+        schema->add_sort_key_idxes(idx);
+    }
     schema->set_next_column_unique_id(next_unique_id);
     if (has_bf_columns && tablet_schema.__isset.bloom_filter_fpp) {
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -924,9 +924,9 @@ PrimaryIndex::PrimaryIndex(const vectorized::Schema& pk_schema) {
 
 void PrimaryIndex::_set_schema(const vectorized::Schema& pk_schema) {
     _pk_schema = pk_schema;
-    std::vector<ColumnId> sort_key_idxes;
+    std::vector<ColumnId> sort_key_idxes(pk_schema.num_fields());
     for (ColumnId i = 0; i < pk_schema.num_fields(); ++i) {
-        sort_key_idxes.push_back(i);
+        sort_key_idxes[i] = i;
     }
     _enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(_pk_schema, sort_key_idxes);
     _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -924,7 +924,11 @@ PrimaryIndex::PrimaryIndex(const vectorized::Schema& pk_schema) {
 
 void PrimaryIndex::_set_schema(const vectorized::Schema& pk_schema) {
     _pk_schema = pk_schema;
-    _enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(_pk_schema);
+    std::vector<ColumnId> sort_key_idxes;
+    for (ColumnId i = 0; i < pk_schema.num_fields(); ++i) {
+        sort_key_idxes.push_back(i);
+    }
+    _enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(_pk_schema, sort_key_idxes);
     _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
     _pkey_to_rssid_rowid = std::move(create_hash_index(_enc_pk_type, _key_size));
 }

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -279,9 +279,9 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const vectorized::Schema& schem
 
 Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema,
                                         std::unique_ptr<vectorized::Column>* pcolumn) {
-    std::vector<ColumnId> sort_key_idxes;
+    std::vector<ColumnId> sort_key_idxes(schema.num_key_fields());
     for (ColumnId i = 0; i < schema.num_key_fields(); ++i) {
-        sort_key_idxes.push_back(i);
+        sort_key_idxes[i] = i;
     }
     return PrimaryKeyEncoder::create_column(schema, pcolumn, sort_key_idxes);
 }

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -244,9 +244,9 @@ bool PrimaryKeyEncoder::is_supported(const vectorized::Field& f) {
     }
 }
 
-bool PrimaryKeyEncoder::is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& sort_key_idxes) {
-    for (const auto sort_key_idx : sort_key_idxes) {
-        if (!is_supported(*schema.field(sort_key_idx))) {
+bool PrimaryKeyEncoder::is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& key_idxes) {
+    for (const auto key_idx : key_idxes) {
+        if (!is_supported(*schema.field(key_idx))) {
             return false;
         }
     }
@@ -254,12 +254,12 @@ bool PrimaryKeyEncoder::is_supported(const vectorized::Schema& schema, const std
 }
 
 FieldType PrimaryKeyEncoder::encoded_primary_key_type(const vectorized::Schema& schema,
-                                                      const std::vector<ColumnId>& sort_key_idxes) {
-    if (!is_supported(schema, sort_key_idxes)) {
+                                                      const std::vector<ColumnId>& key_idxes) {
+    if (!is_supported(schema, key_idxes)) {
         return OLAP_FIELD_TYPE_NONE;
     }
-    if (sort_key_idxes.size() == 1) {
-        return schema.field(sort_key_idxes[0])->type()->type();
+    if (key_idxes.size() == 1) {
+        return schema.field(key_idxes[0])->type()->type();
     }
     return OLAP_FIELD_TYPE_VARCHAR;
 }
@@ -279,26 +279,26 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const vectorized::Schema& schem
 
 Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema,
                                         std::unique_ptr<vectorized::Column>* pcolumn) {
-    std::vector<ColumnId> sort_key_idxes(schema.num_key_fields());
+    std::vector<ColumnId> key_idxes(schema.num_key_fields());
     for (ColumnId i = 0; i < schema.num_key_fields(); ++i) {
-        sort_key_idxes[i] = i;
+        key_idxes[i] = i;
     }
-    return PrimaryKeyEncoder::create_column(schema, pcolumn, sort_key_idxes);
+    return PrimaryKeyEncoder::create_column(schema, pcolumn, key_idxes);
 }
 
 Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn,
-                                        const std::vector<ColumnId>& sort_key_idxes) {
-    if (!is_supported(schema, sort_key_idxes)) {
+                                        const std::vector<ColumnId>& key_idxes) {
+    if (!is_supported(schema, key_idxes)) {
         return Status::NotSupported("type not supported for primary key encoding");
     }
     // TODO: let `Chunk::column_from_field_type` and `Chunk::column_from_field` return a
     // `std::unique_ptr<Column>` instead of `std::shared_ptr<Column>`, in order to reuse
     // its code here.
-    if (sort_key_idxes.size() == 1) {
+    if (key_idxes.size() == 1) {
         // simple encoding
         // integer's use fixed length original column
         // varchar use binary
-        auto type = schema.field(sort_key_idxes[0])->type()->type();
+        auto type = schema.field(key_idxes[0])->type()->type();
         switch (type) {
         case OLAP_FIELD_TYPE_BOOL:
             *pcolumn = vectorized::BooleanColumn::create_mutable();

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -244,18 +244,8 @@ bool PrimaryKeyEncoder::is_supported(const vectorized::Field& f) {
     }
 }
 
-bool PrimaryKeyEncoder::is_supported(const vectorized::Schema& schema) {
-    size_t n = schema.num_key_fields();
-    for (size_t i = 0; i < n; i++) {
-        if (!is_supported(*schema.field(i))) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool PrimaryKeyEncoder::is_supported_with_sort_key(const vectorized::Schema& schema) {
-    for (const auto sort_key_idx : schema.sort_key_idxes()) {
+bool PrimaryKeyEncoder::is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& sort_key_idxes) {
+    for (const auto sort_key_idx : sort_key_idxes) {
         if (!is_supported(*schema.field(sort_key_idx))) {
             return false;
         }
@@ -263,22 +253,13 @@ bool PrimaryKeyEncoder::is_supported_with_sort_key(const vectorized::Schema& sch
     return true;
 }
 
-FieldType PrimaryKeyEncoder::encoded_primary_key_type(const vectorized::Schema& schema) {
-    if (!is_supported(schema)) {
+FieldType PrimaryKeyEncoder::encoded_primary_key_type(const vectorized::Schema& schema,
+                                                      const std::vector<ColumnId>& sort_key_idxes) {
+    if (!is_supported(schema, sort_key_idxes)) {
         return OLAP_FIELD_TYPE_NONE;
     }
-    if (schema.num_key_fields() == 1) {
-        return schema.field(0)->type()->type();
-    }
-    return OLAP_FIELD_TYPE_VARCHAR;
-}
-
-FieldType PrimaryKeyEncoder::encoded_primary_key_type_with_sort_key(const vectorized::Schema& schema) {
-    if (!is_supported_with_sort_key(schema)) {
-        return OLAP_FIELD_TYPE_NONE;
-    }
-    if (schema.sort_key_idxes().size() == 1) {
-        return schema.field(schema.sort_key_idxes()[0])->type()->type();
+    if (sort_key_idxes.size() == 1) {
+        return schema.field(sort_key_idxes[0])->type()->type();
     }
     return OLAP_FIELD_TYPE_VARCHAR;
 }
@@ -298,17 +279,26 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const vectorized::Schema& schem
 
 Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema,
                                         std::unique_ptr<vectorized::Column>* pcolumn) {
-    if (!is_supported(schema)) {
+    std::vector<ColumnId> sort_key_idxes;
+    for (ColumnId i = 0; i < schema.num_key_fields(); ++i) {
+        sort_key_idxes.push_back(i);
+    }
+    return PrimaryKeyEncoder::create_column(schema, pcolumn, sort_key_idxes);
+}
+
+Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn,
+                                        const std::vector<ColumnId>& sort_key_idxes) {
+    if (!is_supported(schema, sort_key_idxes)) {
         return Status::NotSupported("type not supported for primary key encoding");
     }
     // TODO: let `Chunk::column_from_field_type` and `Chunk::column_from_field` return a
     // `std::unique_ptr<Column>` instead of `std::shared_ptr<Column>`, in order to reuse
     // its code here.
-    if (schema.num_key_fields() == 1) {
+    if (sort_key_idxes.size() == 1) {
         // simple encoding
         // integer's use fixed length original column
         // varchar use binary
-        auto type = schema.field(0)->type()->type();
+        auto type = schema.field(sort_key_idxes[0])->type()->type();
         switch (type) {
         case OLAP_FIELD_TYPE_BOOL:
             *pcolumn = vectorized::BooleanColumn::create_mutable();
@@ -343,50 +333,6 @@ Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema,
     } else {
         // composite keys encoding to binary
         // TODO(cbl): support fixed length encoded keys, e.g. (int32, int32) => int64
-        *pcolumn = std::make_unique<vectorized::BinaryColumn>();
-    }
-    return Status::OK();
-}
-
-Status PrimaryKeyEncoder::create_column_with_sort_key(const vectorized::Schema& schema,
-                                                      std::unique_ptr<vectorized::Column>* pcolumn) {
-    if (!is_supported_with_sort_key(schema)) {
-        return Status::NotSupported("type not supported for primary key encoding");
-    }
-    if (schema.sort_key_idxes().size() == 1) {
-        auto type = schema.field(schema.sort_key_idxes()[0])->type()->type();
-        switch (type) {
-        case OLAP_FIELD_TYPE_BOOL:
-            *pcolumn = vectorized::BooleanColumn::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_TINYINT:
-            *pcolumn = vectorized::Int8Column::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_SMALLINT:
-            *pcolumn = vectorized::Int16Column::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_INT:
-            *pcolumn = vectorized::Int32Column::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_BIGINT:
-            *pcolumn = vectorized::Int64Column::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_LARGEINT:
-            *pcolumn = vectorized::Int128Column::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_VARCHAR:
-            *pcolumn = std::make_unique<vectorized::BinaryColumn>();
-            break;
-        case OLAP_FIELD_TYPE_DATE_V2:
-            *pcolumn = vectorized::DateColumn::create_mutable();
-            break;
-        case OLAP_FIELD_TYPE_TIMESTAMP:
-            *pcolumn = vectorized::TimestampColumn::create_mutable();
-            break;
-        default:
-            return Status::NotSupported(StringPrintf("primary key type not support: %s", field_type_to_string(type)));
-        }
-    } else {
         *pcolumn = std::make_unique<vectorized::BinaryColumn>();
     }
     return Status::OK();

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -25,19 +25,18 @@ class PrimaryKeyEncoder {
 public:
     static bool is_supported(const vectorized::Field& f);
 
-    static bool is_supported(const vectorized::Schema& schema);
-    static bool is_supported_with_sort_key(const vectorized::Schema& schema);
+    static bool is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& sort_key_idxes);
 
     // Return |OLAP_FIELD_TYPE_NONE| if no primary key contained in |schema|.
-    static FieldType encoded_primary_key_type(const vectorized::Schema& schema);
-    static FieldType encoded_primary_key_type_with_sort_key(const vectorized::Schema& schema);
+    static FieldType encoded_primary_key_type(const vectorized::Schema& schema,
+                                              const std::vector<ColumnId>& sort_key_idxes);
 
     // Return -1 if encoded key is not fixed size
     static size_t get_encoded_fixed_size(const vectorized::Schema& schema);
 
     static Status create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn);
-    static Status create_column_with_sort_key(const vectorized::Schema& schema,
-                                              std::unique_ptr<vectorized::Column>* pcolumn);
+    static Status create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn,
+                                const std::vector<ColumnId>& sort_key_idxes);
 
     static void encode(const vectorized::Schema& schema, const vectorized::Chunk& chunk, size_t offset, size_t len,
                        vectorized::Column* dest);

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -26,14 +26,18 @@ public:
     static bool is_supported(const vectorized::Field& f);
 
     static bool is_supported(const vectorized::Schema& schema);
+    static bool is_supported_with_sort_key(const vectorized::Schema& schema);
 
     // Return |OLAP_FIELD_TYPE_NONE| if no primary key contained in |schema|.
     static FieldType encoded_primary_key_type(const vectorized::Schema& schema);
+    static FieldType encoded_primary_key_type_with_sort_key(const vectorized::Schema& schema);
 
     // Return -1 if encoded key is not fixed size
     static size_t get_encoded_fixed_size(const vectorized::Schema& schema);
 
     static Status create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn);
+    static Status create_column_with_sort_key(const vectorized::Schema& schema,
+                                              std::unique_ptr<vectorized::Column>* pcolumn);
 
     static void encode(const vectorized::Schema& schema, const vectorized::Chunk& chunk, size_t offset, size_t len,
                        vectorized::Column* dest);

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -25,18 +25,17 @@ class PrimaryKeyEncoder {
 public:
     static bool is_supported(const vectorized::Field& f);
 
-    static bool is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& sort_key_idxes);
+    static bool is_supported(const vectorized::Schema& schema, const std::vector<ColumnId>& key_idxes);
 
     // Return |OLAP_FIELD_TYPE_NONE| if no primary key contained in |schema|.
-    static FieldType encoded_primary_key_type(const vectorized::Schema& schema,
-                                              const std::vector<ColumnId>& sort_key_idxes);
+    static FieldType encoded_primary_key_type(const vectorized::Schema& schema, const std::vector<ColumnId>& key_idxes);
 
     // Return -1 if encoded key is not fixed size
     static size_t get_encoded_fixed_size(const vectorized::Schema& schema);
 
     static Status create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn);
     static Status create_column(const vectorized::Schema& schema, std::unique_ptr<vectorized::Column>* pcolumn,
-                                const std::vector<ColumnId>& sort_key_idxes);
+                                const std::vector<ColumnId>& key_idxes);
 
     static void encode(const vectorized::Schema& schema, const vectorized::Chunk& chunk, size_t offset, size_t len,
                        vectorized::Column* dest);

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -530,7 +530,7 @@ Status HorizontalRowsetWriter::_final_merge() {
                                                      segments.size()) == VERTICAL_COMPACTION) {
         std::vector<std::vector<uint32_t>> column_groups;
         CompactionUtils::split_column_into_groups(_context.tablet_schema->num_columns(),
-                                                  _context.tablet_schema->num_key_columns(),
+                                                  _context.tablet_schema->sort_key_idxes(),
                                                   config::vertical_compaction_max_columns_per_group, &column_groups);
 
         auto schema = ChunkHelper::convert_schema_to_format_v2(*_context.tablet_schema, column_groups[0]);

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -20,7 +20,7 @@ public:
     SeekTuple(Schema schema, std::vector<Datum> values) : _schema(std::move(schema)), _values(std::move(values)) {
 #ifndef NDEBUG
         if (_schema.sort_key_idxes().empty()) {
-            // Ensure the columns are continuously and started from zero.
+            // Ensure the columns are continuous and started from zero.
             for (size_t i = 0; i < _schema.num_fields(); i++) {
                 CHECK_EQ(ColumnId(i), _schema.field(i)->id());
             }

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -19,9 +19,11 @@ public:
 
     SeekTuple(Schema schema, std::vector<Datum> values) : _schema(std::move(schema)), _values(std::move(values)) {
 #ifndef NDEBUG
-        // Ensure the columns are continuously and started from zero.
-        for (size_t i = 0; i < _schema.num_fields(); i++) {
-            CHECK_EQ(ColumnId(i), _schema.field(i)->id());
+        if (_schema.sort_key_idxes().empty()) {
+            // Ensure the columns are continuously and started from zero.
+            for (size_t i = 0; i < _schema.num_fields(); i++) {
+                CHECK_EQ(ColumnId(i), _schema.field(i)->id());
+            }
         }
 #endif
     }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -436,7 +436,7 @@ void TabletSchema::_init_schema() const {
         auto f = ChunkHelper::convert_field_to_format_v2(cid, column(cid));
         fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
     }
-    _schema = std::make_unique<vectorized::Schema>(std::move(fields), keys_type());
+    _schema = std::make_unique<vectorized::Schema>(std::move(fields), keys_type(), _sort_key_idxes);
 }
 
 vectorized::Schema* TabletSchema::schema() const {
@@ -474,6 +474,10 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
         if (column.is_key()) {
             _num_key_columns++;
         }
+    }
+    _sort_key_idxes.reserve(schema.sort_key_idxes_size());
+    for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
+        _sort_key_idxes.push_back(schema.sort_key_idxes(i));
     }
     _num_short_key_columns = schema.num_short_key_columns();
     _num_rows_per_row_block = schema.num_rows_per_row_block();

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -475,9 +475,16 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
             _num_key_columns++;
         }
     }
-    _sort_key_idxes.reserve(schema.sort_key_idxes_size());
-    for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
-        _sort_key_idxes.push_back(schema.sort_key_idxes(i));
+    if (schema.sort_key_idxes().empty()) {
+        _sort_key_idxes.reserve(_num_key_columns);
+        for (auto i = 0; i < _num_key_columns; ++i) {
+            _sort_key_idxes.push_back(i);
+        }
+    } else {
+        _sort_key_idxes.reserve(schema.sort_key_idxes_size());
+        for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
+            _sort_key_idxes.push_back(schema.sort_key_idxes(i));
+        }
     }
     _num_short_key_columns = schema.num_short_key_columns();
     _num_rows_per_row_block = schema.num_rows_per_row_block();

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -233,6 +233,7 @@ public:
     size_t field_index(std::string_view field_name) const;
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
+    const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
     size_t num_columns() const { return _cols.size(); }
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
@@ -289,6 +290,7 @@ private:
 
     uint16_t _num_key_columns = 0;
     uint16_t _num_short_key_columns = 0;
+    std::vector<ColumnId> _sort_key_idxes;
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
     CompressionTypePB _compression_type = CompressionTypePB::LZ4_FRAME;

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -46,7 +46,7 @@ Status VerticalCompactionTask::_vertical_compaction_data(Statistics* statistics)
             _tablet.get(), max_rows_per_segment, _task_info.algorithm, _task_info.output_version, &output_rs_writer));
 
     std::vector<std::vector<uint32_t>> column_groups;
-    CompactionUtils::split_column_into_groups(_tablet->num_columns(), _tablet->num_key_columns(),
+    CompactionUtils::split_column_into_groups(_tablet->num_columns(), _tablet->tablet_schema().sort_key_idxes(),
                                               config::vertical_compaction_max_columns_per_group, &column_groups);
     _task_info.column_group_size = column_groups.size();
 

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -70,16 +70,14 @@ TEST(CompactionUtilsTest, test_get_segment_max_rows) {
 
 TEST(CompactionUtilsTest, test_split_column_into_groups) {
     size_t num_columns = 17;
-    size_t num_key_columns = 1;
     int64_t max_columns_per_group = 5;
     std::vector<std::vector<uint32_t>> column_groups;
-    CompactionUtils::split_column_into_groups(num_columns, num_key_columns, max_columns_per_group, &column_groups);
-    ASSERT_EQ(5, column_groups.size());
-    ASSERT_EQ(1, column_groups[0].size());
+    CompactionUtils::split_column_into_groups(num_columns, {1, 2, 5}, max_columns_per_group, &column_groups);
+    ASSERT_EQ(4, column_groups.size());
+    ASSERT_EQ(3, column_groups[0].size());
     ASSERT_EQ(5, column_groups[1].size());
     ASSERT_EQ(5, column_groups[2].size());
-    ASSERT_EQ(5, column_groups[3].size());
-    ASSERT_EQ(1, column_groups[4].size());
+    ASSERT_EQ(4, column_groups[3].size());
 }
 
 TEST(CompactionUtilsTest, test_choose_compaction_algorithm) {

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -20,7 +20,7 @@ template <FieldType field_type, typename DatumType>
 void test_integral_pk() {
     auto f = std::make_shared<vectorized::Field>(0, "c0", field_type, false);
     f->set_is_key(true);
-    auto schema = std::make_shared<vectorized::Schema>(Fields{f});
+    auto schema = std::make_shared<vectorized::Schema>(Fields{f}, PRIMARY_KEYS, std::vector<ColumnId>{0});
     auto pk_index = TEST_create_primary_index(*schema);
 
     constexpr int kSegmentSize = 20;
@@ -145,7 +145,7 @@ template <FieldType field_type>
 void test_binary_pk() {
     auto f = std::make_shared<vectorized::Field>(0, "c0", field_type, false);
     f->set_is_key(true);
-    auto schema = std::make_shared<vectorized::Schema>(Fields{f});
+    auto schema = std::make_shared<vectorized::Schema>(Fields{f}, PRIMARY_KEYS, std::vector<ColumnId>{0});
     auto pk_index = TEST_create_primary_index(*schema);
 
     constexpr int kSegmentSize = 20;
@@ -260,7 +260,7 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
     f1->set_is_key(true);
     auto f2 = std::make_shared<vectorized::Field>(1, "c1", OLAP_FIELD_TYPE_SMALLINT, false);
     f2->set_is_key(true);
-    auto schema = std::make_shared<vectorized::Schema>(Fields{f1, f2});
+    auto schema = std::make_shared<vectorized::Schema>(Fields{f1, f2}, PRIMARY_KEYS, std::vector<ColumnId>{0, 1});
     auto pk_index = TEST_create_primary_index(*schema);
 
     constexpr int kSegmentSize = 100;

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -15,14 +15,16 @@ namespace starrocks {
 
 static unique_ptr<vectorized::Schema> create_key_schema(const vector<FieldType>& types) {
     vectorized::Fields fields;
+    std::vector<ColumnId> sort_key_idxes(types.size());
     for (int i = 0; i < types.size(); i++) {
         string name = StringPrintf("col%d", i);
         auto fd = new vectorized::Field(i, name, types[i], false);
         fd->set_is_key(true);
         fd->set_aggregate_method(OLAP_FIELD_AGGREGATION_NONE);
         fields.emplace_back(fd);
+        sort_key_idxes[i] = i;
     }
-    return unique_ptr<vectorized::Schema>(new vectorized::Schema(std::move(fields)));
+    return unique_ptr<vectorized::Schema>(new vectorized::Schema(std::move(fields), PRIMARY_KEYS, sort_key_idxes));
 }
 
 TEST(PrimaryKeyEncoderTest, testEncodeInt32) {

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -38,7 +38,6 @@ under the License.
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.5</jacoco.version>
-        <starrocks.thridparty>/home/disk1/sr-deps/thirdparty-hook-tcmalloc</starrocks.thridparty>
         <iceberg.version>0.12.1</iceberg.version>
         <python>python</python>
     </properties>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -38,6 +38,7 @@ under the License.
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.5</jacoco.version>
+        <starrocks.thridparty>/home/disk1/sr-deps/thirdparty-hook-tcmalloc</starrocks.thridparty>
         <iceberg.version>0.12.1</iceberg.version>
         <python>python</python>
     </properties>

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -15,6 +15,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Tablet;
@@ -237,7 +238,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             LakeTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
-
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(table.getBaseIndexId());
             numTablets = partitionIndexMap.values().stream().map(MaterializedIndex::getTablets).count();
             countDownLatch = new MarkedCountDownLatch<>((int) numTablets);
 
@@ -281,7 +282,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                                 shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0, Partition.PARTITION_INIT_VERSION,
                                 originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema, bfColumns, bfFpp,
                                 countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
-                                TTabletType.TABLET_TYPE_LAKE, table.getCompressionType());
+                                TTabletType.TABLET_TYPE_LAKE, table.getCompressionType(), indexMeta.getSortKeyIdxes());
 
                         Long baseTabletId = partitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
                         assert baseTabletId != null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -204,7 +205,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             if (tbl == null) {
                 throw new AlterCancelException("Table " + tableId + " does not exist");
             }
-
+            MaterializedIndexMeta index = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
             for (Map.Entry<Long, MaterializedIndex> entry : this.partitionIdToRollupIndex.entrySet()) {
                 long partitionId = entry.getKey();
@@ -235,7 +236,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 tbl.getCopiedIndexes(),
                                 tbl.isInMemory(),
                                 tbl.enablePersistentIndex(),
-                                tabletType, tbl.getCompressionType());
+                                tabletType, tbl.getCompressionType(), index.getSortKeyIdxes());
                         createReplicaTask.setBaseTablet(tabletIdMap.get(rollupTabletId), baseSchemaHash);
                         if (this.storageFormat != null) {
                             createReplicaTask.setStorageFormat(this.storageFormat);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -804,7 +804,7 @@ public class RestoreJob extends AbstractJob {
                             localTbl.isInMemory(),
                             localTbl.enablePersistentIndex(),
                             localTbl.getPartitionInfo().getTabletType(restorePart.getId()),
-                            localTbl.getCompressionType());
+                            localTbl.getCompressionType(), indexMeta.getSortKeyIdxes());
                     task.setInRestoreMode(true);
                     batchTask.addTask(task);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -46,6 +46,8 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     private long indexId;
     @SerializedName(value = "schema")
     private List<Column> schema = Lists.newArrayList();
+    @SerializedName(value = "sortKeyIdxes")
+    public List<Integer> sortKeyIdxes = Lists.newArrayList();
     @SerializedName(value = "schemaVersion")
     private int schemaVersion;
     @SerializedName(value = "schemaHash")
@@ -61,7 +63,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
                                  short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
-                                 OriginStatement defineStmt) {
+                                 OriginStatement defineStmt, List<Integer> sortKeyIdxes) {
         this.indexId = indexId;
         Preconditions.checkState(schema != null);
         Preconditions.checkState(schema.size() != 0);
@@ -74,6 +76,13 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         Preconditions.checkState(keysType != null);
         this.keysType = keysType;
         this.defineStmt = defineStmt;
+        this.sortKeyIdxes = sortKeyIdxes;
+    }
+
+    public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
+                                 short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
+                                 OriginStatement defineStmt) {
+        this(indexId, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType, defineStmt, null);
     }
 
     public long getIndexId() {
@@ -94,6 +103,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public List<Column> getSchema() {
         return schema;
+    }
+
+    public List<Integer> getSortKeyIdxes() {
+        return sortKeyIdxes;
     }
 
     public int getSchemaHash() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -329,12 +329,19 @@ public class OlapTable extends Table implements GsonPostProcessable {
     public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion,
                              int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
         setIndexMeta(indexId, indexName, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
-                null);
+                null, null);
     }
 
     public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion,
                              int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                              OriginStatement origStmt) {
+        setIndexMeta(indexId, indexName, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
+                origStmt, null);
+    }
+
+    public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion,
+                             int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
+                             OriginStatement origStmt, List<Integer> sortColumns) {
         // Nullable when meta comes from schema change log replay.
         // The replay log only save the index id, so we need to get name by id.
         if (indexName == null) {
@@ -357,7 +364,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
         }
 
         MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion,
-                schemaHash, shortKeyColumnCount, storageType, keysType, origStmt);
+                schemaHash, shortKeyColumnCount, storageType, keysType, origStmt, sortColumns);
         indexIdToMeta.put(indexId, indexMeta);
         indexNameToId.put(indexName, indexId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -859,7 +859,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 olapTable.isInMemory(),
                 olapTable.enablePersistentIndex(),
                 olapTable.getPartitionInfo().getTabletType(partitionId),
-                olapTable.getCompressionType());
+                olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
         createReplicaTask.setIsRecoverTask(true);
         taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -709,7 +709,7 @@ public class ReportHandler extends Daemon {
                                             olapTable.isInMemory(),
                                             olapTable.enablePersistentIndex(),
                                             olapTable.getPartitionInfo().getTabletType(partitionId),
-                                            olapTable.getCompressionType());
+                                            olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
                                     createReplicaTask.setIsRecoverTask(true);
                                     createReplicaBatchTask.addTask(createReplicaTask);
                                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2032,7 +2032,15 @@ public class GlobalStateMgr {
                 }
             }
             sb.append(Joiner.on(", ").join(keysColumnNames)).append(")");
-
+            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());
+            if (index.getSortKeyIdxes() != null) {
+                sb.append("\nORDER BY(");
+                List<String> sortKeysColumnNames = Lists.newArrayList();
+                for (Integer i : index.getSortKeyIdxes()) {
+                    sortKeysColumnNames.add("`" + table.getBaseSchema().get(i).getName() + "`");
+                }
+                sb.append(Joiner.on(", ").join(sortKeysColumnNames)).append(")");
+            }
             if (!Strings.isNullOrEmpty(table.getComment())) {
                 sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
             }
@@ -2731,6 +2739,73 @@ public class GlobalStateMgr {
                 throw new DdlException("Data type of first column cannot be " + indexColumns.get(0).getType());
             }
 
+        } // end calc shortKeyColumnCount
+
+        return shortKeyColumnCount;
+    }
+
+    public static short calcShortKeyColumnCount(List<Column> indexColumns, Map<String, String> properties,
+            List<Integer> sortKeyIdxes)
+            throws DdlException {
+        LOG.debug("index column size: {}", indexColumns.size());
+        Preconditions.checkArgument(indexColumns.size() > 0);
+        // figure out shortKeyColumnCount
+        short shortKeyColumnCount = (short) -1;
+        try {
+            shortKeyColumnCount = PropertyAnalyzer.analyzeShortKeyColumnCount(properties);
+        } catch (AnalysisException e) {
+            throw new DdlException(e.getMessage());
+        }
+        if (shortKeyColumnCount != (short) -1) {
+            // use user specified short key column count
+            if (shortKeyColumnCount <= 0) {
+                throw new DdlException("Invalid short key: " + shortKeyColumnCount);
+            }
+            if (shortKeyColumnCount > indexColumns.size()) {
+                throw new DdlException("Short key is too large. should less than: " + indexColumns.size());
+            }
+            for (int pos = 0; pos < shortKeyColumnCount; pos++) {
+                if (indexColumns.get(sortKeyIdxes.get(pos)).getPrimitiveType() == PrimitiveType.VARCHAR &&
+                        pos != shortKeyColumnCount - 1) {
+                    throw new DdlException("Varchar should not in the middle of short keys.");
+                }
+            }
+        } else {
+            /*
+             * Calc short key column count. NOTE: short key column count is
+             * calculated as follow: 1. All index column are taking into
+             * account. 2. Max short key column count is Min(Num of
+             * indexColumns, META_MAX_SHORT_KEY_NUM). 3. Short key list can
+             * contains at most one VARCHAR column. And if contains, it should
+             * be at the last position of the short key list.
+             */
+            shortKeyColumnCount = 0;
+            int shortKeySizeByte = 0;
+            int maxShortKeyColumnCount = Math.min(indexColumns.size(), FeConstants.shortkey_max_column_count);
+            for (int i = 0; i < maxShortKeyColumnCount && i < sortKeyIdxes.size(); i++) {
+                Column column = indexColumns.get(sortKeyIdxes.get(i));
+                shortKeySizeByte += column.getOlapColumnIndexSize();
+                if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {
+                    if (column.getPrimitiveType().isCharFamily()) {
+                        ++shortKeyColumnCount;
+                    }
+                    break;
+                }
+                if (column.getType().isFloatingPointType() || column.getType().isComplexType()) {
+                    break;
+                }
+                if (column.getPrimitiveType() == PrimitiveType.VARCHAR) {
+                    ++shortKeyColumnCount;
+                    break;
+                }
+                ++shortKeyColumnCount;
+            }
+            if (indexColumns.isEmpty()) {
+                throw new DdlException("Empty schema");
+            }
+            if (shortKeyColumnCount == 0) {
+                throw new DdlException("Data type of first column cannot be " + indexColumns.get(0).getType());
+            }
         } // end calc shortKeyColumnCount
 
         return shortKeyColumnCount;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2670,85 +2670,21 @@ public class GlobalStateMgr {
 
     public static short calcShortKeyColumnCount(List<Column> columns, Map<String, String> properties)
             throws DdlException {
-        List<Column> indexColumns = new ArrayList<Column>();
-        for (Column column : columns) {
+        List<Integer> sortKeyIdxes = new ArrayList<>();
+        for (int i = 0; i < columns.size(); ++i) {
+            Column column = columns.get(i);
             if (column.isKey()) {
-                indexColumns.add(column);
+                sortKeyIdxes.add(i);
             }
         }
-        LOG.debug("index column size: {}", indexColumns.size());
-        Preconditions.checkArgument(indexColumns.size() > 0);
-
-        // figure out shortKeyColumnCount
-        short shortKeyColumnCount = (short) -1;
-        try {
-            shortKeyColumnCount = PropertyAnalyzer.analyzeShortKeyColumnCount(properties);
-        } catch (AnalysisException e) {
-            throw new DdlException(e.getMessage());
-        }
-        if (shortKeyColumnCount != (short) -1) {
-            // use user specified short key column count
-            if (shortKeyColumnCount <= 0) {
-                throw new DdlException("Invalid short key: " + shortKeyColumnCount);
-            }
-
-            if (shortKeyColumnCount > indexColumns.size()) {
-                throw new DdlException("Short key is too large. should less than: " + indexColumns.size());
-            }
-
-            for (int pos = 0; pos < shortKeyColumnCount; pos++) {
-                if (indexColumns.get(pos).getPrimitiveType() == PrimitiveType.VARCHAR &&
-                        pos != shortKeyColumnCount - 1) {
-                    throw new DdlException("Varchar should not in the middle of short keys.");
-                }
-            }
-        } else {
-            /*
-             * Calc short key column count. NOTE: short key column count is
-             * calculated as follow: 1. All index column are taking into
-             * account. 2. Max short key column count is Min(Num of
-             * indexColumns, META_MAX_SHORT_KEY_NUM). 3. Short key list can
-             * contains at most one VARCHAR column. And if contains, it should
-             * be at the last position of the short key list.
-             */
-            shortKeyColumnCount = 0;
-            int shortKeySizeByte = 0;
-            int maxShortKeyColumnCount = Math.min(indexColumns.size(), FeConstants.shortkey_max_column_count);
-            for (int i = 0; i < maxShortKeyColumnCount; i++) {
-                Column column = indexColumns.get(i);
-                shortKeySizeByte += column.getOlapColumnIndexSize();
-                if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {
-                    if (column.getPrimitiveType().isCharFamily()) {
-                        ++shortKeyColumnCount;
-                    }
-                    break;
-                }
-                if (column.getType().isFloatingPointType() || column.getType().isComplexType()) {
-                    break;
-                }
-                if (column.getPrimitiveType() == PrimitiveType.VARCHAR) {
-                    ++shortKeyColumnCount;
-                    break;
-                }
-                ++shortKeyColumnCount;
-            }
-            if (indexColumns.isEmpty()) {
-                throw new DdlException("Empty schema");
-            }
-            if (shortKeyColumnCount == 0) {
-                throw new DdlException("Data type of first column cannot be " + indexColumns.get(0).getType());
-            }
-
-        } // end calc shortKeyColumnCount
-
-        return shortKeyColumnCount;
+        return calcShortKeyColumnCount(columns, properties, sortKeyIdxes);
     }
 
     public static short calcShortKeyColumnCount(List<Column> indexColumns, Map<String, String> properties,
             List<Integer> sortKeyIdxes)
             throws DdlException {
-        LOG.debug("index column size: {}", indexColumns.size());
-        Preconditions.checkArgument(indexColumns.size() > 0);
+        LOG.debug("sort key size: {}", sortKeyIdxes.size());
+        Preconditions.checkArgument(sortKeyIdxes.size() > 0);
         // figure out shortKeyColumnCount
         short shortKeyColumnCount = (short) -1;
         try {
@@ -2761,8 +2697,8 @@ public class GlobalStateMgr {
             if (shortKeyColumnCount <= 0) {
                 throw new DdlException("Invalid short key: " + shortKeyColumnCount);
             }
-            if (shortKeyColumnCount > indexColumns.size()) {
-                throw new DdlException("Short key is too large. should less than: " + indexColumns.size());
+            if (shortKeyColumnCount > sortKeyIdxes.size()) {
+                throw new DdlException("Short key is too large. should less than: " + sortKeyIdxes.size());
             }
             for (int pos = 0; pos < shortKeyColumnCount; pos++) {
                 if (indexColumns.get(sortKeyIdxes.get(pos)).getPrimitiveType() == PrimitiveType.VARCHAR &&
@@ -2775,14 +2711,14 @@ public class GlobalStateMgr {
              * Calc short key column count. NOTE: short key column count is
              * calculated as follow: 1. All index column are taking into
              * account. 2. Max short key column count is Min(Num of
-             * indexColumns, META_MAX_SHORT_KEY_NUM). 3. Short key list can
+             * sortKeyIdxes, META_MAX_SHORT_KEY_NUM). 3. Short key list can
              * contains at most one VARCHAR column. And if contains, it should
              * be at the last position of the short key list.
              */
             shortKeyColumnCount = 0;
             int shortKeySizeByte = 0;
-            int maxShortKeyColumnCount = Math.min(indexColumns.size(), FeConstants.shortkey_max_column_count);
-            for (int i = 0; i < maxShortKeyColumnCount && i < sortKeyIdxes.size(); i++) {
+            int maxShortKeyColumnCount = Math.min(sortKeyIdxes.size(), FeConstants.shortkey_max_column_count);
+            for (int i = 0; i < maxShortKeyColumnCount; i++) {
                 Column column = indexColumns.get(sortKeyIdxes.get(i));
                 shortKeySizeByte += column.getOlapColumnIndexSize();
                 if (shortKeySizeByte > FeConstants.shortkey_maxsize_bytes) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1770,7 +1770,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 } catch (UserException e) {
                     throw new DdlException(e.getMessage());
                 }
-
+                
                 CreateReplicaTask task = new CreateReplicaTask(
                         primaryBackendId,
                         dbId,
@@ -1792,7 +1792,7 @@ public class LocalMetastore implements ConnectorMetadata {
                         table.getPartitionInfo().getIsInMemory(partition.getId()),
                         table.enablePersistentIndex(),
                         TTabletType.TABLET_TYPE_LAKE,
-                        table.getCompressionType());
+                        table.getCompressionType(), indexMeta.getSortKeyIdxes());
                 tasks.add(task);
             } else {
                 for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
@@ -1817,7 +1817,7 @@ public class LocalMetastore implements ConnectorMetadata {
                             table.getPartitionInfo().getIsInMemory(partition.getId()),
                             table.enablePersistentIndex(),
                             table.getPartitionInfo().getTabletType(partition.getId()),
-                            table.getCompressionType());
+                            table.getCompressionType(), indexMeta.getSortKeyIdxes());
                     tasks.add(task);
                 }
             }
@@ -1974,10 +1974,22 @@ public class LocalMetastore implements ConnectorMetadata {
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
 
-        // calc short key column count
-        short shortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(baseSchema, stmt.getProperties());
+        short shortKeyColumnCount = 0;
+        List<Integer> sortKeyIdxes = new ArrayList<>();
+        if (stmt.getSortKeys() != null) {
+            List<String> baseSchemaNames = baseSchema.stream().map(Column::getName).collect(Collectors.toList());
+            for (String column : stmt.getSortKeys()) {
+                int idx = baseSchemaNames.indexOf(column);
+                if (idx == -1) {
+                    throw new DdlException("Invalid column '" + column + "': not exists in all columns.");
+                }
+                sortKeyIdxes.add(idx);
+            }
+            shortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(baseSchema, stmt.getProperties(), sortKeyIdxes);
+        } else {
+            shortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(baseSchema, stmt.getProperties());
+        }
         LOG.debug("create table[{}] short key column count: {}", tableName, shortKeyColumnCount);
-
         // indexes
         TableIndexes indexes = new TableIndexes(stmt.getIndexes());
 
@@ -2171,8 +2183,14 @@ public class LocalMetastore implements ConnectorMetadata {
             throw new DdlException(e.getMessage());
         }
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
-        olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
-                shortKeyColumnCount, baseIndexStorageType, keysType);
+
+        if (stmt.getSortKeys() != null) {
+            olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+                    shortKeyColumnCount, baseIndexStorageType, keysType, null, sortKeyIdxes);
+        } else {
+            olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+                    shortKeyColumnCount, baseIndexStorageType, keysType, null);
+        }
 
         for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
             AddRollupClause addRollupClause = (AddRollupClause) alterClause;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -118,6 +118,11 @@ public class CreateTableAnalyzer {
         statement.setCharsetName(analyzeCharsetName(statement.getCharsetName()).toLowerCase());
 
         KeysDesc keysDesc = statement.getKeysDesc();
+        if (statement.getSortKeys() != null) {
+            if (keysDesc == null || keysDesc.getKeysType() != KeysType.PRIMARY_KEYS) {
+                throw new IllegalArgumentException("only primary key support sort key");
+            }
+        }
         List<ColumnDef> columnDefs = statement.getColumnDefs();
         PartitionDesc partitionDesc = statement.getPartitionDesc();
         // analyze key desc

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
@@ -46,6 +46,7 @@ public class CreateTableStmt extends DdlStmt {
 
     // set in analyze
     private List<Column> columns = Lists.newArrayList();
+    private List<String> sortKeys = Lists.newArrayList();
 
     private List<Index> indexes = Lists.newArrayList();
 
@@ -83,7 +84,7 @@ public class CreateTableStmt extends DdlStmt {
                            Map<String, String> extProperties,
                            String comment) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, null, engineName, null, keysDesc, partitionDesc,
-                distributionDesc, properties, extProperties, comment, null);
+                distributionDesc, properties, extProperties, comment, null, null);
     }
 
     public CreateTableStmt(boolean ifNotExists,
@@ -98,7 +99,7 @@ public class CreateTableStmt extends DdlStmt {
                            Map<String, String> extProperties,
                            String comment, List<AlterClause> ops) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, engineName, null, keysDesc, partitionDesc,
-                distributionDesc, properties, extProperties, comment, ops);
+                distributionDesc, properties, extProperties, comment, ops, null);
     }
 
     public CreateTableStmt(boolean ifNotExists,
@@ -112,9 +113,9 @@ public class CreateTableStmt extends DdlStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> ops) {
+                           String comment, List<AlterClause> ops, List<String> sortKeys) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, null, engineName, charsetName, keysDesc, partitionDesc,
-                distributionDesc, properties, extProperties, comment, ops);
+                distributionDesc, properties, extProperties, comment, ops, sortKeys);
     }
 
     public CreateTableStmt(boolean ifNotExists,
@@ -129,7 +130,7 @@ public class CreateTableStmt extends DdlStmt {
                            DistributionDesc distributionDesc,
                            Map<String, String> properties,
                            Map<String, String> extProperties,
-                           String comment, List<AlterClause> rollupAlterClauseList) {
+                           String comment, List<AlterClause> rollupAlterClauseList, List<String> sortKeys) {
         this.tableName = tableName;
         if (columnDefinitions == null) {
             this.columnDefs = Lists.newArrayList();
@@ -160,6 +161,7 @@ public class CreateTableStmt extends DdlStmt {
 
         this.tableSignature = -1;
         this.rollupAlterClauseList = rollupAlterClauseList == null ? new ArrayList<>() : rollupAlterClauseList;
+        this.sortKeys = sortKeys;
     }
 
     public void addColumnDef(ColumnDef columnDef) {
@@ -212,6 +214,10 @@ public class CreateTableStmt extends DdlStmt {
 
     public String getEngineName() {
         return engineName;
+    }
+
+    public List<String> getSortKeys() {
+        return sortKeys;
     }
 
     public void setEngineName(String engineName) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -514,7 +514,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 extProperties,
                 context.comment() == null ? null : ((StringLiteral) visit(context.comment().string())).getStringValue(),
                 context.rollupDesc() == null ?
-                        null : context.rollupDesc().rollupItem().stream().map(this::getRollup).collect(toList()));
+                        null : context.rollupDesc().rollupItem().stream().map(this::getRollup).collect(toList()),
+                context.orderByDesc() == null ? null :
+                visit(context.orderByDesc().identifierList().identifier(), Identifier.class)
+                        .stream().map(Identifier::getValue).collect(toList()));
     }
 
     private PartitionDesc getPartitionDesc(StarRocksParser.PartitionDescContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -496,11 +496,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 extProperties.put(property.getKey(), property.getValue());
             }
         }
-        if (context.orderByDesc() != null) {
-            if (context.keyDesc() == null || getKeysDesc(context.keyDesc()).getKeysType() != KeysType.PRIMARY_KEYS) {
-                throw new IllegalArgumentException("only primary key support sort key");
-            }
-        }
         return new CreateTableStmt(
                 context.IF() != null,
                 context.EXTERNAL() != null,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -496,7 +496,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 extProperties.put(property.getKey(), property.getValue());
             }
         }
-
+        if (context.orderByDesc() != null) {
+            if (context.keyDesc() == null || getKeysDesc(context.keyDesc()).getKeysType() != KeysType.PRIMARY_KEYS) {
+                throw new IllegalArgumentException("only primary key support sort key");
+            }
+        }
         return new CreateTableStmt(
                 context.IF() != null,
                 context.EXTERNAL() != null,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -279,10 +279,10 @@ createTableStatement
           engineDesc?
           charsetDesc?
           keyDesc?
-          orderByDesc?
           comment?
           partitionDesc?
           distributionDesc?
+          orderByDesc?
           rollupDesc?
           properties?
           extProperties?

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -279,6 +279,7 @@ createTableStatement
           engineDesc?
           charsetDesc?
           keyDesc?
+          orderByDesc?
           comment?
           partitionDesc?
           distributionDesc?
@@ -315,6 +316,10 @@ charsetDesc
 
 keyDesc
     : (AGGREGATE | UNIQUE | PRIMARY | DUPLICATE) KEY identifierList
+    ;
+
+orderByDesc
+    : ORDER BY identifierList
     ;
 
 aggDesc

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -60,6 +60,7 @@ public class CreateReplicaTask extends AgentTask {
     private TStorageMedium storageMedium;
 
     private List<Column> columns;
+    private List<Integer> sortKeyIdxes;
 
     // bloom filter columns
     private Set<String> bfColumns;
@@ -97,6 +98,20 @@ public class CreateReplicaTask extends AgentTask {
                              boolean isInMemory,
                              boolean enablePersistentIndex,
                              TTabletType tabletType, TCompressionType compressionType) {
+        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount,
+                schemaHash, version, keysType, storageType, storageMedium, columns, bfColumns,
+                bfFpp, latch, indexes, isInMemory, enablePersistentIndex, tabletType, compressionType, null);
+    }
+
+    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
+                             short shortKeyColumnCount, int schemaHash, long version,
+                             KeysType keysType, TStorageType storageType,
+                             TStorageMedium storageMedium, List<Column> columns,
+                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
+                             List<Index> indexes,
+                             boolean isInMemory,
+                             boolean enablePersistentIndex,
+                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes) {
         super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId);
 
         this.shortKeyColumnCount = shortKeyColumnCount;
@@ -109,6 +124,7 @@ public class CreateReplicaTask extends AgentTask {
         this.storageMedium = storageMedium;
 
         this.columns = columns;
+        this.sortKeyIdxes = sortKeyIdxes;
 
         this.bfColumns = bfColumns;
         this.indexes = indexes;
@@ -194,6 +210,7 @@ public class CreateReplicaTask extends AgentTask {
             tColumns.add(tColumn);
         }
         tSchema.setColumns(tColumns);
+        tSchema.setSort_key_idxes(sortKeyIdxes);
 
         if (CollectionUtils.isNotEmpty(indexes)) {
             List<TOlapTableIndex> tIndexes = new ArrayList<>();

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -67,6 +67,7 @@ message TabletSchemaPB {
     optional bool DEPRECATED_is_in_memory = 8 [default=false];
     optional int64 deprecated_id = 9; // deprecated
     optional CompressionTypePB compression_type = 10 [default=LZ4_FRAME];
+    repeated uint32 sort_key_idxes = 11;
     optional int64 id = 50;
 }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -39,6 +39,7 @@ struct TTabletSchema {
     7: optional list<Descriptors.TOlapTableIndex> indexes
     8: optional bool is_in_memory
     9: optional i64 id;
+    10: optional list<i32> sort_key_idxes
 }
 
 // this enum stands for different storage format in src_backends


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11733

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
now sort key is primary key, can not assign non-key columns.
it's ok:
```
CREATE TABLE test (
  `k1` int,
  `k2` int,
  `k3` int,
  `v1` int,
  `v2` int,
  `v3` int,
  `v4` int,
  `v5` int
) ENGINE=OLAP
PRIMARY KEY(`k1`, `k2`, `k3`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 1
PROPERTIES ("replication_num" = "1");
```
it's not ok:
```
CREATE TABLE test (
  `k1` int,
  `k2` int,
  `k3` int,
  `v1` int,
  `v2` int,
  `v3` int,
  `v4` int,
  `v5` int
) ENGINE=OLAP
PRIMARY KEY(`k1`, `k2`, `k3`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 1
ORDER BY(`v2`, `v4`)
PROPERTIES ("replication_num" = "1");
```
this PR support the latter.