### PR TITLE
[Enhancement] decimal multiplication opt

### DIFF
--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -110,6 +110,7 @@ public:
     bool is_nullable() const { return _is_nullable; }
 
     bool is_monotonic() const { return _is_monotonic; }
+    virtual bool is_cast_expr() const { return false; }
 
     // In most time, this field is passed from FE
     // Sometimes we want to construct expr on BE implicitly and we have knowledge about `monotonicity`

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -110,7 +110,7 @@ public:
     bool is_nullable() const { return _is_nullable; }
 
     bool is_monotonic() const { return _is_monotonic; }
-    virtual bool is_cast_expr() const { return false; }
+    bool is_cast_expr() const { return _node_type == TExprNodeType::CAST_EXPR; }
 
     // In most time, this field is passed from FE
     // Sometimes we want to construct expr on BE implicitly and we have knowledge about `monotonicity`

--- a/be/src/exprs/vectorized/arithmetic_expr.cpp
+++ b/be/src/exprs/vectorized/arithmetic_expr.cpp
@@ -2,6 +2,8 @@
 
 #include "exprs/vectorized/arithmetic_expr.h"
 
+#include <optional>
+
 #include "common/object_pool.h"
 #include "exprs/vectorized/arithmetic_operation.h"
 #include "exprs/vectorized/binary_function.h"
@@ -9,6 +11,7 @@
 #include "exprs/vectorized/decimal_cast_expr.h"
 #include "exprs/vectorized/unary_function.h"
 #include "runtime/decimalv3.h"
+#include "util/pred_guard.h"
 
 namespace starrocks::vectorized {
 
@@ -18,11 +21,68 @@ namespace starrocks::vectorized {
                                                       \
     virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new CLASS_NAME(*this)); }
 
+static std::optional<PrimitiveType> eliminate_trivial_cast_for_decimal_mul(const Expr* e) {
+    if (!e->is_cast_expr()) {
+        return {};
+    }
+    const auto* e_child = e->get_child(0);
+    const auto& e_type = e->type();
+    const auto& e_child_type = e_child->type();
+    if (e_type.is_decimalv3_type() && e_child_type.is_decimalv3_type() && e_type.scale == e_child_type.scale) {
+        return {e_child->type().type};
+    } else {
+        return {};
+    }
+}
+
 template <PrimitiveType Type, typename OP>
 class VectorizedArithmeticExpr final : public Expr {
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedArithmeticExpr);
+
+    std::optional<ColumnPtr> evaluate_decimal_fast_mul(ExprContext* context, vectorized::Chunk* chunk) {
+        auto lhs_pt_opt = eliminate_trivial_cast_for_decimal_mul(_children[0]);
+        auto rhs_pt_opt = eliminate_trivial_cast_for_decimal_mul(_children[1]);
+        if (lhs_pt_opt.has_value() && rhs_pt_opt.has_value()) {
+            auto lhs_pt = lhs_pt_opt.value();
+            auto rhs_pt = rhs_pt_opt.value();
+            if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
+                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
+                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
+                return VectorizedStrictDecimalBinaryFunction<MulOp64x64_128, false>::template evaluate<
+                        TYPE_DECIMAL64, TYPE_DECIMAL64, Type>(l, r);
+            }
+            if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
+                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
+                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
+                return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
+                        TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(l, r);
+            }
+            if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
+                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
+                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
+                return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
+                        TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(r, l);
+            }
+            if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
+                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
+                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
+                return VectorizedStrictDecimalBinaryFunction<MulOp32x32_128, false>::template evaluate<
+                        TYPE_DECIMAL32, TYPE_DECIMAL32, Type>(r, l);
+            }
+        }
+        return {};
+    }
+
     ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+#if defined(__x86_64__) && defined(__GNUC__)
+        if constexpr (is_mul_op<OP> && pt_is_decimal<Type>) {
+            auto opt_result = evaluate_decimal_fast_mul(context, ptr);
+            if (opt_result.has_value()) {
+                return opt_result.value();
+            }
+        }
+#endif
         auto l = _children[0]->evaluate(context, ptr);
         auto r = _children[1]->evaluate(context, ptr);
         if constexpr (pt_is_decimal<Type>) {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -1031,8 +1031,6 @@ public:
             << ", expr=" << expr_debug_string << ")";
         return out.str();
     }
-
-    bool is_cast_expr() const override { return true; }
 };
 
 DEFINE_BINARY_FUNCTION_WITH_IMPL(timeToDate, date, time) {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -1031,6 +1031,8 @@ public:
             << ", expr=" << expr_debug_string << ")";
         return out.str();
     }
