### PR TITLE
[cherry-pick][branch-2.2][bugfix] report error when reading compressed csv file

### DIFF
--- a/be/src/util/compression_utils.h
+++ b/be/src/util/compression_utils.h
@@ -36,6 +36,26 @@ public:
         }
         return CompressionTypePB::UNKNOWN_COMPRESSION;
     }
+
+    static CompressionTypePB to_compression_pb(const std::string& ext) {
+        if (ext == "gzip" || ext == "gz") {
+            return CompressionTypePB::GZIP;
+        } else if (ext == "bz2") {
+            return CompressionTypePB::BZIP2;
+        } else if (ext == "deflate") {
+            return CompressionTypePB::DEFLATE;
+        } else if (ext == "lz4") {
+            return CompressionTypePB::LZ4;
+        } else if (ext == "snappy") {
+            return CompressionTypePB::SNAPPY;
+        } else if (ext == "lzo") {
+            return CompressionTypePB::LZO;
+        } else if (ext == "zstd" || ext == "zst") {
+            return CompressionTypePB::ZSTD;
+        } else {
+            return CompressionTypePB::UNKNOWN_COMPRESSION;
+        }
+    }
 };
 
 } // namespace starrocks

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -981,5 +981,4 @@ TEST_F(JsonScannerTest, test_illegal_input_with_jsonpath) {
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
 }
 
-
 } // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -772,7 +772,8 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STATUS(Status::NotFound(""),
                   test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[3].key", &output));
 
-    EXPECT_STATUS(Status::DataQualityError(""), test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
+    EXPECT_STATUS(Status::DataQualityError(""),
+                  test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
 }
 
 } // namespace vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

I was supposed to merge following PR to support reading compressed csv.
- https://github.com/StarRocks/starrocks/pull/11546
- https://github.com/StarRocks/starrocks/pull/11277

However it's very hard to cherry-pick directly. So I just report error when reading compressed csv file.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
