### PR TITLE
[BugFix] aggregate query statistic from all executor nodes

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -94,7 +94,7 @@ Status ExchangeNode::open(RuntimeState* state) {
 
 Status ExchangeNode::collect_query_statistics(QueryStatistics* statistics) {
     RETURN_IF_ERROR(ExecNode::collect_query_statistics(statistics));
-    statistics->merge(_sub_plan_query_statistics_recvr.get());
+    statistics->aggregate(_sub_plan_query_statistics_recvr.get());
     return Status::OK();
 }
 

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -94,7 +94,7 @@ Status ExchangeNode::open(RuntimeState* state) {
 
 Status ExchangeNode::collect_query_statistics(QueryStatistics* statistics) {
     RETURN_IF_ERROR(ExecNode::collect_query_statistics(statistics));
-    statistics->aggregate(_sub_plan_query_statistics_recvr.get());
+    _sub_plan_query_statistics_recvr->aggregate(statistics);
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -12,9 +12,10 @@
 namespace starrocks::pipeline {
 Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     SourceOperator::prepare(state);
+    auto query_statistic_recv = state->query_recv();
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, _unique_metrics, true, nullptr, true,
+            config::exchg_node_buffer_size_bytes, _unique_metrics, true, query_statistic_recv, true,
             // ExchangeMergeSort will never perform pipeline level shuffle
             DataStreamRecvr::INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE, true);
     return _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -43,9 +43,11 @@ std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_re
     if (_stream_recvr != nullptr) {
         return _stream_recvr;
     }
+    auto query_statistic_recv = state->query_recv();
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, profile, false, nullptr, true, _degree_of_parallelism, false);
+            config::exchg_node_buffer_size_bytes, profile, false, query_statistic_recv, true, _degree_of_parallelism,
+            false);
     return _stream_recvr;
 }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -437,7 +437,6 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
         }
-        // datasink->set_query_statistics(runtime_state->query_statistic());
         RETURN_IF_ERROR(_decompose_data_sink_to_operator(runtime_state, &context, request, datasink));
     }
     RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -430,6 +430,9 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
     std::unique_ptr<DataSink> datasink;
     if (request.isset_output_sink()) {
         const auto& tsink = request.output_sink();
+        if (tsink.type == TDataSinkType::RESULT_SINK) {
+            _query_ctx->set_result_sink(true);
+        }
         RowDescriptor row_desc;
         RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, tsink, fragment.output_exprs, params,
                                                    request.sender_id(), row_desc, &datasink));

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -437,6 +437,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
         }