+
+    bool is_cast_expr() const override { return true; }
 };
 
 DEFINE_BINARY_FUNCTION_WITH_IMPL(timeToDate, date, time) {

--- a/be/src/exprs/vectorized/decimal_binary_function.h
+++ b/be/src/exprs/vectorized/decimal_binary_function.h
@@ -160,6 +160,9 @@ struct DecimalBinaryFunction {
                 all_null = adjust_evaluate<lhs_is_const, rhs_is_const, true, BinaryOperator>(
                         num_rows, lhs_data, rhs_data, result_data, nulls, &has_null, adjust_scale);
             }
+        } else if constexpr (is_decimal_fast_mul_op<Op>) {
+            all_null = adjust_evaluate<lhs_is_const, rhs_is_const, false, BinaryOperator>(
+                    num_rows, lhs_data, rhs_data, result_data, nulls, &has_null, adjust_scale);
         }
 
         if constexpr (check_overflow) {

--- a/be/src/runtime/int128_arithmetics_x86_64.h
+++ b/be/src/runtime/int128_arithmetics_x86_64.h
@@ -93,13 +93,38 @@ static int asm_mul(T x, U y, Int128Wrapper& res) {
     } else {
         __asm__ __volatile__(
                 "mov %[x], %%rax\n\t"
-                "imul %[y], %%rax\n\t"
+                "imul %[y]\n\t"
+                "mov %%rdx, %[high]\n\t"
                 "mov %%rax, %[low]"
-                : [ low ] "=r"(res.s.low), "=@cco"(overflow)
+                : [ high ] "=r"(res.s.high), [ low ] "=r"(res.s.low), "=@cco"(overflow)
                 : [ x ] "r"(x), [ y ] "r"(y)
                 : "cc", "rdx", "rax");
     }
     return overflow;
+}
+
+static int64_t asm_mul32(int32_t x, int32_t y) {
+    union {
+        int64_t i64;
+        struct {
+#if __BYTE_ORDER == LITTLE_ENDIAN
+            int32_t low;
+            int32_t high;
+#else
+            int32_t high;
+            int32_t low;
+#endif
+        } s;
+    } z;
+    __asm__ __volatile__(
+            "mov %[x], %%eax\n\t"
+            "imul %[y]\n\t"
+            "mov %%edx, %[high]\n\t"
+            "mov %%eax, %[low]"
+            : [ high ] "=r"(z.s.high), [ low ] "=r"(z.s.low)
+            : [ x ] "r"(x), [ y ] "r"(y)
+            : "cc", "rax", "rdx");
+    return z.i64;
 }
 
 static inline bool asm_add_overflow(int128_t x, int128_t y, int128_t* z) {
@@ -150,6 +175,16 @@ static inline int multi3(const Int128Wrapper& x, const Int128Wrapper& y, Int128W
     overflow |= asm_add(res.u.high, t0.u.low, res.u.high);
     overflow |= asm_add(res.u.high, t1.u.low, res.u.high);
     return overflow;
+}
+
+static inline int128_t i64_x_i64_produce_i128(int64_t a, int64_t b) {
+    Int128Wrapper t;
+    asm_mul(a, b, t);
+    return t.s128;
+}
+
+static inline int64_t i32_x_i32_produce_i64(int32_t a, int32_t b) {
+    return asm_mul32(a, b);
 }
 
 static inline int multi3(const int128_t& x, const int128_t& y, int128_t& res) {

--- a/be/test/exprs/vectorized/decimal_binary_function_test.cpp
+++ b/be/test/exprs/vectorized/decimal_binary_function_test.cpp
@@ -16,42 +16,45 @@ class DecimalBinaryFunctionTest : public ::testing::Test {};
 using DecimalTestCase = std::tuple<std::string, std::string, std::string>;
 using DecimalTestCaseArray = std::vector<DecimalTestCase>;
 
-template <PrimitiveType Type>
+template <PrimitiveType LhsType, PrimitiveType RhsType>
 Columns prepare_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                               int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
-    using CppType = RunTimeCppType<Type>;
-    using ColumnType = RunTimeColumnType<Type>;
+    using LhsCppType = RunTimeCppType<LhsType>;
+    using LhsColumnType = RunTimeColumnType<LhsType>;
+
+    using RhsCppType = RunTimeCppType<RhsType>;
+    using RhsColumnType = RunTimeColumnType<RhsType>;
 
     Columns columns;
     columns.reserve(2);
-    auto lhs_column = ColumnType::create(lhs_precision, lhs_scale);
-    auto rhs_column = ColumnType::create(rhs_precision, rhs_scale);
+    auto lhs_column = LhsColumnType::create(lhs_precision, lhs_scale);
+    auto rhs_column = RhsColumnType::create(rhs_precision, rhs_scale);
     auto num_rows = test_cases.size() + front_fill_size + rear_fill_size;
     lhs_column->resize(num_rows);
     rhs_column->resize(num_rows);
 
-    auto lhs_data = &ColumnHelper::cast_to_raw<Type>(lhs_column)->get_data().front();
-    auto rhs_data = &ColumnHelper::cast_to_raw<Type>(rhs_column)->get_data().front();
+    auto lhs_data = &ColumnHelper::cast_to_raw<LhsType>(lhs_column)->get_data().front();
+    auto rhs_data = &ColumnHelper::cast_to_raw<RhsType>(rhs_column)->get_data().front();
 
     // front filling
     for (auto i = 0; i < front_fill_size; ++i) {
-        lhs_data[i] = CppType(0);
-        rhs_data[i] = CppType(0);
+        lhs_data[i] = LhsCppType(0);
+        rhs_data[i] = RhsCppType(0);
     }
 
     for (auto i = front_fill_size; i < front_fill_size + test_cases.size(); ++i) {
         auto& tc = test_cases[i - front_fill_size];
         auto& lhs_datum = std::get<0>(tc);
         auto& rhs_datum = std::get<1>(tc);
-        DecimalV3Cast::from_string<CppType>(&lhs_data[i], lhs_precision, lhs_scale, lhs_datum.c_str(),
-                                            lhs_datum.size());
-        DecimalV3Cast::from_string<CppType>(&rhs_data[i], rhs_precision, rhs_scale, rhs_datum.c_str(),
-                                            rhs_datum.size());
+        DecimalV3Cast::from_string<LhsCppType>(&lhs_data[i], lhs_precision, lhs_scale, lhs_datum.c_str(),
+                                               lhs_datum.size());
+        DecimalV3Cast::from_string<RhsCppType>(&rhs_data[i], rhs_precision, rhs_scale, rhs_datum.c_str(),
+                                               rhs_datum.size());
     }
     // rear filling
     for (auto i = front_fill_size + test_cases.size(); i < num_rows; ++i) {
-        lhs_data[i] = CppType(0);
-        rhs_data[i] = CppType(0);
+        lhs_data[i] = LhsCppType(0);
+        rhs_data[i] = RhsCppType(0);
     }
     // std::cout << "lhs_column=" << lhs_column->debug_string() << std::endl;
     // std::cout << "rhs_column=" << rhs_column->debug_string() << std::endl;
@@ -61,38 +64,47 @@ Columns prepare_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_pr
 }
 
 template <PrimitiveType Type>
+Columns prepare_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
+                              int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
+    return prepare_vector_vector<Type, Type>(test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                             front_fill_size, rear_fill_size);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType>
 Columns prepare_const_vector(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
                              int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
     auto& lhs_datum = std::get<0>(test_case);
     auto& rhs_datum = std::get<1>(test_case);
-    using CppType = RunTimeCppType<Type>;
-    using ColumnType = RunTimeColumnType<Type>;
+    using LhsCppType = RunTimeCppType<LhsType>;
+    using LhsColumnType = RunTimeColumnType<LhsType>;
+    using RhsCppType = RunTimeCppType<RhsType>;
+    using RhsColumnType = RunTimeColumnType<RhsType>;
 
     Columns columns;
     columns.reserve(2);
 
-    auto lhs_column = ColumnType::create(lhs_precision, lhs_scale);
+    auto lhs_column = LhsColumnType::create(lhs_precision, lhs_scale);
     lhs_column->resize(1);
 
-    auto rhs_column = ColumnType::create(rhs_precision, rhs_scale);
+    auto rhs_column = RhsColumnType::create(rhs_precision, rhs_scale);
     auto num_rows = 1 + front_fill_size + rear_fill_size;
     lhs_column->resize(num_rows);
     rhs_column->resize(num_rows);
 
-    auto lhs_data = &ColumnHelper::cast_to_raw<Type>(lhs_column)->get_data().front();
-    auto rhs_data = &ColumnHelper::cast_to_raw<Type>(rhs_column)->get_data().front();
-    DecimalV3Cast::from_string<CppType>(&lhs_data[0], lhs_precision, lhs_scale, lhs_datum.c_str(), lhs_datum.size());
+    auto lhs_data = &ColumnHelper::cast_to_raw<LhsType>(lhs_column)->get_data().front();
+    auto rhs_data = &ColumnHelper::cast_to_raw<RhsType>(rhs_column)->get_data().front();
+    DecimalV3Cast::from_string<LhsCppType>(&lhs_data[0], lhs_precision, lhs_scale, lhs_datum.c_str(), lhs_datum.size());
 
     // front filling
     for (auto i = 0; i < front_fill_size; ++i) {
-        rhs_data[i] = CppType(0);
+        rhs_data[i] = RhsCppType(0);
     }
 
-    DecimalV3Cast::from_string<CppType>(&rhs_data[front_fill_size], rhs_precision, rhs_scale, rhs_datum.c_str(),
-                                        rhs_datum.size());
+    DecimalV3Cast::from_string<RhsCppType>(&rhs_data[front_fill_size], rhs_precision, rhs_scale, rhs_datum.c_str(),
+                                           rhs_datum.size());
     // rear filling
     for (auto i = front_fill_size + 1; i < num_rows; ++i) {
-        rhs_data[i] = CppType(0);
+        rhs_data[i] = RhsCppType(0);
     }
     lhs_column->resize(1);
     columns.push_back(ConstColumn::create(lhs_column, num_rows));
@@ -101,12 +113,27 @@ Columns prepare_const_vector(const DecimalTestCase& test_case, int lhs_precision
 }
 
 template <PrimitiveType Type>
+Columns prepare_const_vector(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
+                             int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
+    return prepare_const_vector<Type, Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                            front_fill_size, rear_fill_size);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType>
 Columns prepare_vector_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
                              int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
     DecimalTestCase const_vector_test_case = {std::get<1>(test_case), std::get<0>(test_case), std::get<2>(test_case)};
-    auto const_vector_columns = prepare_const_vector<Type>(const_vector_test_case, rhs_precision, rhs_scale,
-                                                           lhs_precision, lhs_scale, front_fill_size, rear_fill_size);
+    auto const_vector_columns =
+            prepare_const_vector<RhsType, LhsType>(const_vector_test_case, rhs_precision, rhs_scale, lhs_precision,
+                                                   lhs_scale, front_fill_size, rear_fill_size);
     return Columns{const_vector_columns[1], const_vector_columns[0]};
+}
+
+template <PrimitiveType Type>
+Columns prepare_vector_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
+                             int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
+    return prepare_vector_const<Type, Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                            front_fill_size, rear_fill_size);
 }
 
 ColumnPtr add_null_column(ColumnPtr&& column) {
@@ -118,61 +145,92 @@ ColumnPtr add_null_column(ColumnPtr&& column) {
     return NullableColumn::create(std::move(column), std::move(null_column));
 }
 
+template <PrimitiveType LhsType, PrimitiveType RhsType>
+Columns prepare_nullable_vector_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale,
+                                      int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
+    auto columns = prepare_vector_const<LhsType, RhsType>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                                          front_fill_size, rear_fill_size);
+    return Columns{add_null_column(std::move(columns[0])), columns[1]};
+}
+
 template <PrimitiveType Type>
 Columns prepare_nullable_vector_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale,
                                       int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
