### PR TITLE
[BugFix] Support authentication for StarRocks external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1225,9 +1225,11 @@ public class Config extends ConfigBase {
 
     /**
      * If set to true, auth check for StarRocks external table will be enabled. The check
-     * only happens on the target cluster.
+     * only happens on the target cluster. The default is false to ensure users can upgrade
+     * StarRocks smoothly. Otherwise, the upgrade can fail if the existed external table has
+     * wrong user/password, and the authentication is checked in the new version of StarRocks.
      */
-    @ConfField
+    @ConfField(mutable = true)
     public static boolean enable_starrocks_external_table_auth_check = false;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1224,6 +1224,13 @@ public class Config extends ConfigBase {
     public static boolean enable_auth_check = true;
 
     /**
+     * If set to true, auth check for StarRocks external table will be enabled. The check
+     * only happens on the target cluster.
+     */
+    @ConfField
+    public static boolean enable_starrocks_external_table_auth_check = false;
+
+    /**
      * ldap server host for authentication_ldap_simple
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1224,13 +1224,11 @@ public class Config extends ConfigBase {
     public static boolean enable_auth_check = true;
 
     /**
-     * If set to true, auth check for StarRocks external table will be enabled. The check
-     * only happens on the target cluster. The default is false to ensure users can upgrade
-     * StarRocks smoothly. Otherwise, the upgrade can fail if the existed external table has
-     * wrong user/password, and the authentication is checked in the new version of StarRocks.
+     * If set to false, auth check for StarRocks external table will be disabled. The check
+     * only happens on the target cluster.
      */
     @ConfField(mutable = true)
-    public static boolean enable_starrocks_external_table_auth_check = false;
+    public static boolean enable_starrocks_external_table_auth_check = true;
 
     /**
      * ldap server host for authentication_ldap_simple

--- a/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
@@ -5,7 +5,6 @@ package com.starrocks.external.starrocks;
 import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.rpc.FrontendServiceProxy;
-import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TGetTableMetaRequest;
 import com.starrocks.thrift.TGetTableMetaResponse;
 import com.starrocks.thrift.TNetworkAddress;
@@ -25,10 +24,6 @@ public class TableMetaSyncer {
         TGetTableMetaRequest request = new TGetTableMetaRequest();
         request.setDb_name(table.getSourceTableDbName());
         request.setTable_name(table.getSourceTableName());
-        TAuthenticateParams authInfo = new TAuthenticateParams();
-        authInfo.setUser(table.getSourceTableUser());
-        authInfo.setPasswd(table.getSourceTablePassword());
-        request.setAuth_info(authInfo);
         try {
             TGetTableMetaResponse response = FrontendServiceProxy.call(addr,
                     Config.thrift_rpc_timeout_ms,

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -260,6 +260,14 @@ public abstract class BaseAction implements IAction {
             sb.append(", password: ").append(password);
             return sb.toString();
         }
+
+        public static ActionAuthorizationInfo of(String fullUserName, String password, String remoteIp) {
+            ActionAuthorizationInfo authInfo = new ActionAuthorizationInfo();
+            authInfo.fullUserName = fullUserName;
+            authInfo.remoteIp = remoteIp;
+            authInfo.password = password;
+            return authInfo;
+        }
     }
 
     protected void checkGlobalAuth(UserIdentity currentUser, PrivPredicate predicate) throws UnauthorizedException {
@@ -286,7 +294,7 @@ public abstract class BaseAction implements IAction {
     }
 
     // return currentUserIdentity from StarRocks auth
-    protected UserIdentity checkPassword(ActionAuthorizationInfo authInfo)
+    public static UserIdentity checkPassword(ActionAuthorizationInfo authInfo)
             throws UnauthorizedException {
         List<UserIdentity> currentUser = Lists.newArrayList();
         if (!GlobalStateMgr.getCurrentState().getAuth().checkPlainPassword(authInfo.fullUserName,
@@ -351,6 +359,23 @@ public abstract class BaseAction implements IAction {
             }
         }
         return true;
+    }
+
+    // Refer to {@link #parseAuthInfo(BaseRequest, ActionAuthorizationInfo)}
+    public static ActionAuthorizationInfo parseAuthInfo(String fullUserName, String password, String host) {
+        ActionAuthorizationInfo authInfo = new ActionAuthorizationInfo();
+        final String[] elements = fullUserName.split("@");
+        if (elements.length == 2) {
+            authInfo.fullUserName = elements[0];
+        } else {
+            authInfo.fullUserName = fullUserName;
+        }
+        authInfo.password = password;
+        authInfo.remoteIp = host;
+
+        LOG.debug("Parse result for the input [{} {} {}]: {}", fullUserName, password, host, authInfo);
+
+        return authInfo;
     }
 
     protected int checkIntParam(String strParam) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1219,7 +1219,7 @@ public class StmtExecutor {
             authenticateParams.setPasswd(externalTable.getSourceTablePassword());
             authenticateParams.setHost(context.getRemoteIP());
             authenticateParams.setDb_name(externalTable.getSourceTableDbName());
-            authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableDbName()));
+            authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableName()));
             transactionId =
                     GlobalStateMgr.getCurrentGlobalTransactionMgr()
                             .beginRemoteTransaction(externalTable.getSourceTableDbId(),

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -120,6 +120,7 @@ import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.task.LoadEtlTask;
+import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TQueryOptions;
@@ -1213,6 +1214,12 @@ public class StmtExecutor {
         long transactionId = -1;
         if (targetTable instanceof ExternalOlapTable) {
             ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
+            TAuthenticateParams authenticateParams = new TAuthenticateParams();
+            authenticateParams.setUser(externalTable.getSourceTableUser());
+            authenticateParams.setPasswd(externalTable.getSourceTablePassword());
+            authenticateParams.setHost(context.getRemoteIP());
+            authenticateParams.setDb_name(externalTable.getSourceTableDbName());
+            authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableDbName()));
             transactionId =
                     GlobalStateMgr.getCurrentGlobalTransactionMgr()
                             .beginRemoteTransaction(externalTable.getSourceTableDbId(),
@@ -1222,7 +1229,8 @@ public class StmtExecutor {
                                     new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
                                             FrontendOptions.getLocalHostAddress()),
                                     sourceType,
-                                    ConnectContext.get().getSessionVariable().getQueryTimeoutS());
+                                    ConnectContext.get().getSessionVariable().getQueryTimeoutS(),
+                                    authenticateParams);
         } else {
             transactionId = GlobalStateMgr.getCurrentGlobalTransactionMgr().beginTransaction(
                     database.getId(),

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -52,6 +52,8 @@ import com.starrocks.common.ThriftServerContext;
 import com.starrocks.common.ThriftServerEventProcessor;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.http.BaseAction;
+import com.starrocks.http.UnauthorizedException;
 import com.starrocks.leader.LeaderImpl;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
@@ -83,6 +85,7 @@ import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.FrontendServiceVersion;
 import com.starrocks.thrift.TAbortRemoteTxnRequest;
 import com.starrocks.thrift.TAbortRemoteTxnResponse;
+import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
@@ -1292,8 +1295,63 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return leaderImpl.getTableMeta(request);
     }
 
+    // Authenticate a FrontendServiceImpl#beginRemoteTxn RPC for StarRocks external table.
+    // The beginRemoteTxn is sent by the source cluster, and received by the target cluster.
+    // The target cluster should do authentication using the TAuthenticateParams. This method
+    // will check whether the user has an authorization, and whether the user has a
+    // PrivPredicate.LOAD on the given tables. The implementation is similar with that
+    // of stream load, and you can refer to RestBaseAction#execute and LoadAction#executeWithoutPassword
+    // to know more about the related part.
+    static TStatus checkPasswordAndPrivilege(TAuthenticateParams authParams) {
+        if (authParams == null) {
+            LOG.debug("received null TAuthenticateParams");
+            return new TStatus(TStatusCode.OK);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Receive parameter {}", authParams);
+        }
+        if (!Config.enable_starrocks_external_table_auth_check) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("enable_starrocks_external_table_auth_check is disabled, " +
+                        "and skip to check authorization and privilege for {}", authParams);
+            }
+            return new TStatus(TStatusCode.OK);
+        }
+
+        try {
+            BaseAction.ActionAuthorizationInfo authInfo = BaseAction.parseAuthInfo(
+                    authParams.getUser(), authParams.getPasswd(), authParams.getHost());
+            UserIdentity userIdentity = BaseAction.checkPassword(authInfo);
+            String dbName = authParams.getDb_name();
+            for (String tableName : authParams.getTable_names()) {
+                if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
+                        userIdentity, dbName, tableName, PrivPredicate.LOAD)) {
+                    String errMsg = String.format("Access denied; user '%s'@'%s' need (at least one of) the %s " +
+                                    "privilege(s) for table '%s' in db '%s'", userIdentity.getQualifiedUser(),
+                            userIdentity.getHost(), PrivPredicate.LOAD, tableName, dbName);
+                    throw new UnauthorizedException(errMsg);
+                }
+            }
+            return new TStatus(TStatusCode.OK);
+        } catch (Exception e) {
+            LOG.warn("Failed to check parameter [user: {}, host: {}, db: {}, tables: {}]",
+                    authParams.getUser(), authParams.getHost(), authParams.getDb_name(), authParams.getTable_names(), e);
+
+            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            return status;
+        }
+    }
+
     @Override
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {
+        TStatus status = checkPasswordAndPrivilege(request.getAuth_info());
+        if (status.getStatus_code() != TStatusCode.OK) {
+            TBeginRemoteTxnResponse response = new TBeginRemoteTxnResponse();
+            response.setStatus(status);
+            return response;
+        }
         return leaderImpl.beginRemoteTxn(request);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1302,20 +1302,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     // PrivPredicate.LOAD on the given tables. The implementation is similar with that
     // of stream load, and you can refer to RestBaseAction#execute and LoadAction#executeWithoutPassword
     // to know more about the related part.
-    static TStatus checkPasswordAndPrivilege(TAuthenticateParams authParams) {
+    static TStatus checkPasswordAndLoadPrivilege(TAuthenticateParams authParams) {
         if (authParams == null) {
             LOG.debug("received null TAuthenticateParams");
             return new TStatus(TStatusCode.OK);
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Receive parameter {}", authParams);
-        }
+        LOG.debug("Receive parameter {}", authParams);
         if (!Config.enable_starrocks_external_table_auth_check) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("enable_starrocks_external_table_auth_check is disabled, " +
-                        "and skip to check authorization and privilege for {}", authParams);
-            }
+            LOG.debug("enable_starrocks_external_table_auth_check is disabled, " +
+                    "and skip to check authorization and privilege for {}", authParams);
             return new TStatus(TStatusCode.OK);
         }
 
@@ -1339,14 +1335,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     authParams.getUser(), authParams.getHost(), authParams.getDb_name(), authParams.getTable_names(), e);
 
             TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            status.setError_msgs(Lists.newArrayList(e.getMessage(),
+                    "Set the configuration 'enable_starrocks_external_table_auth_check' to 'false' on the target cluster" +
+                            " if you don't want to check the authorization and LOAD privilege."));
             return status;
         }
     }
 
     @Override
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {
-        TStatus status = checkPasswordAndPrivilege(request.getAuth_info());
+        TStatus status = checkPasswordAndLoadPrivilege(request.getAuth_info());
         if (status.getStatus_code() != TStatusCode.OK) {
             TBeginRemoteTxnResponse response = new TBeginRemoteTxnResponse();
             response.setStatus(status);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1327,9 +1327,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             for (String tableName : authParams.getTable_names()) {
                 if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
                         userIdentity, dbName, tableName, PrivPredicate.LOAD)) {
-                    String errMsg = String.format("Access denied; user '%s'@'%s' need (at least one of) the %s " +
+                    String errMsg = String.format("Access denied; user '%s'@'%s' need (at least one of) the %s" +
                                     "privilege(s) for table '%s' in db '%s'", userIdentity.getQualifiedUser(),
-                            userIdentity.getHost(), PrivPredicate.LOAD, tableName, dbName);
+                            userIdentity.getHost(), PrivPredicate.LOAD.getPrivs().toString(), tableName, dbName);
                     throw new UnauthorizedException(errMsg);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1308,7 +1308,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return new TStatus(TStatusCode.OK);
         }
 
-        LOG.debug("Receive parameter {}", authParams);
+        LOG.debug("Receive TAuthenticateParams [user: {}, host: {}, db: {}, tables: {}]",
+                authParams.user, authParams.getHost(), authParams.getDb_name(), authParams.getTable_names());
         if (!Config.enable_starrocks_external_table_auth_check) {
             LOG.debug("enable_starrocks_external_table_auth_check is disabled, " +
                     "and skip to check authorization and privilege for {}", authParams);
@@ -1324,7 +1325,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     authParams.getUser(), authParams.getPasswd(), authParams.getHost());
             userIdentity = BaseAction.checkPassword(authInfo);
         } catch (Exception e) {
-            LOG.warn("Failed to check parameter {}", authParams, e);
+            LOG.warn("Failed to check TAuthenticateParams [user: {}, host: {}, db: {}, tables: {}]",
+                    authParams.user, authParams.getHost(), authParams.getDb_name(), authParams.getTable_names(), e);
             TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
             status.setError_msgs(Lists.newArrayList(e.getMessage(), "Please check that your user or password " +
                     "is correct", configHintMsg));
@@ -1345,7 +1347,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             return new TStatus(TStatusCode.OK);
         } catch (Exception e) {
-            LOG.warn("Failed to check parameter {}", authParams, e);
+            LOG.warn("Failed to check TAuthenticateParams [user: {}, host: {}, db: {}, tables: {}]",
+                    authParams.user, authParams.getHost(), authParams.getDb_name(), authParams.getTable_names(), e);
             TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
             status.setError_msgs(Lists.newArrayList(e.getMessage(), configHintMsg));
             return status;

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1314,30 +1314,40 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     "and skip to check authorization and privilege for {}", authParams);
             return new TStatus(TStatusCode.OK);
         }
+        String configHintMsg = "Set the configuration 'enable_starrocks_external_table_auth_check' to 'false' on the" +
+                " target cluster if you don't want to check the authorization and privilege.";
 
+        // 1. check user and password
+        UserIdentity userIdentity;
         try {
             BaseAction.ActionAuthorizationInfo authInfo = BaseAction.parseAuthInfo(
                     authParams.getUser(), authParams.getPasswd(), authParams.getHost());
-            UserIdentity userIdentity = BaseAction.checkPassword(authInfo);
+            userIdentity = BaseAction.checkPassword(authInfo);
+        } catch (Exception e) {
+            LOG.warn("Failed to check parameter {}", authParams, e);
+            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
+            status.setError_msgs(Lists.newArrayList(e.getMessage(), "Please check that your user or password " +
+                    "is correct", configHintMsg));
+            return status;
+        }
+
+        // 2. check privilege
+        try {
             String dbName = authParams.getDb_name();
             for (String tableName : authParams.getTable_names()) {
                 if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
                         userIdentity, dbName, tableName, PrivPredicate.LOAD)) {
-                    String errMsg = String.format("Access denied; user '%s'@'%s' need (at least one of) the %s" +
-                                    "privilege(s) for table '%s' in db '%s'", userIdentity.getQualifiedUser(),
-                            userIdentity.getHost(), PrivPredicate.LOAD.getPrivs().toString(), tableName, dbName);
+                    String errMsg = String.format("Access denied; user '%s'@'%s' need (at least one of) the " +
+                                    "privilege(s) in [%s] for table '%s' in database '%s'", userIdentity.getQualifiedUser(),
+                            userIdentity.getHost(), PrivPredicate.LOAD.getPrivs().toString().trim(), tableName, dbName);
                     throw new UnauthorizedException(errMsg);
                 }
             }
             return new TStatus(TStatusCode.OK);
         } catch (Exception e) {
-            LOG.warn("Failed to check parameter [user: {}, host: {}, db: {}, tables: {}]",
-                    authParams.getUser(), authParams.getHost(), authParams.getDb_name(), authParams.getTable_names(), e);
-
+            LOG.warn("Failed to check parameter {}", authParams, e);
             TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList(e.getMessage(),
-                    "Set the configuration 'enable_starrocks_external_table_auth_check' to 'false' on the target cluster" +
-                            " if you don't want to check the authorization and LOAD privilege."));
+            status.setError_msgs(Lists.newArrayList(e.getMessage(), configHintMsg));
             return status;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -37,6 +37,7 @@ import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAbortRemoteTxnRequest;
 import com.starrocks.thrift.TAbortRemoteTxnResponse;
+import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
 import com.starrocks.thrift.TBeginRemoteTxnResponse;
 import com.starrocks.thrift.TCommitRemoteTxnRequest;
@@ -118,7 +119,8 @@ public class GlobalTransactionMgr implements Writable {
     // begin transaction in remote StarRocks cluster
     public long beginRemoteTransaction(long dbId, List<Long> tableIds, String label,
                                        String host, int port, TxnCoordinator coordinator,
-                                       LoadJobSourceType sourceType, long timeoutSecond)
+                                       LoadJobSourceType sourceType, long timeoutSecond,
+                                       TAuthenticateParams authenticateParams)
             throws AnalysisException, BeginTransactionException {
         if (Config.disable_load_job) {
             throw new AnalysisException("disable_load_job is set to true, all load jobs are prevented");
@@ -142,6 +144,7 @@ public class GlobalTransactionMgr implements Writable {
         request.setLabel(label);
         request.setSource_type(sourceType.ordinal());
         request.setTimeout_second(timeoutSecond);
+        request.setAuth_info(authenticateParams);
         TBeginRemoteTxnResponse response;
         try {
             response = FrontendServiceProxy.call(addr,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -158,7 +158,7 @@ public class GlobalTransactionMgr implements Writable {
         if (response.status.getStatus_code() != TStatusCode.OK) {
             String errStr;
             if (response.status.getError_msgs() != null) {
-                errStr = String.join(",", response.status.getError_msgs());
+                errStr = String.join(". ", response.status.getError_msgs());
             } else {
                 errStr = "";
             }

--- a/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BasicActionTest {
+
+    @Test
+    public void testParseAuthInfo() {
+        BaseAction.ActionAuthorizationInfo authInfo =
+                BaseAction.parseAuthInfo("abc", "123", "127.0.0.1");
+        verifyAuthInfo(BaseAction.ActionAuthorizationInfo.of(
+                "abc", "123", "127.0.0.1"), authInfo);
+
+        authInfo = BaseAction.parseAuthInfo("test#cluster_id", "", "192.168.19.10");
+        verifyAuthInfo(BaseAction.ActionAuthorizationInfo.of(
+                "test", "", "127.0.0.1"), authInfo);
+    }
+
+    private void verifyAuthInfo(BaseAction.ActionAuthorizationInfo expect, BaseAction.ActionAuthorizationInfo actual) {
+        assertEquals(expect.fullUserName, actual.fullUserName);
+        assertEquals(expect.remoteIp, actual.remoteIp);
+        assertEquals(expect.password, actual.password);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
@@ -15,9 +15,9 @@ public class BasicActionTest {
         verifyAuthInfo(BaseAction.ActionAuthorizationInfo.of(
                 "abc", "123", "127.0.0.1"), authInfo);
 
-        authInfo = BaseAction.parseAuthInfo("test#cluster_id", "", "192.168.19.10");
+        authInfo = BaseAction.parseAuthInfo("test@cluster_id", "", "192.168.19.10");
         verifyAuthInfo(BaseAction.ActionAuthorizationInfo.of(
-                "test", "", "127.0.0.1"), authInfo);
+                "test", "", "192.168.19.10"), authInfo);
     }
 
     private void verifyAuthInfo(BaseAction.ActionAuthorizationInfo expect, BaseAction.ActionAuthorizationInfo actual) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
@@ -93,17 +93,18 @@ public class FrontendServiceTest {
         verifyCheckResult(true, null, FrontendServiceImpl.checkPasswordAndLoadPrivilege(authParam));
 
         String hintMsg = "Set the configuration 'enable_starrocks_external_table_auth_check' to 'false' on the target " +
-                "cluster if you don't want to check the authorization and LOAD privilege.";
+                "cluster if you don't want to check the authorization and privilege.";
 
         // test password check failed
         authParam = createTAuthenticateParams(
                 "abc", "12", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
-        verifyCheckResult(false, Arrays.asList("Access denied for abc@192.168.92.3", hintMsg),
+        verifyCheckResult(false, Arrays.asList("Access denied for abc@192.168.92.3", "Please check that your user " +
+                        "or password is correct", hintMsg),
                 FrontendServiceImpl.checkPasswordAndLoadPrivilege(authParam));
 
         // test privilege check failed on different tables
-        String errMsgFormat = "Access denied; user 'abc'@'192.168.92.3' need (at least one of) the Admin_priv Load_priv " +
-                        "privilege(s) for table '%s' in db 'db1'";
+        String errMsgFormat = "Access denied; user 'abc'@'192.168.92.3' need (at least one of) the " +
+                        "privilege(s) in [Admin_priv Load_priv] for table '%s' in database 'db1'";
 
         authParam = createTAuthenticateParams(
                 "abc", "123", "192.168.92.3", "db1", Arrays.asList("t4", "t2", "t3"));

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
@@ -81,9 +81,9 @@ public class FrontendServiceTest {
 
         grantTable("abc", "192.168.92.3", "db1", "t1",
                 Collections.singletonList(AccessPrivilege.LOAD_PRIV));
-        grantTable("abc", "192.168.92.3", "db2", "t2",
+        grantTable("abc", "192.168.92.3", "db1", "t2",
                 Collections.singletonList(AccessPrivilege.LOAD_PRIV));
-        grantTable("abc", "192.168.92.3", "db2", "t3",
+        grantTable("abc", "192.168.92.3", "db1", "t3",
                 Collections.singletonList(AccessPrivilege.LOAD_PRIV));
 
         Config.enable_starrocks_external_table_auth_check = true;
@@ -95,23 +95,23 @@ public class FrontendServiceTest {
         // test password check failed
         authParam = createTAuthenticateParams(
                 "abc", "12", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
-        verifyCheckResult(false, "Access denied for abc @ 192.168.92.3",
+        verifyCheckResult(false, "Access denied for abc@192.168.92.3",
                 FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
         // test privilege check failed on different tables
-        String errMsg = "Access denied; user 'abc'@'192.168.92.3' need (at least one of) the t4 " +
-                        "privilege(s) for table '%s' in db 'default_cluster.db1'";
+        String errMsgFormat = "Access denied; user 'abc'@'192.168.92.3' need (at least one of) the Admin_priv Load_priv " +
+                        "privilege(s) for table '%s' in db 'db1'";
         authParam = createTAuthenticateParams(
                 "abc", "123", "192.168.92.3", "db1", Arrays.asList("t4", "t2", "t3"));
-        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+        verifyCheckResult(false, String.format(errMsgFormat, "t4"), FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
         authParam = createTAuthenticateParams(
-                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t4", "t3"));
-        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t5", "t3"));
+        verifyCheckResult(false, String.format(errMsgFormat, "t5"), FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
         authParam = createTAuthenticateParams(
-                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t4"));
-        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t6"));
+        verifyCheckResult(false, String.format(errMsgFormat, "t6"), FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
 
         // test disable check configuration
@@ -125,12 +125,12 @@ public class FrontendServiceTest {
         // incorrect password passed
         authParam = createTAuthenticateParams(
                 "abc", "12", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
-        verifyCheckResult(false, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+        verifyCheckResult(true, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
         // incorrect privilege passed
         authParam = createTAuthenticateParams(
                 "abc", "123", "192.168.92.3", "db1", Arrays.asList("t4", "t2", "t3"));
-        verifyCheckResult(false, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+        verifyCheckResult(true, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceTest.java
@@ -1,0 +1,193 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.service;
+
+import com.starrocks.analysis.CreateUserStmt;
+import com.starrocks.analysis.UserIdentity;
+import com.starrocks.catalog.AccessPrivilege;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.GrantPrivilegeStmt;
+import com.starrocks.thrift.TAuthenticateParams;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FrontendServiceTest {
+
+    private Auth auth;
+    @Mocked
+    public GlobalStateMgr globalStateMgr;
+    @Mocked
+    private ConnectContext ctx;
+
+    @Before
+    public void setUp() throws NoSuchMethodException, SecurityException {
+        auth = new Auth();
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getAuth();
+                minTimes = 0;
+                result = auth;
+
+                ConnectContext.get();
+                minTimes = 0;
+                result = ctx;
+
+                ctx.getQualifiedUser();
+                minTimes = 0;
+                result = "root";
+
+                ctx.getRemoteIP();
+                minTimes = 0;
+                result = "192.168.1.1";
+
+                ctx.getState();
+                minTimes = 0;
+                result = new QueryState();
+
+                ctx.getCurrentUserIdentity();
+                minTimes = 0;
+                result = UserIdentity.createAnalyzedUserIdentWithIp("root", "%");
+            }
+        };
+    }
+
+    @Test
+    public void testCheckPasswordAndPrivilege() {
+        createUser("abc", "123", "192.168.92.3");
+
+        grantTable("abc", "192.168.92.3", "db1", "t1",
+                Collections.singletonList(AccessPrivilege.LOAD_PRIV));
+        grantTable("abc", "192.168.92.3", "db2", "t2",
+                Collections.singletonList(AccessPrivilege.LOAD_PRIV));
+        grantTable("abc", "192.168.92.3", "db2", "t3",
+                Collections.singletonList(AccessPrivilege.LOAD_PRIV));
+
+        Config.enable_starrocks_external_table_auth_check = true;
+        // test check passed
+        TAuthenticateParams authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
+        verifyCheckResult(true, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        // test password check failed
+        authParam = createTAuthenticateParams(
+                "abc", "12", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
+        verifyCheckResult(false, "Access denied for abc @ 192.168.92.3",
+                FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        // test privilege check failed on different tables
+        String errMsg = "Access denied; user 'abc'@'192.168.92.3' need (at least one of) the t4 " +
+                        "privilege(s) for table '%s' in db 'default_cluster.db1'";
+        authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t4", "t2", "t3"));
+        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t4", "t3"));
+        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t4"));
+        verifyCheckResult(false, errMsg, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+
+        // test disable check configuration
+        Config.enable_starrocks_external_table_auth_check = false;
+
+        // normal passed
+        authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
+        verifyCheckResult(true, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        // incorrect password passed
+        authParam = createTAuthenticateParams(
+                "abc", "12", "192.168.92.3", "db1", Arrays.asList("t1", "t2", "t3"));
+        verifyCheckResult(false, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+        // incorrect privilege passed
+        authParam = createTAuthenticateParams(
+                "abc", "123", "192.168.92.3", "db1", Arrays.asList("t4", "t2", "t3"));
+        verifyCheckResult(false, null, FrontendServiceImpl.checkPasswordAndPrivilege(authParam));
+
+    }
+
+    private void verifyCheckResult(boolean expectOk, String errMsg, TStatus actualStatus) {
+        assertEquals(expectOk, actualStatus.getStatus_code() == TStatusCode.OK);
+        if (errMsg == null) {
+            assertNull(actualStatus.getError_msgs());
+        } else {
+            assertEquals(1, actualStatus.getError_msgs().size());
+            assertEquals(errMsg, actualStatus.getError_msgs().get(0));
+        }
+    }
+
+    private TAuthenticateParams createTAuthenticateParams(
+            String userName, String password, String host, String dbName, List<String> tableNames) {
+        TAuthenticateParams authParams = new TAuthenticateParams();
+        authParams.setUser(userName);
+        authParams.setPasswd(password);
+        authParams.setHost(host);
+        authParams.setDb_name(dbName);
+        authParams.setTable_names(tableNames);
+        return authParams;
+    }
+
+    private void createUser(String userName, String password, String host) {
+        String sql = String.format("create user '%s'@'%s' identified by '%s'", userName, host, password);
+        CreateUserStmt createUserStmt = null;
+        try {
+            createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+
+        try {
+            auth.createUser(createUserStmt);
+        } catch (DdlException e) {
+            Assert.fail();
+        }
+    }
+
+    private void grantTable(String userName, String host, String dbName, String tableName, List<AccessPrivilege> privileges) {
+        String sql = String.format("GRANT %s on %s.%s to '%s'@'%s'",
+                privileges.stream().map(AccessPrivilege::name).collect(Collectors.joining(",")),
+                dbName, tableName, userName, host);
+
+        GrantPrivilegeStmt grantStmt = null;
+        try {
+            grantStmt = (GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            auth.grant(grantStmt);
+        } catch (DdlException e) {
+            Assert.fail();
+        }
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -45,6 +45,9 @@ struct TSetSessionParams {
 struct TAuthenticateParams {
     1: required string user
     2: required string passwd
+    3: required string host
+    4: required string db_name
+    5: required list<string> table_names;
 }
 
 struct TColumnDesc {


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
When creating StarRocks external table,  properties of `user` and `password` are required. But currently the target cluster does't check the password and `LOAD_PRIV `,  so the `INSERT INTO` will be successful even if the user does not exist, or the user has no `LOAD_PRIV ` on the target cluster. We should fix this problem.

## How we fix it
When inserting data into the table on the target cluster, the source cluster will issue multiple RPCs to the target cluster in order, including `beginRemoteTxn`, `commitRemoteTxn`, and `abortRemoteTxn` in `FrontendServiceImpl`. We only need to 
do the check in the first RPC `beginRemoteTxn`. So authentication information will be carried by the RPC, and checked in the target `beginRemoteTxn`.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
