### PR TITLE
[BugFix] Fix NestedLoopJoin crash when having join conjuncts

### DIFF
--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -73,6 +73,7 @@ Status CrossJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
 Status CrossJoinNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
+    RETURN_IF_ERROR(Expr::prepare(_join_conjuncts, state));
 
     _build_timer = ADD_TIMER(runtime_profile(), "BuildTime");
     _probe_timer = ADD_TIMER(runtime_profile(), "ProbeTime");
@@ -86,6 +87,7 @@ Status CrossJoinNode::prepare(RuntimeState* state) {
 Status CrossJoinNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
+    RETURN_IF_ERROR(Expr::open(_join_conjuncts, state));
 
     RETURN_IF_ERROR(_build(state));
 
@@ -487,6 +489,7 @@ Status CrossJoinNode::close(RuntimeState* state) {
         _probe_chunk->reset();
     }
 
+    Expr::close(_join_conjuncts, state);
     return ExecNode::close(state);
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
introduced by #11977
mini reproduce case:
```
with tbl1 as (     SELECT 1 as k7 ),  tbl2 as ( select 0 ) select * from tbl1 where cast(k7 as string) like cast((         select *         from tbl2    ) as string );
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