-    auto columns = prepare_vector_const<Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                              front_fill_size, rear_fill_size);
-    return Columns{add_null_column(std::move(columns[0])), columns[1]};
+    return prepare_nullable_vector_const<Type, Type>(test_case, lhs_precision, rhs_scale, rhs_precision, rhs_scale,
+                                                     front_fill_size, rear_fill_size);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType>
+Columns prepare_const_nullable_vector(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale,
+                                      int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
+    auto columns = prepare_const_vector<LhsType, RhsType>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                                          front_fill_size, rear_fill_size);
+    return Columns{columns[0], add_null_column(std::move(columns[1]))};
 }
 
 template <PrimitiveType Type>
 Columns prepare_const_nullable_vector(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale,
                                       int rhs_precision, int rhs_scale, size_t front_fill_size, size_t rear_fill_size) {
-    auto columns = prepare_const_vector<Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                              front_fill_size, rear_fill_size);
-    return Columns{columns[0], add_null_column(std::move(columns[1]))};
+    return prepare_const_nullable_vector<Type, Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                                     front_fill_size, rear_fill_size);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType>
+Columns prepare_nullable_vector_nullable_vector(const DecimalTestCaseArray& test_case, int lhs_precision, int lhs_scale,
+                                                int rhs_precision, int rhs_scale, size_t front_fill_size,
+                                                size_t rear_fill_size) {
+    auto columns = prepare_vector_vector<LhsType, RhsType>(test_case, lhs_precision, lhs_scale, rhs_precision,
+                                                           rhs_scale, front_fill_size, rear_fill_size);
+    return Columns{add_null_column(std::move(columns[0])), add_null_column(std::move(columns[1]))};
 }
 
 template <PrimitiveType Type>
 Columns prepare_nullable_vector_nullable_vector(const DecimalTestCaseArray& test_case, int lhs_precision, int lhs_scale,
                                                 int rhs_precision, int rhs_scale, size_t front_fill_size,
                                                 size_t rear_fill_size) {
-    auto columns = prepare_vector_vector<Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                               front_fill_size, rear_fill_size);
-    return Columns{add_null_column(std::move(columns[0])), add_null_column(std::move(columns[1]))};
+    return prepare_nullable_vector_nullable_vector<Type, Type>(test_case, lhs_precision, lhs_scale, rhs_precision,
+                                                               rhs_scale, front_fill_size, rear_fill_size);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType>
+Columns prepare_const_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
+                            int rhs_scale) {
+    using LhsCppType = RunTimeCppType<LhsType>;
+    using LhsColumnType = RunTimeColumnType<LhsType>;
+    using RhsCppType = RunTimeCppType<RhsType>;
+    using RhsColumnType = RunTimeColumnType<RhsType>;
+
+    auto lhs_datum = std::get<0>(test_case);
+    auto rhs_datum = std::get<1>(test_case);
+
+    auto lhs_column = LhsColumnType::create(lhs_precision, lhs_scale);
+    auto rhs_column = RhsColumnType::create(rhs_precision, rhs_scale);
+    lhs_column->resize(1);
+    rhs_column->resize(1);
+    auto lhs_data = &ColumnHelper::cast_to_raw<LhsType>(lhs_column)->get_data().front();
+    auto rhs_data = &ColumnHelper::cast_to_raw<RhsType>(rhs_column)->get_data().front();
+    DecimalV3Cast::from_string<LhsCppType>(&lhs_data[0], lhs_precision, lhs_scale, lhs_datum.c_str(), lhs_datum.size());
+    DecimalV3Cast::from_string<RhsCppType>(&rhs_data[0], rhs_precision, rhs_scale, rhs_datum.c_str(), rhs_datum.size());
+    return Columns{ConstColumn::create(lhs_column, 1), ConstColumn::create(rhs_column, 1)};
 }
 
 template <PrimitiveType Type>
 Columns prepare_const_const(const DecimalTestCase& test_case, int lhs_precision, int lhs_scale, int rhs_precision,
                             int rhs_scale) {
-    using CppType = RunTimeCppType<Type>;
-    using ColumnType = RunTimeColumnType<Type>;
-
-    auto lhs_datum = std::get<0>(test_case);
-    auto rhs_datum = std::get<1>(test_case);
-
-    auto lhs_column = ColumnType::create(lhs_precision, lhs_scale);
-    auto rhs_column = ColumnType::create(rhs_precision, rhs_scale);
-    lhs_column->resize(1);
-    rhs_column->resize(1);
-    auto lhs_data = &ColumnHelper::cast_to_raw<Type>(lhs_column)->get_data().front();
-    auto rhs_data = &ColumnHelper::cast_to_raw<Type>(rhs_column)->get_data().front();
-    DecimalV3Cast::from_string<CppType>(&lhs_data[0], lhs_precision, lhs_scale, lhs_datum.c_str(), lhs_datum.size());
-    DecimalV3Cast::from_string<CppType>(&rhs_data[0], rhs_precision, rhs_scale, rhs_datum.c_str(), rhs_datum.size());
-    return Columns{ConstColumn::create(lhs_column, 1), ConstColumn::create(rhs_column, 1)};
+    return prepare_const_const<Type, Type>(test_case, lhs_precision, lhs_scale, rhs_precision, rhs_scale);
 }
 
 using Func = std::function<ColumnPtr(ColumnPtr const&, ColumnPtr const&)>;
 
