### PR TITLE
[Enhancement] Ranking window function support pushing down eq predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
@@ -104,7 +104,8 @@ public class PushDownPredicateRankingWindowRule extends TransformationRule {
                 filters.stream().filter(op -> op instanceof BinaryPredicateOperator)
                         .map(ScalarOperator::<BinaryPredicateOperator>cast)
                         .filter(op -> Objects.equals(BinaryPredicateOperator.BinaryType.LE, op.getBinaryType()) ||
-                                Objects.equals(BinaryPredicateOperator.BinaryType.LT, op.getBinaryType()))
+                                Objects.equals(BinaryPredicateOperator.BinaryType.LT, op.getBinaryType()) ||
+                                Objects.equals(BinaryPredicateOperator.BinaryType.EQ, op.getBinaryType()))
                         .filter(op -> Objects.equals(windowCol, op.getChild(0)))
                         .filter(op -> op.getChild(1) instanceof ConstantOperator)
                         .collect(Collectors.toList());

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
@@ -400,7 +400,9 @@ select * from (select * from (select v1, row_number() over(partition by v1) as `
 PREDICATE 4: row_number() = 1
     ANALYTIC ({4: row_number()=row_number()} [1: v1] [] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
         TOP-N (order by [[1: v1 ASC NULLS FIRST]])
-            SCAN (columns[1: v1] predicate[1: v1 = 1])
+            EXCHANGE SHUFFLE[1]
+                TOP-N (order by [[1: v1 ASC NULLS FIRST]])
+                    SCAN (columns[1: v1] predicate[1: v1 = 1])
 [end]
 
 [sql]


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5885

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This pr is a continuate work of #5886, #6118, #6119, #6120 and #6411. For the following query, `relop` can be `<=`, `<` and `=`, `<=`, `<` are supported in the previous work, and this pr, we take `=` into consideration.

```sql
select * from (
    select *, rank() over (partition by v2 order by v3) as rk from t0
) sub_t0
where rk relop 5;
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
