### PR TITLE
[Cherry-pick-2.2][Enhancement] Change LinkedListMultimap to ArrayListMultimap to better support for getting elements by index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -22,7 +22,7 @@
 package com.starrocks.master;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -310,23 +310,23 @@ public class ReportHandler extends Daemon {
         HashMap<Long, TStorageMedium> storageMediumMap = Catalog.getCurrentCatalog().getPartitionIdToStorageMediumMap();
 
         // db id -> tablet id
-        ListMultimap<Long, Long> tabletSyncMap = LinkedListMultimap.create();
+        ListMultimap<Long, Long> tabletSyncMap = ArrayListMultimap.create();
         // db id -> tablet id
-        ListMultimap<Long, Long> tabletDeleteFromMeta = LinkedListMultimap.create();
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
         // tablet ids which schema hash is valid
         Set<Long> foundTabletsWithValidSchema = new HashSet<Long>();
         // tablet ids which schema hash is invalid
         Map<Long, TTabletInfo> foundTabletsWithInvalidSchema = new HashMap<Long, TTabletInfo>();
         // storage medium -> tablet id
-        ListMultimap<TStorageMedium, Long> tabletMigrationMap = LinkedListMultimap.create();
+        ListMultimap<TStorageMedium, Long> tabletMigrationMap = ArrayListMultimap.create();
 
         // dbid -> txn id -> [partition info]
         Map<Long, ListMultimap<Long, TPartitionVersionInfo>> transactionsToPublish = Maps.newHashMap();
         Map<Long, Long> transactionsToCommitTime = Maps.newHashMap();
-        ListMultimap<Long, Long> transactionsToClear = LinkedListMultimap.create();
+        ListMultimap<Long, Long> transactionsToClear = ArrayListMultimap.create();
 
         // db id -> tablet id
-        ListMultimap<Long, Long> tabletRecoveryMap = LinkedListMultimap.create();
+        ListMultimap<Long, Long> tabletRecoveryMap = ArrayListMultimap.create();
 
         Set<Pair<Long, Integer>> tabletWithoutPartitionId = Sets.newHashSet();
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11772

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When creating a table, FE will first put the tablet to be created into the TabletInvertedIndex and then send the task to BE to create the tablet. And when BE reports the tablet, FE will find the difference between the tablet reported by BE and the tablet in TabletInvertedIndex, at this time, if the bucket of table creation is relatively large, there will be a lot of extra tablet in TabletInvertedIndex. But in processing these extra tablet, FE put it into a LinkedList, and when getting the elements, it uses the get(int index) method, resulting in extremely inefficient. And this processing logic is put into the database write lock, resulting in the database stuck.
To fix this bug, we should use arrayList.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
