### PR TITLE
[Enhancement] Add more info for write failure err message (#11838)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -793,7 +793,7 @@ Status OlapTableSink::open_wait() {
                 LOG(WARNING) << ch->name() << ", tablet open failed, " << ch->print_load_info()
                              << ", node=" << ch->node_info()->host << ":" << ch->node_info()->brpc_port
                              << ", errmsg=" << st.get_error_msg();
-                err_st = st;
+                err_st = st.clone_and_append(string(" be:") + ch->node_info()->host);
                 index_channel->mark_as_failed(ch);
             }
         });

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.transaction;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -21,7 +20,6 @@ import com.starrocks.task.ClearTransactionTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,7 +119,6 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
 
                     // save the error replica ids for current tablet
                     // this param is used for log
-                    Set<Long> errorBackendIdsForTablet = Sets.newHashSet();
                     StringBuilder failedReplicaInfoSB = new StringBuilder();
                     int successReplicaNum = 0;
                     for (long tabletBackend : tabletBackends) {
@@ -141,11 +138,17 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                             if (lfv < 0) {
                                 ++successReplicaNum;
                             } else {
+                                Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(tabletBackend);
                                 failedReplicaInfoSB.append(
-                                        String.format("[be:%d V:%d LFV:%d]", tabletBackend, replica.getVersion(), lfv));
+                                        String.format("%d:{be:%d %s V:%d LFV:%d},", replica.getId(), tabletBackend,
+                                                backend == null ? "" : backend.getHost(), replica.getVersion(), lfv));
                             }
                         } else {
-                            errorBackendIdsForTablet.add(tabletBackend);
+                            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(tabletBackend);
+                            failedReplicaInfoSB.append(
+                                    String.format("%d:{be:%d %s V:%d LFV:%d},", replica.getId(), tabletBackend,
+                                            backend == null ? "" : backend.getHost(), replica.getVersion(),
+                                            replica.getLastSuccessVersion()));
                             errorReplicaIds.add(replica.getId());
                             // not remove rollup task here, because the commit maybe failed
                             // remove rollup task when commit successfully
@@ -153,18 +156,11 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                     }
 
                     if (successReplicaNum < quorumReplicaNum) {
-                        List<String> errorBackends = new ArrayList<>();
-                        for (long backendId : errorBackendIdsForTablet) {
-                            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
-                            errorBackends.add(backend.getId() + ":" + backend.getHost());
-                        }
-
-                        String failedReplicaInfo = failedReplicaInfoSB.toString();
-                        LOG.warn("Fail to load files. tablet_id: {}, txn_id: {}, backends: {} failed replicas: {}",
-                                tablet.getId(), txnState.getTransactionId(),
-                                Joiner.on(",").join(errorBackends), failedReplicaInfo);
-                        throw new TabletQuorumFailedException(tablet.getId(), txnState.getTransactionId(), errorBackends,
-                                failedReplicaInfo);
+                        String msg = String.format("Commit failed. txn: %d table: %s tablet: %d quorum: %d<%d errorReplicas: %s",
+                                txnState.getTransactionId(), table.getName(), tablet.getId(), successReplicaNum, quorumReplicaNum,
+                                failedReplicaInfoSB.toString());
+                        LOG.warn(msg);
+                        throw new TabletQuorumFailedException(msg);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletQuorumFailedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletQuorumFailedException.java
@@ -21,27 +21,8 @@
 
 package com.starrocks.transaction;
 
-import com.google.common.base.Joiner;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public class TabletQuorumFailedException extends TransactionException {
-
-    private static final String TABLET_QUORUM_FAILED_MSG = "Fail to load files. tablet_id: %s"
-            + ", txn_id: %s, backends: %s, replicas: %s";
-
-    private long tabletId;
-    private List<String> errorBackends = new ArrayList<String>();
-
-    private String replicaInfos;
-
-    public TabletQuorumFailedException(long tabletId, long transactionId,
-                                       List<String> errorBackends, String replicaInfos) {
-        super(String.format(TABLET_QUORUM_FAILED_MSG, tabletId, transactionId,
-                Joiner.on(",").join(errorBackends), replicaInfos));
-        this.tabletId = tabletId;
-        this.errorBackends = errorBackends;
-        this.replicaInfos = replicaInfos;
+    public TabletQuorumFailedException(String msg) {
+        super(msg);
     }
 }


### PR DESCRIPTION
Add error BE's hostname for tablesink open failure. Change the error message for Fail to load file error, this error happens in TXN's commit phrase in FE, so it's better to rename the error message to commit failed, and add more information about table, quorum number and the related error replicas.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Cherrypick: #11838 

## Problem Summary(Required) ：
Add error BE's hostname for tablesink open failure.
Change the error message for Fail to load file error, this error happens in TXN's commit phrase in FE, so it's better to rename the error message to commit failed, and add more information about table, quorum number and the related error replicas.
