### PR TITLE
[Cherry-pick][branch-2.2][BugFix] ALTER DATABASE RENAME check Privilege Error (#8192)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterDatabaseRename.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterDatabaseRename.java
@@ -59,6 +59,7 @@ public class AlterDatabaseRename extends DdlStmt {
             throw new AnalysisException("Database name is not set");
         }
 
+        dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
         if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(ConnectContext.get(), dbName,
                 PrivPredicate.of(PrivBitSet.of(Privilege.ADMIN_PRIV,
                         Privilege.ALTER_PRIV),
@@ -72,7 +73,6 @@ public class AlterDatabaseRename extends DdlStmt {
 
         FeNameFormat.checkDbName(newDbName);
 
-        dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
         newDbName = ClusterNamespace.getFullName(getClusterName(), newDbName);
     }
 


### PR DESCRIPTION
because granstmt will analyze tablepattern that will make the dbname to clusterdbname, so when check privilege, should get clusterdbname first.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8191

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
