### PR TITLE
[bugfix][branch-2.2] take unknown compression as no compression

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -114,7 +114,8 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
 
 Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     CompressionTypePB compression_type = return_compression_type_from_filename(_scanner_params.path);
-    if (compression_type != CompressionTypePB::NO_COMPRESSION) {
+    if (compression_type != CompressionTypePB::NO_COMPRESSION &&
+        compression_type != CompressionTypePB::UNKNOWN_COMPRESSION) {
         return Status::InternalError(strings::Substitute("Unsupported compress file format $0", _scanner_params.path));
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksTest/issues/1237

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Takes unknown compression format as no compression, to keep backward-compatibility.

For example, we take 'xxx.tbl' as no compressed file too.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