-template <PrimitiveType Type, typename Op, bool check_overflow, bool assert_overflow = false>
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow,
+          bool assert_overflow = false>
 void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Columns columns, int result_precision,
                                    int result_scale, size_t off, [[maybe_unused]] const std::vector<bool>& overflows) {
     using ColumnWiseOp = UnpackConstColumnDecimalBinaryFunction<Op, check_overflow>;
-    using CppType = RunTimeCppType<Type>;
-    using ColumnType = RunTimeColumnType<Type>;
+    using CppType = RunTimeCppType<ResultType>;
+    using ColumnType = RunTimeColumnType<ResultType>;
     ASSERT_TRUE(columns.size() == 2);
-    auto result = ColumnWiseOp::template evaluate<Type, Type, Type>(columns[0], columns[1]);
+    auto result = ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(columns[0], columns[1]);
 
     ASSERT_TRUE(result.get() != nullptr);
     // lhs is const and rhs is const -> result is const
@@ -214,7 +272,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
         auto nullable_column = down_cast<NullableColumn*>(result.get());
         decimal_column = (ColumnType*)ColumnHelper::get_data_column(nullable_column);
     } else {
-        decimal_column = ColumnHelper::cast_to_raw<Type>(result);
+        decimal_column = ColumnHelper::cast_to_raw<ResultType>(result);
     }
     ASSERT_EQ(result_precision, decimal_column->precision());
     ASSERT_EQ(result_scale, decimal_column->scale());
@@ -251,21 +309,22 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
     }
 }
 
-template <PrimitiveType Type, typename Op, bool check_overflow, bool assert_overflow = false>
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow,
+          bool assert_overflow = false>
 void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray const& test_cases, Columns columns,
                                                          int result_precision, int result_scale, size_t off,
                                                          [[maybe_unused]] const std::vector<bool>& overflows) {
-    using CppType = RunTimeCppType<Type>;
-    using ColumnType = RunTimeColumnType<Type>;
+    using CppType = RunTimeCppType<ResultType>;
+    using ColumnType = RunTimeColumnType<ResultType>;
 
     ASSERT_TRUE(columns.size() == 2);
     ColumnPtr result = nullptr;
     if constexpr (is_add_op<Op> || is_sub_op<Op> || is_mul_op<Op>) {
         using ColumnWiseOp = VectorizedStrictDecimalBinaryFunction<Op, check_overflow>;
-        result = ColumnWiseOp::template evaluate<Type, Type, Type>(columns[0], columns[1]);
+        result = ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(columns[0], columns[1]);
     } else {
-        using ColumnWiseOp = VectorizedUnstrictDecimalBinaryFunction<Type, Op, check_overflow>;
-        result = ColumnWiseOp::template evaluate<Type, Type, Type>(columns[0], columns[1]);
+        using ColumnWiseOp = VectorizedUnstrictDecimalBinaryFunction<ResultType, Op, check_overflow>;
+        result = ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(columns[0], columns[1]);
     }
 
     ASSERT_TRUE(result.get() != nullptr);
@@ -274,7 +333,7 @@ void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray co
         auto nullable_column = down_cast<NullableColumn*>(result.get());
         decimal_column = (ColumnType*)ColumnHelper::get_data_column(nullable_column);
     } else {
-        decimal_column = ColumnHelper::cast_to_raw<Type>(result);
+        decimal_column = ColumnHelper::cast_to_raw<ResultType>(result);
     }
     ASSERT_EQ(result_precision, decimal_column->precision());
     ASSERT_EQ(result_scale, decimal_column->scale());
