### PR TITLE
[Feature] Support Primary Key table Backup & Restore

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -609,7 +609,12 @@ AgentStatus move_dir(TTabletId tablet_id, TSchemaHash schema_hash, const std::st
 
     std::string dest_tablet_dir = tablet->schema_hash_path();
     SnapshotLoader loader(exec_env, job_id, tablet_id);
-    Status status = loader.move(src, tablet, overwrite);
+    Status status;
+    if (tablet->updates() == nullptr) {
+        status = loader.move(src, tablet, overwrite);
+    } else {
+        status = loader.primary_key_move(src, tablet, overwrite);
+    }
 
     if (!status.ok()) {
         LOG(WARNING) << "Fail to move job id=" << job_id << ", " << status.get_error_msg();

--- a/be/src/runtime/snapshot_loader.h
+++ b/be/src/runtime/snapshot_loader.h
@@ -71,6 +71,8 @@ public:
 
     Status move(const std::string& snapshot_path, const TabletSharedPtr& tablet, bool overwrite);
 
+    Status primary_key_move(const std::string& snapshot_path, const TabletSharedPtr& tablet, bool overwrite);
+
 private:
     Status _get_tablet_id_and_schema_hash_from_file_path(const std::string& src_path, int64_t* tablet_id,
                                                          int32_t* schema_hash);

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -79,7 +79,8 @@ public:
                                                const std::vector<int64_t>& delta_versions, int64_t timeout_s);
 
     // On success, return the absolute path of the root directory of snapshot.
-    StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
+    StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s,
+                                        bool ignore = false);
 
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_primary(const TabletSharedPtr& tablet,

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -161,7 +161,7 @@ public:
     Status convert_from(const std::shared_ptr<Tablet>& base_tablet, int64_t request_version,
                         vectorized::ChunkChanger* chunk_changer);
 
-    Status load_snapshot(const SnapshotMeta& snapshot_meta);
+    Status load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup = false);
 
     Status get_latest_applied_version(EditVersion* latest_applied_version);
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -30,7 +30,6 @@ import com.starrocks.backup.AbstractJob.JobType;
 import com.starrocks.backup.BackupJob.BackupJobState;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -311,10 +310,6 @@ public class BackupHandler extends LeaderDaemon implements Writable {
                 }
 
                 OlapTable olapTbl = (OlapTable) tbl;
-                if (olapTbl.getKeysType() == KeysType.PRIMARY_KEYS) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                            "backup do not support primary key table: " + tblName);
-                }
                 if (olapTbl.existTempPartitions()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                             "Do not support backup table with temp partitions");

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -623,7 +623,7 @@ public class BackupJob extends AbstractJob {
                             .forEach(File::delete);
                 }
             }
