### PR TITLE
[Feature] Add cast varchar to bitmap

### DIFF
--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -172,8 +172,7 @@ ColumnPtr BitmapFunctions::bitmap_from_string(FunctionContext* context, const Co
 
         auto slice = viewer.value(row);
 
-        bits.clear();
-        if (slice.size > INT32_MAX || !SplitStringAndParse({slice.data, (int)slice.size}, ",", &safe_strtou64, &bits)) {
+        if (!BitmapValue::split_as_uint64_t(slice, &bits)) {
             builder.append_null();
             continue;
         }

--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -172,7 +172,8 @@ ColumnPtr BitmapFunctions::bitmap_from_string(FunctionContext* context, const Co
 
         auto slice = viewer.value(row);
 
-        if (!BitmapValue::split_as_uint64_t(slice, &bits)) {
+        bits.clear();
+        if (slice.size > INT32_MAX || !SplitStringAndParse({slice.data, (int)slice.size}, ",", &safe_strtou64, &bits)) {
             builder.append_null();
             continue;
         }

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -364,6 +364,9 @@ static ColumnPtr cast_from_string_to_bitmap_fn(ColumnPtr& column) {
         if (bitmap.deserialize(value.data, value.size)) {
             builder.append(&bitmap);
         } else {
+            if constexpr (AllowThrowException) {
+                THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(TYPE_VARCHAR, TYPE_OBJECT, value.to_string());
+            }
             builder.append_null();
         }
     }

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -361,7 +361,7 @@ static ColumnPtr cast_from_string_to_bitmap_fn(ColumnPtr& column) {
         auto value = viewer.value(row);
 
         BitmapValue bitmap;
-        if (bitmap.deserialize(value.data, value.size)) {
+        if (bitmap.valid_and_deserialize(value.data, value.size)) {
             builder.append(&bitmap);
         } else {
             if constexpr (AllowThrowException) {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -347,6 +347,36 @@ static ColumnPtr cast_from_string_to_hll_fn(ColumnPtr& column) {
 }
 CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_HLL, cast_from_string_to_hll_fn);
 
+template <PrimitiveType FromType, PrimitiveType ToType, bool AllowThrowException>
+static ColumnPtr cast_from_string_to_bitmap_fn(ColumnPtr& column) {
+    ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_OBJECT> builder(viewer.size());
+
+    std::vector<uint64_t> bits;
+    for (int row = 0; row < viewer.size(); ++row) {
+        if (viewer.is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+
+        auto value = viewer.value(row);
+
+        if (!BitmapValue::split_as_uint64_t(value, &bits)) {
+            if constexpr (AllowThrowException) {
+                THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(TYPE_VARCHAR, TYPE_OBJECT, value.to_string());
+            }
+            builder.append_null();
+            continue;
+        }
+
+        BitmapValue bitmap(bits);
+        builder.append(&bitmap);
+    }
+
+    return builder.build(column->is_constant());
+}
+CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_OBJECT, cast_from_string_to_bitmap_fn);
+
 // all int(tinyint, smallint, int, bigint, largeint) cast implements
 DEFINE_UNARY_FN_WITH_IMPL(ImplicitToNumber, value) {
     return value;
@@ -1453,6 +1483,14 @@ Expr* VectorizedCastExprFactory::from_thrift(ObjectPool* pool, const TExprNode& 
             return new CastStringToArray(node, cast_element_expr, cast_to);
         } else {
             return new CastJsonToArray(node, cast_element_expr, cast_to);
+        }
+    }
+
+    if (from_type == TYPE_VARCHAR && to_type == TYPE_OBJECT) {
+        if (allow_throw_exception) {
+            return new VectorizedCastExpr<TYPE_VARCHAR, TYPE_OBJECT, true>(node);
+        } else {
+            return new VectorizedCastExpr<TYPE_VARCHAR, TYPE_OBJECT, false>(node);
         }
     }
 

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -21,6 +21,8 @@
 
 #include "types/bitmap_value.h"
 
+#include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
 #include "types/bitmap_value_detail.h"
 #include "util/phmap/phmap.h"
 
@@ -738,6 +740,14 @@ bool BitmapValue::deserialize(const char* src) {
         break;
     }
     default:
+        return false;
+    }
+    return true;
+}
+
+bool BitmapValue::split_as_uint64_t(const Slice& slice, std::vector<uint64_t>* result) {
+    result->clear();
+    if (slice.size > INT32_MAX || !SplitStringAndParse({slice.data, (int)slice.size}, ",", &safe_strtou64, result)) {
         return false;
     }
     return true;

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -745,7 +745,7 @@ bool BitmapValue::deserialize(const char* src) {
     return true;
 }
 
-bool BitmapValue::deserialize(const char* src, size_t max_bytes) {
+bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
     if (!max_bytes) {
         return false;
     }

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -820,14 +820,6 @@ bool BitmapValue::deserialize(const char* src, size_t max_bytes) {
     }
 }
 
-bool BitmapValue::split_as_uint64_t(const Slice& slice, std::vector<uint64_t>* result) {
-    result->clear();
-    if (slice.size > INT32_MAX || !SplitStringAndParse({slice.data, (int)slice.size}, ",", &safe_strtou64, result)) {
-        return false;
-    }
-    return true;
-}
-
 // TODO limit string size to avoid OOM
 std::string BitmapValue::to_string() const {
     std::stringstream ss;

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -115,7 +115,7 @@ public:
     // Return false if `src` begins with unknown type code, true otherwise.
     bool deserialize(const char* src);
     // Use max_bytes to read from src safely.
-    bool deserialize(const char* src, size_t max_bytes);
+    bool valid_and_deserialize(const char* src, size_t max_bytes);
 
     // TODO limit string size to avoid OOM
     std::string to_string() const;

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -37,6 +37,7 @@
 #include "common/logging.h"
 #include "util/coding.h"
 #include "util/phmap/phmap_fwd_decl.h"
+#include "util/slice.h"
 
 namespace starrocks {
 
@@ -129,6 +130,10 @@ public:
     void compress() const;
 
     void clear();
+
+    // return false means varchar to bitmap failed,
+    // else true, and collect uint64_t into result.
+    static bool split_as_uint64_t(const Slice& slice, std::vector<uint64_t>* result);
 
 private:
     void _convert_to_smaller_type();

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -114,6 +114,7 @@ public:
     // Deserialize a bitmap value from `src`.
     // Return false if `src` begins with unknown type code, true otherwise.
     bool deserialize(const char* src);
+    // Use max_bytes to read from src safely.
     bool deserialize(const char* src, size_t max_bytes);
 
     // TODO limit string size to avoid OOM

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -133,10 +133,6 @@ public:
 
     void clear();
 
-    // return false means varchar to bitmap failed,
-    // else true, and collect uint64_t into result.
-    static bool split_as_uint64_t(const Slice& slice, std::vector<uint64_t>* result);
-
 private:
     void _convert_to_smaller_type();
     void _from_set_to_bitmap();

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -114,6 +114,7 @@ public:
     // Deserialize a bitmap value from `src`.
     // Return false if `src` begins with unknown type code, true otherwise.
     bool deserialize(const char* src);
+    bool deserialize(const char* src, size_t max_bytes);
 
     // TODO limit string size to avoid OOM
     std::string to_string() const;

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -654,6 +654,7 @@ public:
             *is_valid_ptr = false;
             return NULL;
         }
+
         const char* bufaschar = (const char*)buf;
         if (*(const unsigned char*)buf == SERIALIZATION_ARRAY_UINT32) {
             if (max_bytes < (1 + sizeof(uint32_t))) {
@@ -681,7 +682,7 @@ public:
     }
 
     static roaring_bitmap_t* read_roaring_manually(const char* buf, size_t max_bytes, bool* is_valid_ptr,
-                                                   bool portable) {
+                                                   bool portable = true) {
         roaring_bitmap_t* r = portable ? roaring_bitmap_portable_deserialize_safe(buf, max_bytes, is_valid_ptr)
                                        : roaring_bitmap_deserialize_safe(buf, max_bytes, is_valid_ptr);
 
@@ -690,11 +691,6 @@ public:
 
     static Roaring64Map read_safe(const char* buf, size_t max_bytes, bool* is_valid_ptr) {
         Roaring64Map result;
-        if (max_bytes < 1) {
-            *is_valid_ptr = false;
-            return result;
-        }
-
         bool usev1 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP64 == *buf;
         bool is_bitmap32 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP32_SERIV2 == *buf;
         if (is_bitmap32) {
@@ -722,7 +718,7 @@ public:
                 *is_valid_ptr = false;
                 return result;
             }
-            
+
             uint32_t key = decode_fixed32_le(reinterpret_cast<const uint8_t*>(buf));
             buf += sizeof(uint32_t);
             max_bytes -= sizeof(uint32_t);

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -718,6 +718,11 @@ public:
         DCHECK(buf != nullptr);
         for (uint64_t lcv = 0; lcv < map_size; lcv++) {
             // get map key
+            if (max_bytes < sizeof(uint32_t)) {
+                *is_valid_ptr = false;
+                return result;
+            }
+            
             uint32_t key = decode_fixed32_le(reinterpret_cast<const uint8_t*>(buf));
             buf += sizeof(uint32_t);
             max_bytes -= sizeof(uint32_t);

--- a/be/test/exprs/vectorized/cast_expr_test.cpp
+++ b/be/test/exprs/vectorized/cast_expr_test.cpp
@@ -907,12 +907,13 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap) {
     }
 }
 
-TEST_F(VectorizedCastExprTest, stringCastBitmap) {
+TEST_F(VectorizedCastExprTest, stringCastBitmapFailed0) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
 
     std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
 
+    // readable string
     std::string p("1, 342, 2222");
 
     MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(p));
@@ -922,7 +923,216 @@ TEST_F(VectorizedCastExprTest, stringCastBitmap) {
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
-        ASSERT_TRUE(ptr->is_timestamp());
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_TRUE(v->is_null(j));
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapFailed1) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::vector<uint64_t> bits;
+    bits.push_back(1);
+    bits.push_back(342);
+    bits.push_back(2222);
+    BitmapValue bitmap_value(bits);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+    // non-exist type bitmap.
+    *((uint8_t*)(buf.c_str())) = (uint8_t)14;
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_TRUE(v->is_null(j));
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapSingle) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    BitmapValue bitmap_value;
+    bitmap_value.add(1);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        std::vector<int64_t> expect_array;
+        expect_array.push_back(1);
+
+        for (int j = 0; j < v->size(); ++j) {
+            std::vector<int64_t> array;
+            v->get_data()[j]->to_array(&array);
+            ASSERT_EQ(expect_array, array);
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapSingleFailed) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    BitmapValue bitmap_value;
+    bitmap_value.add(1);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+
+    size_t half_length = buf.size() / 2;
+
+    // set smaller length.
+    buf.resize(half_length);
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_TRUE(v->is_null(j));
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapSet) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    BitmapValue bitmap_value;
+    bitmap_value.add(1);
+    bitmap_value.add(2);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        std::vector<int64_t> expect_array;
+        expect_array.push_back(1);
+        expect_array.push_back(2);
+
+        for (int j = 0; j < v->size(); ++j) {
+            std::vector<int64_t> array;
+            v->get_data()[j]->to_array(&array);
+            ASSERT_EQ(expect_array, array);
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapSetFailed) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    BitmapValue bitmap_value;
+    bitmap_value.add(1);
+    bitmap_value.add(2);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+
+    size_t half_length = buf.size() / 2;
+
+    // set smaller length.
+    buf.resize(half_length);
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        // right cast
+        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_TRUE(v->is_null(j));
+        }
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastBitmapMap) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::vector<uint64_t> bits;
+    bits.push_back(1);
+    bits.push_back(342);
+    bits.push_back(2222);
+    BitmapValue bitmap_value(bits);
+
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
         auto v = std::static_pointer_cast<BitmapColumn>(ptr);
@@ -932,6 +1142,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmap) {
         expect_array.push_back(1);
         expect_array.push_back(342);
         expect_array.push_back(2222);
+
         for (int j = 0; j < v->size(); ++j) {
             std::vector<int64_t> array;
             v->get_data()[j]->to_array(&array);
@@ -940,22 +1151,32 @@ TEST_F(VectorizedCastExprTest, stringCastBitmap) {
     }
 }
 
-TEST_F(VectorizedCastExprTest, stringCastBitmapFailed) {
+TEST_F(VectorizedCastExprTest, stringCastBitmapMapFailed) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::OBJECT);
 
     std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
 
-    std::string p("1, 342,sdf 2222");
+    std::vector<uint64_t> bits;
+    bits.push_back(1);
+    bits.push_back(342);
+    bits.push_back(2222);
+    BitmapValue bitmap_value(bits);
 
-    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(p));
+    std::string buf;
+    buf.resize(bitmap_value.getSizeInBytes());
+    bitmap_value.write((char*)buf.c_str());
+    size_t half_length = buf.size() / 2;
+
+    // set smaller length.
+    buf.resize(half_length);
+
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 10, Slice(buf));
 
     expr->_children.push_back(&col1);
 
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-
-        ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
         auto v = std::static_pointer_cast<BitmapColumn>(ptr);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -964,6 +964,8 @@ public abstract class Type implements Cloneable {
     public static boolean canCastTo(Type from, Type to) {
         if (from.isNull()) {
             return true;
+        } else if (from.isStringType() && to.isBitmapType()) {
+            return true;
         } else if (from.isScalarType() && to.isScalarType()) {
             return ScalarType.canCastTo((ScalarType) from, (ScalarType) to);
         } else if (from.isArrayType() && to.isArrayType()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -982,6 +982,13 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testVarcharAsBitmapCast() throws Exception {
+        String sql = "select cast(t1a as BITMAP) from test_all_type;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(1: t1a AS BITMAP)");
+    }
+
+    @Test
     public void testReduceNumberCast() throws Exception {
         String sql;
         String plan;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：

## TARGET
Add cast varchar to bitmap.
**varchar should be serialized bytes from bitmap**.
**We just use this expr for serialized bitmap.**

## IMPLEMENTATION
- Add deserialize with **parameter max_bytes** to read from serialized datas safely.
- Internal logic of Roaring64Map is re-implemented with check for invalid bitmap.
- We check there is valid bitmap(**read_roaring_check**) before read from serialized datas.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
