### PR TITLE
[BugFix] fix alter lake table "in_memory" property bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -490,12 +490,16 @@ public class Alter {
                 List<String> partitionNames = clause.getPartitionNames();
                 // currently, only in memory property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY));
+                OlapTable olapTable = (OlapTable) db.getTable(tableName);
+                if (olapTable.isLakeTable()) {
+                    throw new DdlException("Lake table not support alter in_memory");
+                }
+
                 ((SchemaChangeHandler) schemaChangeHandler).updatePartitionsInMemoryMeta(
                         db, tableName, partitionNames, properties);
 
                 db.writeLock();
                 try {
-                    OlapTable olapTable = (OlapTable) db.getTable(tableName);
                     modifyPartitionsProperty(db, olapTable, partitionNames, properties);
                 } finally {
                     db.writeUnlock();
@@ -505,6 +509,12 @@ public class Alter {
                 // currently, only in memory property and enable persistent index property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX));
+
+                OlapTable olapTable = (OlapTable) db.getTable(tableName);
+                if (olapTable.isLakeTable()) {
+                    throw new DdlException("Lake table not support alter in_memory or enable_persistent_index");
+                }
+
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName,
                             properties, TTabletMetaType.INMEMORY);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1286,7 +1286,7 @@ public class SchemaChangeHandler extends AlterHandler {
             OlapTable olapTable = (OlapTable) db.getTable(tableName);
             // LakeTable not support update tablet meta
             if (olapTable instanceof LakeTable) {
-                return;
+                throw new DdlException("LakeTable does not support this op");
             }
             Partition partition = olapTable.getPartition(partitionName);
             if (partition == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1204,10 +1204,6 @@ public class SchemaChangeHandler extends AlterHandler {
 
         boolean metaValue = false;
         if (metaType == TTabletMetaType.INMEMORY) {
-            // LakeTable not support alter in_memory
-            if (olapTable.isLakeTable()) {
-                throw new DdlException("LakeTable does not support alter in_memory property");
-            }
             metaValue = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_INMEMORY));
             if (metaValue == olapTable.isInMemory()) {
                 return;
@@ -1245,9 +1241,6 @@ public class SchemaChangeHandler extends AlterHandler {
         db.readLock();
         try {
             olapTable = (OlapTable) db.getTable(tableName);
-            if (olapTable.isLakeTable()) {
-                throw new DdlException("Lake table does not support alter in_memory property");
-            }
             for (String partitionName : partitionNames) {
                 Partition partition = olapTable.getPartition(partitionName);
                 if (partition == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -64,6 +64,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
@@ -1283,6 +1284,10 @@ public class SchemaChangeHandler extends AlterHandler {
         db.readLock();
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableName);
+            // LakeTable not support update tablet meta
+            if (olapTable instanceof LakeTable) {
+                return;
+            }
             Partition partition = olapTable.getPartition(partitionName);
             if (partition == null) {
                 throw new DdlException(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1285,7 +1285,7 @@ public class SchemaChangeHandler extends AlterHandler {
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableName);
             // LakeTable not support update tablet meta
-            if (olapTable instanceof LakeTable) {
+            if (olapTable.isLakeTable()) {
                 throw new DdlException("LakeTable does not support this op");
             }
             Partition partition = olapTable.getPartition(partitionName);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
When alter lake table's in_memory property, it reports this error:
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/10295131/194705369-113b8143-cb02-473c-848c-c4528fbccd4d.png">

Given the fact that 'in_memory' property will be deprecated in the future, we will do nothing but only return ok when the modified table is a lake table.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