@@ -309,24 +368,41 @@ void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray co
     }
 }
 
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
+void test_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
+                        int rhs_scale, int result_precision, int result_scale) {
+    Columns columns = prepare_vector_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                              rhs_scale, 0, 0);
+    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+            test_cases, columns, result_precision, result_scale, 0, std::vector<bool>());
+}
+
 template <PrimitiveType Type, typename Op, bool check_overflow>
 void test_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                         int rhs_scale, int result_precision, int result_scale) {
-    Columns columns = prepare_vector_vector<Type>(test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, 0, 0);
-    test_decimal_binary_functions<Type, Op, check_overflow>(test_cases, columns, result_precision, result_scale, 0,
-                                                            std::vector<bool>());
+    test_vector_vector<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                             rhs_scale, result_precision, result_scale);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
+void test_vector_vector_assert_overflow(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
+                                        int rhs_precision, int rhs_scale, int result_precision, int result_scale,
+                                        const std::vector<bool>& overflows) {
+    Columns columns = prepare_vector_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                              rhs_scale, 0, 0);
+    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow, true>(
+            test_cases, columns, result_precision, result_scale, 0, overflows);
 }
 
 template <PrimitiveType Type, typename Op, bool check_overflow>
 void test_vector_vector_assert_overflow(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                         int rhs_precision, int rhs_scale, int result_precision, int result_scale,
                                         const std::vector<bool>& overflows) {
-    Columns columns = prepare_vector_vector<Type>(test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, 0, 0);
-    test_decimal_binary_functions<Type, Op, check_overflow, true>(test_cases, columns, result_precision, result_scale,
-                                                                  0, overflows);
+    test_vector_vector_assert_overflow<Type, Type, Type, Op, check_overflow>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale, overflows);
 }
 
-template <PrimitiveType Type, typename Op, bool check_overflow>
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
 void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -335,14 +411,22 @@ void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision
     int front_fill_size = rand_int(gen);
     int rear_fill_size = rand_int(gen);
     for (auto& tc : test_cases) {
-        Columns columns = prepare_const_vector<Type>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                                     front_fill_size, rear_fill_size);
-        test_decimal_binary_functions<Type, Op, check_overflow>(DecimalTestCaseArray{tc}, columns, result_precision,
-                                                                result_scale, front_fill_size, std::vector<bool>());
+        Columns columns = prepare_const_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                                                 front_fill_size, rear_fill_size);
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
+                std::vector<bool>());
     }
 }
 
 template <PrimitiveType Type, typename Op, bool check_overflow>
+void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
+                       int rhs_scale, int result_precision, int result_scale) {
+    test_const_vector<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                            rhs_scale, result_precision, result_scale);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
 void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -351,24 +435,39 @@ void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision
     int front_fill_size = rand_int(gen);
     int rear_fill_size = rand_int(gen);
     for (auto& tc : test_cases) {
-        Columns columns = prepare_vector_const<Type>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                                     front_fill_size, rear_fill_size);
-        test_decimal_binary_functions<Type, Op, check_overflow>(DecimalTestCaseArray{tc}, columns, result_precision,
-                                                                result_scale, front_fill_size, std::vector<bool>());
+        Columns columns = prepare_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
+                                                                 front_fill_size, rear_fill_size);
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
+                std::vector<bool>());
+    }
+}
+
+template <PrimitiveType Type, typename Op, bool check_overflow>
+void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
+                       int rhs_scale, int result_precision, int result_scale) {
+    return test_vector_const<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                                   rhs_scale, result_precision, result_scale);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
+void test_const_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
+                      int rhs_scale, int result_precision, int result_scale) {
+    for (auto& tc : test_cases) {
+        Columns columns = prepare_const_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale);
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
     }
 }
 
 template <PrimitiveType Type, typename Op, bool check_overflow>
 void test_const_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                       int rhs_scale, int result_precision, int result_scale) {
-    for (auto& tc : test_cases) {
-        Columns columns = prepare_const_const<Type>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale);
-        test_decimal_binary_functions<Type, Op, check_overflow>(DecimalTestCaseArray{tc}, columns, result_precision,
-                                                                result_scale, 0, std::vector<bool>());
-    }
+    test_const_const<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                           rhs_scale, result_precision, result_scale);
 }
 
-template <PrimitiveType Type, typename Op, bool check_overflow>
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
 void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -377,14 +476,20 @@ void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_
     int front_fill_size = rand_int(gen);
     int rear_fill_size = rand_int(gen);
     for (auto& tc : test_cases) {
-        Columns columns = prepare_nullable_vector_const<Type>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                                              front_fill_size, rear_fill_size);
-        test_decimal_binary_functions_with_nullable_columns<Type, Op, check_overflow>(
+        Columns columns = prepare_nullable_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
+                                                                          rhs_scale, front_fill_size, rear_fill_size);
+        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
     }
 }
-
 template <PrimitiveType Type, typename Op, bool check_overflow>
+void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
+                                int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
+    test_nullable_vector_const<Type, Type, Type, Op, check_overflow>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+}
+
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
 void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -393,20 +498,32 @@ void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_
     int front_fill_size = rand_int(gen);
     int rear_fill_size = rand_int(gen);
     for (auto& tc : test_cases) {
-        Columns columns = prepare_const_nullable_vector<Type>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
-                                                              front_fill_size, rear_fill_size);
-        test_decimal_binary_functions_with_nullable_columns<Type, Op, check_overflow>(
+        Columns columns = prepare_const_nullable_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
+                                                                          rhs_scale, front_fill_size, rear_fill_size);
+        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
     }
 }
+template <PrimitiveType Type, typename Op, bool check_overflow>
+void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
+                                int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
+    test_const_nullable_vector<Type, Type, Type, Op, check_overflow>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+}
 
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op, bool check_overflow>
+void test_nullable_vector_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
+                                          int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
+    Columns columns = prepare_nullable_vector_nullable_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale,
+                                                                                rhs_precision, rhs_scale, 0, 0);
+    test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
+            test_cases, columns, result_precision, result_scale, 0, std::vector<bool>());
+}
 template <PrimitiveType Type, typename Op, bool check_overflow>
 void test_nullable_vector_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                           int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
