### PR TITLE
[BugFix] Fix create iceberg resource failed when fe restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
@@ -112,7 +112,7 @@ public abstract class Resource implements Writable {
     }
 
     public boolean needMappingCatalog() {
-        return type == ResourceType.HIVE || type == ResourceType.ICEBERG || type == ResourceType.HUDI;
+        return type == ResourceType.HIVE || type == ResourceType.HUDI;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -69,7 +69,7 @@ public class ResourceMgr implements Writable {
             .build();
 
     public static final ImmutableList<String> NEED_MAPPING_CATALOG_RESOURCES = new ImmutableList.Builder<String>()
-            .add("hive").add("iceberg").add("hudi")
+            .add("hive").add("hudi")
             .build();
 
     @SerializedName(value = "nameToResource")


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Parameter "starrocks.catalog-type" in Iceberg resource is replaced by parameter "iceberg.catalog.type".  "starrocks.catalog-type" is deprecated. Both are compatible when creating resource. But only "iceberg.catalog.type" is used  when creating IcebergMetadata. So if resource with old params "starrocks.catalog-type" exists in image. it will create iceberg metadata After creating iceberg resource when fe restarting. So it throws exception.

java.lang.RuntimeException: Property iceberg.catalog.type is missing or not supported now.
        at com.starrocks.connector.iceberg.IcebergMetadata.<init>(IcebergMetadata.java:53) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.iceberg.IcebergConnector.getMetadata(IcebergConnector.java:36) [starrocks-fe.jar:?]
        at com.starrocks.connector.ConnectorMgr.registerConnectorInternal(ConnectorMgr.java:116) [starrocks-fe.jar:?]
        at com.starrocks.connector.ConnectorMgr.createConnector(ConnectorMgr.java:73) [starrocks-fe.jar:?]



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
