### PR TITLE
[Enhancement] optimize binary to decimal converter in parquet

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -196,11 +196,32 @@ bool BinaryColumnBase<T>::append_continuous_strings(const Buffer<Slice>& strs) {
     const uint8_t* p = reinterpret_cast<const uint8_t*>(strs.front().data);
     const uint8_t* q = reinterpret_cast<const uint8_t*>(strs.back().data + strs.back().size);
     _bytes.insert(_bytes.end(), p, q);
+
+    _offsets.reserve(_offsets.size() + strs.size());
     for (const Slice& s : strs) {
         new_size += s.size;
         _offsets.emplace_back(new_size);
     }
     DCHECK_EQ(_bytes.size(), new_size);
+    _slices_cache = false;
+    return true;
+}
+
+template <typename T>
+bool BinaryColumnBase<T>::append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
+    if (size == 0) return true;
+    size_t bytes_size = _bytes.size();
+    size_t data_size = size * fixed_length;
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(data);
+    const uint8_t* q = reinterpret_cast<const uint8_t*>(data + data_size);
+    _bytes.insert(_bytes.end(), p, q);
+
+    _offsets.reserve(_offsets.size() + size);
+    for (int i = 0; i < size; i++) {
+        bytes_size += fixed_length;
+        _offsets.emplace_back(bytes_size);
+    }
+    DCHECK_EQ(_bytes.size(), bytes_size);
     _slices_cache = false;
     return true;
 }

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -168,6 +168,8 @@ public:
 
     bool append_continuous_strings(const Buffer<Slice>& strs) override;
 
+    bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) override;
+
     size_t append_numbers(const void* buff, size_t length) override { return -1; }
 
     void append_value_multiple_times(const void* value, size_t count) override;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -215,6 +215,10 @@ public:
     // memory at once.
     [[nodiscard]] virtual bool append_continuous_strings(const Buffer<Slice>& strs) { return append_strings(strs); }
 
+    [[nodiscard]] virtual bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
+        return false;
+    }
+
     // Copy |length| bytes from |buff| into this column and cast them as integers.
     // The count of copied integers depends on |length| and the size of column value:
     //  - `int8_t` column:  |length| integers will be copied.

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -148,6 +148,15 @@ bool NullableColumn::append_continuous_strings(const Buffer<Slice>& strs) {
     return false;
 }
 
+bool NullableColumn::append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
+    if (_data_column->append_continuous_fixed_length_strings(data, size, fixed_length)) {
+        null_column_data().resize(_null_column->size() + size, 0);
+        return true;
+    }
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+    return false;
+}
+
 size_t NullableColumn::append_numbers(const void* buff, size_t length) {
     size_t n;
     if ((n = _data_column->append_numbers(buff, length)) > 0) {

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -136,6 +136,8 @@ public:
 
     bool append_continuous_strings(const Buffer<Slice>& strs) override;
 
+    bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) override;
+
     size_t append_numbers(const void* buff, size_t length) override;
 
     void append_value_multiple_times(const void* value, size_t count) override;

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -262,7 +262,7 @@ public:
         // hive only support null column
         // TODO: support not null
         auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
+        dst_nullable_column->resize_uninitialized(src_nullable_column->size());
 
         auto* src_column =
                 vectorized::ColumnHelper::as_raw_column<vectorized::BinaryColumn>(src_nullable_column->data_column());

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -331,14 +331,8 @@ public:
             return Status::InternalError(strings::Substitute(
                     "going to read out-of-bounds data, offset=$0,count=$1,size=$2", _offset, count, _data.size));
         }
-        std::vector<Slice> slices;
-        slices.resize(count);
-        for (int i = 0; i < count; ++i) {
-            slices[i] = Slice(_data.data + _offset, _type_length);
-            _offset += _type_length;
-        }
-
-        dst->append_continuous_strings(slices);
+        dst->append_continuous_fixed_length_strings(_data.data + _offset, count, _type_length);
+        _offset += count * _type_length;
         return Status::OK();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Effect
