### PR TITLE
[Cherry-pick][BugFix][Branch-2.4] Fix l1 file size keep growing (#11867)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -803,13 +803,6 @@ CONF_Int64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
 CONF_Int64(max_length_for_bitmap_function, "1000000");
 
-CONF_Bool(block_cache_enable, "false");
-CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
-CONF_Int64(block_cache_disk_size, "21474836480"); // 20GB
-//CONF_Int64(block_cache_block_size, "4194304");    // 4MB
-CONF_Int64(block_cache_block_size, "1048576");
-CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
-
 CONF_mInt64(l0_l1_merge_ratio, "10");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -802,4 +802,14 @@ CONF_Int32(internal_service_async_thread_num, "10");
 CONF_Int64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
 CONF_Int64(max_length_for_bitmap_function, "1000000");
+
+CONF_Bool(block_cache_enable, "false");
+CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
+CONF_Int64(block_cache_disk_size, "21474836480"); // 20GB
+//CONF_Int64(block_cache_block_size, "4194304");    // 4MB
+CONF_Int64(block_cache_block_size, "1048576");
+CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
+
+CONF_mInt64(l0_l1_merge_ratio, "10");
+
 } // namespace starrocks::config

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -38,11 +38,7 @@ constexpr size_t kPackSize = 16;
 constexpr size_t kPagePackLimit = (kPageSize - kPageHeaderSize) / kPackSize;
 constexpr size_t kBucketSizeMax = 256;
 // if l0_mem_size exceeds this value, l0 need snapshot
-constexpr size_t kL0SnapshotSizeMax = 4 * 1024 * 1024;
-// if l0_mem_size exceeds this value and l1 is null, need flush to l1
-constexpr size_t kL0FlushSizeMin = 8 * 1024 * 1024;
-// if l0_mem_size / l1_file_size >= this value and l0_mem_size > kL0SnapshotSizeMax, l0 l1 need merge compaction
-constexpr double kL0L1MergeRatio = 0.1;
+constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
 constexpr size_t kLongKeySize = 64;
 
 const char* const kIndexFileMagic = "IDX1";
@@ -493,12 +489,16 @@ Status ImmutableIndexWriter::write_shard(size_t key_size, size_t npage_hint, siz
     ptr_meta->set_size(pos_after - pos_before);
     _total += kvs.size();
     _total_moved += shard->num_entry_moved;
+    size_t shard_kv_size = 0;
     if (key_size != 0) {
-        _total_kv_size += (key_size + kIndexValueSize) * kvs.size();
+        shard_kv_size = (key_size + kIndexValueSize) * kvs.size();
+        _total_kv_size += shard_kv_size;
     } else {
-        _total_kv_size +=
+        shard_kv_size =
                 std::accumulate(kvs.begin(), kvs.end(), (size_t)0, [](size_t s, const auto& e) { return s + e.size; });
+        _total_kv_size += shard_kv_size;
     }
+    shard_meta->set_data_size(shard_kv_size);
     _total_bytes += pos_after - pos_before;
     auto iter = _shard_info_by_length.find(_cur_key_size);
     if (iter == _shard_info_by_length.end()) {
@@ -538,6 +538,7 @@ Status ImmutableIndexWriter::write_shard_as_rawbuff(const ImmutableIndex::ShardI
     shard_info->set_key_size(old_shard_info.key_size);
     shard_info->set_value_size(old_shard_info.value_size);
     shard_info->set_nbucket(old_shard_info.nbucket);
+    shard_info->set_data_size(old_shard_info.data_size);
     auto page_pointer = shard_info->mutable_data();
     page_pointer->set_offset(pos_before);
     page_pointer->set_size(pos_after - pos_before);
@@ -698,6 +699,8 @@ public:
             uint64_t hash = FixedKeyHash<KeySize>()(key);
             if (auto [it, inserted] = _map.emplace_with_hash(hash, key, value); !inserted) {
                 it->second = value;
+            } else {
+                _overlap_size += 1;
             }
         }
         return Status::OK();
@@ -810,7 +813,11 @@ public:
 
     size_t memory_usage() { return _map.capacity() * (1 + (KeySize + 3) / 4 * 4 + kIndexValueSize); }
 
+    void update_overlap_info(size_t overlap_size, size_t overlap_usage) override { _overlap_size += overlap_size; }
+    size_t overlap_size() { return _overlap_size; }
+
 private:
+    size_t _overlap_size = 0;
     phmap::flat_hash_map<KeyType, IndexValue, FixedKeyHash<KeySize>> _map;
 };
 
@@ -911,7 +918,7 @@ public:
                 old_values[idx] = old_value;
                 nfound += old_value != NullIndexValue;
                 _set.erase(it);
-                _set.emplace(composite_key);
+                _set.emplace_with_hash(hash, composite_key);
             }
         }
         *num_found = nfound;
