### PR TITLE
[BugFix] Fix subquery relation miss limit bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
@@ -233,7 +233,8 @@ public class AST2SQL {
 
         @Override
         public String visitSubquery(SubqueryRelation subquery, Void context) {
-            return "(" + visit(subquery.getQueryStatement()) + ")" + " " + subquery.getAlias();
+            return "(" + visit(subquery.getQueryStatement()) + ")"
+                    + " " + (subquery.getAlias() == null ? "" : subquery.getAlias());
         }
 
         @Override
@@ -503,7 +504,7 @@ public class AST2SQL {
 
             }
             strBuilder.append("EXISTS ");
-            strBuilder.append(printWithParentheses(node.getChild(0)));
+            strBuilder.append(visit(node.getChild(0)));
             return strBuilder.toString();
         }
 
@@ -576,6 +577,7 @@ public class AST2SQL {
             return node.getColumnName();
         }
 
+        @Override
         public String visitSubquery(Subquery node, Void context) {
             return "(" + visit(node.getQueryStatement()) + ")";
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -445,7 +445,7 @@ public class QueryAnalyzer {
 
         @Override
         public Scope visitSubquery(SubqueryRelation subquery, Scope context) {
-            if (subquery.getResolveTableName() == null) {
+            if (subquery.getResolveTableName() != null && subquery.getResolveTableName().getTbl() == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_DERIVED_MUST_HAVE_ALIAS);
             }
 
@@ -457,6 +457,31 @@ public class QueryAnalyzer {
                         field.getOriginExpression()));
             }
             Scope scope = new Scope(RelationId.of(subquery), new RelationFields(outputFields.build()));
+
+            if (subquery.hasOrderByClause()) {
+                List<Expr> outputExpressions = subquery.getOutputExpression();
+                for (OrderByElement orderByElement : subquery.getOrderBy()) {
+                    Expr expression = orderByElement.getExpr();
+                    AnalyzerUtils.verifyNoGroupingFunctions(expression, "ORDER BY");
+
+                    if (expression instanceof IntLiteral) {
+                        long ordinal = ((IntLiteral) expression).getLongValue();
+                        if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                            throw new SemanticException("ORDER BY position %s is not in select list", ordinal);
+                        }
+                        expression = new FieldReference((int) ordinal - 1, null);
+                    }
+
+                    analyzeExpression(expression, new AnalyzeState(), scope);
+
+                    if (!expression.getType().canOrderBy()) {
+                        throw new SemanticException(Type.ONLY_METRIC_TYPE_ERROR_MSG);
+                    }
+
+                    orderByElement.setExpr(expression);
+                }
+            }
+
             subquery.setScope(scope);
             return scope;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -1,13 +1,17 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.sql.ast;
 
