### PR TITLE
[Refactor] Fix moving a temporary object prevents copy elision

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -118,7 +118,7 @@ private:
 
 inline void DeltaWriterImpl::reset_memtable() {
     if (!_schema_initialized) {
-        _vectorized_schema = std::move(MemTable::convert_schema(_tablet_schema.get(), _slots));
+        _vectorized_schema = MemTable::convert_schema(_tablet_schema.get(), _slots);
         _schema_initialized = true;
     }
     if (_slots != nullptr) {


### PR DESCRIPTION
Fix clang-tidy warning: moving a temporary object prevents copy elision

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