@@ -940,7 +947,7 @@ public:
                 nfound += old_value != NullIndexValue;
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
-                _set.emplace(composite_key);
+                _set.emplace_with_hash(hash, composite_key);
             }
         }
         *num_found = nfound;
@@ -991,7 +998,7 @@ public:
                 nfound += old_value != NullIndexValue;
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
-                _set.emplace(composite_key);
+                _set.emplace_with_hash(hash, composite_key);
             }
         }
         *num_found = nfound;
@@ -1009,10 +1016,12 @@ public:
             uint64_t hash = StringHash()(composite_key);
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 _total_kv_pairs_usage += composite_key.size();
+                _overlap_kv_pairs_usage += composite_key.size();
+                _overlap_size += 1;
             } else {
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
-                _set.emplace(composite_key);
+                _set.emplace_with_hash(hash, composite_key);
             }
         }
         return Status::OK();
@@ -1056,7 +1065,7 @@ public:
             } else {
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
-                _set.emplace(composite_key);
+                _set.emplace_with_hash(hash, composite_key);
             }
         }
         return Status::OK();
@@ -1077,7 +1086,7 @@ public:
             return true;
         }
         for (const auto& composite_key : _set) {
-            if (!ar.dump(composite_key.size())) {
+            if (!ar.dump(static_cast<size_t>(composite_key.size()))) {
                 LOG(ERROR) << "Failed to dump compose_key_size";
                 return false;
             }
@@ -1121,7 +1130,13 @@ public:
                 LOG(ERROR) << "Failed to load composite_key";
                 return false;
             }
-            _set.emplace(composite_key);
+            auto [it, inserted] = _set.emplace(composite_key);
+            if (inserted) {
+                _total_kv_pairs_usage += composite_key.size();
+            } else {
+                _set.erase(it);
+                _set.emplace(composite_key);
+            }
         }
         return true;
 
@@ -1139,23 +1154,28 @@ public:
         offset += kv_header_size;
         const auto key_size = UNALIGNED_LOAD32(buff.data());
         DCHECK(key_size == kKeySizeMagicNum);