-public class SubqueryRelation extends Relation {
+import com.starrocks.analysis.Expr;
+
+import java.util.List;
+
+public class SubqueryRelation extends QueryRelation {
     private final QueryStatement queryStatement;
 
     public SubqueryRelation(QueryStatement queryStatement) {
         this.queryStatement = queryStatement;
-        // The order by is meaningless in subquery
         QueryRelation queryRelation = this.queryStatement.getQueryRelation();
+        // The order by is meaningless in subquery
         if (!queryRelation.hasLimit()) {
             queryRelation.clearOrder();
         }
@@ -20,6 +24,11 @@ public class SubqueryRelation extends Relation {
     @Override
     public String toString() {
         return alias == null ? "anonymous" : alias.toString();
+    }
+
+    @Override
+    public List<Expr> getOutputExpression() {
+        return this.queryStatement.getQueryRelation().getOutputExpression();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -519,6 +519,30 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
                 logicalPlan.getRoot().getOp(),
                 logicalPlan.getRootBuilder().getInputs(),
                 new ExpressionMapping(node.getScope(), logicalPlan.getOutputColumn()));
+
+
+        if (node.hasOrderByClause()) {
+            List<Ordering> orderings = new ArrayList<>();
+            List<ColumnRefOperator> orderByColumns = Lists.newArrayList();
+            for (OrderByElement item : node.getOrderBy()) {
+                ColumnRefOperator column = (ColumnRefOperator) SqlToScalarOperatorTranslator.translate(item.getExpr(),
+                        builder.getExpressionMapping(), columnRefFactory);
+                Ordering ordering = new Ordering(column, item.getIsAsc(),
+                        OrderByElement.nullsFirst(item.getNullsFirstParam()));
+                if (!orderByColumns.contains(column)) {
+                    orderByColumns.add(column);
+                    orderings.add(ordering);
+                }
+            }
+            builder = builder.withNewRoot(new LogicalTopNOperator(orderings));
+        }
+
+        LimitElement limit = node.getLimit();
+        if (limit != null) {
+            LogicalLimitOperator limitOperator = LogicalLimitOperator.init(limit.getLimit(), limit.getOffset());
+            builder = builder.withNewRoot(limitOperator);
+        }
+
         return new LogicalPlan(builder, logicalPlan.getOutputColumn(), logicalPlan.getCorrelation());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2124,7 +2124,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitQueryStatement(StarRocksParser.QueryStatementContext context) {
-        QueryRelation queryRelation = (QueryRelation) visit(context.queryBody());
+        QueryRelation queryRelation = (QueryRelation) visit(context.queryRelation());
         QueryStatement queryStatement = new QueryStatement(queryRelation);
         if (context.outfile() != null) {
             queryStatement.setOutFileClause((OutFileClause) visit(context.outfile()));
@@ -2138,7 +2138,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitQueryBody(StarRocksParser.QueryBodyContext context) {
+    public ParseNode visitQueryRelation(StarRocksParser.QueryRelationContext context) {
         QueryRelation queryRelation = (QueryRelation) visit(context.queryNoWith());
 
         List<CTERelation> withQuery = new ArrayList<>();
@@ -2162,7 +2162,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             columnNames = columns.stream().map(Identifier::getValue).collect(toList());
         }
 
-        QueryRelation queryRelation = (QueryRelation) visit(context.queryBody());
+        QueryRelation queryRelation = (QueryRelation) visit(context.queryRelation());
         // Regenerate cteID when generating plan
         return new CTERelation(
                 RelationId.of(queryRelation).hashCode(),
@@ -2173,7 +2173,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitQueryNoWith(StarRocksParser.QueryNoWithContext context) {
-
         List<OrderByElement> orderByElements = new ArrayList<>();
         if (context.ORDER() != null) {
             orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
@@ -2184,10 +2183,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             limitElement = (LimitElement) visit(context.limitElement());
         }
 
-        QueryRelation term = (QueryRelation) visit(context.queryTerm());
-        term.setOrderBy(orderByElements);
-        term.setLimit(limitElement);
-        return term;
+        QueryRelation queryRelation = (QueryRelation) visit(context.queryPrimary());
+        queryRelation.setOrderBy(orderByElements);
+        queryRelation.setLimit(limitElement);
+        return queryRelation;
     }
 
     @Override
@@ -2626,42 +2625,46 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitSubquery(StarRocksParser.SubqueryContext context) {
-        return new SubqueryRelation(new QueryStatement((QueryRelation) visit(context.queryBody())));
+        return visit(context.queryRelation());
     }
 
     @Override
-    public ParseNode visitSubqueryPrimary(StarRocksParser.SubqueryPrimaryContext context) {
-        SubqueryRelation subqueryRelation = (SubqueryRelation) visit(context.subquery());
-        return subqueryRelation.getQueryStatement().getQueryRelation();
+    public ParseNode visitQueryWithParentheses(StarRocksParser.QueryWithParenthesesContext context) {
+        QueryRelation relation = (QueryRelation) visit(context.subquery());
+        return new SubqueryRelation(new QueryStatement(relation));
     }
 
     @Override
-    public ParseNode visitSubqueryRelation(StarRocksParser.SubqueryRelationContext context) {
-        SubqueryRelation subqueryRelation = (SubqueryRelation) visit(context.subquery());
+    public ParseNode visitSubqueryWithAlias(StarRocksParser.SubqueryWithAliasContext context) {
+        QueryRelation queryRelation = (QueryRelation) visit(context.subquery());
+        SubqueryRelation subqueryRelation = new SubqueryRelation(new QueryStatement(queryRelation));
+
         if (context.alias != null) {
             Identifier identifier = (Identifier) visit(context.alias);
             subqueryRelation.setAlias(new TableName(null, identifier.getValue()));
+        } else {
+            subqueryRelation.setAlias(new TableName(null, null));
         }
         return subqueryRelation;
     }
 
     @Override
     public ParseNode visitSubqueryExpression(StarRocksParser.SubqueryExpressionContext context) {
-        SubqueryRelation subqueryRelation = (SubqueryRelation) visit(context.subquery());
-        return new Subquery(subqueryRelation.getQueryStatement());
+        QueryRelation queryRelation = (QueryRelation) visit(context.subquery());
+        return new Subquery(new QueryStatement(queryRelation));
     }
 
     @Override
     public ParseNode visitInSubquery(StarRocksParser.InSubqueryContext context) {
         boolean isNotIn = context.NOT() != null;
-        QueryRelation query = (QueryRelation) visit(context.queryBody());
+        QueryRelation query = (QueryRelation) visit(context.queryRelation());
 
         return new InPredicate((Expr) visit(context.value), new Subquery(new QueryStatement(query)), isNotIn);
     }
 
     @Override
     public ParseNode visitExists(StarRocksParser.ExistsContext context) {
-        QueryRelation query = (QueryRelation) visit(context.queryBody());
+        QueryRelation query = (QueryRelation) visit(context.queryRelation());
         return new ExistsPredicate(new Subquery(new QueryStatement(query)), false);
     }
 
@@ -2669,7 +2672,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitScalarSubquery(StarRocksParser.ScalarSubqueryContext context) {
         BinaryPredicate.Operator op = getComparisonOperator(((TerminalNode) context.comparisonOperator().getChild(0))
                 .getSymbol());
-        Subquery subquery = new Subquery(new QueryStatement((QueryRelation) visit(context.queryBody())));
+        Subquery subquery = new Subquery(new QueryStatement((QueryRelation) visit(context.queryRelation())));
         return new BinaryPredicate(op, (Expr) visit(context.booleanExpression()), subquery);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1219,9 +1219,9 @@ syncStatement
 // ------------------------------------------- Query Statement ---------------------------------------------------------
 
 queryStatement
-    : explainDesc? queryBody outfile?;
+    : explainDesc? queryRelation outfile?;
 
-queryBody
+queryRelation
     : withClause? queryNoWith
     ;
 
@@ -1230,23 +1230,19 @@ withClause
     ;
 
 queryNoWith
-    :queryTerm (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
-    ;
-
-queryTerm
-    : queryPrimary                                                             #queryTermDefault
-    | left=queryTerm operator=INTERSECT setQuantifier? right=queryTerm         #setOperation
-    | left=queryTerm operator=(UNION | EXCEPT | MINUS)
-        setQuantifier? right=queryTerm                                         #setOperation
+    : queryPrimary (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
     ;
 
 queryPrimary
-    : querySpecification                           #queryPrimaryDefault
-    | subquery                                     #subqueryPrimary
+    : querySpecification                                                                    #queryPrimaryDefault
+    | subquery                                                                              #queryWithParentheses
+    | left=queryPrimary operator=INTERSECT setQuantifier? right=queryPrimary                #setOperation
+    | left=queryPrimary operator=(UNION | EXCEPT | MINUS)
+        setQuantifier? right=queryPrimary                                                   #setOperation
     ;
 
 subquery
-    : '(' queryBody  ')'
+    : '(' queryRelation ')'
     ;
 
 rowConstructor
@@ -1287,7 +1283,7 @@ groupingSet
     ;
 
 commonTableExpression
-    : name=identifier (columnAliases)? AS '(' queryBody ')'
+    : name=identifier (columnAliases)? AS '(' queryRelation ')'
     ;
 
 setQuantifier
@@ -1315,7 +1311,7 @@ relationPrimary
         AS? alias=identifier columnAliases?)? bracketHint?                              #tableAtom
     | '(' VALUES rowConstructor (',' rowConstructor)* ')'
         (AS? alias=identifier columnAliases?)?                                          #inlineTable
-    | subquery (AS? alias=identifier columnAliases?)?                                   #subqueryRelation
+    | subquery (AS? alias=identifier columnAliases?)?                                   #subqueryWithAlias
     | qualifiedName '(' expression (',' expression)* ')'
         (AS? alias=identifier columnAliases?)?                                          #tableFunction
     | '(' relations ')'                                                                 #parenthesizedRelation
@@ -1456,7 +1452,7 @@ booleanExpression
     : predicate                                                                           #booleanExpressionDefault
     | booleanExpression IS NOT? NULL                                                      #isNull
     | left = booleanExpression comparisonOperator right = predicate                       #comparison
-    | booleanExpression comparisonOperator '(' queryBody ')'                              #scalarSubquery
+    | booleanExpression comparisonOperator '(' queryRelation ')'                          #scalarSubquery
     ;
 
 predicate
@@ -1465,7 +1461,7 @@ predicate
 
 predicateOperations [ParserRuleContext value]
     : NOT? IN '(' expression (',' expression)* ')'                                        #inList
-    | NOT? IN '(' queryBody ')'                                                           #inSubquery
+    | NOT? IN '(' queryRelation ')'                                                       #inSubquery
     | NOT? BETWEEN lower = valueExpression AND upper = predicate                          #between
     | NOT? (LIKE | RLIKE | REGEXP) pattern=valueExpression                                #like
     ;
@@ -1498,7 +1494,7 @@ primaryExpression
     | operator = (MINUS_SYMBOL | PLUS_SYMBOL | BITNOT) primaryExpression                  #arithmeticUnary
     | operator = LOGICAL_NOT primaryExpression                                            #arithmeticUnary
     | '(' expression ')'                                                                  #parenthesizedExpression
-    | EXISTS '(' queryBody ')'                                                            #exists
+    | EXISTS '(' queryRelation ')'                                                        #exists
     | subquery                                                                            #subqueryExpression
     | CAST '(' expression AS type ')'                                                     #cast
     | CONVERT '(' expression ',' type ')'                                                 #convert

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
@@ -38,6 +38,13 @@ public class AnalyzeSubqueryTest {
         analyzeSuccess(
                 "select v1 from t0 where v2 in (select v4 from t1 where v3 = v5) or v2 = (select v4 from t1 where v3 = v5)");
         analyzeFail("select v1 from t0 order by (select v4 from t1)", "ORDER BY clause cannot contain subquery");
+
+        analyzeSuccess("(((select * from t0)))");
+        analyzeSuccess("(select * from t0) limit 1");
+        analyzeSuccess("(select v1 from t0) order by v1 desc limit 1");
+        analyzeSuccess("((select v1 from t0) order by v1 desc limit 1) order by v1");
+        analyzeSuccess("((select v1 from t0) order by v1 desc limit 1) limit 2");
+        analyzeFail("(select v1 from t0) order by err desc limit 1", "Column 'err' cannot be resolved");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1435,4 +1435,103 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  other join predicates: 1: t1a LIKE 11: t1a");
     }
+
+    @Test
+    public void testSubqueryMissLimit() throws Exception {
+        String sql = "select * from t0 limit 1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "select * from (select * from t0 limit 1) t";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "(select * from t0 limit 1)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "(select * from t0) limit 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "((select * from t0) limit 2) limit 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "((select * from t0) limit 1) limit 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 1");
+
+        sql = "((select * from t0) limit 1) order by v1 limit 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  2:TOP-N\n" +
+                "  |  order by: <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 2\n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
+                "     limit: 1\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1\n" +
+                "     rollup: t0\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=3.0\n" +
+                "     numNodes=0\n" +
+                "     limit: 1");
+
+        sql = "((select * from t0) limit 2) order by v1 limit 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  2:TOP-N\n" +
+                "  |  order by: <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 1\n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
+                "     limit: 2\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1\n" +
+                "     rollup: t0\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=3.0\n" +
+                "     numNodes=0\n" +
+                "     limit: 2");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11814 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For compatibility with mysql syntax, subqueries can be used alone as part of a statement, such as (select * from t0 limit 1). This sql will generate two QueryRelations, the outside is an independent QueryRelation, and there is a SubqueryRelation inside, because there is no special processing of the subquery relation, for the subquery, the internal QueryRelation is directly returned, and the external QueryRelation will process the limit, and the external QueryRelation will be processed. limit == null is copied to the internal, causing the internal limit to be lost
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
