### PR TITLE
[Enhancement] Add more info for write failure err message (#11838)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -782,7 +782,7 @@ Status OlapTableSink::open_wait() {
                 LOG(WARNING) << ch->name() << ", tablet open failed, " << ch->print_load_info()
                              << ", node=" << ch->node_info()->host << ":" << ch->node_info()->brpc_port
                              << ", errmsg=" << st.get_error_msg();
-                err_st = st;
+                err_st = st.clone_and_append(string(" be:") + ch->node_info()->host);
                 index_channel->mark_as_failed(ch);
             }
         });

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletQuorumFailedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletQuorumFailedException.java
@@ -21,24 +21,8 @@
 
 package com.starrocks.transaction;
 
-import com.google.common.base.Joiner;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public class TabletQuorumFailedException extends TransactionException {
-
-    private static final String TABLET_QUORUM_FAILED_MSG = "Fail to load files. tablet_id: %s"
-            + ", txn_id: %s, backends: %s";
-
-    private long tabletId;
-    private List<String> errorBackends = new ArrayList<String>();
-
-    public TabletQuorumFailedException(long transactionId, long tabletId,
-                                       List<String> errorBackends) {
-        super(String.format(TABLET_QUORUM_FAILED_MSG, tabletId, transactionId,
-                Joiner.on(",").join(errorBackends)));
-        this.tabletId = tabletId;
-        this.errorBackends = errorBackends;
+    public TabletQuorumFailedException(String msg) {
+        super(msg);
     }
 }


### PR DESCRIPTION
Add error BE's hostname for tablesink open failure. Change the error message for Fail to load file error, this error happens in TXN's commit phrase in FE, so it's better to rename the error message to commit failed, and add more information about table, quorum number and the related error replicas.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Cherrypick: https://github.com/StarRocks/starrocks/pull/11838

## Problem Summary(Required) ：
Add error BE's hostname for tablesink open failure.
Change the error message for Fail to load file error, this error happens in TXN's commit phrase in FE, so it's better to rename the error message to commit failed, and add more information about table, quorum number and the related error replicas.