-            if (!jobDir.mkdir()) {
+            if (!jobDir.mkdirs()) {
                 status = new Status(ErrCode.COMMON_ERROR, "Failed to create tmp dir: " + localJobDirPath);
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/task/SnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/SnapshotTask.java
@@ -79,6 +79,7 @@ public class SnapshotTask extends AgentTask {
         request.setList_files(true);
         request.setPreferred_snapshot_format(TypesConstants.TPREFER_SNAPSHOT_REQ_VERSION);
         request.setTimeout(timeoutMs / 1000);
+        request.setIs_restore_task(isRestoreTask);
         return request;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -55,6 +55,7 @@ import com.starrocks.task.DownloadTask;
 import com.starrocks.task.SnapshotTask;
 import com.starrocks.task.UploadTask;
 import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TSnapshotRequest;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.utframe.UtFrameUtils;
@@ -307,19 +308,63 @@ public class BackupHandlerTest {
             Assert.fail();
         }
 
-        {
-            // process backup for primary key, will be forbidden
-            List<TableRef> tblRefs1 = Lists.newArrayList();
-            tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
-            BackupStmt backupStmt1 =
-                    new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1,
-                            null);
-            try {
-                handler.process(backupStmt1);
-            } catch (DdlException e1) {
-                Assert.assertEquals(e1.toString(),
-                        "com.starrocks.common.DdlException: backup do not support primary key table: test_tbl3");
-            }
+        // process primary key table backup
+        List<TableRef> tblRefs1 = Lists.newArrayList();
+        tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
+        BackupStmt backupStmt1 =
+                new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1,
+                        null);
+        try {
+            handler.process(backupStmt1);
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assert.fail();
+        }
+
+        // handleFinishedSnapshotTask
+        BackupJob backupJob1 = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        SnapshotTask snapshotTask1 = new SnapshotTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
+                0, 0, 0, 0, 0, 0, 1, false);
+        TFinishTaskRequest request1 = new TFinishTaskRequest();
+        List<String> snapshotFiles1 = Lists.newArrayList();
+        request1.setSnapshot_files(snapshotFiles1);
+        request1.setSnapshot_path("./snapshot/path1");
+        request1.setTask_status(new TStatus(TStatusCode.OK));
+        handler.handleFinishedSnapshotTask(snapshotTask1, request1);
+
+        // handleFinishedSnapshotUploadTask
+        Map<String, String> srcToDestPath1 = Maps.newHashMap();
+        UploadTask uploadTask1 = new UploadTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
+                srcToDestPath1, null, null);
+        request1 = new TFinishTaskRequest();
+        Map<Long, List<String>> tabletFiles1 = Maps.newHashMap();
+        request1.setTablet_files(tabletFiles1);
+        request1.setTask_status(new TStatus(TStatusCode.OK));
+        handler.handleFinishedSnapshotUploadTask(uploadTask1, request1);
+
+        // test file persist
+        File tmpFile1 = new File("./tmp1" + System.currentTimeMillis());
+        try {
+            DataOutputStream out = new DataOutputStream(new FileOutputStream(tmpFile1));
+            handler.write(out);
+            out.flush();
+            out.close();
+            DataInputStream in = new DataInputStream(new FileInputStream(tmpFile1));
+            BackupHandler.read(in);
+            in.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail();
+        } finally {
+            tmpFile1.delete();
+        }
+
+        // cancel backup
+        try {
+            handler.cancel(new CancelBackupStmt(CatalogMocker.TEST_DB_NAME, false));
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assert.fail();
         }
 
         // process restore
@@ -399,6 +444,79 @@ public class BackupHandlerTest {
         };
         // cancel restore
         handler.cancel(new CancelBackupStmt(CatalogMocker.TEST_DB_NAME, true));
+
+        // process primary key table restore
+        List<TableRef> tblRefs3 = Lists.newArrayList();
+        tblRefs3.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
+        Map<String, String> properties1 = Maps.newHashMap();
+        properties1.put("backup_timestamp", "2018-08-08-08-08-08");
+        RestoreStmt restoreStmt1 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs3,
+                properties1);
+        try {
+            BackupRestoreAnalyzer.analyze(restoreStmt1, new ConnectContext());
+        } catch (SemanticException e2) {
+            e2.printStackTrace();
+            Assert.fail();
+        }
+
+        try {
+            handler.process(restoreStmt1);
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assert.fail();
+        }
+
+        // handleFinishedSnapshotTask
+        RestoreJob restoreJob1 = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        snapshotTask1 = new SnapshotTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
+                0, 0, 0, 0, 0, 0, 1, true);
+        request1 = new TFinishTaskRequest();
+        request1.setSnapshot_path("./snapshot/path1");
+        request1.setTask_status(new TStatus(TStatusCode.OK));
+        handler.handleFinishedSnapshotTask(snapshotTask1, request1);
+
+        // handleDownloadSnapshotTask
+        DownloadTask downloadTask1 = new DownloadTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
+                srcToDestPath1, null, null);
+        request1 = new TFinishTaskRequest();
+        List<Long> downloadedTabletIds1 = Lists.newArrayList();
+        request1.setDownloaded_tablet_ids(downloadedTabletIds1);
+        request1.setTask_status(new TStatus(TStatusCode.OK));
+        handler.handleDownloadSnapshotTask(downloadTask1, request1);
+
+        // handleDirMoveTask
+        DirMoveTask dirMoveTask1 = new DirMoveTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
+                0, "", 0, true);
+        request1 = new TFinishTaskRequest();
+        request1.setTask_status(new TStatus(TStatusCode.OK));
+        handler.handleDirMoveTask(dirMoveTask1, request1);
+
+        // test file persist
+        tmpFile1 = new File("./tmp1" + System.currentTimeMillis());
+        try {
+            DataOutputStream out = new DataOutputStream(new FileOutputStream(tmpFile1));
+            handler.write(out);
+            out.flush();
+            out.close();
+            DataInputStream in = new DataInputStream(new FileInputStream(tmpFile1));
+            BackupHandler.read(in);
+            in.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail();
+        } finally {
+            tmpFile1.delete();
+        }
+
+        // cancel restore
+        try {
+            handler.cancel(new CancelBackupStmt(CatalogMocker.TEST_DB_NAME, true));
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assert.fail();
+        }
+
+        TSnapshotRequest requestSnapshot = snapshotTask1.toThrift();
 
         // drop repo
         DDLStmtExecutor.execute(new DropRepositoryStmt("repo"), new ConnectContext());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
