### PR TITLE
[Enhancement] Optimize primary replica selection

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -65,6 +65,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class OlapTableSinkTest {
@@ -268,5 +269,95 @@ public class OlapTableSinkTest {
         Assert.assertEquals(3, nodes.size());
         Collections.sort(nodes);
         Assert.assertEquals(Lists.newArrayList(backendId, backendId + 1, backendId + 2), nodes);
+    }
+
+    @Test
+    public void testReplicatedStorageWithLocalTablet(@Mocked GlobalStateMgr globalStateMgr,
+            @Mocked SystemInfoService systemInfoService) {
+        long dbId = 1L;
+        long tableId = 2L;
+        long partitionId = 3L;
+        long indexId = 4L;
+        long tabletId = 5L;
+        long replicaId = 10L;
+        long backendId = 20L;
+
+        // Columns
+        List<Column> columns = new ArrayList<Column>();
+        Column k1 = new Column("k1", Type.INT, true, null, "", "");
+        columns.add(k1);
+        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
+
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+
+        for (int i = 0; i < 9; i++) {
+            // Replica
+            Replica replica1 = new Replica(replicaId, backendId, Replica.ReplicaState.NORMAL, 1, 0);
+            Replica replica2 = new Replica(replicaId + 1, backendId + 1, Replica.ReplicaState.NORMAL, 1, 0);
+            Replica replica3 = new Replica(replicaId + 2, backendId + 2, Replica.ReplicaState.NORMAL, 1, 0);
+
+            // Tablet
+            LocalTablet tablet = new LocalTablet(tabletId);
+            tablet.addReplica(replica1);
+            tablet.addReplica(replica2);
+            tablet.addReplica(replica3);
+
+            // Index
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.SSD);
+            index.addTablet(tablet, tabletMeta);
+        }
+
+        // Partition info and distribution info
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, Lists.newArrayList(k1));
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.SSD));
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        partitionInfo.setReplicationNum(partitionId, (short) 3);
+
+        // Partition
+        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
+
+        // Table
+        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", indexId);
+        table.addPartition(partition);
+        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.checkExceedDiskCapacityLimit((Multimap<Long, Long>) any, anyBoolean);
+                result = Status.OK;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getOrCreateSystemInfo(anyInt);
+                result = systemInfoService;
+                systemInfoService.checkBackendAlive(anyLong);
+                result = true;
+            }
+        };
+
+        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId));
+        TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
+        System.out.println(param);
+
+        // Check
+        List<TTabletLocation> locations = param.getTablets();
+        Assert.assertEquals(9, locations.size());
+
+        HashMap<Long, Integer> beCount = new HashMap<>();
+        for (TTabletLocation location : locations) {
+            List<Long> nodes = location.getNode_ids();
+            Assert.assertEquals(3, nodes.size());
+
+            beCount.put(nodes.get(0), beCount.getOrDefault(nodes.get(0), 0) + 1);
+        }
+        
+        for (Integer v : beCount.values()) {
+            Assert.assertEquals(3, v.longValue());
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

At present, we use a `random algorithm` to select the primary replicas in the replicated storage to distribute them as evenly as possible on each BE. Now we use a simple `greedy algorithm` to improve the distribution result.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
