### PR TITLE
[BugFix] Fix l1 file size keep growing

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -834,4 +834,6 @@ CONF_Int64(block_cache_disk_size, "21474836480"); // 20GB
 CONF_Int64(block_cache_block_size, "1048576");
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 
+CONF_mInt64(kL0L1MergeRatio, "10");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -834,6 +834,6 @@ CONF_Int64(block_cache_disk_size, "21474836480"); // 20GB
 CONF_Int64(block_cache_block_size, "1048576");
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 
-CONF_mInt64(kL0L1MergeRatio, "10");
+CONF_mInt64(l0_l1_merge_ratio, "10");
 
 } // namespace starrocks::config

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1086,7 +1086,7 @@ public:
             return true;
         }
         for (const auto& composite_key : _set) {
-            if (!ar.dump(composite_key.size())) {
+            if (!ar.dump(static_cast<size_t>(composite_key.size()))) {
                 LOG(ERROR) << "Failed to dump compose_key_size";
                 return false;
             }
@@ -1130,7 +1130,13 @@ public:
                 LOG(ERROR) << "Failed to load composite_key";
                 return false;
             }
-            _set.emplace(composite_key);
+            auto [it, inserted] = _set.emplace(composite_key);
+            if (inserted) {
+                _total_kv_pairs_usage += composite_key.size();
+            } else {
+                _set.erase(it);
+                _set.emplace(composite_key);
+            }
         }
         return true;
 

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2829,8 +2829,8 @@ Status PersistentIndex::_check_and_flush_l0() {
         }
     } else {
         // l1 is not empty
-        // perform l0 l1 merge compaction if l0_memory * config::kL0L1MergeRatio > l1_file_size
-        if (l0_mem_size * config::kL0L1MergeRatio <= l1_file_size) {
+        // perform l0 l1 merge compaction if l0_memory * config::l0_l1_merge_ratio > l1_file_size
+        if (l0_mem_size * config::l0_l1_merge_ratio <= l1_file_size) {
             return Status::OK();
         }
     }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2087,7 +2087,6 @@ Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* ke
                                      IndexValue* values, size_t* num_found) const {
     const auto& shard_info = _shards[shard_idx];
     if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
-        //LOG(WARNING) << "shard exist but size is empty, nshard: " << shard_info.size << " npage: " << shard_info.npage << " size: " << keys_info.size();
         return Status::OK();
     }
     std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
