### PR TITLE
[Enhancement] Optimize commit quorum wait time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -828,7 +828,13 @@ public class DatabaseTransactionMgr {
                                     && !unfinishedBackends.isEmpty()
                                     && currentTs
                                     - txn.getCommitTime() < Config.quorom_publish_wait_time_ms) {
-                                return false;
+
+                                // if all unfinished backends already down through heartbeat detect, we don't need to wait anymore
+                                for (Long backendID : unfinishedBackends) {
+                                    if (globalStateMgr.getCurrentSystemInfo().checkBackendAlive(backendID)) {
+                                        return false;
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now we using `quorom_publish_wait_time_ms` wait unfinished backends to reduce partial commits caused by slow nodes.
But when we confirm the backend is down(through heartbeat), then there is no need to wait.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