@@ -68,20 +68,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class BackupJobTest {
+public class BackupJobPrimaryKeyTest {
 
     private BackupJob job;
     private Database db;
 
-    private long dbId = 1;
-    private long tblId = 2;
-    private long partId = 3;
-    private long idxId = 4;
-    private long tabletId = 5;
+    private long dbId = 11;
+    private long tblId = 12;
+    private long partId = 13;
+    private long idxId = 14;
+    private long tabletId = 15;
     private long backendId = 10000;
-    private long version = 6;
+    private long version = 16;
 
-    private long repoId = 20000;
+    private long repoId = 30000;
     private AtomicLong id = new AtomicLong(50000);
 
     @Mocked
@@ -148,7 +148,7 @@ public class BackupJobTest {
         // Thread is unmockable after Jmockit version 1.48, so use reflection to set field instead.
         Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
 
-        db = UnitTestUtil.createDb(dbId, tblId, partId, idxId, tabletId, backendId, version, KeysType.AGG_KEYS);
+        db = UnitTestUtil.createDb(dbId, tblId, partId, idxId, tabletId, backendId, version, KeysType.PRIMARY_KEYS);
 
         new Expectations(globalStateMgr) {
             {
@@ -236,8 +236,7 @@ public class BackupJobTest {
         String snapshotPath = "/path/to/snapshot";
         List<String> snapshotFiles = Lists.newArrayList();
         snapshotFiles.add("1.dat");
-        snapshotFiles.add("1.idx");
-        snapshotFiles.add("1.hdr");
+        snapshotFiles.add("meta");
         TStatus taskStatus = new TStatus(TStatusCode.OK);
         TBackend tBackend = new TBackend("", 0, 1);
         TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
@@ -280,13 +279,11 @@ public class BackupJobTest {
         tabletFileMap.put(tabletId, tabletFiles);
         Assert.assertFalse(job.finishSnapshotUploadTask(upTask, request));
         tabletFiles.add("1.dat.4f158689243a3d6030352fec3cfd3798");
-        tabletFiles.add("wrong_files.idx.4f158689243a3d6030352fec3cfd3798");
-        tabletFiles.add("wrong_files.hdr.4f158689243a3d6030352fec3cfd3798");
+        tabletFiles.add("wrong_files.4f158689243a3d6030352fec3cfd3798");
         Assert.assertFalse(job.finishSnapshotUploadTask(upTask, request));
         tabletFiles.clear();
         tabletFiles.add("1.dat.4f158689243a3d6030352fec3cfd3798");
-        tabletFiles.add("1.idx.4f158689243a3d6030352fec3cfd3798");
-        tabletFiles.add("1.hdr.4f158689243a3d6030352fec3cfd3798");
+        tabletFiles.add("meta.4f158689243a3d6030352fec3cfd3798");
         Assert.assertTrue(job.finishSnapshotUploadTask(upTask, request));
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -1,0 +1,391 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.backup;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.backup.BackupJobInfo.BackupIndexInfo;
+import com.starrocks.backup.BackupJobInfo.BackupPartitionInfo;
+import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
+import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
+import com.starrocks.backup.RestoreJob.RestoreJobState;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.MarkedCountDownLatch;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.EditLog;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskQueue;
+import com.starrocks.task.DirMoveTask;
+import com.starrocks.task.DownloadTask;
+import com.starrocks.task.SnapshotTask;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTaskType;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.Adler32;
+
+public class RestoreJobPrimaryKeyTest {
+
+    private Database db;
+    private BackupJobInfo jobInfo;
+    private RestoreJob job;
+    private String label = "test_label";
+
+    private AtomicLong id = new AtomicLong(50000);
+
+    private OlapTable expectedRestoreTbl;
+
+    private long repoId = 30000;
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+
+    private MockBackupHandler backupHandler;
+
+    private MockRepositoryMgr repoMgr;
+
+    // Thread is not mockable in Jmockit, use subclass instead
+    private final class MockBackupHandler extends BackupHandler {
+        public MockBackupHandler(GlobalStateMgr globalStateMgr) {
+            super(globalStateMgr);
+        }
+
+        @Override
+        public RepositoryMgr getRepoMgr() {
+            return repoMgr;
+        }
+    }
+
+    // Thread is not mockable in Jmockit, use subclass instead
+    private final class MockRepositoryMgr extends RepositoryMgr {
+        public MockRepositoryMgr() {
+            super();
+        }
+
+        @Override
+        public Repository getRepo(long repoId) {
+            return repo;
+        }
+    }
+
+    @Mocked
+    private EditLog editLog;
+    @Mocked
+    private SystemInfoService systemInfoService;
+
+    @Injectable
+    private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
+            new BlobStorage("broker", Maps.newHashMap()));
+
+    private BackupMeta backupMeta;
+
+    @Before
+    public void setUp() throws AnalysisException {
+        db = CatalogMocker.mockDb();
+        backupHandler = new MockBackupHandler(globalStateMgr);
+        repoMgr = new MockRepositoryMgr();
+
+        Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
+
+        new Expectations() {
+            {
+                globalStateMgr.getDb(anyLong);
+                minTimes = 0;
+                result = db;
+
+                GlobalStateMgr.getCurrentStateJournalVersion();
+                minTimes = 0;
+                result = FeConstants.meta_version;
+
+                globalStateMgr.getNextId();
+                minTimes = 0;
+                result = id.getAndIncrement();
+
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+
+                GlobalStateMgr.getCurrentSystemInfo();
+                minTimes = 0;
+                result = systemInfoService;
+            }
+        };
+
+        new Expectations() {
+            {
+                systemInfoService.seqChooseBackendIds(anyInt, anyBoolean, anyBoolean);
+                minTimes = 0;
+                result = new Delegate() {
+                    public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAlive,
+                                                                       boolean isCreate, String clusterName) {
+                        List<Long> beIds = Lists.newArrayList();
+                        beIds.add(CatalogMocker.BACKEND1_ID);
+                        beIds.add(CatalogMocker.BACKEND2_ID);
+                        beIds.add(CatalogMocker.BACKEND3_ID);
+                        return beIds;
+                    }
+                };
+            }
+        };
+
+        new Expectations() {
+            {
+                editLog.logBackupJob((BackupJob) any);
+                minTimes = 0;
+                result = new Delegate() {
+                    public void logBackupJob(BackupJob job) {
+                        System.out.println("log backup job: " + job);
+                    }
+                };
+            }
+        };
+
+        new Expectations() {
+            {
+                repo.upload(anyString, anyString);
+                result = Status.OK;
+                minTimes = 0;
+
+                List<BackupMeta> backupMetas = Lists.newArrayList();
+                repo.getSnapshotMetaFile(label, backupMetas, -1, -1);
+                minTimes = 0;
+                result = new Delegate() {
+                    public Status getSnapshotMetaFile(String label, List<BackupMeta> backupMetas) {
+                        backupMetas.add(backupMeta);
+                        return Status.OK;
+                    }
+                };
+            }
+        };
+
+        new MockUp<MarkedCountDownLatch>() {
+            @Mock
+            boolean await(long timeout, TimeUnit unit) {
+                return true;
+            }
+        };
+
+        // gen BackupJobInfo
+        jobInfo = new BackupJobInfo();
+        jobInfo.backupTime = System.currentTimeMillis();
+        jobInfo.dbId = CatalogMocker.TEST_DB_ID;
+        jobInfo.dbName = CatalogMocker.TEST_DB_NAME;
+        jobInfo.name = label;
+        jobInfo.success = true;
+
+        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL3_ID);
+        BackupTableInfo tblInfo = new BackupTableInfo();
+        tblInfo.id = CatalogMocker.TEST_TBL3_ID;
+        tblInfo.name = CatalogMocker.TEST_TBL3_NAME;
+        jobInfo.tables.put(tblInfo.name, tblInfo);
+
+        for (Partition partition : expectedRestoreTbl.getPartitions()) {
+            BackupPartitionInfo partInfo = new BackupPartitionInfo();
+            partInfo.id = partition.getId();
+            partInfo.name = partition.getName();
+            tblInfo.partitions.put(partInfo.name, partInfo);
+
+            for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                BackupIndexInfo idxInfo = new BackupIndexInfo();
+                idxInfo.id = index.getId();
+                idxInfo.name = expectedRestoreTbl.getIndexNameById(index.getId());
+                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexId(index.getId());
+                partInfo.indexes.put(idxInfo.name, idxInfo);
+
+                for (Tablet tablet : index.getTablets()) {
+                    BackupTabletInfo tabletInfo = new BackupTabletInfo();
+                    tabletInfo.id = tablet.getId();
+                    tabletInfo.files.add(tabletInfo.id + ".dat");
+                    tabletInfo.files.add("meta");
+                    idxInfo.tablets.add(tabletInfo);
+                }
+            }
+        }
+
+        // drop this table, cause we want to try restoring this table
+        db.dropTable(expectedRestoreTbl.getName());
+
+        List<Table> tbls = Lists.newArrayList();
+        tbls.add(expectedRestoreTbl);
+        backupMeta = new BackupMeta(tbls);
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                jobInfo, false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta);
+    }
+
+    @Ignore
+    @Test
+    public void testRun() {
+        // pending
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.SNAPSHOTING, job.getState());
+        Assert.assertEquals(12, job.getFileMapping().getMapping().size());
+
+        // 2. snapshoting
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.SNAPSHOTING, job.getState());
+        Assert.assertEquals(12 * 2, AgentTaskQueue.getTaskNum());
+
+        // 3. snapshot finished
+        List<AgentTask> agentTasks = Lists.newArrayList();
+        Map<TTaskType, Set<Long>> runningTasks = Maps.newHashMap();
+        agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
+        agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
+        agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
+        Assert.assertEquals(12 * 2, agentTasks.size());
+
+        for (AgentTask agentTask : agentTasks) {
+            if (agentTask.getTaskType() != TTaskType.MAKE_SNAPSHOT) {
+                continue;
+            }
+
+            SnapshotTask task = (SnapshotTask) agentTask;
+            String snapshotPath = "/path/to/snapshot/" + System.currentTimeMillis();
+            TStatus taskStatus = new TStatus(TStatusCode.OK);
+            TBackend tBackend = new TBackend("", 0, 1);
+            TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
+                    task.getSignature(), taskStatus);
+            request.setSnapshot_path(snapshotPath);
+            Assert.assertTrue(job.finishTabletSnapshotTask(task, request));
+        }
+
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.DOWNLOAD, job.getState());
+
+        // download
+        AgentTaskQueue.clearAllTasks();
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.DOWNLOADING, job.getState());
+        Assert.assertEquals(9, AgentTaskQueue.getTaskNum());
+
+        // downloading
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.DOWNLOADING, job.getState());
+
+        List<AgentTask> downloadTasks = Lists.newArrayList();
+        runningTasks = Maps.newHashMap();
+        downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
+        downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
+        downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
+        Assert.assertEquals(9, downloadTasks.size());
+
+        List<Long> downloadedTabletIds = Lists.newArrayList();
+        for (AgentTask agentTask : downloadTasks) {
+            TStatus taskStatus = new TStatus(TStatusCode.OK);
+            TBackend tBackend = new TBackend("", 0, 1);
+            TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
+                    agentTask.getSignature(), taskStatus);
+            request.setDownloaded_tablet_ids(downloadedTabletIds);
+            Assert.assertTrue(job.finishTabletDownloadTask((DownloadTask) agentTask, request));
+        }
+
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.COMMIT, job.getState());
+
+        // commit
+        AgentTaskQueue.clearAllTasks();
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.COMMITTING, job.getState());
+        Assert.assertEquals(12, AgentTaskQueue.getTaskNum());
+
+        // committing
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.COMMITTING, job.getState());
+
+        List<AgentTask> dirMoveTasks = Lists.newArrayList();
+        runningTasks = Maps.newHashMap();
+        dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
+        dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
+        dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
+        Assert.assertEquals(12, dirMoveTasks.size());
+
+        for (AgentTask agentTask : dirMoveTasks) {
+            TStatus taskStatus = new TStatus(TStatusCode.OK);
+            TBackend tBackend = new TBackend("", 0, 1);
+            TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
+                    agentTask.getSignature(), taskStatus);
+            job.finishDirMoveTask((DirMoveTask) agentTask, request);
+        }
+
+        job.run();
+        Assert.assertEquals(Status.OK, job.getStatus());
+        Assert.assertEquals(RestoreJobState.FINISHED, job.getState());
+    }
+
+    @Test
+    public void testSignature() {
+        Adler32 sig1 = new Adler32();
+        sig1.update("name1".getBytes());
+        sig1.update("name2".getBytes());
+        System.out.println("sig1: " + Math.abs((int) sig1.getValue()));
+
+        Adler32 sig2 = new Adler32();
+        sig2.update("name2".getBytes());
+        sig2.update("name1".getBytes());
+        System.out.println("sig2: " + Math.abs((int) sig2.getValue()));
+
+        OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+        List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
+        System.out.println(partNames);
+        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames));
+        tbl.setName("newName");
+        partNames = Lists.newArrayList(tbl.getPartitionNames());
+        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames));
+    }
+
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -24,6 +24,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.IndexDef;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.FastByteArrayOutputStream;
@@ -50,7 +51,7 @@ public class OlapTableTest {
             }
         };
 
