### PR TITLE
[Enhancement] Optimize colocate balance on backend restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -198,7 +198,7 @@ public abstract class AlterJobV2 implements Writable {
     }
 
     /**
-     * should be call before executing the job.
+     * should be called before executing the job.
      * return false if table is not stable.
      */
     protected boolean checkTableStable(Database db) throws AlterCancelException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -357,6 +357,25 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    public int getNumOfTabletsPerBucket(GroupId groupId) {
+        List<Long> allTableIds = getAllTableIds(groupId);
+        Database db = GlobalStateMgr.getCurrentState().getDb(groupId.dbId);
+        if (!allTableIds.isEmpty() && db != null) {
+            db.readLock();
+            try {
+                OlapTable tbl = (OlapTable) db.getTable(allTableIds.get(0));
+                if (tbl != null) {
+                    return allTableIds.size() * tbl.getNumberOfPartitions();
+                } else {
+                    return -1;
+                }
+            } finally {
+                db.readUnlock();
+            }
+        }
+        return -1;
+    }
+
     public List<List<Long>> getBackendsPerBucketSeq(GroupId groupId) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -112,7 +112,7 @@ public class OlapTable extends Table implements GsonPostProcessable {
          * this state means table is under PENDING alter operation(SCHEMA_CHANGE or ROLLUP), and is not
          * stable. The tablet scheduler will continue fixing the tablets of this table. And the state will
          * change back to SCHEMA_CHANGE or ROLLUP after table is stable, and continue doing alter operation.
-         * This state is a in-memory state and no need to persist.
+         * This state is an in-memory state and no need to persist.
          */
         WAITING_STABLE
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -865,6 +865,10 @@ public class OlapTable extends Table implements GsonPostProcessable {
         return idToPartition.values();
     }
 
+    public int getNumberOfPartitions() {
+        return idToPartition.size();
+    }
+
     // get only temp partitions
     public Collection<Partition> getTempPartitions() {
         return tempPartitions.getAllPartitions();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -727,7 +727,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
                 return num;
             }
         } else {
-            return 1;
+            return Integer.MAX_VALUE;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -243,7 +243,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
             if (relocateAndBalance(groupId, unavailableBeIdsInGroup, availableBeIds, colocateIndex, infoService,
                     statistic, balancedBackendsPerBucketSeq)) {
                 group2ColocateRelocationInfo.put(groupId,
-                        new ColocateRelocationInfo(!unavailableBeIdsInGroup.isEmpty() ? true : false,
+                        new ColocateRelocationInfo(!unavailableBeIdsInGroup.isEmpty(),
                                 colocateIndex.getBackendsPerBucketSeq(groupId), Maps.newHashMap()));
                 colocateIndex.addBackendsPerBucketSeq(groupId, balancedBackendsPerBucketSeq);
                 ColocatePersistInfo info =

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -90,6 +90,8 @@ public class ColocateTableBalancer extends LeaderDaemon {
         /**
          * Count the number of tablets which have been successfully scheduled by TabletScheduler after a relocation
          * decision has been made.
+         * <p>
+         * bucket index -> number of finished scheduling tablets
          */
         private Map<Integer, Integer> scheduledTabletNumPerBucket;
 
@@ -109,7 +111,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
             return lastBackendsPerBucketSeq;
         }
 
-        public Map<Integer, Integer> getScheduledTabletNumPerBucket() {
+        public synchronized Map<Integer, Integer> getScheduledTabletNumPerBucket() {
             return scheduledTabletNumPerBucket;
         }
 
@@ -221,6 +223,11 @@ public class ColocateTableBalancer extends LeaderDaemon {
             if (inScheduleTabletNum != null && inScheduleTabletNum >= 1L) {
                 LOG.info("colocate group {} still has {} tablets in schedule, won't make new relocation decision",
                         groupId, inScheduleTabletNum);
+                ColocateRelocationInfo info = group2ColocateRelocationInfo.get(groupId);
+                if (info != null) {
+                    LOG.info("number of finished scheduling tablets per bucket: {} for colocate group {}",
+                            info.getScheduledTabletNumPerBucket(), groupId);
+                }
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -197,8 +197,9 @@ public class ColocateTableBalancer extends LeaderDaemon {
 
         // get all groups
         Set<GroupId> groupIds = colocateIndex.getAllGroupIds();
-        Map<GroupId, Long> group2InScheduleTabletNum =
-                globalStateMgr.getTabletScheduler().getTabletsNumInScheduleForEachCG();
+        TabletScheduler tabletScheduler = globalStateMgr.getTabletScheduler();
+        TabletSchedulerStat stat = tabletScheduler.getStat();
+        Map<GroupId, Long> group2InScheduleTabletNum = tabletScheduler.getTabletsNumInScheduleForEachCG();
         for (GroupId groupId : groupIds) {
             Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
             if (db == null) {
@@ -223,6 +224,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
                 continue;
             }
 
+            stat.counterColocateBalanceRound.incrementAndGet();
             Set<Long> unavailableBeIdsInGroup = getUnavailableBeIdsInGroup(infoService, colocateIndex, groupId);
             List<Long> availableBeIds = getAvailableBeIds(infoService);
             List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletStatus;
@@ -204,6 +205,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
     private Set<Long> colocateBackendsSet = null;
     private int tabletOrderIdx = -1;
+    // ID of colocate group that this tablet belongs to
+    private GroupId colocateGroupId = null;
+    private boolean relocationForRepair = false;
 
     private SystemInfoService infoService;
 
@@ -458,6 +462,22 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
     public Set<Long> getColocateBackendsSet() {
         return colocateBackendsSet;
+    }
+
+    public void setColocateGroupId(GroupId gid) {
+        colocateGroupId = gid;
+    }
+
+    public GroupId getColocateGroupId() {
+        return colocateGroupId;
+    }
+
+    public void setRelocationForRepair(boolean isRepair) {
+        relocationForRepair = isRepair;
+    }
+
+    public boolean getRelocationForRepair() {
+        return relocationForRepair;
     }
 
     public void setTabletOrderIdx(int idx) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -661,7 +661,7 @@ public class TabletScheduler extends LeaderDaemon {
 
                 Set<Long> backendsSet = colocateTableIndex.getTabletBackendsByGroup(groupId, tabletOrderIdx);
                 trySkipRelocateSchedAndResetBackendSeq(tabletCtx, partition.getVisibleVersion(),
-                        replicaNum, backendsSet);
+                        replicaNum, backendsSet, tablet);
                 TabletStatus st = tablet.getColocateHealthStatus(
                         partition.getVisibleVersion(),
                         replicaNum,
@@ -733,7 +733,7 @@ public class TabletScheduler extends LeaderDaemon {
      * which have finished scheduling to be scheduled again.
      */
     private void trySkipRelocateSchedAndResetBackendSeq(TabletSchedCtx ctx, long visibleVersion, short replicaNum,
-                                                        Set<Long> currentBackendsSet) {
+                                                        Set<Long> currentBackendsSet, LocalTablet tablet) {
         if (ctx.getRelocationForRepair()) {
             Set<Long> lastBackendsSet = ColocateTableBalancer.getInstance().getLastBackendSeqForBucket(ctx);
             // if we have already reset the backend set to last backend set, skip the reset action
@@ -752,7 +752,7 @@ public class TabletScheduler extends LeaderDaemon {
             int num = ColocateTableBalancer.getInstance().getScheduledTabletNumForBucket(ctx);
             int totalTabletsPerBucket = colocateTableIndex.getNumOfTabletsPerBucket(ctx.getColocateGroupId());
             if (num <= totalTabletsPerBucket * COLOCATE_BACKEND_RESET_RATIO) {
-                TabletStatus st = ctx.getTablet().getColocateHealthStatus(visibleVersion, replicaNum, lastBackendsSet);
+                TabletStatus st = tablet.getColocateHealthStatus(visibleVersion, replicaNum, lastBackendsSet);
                 if (st != TabletStatus.COLOCATE_MISMATCH) {
                     colocateTableIndex.setBackendsSetByIdxForGroup(ctx.getColocateGroupId(),
                             ctx.getTabletOrderIdx(), lastBackendsSet);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -206,6 +206,10 @@ public class TabletScheduler extends LeaderDaemon {
         currentSlotPerPathConfig = cappedVal;
 
         ImmutableMap<Long, Backend> backends = infoService.getIdToBackend();
+        if (backends == null) {
+            return false;
+        }
+
         for (Backend backend : backends.values()) {
             if (!backend.hasPathHash() && backend.isAlive()) {
                 // when upgrading, backend may not get path info yet. so return false and wait for next round.
@@ -746,8 +750,9 @@ public class TabletScheduler extends LeaderDaemon {
                 if (st != TabletStatus.COLOCATE_MISMATCH) {
                     colocateTableIndex.setBackendsSetByIdxForGroup(ctx.getColocateGroupId(),
                             ctx.getTabletOrderIdx(), lastBackendsSet);
-                    LOG.info("all current backends are available for tablet {}, reset backend set to: {}" +
-                            " for colocate group {}, before backend set: {}", ctx.getTabletId(), lastBackendsSet,
+                    LOG.info("all current backends are available for tablet {}, bucket index: {}, reset backend set to: {}" +
+                            " for colocate group {}, before backend set: {}", ctx.getTabletId(),
+                            ctx.getTabletOrderIdx(), lastBackendsSet,
                             ctx.getColocateGroupId(), currentBackendsSet);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -715,8 +715,8 @@ public class TabletScheduler extends LeaderDaemon {
      * If all the replicas for tablets that belongs to some bucket are healthy(e.g. previously
      * considered not alive backend comes alive or backend decommission is canceled), in this case,
      * we don't really need to continue to execute the previously made relocation decision, we just
-     * cancel the scheduling by setting the status to HEALTHY.<p>
-     *
+     * cancel the scheduling by setting the status to HEALTHY.
+     * <p>
      * If some tablets belongs to the same bucket are already scheduled based on the new backend sequence,
      * we won't try to skip the current scheduling and reset the backend sequence because this will cause the tablets
      * which have finished scheduling to be scheduled again.
@@ -1108,6 +1108,7 @@ public class TabletScheduler extends LeaderDaemon {
      */
     private boolean handleColocateRedundant(TabletSchedCtx tabletCtx) throws SchedException {
         Preconditions.checkNotNull(tabletCtx.getColocateBackendsSet());
+        stat.counterReplicaColocateRedundant.incrementAndGet();
         for (Replica replica : tabletCtx.getReplicas()) {
             if (tabletCtx.getColocateBackendsSet().contains(replica.getBackendId())) {
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -724,8 +724,6 @@ public class TabletScheduler extends LeaderDaemon {
      * If some tablets belongs to the same bucket are already scheduled based on the new backend sequence,
      * we won't try to skip the current scheduling and reset the backend sequence because this will cause the tablets
      * which have finished scheduling to be scheduled again.
-     *
-     * @return true, if we can skip the schedule, otherwise false
      */
     private void trySkipRelocateSchedAndResetBackendSeq(TabletSchedCtx ctx, long visibleVersion, short replicaNum,
                                                         Set<Long> currentBackendsSet) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -746,6 +746,9 @@ public class TabletScheduler extends LeaderDaemon {
                 if (st != TabletStatus.COLOCATE_MISMATCH) {
                     colocateTableIndex.setBackendsSetByIdxForGroup(ctx.getColocateGroupId(),
                             ctx.getTabletOrderIdx(), lastBackendsSet);
+                    LOG.info("all current backends are available for tablet {}, reset backend set to: {}" +
+                            " for colocate group {}, before backend set: {}", ctx.getTabletId(), lastBackendsSet,
+                            ctx.getColocateGroupId(), currentBackendsSet);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
@@ -114,6 +114,8 @@ public class TabletSchedulerStat {
     public AtomicLong counterReplicaColocateMismatch = new AtomicLong(0L);
     @StatField("num of colocate replica redundant")
     public AtomicLong counterReplicaColocateRedundant = new AtomicLong(0L);
+    @StatField("num of ")
+    public AtomicLong counterColocateBalanceRound = new AtomicLong(0L);
 
     private TabletSchedulerStat lastSnapshot = null;
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
@@ -114,7 +114,7 @@ public class TabletSchedulerStat {
     public AtomicLong counterReplicaColocateMismatch = new AtomicLong(0L);
     @StatField("num of colocate replica redundant")
     public AtomicLong counterReplicaColocateRedundant = new AtomicLong(0L);
-    @StatField("num of ")
+    @StatField("num of colocate balancer running round")
     public AtomicLong counterColocateBalanceRound = new AtomicLong(0L);
 
     private TabletSchedulerStat lastSnapshot = null;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1215,7 +1215,7 @@ public class ReportHandler extends Daemon {
                         + olapTable.getSchemaHashByIndexId(indexId) + "]");
             }
 
-            // colocate table will delete Replica in meta when balance
+            // colocate table will delete Replica in meta when balancing,
             // but we need to rely on MetaNotFoundException to decide whether delete the tablet in backend.
             // delete tablet from backend if colocate tablet is healthy.
             ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentColocateIndex();
@@ -1298,7 +1298,7 @@ public class ReportHandler extends Daemon {
             try {
                 task = reportQueue.take();
                 synchronized (pendingTaskMap) {
-                    // using lastest task
+                    // using the lastest task
                     task = pendingTaskMap.get(task.type).get(task.beId);
                     if (task == null) {
                         throw new Exception("pendingTaskMap not exists " + task.beId);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -731,7 +731,7 @@ public class ColocateTableBalancerTest {
     }
 
     @Test
-    public void testMatchGroup() throws Exception {
+    public void testMatchGroup() {
         Database database = GlobalStateMgr.getCurrentState().getDb("db1");
         OlapTable table = (OlapTable) database.getTable("tbl");
         // add its tablet to TabletScheduler

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -53,6 +53,8 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -765,6 +767,13 @@ public class ColocateTableBalancerTest {
         Database database = GlobalStateMgr.getCurrentState().getDb("db1");
         OlapTable table = (OlapTable) database.getTable("tbl");
         addTabletsToScheduler("db1", "tbl", false);
+
+        ColocateTableIndex colocateIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<List<Long>> bl = Lists.newArrayList();
+        bl.add(new ArrayList<>(Arrays.asList(1L, 2L, 3L)));
+        bl.add(new ArrayList<>(Arrays.asList(1L, 2L, 3L)));
+        bl.add(new ArrayList<>(Arrays.asList(1L, 2L, 3L)));
+        colocateIndex.addBackendsPerBucketSeq(colocateIndex.getGroup(table.getId()), Lists.newArrayList(bl));
 
         // test if group is unstable when all its tablets are in TabletScheduler
         long tableId = table.getId();

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -2,14 +2,17 @@
 
 package com.starrocks.clone;
 
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -30,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TabletSchedulerTest {
@@ -198,5 +202,43 @@ public class TabletSchedulerTest {
 
         freeSlotNTimes(2, bslots.get(1L), 11L);
         Assert.assertEquals(bslots.get(1L).peekSlot(11), bslots.get(1L).getSlotTotal(11));
+    }
+
+    @Test
+    public void testGetTabletsNumInScheduleForEachCG() {
+        TabletScheduler tabletScheduler =
+                new TabletScheduler(globalStateMgr, systemInfoService, tabletInvertedIndex, tabletSchedulerStat);
+        Map<Long, ColocateTableIndex.GroupId> tabletIdToCGIdForPending = Maps.newHashMap();
+        tabletIdToCGIdForPending.put(101L, new ColocateTableIndex.GroupId(200L, 300L));
+        tabletIdToCGIdForPending.put(102L, new ColocateTableIndex.GroupId(200L, 300L));
+        tabletIdToCGIdForPending.put(103L, new ColocateTableIndex.GroupId(200L, 301L));
+        tabletIdToCGIdForPending.forEach((k, v) -> {
+            TabletSchedCtx ctx = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, 200L, 201L, 202L,
+                    203L, k, System.currentTimeMillis());
+            ctx.setColocateGroupId(v);
+            ctx.setOrigPriority(TabletSchedCtx.Priority.LOW);
+            Deencapsulation.invoke(tabletScheduler, "addToPendingTablets", ctx);
+        });
+
+        Map<Long, ColocateTableIndex.GroupId> tabletIdToCGIdForRunning = Maps.newHashMap();
+        tabletIdToCGIdForRunning.put(104L, new ColocateTableIndex.GroupId(200L, 300L));
+        tabletIdToCGIdForRunning.put(105L, new ColocateTableIndex.GroupId(200L, 300L));
+        tabletIdToCGIdForRunning.put(106L, new ColocateTableIndex.GroupId(200L, 301L));
+        tabletIdToCGIdForRunning.forEach((k, v) -> {
+            TabletSchedCtx ctx = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, 200L, 201L, 202L,
+                    203L, k, System.currentTimeMillis());
+            ctx.setColocateGroupId(v);
+            ctx.setOrigPriority(TabletSchedCtx.Priority.LOW);
+            if (k == 104L) {
+                ctx.setTabletStatus(LocalTablet.TabletStatus.VERSION_INCOMPLETE);
+            }
+            Deencapsulation.invoke(tabletScheduler, "addToRunningTablets", ctx);
+        });
+
+        Map<ColocateTableIndex.GroupId, Long> result = tabletScheduler.getTabletsNumInScheduleForEachCG();
+        Assert.assertEquals(Optional.of(3L).get(),
+                result.get(new ColocateTableIndex.GroupId(200L, 300L)));
+        Assert.assertEquals(Optional.of(2L).get(),
+                result.get(new ColocateTableIndex.GroupId(200L, 301L)));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10619

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This pr mainly do three things:
1. Won't make new relocation decision if there is still colocate relocation tasks in schedule.
    We want the previous relocation decision is handled completely before new decision is made, so
    this won't trigger concurrent relocation decision and may mess up the scheduling.
2. Let colocate repair take precedence over colocate balance because repair is more urgent to finish.
    If there is unavailable backend, balance task won't be scheduled.
3. Support fast recovery of scheduled tablets if previously considered backend comes alive, which can
    avoid lots of COLOCATE_MISMATCH task being scheduled and accelerate the colocate group to be
    in stable state.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
