### PR TITLE
[BugFix][Lake] Fix unexpected I/O operation in bthread

### DIFF
--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -16,9 +16,9 @@ GeneralTabletWriter::GeneralTabletWriter(Tablet tablet) : _tablet(std::move(tabl
 
 GeneralTabletWriter::~GeneralTabletWriter() {}
 
+// To developers: Do NOT perform any I/O in this method, because this method may be invoked
+// in a bthread.
 Status GeneralTabletWriter::open() {
-    DCHECK(_schema == nullptr);
-    ASSIGN_OR_RETURN(_schema, _tablet.get_schema());
     return Status::OK();
 }
 
@@ -60,6 +60,9 @@ void GeneralTabletWriter::close() {
 }
 
 Status GeneralTabletWriter::reset_segment_writer() {
+    if (_schema == nullptr) {
+        ASSIGN_OR_RETURN(_schema, _tablet.get_schema());
+    }
     auto name = fmt::format("{}.dat", generate_uuid_string());
     ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet.segment_location(name)));
     SegmentWriterOptions opts;

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -477,7 +477,6 @@ TEST_F(CumulativeCompactionTest, test_missed_version_after_cumulative_point) {
         ASSERT_EQ(2, versions[1].second);
         ASSERT_EQ(3, versions[2].first);
         ASSERT_EQ(4, versions[2].second);
-
     }
 }
 

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -137,8 +137,8 @@ TEST_F(AsyncDeltaWriterTest, test_open) {
     {
         auto tablet_id = -1;
         auto delta_writer = AsyncDeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
-        ASSERT_ERROR(delta_writer->open());
-        ASSERT_ERROR(delta_writer->open());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->open());
         delta_writer->close();
     }
     // Call open() multiple times

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -136,7 +136,7 @@ TEST_F(DeltaWriterTest, test_open) {
     {
         auto tablet_id = -1;
         auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
-        ASSERT_ERROR(delta_writer->open());
+        ASSERT_OK(delta_writer->open());
         delta_writer->close();
     }
 }

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -169,15 +169,6 @@ TEST_F(DuplicateTabletWriterTest, test_write_success) {
     check_segment(seg1);
 }
 
-TEST_F(DuplicateTabletWriterTest, test_open_fail) {
-    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
-    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer());
-    ASSERT_OK(fs::remove_all(kTestGroupPath));
-    ASSERT_ERROR(writer->open());
-    writer->close();
-}
-
 TEST_F(DuplicateTabletWriterTest, test_write_fail) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
     std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};


### PR DESCRIPTION
lake::DeltaWriter::open() may be invoked in a bthread so should not
perform any I/O operation(e.g., Tablet::get_schema()) in it otherwise
the RPC threads may be blocked by I/O operations.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
