### PR TITLE
[BugFix] Fix unknown error when query iceberg table with array type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -215,7 +215,7 @@ public class IcebergUtil {
                 fullSchema, properties);
     }
 
-    static Type convertColumnType(org.apache.iceberg.types.Type icebergType) {
+    public static Type convertColumnType(org.apache.iceberg.types.Type icebergType) {
         if (icebergType == null) {
             return Type.NULL;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/cost/IcebergTableStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/cost/IcebergTableStatisticCalculator.java
@@ -67,17 +67,17 @@ public class IcebergTableStatisticCalculator {
         IcebergFileStats icebergFileStats = new IcebergTableStatisticCalculator(icebergTable).
                 generateIcebergFileStats(icebergPredicates, columns);
 
-        Map<Integer, String> idToColumnNames = columns.stream()
-                .filter(column -> column.type().isPrimitiveType())
-                .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.name()));
+        Map<Integer, String> idToColumnNames = columns.stream().
+                filter(column -> !IcebergUtil.convertColumnType(column.type()).isUnknown())
+                .collect(Collectors.toMap(Types.NestedField::fieldId, Types.NestedField::name));
 
         double recordCount = Math.max(icebergFileStats == null ? 0 : icebergFileStats.getRecordCount(), 1);
         for (Map.Entry<Integer, String> idColumn : idToColumnNames.entrySet()) {
             List<ColumnRefOperator> columnList = colRefToColumnMetaMap.keySet().stream().filter(
                     key -> key.getName().equalsIgnoreCase(idColumn.getValue())).collect(Collectors.toList());
-            if (columnList == null || columnList.size() != 1) {
+            if (columnList.size() != 1) {
                 LOG.debug("This column is not required column name " + idColumn.getValue() + " column list size "
-                        + (columnList == null ? "null" : columnList.size()));
+                        + columnList.size());
                 continue;
             }
 
@@ -95,17 +95,17 @@ public class IcebergTableStatisticCalculator {
         IcebergFileStats icebergFileStats = generateIcebergFileStats(icebergPredicates, columns);
 
         Map<Integer, String> idToColumnNames = columns.stream()
-                .filter(column -> column.type().isPrimitiveType())
-                .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.name()));
+                .filter(column -> !IcebergUtil.convertColumnType(column.type()).isUnknown())
+                .collect(Collectors.toMap(Types.NestedField::fieldId, Types.NestedField::name));
 
         Statistics.Builder statisticsBuilder = Statistics.builder();
         double recordCount = Math.max(icebergFileStats == null ? 0 : icebergFileStats.getRecordCount(), 1);
         for (Map.Entry<Integer, String> idColumn : idToColumnNames.entrySet()) {
             List<ColumnRefOperator> columnList = colRefToColumnMetaMap.keySet().stream().filter(
                     key -> key.getName().equalsIgnoreCase(idColumn.getValue())).collect(Collectors.toList());
-            if (columnList == null || columnList.size() != 1) {
+            if (columnList.size() != 1) {
                 LOG.debug("This column is not required column name " + idColumn.getValue() + " column list size "
-                        + (columnList == null ? "null" : columnList.size()));
+                        + columnList.size());
                 continue;
             }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11683 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
SR already support read array type from iceberg table， but not compute column statistics for array type, which will result in execption in query.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