+        // datasink->set_query_statistics(runtime_state->query_statistic());
         RETURN_IF_ERROR(_decompose_data_sink_to_operator(runtime_state, &context, request, datasink));
     }
     RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -108,31 +108,32 @@ Status QueryContext::init_query(workgroup::WorkGroup* wg) {
 void QueryContext::set_query_trace(std::shared_ptr<starrocks::debug::QueryTrace> query_trace) {
     std::call_once(_query_trace_init_flag, [this, &query_trace]() { _query_trace = std::move(query_trace); });
 }
-std::shared_ptr<QueryStatistics> QueryContext::total_query_statistic() {
-    auto query_statistic = std::make_shared<QueryStatistics>();
-    query_statistic->add_scan_stats(_total_scan_rows_num, _total_scan_bytes);
-    query_statistic->add_cpu_costs(_total_cpu_cost_ns);
-    // TODO: how to accumulate memory cost
-    query_statistic->add_mem_costs(mem_cost_bytes());
-    return query_statistic;
-}
-
-std::shared_ptr<QueryStatistics> QueryContext::delta_query_statistic() {
-    auto query_statistic = std::make_shared<QueryStatistics>();
-    query_statistic->add_scan_stats(_delta_scan_rows_num.exchange(0), _delta_scan_bytes.exchange(0));
-    query_statistic->add_cpu_costs(_delta_cpu_cost_ns.exchange(0));
-    // TODO: how to accumulate memory cost
-    query_statistic->add_mem_costs(mem_cost_bytes());
-    return query_statistic;
-}
 
 std::shared_ptr<QueryStatisticsRecvr> QueryContext::maintained_query_recv() {
     return _sub_plan_query_statistics_recvr;
 }
 
-std::shared_ptr<QueryStatistics> QueryContext::merged_query_statistic() {
-    auto res = delta_query_statistic();
-    res->aggregate(_sub_plan_query_statistics_recvr.get());
+std::shared_ptr<QueryStatistics> QueryContext::intermediate_query_statistic() {
+    auto query_statistic = std::make_shared<QueryStatistics>();
+    // Not transmit delta if it's the result sink node
+    if (_is_result_sink) {
+        return query_statistic;
+    }
+    query_statistic->add_scan_stats(_delta_scan_rows_num.exchange(0), _delta_scan_bytes.exchange(0));
+    query_statistic->add_cpu_costs(_delta_cpu_cost_ns.exchange(0));
+    query_statistic->add_mem_costs(mem_cost_bytes());
+    _sub_plan_query_statistics_recvr->aggregate(query_statistic.get());
+    return query_statistic;
+}
+
+std::shared_ptr<QueryStatistics> QueryContext::final_query_statistic() {
+    DCHECK(_is_result_sink) << "must be the result sink";
+    auto res = std::make_shared<QueryStatistics>();
+    res->add_scan_stats(_total_scan_rows_num, _total_scan_bytes);
+    res->add_cpu_costs(_total_cpu_cost_ns);
+    res->add_mem_costs(mem_cost_bytes());
+
+    _sub_plan_query_statistics_recvr->aggregate(res.get());
     return res;
 }
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -10,6 +10,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/data_stream_mgr.h"
 #include "runtime/exec_env.h"
+#include "runtime/query_statistics.h"
 #include "runtime/runtime_filter_cache.h"
 #include "util/thread.h"
 
@@ -23,7 +24,10 @@ QueryContext::QueryContext()
         : _fragment_mgr(new FragmentContextManager()),
           _total_fragments(0),
           _num_fragments(0),
-          _num_active_fragments(0) {}
+          _num_active_fragments(0) {
+    _query_statistics = std::make_shared<QueryStatistics>();
+    _sub_plan_query_statistics_recvr = std::make_shared<QueryStatisticsRecvr>();
+}
 
 QueryContext::~QueryContext() {
     // When destruct FragmentContextManager, we use query-level MemTracker. since when PipelineDriver executor

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -12,6 +12,7 @@
 #include "gen_cpp/InternalService_types.h" // for TQueryOptions
 #include "gen_cpp/Types_types.h"           // for TUniqueId
 #include "runtime/profile_report_worker.h"
+#include "runtime/query_statistics.h"
 #include "runtime/runtime_state.h"
 #include "util/debug/query_trace.h"
 #include "util/hash_util.hpp"
@@ -98,13 +99,22 @@ public:
     Status init_query(workgroup::WorkGroup* wg);
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
-    void incr_cpu_cost(int64_t cost) { _cur_cpu_cost_ns += cost; }
-    int64_t cpu_cost() const { return _cur_cpu_cost_ns; }
     int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
-    void incr_cur_scan_rows_num(int64_t rows_num) { _cur_scan_rows_num += rows_num; }
-    int64_t cur_scan_rows_num() const { return _cur_scan_rows_num; }
-    void incr_cur_scan_bytes(int64_t scan_bytes) { _cur_scan_bytes += scan_bytes; }
-    int64_t get_scan_bytes() const { return _cur_scan_bytes; }
+    void incr_cpu_cost(int64_t cost) {
+        _total_scan_bytes += cost;
+        _delta_scan_bytes += cost;
+    }
+    void incr_cur_scan_rows_num(int64_t rows_num) {
+        _total_scan_rows_num += rows_num;
+        _delta_scan_rows_num += rows_num;
+    }
+    void incr_cur_scan_bytes(int64_t scan_bytes) {
+        _total_scan_bytes += scan_bytes;
+        _delta_scan_bytes += scan_bytes;
+    }
+    int64_t cpu_cost() const { return _total_cpu_cost_ns; }
+    int64_t cur_scan_rows_num() const { return _total_scan_rows_num; }
+    int64_t get_scan_bytes() const { return _total_scan_bytes; }
 
     // Query start time, used to check how long the query has been running
     // To ensure that the minimum run time of the query will not be killed by the big query checking mechanism
@@ -118,6 +128,31 @@ public:
     starrocks::debug::QueryTrace* query_trace() { return _query_trace.get(); }
 
     std::shared_ptr<starrocks::debug::QueryTrace> shared_query_trace() { return _query_trace; }
+
+    std::shared_ptr<QueryStatistics> total_query_statistic() {
+        auto query_statistic = std::make_shared<QueryStatistics>();
+        query_statistic->add_scan_stats(_total_scan_rows_num, _total_scan_bytes);
+        query_statistic->add_cpu_costs(_total_cpu_cost_ns);
+        // TODO: how to accumulate memory cost
+        query_statistic->add_mem_costs(mem_cost_bytes());
+        return query_statistic;
+    }
+
+    std::shared_ptr<QueryStatistics> delta_query_statistic() {
+        auto query_statistic = std::make_shared<QueryStatistics>();
+        query_statistic->add_scan_stats(_delta_scan_rows_num.exchange(0), _delta_scan_bytes.exchange(0));
+        query_statistic->add_cpu_costs(_delta_cpu_cost_ns.exchange(0));
+        // TODO: how to accumulate memory cost
+        query_statistic->add_mem_costs(mem_cost_bytes());
+        return query_statistic;
+    }
+
+    std::shared_ptr<QueryStatistics> maintained_query_statistic() { return _query_statistics; }
+    std::shared_ptr<QueryStatisticsRecvr> maintained_query_recv() { return _sub_plan_query_statistics_recvr; }
+    std::shared_ptr<QueryStatistics> merged_query_statistic() {
+        _query_statistics->merge(_sub_plan_query_statistics_recvr.get());
+        return _query_statistics;
+    }
 
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
@@ -144,9 +179,14 @@ private:
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;
-    std::atomic<int64_t> _cur_cpu_cost_ns = 0;
-    std::atomic<int64_t> _cur_scan_rows_num = 0;
-    std::atomic<int64_t> _cur_scan_bytes = 0;
+    std::atomic<int64_t> _total_cpu_cost_ns = 0;
+    std::atomic<int64_t> _total_scan_rows_num = 0;
+    std::atomic<int64_t> _total_scan_bytes = 0;
+    std::atomic<int64_t> _delta_cpu_cost_ns = 0;
+    std::atomic<int64_t> _delta_scan_rows_num = 0;
+    std::atomic<int64_t> _delta_scan_bytes = 0;
+    std::shared_ptr<QueryStatistics> _query_statistics;                     // For local aggregate
+    std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr; // For receive
 
     int64_t _scan_limit = 0;
 };

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -101,8 +101,8 @@ public:
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
     int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
     void incr_cpu_cost(int64_t cost) {
-        _total_scan_bytes += cost;
-        _delta_scan_bytes += cost;
+        _total_cpu_cost_ns += cost;
+        _delta_cpu_cost_ns += cost;
     }
     void incr_cur_scan_rows_num(int64_t rows_num) {
         _total_scan_rows_num += rows_num;
@@ -129,12 +129,13 @@ public:
 
     std::shared_ptr<starrocks::debug::QueryTrace> shared_query_trace() { return _query_trace; }
 
-    std::shared_ptr<QueryStatistics> total_query_statistic();
     // Delta statistic since last retrieve
-    std::shared_ptr<QueryStatistics> delta_query_statistic();
-    std::shared_ptr<QueryStatisticsRecvr> maintained_query_recv();
+    std::shared_ptr<QueryStatistics> intermediate_query_statistic();
     // Merged statistic from all executor nodes
-    std::shared_ptr<QueryStatistics> merged_query_statistic();
+    std::shared_ptr<QueryStatistics> final_query_statistic();
+    std::shared_ptr<QueryStatisticsRecvr> maintained_query_recv();
+    bool is_result_sink() const { return _is_result_sink; }
+    void set_result_sink(bool value) { _is_result_sink = value; }
 
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
@@ -167,6 +168,7 @@ private:
     std::atomic<int64_t> _delta_cpu_cost_ns = 0;
     std::atomic<int64_t> _delta_scan_rows_num = 0;
     std::atomic<int64_t> _delta_scan_bytes = 0;
+    bool _is_result_sink = false;
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr; // For receive
 
     int64_t _scan_limit = 0;

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -50,7 +50,7 @@ void ResultSinkOperator::close(RuntimeState* state) {
             _sender->update_num_written_rows(_num_written_rows.load(std::memory_order_relaxed));
 
             QueryContext* query_ctx = state->query_ctx();
-            auto query_statistic = query_ctx->merged_query_statistic();
+            auto query_statistic = query_ctx->final_query_statistic();
             query_statistic->set_returned_rows(_num_written_rows);
             _sender->set_query_statistics(query_statistic);
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -49,11 +49,8 @@ void ResultSinkOperator::close(RuntimeState* state) {
             // the visibility of _num_written_rows is guaranteed by _num_result_sinkers.fetch_sub().
             _sender->update_num_written_rows(_num_written_rows.load(std::memory_order_relaxed));
 
-            auto query_statistic = std::make_shared<QueryStatistics>();
             QueryContext* query_ctx = state->query_ctx();
-            query_statistic->add_scan_stats(query_ctx->cur_scan_rows_num(), query_ctx->get_scan_bytes());
-            query_statistic->add_cpu_costs(query_ctx->cpu_cost());
-            query_statistic->add_mem_costs(query_ctx->mem_cost_bytes());
+            auto query_statistic = query_ctx->merged_query_statistic();
             query_statistic->set_returned_rows(_num_written_rows);
             _sender->set_query_statistics(query_statistic);
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
     DCHECK(pass_through_chunk_buffer != nullptr);
     std::shared_ptr<DataStreamRecvr> recvr(
             new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
-                                buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline,
+                                buffer_size, profile, sub_plan_query_statistics_recvr, is_pipeline,
                                 degree_of_parallelism, keep_order, pass_through_chunk_buffer));
 
     uint32_t bucket = get_bucket(fragment_instance_id);

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -58,6 +58,13 @@ void QueryStatisticsRecvr::insert(const PQueryStatistics& statistics, int sender
     query_statistics->merge_pb(statistics);
 }
 
+void QueryStatisticsRecvr::merge(QueryStatistics* statistics) {
+    std::lock_guard<SpinLock> l(_lock);
+    for (auto& pair : _query_statistics) {
+        statistics->merge(*(pair.second));
+    }
+}
+
 QueryStatisticsRecvr::~QueryStatisticsRecvr() {
     // It is unnecessary to lock here, because the destructor will be
     // called alter DataStreamRecvr's close in ExchangeNode.

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -33,15 +33,42 @@ void QueryStatistics::to_pb(PQueryStatistics* statistics) {
     *statistics->mutable_stats_items() = {_stats_items.begin(), _stats_items.end()};
 }
 
-void QueryStatistics::aggregate(QueryStatisticsRecvr* recvr) {
-    recvr->aggregate(this);
+void QueryStatistics::clear() {
+    scan_rows = 0;
+    scan_bytes = 0;
+    cpu_ns = 0;
+    returned_rows = 0;
+    _stats_items.clear();
 }
 
-void QueryStatistics::merge(const QueryStatistics& other) {
-    scan_rows += other.scan_rows;
-    scan_bytes += other.scan_bytes;
-    cpu_ns += other.cpu_ns;
-    mem_cost_bytes += other.mem_cost_bytes;
+void QueryStatistics::add_stats_item(QueryStatisticsItemPB& stats_item) {
+    this->_stats_items.emplace_back(stats_item);
+    this->scan_rows += stats_item.scan_rows();
+    this->scan_bytes += stats_item.scan_bytes();
+}
+
+void QueryStatistics::add_scan_stats(int64_t scan_rows, int64_t scan_bytes) {
+    this->scan_rows += scan_rows;
+    this->scan_bytes += scan_bytes;
+}
+
+void QueryStatistics::merge(int sender_id, QueryStatistics& other) {
+    // Make the exchange action atomic
+    int64_t rows = other.scan_rows.load();
+    scan_rows += rows;
+    other.scan_rows -= rows;
+
+    int64_t bytes = other.scan_bytes.load();
+    scan_bytes += bytes;
+    other.scan_bytes -= bytes;
+
+    int64_t cpu_ns = other.cpu_ns.load();
+    cpu_ns += cpu_ns;
+    other.cpu_ns -= cpu_ns;
+
+    int64_t mem_bytes = other.mem_cost_bytes.load();
+    mem_cost_bytes = std::max<int64_t>(mem_cost_bytes, mem_bytes);
+
     _stats_items.insert(_stats_items.end(), other._stats_items.begin(), other._stats_items.end());
 }
 
@@ -49,7 +76,7 @@ void QueryStatistics::merge_pb(const PQueryStatistics& statistics) {
     scan_rows += statistics.scan_rows();
     scan_bytes += statistics.scan_bytes();
     cpu_ns += statistics.cpu_cost_ns();
-    mem_cost_bytes += statistics.mem_cost_bytes();
+    mem_cost_bytes = std::max<int64_t>(mem_cost_bytes, statistics.mem_cost_bytes());
     _stats_items.insert(_stats_items.end(), statistics.stats_items().begin(), statistics.stats_items().end());
 }
 
@@ -69,7 +96,7 @@ void QueryStatisticsRecvr::insert(const PQueryStatistics& statistics, int sender
 void QueryStatisticsRecvr::aggregate(QueryStatistics* statistics) {
     std::lock_guard<SpinLock> l(_lock);
     for (auto& pair : _query_statistics) {
-        statistics->merge(*(pair.second));
+        statistics->merge(pair.first, *pair.second);
     }
 }
 

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -94,12 +94,7 @@ public:
 private:
     friend class QueryStatistics;
 
-    void merge(QueryStatistics* statistics) {
-        std::lock_guard<SpinLock> l(_lock);
-        for (auto& pair : _query_statistics) {
-            statistics->merge(*(pair.second));
-        }
-    }
+    void merge(QueryStatistics* statistics);
 
     std::map<int, QueryStatistics*> _query_statistics;
     SpinLock _lock;

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -37,12 +37,6 @@ class QueryStatistics {
 public:
     QueryStatistics() {}
 
-    void merge(const QueryStatistics& other) {
-        scan_rows += other.scan_rows;
-        scan_bytes += other.scan_bytes;
-        _stats_items.insert(_stats_items.end(), other._stats_items.begin(), other._stats_items.end());
-    }
-
     void set_returned_rows(int64_t num_rows) { this->returned_rows = num_rows; }
 
     void add_stats_item(QueryStatisticsItemPB& stats_item) {
@@ -60,7 +54,8 @@ public:
 
     void add_mem_costs(int64_t bytes) { mem_cost_bytes += bytes; }
 
-    void merge(QueryStatisticsRecvr* recvr);
+    void merge(const QueryStatistics& other);
+    void aggregate(QueryStatisticsRecvr* recvr);
 
     void clear() {
         scan_rows = 0;
@@ -90,11 +85,9 @@ public:
     ~QueryStatisticsRecvr();
 
     void insert(const PQueryStatistics& statistics, int sender_id);
+    void aggregate(QueryStatistics* statistics);
 
 private:
-    friend class QueryStatistics;
-
-    void merge(QueryStatistics* statistics);
 
     std::map<int, QueryStatistics*> _query_statistics;
     SpinLock _lock;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -398,8 +398,8 @@ Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list,
     return Status::OK();
 }
 
-std::shared_ptr<QueryStatistics> RuntimeState::delta_query_statistic() {
-    return _query_ctx->delta_query_statistic();
+std::shared_ptr<QueryStatistics> RuntimeState::intermediate_query_statistic() {
+    return _query_ctx->intermediate_query_statistic();
 }
 
 std::shared_ptr<QueryStatisticsRecvr> RuntimeState::query_recv() {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -401,9 +401,7 @@ Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list,
 std::shared_ptr<QueryStatistics> RuntimeState::delta_query_statistic() {
     return _query_ctx->delta_query_statistic();
 }
-std::shared_ptr<QueryStatistics> RuntimeState::query_statistic() {
-    return _query_ctx->maintained_query_statistic();
-}
+
 std::shared_ptr<QueryStatisticsRecvr> RuntimeState::query_recv() {
     return _query_ctx->maintained_query_recv();
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -38,6 +38,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/load_path_mgr.h"
 #include "runtime/mem_tracker.h"
+#include "runtime/query_statistics.h"
 #include "runtime/runtime_filter_worker.h"
 #include "util/pretty_printer.h"
 #include "util/timezone_utils.h"
@@ -397,4 +398,13 @@ Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list,
     return Status::OK();
 }
 
+std::shared_ptr<QueryStatistics> RuntimeState::delta_query_statistic() {
+    return _query_ctx->delta_query_statistic();
+}
+std::shared_ptr<QueryStatistics> RuntimeState::query_statistic() {
+    return _query_ctx->maintained_query_statistic();
+}
+std::shared_ptr<QueryStatisticsRecvr> RuntimeState::query_recv() {
+    return _query_ctx->maintained_query_recv();
+}
 } // end namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -306,7 +306,7 @@ public:
     void set_enable_pipeline_engine(bool enable_pipeline_engine) { _enable_pipeline_engine = enable_pipeline_engine; }
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
 
-    std::shared_ptr<QueryStatistics> delta_query_statistic();
+    std::shared_ptr<QueryStatistics> intermediate_query_statistic();
     std::shared_ptr<QueryStatisticsRecvr> query_recv();
 
 private:

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -307,7 +307,6 @@ public:
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
 
     std::shared_ptr<QueryStatistics> delta_query_statistic();
-    std::shared_ptr<QueryStatistics> query_statistic();
     std::shared_ptr<QueryStatisticsRecvr> query_recv();
 
 private:

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -58,6 +58,8 @@ class ResultBufferMgr;
 class LoadErrorHub;
 class RowDescriptor;
 class RuntimeFilterPort;
+class QueryStatistics;
+class QueryStatisticsRecvr;
 
 namespace pipeline {
 class QueryContext;
@@ -303,6 +305,10 @@ public:
 
     void set_enable_pipeline_engine(bool enable_pipeline_engine) { _enable_pipeline_engine = enable_pipeline_engine; }
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
+
+    std::shared_ptr<QueryStatistics> delta_query_statistic();
+    std::shared_ptr<QueryStatistics> query_statistic();
+    std::shared_ptr<QueryStatisticsRecvr> query_recv();
 
 private:
     Status create_error_log_file();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9673

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Aggregate query-statistic from multiple executor nodes.
- Collect local statistic at `QueryContext`
- Transmit statistic to other nodes through `transmit_chunk` and `transmit_data` RPC
- Statistic received from remote notes are maintained at `QueryStatisticsRecvr`
- Before send statistic to other nodes(excluding final sink node), aggregate local statistic and received statistics
- Since all statistics is transmitted in delta, and finally it could be aggregated exactly once

Concurrency:
- Local statistic in QueryContext is maintained through atomic integers, and accessed by pipeline executors
- Received statistics is protected a big lock, accessed by both `DataStreamRecv` and `ExchangeSinkOperator`


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