-        const auto nums = UNALIGNED_LOAD32(buff.data() + kv_header_size - 4);
-        Slice keys[nums];
-        std::vector<IndexValue> values;
-        values.reserve(nums);
-        for (auto i = 0; i < nums; ++i) {
-            raw::stl_string_resize_uninitialized(&buff, sizeof(uint32_t));
-            RETURN_IF_ERROR(file->read_at_fully(offset, buff.data(), buff.size()));
-            offset += sizeof(uint32_t);
-            const auto kv_pair_size = UNALIGNED_LOAD32(buff.data());
-            raw::stl_string_resize_uninitialized(&buff, kv_pair_size);
-            RETURN_IF_ERROR(file->read_at_fully(offset, buff.data(), buff.size()));
-            keys[i] = Slice(buff.data(), kv_pair_size - kIndexValueSize);
-            const auto value = UNALIGNED_LOAD64(buff.data() + kv_pair_size - kIndexValueSize);
-            values.emplace_back(value);
-            offset += kv_pair_size;
+        auto nums = UNALIGNED_LOAD32(buff.data() + kv_header_size - 4);
+        while (nums > 0) {
+            size_t batch_num = (nums > 4096) ? 4096 : nums;
+            Slice keys[batch_num];
+            std::vector<IndexValue> values;
+            values.reserve(batch_num);
+            std::vector<std::string> kv_buffs(batch_num);
+            for (size_t i = 0; i < batch_num; ++i) {
+                raw::stl_string_resize_uninitialized(&buff, sizeof(uint32_t));
+                RETURN_IF_ERROR(file->read_at_fully(offset, buff.data(), buff.size()));
+                offset += sizeof(uint32_t);
+                const auto kv_pair_size = UNALIGNED_LOAD32(buff.data());
+                raw::stl_string_resize_uninitialized(&kv_buffs[i], kv_pair_size);
+                RETURN_IF_ERROR(file->read_at_fully(offset, kv_buffs[i].data(), kv_buffs[i].size()));
+                keys[i] = Slice(kv_buffs[i].data(), kv_pair_size - kIndexValueSize);
+                const auto value = UNALIGNED_LOAD64(kv_buffs[i].data() + kv_pair_size - kIndexValueSize);
+                values.emplace_back(value);
+                offset += kv_pair_size;
+            }
+            RETURN_IF_ERROR(load_wals(nums, keys, values.data()));
+            nums -= batch_num;
         }
-        RETURN_IF_ERROR(load_wals(nums, keys, values.data()));
         return Status::OK();
     }
 
@@ -1206,11 +1226,22 @@ public:
         return ret;
     }
 
+    void update_overlap_info(size_t overlap_size, size_t overlap_usage) override {
+        _overlap_kv_pairs_usage += overlap_usage;
+        _overlap_size += overlap_size;
+    }
+
+    size_t overlap_size() { return _overlap_size; }
+
 private:
     friend ShardByLengthMutableIndex;
     friend PersistentIndex;
     phmap::flat_hash_set<KeyType, StringHash, EqualOnStringWithHash> _set;
     size_t _total_kv_pairs_usage = 0;