-    Columns columns = prepare_nullable_vector_nullable_vector<Type>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                                    rhs_scale, 0, 0);
-    test_decimal_binary_functions_with_nullable_columns<Type, Op, check_overflow>(test_cases, columns, result_precision,
-                                                                                  result_scale, 0, std::vector<bool>());
+    return test_nullable_vector_nullable_vector<Type, Type, Type, Op, check_overflow>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p30s20_add_decimal128p38s28_eq_decimal128p38s28) {
@@ -1527,6 +1644,7 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s0_mod_decimal32p3s1_eq_decima
     test_nullable_vector_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
     test_nullable_vector_nullable_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
 }
+
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p10s0_mod_decimal64p9s5_eq_decimal64p18s5) {
     DecimalTestCaseArray test_cases = {{"9999999999", "9999.99999", "9"},
                                        {"9999999999", "-9999.99999", "9"},
@@ -2837,4 +2955,121 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s14_div_decimal128p38s14_eq_
     test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, true>(test_case_array, 38, 14, 38, 14, 38, 14,
                                                                      overflows);
 }
+
+template <PrimitiveType LhsType, PrimitiveType RhsType, PrimitiveType ResultType, typename Op>
+void test_decimal_fast_mul_help(const DecimalTestCaseArray& test_cases, int lhs_precision, int lhs_scale,
+                                int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
+    test_vector_vector<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                                rhs_scale, result_precision, result_scale);
+    test_vector_const<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                               rhs_scale, result_precision, result_scale);
+    test_const_vector<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                               rhs_scale, result_precision, result_scale);
+    test_const_const<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                              rhs_scale, result_precision, result_scale);
+    test_nullable_vector_const<LhsType, RhsType, ResultType, Op, false>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_const_nullable_vector<LhsType, RhsType, ResultType, Op, false>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_nullable_vector_nullable_vector<LhsType, RhsType, ResultType, Op, false>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_vector_vector<ResultType, ResultType, ResultType, MulOp, false>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+}
+TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x32) {
+    DecimalTestCaseArray test_cases = {{"0.14", "3348947.24", "468852.6136"},
+                                       {"-9786689.10", "7798141.97", "-76317991018051.5270"},
+                                       {"-4791887.62", "3743357.14", "-17937746736404.6068"},
+                                       {"32559.38", "1932061.44", "62906722608.3072"},
+                                       {"9967778.87", "-4436693.25", "-44223977230021.6275"},
+                                       {"66.04", "1745489.71", "115272140.4484"},
+                                       {"8730215.73", "9461462.88", "82600612063787.1024"},
+                                       {"-1640031.37", "-3649585.51", "5985434723897.4487"},
+                                       {"0.40", "-5992669.43", "-2397067.7720"},
+                                       {"-4915774.24", "2601554.88", "-12788656463050.2912"},
+                                       {"2321876.63", "6786.86", "15758251625.0818"},
+                                       {"5795924.12", "-7510017.32", "-43527490526605.7584"},
+                                       {"-1477602.43", "7417972.70", "-10960814487193.6610"},
+                                       {"4982776.64", "9458572.68", "47129954997646.1952"},
+                                       {"-4157714.37", "-319363.42", "1327821880586.3454"},
+                                       {"-1338202.52", "9712047.22", "-12996686064162.9944"},
+                                       {"5568896.04", "-4178259.11", "-23268290611772.9244"},
+                                       {"1216062.54", "-8740084.85", "-10628489782506.5190"},
+                                       {"-1011533.50", "1754253.55", "-1774486233318.9250"},
+                                       {"-7485146.41", "4185814.42", "-31331433778789.2322"},
+                                       {"569696.96", "735990.44", "419291516257.0624"},
+                                       {"-1022446.87", "-8669363.57", "8863963647038.5259"},
+                                       {"7038776.17", "-9960876.32", "-70112378873533.2944"},
+                                       {"-4530254.27", "-1483099.01", "6718815622885.2727"},
+                                       {"8033925.05", "4639565.36", "37273920366816.2680"},
+                                       {"-4060954.23", "-7233186.83", "29373640653668.7909"}};
+    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL32, TYPE_DECIMAL64, MulOp32x32_64>(test_cases, 9, 2, 9, 2,
+                                                                                              18, 4);
+    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL32, TYPE_DECIMAL128, MulOp32x32_128>(test_cases, 9, 2, 9, 2,
+                                                                                                38, 4);
+    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL64, MulOp32x64_128>(test_cases, 9, 2, 9, 2,
+                                                                                               38, 4);
+}
+
+TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x64) {
+    DecimalTestCaseArray test_cases = {{"9032611.72", "-99999987017825.7359", "-903261054737060591007.964748"},
+                                       {"2736895.22", "-92663866986328.7512", "-253611294621598964507.849264"},
+                                       {"-3828865.35", "80937842651332.4369", "-309900101231438898977.471415"},
+                                       {"-7148341.89", "-89822041958723.6528", "642078665178881938244.055792"},
+                                       {"-6484113.59", "-37888289565618.6030", "245671973274282780469.114770"},
+                                       {"-1714464.49", "-33647025220542.7704", "57686629934754998377.023096"},
+                                       {"3058437.45", "-99999999957006.6629", "-305843744868507567712.885605"},
+                                       {"-8195353.44", "-99999999989236.8008", "819535343911791778410.874752"},
+                                       {"-7133537.38", "-2003684724783.3757", "14293359881977222958.533666"},
+                                       {"5696891.54", "-38236526225684.3015", "-217829342774089027926.159310"},
+                                       {"-5730753.29", "4.0217", "-23047370.506393"},
+                                       {"3.04", "55199582163813.2378", "167806729777992.242912"},
+                                       {"-6562428.11", "-99999999493883.1965", "656242807678644861768.253615"},
+                                       {"0.00", "0.7476", "0.000000"},
+                                       {"823750.91", "23145425564409.9206", "19066065371019935707.277746"},
+                                       {"1230710.88", "0.7183", "884019.625104"},
+                                       {"72.10", "5140290622005.2846", "370614953846581.019660"},
+                                       {"4746532.04", "-40180624201993.8931", "-190718620161963445483.484924"},
+                                       {"-170865.42", "46959038948537.3316", "-8023675912738189549.513272"},
+                                       {"2569778.63", "-79738078104668.9157", "-204909209110649082791.131491"},
+                                       {"-3481236.21", "-99999999999894.5607", "348123620999632940890.882947"},
+                                       {"-6347458.75", "-84505412562356.0775", "536394620391287004743.053125"},
+                                       {"2059495.57", "0.0486", "100091.484702"},
+                                       {"533.04", "3067942701.0884", "1635336177388.160736"},
+                                       {"2742930.04", "-99999834076370.4796", "-274292548883092242664.047184"},
+                                       {"2269330.25", "0.0361", "81922.822025"}};
+    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp32x64_128>(test_cases, 9, 2, 18, 4,
+                                                                                                38, 6);
+    test_decimal_fast_mul_help<TYPE_DECIMAL64, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp64x64_128>(test_cases, 9, 2, 18, 4,
+                                                                                                38, 6);
+}
+
+TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_64x64) {
+    DecimalTestCaseArray test_cases = {
+            {"0.0006", "-82780021658097.3483", "-49668012994.85840898"},
+            {"0.0074", "-99827652105771.3123", "-738724625582.70771102"},
+            {"-99973172481064.8851", "41055058.0121", "-4104404395863798146564.72090971"},
+            {"10418.0297", "-78182709607827.6816", "-814509790720824139.39094352"},
+            {"84231788195839.5714", "77738262261.3072", "6548032841507056635908796.85173408"},
+            {"-95593465131926.9776", "-2201368772639.3279", "210436469009810477989501604.74235504"},
+            {"-5829918858943.4969", "41160.0999", "-239960042643008340.85934031"},
+            {"22286515224419.0423", "-45199673982539.5695", "-1007343222350645401189049609.04428985"},
+            {"0.3026", "-67285817488933.7073", "-20360688372151.33982898"},
+            {"93643928070236.3651", "-85952437612924.2777", "-8048923885286159719807127647.19098827"},
+            {"-68455776580233.7557", "5711626623.7667", "-390993836066288058523463.22159519"},
+            {"96190766579211.5819", "-99999999999998.3166", "-9619076657920996262463540555.22302954"},
+            {"-99999999911670.1121", "-7286176685749.2421", "728617667931337040128175917.79703941"},
+            {"5300.1993", "-14319371956134.8862", "-75895525218345754.54281966"},
+            {"52771758641568.0008", "-25416153656949.7962", "-1341255126381560552930609374.00143696"},
+            {"3.2917", "-99999999999999.9213", "-329169999999999.74094321"},
+            {"-78809072751576.0845", "-14758895507471.3475", "1163134869781218860114475849.98886375"},
+            {"-63650347027092.4971", "83952744775493.0151", "-5343621338837057001558324362.66700621"},
+            {"197070.9764", "20234892726480.4061", "3987710066956751765.59551604"},
+            {"0.0114", "-75288876496539.0058", "-858293192060.54466612"},
+            {"-72638466358742.9662", "3.1225", "-226813611205174.91195950"},
+            {"60915079068521.5269", "-99999121308263.0016", "-6091454381275516575941632856.40914304"}};
+    test_decimal_fast_mul_help<TYPE_DECIMAL64, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp64x64_128>(test_cases, 18, 4, 18,
+                                                                                                4, 38, 8);
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/decimal_binary_function_test.cpp
+++ b/be/test/exprs/vectorized/decimal_binary_function_test.cpp
@@ -479,7 +479,7 @@ void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_
         Columns columns = prepare_nullable_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
         test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
-                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size, std::vector<bool>());
     }
 }
 template <PrimitiveType Type, typename Op, bool check_overflow>
