### PR TITLE
[Enhancement] dump fragment instance id when be crash in DataStreamRecvr

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -84,7 +84,7 @@ static void failure_writer(const char* data, int size) {
         res = print_unique_id(buffer + res, query_id) + res;
         res = sprintf(buffer + res, ", ") + res;
         res = sprintf(buffer + res, "fragment_instance:") + res;
-        res = print_unique_id(buffer + res, query_id) + res;
+        res = print_unique_id(buffer + res, fragment_instance_id) + res;
         res = sprintf(buffer + res, "\n") + res;
         [[maybe_unused]] auto wt = write(STDERR_FILENO, buffer, res);
     }

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <utility>
 
+#include "runtime/current_thread.h"
 #include "runtime/data_stream_recvr.h"
 #include "runtime/raw_value.h"
 #include "runtime/runtime_state.h"
@@ -129,6 +130,7 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
     TUniqueId t_finst_id;
     t_finst_id.hi = finst_id.hi();
     t_finst_id.lo = finst_id.lo();
+    SCOPED_SET_TRACE_INFO({}, {}, t_finst_id);
     std::shared_ptr<DataStreamRecvr> recvr = find_recvr(t_finst_id, request.node_id());
     if (recvr == nullptr) {
         // The receiver may remove itself from the receiver map via deregister_recvr()


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
it's helpful to found the issue 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
