### PR TITLE
[Enhancement] Support adjust cachesize automatically

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -60,7 +60,7 @@ CONF_mInt64(memory_urgent_level, "85");
 // the Pagecache slowly, it should be between [1, memory_urgent_level).
 CONF_mInt64(memory_high_level, "75");
 // Pagecache size adjust period, default 20, it should be between [1, 180].
-CONF_Int64(pagecache_adjuct_period, "20");
+CONF_Int64(pagecache_adjust_period, "20");
 // Sleep time in seconds between pagecache adjust iterations.
 CONF_Int64(auto_adjust_pagecache_interval_seconds, "10");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -62,7 +62,7 @@ CONF_mInt64(memory_high_level, "75");
 // Pagecache size adjust period, default 20, it should be between [1, 180].
 CONF_Int64(pagecache_adjuct_period, "20");
 // Sleep time in seconds between pagecache adjust iterations.
-CONF_Int64(auto_adjust_pagecache_interval, "10");
+CONF_Int64(auto_adjust_pagecache_seconds, "10");
 
 // Bound on the total amount of bytes allocated to thread caches.
 // This bound is not strict, so it is possible for the cache to go over this bound

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -52,6 +52,18 @@ CONF_mInt64(tc_free_memory_rate, "0");
 // tcmalloc gc period, default 60, it should be between [1, 180]
 CONF_mInt64(tc_gc_period, "60");
 
+CONF_mBool(enable_auto_adjust_pagecache, "false");
+// Memory urget water level, if the memory usage exceeds this level, reduce the size of
+// the Pagecache immediately, it should be between (memory_high_level, 100].
+CONF_mInt64(memory_urgent_level, "85");
+// Memory high water level, if the memory usage exceeds this level, reduce the size of
+// the Pagecache slowly, it should be between [1, memory_urgent_level).
+CONF_mInt64(memory_high_level, "75");
+// Pagecache size adjust period, default 20, it should be between [1, 180].
+CONF_Int64(pagecache_adjuct_period, "20");
+// Sleep time in seconds between pagecache adjust iterations.
+CONF_Int64(auto_adjust_pagecache_interval, "10");
+
 // Bound on the total amount of bytes allocated to thread caches.
 // This bound is not strict, so it is possible for the cache to go over this bound
 // in certain circumstances. The maximum value of this flag is capped to 1GB.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -62,7 +62,7 @@ CONF_mInt64(memory_high_level, "75");
 // Pagecache size adjust period, default 20, it should be between [1, 180].
 CONF_Int64(pagecache_adjuct_period, "20");
 // Sleep time in seconds between pagecache adjust iterations.
-CONF_Int64(auto_adjust_pagecache_seconds, "10");
+CONF_Int64(auto_adjust_pagecache_interval_seconds, "10");
 
 // Bound on the total amount of bytes allocated to thread caches.
 // This bound is not strict, so it is possible for the cache to go over this bound

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -60,9 +60,9 @@ CONF_mInt64(memory_urgent_level, "85");
 // the Pagecache slowly, it should be between [1, memory_urgent_level).
 CONF_mInt64(memory_high_level, "75");
 // Pagecache size adjust period, default 20, it should be between [1, 180].
-CONF_Int64(pagecache_adjust_period, "20");
+CONF_mInt64(pagecache_adjust_period, "20");
 // Sleep time in seconds between pagecache adjust iterations.
-CONF_Int64(auto_adjust_pagecache_interval_seconds, "10");
+CONF_mInt64(auto_adjust_pagecache_interval_seconds, "10");
 
 // Bound on the total amount of bytes allocated to thread caches.
 // This bound is not strict, so it is possible for the cache to go over this bound

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -52,7 +52,7 @@ CONF_mInt64(tc_free_memory_rate, "0");
 // tcmalloc gc period, default 60, it should be between [1, 180]
 CONF_mInt64(tc_gc_period, "60");
 