@@ -501,7 +501,7 @@ void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_
         Columns columns = prepare_const_nullable_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
         test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
-                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size, std::vector<bool>());
     }
 }
 template <PrimitiveType Type, typename Op, bool check_overflow>
@@ -3007,7 +3007,7 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x32) {
                                                                                               18, 4);
     test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL32, TYPE_DECIMAL128, MulOp32x32_128>(test_cases, 9, 2, 9, 2,
                                                                                                 38, 4);
-    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL64, MulOp32x64_128>(test_cases, 9, 2, 9, 2,
+    test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp32x64_128>(test_cases, 9, 2, 9, 2,
                                                                                                38, 4);
 }
 

--- a/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
+++ b/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
@@ -31,6 +31,7 @@ static void compare_decimal_string(const std::string& expect, const std::string&
     if (actual.size() == expect.size()) {
         ASSERT_EQ(actual, expect);
     } else {
+        std::cout << "expect=" << expect << ", actual=" << actual << std::endl;
         ASSERT_EQ(actual.size() - scale - 1, expect.size());
         ASSERT_EQ(actual.substr(0, actual.size() - scale - 1), expect);
         ASSERT_EQ(actual[expect.size()], '.');

--- a/be/test/runtime/int128_arithmetic_ops_test.cpp
+++ b/be/test/runtime/int128_arithmetic_ops_test.cpp
@@ -157,7 +157,7 @@ TEST_F(Int128ArithmeticOpsTest, test_i32xi32_produce_i64) {
     };
     for (auto a : values) {
         for (auto b : values) {
-            ASSERT_EQ(i32_x_i32_produce_i64(a, b), (int64_t)a * (int64_t)a);
+            ASSERT_EQ(i32_x_i32_produce_i64(a, b), (int64_t)a * (int64_t)b);
         }
     }
 }
@@ -179,7 +179,7 @@ TEST_F(Int128ArithmeticOpsTest, test_i64xi64_produce_i128) {
     };
     for (auto a : values) {
         for (auto b : values) {
-            ASSERT_EQ(i64_x_i64_produce_i128(a, b), (int128_t)a * (int128_t)a);
+            ASSERT_EQ(i64_x_i64_produce_i128(a, b), (int128_t)a * (int128_t)b);
         }
     }
 }

--- a/be/test/runtime/int128_arithmetic_ops_test.cpp
+++ b/be/test/runtime/int128_arithmetic_ops_test.cpp
@@ -139,5 +139,50 @@ TEST_F(Int128ArithmeticOpsTest, testMulOverflow) {
         ASSERT_EQ(expect_overflow, actual_overflow);
     }
 }
