### PR TITLE
[cherry-pick][branch-2.3][BugFix] mysql client automatically reconnect bug(#11668)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -56,8 +56,10 @@ public class MysqlChannel {
     protected String remoteHostPortString;
     protected String remoteIp;
     protected boolean isSend;
+    protected boolean closed;
 
     protected MysqlChannel() {
+        this.closed = false;
         this.sequenceId = 0;
         this.isSend = false;
         this.remoteHostPortString = "";
@@ -115,11 +117,16 @@ public class MysqlChannel {
     }
 
     // Close channel
-    public void close() {
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
         try {
             channel.close();
         } catch (IOException e) {
             LOG.warn("Close channel exception, ignore.");
+        } finally {
+            closed = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NConnectContext.java
@@ -39,7 +39,11 @@ public class NConnectContext extends ConnectContext {
     }
 
     @Override
-    public void cleanup() {
+    public synchronized void cleanup() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         mysqlChannel.close();
         returnRows = 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NMysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NMysqlChannel.java
@@ -89,11 +89,16 @@ public class NMysqlChannel extends MysqlChannel {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
         try {
             conn.close();
         } catch (IOException e) {
             LOG.warn("Close channel exception, ignore.");
+        } finally {
+            closed = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -91,7 +91,7 @@ public class ConnectContext {
     // the protocol capability after server and client negotiate
     protected MysqlCapability capability;
     // Indicate if this client is killed.
-    protected boolean isKilled;
+    protected volatile boolean isKilled;
     // catalog
     protected volatile String currentCatalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
     // Db
@@ -129,6 +129,8 @@ public class ConnectContext {
     protected AuditEventBuilder auditEventBuilder = new AuditEventBuilder();
 
     protected String remoteIP;
+
+    protected volatile boolean closed;
 
     // set with the randomstring extracted from the handshake data at connecting stage
     // used for authdata(password) salting
@@ -169,6 +171,7 @@ public class ConnectContext {
     }
 
     public ConnectContext() {
+        closed = false;
         state = new QueryState();
         returnRows = 0;
         serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
@@ -387,7 +390,11 @@ public class ConnectContext {
         this.executor = executor;
     }
 
-    public void cleanup() {
+    public synchronized void cleanup() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         mysqlChannel.close();
         threadLocalInfo.remove();
         returnRows = 0;
@@ -498,16 +505,32 @@ public class ConnectContext {
     public void kill(boolean killConnection) {
         LOG.warn("kill timeout query, {}, kill connection: {}",
                 getMysqlChannel().getRemoteHostPortString(), killConnection);
-
-        if (killConnection) {
-            isKilled = true;
-            // Close channel to break connection with client
-            getMysqlChannel().close();
-        }
         // Now, cancel running process.
         StmtExecutor executorRef = executor;
+        if (killConnection) {
+            isKilled = true;
+        }
         if (executorRef != null) {
             executorRef.cancel();
+        }
+        if (killConnection) {
+            int times = 0;
+            while (!closed) {
+                try {
+                    Thread.sleep(10);
+                    times++;
+                    if (times > 100) {
+                        LOG.warn("wait for close fail, break.");
+                        break;
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    LOG.warn("sleep exception, ignore.");
+                    break;
+                }
+            }
+            // Close channel to break connection with client
+            getMysqlChannel().close();
         }
     }
 


### PR DESCRIPTION
If we execute a long query and kill it in the middle process,
MySQL will automatically start a new session and rerun the query
(this bug only triggers will StarRocks and MySQL client is not in the same LAN,
and we add an ssh tunnel to make the MySQL client connects to the StarRocks)

To fix this bug, we need to make sure the cancel operation happens before we
close the session; also, we need to wait for some time until the cancel state is
sent back to the MySQL client.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11667

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