-CONF_mBool(enable_auto_adjust_pagecache, "false");
+CONF_mBool(enable_auto_adjust_pagecache, "true");
 // Memory urget water level, if the memory usage exceeds this level, reduce the size of
 // the Pagecache immediately, it should be between (memory_high_level, 100].
 CONF_mInt64(memory_urgent_level, "85");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -53,6 +53,7 @@ void UpdateConfigAction::handle(HttpRequest* req) {
         });
         _config_callback.emplace("storage_page_cache_limit", [&]() {
             int64_t cache_limit = _exec_env->get_storage_page_cache_size();
+            cache_limit = _exec_env->check_storage_page_cache_size(cache_limit);
             StoragePageCache::instance()->set_capacity(cache_limit);
         });
     });

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -400,7 +400,11 @@ int64_t ExecEnv::get_storage_page_cache_size() {
     if (_mem_tracker->has_limit()) {
         mem_limit = _mem_tracker->limit();
     }
-    int64_t storage_cache_limit = ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+}
+
+int64_t ExecEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
+    int64_t new_cache_limit = 0;
     if (storage_cache_limit > MemInfo::physical_mem()) {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
                      << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
@@ -408,15 +412,16 @@ int64_t ExecEnv::get_storage_page_cache_size() {
     if (!config::disable_storage_page_cache) {
         if (storage_cache_limit < kcacheMinSize) {
             LOG(WARNING) << "Storage cache limit is too small, use default size.";
-            storage_cache_limit = kcacheMinSize;
+            new_cache_limit = kcacheMinSize;
         }
-        LOG(INFO) << "Set storage page cache size " << storage_cache_limit;
+        LOG(INFO) << "Set storage page cache size " << new_cache_limit;
     }
-    return storage_cache_limit;
+    return new_cache_limit;
 }
 
 Status ExecEnv::_init_storage_page_cache() {
     int64_t storage_cache_limit = get_storage_page_cache_size();
+    storage_cache_limit = check_storage_page_cache_size(storage_cache_limit);
     StoragePageCache::create_global_cache(_page_cache_mem_tracker, storage_cache_limit);
 
     // TODO(zc): The current memory usage configuration is a bit confusing,

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -404,7 +404,6 @@ int64_t ExecEnv::get_storage_page_cache_size() {
 }
 
 int64_t ExecEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
-    int64_t new_cache_limit = 0;
     if (storage_cache_limit > MemInfo::physical_mem()) {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
                      << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
@@ -412,11 +411,11 @@ int64_t ExecEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
     if (!config::disable_storage_page_cache) {
         if (storage_cache_limit < kcacheMinSize) {
             LOG(WARNING) << "Storage cache limit is too small, use default size.";
-            new_cache_limit = kcacheMinSize;
+            storage_cache_limit = kcacheMinSize;
         }
-        LOG(INFO) << "Set storage page cache size " << new_cache_limit;
+        LOG(INFO) << "Set storage page cache size " << storage_cache_limit;
     }
-    return new_cache_limit;
+    return storage_cache_limit;
 }
 
 Status ExecEnv::_init_storage_page_cache() {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -207,6 +207,7 @@ public:
     AgentServer* agent_server() const { return _agent_server; }
 
     int64_t get_storage_page_cache_size();
+    int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
 
     query_cache::CacheManagerRawPtr cache_mgr() const { return _cache_mgr; }
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -233,9 +233,9 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-    GCHelper dec_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds,
+    GCHelper dec_advisor(config::pagecache_adjust_period, config::auto_adjust_pagecache_interval_seconds,
                          MonoTime::Now());
-    GCHelper inc_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds,
+    GCHelper inc_advisor(config::pagecache_adjust_period, config::auto_adjust_pagecache_interval_seconds,
                          MonoTime::Now());
     auto cache = StoragePageCache::instance();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
@@ -260,6 +260,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
                        << " memory_high_level=" << memory_high_level;
             continue;
         }
+        
 
         int64_t memory_urgent = memtracker->limit() * memory_urgent_level / 100;
         int64_t delta_urgent = memtracker->consumption() - memory_urgent;

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -272,7 +272,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
             size_t bytes_to_dec = dec_advisor.bytes_should_gc(MonoTime::Now(), delta_high);
             evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec));
         } else {
-            int64_t max_cache_size = std::min(ExecEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
+            int64_t max_cache_size = std::max(ExecEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
             int64_t cur_cache_size = cache->get_capacity();
             if (cur_cache_size >= max_cache_size) {
                 continue;

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -255,7 +255,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
         if (UNLIKELY(!(memory_urgent_level > memory_high_level && memory_high_level >= 1 &&
                        memory_urgent_level <= 100))) {
             LOG(ERROR) << "memory water level config is illegal: memory_urgent_level=" << memory_urgent_level
-                         << " memory_high_level=" << memory_high_level;
+                       << " memory_high_level=" << memory_high_level;
             continue;
         }
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -233,11 +233,11 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-    GCHelper dec_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_seconds, MonoTime::Now());
-    GCHelper inc_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_seconds, MonoTime::Now());
+    GCHelper dec_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds, MonoTime::Now());
+    GCHelper inc_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds, MonoTime::Now());
     auto cache = StoragePageCache::instance();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
