### PR TITLE
[Enhancement] Distributing `TabletShards` to multiple compaction threads

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -78,7 +78,7 @@ Status StorageEngine::start_bg_threads() {
     for (auto& tmp_store : _store_map) {
         data_dirs.push_back(tmp_store.second);
     }
-    int32_t data_dir_num = data_dirs.size();
+    auto data_dir_num = static_cast<int32_t>(data_dirs.size());
 
     if (!config::enable_event_based_compaction_framework) {
         // base and cumulative compaction threads
@@ -98,19 +98,45 @@ Status StorageEngine::start_bg_threads() {
         vectorized::Compaction::init(max_compaction_concurrency);
 
         _base_compaction_threads.reserve(base_compaction_num_threads);
-        for (uint32_t i = 0; i < base_compaction_num_threads; ++i) {
-            _base_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
-                _base_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
-            });
-            Thread::set_thread_name(_base_compaction_threads.back(), "base_compact");
+        // The config::tablet_map_shard_size is preferably a multiple of `base_compaction_num_threads_per_disk`,
+        // otherwise the compaction thread will be distributed unevenly.
+        int32_t base_step = config::tablet_map_shard_size / base_compaction_num_threads_per_disk +
+                            (config::tablet_map_shard_size % base_compaction_num_threads_per_disk != 0);
+        for (int32_t i = 0; i < base_compaction_num_threads_per_disk; i++) {
+            std::pair<int32_t, int32_t> tablet_shards_range;
+            if (config::tablet_map_shard_size >= base_compaction_num_threads_per_disk) {
+                tablet_shards_range.first = std::min(config::tablet_map_shard_size, base_step * i);
+                tablet_shards_range.second = std::min(config::tablet_map_shard_size, base_step * (i + 1));
+            } else {
+                tablet_shards_range.first = 0;
+                tablet_shards_range.second = config::tablet_map_shard_size;
+            }
+            for (int32_t j = 0; j < data_dir_num; j++) {
+                _base_compaction_threads.emplace_back([this, data_dirs, j, tablet_shards_range] {
+                    _base_compaction_thread_callback(nullptr, data_dirs[j], tablet_shards_range);
+                });
+                Thread::set_thread_name(_base_compaction_threads.back(), "base_compact");
+            }
         }
 
         _cumulative_compaction_threads.reserve(cumulative_compaction_num_threads);
-        for (uint32_t i = 0; i < cumulative_compaction_num_threads; ++i) {
-            _cumulative_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
-                _cumulative_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
-            });
-            Thread::set_thread_name(_cumulative_compaction_threads.back(), "cumulat_compact");
+        int32_t cumulative_step = config::tablet_map_shard_size / cumulative_compaction_num_threads_per_disk +
+                                  (config::tablet_map_shard_size % cumulative_compaction_num_threads_per_disk != 0);
+        for (int32_t i = 0; i < cumulative_compaction_num_threads_per_disk; i++) {
+            std::pair<int32_t, int32_t> tablet_shards_range;
+            if (config::tablet_map_shard_size >= cumulative_compaction_num_threads_per_disk) {
+                tablet_shards_range.first = std::min(config::tablet_map_shard_size, cumulative_step * i);
+                tablet_shards_range.second = std::min(config::tablet_map_shard_size, cumulative_step * (i + 1));
+            } else {
+                tablet_shards_range.first = 0;
+                tablet_shards_range.second = config::tablet_map_shard_size;
+            }
+            for (int32_t j = 0; j < data_dir_num; j++) {
+                _cumulative_compaction_threads.emplace_back([this, data_dirs, j, tablet_shards_range] {
+                    _cumulative_compaction_thread_callback(nullptr, data_dirs[j], tablet_shards_range);
+                });
+                Thread::set_thread_name(_cumulative_compaction_threads.back(), "cumulat_compact");
+            }
         }
     } else {
         int32_t max_task_num = 0;
@@ -198,7 +224,8 @@ void* StorageEngine::_fd_cache_clean_callback(void* arg) {
     return nullptr;
 }
 
-void* StorageEngine::_base_compaction_thread_callback(void* arg, DataDir* data_dir) {
+void* StorageEngine::_base_compaction_thread_callback(void* arg, DataDir* data_dir,
+                                                      std::pair<int32_t, int32_t> tablet_shards) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
@@ -208,7 +235,7 @@ void* StorageEngine::_base_compaction_thread_callback(void* arg, DataDir* data_d
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         // must be here, because this thread is start on start and
         if (!data_dir->capacity_limit_reached(0)) {
-            status = _perform_base_compaction(data_dir);
+            status = _perform_base_compaction(data_dir, tablet_shards);
         } else {
             status = Status::InternalError("data dir out of capacity");
         }
@@ -421,7 +448,8 @@ void* StorageEngine::_disk_stat_monitor_thread_callback(void* arg) {
     return nullptr;
 }
 
-void* StorageEngine::_cumulative_compaction_thread_callback(void* arg, DataDir* data_dir) {
+void* StorageEngine::_cumulative_compaction_thread_callback(void* arg, DataDir* data_dir,
+                                                            std::pair<int32_t, int32_t> tablet_shards_range) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
@@ -429,7 +457,7 @@ void* StorageEngine::_cumulative_compaction_thread_callback(void* arg, DataDir* 
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         // must be here, because this thread is start on start and
         if (!data_dir->capacity_limit_reached(0)) {
-            status = _perform_cumulative_compaction(data_dir);
+            status = _perform_cumulative_compaction(data_dir, tablet_shards_range);
         } else {
             status = Status::InternalError("data dir out of capacity");
         }

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -78,7 +78,7 @@ Status StorageEngine::start_bg_threads() {
     for (auto& tmp_store : _store_map) {
         data_dirs.push_back(tmp_store.second);
     }
-    auto data_dir_num = static_cast<int32_t>(data_dirs.size());
+    const auto data_dir_num = static_cast<int32_t>(data_dirs.size());
 
     if (!config::enable_event_based_compaction_framework) {
         // base and cumulative compaction threads
@@ -449,7 +449,7 @@ void* StorageEngine::_disk_stat_monitor_thread_callback(void* arg) {
 }
 
 void* StorageEngine::_cumulative_compaction_thread_callback(void* arg, DataDir* data_dir,
-                                                            std::pair<int32_t, int32_t> tablet_shards_range) {
+                                                            const std::pair<int32_t, int32_t>& tablet_shards_range) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -635,7 +635,8 @@ size_t StorageEngine::_compaction_check_one_round() {
     return tablets_num_checked;
 }
 
-Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
+Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
+                                                     std::pair<int32_t, int32_t> tablet_shards_range) {
     scoped_refptr<Trace> trace(new Trace);
     MonotonicStopWatch watch;
     watch.start();
@@ -646,8 +647,8 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     });
     ADOPT_TRACE(trace.get());
     TRACE("start to perform cumulative compaction");
-    TabletSharedPtr best_tablet =
-            _tablet_manager->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION, data_dir);
+    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION,
+                                                                                  data_dir, tablet_shards_range);
     if (best_tablet == nullptr) {
         return Status::NotFound("there are no suitable tablets");
     }
@@ -676,7 +677,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     return Status::OK();
 }
 
-Status StorageEngine::_perform_base_compaction(DataDir* data_dir) {
+Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range) {
     scoped_refptr<Trace> trace(new Trace);
     MonotonicStopWatch watch;
     watch.start();
@@ -687,8 +688,8 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir) {
     });
     ADOPT_TRACE(trace.get());
     TRACE("start to perform base compaction");
-    TabletSharedPtr best_tablet =
-            _tablet_manager->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION, data_dir);
+    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION,
+                                                                                  data_dir, tablet_shards_range);
     if (best_tablet == nullptr) {
         return Status::NotFound("there are no suitable tablets");
     }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -233,7 +233,7 @@ private:
     void* _base_compaction_thread_callback(void* arg, DataDir* data_dir,
                                            std::pair<int32_t, int32_t> tablet_shards_range);
     void* _cumulative_compaction_thread_callback(void* arg, DataDir* data_dir,
-                                                 std::pair<int32_t, int32_t> tablet_shards_range);
+                                                 const std::pair<int32_t, int32_t>& tablet_shards_range);
     // update compaction function
     void* _update_compaction_thread_callback(void* arg, DataDir* data_dir);
     // repair compaction function

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -230,10 +230,10 @@ private:
     // unused rowset monitor thread
     void* _unused_rowset_monitor_thread_callback(void* arg);
 
