### PR TITLE
[BugFix] Fix FE restart failed when replaying schema change job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -508,7 +508,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
          * all tasks are finished. check the integrity.
          * we just check whether all new replicas are healthy.
          */
-        EditLog editLog =GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
         Future<Boolean> future;
         long start = System.nanoTime();
         db.writeLock();
@@ -566,6 +566,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         } finally {
             db.writeUnlock();
         }
+
+        LOG.info("start to sleep ======= ");
+        try {
+            Thread.sleep(60000L);
+        } catch (Exception e) {
+        }
+        LOG.info("end to sleep ======= ");
 
         editLog.waitInfinity(start, future);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -54,6 +54,7 @@ import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.common.SchemaVersionAndHash;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -79,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /*
@@ -506,6 +508,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
          * all tasks are finished. check the integrity.
          * we just check whether all new replicas are healthy.
          */
+        EditLog editLog =GlobalStateMgr.getCurrentState().getEditLog();
+        Future<Boolean> future;
+        long start = System.nanoTime();
         db.writeLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
@@ -552,15 +557,18 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
             // If schema changes include fields which defined in related mv, set those mv state to inactive.
             inactiveRelatedMv(modifiedColumns, tbl);
+
+            pruneMeta();
+            this.jobState = JobState.FINISHED;
+            this.finishedTimeMs = System.currentTimeMillis();
+
+            future = editLog.logAlterJobNoWait(this);
         } finally {
             db.writeUnlock();
         }
 
-        pruneMeta();
-        this.jobState = JobState.FINISHED;
-        this.finishedTimeMs = System.currentTimeMillis();
+        editLog.waitInfinity(start, future);
 
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         LOG.info("schema change job finished: {}", jobId);
         this.span.end();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -510,7 +510,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
          */
         EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
         Future<Boolean> future;
-        long start = System.nanoTime();
+        long start;
         db.writeLock();
         try {
             OlapTable tbl = (OlapTable) db.getTable(tableId);
@@ -562,6 +562,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
 
+            start = System.nanoTime();
             future = editLog.logAlterJobNoWait(this);
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -567,13 +567,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             db.writeUnlock();
         }
 
-        LOG.info("start to sleep ======= ");
-        try {
-            Thread.sleep(60000L);
-        } catch (Exception e) {
-        }
-        LOG.info("end to sleep ======= ");
-
         editLog.waitInfinity(start, future);
 
         LOG.info("schema change job finished: {}", jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1008,7 +1008,7 @@ public class EditLog {
             }
         }
 
-        // for now if journal writer fails, it will exit directly, so this function should always return true.
+        // for now if journal writer fails, it will exit directly, so this property should always be true.
         assert (result);
         if (MetricRepo.isInit) {
             MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((System.nanoTime() - startTime) / 1000000);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11990

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This bug arises during the process of finishing schema change job, a partition is added to table just after the table state is change to Normal and before the alter log is written to bdb. This is a common safe problem in our system: bdb log is written outside the db lock.
To fix this bug we should write bdb log inside the db lock. But to reduce the lock occupancy time, we just put the log item to the buffer queue before releasing the db lock, and wait the log to persist outside the db lock. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