+    // _overlap_num and _overlap_kv_pairs_usage will lost after be restart,
+    // but it is not very important because it will be fixed in later _merge_compaction.
+    size_t _overlap_size = 0;
+    size_t _overlap_kv_pairs_usage = 0;
 };
 
 StatusOr<std::unique_ptr<MutableIndex>> MutableIndex::create(size_t key_size) {
@@ -1598,6 +1629,36 @@ Status ShardByLengthMutableIndex::erase(size_t n, const Slice* keys, IndexValue*
     return Status::OK();
 }
 
+Status ShardByLengthMutableIndex::update_overlap_info(size_t key_size, size_t num_overlap, const Slice* keys,
+                                                      const IndexValue* values, const KeysInfo& keys_info, bool erase) {
+    DCHECK(_fixed_key_size != -1);
+    const auto [shard_offset, shard_size] = _shard_info_by_key_size[key_size];
+    DCHECK(shard_size == 1);
+    if (key_size > 0) {
+        for (size_t i = 0; i < shard_size; ++i) {
+            _shards[shard_offset + i]->update_overlap_info(num_overlap, 0);
+        }
+    } else {
+        DCHECK(key_size == 0);
+        DCHECK(_fixed_key_size == 0);
+        size_t overlap_size = 0;
+        for (size_t i = 0; i < keys_info.size(); i++) {
+            auto key_idx = keys_info.key_idxes[i];
+            if (values[key_idx].get_value() != NullIndexValue) {
+                overlap_size += keys[key_idx].get_size() + kIndexValueSize;
+            }
+        }
+        if (erase) {
+            overlap_size *= 2;
+        }
+        for (size_t i = 0; i < shard_size; ++i) {
+            _shards[shard_offset + i]->update_overlap_info(num_overlap, overlap_size);
+        }
+    }
+
+    return Status::OK();
+}
+
 Status ShardByLengthMutableIndex::append_wal(size_t n, const Slice* keys, const IndexValue* values) {
     DCHECK(_fixed_key_size != -1);
     if (_fixed_key_size > 0) {
@@ -1675,7 +1736,7 @@ bool ShardByLengthMutableIndex::load_snapshot(phmap::BinaryInputArchive& ar, con
 }
 
 size_t ShardByLengthMutableIndex::dump_bound() {
-    return std::accumulate(_shards.begin(), _shards.end(), 0,
+    return std::accumulate(_shards.begin(), _shards.end(), 0UL,
                            [](size_t s, const auto& e) { return e->size() > 0 ? s + e->dump_bound() : s; });
 }
 
@@ -1709,6 +1770,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         });
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
+        snapshot->clear_dumped_shard_idxes();
         version.to_pb(snapshot->mutable_version());
         PagePointerPB* data = snapshot->mutable_data();
         // create a new empty _l0 file, set _offset to 0
@@ -1724,7 +1786,6 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         // be maybe crash after create index file during last commit
         // so we delete expired index file first to make sure no garbage left
         FileSystem::Default()->delete_file(file_name);
-        size_t snapshot_size = dump_bound();
         phmap::BinaryOutputArchive ar_out(file_name.data());
         std::set<uint32_t> dumped_shard_idxes;
         if (!dump(ar_out, dumped_shard_idxes)) {
@@ -1736,6 +1797,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         WritableFileOptions wblock_opts;
         wblock_opts.mode = FileSystem::MUST_EXIST;
         ASSIGN_OR_RETURN(_index_file, fs->new_writable_file(wblock_opts, file_name));
+        size_t snapshot_size = _index_file->size();
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
         version.to_pb(snapshot->mutable_version());
@@ -1859,7 +1921,7 @@ size_t ShardByLengthMutableIndex::capacity() {
 }
 
 size_t ShardByLengthMutableIndex::memory_usage() {
-    return std::accumulate(_shards.begin(), _shards.end(), (size_t)0,
+    return std::accumulate(_shards.begin(), _shards.end(), 0UL,
                            [](size_t s, const auto& e) { return s + e->memory_usage(); });
 }
 
@@ -2218,6 +2280,7 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         dest.key_size = src.key_size();
         dest.value_size = src.value_size();
         dest.nbucket = src.nbucket();
+        dest.data_size = src.data_size();
     }
     size_t nlength = meta.shard_info_size();
     for (size_t i = 0; i < nlength; i++) {
@@ -2632,8 +2695,11 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
     RETURN_IF_ERROR(_l0->upsert(n, keys, values, old_values, &num_found, not_founds_by_key_size));
     _dump_snapshot |= _can_dump_directly();
     if (_l1) {
+        size_t num_found_before = num_found;
         for (const auto& [key_size, keys_info] : not_founds_by_key_size) {
             RETURN_IF_ERROR(_l1->get(n, keys, keys_info, old_values, &num_found, key_size));
+            _l0->update_overlap_info(key_size, num_found - num_found_before, keys, old_values, keys_info, false);
+            num_found_before = num_found;
         }
     }
     _size += n - num_found;
@@ -2665,8 +2731,11 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     RETURN_IF_ERROR(_l0->erase(n, keys, old_values, &num_erased, not_founds_by_key_size));
     _dump_snapshot |= _can_dump_directly();
     if (_l1) {
+        size_t num_erased_before = num_erased;
         for (const auto& [key_size, keys_info] : not_founds_by_key_size) {
             RETURN_IF_ERROR(_l1->get(n, keys, keys_info, old_values, &num_erased, key_size));
+            _l0->update_overlap_info(key_size, num_erased - num_erased_before, keys, old_values, keys_info, true);
+            num_erased_before = num_erased;
         }
     }
     CHECK(_size >= num_erased) << strings::Substitute("_size($0) < num_erased($1)", _size, num_erased);
@@ -2681,11 +2750,11 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
                                                      const std::vector<uint32_t>& src_rssid,
                                                      std::vector<uint32_t>* failed) {
     std::vector<IndexValue> found_values;
-    found_values.reserve(n);
+    found_values.resize(n);
     RETURN_IF_ERROR(get(n, keys, found_values.data()));
     std::vector<size_t> replace_idxes;
     for (size_t i = 0; i < n; ++i) {
-        if (values[i].get_value() != NullIndexValue &&
+        if (found_values[i].get_value() != NullIndexValue &&
             ((uint32_t)(found_values[i].get_value() >> 32)) == src_rssid[i]) {
             replace_idxes.emplace_back(i);
         } else {
@@ -2703,14 +2772,18 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
 Status PersistentIndex::try_replace(size_t n, const Slice* keys, const IndexValue* values, const uint32_t max_src_rssid,
                                     std::vector<uint32_t>* failed) {
     std::vector<IndexValue> found_values;
-    found_values.reserve(n);
+    found_values.resize(n);
     RETURN_IF_ERROR(get(n, keys, found_values.data()));
     std::vector<size_t> replace_idxes;
+    size_t num_not_found = 0;
     for (size_t i = 0; i < n; ++i) {
-        if (values[i].get_value() != NullIndexValue &&
+        if (found_values[i].get_value() != NullIndexValue &&
             ((uint32_t)(found_values[i].get_value() >> 32)) <= max_src_rssid) {
             replace_idxes.emplace_back(i);
         } else {
+            if (found_values[i].get_value() == NullIndexValue) {
+                num_not_found++;
+            }
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
         }
     }
@@ -2752,12 +2825,20 @@ Status PersistentIndex::_check_and_flush_l0() {
     if (_l1 != nullptr) {
         _l1->file_size(&l1_file_size);
     }
-    const bool need_flush_l0 = l0_mem_size > kL0FlushSizeMin;
-    const bool need_flush_l1 = l0_mem_size > kL0SnapshotSizeMax &&
-                               l0_mem_size >= static_cast<size_t>(static_cast<double>(l1_file_size) * kL0L1MergeRatio);
-    if (!(need_flush_l0 || need_flush_l1)) {
-        return Status::OK();
+
+    // l1 is empty, if l0 memory usage is bigger than kL0SnapshotSizeMax, flush to l1
+    if (l1_file_size == 0) {
+        if (l0_mem_size <= kL0SnapshotSizeMax) {
+            return Status::OK();
+        }
+    } else {
+        // l1 is not empty
+        // perform l0 l1 merge compaction if l0_memory * config::l0_l1_merge_ratio > l1_file_size
+        if (l0_mem_size * config::l0_l1_merge_ratio <= l1_file_size) {
+            return Status::OK();
+        }
     }
+
     _flushed = true;
     if (_l1 == nullptr) {
         RETURN_IF_ERROR(_flush_l0());
@@ -2810,7 +2891,8 @@ struct KVRefEq {
 template <>
 struct KVRefEq<0> {
     bool operator()(const KVRef& lhs, const KVRef& rhs) const {
-        return lhs.hash == rhs.hash && memcmp(lhs.kv_pos, rhs.kv_pos, lhs.size - kIndexValueSize) == 0;
+        return lhs.hash == rhs.hash && lhs.size == rhs.size &&
+               memcmp(lhs.kv_pos, rhs.kv_pos, lhs.size - kIndexValueSize) == 0;
     }
 };
 
@@ -2939,7 +3021,7 @@ Status PersistentIndex::_merge_compaction() {
         auto [l0_shard_offset, l0_shard_size] = shard_info;
         const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
-                                                      (size_t)0, [](size_t s, const auto& e) { return s + e->size(); });
+                                                      0UL, [](size_t s, const auto& e) { return s + e->size(); });
         size_t l0_kv_pairs_usage = 0;
         if (key_size == 0) {
             l0_kv_pairs_usage = dynamic_cast<SliceMutableIndex*>(_l0->_shards[0].get())->_total_kv_pairs_usage;
@@ -2965,15 +3047,28 @@ Status PersistentIndex::_merge_compaction() {
                                                       (size_t)0, [](size_t s, const auto& e) { return s + e.size; });
         const auto l1_kv_pairs_usage = std::accumulate(std::next(_l1->_shards.begin(), l1_shard_offset),
                                                        std::next(_l1->_shards.begin(), l1_shard_offset + l1_shard_size),
-                                                       (size_t)0, [](size_t s, const auto& e) { return s + e.bytes; });
+                                                       0UL, [](size_t s, const auto& e) { return s + e.data_size; });
         if (l0_kv_pairs_size == 0 && l1_kv_pairs_size != 0) {
             for (auto i = 0; i < l1_shard_size; i++) {
                 RETURN_IF_ERROR(writer->write_shard_as_rawbuff(_l1->_shards[l1_shard_offset + i], _l1.get()));
             }
             continue;
         }
-        const auto total_kv_pairs_size = l0_kv_pairs_size + l1_kv_pairs_size;
-        const auto total_kv_pairs_usage = l0_kv_pairs_usage + l1_kv_pairs_usage;
+        auto total_kv_pairs_size = l0_kv_pairs_size + l1_kv_pairs_size;
+        auto total_kv_pairs_usage = l0_kv_pairs_usage + l1_kv_pairs_usage;
+        if (key_size == 0) {
+            size_t overlap_usage = dynamic_cast<SliceMutableIndex*>(_l0->_shards[0].get())->_overlap_kv_pairs_usage;
+            size_t overlap_size = dynamic_cast<SliceMutableIndex*>(_l0->_shards[0].get())->_overlap_size;
+            CHECK(total_kv_pairs_usage >= overlap_usage);
+            CHECK(total_kv_pairs_size >= overlap_size);
+            total_kv_pairs_size -= overlap_size;
+            total_kv_pairs_usage -= overlap_usage;
+        } else {
+            size_t overlap_size = _l0->_shards[l0_shard_offset]->overlap_size();
+            CHECK(total_kv_pairs_size >= overlap_size);
+            total_kv_pairs_size -= overlap_size;
+            total_kv_pairs_usage -= (key_size + kIndexValueSize) * overlap_size;
+        }
         const auto [nshard, npage_hint] = MutableIndex::estimate_nshard_and_npage(total_kv_pairs_usage);
         const auto nbucket = MutableIndex::estimate_nbucket(key_size, total_kv_pairs_size, nshard, npage_hint);
         const auto estimated_size_per_shard = total_kv_pairs_size / nshard;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -164,6 +164,10 @@ public:
 
     virtual size_t memory_usage() = 0;
 
+    virtual void update_overlap_info(size_t overlap_size, size_t overlap_usage) = 0;
+
+    virtual size_t overlap_size() = 0;
+
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
     static std::tuple<size_t, size_t> estimate_nshard_and_npage(const size_t total_kv_pairs_usage);
@@ -273,6 +277,9 @@ public:
 
     size_t memory_usage();
 
+    Status update_overlap_info(size_t key_size, size_t num_overlap, const Slice* keys, const IndexValue* values,
+                               const KeysInfo& keys_info, bool erase);
+
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
 private:
@@ -376,6 +383,7 @@ private:
         uint32_t key_size;
         uint32_t value_size;
         uint32_t nbucket;
+        uint64_t data_size;
     };
 
     std::vector<ShardInfo> _shards;

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -31,6 +31,7 @@ message ImmutableIndexShardMetaPB {
     uint64 key_size = 4;
     uint64 value_size = 5;
     uint64 nbucket = 6;
+    uint64 data_size = 7;
 }
 
 message ShardInfoPB {


### PR DESCRIPTION
For #11868:

In branch-2.4, we support the varlen key of persistent index. But the estimate l1 size is not accurate because the following two reasons:

We use the total file size of previous l1 file as the real l1 data size We ignore the same key in l0 and l1, and calculate size twice These two reasons will cause l1 file size keep growing but the real data size is far smaller than file size.

For #11721:

_total_kv_pairs_usage of SliceMutableIndex is not update when load snapshot. So the _total_kv_pairs_usage is not accurate after load snapshot which leads to an error in the result of dump_bound(). And it may lead to subsequent metadata errors.

So we will use the read data file size as the snapshot size to avoid potential errors.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
