### PR TITLE
[BugFix] Fix bug of update compaction

### DIFF
--- a/be/src/storage/chunk_iterator.h
+++ b/be/src/storage/chunk_iterator.h
@@ -113,7 +113,11 @@ protected:
         return Status::NotSupported("Chunk* chunk, vector<uint32_t>* rowid) not supported");
     }
     virtual Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) {
-        return Status::NotSupported("get chunk with sources not supported");
+        if (source_masks == nullptr) {
+            return do_get_next(chunk);
+        } else {
+            return Status::NotSupported("get chunk with sources not supported");
+        }
     }
 
     vectorized::Schema _schema;

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -281,7 +281,7 @@ private:
                 entry.chunk_pk_column = pk_column->clone_shared();
                 entry.chunk_pk_column->reserve(_chunk_size);
             }
-            if (rowsets_mask_buffer) {
+            if (rowsets_mask_buffer && res.value().size() > 1) {
                 std::unique_ptr<vector<RowSourceMask>> rowset_source_masks = std::make_unique<vector<RowSourceMask>>();
                 rowsets_source_masks.emplace_back(std::move(rowset_source_masks));
                 entry.source_masks = rowsets_source_masks[order].get();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/11957

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The bug is introduced by this pr(https://github.com/StarRocks/starrocks/pull/10903). If the primarykey table data volume is very small, there may be compaction failure problem because not all `column_iterator` support function `get_chunk` with `source_mask`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