-        Database db = UnitTestUtil.createDb(1, 2, 3, 4, 5, 6, 7);
+        Database db = UnitTestUtil.createDb(1, 2, 3, 4, 5, 6, 7, KeysType.AGG_KEYS);
         List<Table> tables = db.getTables();
 
         for (Table table : tables) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -60,7 +60,7 @@ public class UnitTestUtil {
     public static final int SCHEMA_HASH = 0;
 
     public static Database createDb(long dbId, long tableId, long partitionId, long indexId,
-                                    long tabletId, long backendId, long version) {
+                                    long tabletId, long backendId, long version, KeysType type) {
         // GlobalStateMgr.getCurrentInvertedIndex().clear();
 
         // replica
@@ -110,11 +110,11 @@ public class UnitTestUtil {
         partitionInfo.setIsInMemory(partitionId, false);
         partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
         OlapTable table = new OlapTable(tableId, TABLE_NAME, columns,
-                KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+                type, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
         table.setIndexMeta(indexId, TABLE_NAME, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
-                KeysType.AGG_KEYS);
+                type);
 
         // db
         Database db = new Database(dbId, DB_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -52,6 +52,8 @@ public class AnalyzeBackupRestoreTest {
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP SNAPSHOT snapshot_label2 TO `repo` " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT snapshot_pk_label TO `repo` ON ( tprimary ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t0 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t1 ) " +
@@ -87,6 +89,10 @@ public class AnalyzeBackupRestoreTest {
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
         analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` " +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
+                "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
+                "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
+        analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_pk_label` FROM `repo` ON ( `tprimary` )" +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -224,6 +224,7 @@ struct TSnapshotRequest {
     // [range1_start, range1_end(inclusive), ... rangeN_start (implicit to INT64_MAX)]
     // size must be 2*N + 1
     10:optional list<Types.TVersion> missing_version_ranges
+    11:optional bool is_restore_task = false;
 }
 
 struct TReleaseSnapshotRequest {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11879

## Problem Summary(Required) ：
[Feature] Support Primary Key table Backup & Restore(#11879)

Problem:
Currently, StarRocks does not support the backup and restore of Primary Key tables. This feature will support it.

Solution:
We reused the code of the primary-key clone and transformed it to adapt to the backup restore process.
