### PR TITLE
[BugFix] Potential consumer group pool leak

### DIFF
--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -30,11 +30,18 @@ namespace starrocks {
 template <class DeferFunction>
 class DeferOp {
 public:
-    explicit DeferOp(DeferFunction func) : _func(std::move(func)) {}
+    explicit DeferOp(DeferFunction func) : cancelled(false), _func(std::move(func)) {}
 
-    ~DeferOp() { _func(); };
+    ~DeferOp() {
+        if (LIKELY(!cancelled)) {
+            _func();
+        }
+    };
+
+    void cancel() { cancelled = true; }
 
 private:
+    bool cancelled;
     DeferFunction _func;
 };
 


### PR DESCRIPTION
HANDLE_ERROR in routine_load_task_executor may lead to exec_task return without return consumer group.
Here we make sure the consumer group is returned to the pool by DeferOp.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11891

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