-        SLEEP_IN_BG_WORKER(config::auto_adjust_pagecache_seconds);
+        SLEEP_IN_BG_WORKER(config::auto_adjust_pagecache_interval_seconds);
         if (!config::enable_auto_adjust_pagecache) {
             continue;
         }

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -233,8 +233,10 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-    GCHelper dec_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds, MonoTime::Now());
-    GCHelper inc_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds, MonoTime::Now());
+    GCHelper dec_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds,
+                         MonoTime::Now());
+    GCHelper inc_advisor(config::pagecache_adjuct_period, config::auto_adjust_pagecache_interval_seconds,
+                         MonoTime::Now());
     auto cache = StoragePageCache::instance();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         SLEEP_IN_BG_WORKER(config::auto_adjust_pagecache_interval_seconds);

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -95,6 +95,10 @@ uint64_t StoragePageCache::get_hit_count() {
     return _cache->get_hit_count();
 }
 
+bool StoragePageCache::adjust_capacity(int64_t delta, size_t min_capacity) {
+    return _cache->adjust_capacity(delta, min_capacity);
+}
+
 bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle) {
     auto* lru_handle = _cache->lookup(key.encode());
     if (lru_handle == nullptr) {

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -100,7 +100,7 @@ public:
     uint64_t get_lookup_count();
 
     uint64_t get_hit_count();
-    
+
     bool adjust_capacity(int64_t delta, size_t min_capacity = 0);
 
 private:

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -100,6 +100,8 @@ public:
     uint64_t get_lookup_count();
 
     uint64_t get_hit_count();
+    
+    bool adjust_capacity(int64_t delta, size_t min_capacity = 0);
 
 private:
     static StoragePageCache* _s_instance;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -527,6 +527,9 @@ void StorageEngine::stop() {
     if (_fd_cache_clean_thread.joinable()) {
         _fd_cache_clean_thread.join();
     }
+    if (_adjust_cache_thread.joinable()) {
+        _adjust_cache_thread.join();
+    }
     if (config::path_gc_check) {
         for (auto& thread : _path_scan_threads) {
             if (thread.joinable()) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -255,6 +255,8 @@ private:
 
     void* _tablet_checkpoint_callback(void* arg);
 
+    void* _adjust_pagecache_callback(void* arg);
+
     void _start_clean_fd_cache();
     Status _perform_cumulative_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
     Status _perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
@@ -320,6 +322,7 @@ private:
     std::vector<std::pair<int64_t, std::vector<std::pair<uint32_t, std::string>>>> _executed_repair_compaction_tasks;
     // threads to clean all file descriptor not actively in use
     std::thread _fd_cache_clean_thread;
+    std::thread _adjust_cache_thread;
     std::vector<std::thread> _path_gc_threads;
     // threads to scan disk paths
     std::vector<std::thread> _path_scan_threads;

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -327,12 +327,9 @@ public:
     void get_cache_status(rapidjson::Document* document) override;
     void set_capacity(size_t capacity) override;
     size_t get_capacity() override;
-<<<<<<< HEAD
     uint64_t get_lookup_count() override;
     uint64_t get_hit_count() override;
-=======
     bool adjust_capacity(int64_t delta, size_t min_capacity = 0) override;
->>>>>>> 4f2d65199 (Add adjust size api to page cache)
 
 private:
     static uint32_t _hash_slice(const CacheKey& s);

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -184,7 +184,7 @@ public:
 
     virtual uint64_t get_lookup_count() = 0;
     virtual uint64_t get_hit_count() = 0;
-    
+
     //  Decrease or increase cache capacity.
     virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
 

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -184,6 +184,9 @@ public:
 
     virtual uint64_t get_lookup_count() = 0;
     virtual uint64_t get_hit_count() = 0;
+    
+    //  Decrease or increase cache capacity.
+    virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
 
 private:
     Cache(const Cache&) = delete;
@@ -324,12 +327,17 @@ public:
     void get_cache_status(rapidjson::Document* document) override;
     void set_capacity(size_t capacity) override;
     size_t get_capacity() override;
+<<<<<<< HEAD
     uint64_t get_lookup_count() override;
     uint64_t get_hit_count() override;
+=======
+    bool adjust_capacity(int64_t delta, size_t min_capacity = 0) override;
+>>>>>>> 4f2d65199 (Add adjust size api to page cache)
 
 private:
     static uint32_t _hash_slice(const CacheKey& s);
     static uint32_t _shard(uint32_t hash);
+    void _set_capacity(size_t capacity);
 
     LRUCache _shards[kNumShards];
     std::mutex _mutex;

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -98,6 +98,32 @@ TEST_F(StoragePageCacheTest, normal) {
         size_t ori = cache.get_capacity();
         cache.set_capacity(ori / 2);
         ASSERT_EQ(ori / 2, cache.get_capacity());
+        cache.set_capacity(ori);
+    }
+
+    // adjust capacity
+    {
+        size_t ori = cache.get_capacity();
+        for (int i = 1; i <= 10; i++) {
+            cache.adjust_capacity(32);
+            ASSERT_EQ(cache.get_capacity(), ori + 32 * i);
+        }
+        cache.set_capacity(ori);
+        for (int i = 1; i <= 10; i++) {
+            cache.adjust_capacity(-32);
+            ASSERT_EQ(cache.get_capacity(), ori - 32 * i);
+        }
+        cache.set_capacity(ori);
+
+        int64_t delta = ori;
+        ASSERT_FALSE(cache.adjust_capacity(-delta / 2, ori));
+        ASSERT_EQ(cache.get_capacity(), ori);
+        ASSERT_TRUE(cache.adjust_capacity(-delta / 2, ori / 4));
+        cache.set_capacity(ori);
+
+        // overflow
+        cache.set_capacity(kNumShards);
+        ASSERT_FALSE(cache.adjust_capacity(-2 * kNumShards, 0));
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The BE memory is used by many logics, such as queries, ingestions, compactions, pagecache, and so on. pagecache is enabled by default, and the user can adjust the maximum amount of memory. Furthermore, we would like to have a pagecache self-adjustment policy, so that when memory pressure is low, pagecache can buffer more data, and when memory pressure is high, Pagecache can buffer less data. pagecache can actively evict some data to ensure the running of BE.

This PR automatically resize the Pagecache by monitoring the current memory water level. Below is a test result with auto-tuning cachesize enabled. This test specifies a urgent water level of 30% and a high water level of 20%. The memory usage fluctuates between urgent and high water levels. 
![image](https://user-images.githubusercontent.com/45813655/194747719-26a14c3f-e821-495b-8bbf-6a8d7b98c7c6.png)

If auto-tuning cachesize is turned off, memory usage is not constrained.
![image](https://user-images.githubusercontent.com/45813655/194747748-462be005-494c-483b-b334-3df776acf192.png)


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
