### PR TITLE
[Enhancement][Lake] Close DeltaWriter in pthread

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -83,11 +83,12 @@ AsyncDeltaWriterImpl::~AsyncDeltaWriterImpl() {
 }
 
 inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<AsyncDeltaWriterImpl::Task>& iter) {
-    if (iter.is_queue_stopped()) {
-        return 0;
-    }
     auto async_writer = static_cast<AsyncDeltaWriterImpl*>(meta);
     auto delta_writer = async_writer->_writer.get();
+    if (iter.is_queue_stopped()) {
+        delta_writer->close();
+        return 0;
+    }
     auto st = Status{};
     for (; iter; ++iter) {
         // It's safe to run without checking `_closed` but doing so can make the task quit earlier on cancel/error.
@@ -177,10 +178,9 @@ inline void AsyncDeltaWriterImpl::close() {
         r = bthread::execution_queue_join(_queue_id);
         PLOG_IF(WARNING, r != 0) << "Fail to join execution queue";
 
-        // Close and destroy TabletWriter. Since the execution_queue has been stopped and all
+        // Destroy TabletWriter. Since the execution_queue has been stopped and all
         // running tasks have finished, no further execution will call `_writer` anymore, it's
         // safe to destroy it.
-        _writer->close();
         _writer.reset();
     }
 }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -2,6 +2,13 @@
 
 #include "storage/lake/delta_writer.h"
 
+#ifndef NDEBUG
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE("-Wclass-memaccess")
+#include <bthread/bthread.h>
+DIAGNOSTIC_POP
+#endif
+
 #include "column/chunk.h"
 #include "column/column.h"
 #include "gutil/strings/util.h"
@@ -243,14 +250,17 @@ Status DeltaWriter::open() {
 }
 
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size) {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::write() in a bthread";
     return _impl->write(chunk, indexes, indexes_size);
 }
 
 Status DeltaWriter::finish() {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::finish() in a bthread";
     return _impl->finish();
 }
 
 void DeltaWriter::close() {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::close() in a bthread";
     _impl->close();
 }
 
@@ -275,10 +285,12 @@ TabletWriter* DeltaWriter::tablet_writer() {
 }
 
 Status DeltaWriter::flush() {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::flush() in a bthread";
     return _impl->flush();
 }
 
 Status DeltaWriter::flush_async() {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::flush_async() in a bthread";
     return _impl->flush_async();
 }
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -2,12 +2,10 @@
 
 #include "storage/lake/delta_writer.h"
 
-#ifndef NDEBUG
 DIAGNOSTIC_PUSH
 DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include <bthread/bthread.h>
 DIAGNOSTIC_POP
-#endif
 
 #include "column/chunk.h"
 #include "column/column.h"

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -41,18 +41,24 @@ public:
 
     DISALLOW_COPY_AND_MOVE(DeltaWriter);
 
+    // NOTE: It's ok to invoke this method in a bthread, there is no I/O operation in this method.
     [[nodiscard]] Status open();
 
+    // NOTE: Do NOT invoke this method in a bthread.
     [[nodiscard]] Status write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size);
 
+    // NOTE: Do NOT invoke this method in a bthread.
     [[nodiscard]] Status finish();
 
     // Manual flush, mainly used in UT
+    // NOTE: Do NOT invoke this method in a bthread.
     [[nodiscard]] Status flush();
 
     // Manual flush, mainly used in UT
+    // NOTE: Do NOT invoke this method in a bthread.
     [[nodiscard]] Status flush_async();
 
+    // NOTE: Do NOT invoke this method in a bthread unless you are sure that `write()` has never been called.
     void close();
 
     [[nodiscard]] int64_t partition_id() const;


### PR DESCRIPTION
There may be some I/O operations in lake::DeltaWriter::close(), to avoid blocking bthread worker threads, invoke lake::DeltaWriter::close() in pthread instead of bthread.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
