### PR TITLE
[Enhancement] enable shared scan in connector scan node

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -314,11 +314,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                          scan_node->convert_scan_range_to_morsel_queue_factory(
                                  scan_ranges, scan_ranges_per_driver_seq, scan_node->id(), dop,
                                  enable_tablet_internal_parallel, tablet_internal_parallel_mode));
-
-        if (auto* olap_scan = dynamic_cast<vectorized::OlapScanNode*>(scan_node)) {
-            olap_scan->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
-        }
-
+        scan_node->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
     }
 

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -130,4 +130,11 @@ StatusOr<pipeline::MorselQueuePtr> ScanNode::convert_scan_range_to_morsel_queue(
     return std::make_unique<pipeline::FixedMorselQueue>(std::move(morsels));
 }
 
+void ScanNode::enable_shared_scan(bool enable) {
+    _enable_shared_scan = enable;
+}
+
+bool ScanNode::is_shared_scan_enabled() const {
+    return _enable_shared_scan;
+}
 } // namespace starrocks

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -105,6 +105,10 @@ public:
 
     virtual int io_tasks_per_scan_operator() const { return MAX_IO_TASKS_PER_OP; }
 
+    // TODO: support more share_scan strategy
+    void enable_shared_scan(bool enable);
+    bool is_shared_scan_enabled() const;
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
@@ -119,6 +123,7 @@ protected:
     RuntimeProfile::ThreadCounters* _scanner_thread_counters;
     RuntimeProfile::Counter* _num_scanner_threads_started_counter;
     std::string _name;
+    bool _enable_shared_scan = false;
 };
 
 } // namespace starrocks

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -340,10 +340,6 @@ Status OlapScanNode::set_scan_ranges(const std::vector<TScanRangeParams>& scan_r
     return Status::OK();
 }
 
-void OlapScanNode::enable_shared_scan(bool enable) {
-    _enable_shared_scan = enable;
-}
-
 StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -67,9 +67,6 @@ public:
 
     Status set_scan_range(const TInternalScanRange& range);
 
-    // TODO: support more share_scan strategy
-    void enable_shared_scan(bool enable);
-
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;
 
@@ -180,9 +177,6 @@ private:
     // of the left table are compacted at building the right hash table. Therefore, reference
     // the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
-
-    bool _enable_shared_scan = false;
-
     // profile
     RuntimeProfile* _scan_profile = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

A very quick benchmark on tpch-100g with block-cache, with `enable_shared_scan` we can save 3 seconds in total (50s -> 47s), and latency is much steadier then before.



  | SR(Parquet + cache) | Optimization | Enable Shared Scan
-- | -- | -- | --
Q01 | 5215 | 4527 | 3813
Q02 | 652 | 571 | 526
Q03 | 2936 | 2400 | 2461
Q04 | 1189 | 1133 | 1062
Q05 | 2543 | 2065 | 1893
Q06 | 1834 | 983 | 991
Q07 | 2369 | 2107 | 1847
Q08 | 2149 | 1631 | 1655
Q09 | 5335 | 4732 | 4386
Q10 | 3371 | 2743 | 2721
Q11 | 519 | 430 | 405
Q12 | 1403 | 1254 | 1353
Q13 | 2545 | 2549 | 2532
Q14 | 1745 | 1159 | 1173
Q15 | 1629 | 1059 | 1063
Q16 | 1255 | 1233 | 1269
Q17 | 2766 | 2066 | 1980
Q18 | 10720 | 10837 | 9563
Q19 | 2062 | 1246 | 1270
Q20 | 1605 | 1313 | 1292
Q21 | 3676 | 3624 | 3398
Q22 | 752 | 691 | 686
SUM | 58270 | 50353 | 47339




## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
