### PR TITLE
[Refactor][Lake] Remove unused protobuf fields

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -186,7 +186,6 @@ Status DeltaWriterImpl::finish() {
 
     // TODO: move file type checking to a common place
     auto is_seg_file = [](const std::string& name) -> bool { return HasSuffixString(name, ".dat"); };
-    auto is_del_file = [](const std::string& name) -> bool { return HasSuffixString(name, ".del"); };
 
     RETURN_IF_ERROR(flush());
     RETURN_IF_ERROR(_tablet_writer->finish());
@@ -198,8 +197,6 @@ Status DeltaWriterImpl::finish() {
     for (auto& f : _tablet_writer->files()) {
         if (is_seg_file(f)) {
             op_write->mutable_rowset()->add_segments(std::move(f));
-        } else if (is_del_file(f)) {
-            op_write->add_deletes(std::move(f));
         } else {
             return Status::InternalError(fmt::format("unknown file {}", f));
         }

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -2,11 +2,12 @@
 
 #include "block_cache/block_cache.h"
 
-#include <cstring>
 #include <gtest/gtest.h>
 
-#include "common/statusor.h"
+#include <cstring>
+
 #include "common/logging.h"
+#include "common/statusor.h"
 #include "fs/fs_util.h"
 
 namespace starrocks {
@@ -24,7 +25,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     CacheOptions options;
     options.mem_space_size = 20 * 1024 * 1024;
     size_t quota = 500 * 1024 * 1024;
-    options.disk_spaces.push_back({ .path = "./ut_dir/block_disk_cache", .size = quota });
+    options.disk_spaces.push_back({.path = "./ut_dir/block_disk_cache", .size = quota});
     options.block_size = block_size;
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -2422,14 +2422,13 @@ TEST_F(JoinHashMapTest, NullAwareAntiJoinTest) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_null_aware_anti_join_with_other_conjunct<true>(
-            _runtime_state.get(), build_data,probe_data);
+    join_hash_map->_probe_from_ht_for_null_aware_anti_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
+                                                                                     probe_data);
 
     // null in probe table match all build table rows
     ASSERT_EQ(probe_state.probe_match_index[0], build_row_count);
     // value in probe table not hit hash table match all null value rows in build table
     ASSERT_EQ(probe_state.probe_match_index[1], 1);
-
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -1,18 +1,18 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
+#include "io/cache_input_stream.h"
+
 #include <gtest/gtest.h>
 
-#include "fs/fs_util.h"
-#include "io/cache_input_stream.h"
 #include "block_cache/block_cache.h"
+#include "fs/fs_util.h"
 #include "testutil/assert.h"
 
 namespace starrocks::io {
 
 class MockSeekableInputStream : public io::SeekableInputStream {
 public:
-    explicit MockSeekableInputStream(char* contents, int64_t size)
-            : _contents(contents), _size(size), _offset(0) {}
+    explicit MockSeekableInputStream(char* contents, int64_t size) : _contents(contents), _size(size), _offset(0) {}
 
     StatusOr<int64_t> read(void* data, int64_t count) override {
         count = std::min(count, _size - _offset);
@@ -43,14 +43,12 @@ public:
         auto cache = BlockCache::instance();
         CacheOptions options;
         options.mem_space_size = 20 * 1024 * 1024;
-        options.disk_spaces.push_back({ .path = "./ut_dir/block_disk_cache", .size = 50 * 1024 * 1024 });
+        options.disk_spaces.push_back({.path = "./ut_dir/block_disk_cache", .size = 50 * 1024 * 1024});
         options.block_size = block_size;
         ASSERT_OK(cache->init(options));
     }
 
-    static void TearDownTestCase() {
-        ASSERT_TRUE(fs::remove_all("./ut_dir").ok());
-    }
+    static void TearDownTestCase() { ASSERT_TRUE(fs::remove_all("./ut_dir").ok()); }
 
     void SetUp() override {}
     void TearDown() override {}
@@ -81,12 +79,12 @@ public:
     static const int64_t block_size;
 };
 
-const int64_t CacheInputStreamTest::block_size = 1024 * 1024; 
+const int64_t CacheInputStreamTest::block_size = 1024 * 1024;
 
 TEST_F(CacheInputStreamTest, test_aligned_read) {
     const int64_t block_count = 4;
 
-    int64_t data_size = block_size * block_count; 
+    int64_t data_size = block_size * block_count;
     char data[data_size + 1];
     gen_test_data(data, data_size, block_size);
 
@@ -94,7 +92,7 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
     io::CacheInputStream cache_stream("test_file1", stream);
     auto& stats = cache_stream.stats();
 
-    // first read from backend 
+    // first read from backend
     for (int i = 0; i < block_count; ++i) {
         char buffer[block_size];
         read_stream_data(&cache_stream, i * block_size, block_size, buffer);
@@ -103,7 +101,7 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
     ASSERT_EQ(stats.read_cache_count, 0);
     ASSERT_EQ(stats.write_cache_count, block_count);
 
-    // first read from cache 
+    // first read from cache
     for (int i = 0; i < block_count; ++i) {
         char buffer[block_size];
         read_stream_data(&cache_stream, i * block_size, block_size, buffer);
@@ -115,7 +113,7 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
 TEST_F(CacheInputStreamTest, test_random_read) {
     const int64_t block_count = 4;
 
-    const int64_t data_size = block_size * block_count; 
+    const int64_t data_size = block_size * block_count;
     char data[data_size + 1];
     gen_test_data(data, data_size, block_size);
 
@@ -123,7 +121,7 @@ TEST_F(CacheInputStreamTest, test_random_read) {
     io::CacheInputStream cache_stream("test_file2", stream);
     auto& stats = cache_stream.stats();
 
-    // first read from backend 
+    // first read from backend
     for (int i = 0; i < block_count; ++i) {
         char buffer[block_size];
         read_stream_data(&cache_stream, i * block_size, block_size, buffer);

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -215,7 +215,6 @@ TEST_F(AsyncDeltaWriterTest, test_write) {
     ASSERT_FALSE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(2 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 
     // Check segment file
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
@@ -310,7 +309,6 @@ TEST_F(AsyncDeltaWriterTest, test_write_concurrently) {
     ASSERT_FALSE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(kNumThreads * kChunksPerThread * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 
     // Check segment file
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -178,7 +178,6 @@ TEST_F(DeltaWriterTest, test_write) {
     ASSERT_TRUE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(2 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 
     // Check segment file
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
@@ -280,7 +279,6 @@ TEST_F(DeltaWriterTest, test_memory_limit_unreached) {
     ASSERT_FALSE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(3 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 }
 
 TEST_F(DeltaWriterTest, test_reached_memory_limit) {
@@ -324,7 +322,6 @@ TEST_F(DeltaWriterTest, test_reached_memory_limit) {
     ASSERT_TRUE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(3 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 }
 
 TEST_F(DeltaWriterTest, test_reached_parent_memory_limit) {
@@ -368,7 +365,6 @@ TEST_F(DeltaWriterTest, test_reached_parent_memory_limit) {
     ASSERT_TRUE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(3 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 }
 
 TEST_F(DeltaWriterTest, test_memtable_full) {
@@ -412,7 +408,6 @@ TEST_F(DeltaWriterTest, test_memtable_full) {
     ASSERT_TRUE(txnlog->op_write().rowset().overlapped());
     ASSERT_EQ(3 * kChunkSize, txnlog->op_write().rowset().num_rows());
     ASSERT_GT(txnlog->op_write().rowset().data_size(), 0);
-    ASSERT_EQ(0, txnlog->op_write().rowset().del_vectors_size());
 }
 
 } // namespace starrocks::lake

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -12,42 +12,29 @@ message RowsetMetadataPB {
     optional uint32 id = 1;
     optional bool overlapped = 2;
     repeated string segments = 3; 
-    repeated string del_vectors = 4;
-    optional int64 num_rows = 5;
-    optional int64 data_size = 6;
-    optional DeletePredicatePB delete_predicate = 7;
-}
-
-message PrimaryIndexMetadataPB {
-    optional uint64 key_size = 1;
-    optional uint64 size = 2;
-    optional string l0 = 3;
-    optional string l1 = 4;
+    optional int64 num_rows = 4;
+    optional int64 data_size = 5;
+    optional DeletePredicatePB delete_predicate = 6;
 }
 
 message TabletMetadataPB {
     optional int64 id = 1;
     optional int64 version = 2;
-    optional int64 flags = 3; 
-    optional TabletSchemaPB schema = 4;
-    repeated RowsetMetadataPB rowsets = 5;
-    optional PrimaryIndexMetadataPB primary_index = 6;
-    optional uint32 next_rowset_id = 7;
+    optional TabletSchemaPB schema = 3;
+    repeated RowsetMetadataPB rowsets = 4;
+    optional uint32 next_rowset_id = 5;
     // cumulative point rowset index
-    optional uint32 cumulative_point = 8;
+    optional uint32 cumulative_point = 6;
 }
 
 message TxnLogPB {
     message OpWrite {
         optional RowsetMetadataPB rowset = 1;
-        repeated string deletes = 2; 
-        repeated uint32 partial_column_ids = 3;
     }
     
     message OpCompaction {
         repeated uint32 input_rowsets = 1;
         optional RowsetMetadataPB output_rowset = 2;
-        repeated string rssids = 3;
     }
     
     message OpSchemaChange {


### PR DESCRIPTION
This PR will break backward compatibility of Lake table, but since Lake table not released yet
it will not bring problems to our users.