+
+TEST_F(Int128ArithmeticOpsTest, test_i32xi32_produce_i64) {
+    std::vector<int32_t> values{
+            0,
+            1,
+            (int32_t)0xffff0000,
+            -1,
+            (int32_t)0xdeadbeef,
+            99999'9999,
+            -99999'9999,
+            1 << 31,
+            1 << 30,
+            0x60606060,
+            (int32_t)0xc0c0c0c0c,
+            0x0c0c0c0c,
+    };
+    for (auto a : values) {
+        for (auto b : values) {
+            ASSERT_EQ(i32_x_i32_produce_i64(a, b), (int64_t)a * (int64_t)a);
+        }
+    }
+}
+
+TEST_F(Int128ArithmeticOpsTest, test_i64xi64_produce_i128) {
+    std::vector<int64_t> values{
+            0L,
+            1L,
+            (int64_t)0xffff0000ffff0000L,
+            -1L,
+            (int64_t)0xdeadbeefdeadbeefL,
+            99999'9999'99999'9999L,
+            -99999'9999'99999'9999L,
+            1L << 63,
+            1L << 62,
+            0x6060'6060'6060'6060L,
+            (int64_t)0xc0c0'c0c0'c0c0'c0c0L,
+            0x0c0c'0c0c'0c0c'0c0cL,
+    };
+    for (auto a : values) {
+        for (auto b : values) {
+            ASSERT_EQ(i64_x_i64_produce_i128(a, b), (int128_t)a * (int128_t)a);
+        }
+    }
+}
+
 #endif // defined(__X86_64__) && defined(__GNUC__)
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
Implement fast decimal multiplication for cases following:
1. decimal32 x decimal32 produces decimal64/decimal128 directly without casting decimal32 to decimal64/decimal128.
2. decimal32 x decimal64 produces decimal64 directly without casting decimal32/decimal64 to decimal decimal128.
3. decimal64 x decimal64 produces decimal128 directly without casting decimal64 to decimal128.

## Test

Several tests have be conducted on TPCDS-10T. table store_sales(28800104574) are used.

**Test queries**
```
 Q1(i64xi64=i64) : select sum((ss_wholesale_cost * ss_list_price)) from store_sales;
 Q2(i128xi128=i128): select sum(((ss_wholesale_cost+1000000000.00000001) * ss_list_price)) from store_sales;
 Q3(i64xi64=i128): select sum((ss_wholesale_cost + (CAST(1000000000.01 AS DECIMAL64(13,2)))) * ss_list_price) from store_sales;
``` 
Q1 is decimal64 multiplying decimal64 produces decimal64, so it is not optimized.
Q2 is decimal128 multiplying decimal64 produces decimal64, it is also not optimized.
Q3 is decimal64 multiplying decimal64 produces decimal128, it is optimized.

decimal multiplication adopts integer multiplication underlyingly.

i64 x i64 => i128 use inline assembly, reduce 3 64-bit mul instructions to 1.
```cpp
template <class T, class U, std::enable_if_t<is_bit64<T>, T> = 0, std::enable_if_t<is_bit64<U>, U> = 0>
static int asm_mul(T x, U y, Int128Wrapper& res) {
    int8_t overflow;
    if constexpr (std::is_unsigned<T>::value && std::is_unsigned<U>::value) {
        __asm__ __volatile__(
                "mov %[x], %%rax\n\t"
                "mul %[y]\n\t"
                "mov %%rdx, %[high]\n\t"
                "mov %%rax, %[low]"
                : [ high ] "=r"(res.u.high), [ low ] "=r"(res.u.low), "=@cco"(overflow)
                : [ x ] "r"(x), [ y ] "r"(y)
                : "cc", "rdx", "rax");
    } else {
        __asm__ __volatile__(
                "mov %[x], %%rax\n\t"
                "imul %[y]\n\t"
                "mov %%rdx, %[high]\n\t"
                "mov %%rax, %[low]"
                : [ high ] "=r"(res.s.high), [ low ] "=r"(res.s.low), "=@cco"(overflow)
                : [ x ] "r"(x), [ y ] "r"(y)
                : "cc", "rdx", "rax");
    }
    return overflow;
}

```

i32 x i32 =>i64 can also optimized in the same way, but decimal32 is not exposed to our users, the inline assembly codes as follows:
```cpp
static int64_t asm_mul32(int32_t x, int32_t y) {
    union {
        int64_t i64;
        struct {
#if __BYTE_ORDER == LITTLE_ENDIAN
            int32_t low;
            int32_t high;
#else
            int32_t high;
            int32_t low;
#endif
        } s;
    } z;
    __asm__ __volatile__(
            "mov %[x], %%eax\n\t"
            "imul %[y]\n\t"
            "mov %%edx, %[high]\n\t"
            "mov %%eax, %[low]"
            : [ high ] "=r"(z.s.high), [ low ] "=r"(z.s.low)
            : [ x ] "r"(x), [ y ] "r"(y)
            : "cc", "rax", "rdx");
    return z.i64;
}
```


**Test result(pipeline_dop=1)**
``` 
+===================+=================+======================+==================+=======================+=========+
| query             | pre-opt latency | pre-opt project cost | post-opt latency | post-opt project cost | speedup |
+===================+=================+======================+==================+=======================+=========+
| Q1(i64xi64=i64)   | 20.190s         | 5.736s               | 18.795s          | 5.743s                | 1X      |
| Q2(i128xi28=i128) | 102.887s        | 80s                  | 95.574s          | 81s                   | 1X      |
| Q3(i64xi64=i128)  | 69.426s         | 50.705s              | 27.861s          | 14.354s              | 3.54X   |
+-------------------+-----------------+----------------------+------------------+-----------------------+---------+
```
- {pre-opt, post-opt} latency means the entire cost of the query.
- {pre-opt, post-opt} project cost means the PushTotalTime of ProjectOperator of the query, this profile metric can be used to show the cost of the multiplication. 
- speedup means pre-opt  ratio of project cost / post-opt project cost.
- **so we can find that Q3 show the 3.54X speedup  in the terms of project cost.** and in pre-opt test, project cost in Q3 is close to Q2.

**Test result(pipeline_dop=0)**
```
+===================+=================+======================+==================+=======================+=========+
| query             | pre-opt latency | pre-opt project cost | post-opt latency | post-opt project cost | speedup |
+===================+=================+======================+==================+=======================+=========+
| Q1(i64xi64=i64)   | 8.247s          | 1.421s               | 7.923s           | 1.418s                | 1X      |
| Q2(i128xi28=i128) | 21.271s         | 16.699s              | 20.853s          | 17.1s                 | 1X      |
| Q3(i64xi64=i128)  | 15.430s         | 10.908s              | 9.337s           | 3.80s                 | 2.87X   |
+-------------------+-----------------+----------------------+------------------+-----------------------+---------+
```
- **In Q3, post-opt project  outperform pre-opt project 2.87X.**