### PR TITLE
[BugFix] [branch-2.3] Fix list view parse fail bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.SetType;
 import com.starrocks.analysis.TableName;
-import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -75,6 +74,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.StreamLoadTask;
@@ -154,7 +154,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -312,12 +311,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     if (listingViews) {
                         View view = (View) table;
                         String ddlSql = view.getInlineViewDef();
-                        List<TableRef> tblRefs = new ArrayList<>();
-                        view.getQueryStmt().collectTableRefs(tblRefs);
-                        for (TableRef tblRef : tblRefs) {
-                            if (!GlobalStateMgr.getCurrentState().getAuth()
-                                    .checkTblPriv(currentUser, tblRef.getName().getDb(),
-                                            tblRef.getName().getTbl(), PrivPredicate.SHOW)) {
+                        Map<TableName, Table> allTables = AnalyzerUtils.collectAllTable(view.getQueryStatement());
+                        for (TableName tableName : allTables.keySet()) {
+                            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(
+                                    currentUser, tableName.getDb(), tableName.getTbl(), PrivPredicate.SHOW)) {
                                 ddlSql = "";
                                 break;
                             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -4,7 +4,13 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.analysis.AlterViewStmt;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.thrift.TGetTablesParams;
+import com.starrocks.thrift.TListTableStatusResult;
+import com.starrocks.thrift.TTableType;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -1698,5 +1704,18 @@ public class ViewPlanTest extends PlanTestBase {
         sqlPlan = getFragmentPlan(alterStmt);
         viewPlan = getFragmentPlan("select * from " + viewName);
         Assert.assertEquals(sqlPlan, viewPlan);
+    }
+
+    @Test
+    public void testListViews() throws TException {
+        ExecuteEnv instance = ExecuteEnv.getInstance();
+        FrontendServiceImpl frontendService = new FrontendServiceImpl(instance);
+        TGetTablesParams params = new TGetTablesParams();
+        params.db = "default_cluster:test";
+        params.user = "root";
+        params.user_ip = "%";
+        params.type = TTableType.VIEW;
+        TListTableStatusResult result = frontendService.listTableStatus(params);
+        Assert.assertTrue(result.tables.size() > 0);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12024

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Because in the branch2.3 version, view create is a new version of parser used. And select * from information_schema.views is still using the old version of parser. This causes an error to be reported when show view is present if there is some newly supported syntax in the view, causing the command to fail
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
