### PR TITLE
[BugFix] Fix _do_merge_horizontally potential crash.

### DIFF
--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -284,7 +284,7 @@ private:
             if (rowsets_mask_buffer && res.value().size() > 1) {
                 std::unique_ptr<vector<RowSourceMask>> rowset_source_masks = std::make_unique<vector<RowSourceMask>>();
                 rowsets_source_masks.emplace_back(std::move(rowset_source_masks));
-                entry.source_masks = rowsets_source_masks[order].get();
+                entry.source_masks = rowsets_source_masks.back().get();
             }
             entry.order = order++;
             auto st = entry.init();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12063

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
the variable order increase outside, the rowsets_source_masks use the order inside, will be out of bound.
```
start time: Tue Oct 11 14:39:28 CST 2022
=================================================================
==11210==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020025b7f18 at pc 0x0000069a880c bp 0x7f7486eb3350 sp 0x7f7486eb3348
READ of size 8 at 0x6020025b7f18 thread T603
    #0 0x69a880b in std::__uniq_ptr_impl<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >::_M_ptr() const /usr/include/c++/10.3.0/bits/unique_ptr.h:173
    #1 0x69a7ba9 in std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >::get() const /usr/include/c++/10.3.0/bits/unique_ptr.h:422
    #2 0x69bfec8 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_horizontally(starrocks::Tablet&, long, starrocks::vectorized::Schema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*, starrocks::vectorized::RowSourceMaskBuffer*, std::vector<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> >, std::allocator<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> > > >*) /root/starrocks/be/src/storage/rowset_merger.cpp:287
    #3 0x69bcade in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_vertically(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, std::vector<std::vector<unsigned int, std::allocator<unsigned int> >, std::allocator<std::vector<unsigned int, std::allocator<unsigned int> > > > const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*) /root/starrocks/be/src/storage/rowset_merger.cpp:407
    #4 0x69b4a2b in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::do_merge(starrocks::Tablet&, long, starrocks::vectorized::Schema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /root/starrocks/be/src/storage/rowset_merger.cpp:224
    #5 0x69aa2b7 in starrocks::vectorized::compaction_merge_rowsets(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /root/starrocks/be/src/storage/rowset_merger.cpp:545
    #6 0x660404e in starrocks::TabletUpdates::_do_compaction(std::unique_ptr<starrocks::CompactionInfo, std::default_delete<starrocks::CompactionInfo> >*) /root/starrocks/be/src/storage/tablet_updates.cpp:1146
    #7 0x66154b5 in starrocks::TabletUpdates::compaction(starrocks::MemTracker*) /root/starrocks/be/src/storage/tablet_updates.cpp:1752
    #8 0x64692a9 in starrocks::StorageEngine::_perform_update_compaction(starrocks::DataDir*) /root/starrocks/be/src/storage/storage_engine.cpp:749
    #9 0x6ad5b1d in starrocks::StorageEngine::_update_compaction_thread_callback(void*, starrocks::DataDir*) /root/starrocks/be/src/storage/olap_server.cpp:270
    #10 0x6ad1537 in operator() /root/starrocks/be/src/storage/olap_server.cpp:178
    #11 0x6ae1657 in __invoke_impl<void, starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:60
    #12 0x6ae11ed in __invoke<starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:95
    #13 0x6ae0ee9 in _M_invoke<0> /usr/include/c++/10.3.0/thread:264
    #14 0x6ae0d21 in operator() /usr/include/c++/10.3.0/thread:271
    #15 0x6ae0b71 in _M_run /usr/include/c++/10.3.0/thread:215
    #16 0x102b738f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/[thread.cc:80](http://thread.cc/)
    #17 0x7f75b2d81ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #18 0x7f75b239c8dc in __clone (/lib64/libc.so.6+0xfe8dc)

0x6020025b7f18 is located 0 bytes to the right of 8-byte region [0x6020025b7f10,0x6020025b7f18)
allocated by thread T603 here:
    #0 0x61158a7 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x6a16c80 in __gnu_cxx::new_allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > >::allocate(unsigned long, void const*) /usr/include/c++/10.3.0/ext/new_allocator.h:115
    #2 0x6a0e533 in std::allocator_traits<std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > > >::allocate(std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > >&, unsigned long) /usr/include/c++/10.3.0/bits/alloc_traits.h:460
    #3 0x6a03bb5 in std::_Vector_base<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >, std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > > >::_M_allocate(unsigned long) /usr/include/c++/10.3.0/bits/stl_vector.h:346
    #4 0x69f53a6 in void std::vector<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >, std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > > >::_M_realloc_insert<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > >(__gnu_cxx::__normal_iterator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >*, std::vector<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >, std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > > > >, std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >&&) (/home/disk1/sr/master_asan/be/lib/starrocks_be+0x69f53a6)
    #5 0x69e7714 in std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >& std::vector<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >, std::allocator<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > > >::emplace_back<std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > > >(std::unique_ptr<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >&&) (/home/disk1/sr/master_asan/be/lib/starrocks_be+0x69e7714)
    #6 0x69bfea7 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_horizontally(starrocks::Tablet&, long, starrocks::vectorized::Schema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*, starrocks::vectorized::RowSourceMaskBuffer*, std::vector<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> >, std::allocator<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> > > >*) /root/starrocks/be/src/storage/rowset_merger.cpp:286
    #7 0x69bcade in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_vertically(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, std::vector<std::vector<unsigned int, std::allocator<unsigned int> >, std::allocator<std::vector<unsigned int, std::allocator<unsigned int> > > > const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*) /root/starrocks/be/src/storage/rowset_merger.cpp:407
    #8 0x69b4a2b in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::do_merge(starrocks::Tablet&, long, starrocks::vectorized::Schema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /root/starrocks/be/src/storage/rowset_merger.cpp:224
    #9 0x69aa2b7 in starrocks::vectorized::compaction_merge_rowsets(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /root/starrocks/be/src/storage/rowset_merger.cpp:545
    #10 0x660404e in starrocks::TabletUpdates::_do_compaction(std::unique_ptr<starrocks::CompactionInfo, std::default_delete<starrocks::CompactionInfo> >*) /root/starrocks/be/src/storage/tablet_updates.cpp:1146
    #11 0x66154b5 in starrocks::TabletUpdates::compaction(starrocks::MemTracker*) /root/starrocks/be/src/storage/tablet_updates.cpp:1752
    #12 0x64692a9 in starrocks::StorageEngine::_perform_update_compaction(starrocks::DataDir*) /root/starrocks/be/src/storage/storage_engine.cpp:749
    #13 0x6ad5b1d in starrocks::StorageEngine::_update_compaction_thread_callback(void*, starrocks::DataDir*) /root/starrocks/be/src/storage/olap_server.cpp:270
    #14 0x6ad1537 in operator() /root/starrocks/be/src/storage/olap_server.cpp:178
    #15 0x6ae1657 in __invoke_impl<void, starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:60
    #16 0x6ae11ed in __invoke<starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:95
    #17 0x6ae0ee9 in _M_invoke<0> /usr/include/c++/10.3.0/thread:264
    #18 0x6ae0d21 in operator() /usr/include/c++/10.3.0/thread:271
    #19 0x6ae0b71 in _M_run /usr/include/c++/10.3.0/thread:215
    #20 0x102b738f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/[thread.cc:80](http://thread.cc/)

Thread T603 created by T0 here:
    #0 0x60bf5a2 in __interceptor_pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x102b7454 in __gthread_create /var/local/gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663
    #2 0x102b7454 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) ../../../.././libstdc++-v3/src/c++11/[thread.cc:135](http://thread.cc:135/)
    #3 0x6add962 in construct<std::thread, starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/ext/new_allocator.h:150
    #4 0x6adbeb8 in construct<std::thread, starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/alloc_traits.h:512
    #5 0x6adaa25 in emplace_back<starrocks::StorageEngine::start_bg_threads()::<lambda()> > /usr/include/c++/10.3.0/bits/vector.tcc:115
    #6 0x6ad3c3f in starrocks::StorageEngine::start_bg_threads() /root/starrocks/be/src/storage/olap_server.cpp:179
    #7 0x6155d5b in main /root/starrocks/be/src/service/starrocks_main.cpp:277
    #8 0x7f75b22c0554 in __libc_start_main (/lib64/libc.so.6+0x22554)

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/include/c++/10.3.0/bits/unique_ptr.h:173 in std::__uniq_ptr_impl<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> >, std::default_delete<std::vector<starrocks::vectorized::RowSourceMask, std::allocator<starrocks::vectorized::RowSourceMask> > > >::_M_ptr() const
Shadow bytes around the buggy address:
  0x0c04804aef90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04804aefa0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04804aefb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04804aefc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04804aefd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c04804aefe0: fa fa 00[fa]fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c04804aeff0: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c04804af000: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c04804af010: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c04804af020: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c04804af030: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==11210==ABORTING
```