### PR TITLE
[Enhancement] Optimize the use of thread pool for thrift server

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -501,7 +501,7 @@ public class Config extends ConfigBase {
      * some hang up problems in java.net.SocketInputStream.socketRead0
      */
     @ConfField
-    public static int thrift_client_timeout_ms = 0;
+    public static int thrift_client_timeout_ms = 28800000;
 
     /**
      * The backlog_num for thrift server
@@ -528,6 +528,18 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int thrift_rpc_retry_times = 3;
+
+    /**
+     * The thrift server max worker threads
+     */
+    @ConfField
+    public static int thrift_server_max_worker_threads = 4096;
+
+    /**
+     * The thrift server executor pending queue size
+     */
+    @ConfField
+    public static int thrift_server_queue_size = 4096;
 
     // May be necessary to modify the following BRPC configurations in high concurrency scenarios.
 
@@ -618,12 +630,6 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static int publish_version_interval_ms = 10;
-
-    /**
-     * The thrift server max worker threads
-     */
-    @ConfField
-    public static int thrift_server_max_worker_threads = 4096;
 
     /**
      * Maximal wait seconds for straggler node in load

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -499,6 +499,7 @@ public class Config extends ConfigBase {
      * The connection timeout and socket timeout config for thrift server
      * The value for thrift_client_timeout_ms is set to be larger than zero to prevent
      * some hang up problems in java.net.SocketInputStream.socketRead0
+     * default is 8h
      */
     @ConfField
     public static int thrift_client_timeout_ms = 28800000;

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -99,7 +99,8 @@ public class ThriftServer {
                         .protocolFactory(
                                 new TBinaryProtocol.Factory()).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager
-                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
+                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, Config.thrift_server_queue_size,
+                        "thrift-server-pool", true);
         args.executorService(threadPoolExecutor);
         server = new TThreadedSelectorServer(args);
     }
@@ -114,7 +115,8 @@ public class ThriftServer {
                 new SRTThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
                         new TBinaryProtocol.Factory()).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager
-                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
+                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, Config.thrift_server_queue_size,
+                        "thrift-server-pool", true);
         serverArgs.executorService(threadPoolExecutor);
         server = new SRTThreadPoolServer(serverArgs);
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Set the socket timeout to 8h, so that the thread can be released if no request send in 8 hours.
2. Add a config param to the thread pool pending queue, default value is 4096. The old value is 0, and this is not configurable, which makes service cannot respond to burst requests.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