======

This problem is found in tpch/q01 when block cache is enabled.

Before optimization, there are  about (14.74-2.5) = 12.22% CPU samples (2.5% is `build_slices`)

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1081215/193023715-df1feee7-696b-4106-802f-3febbc7c3756.png">

After optmization, there are about (10.73-4.01) = 6.72% CPU samples (2.5% is `build_slices`)

<img width="1337" alt="image" src="https://user-images.githubusercontent.com/1081215/193023997-52e9cce9-92a9-4882-af83-0980191d33a1.png">


Method
=======

the optimization is based on several observations:
1.  int64_t operation is faster than int128_t (and actually int128_t works well too)
2.  there are extra (mem->reg) and (reg->mem) operations caused by `memcpy` because of irregular copy size

`BinaryToDecimalConverter` works only on fixed length binary, and string data is contiguous, so we can
- use C++ template to do optimization on fixed length
- call `memcpy` 8 bytes to avoid (mem->reg) and (reg->mem) operations
- use arithmetic right shift

Prototype
=======

I wrote a benchmark to compare two methods(also with verification inside)

```cpp
#include <benchmark/benchmark.h>
#include <emmintrin.h>
#include <immintrin.h>

#include <cmath>
#include <cstdlib>
#include <cstring>
#include <functional>
#include <iostream>
#include <random>

typedef __int128 int128_t;

struct Slice {
    const char* data;
    size_t size;
};
static constexpr int BYTE_SIZE = 11;
static constexpr int GAP_SIZE = 0;
static constexpr bool verify = false;

#define bswap_64(x) __bswap_64(x)

inline unsigned __int128 bswap_128(unsigned __int128 host_int) {
    return static_cast<unsigned __int128>(bswap_64(static_cast<uint64_t>(host_int >> 64))) |
           (static_cast<unsigned __int128>(bswap_64(static_cast<uint64_t>(host_int))) << 64);
}

static unsigned __int128 ToHost128(unsigned __int128 x) {
    return bswap_128(x);
}

static uint64_t ToHost64(uint64_t x) {
    return __bswap_64(x);
}

void make_src_data(size_t size, std::string* blob, std::vector<Slice>* src_data) {
    // assume each data is 7 bytes
    // and bewteen each data there is 4 bytes.

    // add some extra padding bytes.
    size_t bytes = (BYTE_SIZE + GAP_SIZE) * (size) + 16;
    std::mt19937_64 gen64;
    blob->resize(bytes);
    for (size_t i = 0; i < bytes; i++) {
        (*blob)[i] = gen64() & 0xff;
    }

    // construct src data.
    const char* p = blob->data();
    for (size_t i = 0; i < size; i++) {
        src_data->emplace_back(Slice{.data = p, .size = BYTE_SIZE});
        p += (BYTE_SIZE + GAP_SIZE);
    }
}

void binary_to_int128(const std::vector<Slice>& src_data, std::vector<int128_t>& dst_data) {
    size_t size = src_data.size();
    for (size_t i = 0; i < size; i++) {
        const Slice& s = src_data[i];
        int128_t value = s.data[0] & 0x80 ? -1 : 0;
        memcpy(reinterpret_cast<char*>(&value) + sizeof(value) - s.size, s.data, s.size);
        value = ToHost128(value);
        dst_data[i] = value;
    }
    return;
}

static void run_binary_to_int128(benchmark::State& state) {
    // Code inside this loop is measured repeatedly
    std::string blob;
    size_t size = state.range(0);
    std::vector<Slice> src_data;
    std::vector<int128_t> dst_data(size);
    make_src_data(size, &blob, &src_data);

    for (auto _ : state) {
        // state.PauseTiming();
        // state.ResumeTiming();
        binary_to_int128(src_data, dst_data);
    }
}

void binary_to_int128_fixed(const std::vector<Slice>& src_data, std::vector<int128_t>& dst_data) {
    size_t size = src_data.size();
    for (size_t i = 0; i < size; i++) {
        const Slice& s = src_data[i];
        int128_t value = s.data[0] & 0x80 ? -1 : 0;
        memcpy(reinterpret_cast<char*>(&value) + sizeof(value) - 7, s.data, 7);
        value = ToHost128(value);
        dst_data[i] = value;
    }
    return;
}

static void run_binary_to_int128_fixed(benchmark::State& state) {
    // Code inside this loop is measured repeatedly
    std::string blob;
    size_t size = state.range(0);
    std::vector<Slice> src_data;
    std::vector<int128_t> dst_data(size);
    make_src_data(size, &blob, &src_data);

    for (auto _ : state) {
        // state.PauseTiming();
        // state.ResumeTiming();
        binary_to_int128_fixed(src_data, dst_data);
    }
}

template <typename TYPE>
void binary_to_int128_ex(const std::vector<Slice>& src_data, std::vector<int128_t>& dst_data) {
    size_t size = src_data.size();
    for (size_t i = 0; i < size; i++) {
        const Slice& s = src_data[i];

        TYPE value = 0;
        memcpy((char*)&value, s.data, sizeof(TYPE));
        if constexpr (std::is_same_v<TYPE, int64_t>) {
            value = ToHost64(value);
        } else {
            value = ToHost128(value);
        }
        value = value >> ((sizeof(TYPE) - BYTE_SIZE) * 8);

        if constexpr ((BYTE_SIZE <= sizeof(TYPE)) && verify) {
            TYPE value2 = s.data[0] & 0x80 ? -1 : 0;
            memcpy(reinterpret_cast<char*>(&value2) + sizeof(value2) - BYTE_SIZE, s.data, BYTE_SIZE);
            if constexpr (std::is_same_v<TYPE, int64_t>) {
                value2 = ToHost64(value2);
            } else {
                value2 = ToHost128(value2);
            }
            if (value != value2) {
                printf("FAILED at %s. v = %p, v2 = %p, raw = ", __func__, value, value2);
                for (int j = 0; j < BYTE_SIZE; j++) {
                    printf("%x ", s.data[j]);
                }
                printf("\n");
                exit(-1);
            }
        }
        dst_data[i] = value;
    }
    return;
}

static void run_binary_to_int128_ex(benchmark::State& state) {
    // Code inside this loop is measured repeatedly
    std::string blob;
    size_t size = state.range(0);
    std::vector<Slice> src_data;
    std::vector<int128_t> dst_data(size);
    make_src_data(size, &blob, &src_data);

    for (auto _ : state) {
        // state.PauseTiming();
        // state.ResumeTiming();
        binary_to_int128_ex<int64_t>(src_data, dst_data);
    }
}

static void run_binary_to_int128_ex_128(benchmark::State& state) {
    // Code inside this loop is measured repeatedly
    std::string blob;
    size_t size = state.range(0);
    std::vector<Slice> src_data;
    std::vector<int128_t> dst_data(size);
    make_src_data(size, &blob, &src_data);

    for (auto _ : state) {
        // state.PauseTiming();
        // state.ResumeTiming();
        binary_to_int128_ex<int128_t>(src_data, dst_data);
    }
}

static constexpr size_t N = 1000000;
BENCHMARK(run_binary_to_int128)->Args({N});
BENCHMARK(run_binary_to_int128_fixed)->Args({N});
BENCHMARK(run_binary_to_int128_ex)->Args({N});
BENCHMARK(run_binary_to_int128_ex_128)->Args({N});

```

And here is benchmark result

```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
run_binary_to_int128/1000000       8369532 ns      8368588 ns           84
run_binary_to_int128_ex/1000000    1903332 ns      1903122 ns          311
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
