### PR TITLE
[BugFix] Fix broker load start time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -204,8 +204,6 @@ public class BrokerLoadJob extends BulkLoadJob {
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
             return;
         }
-
-        loadStartTimestamp = System.currentTimeMillis();
     }
 
     private void createLoadingTask(Database db, BrokerPendingTaskAttachment attachment) throws UserException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -224,6 +224,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public void initLoadProgress(TUniqueId loadId, Set<TUniqueId> fragmentIds, List<Long> relatedBackendIds) {
         loadingStatus.getLoadStatistic().initLoad(loadId, fragmentIds, relatedBackendIds);
         startLoad = true;
+        loadStartTimestamp = System.currentTimeMillis();
     }
 
     public void updateProgess(Long beId, TUniqueId loadId, TUniqueId fragmentId, 
@@ -449,7 +450,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     }
 
     private void executeLoad() {
-        loadStartTimestamp = System.currentTimeMillis();
         state = JobState.LOADING;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -187,7 +187,6 @@ public class LoadJobTest {
         LoadJob loadJob = new BrokerLoadJob();
         loadJob.updateState(JobState.LOADING);
         Assert.assertEquals(JobState.LOADING, loadJob.getState());
-        Assert.assertNotEquals(-1, (long) Deencapsulation.getField(loadJob, "loadStartTimestamp"));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`LoadStartTime` is set after pending task finished now.
In actual, execution before load the task will also be blocked in the waiting queue,
so a more reasonable `LoadStartTime` should be the moment when the actual execution starts

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