@@ -2189,7 +2188,6 @@ Status ImmutableIndex::get(size_t n, const Slice* keys, const KeysInfo& keys_inf
                            size_t* num_found, size_t key_size) const {
     auto iter = _shard_info_by_length.find(key_size);
     if (iter == _shard_info_by_length.end()) {
-        //LOG(WARNING) << "no key length: " << key_size << " in l1";
         return Status::OK();
     }
     size_t found = 0;
@@ -2640,7 +2638,6 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
     RETURN_IF_ERROR(_check_and_flush_l0());
     // for case1 and case2
     if (_flushed) {
-        //LOG(INFO) << "flush version " << _version.to_string();
         // update PersistentIndexMetaPB
         index_meta->set_size(_size);
         index_meta->set_format_version(PERSISTENT_INDEX_VERSION_2);
@@ -2651,14 +2648,12 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         // clear _l0 and reload _l1
         RETURN_IF_ERROR(_reload(*index_meta));
     } else if (_dump_snapshot) {
-        //LOG(INFO) << "dump snapshot version " << _version.to_string();
         index_meta->set_size(_size);
         index_meta->set_format_version(PERSISTENT_INDEX_VERSION_2);
         _version.to_pb(index_meta->mutable_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
         RETURN_IF_ERROR(_l0->commit(l0_meta, _version, kSnapshot));
     } else {
-        //LOG(INFO) << "append wal version " << _version.to_string();
         index_meta->set_size(_size);
         index_meta->set_format_version(PERSISTENT_INDEX_VERSION_2);
         _version.to_pb(index_meta->mutable_version());
@@ -2787,7 +2782,6 @@ Status PersistentIndex::try_replace(size_t n, const Slice* keys, const IndexValu
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
         }
     }
-    //LOG(INFO) << "try_replace total num is " << n << ", not found num is " << num_not_found;
     RETURN_IF_ERROR(_l0->replace(keys, values, replace_idxes));
     _dump_snapshot |= _can_dump_directly();
     if (!_dump_snapshot) {
@@ -2834,10 +2828,8 @@ Status PersistentIndex::_check_and_flush_l0() {
     }
     _flushed = true;
     if (_l1 == nullptr) {
-        //LOG(INFO) << "flush l0";
         RETURN_IF_ERROR(_flush_l0());
     } else {
-        //LOG(INFO) << "merge compaction";
         RETURN_IF_ERROR(_merge_compaction());
     }
     return Status::OK();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -164,6 +164,9 @@ public:
 
     virtual size_t memory_usage() = 0;
 
+    virtual void update_overlap_size(size_t num_overlap) = 0;
+    virtual size_t overlap_num() = 0;
+
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
     static std::tuple<size_t, size_t> estimate_nshard_and_npage(const size_t total_kv_pairs_usage);
@@ -273,6 +276,8 @@ public:
 
     size_t memory_usage();
 
+    Status update_overlap_size(size_t key_size, size_t num_overlap);
+
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
 private:
@@ -376,6 +381,7 @@ private:
         uint32_t key_size;
         uint32_t value_size;
         uint32_t nbucket;
+        uint64_t data_size;
     };
 
     std::vector<ShardInfo> _shards;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -164,8 +164,9 @@ public:
 
     virtual size_t memory_usage() = 0;
 
-    virtual void update_overlap_size(size_t num_overlap) = 0;
-    virtual size_t overlap_num() = 0;
+    virtual void update_overlap_info(size_t overlap_size, size_t overlap_usage) = 0;
+
+    virtual size_t overlap_size() = 0;
 
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
@@ -276,7 +277,8 @@ public:
 
     size_t memory_usage();
 
-    Status update_overlap_size(size_t key_size, size_t num_overlap);
+    Status update_overlap_info(size_t key_size, size_t num_overlap, const Slice* keys, const IndexValue* values,
+                               const KeysInfo& keys_info, bool erase);
 
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1334,6 +1334,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     }
     uint32_t max_src_rssid = max_rowset_id + rowset->num_segments() - 1;
 
+    LOG(INFO) << "max_src_rssid is " << max_src_rssid;
     for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
         auto& pk_col = _compaction_state->pk_cols[i];
         total_rows += pk_col->size();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1334,7 +1334,6 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     }
     uint32_t max_src_rssid = max_rowset_id + rowset->num_segments() - 1;
 
-    LOG(INFO) << "max_src_rssid is " << max_src_rssid;
     for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
         auto& pk_col = _compaction_state->pk_cols[i];
         total_rows += pk_col->size();

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -31,6 +31,7 @@ message ImmutableIndexShardMetaPB {
     uint64 key_size = 4;
     uint64 value_size = 5;
     uint64 nbucket = 6;
+    uint64 data_size = 7;
 }
 
 message ShardInfoPB {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/11868 https://github.com/StarRocks/starrocks/issues/11721

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For https://github.com/StarRocks/starrocks/issues/11868:

In branch-2.4, we support the varlen key of persistent index. But the estimate l1 size is not  accurate because the following two reasons:
1.  We use the total file size of previous l1 file as the real l1 data size
2.  We ignore the same key in l0 and l1, and calculate size twice

These two reasons will cause l1 file size keep growing but the real data size is far smaller than file size.

For https://github.com/StarRocks/starrocks/issues/11721:

`_total_kv_pairs_usage` of `SliceMutableIndex` is not update when load snapshot. So the `_total_kv_pairs_usage` is not accurate after load snapshot which leads to an error in the result of `dump_bound()`. And it may  lead to subsequent metadata errors.

So we will use the read data file size as the snapshot size to avoid potential errors.

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