-    // base compaction thread process function
-    void* _base_compaction_thread_callback(void* arg, DataDir* data_dir);
-    // cumulative process function
-    void* _cumulative_compaction_thread_callback(void* arg, DataDir* data_dir);
+    void* _base_compaction_thread_callback(void* arg, DataDir* data_dir,
+                                           std::pair<int32_t, int32_t> tablet_shards_range);
+    void* _cumulative_compaction_thread_callback(void* arg, DataDir* data_dir,
+                                                 std::pair<int32_t, int32_t> tablet_shards_range);
     // update compaction function
     void* _update_compaction_thread_callback(void* arg, DataDir* data_dir);
     // repair compaction function
@@ -256,8 +256,8 @@ private:
     void* _tablet_checkpoint_callback(void* arg);
 
     void _start_clean_fd_cache();
-    Status _perform_cumulative_compaction(DataDir* data_dir);
-    Status _perform_base_compaction(DataDir* data_dir);
+    Status _perform_cumulative_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
+    Status _perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
     Status _perform_update_compaction(DataDir* data_dir);
     Status _start_trash_sweep(double* usage);
     void _start_disk_stat_monitor();

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -484,15 +484,16 @@ bool TabletManager::get_next_batch_tablets(size_t batch_size, std::vector<Tablet
     }
 }
 
-TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir) {
+TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir,
+                                                              std::pair<int32_t, int32_t> tablet_shards_range) {
     int64_t now_ms = UnixMillis();
     const std::string& compaction_type_str = compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
     // only do compaction if compaction #rowset > 1
     uint32_t highest_score = 1;
     TabletSharedPtr best_tablet;
-    for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(tablets_shard.lock);
-        for (auto [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+    for (int32_t i = tablet_shards_range.first; i < tablet_shards_range.second; i++) {
+        std::shared_lock rlock(_tablets_shards[i].lock);
+        for (auto [tablet_id, tablet_ptr] : _tablets_shards[i].tablet_map) {
             if (tablet_ptr->keys_type() == PRIMARY_KEYS) {
                 continue;
             }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -74,7 +74,8 @@ public:
 
     Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
-    TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir);
+    TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir,
+                                                   std::pair<int32_t, int32_t> tablet_shards_range);
 
     TabletSharedPtr find_best_tablet_to_do_update_compaction(DataDir* data_dir);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11746 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The old compaction framework (branch 2.1, 2.2, 2.3, 2.4) occupies a relatively high CPU when there are many `Tablets`.

the is the first pr: Distributing `TabletShards` to multiple compaction threads

500000 tablet per be, 4 cumulative compaction threads per disk:

* before optimize (schedule time): 900ms
* after optimize (schedule time): 150ms

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
