### PR TITLE
[Refactor] fix the clang-tidy check

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -406,7 +406,7 @@ struct StatusInstance {
         auto&& st__ = (stmt);                                        \
         if (UNLIKELY(!st__.ok())) {                                  \
             LOG(WARNING) << (warning_prefix) << ", error: " << st__; \
-            return st__;                                             \
+            return std::move(st__);                                  \
         }                                                            \
     } while (0);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

https://stackoverflow.com/questions/66787397/why-is-the-local-variable-copied-despite-being-returned-by-name

```
warning: local variable 'st__' will be copied despite being returned by name
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
