### PR TITLE
[UT]Fix ColocateTableBalancerTest fail accidentally bug

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -238,6 +238,18 @@ public class ColocateTableBalancerTest {
                 minTimes = 0;
             }
         };
+
+        // TODO find the root cause of
+        // Missing 1 invocation to:
+        // com.starrocks.system.SystemInfoService#getIdToBackend()
+        //  on mock instance: com.starrocks.system.SystemInfoService@cf1d636
+        // Caused by: Missing invocations
+        //  at com.starrocks.system.SystemInfoService.getIdToBackend(SystemInfoService.java)
+        //  at com.starrocks.system.HeartbeatMgr.runAfterCatalogReady(HeartbeatMgr.java:120)
+        //  at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:60)
+        //  at com.starrocks.common.util.Daemon.run(Daemon.java:115)
+
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", Type.INT));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
UT fails accidentally with error:
Missing 1 invocation to:
 com.starrocks.system.SystemInfoService#getIdToBackend()
This can occur in a high pressure environment. To fix this quickly, we call this method by hand.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
