### PR TITLE
[BugFix] Fix fe restart failed caused by catalog creation failure due to repeated replay create resource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -138,7 +138,7 @@ public class ResourceMgr implements Writable {
             GlobalStateMgr.getCurrentState().getHiveRepository().clearCache(resource.getName());
         }
 
-        if (resource.needMappingCatalog()) {
+        if (resource.needMappingCatalog() && !nameToResource.containsKey(resource.getName())) {
             String type = resource.getType().name().toLowerCase(Locale.ROOT);
             String catalogName = getResourceMappingCatalogName(resource.getName(), type);
             Map<String, String> properties = Maps.newHashMap(resource.getProperties());


### PR DESCRIPTION
… to repeated replay create resource

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
AlterResource operation will use `create resource` to write edit log. But we will create a mapping catalog for each hive/hudi resource.  Since multiple duplicate `replay create resource` will be generated from alter and creation operation. So it will throw exception when creating repeated mapping catalog.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
