### PR TITLE
[BugFix] Fix insert overwrite concurrent with dropping partition bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -109,7 +109,7 @@ public class InsertOverwriteJobRunner {
                 doLoad();
                 break;
             case OVERWRITE_FAILED:
-                gc();
+                gc(false);
                 LOG.warn("insert overwrite job:{} failed. createPartitionElapse:{} ms, insertElapse:{} ms",
                         job.getJobId(), createPartitionElapse, insertElapse);
                 break;
@@ -127,7 +127,7 @@ public class InsertOverwriteJobRunner {
         createTempPartitions();
         prepareInsert();
         executeInsert();
-        doCommit();
+        doCommit(false);
         transferTo(InsertOverwriteJobState.OVERWRITE_SUCCESS);
     }
 
@@ -147,11 +147,11 @@ public class InsertOverwriteJobRunner {
             case OVERWRITE_FAILED:
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_FAILED);
                 LOG.info("replay insert overwrite job:{} to FAILED", job.getJobId());
-                gc();
+                gc(true);
                 break;
             case OVERWRITE_SUCCESS:
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_SUCCESS);
-                doCommit();
+                doCommit(true);
                 LOG.info("replay insert overwrite job:{} to SUCCESS", job.getJobId());
                 break;
             default:
@@ -214,7 +214,7 @@ public class InsertOverwriteJobRunner {
         createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;
     }
 
-    private void gc() {
+    private void gc(boolean isReplay) {
         LOG.info("start to garbage collect");
         Database db = getAndWriteLockDatabase(dbId);
         try {
@@ -236,9 +236,11 @@ public class InsertOverwriteJobRunner {
                     }
                 }
             }
-            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                    InsertOverwriteJobState.OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getTmpPartitionIds());
-            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            if (!isReplay) {
+                InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
+                        InsertOverwriteJobState.OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getTmpPartitionIds());
+                GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            }
         } catch (Exception e) {
             LOG.warn("exception when gc insert overwrite job.", e);
         } finally {
@@ -246,7 +248,7 @@ public class InsertOverwriteJobRunner {
         }
     }
 
-    private void doCommit() {
+    private void doCommit(boolean isReplay) {
         Database db = getAndWriteLockDatabase(dbId);
         try {
             OlapTable targetTable = checkAndGetTable(db, tableId);
@@ -261,9 +263,11 @@ public class InsertOverwriteJobRunner {
             } else {
                 targetTable.replacePartition(sourcePartitionNames.get(0), tmpPartitionNames.get(0));
             }
-            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                    InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getTmpPartitionIds());
-            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            if (!isReplay) {
+                InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
+                        InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getTmpPartitionIds());
+                GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            }
         } catch (Exception e) {
             LOG.warn("replace partitions failed when insert overwrite into dbId:{}, tableId:{}",
                     job.getTargetDbId(), job.getTargetTableId(), e);


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11857 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix insert overwrite concurrent with dropping partition bug. The drop partition edit log during insert overwrite gc is written within the same lock with drop partition operation, which will lead to the failure of restart of FE. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
