### PR TITLE
[Feature] tablet sink pipeline dop set

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -445,7 +445,8 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
         }
-        RETURN_IF_ERROR(_decompose_data_sink_to_operator(runtime_state, &context, request, datasink));
+        RETURN_IF_ERROR(_decompose_data_sink_to_operator(runtime_state, &context, request, datasink, tsink,
+                                                         fragment.output_exprs));
     }
     RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());
 
@@ -647,7 +648,9 @@ std::shared_ptr<ExchangeSinkOperatorFactory> _create_exchange_sink_operator(Pipe
 
 Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_state, PipelineBuilderContext* context,
                                                           const UnifiedExecPlanFragmentParams& request,
-                                                          std::unique_ptr<starrocks::DataSink>& datasink) {
+                                                          std::unique_ptr<starrocks::DataSink>& datasink,
+                                                          const TDataSink& thrift_sink,
+                                                          const std::vector<TExpr>& output_exprs) {
     auto fragment_ctx = context->fragment_context();
     if (typeid(*datasink) == typeid(starrocks::ResultSink)) {
         ResultSink* result_sink = down_cast<starrocks::ResultSink*>(datasink.get());
@@ -720,11 +723,71 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             fragment_ctx->pipelines().emplace_back(pp);
         }
     } else if (typeid(*datasink) == typeid(starrocks::stream_load::OlapTableSink)) {
-        runtime_state->set_per_fragment_instance_idx(request.sender_id());
+        size_t desired_tablet_sink_dop = request.pipeline_sink_dop();
+        DCHECK(desired_tablet_sink_dop > 0);
+        size_t source_operator_dop =
+                fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
+
         runtime_state->set_num_per_fragment_instances(request.common().params.num_senders);
-        OpFactoryPtr op =
-                std::make_shared<OlapTableSinkOperatorFactory>(context->next_operator_id(), datasink, fragment_ctx);
-        fragment_ctx->pipelines().back()->add_op_factory(op);
+        std::vector<std::unique_ptr<starrocks::stream_load::OlapTableSink>> tablet_sinks;
+        for (int i = 1; i < desired_tablet_sink_dop; i++) {
+            Status st;
+            std::unique_ptr<starrocks::stream_load::OlapTableSink> sink =
+                    std::make_unique<starrocks::stream_load::OlapTableSink>(runtime_state->obj_pool(), output_exprs,
+                                                                            &st);
+            RETURN_IF_ERROR(st);
+            if (sink != nullptr) {
+                RETURN_IF_ERROR(sink->init(thrift_sink));
+            }
+            RuntimeProfile* sink_profile = sink->profile();
+            if (sink_profile != nullptr) {
+                runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
+            }
+            tablet_sinks.emplace_back(std::move(sink));
+        }
+        OpFactoryPtr tablet_sink_op = std::make_shared<OlapTableSinkOperatorFactory>(
+                context->next_operator_id(), datasink, fragment_ctx, request.sender_id(), desired_tablet_sink_dop,
+                tablet_sinks);
+        // FE will pre-set the parallelism for all fragment instance which contains the tablet sink,
+        // For stream load, routine load or broker load, the desired_tablet_sink_dop set
+        // by FE is same as the source_operator_dop.
+        // For insert into select, in the simplest case like insert into table select * from table2;
+        // the desired_tablet_sink_dop set by FE is same as the source_operator_dop.
+        // However, if the select statement is complex, like insert into table select * from table2 limit 1,
+        // the desired_tablet_sink_dop set by FE is same as the source_operator_dop, and it needs to
+        // add a local passthrough exchange here
+        if (desired_tablet_sink_dop != source_operator_dop) {
+            std::vector<OpFactories> pred_operators_list;
+            pred_operators_list.push_back(fragment_ctx->pipelines().back()->get_op_factories());
+
+            size_t max_row_count = 0;
+            auto* source_operator =
+                    down_cast<SourceOperatorFactory*>(fragment_ctx->pipelines().back()->get_op_factories()[0].get());
+            max_row_count += source_operator->degree_of_parallelism() * runtime_state->chunk_size();
+
+            auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
+            auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(
+                    max_row_count * PipelineBuilderContext::localExchangeBufferChunks());
+            auto local_exchange_source = std::make_shared<LocalExchangeSourceOperatorFactory>(
+                    context->next_operator_id(), pseudo_plan_node_id, mem_mgr);
+            local_exchange_source->set_runtime_state(runtime_state);
+            auto exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
+
+            auto local_exchange_sink = std::make_shared<LocalExchangeSinkOperatorFactory>(
+                    context->next_operator_id(), pseudo_plan_node_id, exchanger);
+            fragment_ctx->pipelines().back()->add_op_factory(local_exchange_sink);
+
+            OpFactories operators_source_with_local_exchange;
+            local_exchange_source->set_degree_of_parallelism(desired_tablet_sink_dop);
+            operators_source_with_local_exchange.emplace_back(std::move(local_exchange_source));
+            operators_source_with_local_exchange.emplace_back(std::move(tablet_sink_op));
+
+            auto pipeline_with_local_exchange_source =
+                    std::make_shared<Pipeline>(context->next_pipe_id(), operators_source_with_local_exchange);
+            fragment_ctx->pipelines().emplace_back(std::move(pipeline_with_local_exchange_source));
+        } else {
+            fragment_ctx->pipelines().back()->add_op_factory(std::move(tablet_sink_op));
+        }
     } else if (typeid(*datasink) == typeid(starrocks::ExportSink)) {
         ExportSink* export_sink = down_cast<starrocks::ExportSink*>(datasink.get());
         auto dop = fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -51,6 +51,10 @@ public:
     // Access the unique fields by the following methods.
     int32_t backend_num() const { return _unique_request.backend_num; }
     int32_t pipeline_dop() const { return _unique_request.__isset.pipeline_dop ? _unique_request.pipeline_dop : 0; }
+    int32_t pipeline_sink_dop() const {
+        return _unique_request.params.__isset.pipeline_sink_dop ? _unique_request.params.pipeline_sink_dop : 0;
+    }
+
     const TUniqueId& fragment_instance_id() const { return _unique_request.params.fragment_instance_id; }
     int32_t sender_id() const { return _unique_request.params.sender_id; }
 
@@ -99,7 +103,8 @@ private:
 
     Status _decompose_data_sink_to_operator(RuntimeState* runtime_state, PipelineBuilderContext* context,
                                             const UnifiedExecPlanFragmentParams& request,
-                                            std::unique_ptr<starrocks::DataSink>& datasink);
+                                            std::unique_ptr<starrocks::DataSink>& datasink,
+                                            const TDataSink& thrift_sink, const std::vector<TExpr>& output_exprs);
 
     int64_t _fragment_start_time = 0;
     QueryContext* _query_ctx = nullptr;

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -75,6 +75,8 @@ public:
     // disable to ignore local data after aggregations with profile exchange speed.
     bool has_aggregation = false;
 
+    static int localExchangeBufferChunks() { return kLocalExchangeBufferChunks; }
+
 private:
     static constexpr int kLocalExchangeBufferChunks = 8;
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -662,9 +662,7 @@ Status NodeChannel::close_wait(RuntimeState* state) {
     RETURN_IF_ERROR(_wait_all_prev_request());
 
     // 3. commit tablet infos
-    state->tablet_commit_infos().insert(state->tablet_commit_infos().end(),
-                                        std::make_move_iterator(_tablet_commit_infos.begin()),
-                                        std::make_move_iterator(_tablet_commit_infos.end()));
+    state->append_tablet_commit_infos(_tablet_commit_infos);
 
     return _err_st;
 }
@@ -1380,9 +1378,7 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
         COUNTER_SET(_send_rpc_timer, actual_consume_ns);
 
         // _number_input_rows don't contain num_rows_load_filtered and num_rows_load_unselected in scan node
-        int64_t num_rows_load_total =
-                _number_input_rows + state->num_rows_load_filtered() + state->num_rows_load_unselected();
-        state->set_num_rows_load_from_sink(num_rows_load_total);
+        state->update_num_rows_load_from_sink(state->num_rows_load_filtered() + state->num_rows_load_unselected());
         state->update_num_rows_load_filtered(_number_filtered_rows);
 
         // print log of add batch time of all node, for tracing load performance easily

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -284,6 +284,8 @@ public:
     // Returns the runtime profile for the sink.
     RuntimeProfile* profile() override { return _profile; }
 
+    ObjectPool* pool() { return _pool; }
+
 private:
     template <PrimitiveType PT>
     void _validate_decimal(RuntimeState* state, vectorized::Column* column, const SlotDescriptor* desc,

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -312,6 +312,7 @@ bool RuntimeState::has_reached_max_error_msg_num(bool is_summary) {
 }
 
 void RuntimeState::append_error_msg_to_file(const std::string& line, const std::string& error_msg, bool is_summary) {
+    std::lock_guard<std::mutex> l(_error_log_lock);
     if (_query_options.query_type != TQueryType::LOAD) {
         return;
     }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -286,6 +286,12 @@ public:
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }
 
+    void append_tablet_commit_infos(std::vector<TTabletCommitInfo>& commit_info) {
+        std::lock_guard<std::mutex> l(_tablet_commit_infos_lock);
+        _tablet_commit_infos.insert(_tablet_commit_infos.end(), std::make_move_iterator(commit_info.begin()),
+                                    std::make_move_iterator(commit_info.end()));
+    }
+
     // get mem limit for load channel
     // if load mem limit is not set, or is zero, using query mem limit instead.
     int64_t get_load_mem_limit() const;
@@ -411,6 +417,7 @@ private:
 
     std::string _error_log_file_path;
     std::ofstream* _error_log_file = nullptr; // error file path, absolute path
+    std::mutex _tablet_commit_infos_lock;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
 
     // prohibit copies

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -108,6 +108,7 @@ public class LoadLoadingTask extends LoadTask {
         if (!Config.enable_pipeline_load) {
             planner = new LoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc, fileGroups,
                     strictMode, timezone, timeoutS, createTimestamp, partialUpdate, sessionVariables);
+            planner.setConnectContext(context);
             planner.plan(loadId, fileStatusList, fileNum);
         } else {
             loadPlanner = new LoadPlanner(callback.getCallbackId(), loadId, txnId, db.getId(), table, strictMode,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -102,6 +102,7 @@ public class LoadingTaskPlanner {
     private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
 
     private Map<String, String> sessionVariables = null;
+    ConnectContext context = null;
 
     public LoadingTaskPlanner(Long loadJobId, long txnId, long dbId, OlapTable table,
             BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
@@ -120,6 +121,10 @@ public class LoadingTaskPlanner {
         this.parallelInstanceNum = Config.load_parallel_instance_num;
         this.startTime = startTime;
         this.sessionVariables = sessionVariables;
+    }
+
+    public void setConnectContext(ConnectContext context) {
+        this.context = context;
     }
 
     public void plan(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusesList, int filesAdded)
@@ -188,8 +193,7 @@ public class LoadingTaskPlanner {
         TWriteQuorumType writeQuorum = table.writeQuorum();
 
         List<Long> partitionIds = getAllPartitionIds();
-        // Parallel pipeline loads are currently not supported, so disable the pipeline engine when users need parallel load
-        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, parallelInstanceNum <= 1, writeQuorum);
+        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, true, writeQuorum);
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
         olapTableSink.complete();
 
@@ -197,12 +201,21 @@ public class LoadingTaskPlanner {
         // 3. Plan fragment
         PlanFragment sinkFragment = new PlanFragment(new PlanFragmentId(0), scanNode, DataPartition.RANDOM);
         sinkFragment.setSink(olapTableSink);
-        // At present, we only support dop=1 for olap table sink.
-        // because tablet writing needs to know the number of senders in advance
-        // and guaranteed order of data writing
-        // It can be parallel only in some scenes, for easy use 1 dop now.
-        sinkFragment.setPipelineDop(1);
-        sinkFragment.setParallelExecNum(parallelInstanceNum);
+
+        if (this.context != null) {
+            if (this.context.getSessionVariable().isEnablePipelineEngine() && Config.enable_pipeline_load) {
+                sinkFragment.setPipelineDop(parallelInstanceNum);
+                sinkFragment.setParallelExecNum(1);
+                sinkFragment.setHasOlapTableSink();
+                sinkFragment.setForceAssignScanRangesPerDriverSeq();
+            } else {
+                sinkFragment.setPipelineDop(1);
+                sinkFragment.setParallelExecNum(parallelInstanceNum);
+            }
+        } else {
+            sinkFragment.setPipelineDop(1);
+            sinkFragment.setParallelExecNum(parallelInstanceNum);
+        }
         // After data loading, we need to check the global dict for low cardinality string column
         // whether update.
         sinkFragment.setLoadGlobalDicts(globalDicts);
@@ -231,7 +244,6 @@ public class LoadingTaskPlanner {
 
         // 3. Scan plan fragment
         PlanFragment scanFragment = new PlanFragment(new PlanFragmentId(0), scanNode, DataPartition.RANDOM);
-        scanFragment.setParallelExecNum(parallelInstanceNum);
 
         fragments.add(scanFragment);
 
@@ -256,19 +268,26 @@ public class LoadingTaskPlanner {
         TWriteQuorumType writeQuorum = table.writeQuorum();
 
         List<Long> partitionIds = getAllPartitionIds();
-        // Parallel pipeline loads are currently not supported, so disable the pipeline engine when users need parallel load
-        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, parallelInstanceNum <= 1, writeQuorum);
+
+        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, true, writeQuorum);
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
         olapTableSink.complete();
 
         // 6. Sink plan fragment
         sinkFragment.setSink(olapTableSink);
-        // At present, we only support dop=1 for olap table sink.
-        // because tablet writing needs to know the number of senders in advance
-        // and guaranteed order of data writing
-        // It can be parallel only in some scenes, for easy use 1 dop now.
-        sinkFragment.setPipelineDop(1);
-        sinkFragment.setParallelExecNum(parallelInstanceNum);
+        // For shuffle broker load, we only support tablet sink dop = 1
+        // because for tablet sink dop > 1, local passthourgh exchange will influence the order of sending,
+        // which may lead to inconsistent replica for primary key.
+        // If you want to set tablet sink dop > 1, please enable single tablet loading and disable shuffle service
+        if (this.context != null) {
+            if (this.context.getSessionVariable().isEnablePipelineEngine() && Config.enable_pipeline_load) {
+                sinkFragment.setHasOlapTableSink();
+                sinkFragment.setForceSetTableSinkDop();
+                sinkFragment.setForceAssignScanRangesPerDriverSeq();
+            }
+            sinkFragment.setPipelineDop(1);
+            sinkFragment.setParallelExecNum(parallelInstanceNum);
+        }
         // After data loading, we need to check the global dict for low cardinality string column
         // whether update.
         sinkFragment.setLoadGlobalDicts(globalDicts);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -145,6 +145,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private ByteBuffer digest = null;
     private Map<Integer, Integer> slotRemapping = Maps.newHashMap();
     private Map<Long, String> rangeMap = Maps.newHashMap();
+    private boolean hasOlapTableSink = false;
+    private boolean forceSetTableSinkDop = false;
+    private boolean forceAssignScanRangesPerDriverSeq = false;
 
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
@@ -222,6 +225,22 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.pipelineDop = dop;
     }
 
+    public boolean hasOlapTableSink() {
+        return this.hasOlapTableSink;
+    }
+
+    public void setHasOlapTableSink() {
+        this.hasOlapTableSink = true;
+    }
+
+    public boolean forceSetTableSinkDop() {
+        return this.forceSetTableSinkDop;
+    }
+
+    public void setForceSetTableSinkDop() {
+        this.forceSetTableSinkDop = true;
+    }
+
     public void setEnableSharedScan(boolean enable) {
         this.enableSharedScan = enable;
     }
@@ -236,6 +255,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setAssignScanRangesPerDriverSeq(boolean assignScanRangesPerDriverSeq) {
         this.assignScanRangesPerDriverSeq = assignScanRangesPerDriverSeq;
+    }
+
+    public boolean isForceAssignScanRangesPerDriverSeq() {
+        return forceAssignScanRangesPerDriverSeq;
+    }
+
+    public void setForceAssignScanRangesPerDriverSeq() {
+        this.forceAssignScanRangesPerDriverSeq = true;
     }
 
     public void computeLocalRfWaitingSet(PlanNode root, boolean clearGlobalRuntimeFilter) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -778,6 +778,28 @@ public class Coordinator {
                     infightFInstanceExecParamList.add(params.instanceExecParams);
                 }
 
+                // if pipeline is enable and current fragment contain olap table sink, in fe we will 
+                // calculate the number of all tablet sinks in advance and assign them to each fragment instance
+                boolean enablePipelineTableSinkDop = enablePipelineEngine && fragment.hasOlapTableSink();
+                boolean forceSetTableSinkDop = fragment.forceSetTableSinkDop();
+                int tabletSinkTotalDop = 0;
+                int accTabletSinkDop = 0;
+                if (enablePipelineTableSinkDop) {
+                    for (List<FInstanceExecParam> fInstanceExecParamList : infightFInstanceExecParamList) {
+                        for (FInstanceExecParam instanceExecParam : fInstanceExecParamList) {
+                            if (!forceSetTableSinkDop) {
+                                tabletSinkTotalDop += instanceExecParam.getPipelineDop();
+                            } else {
+                                tabletSinkTotalDop += fragment.getPipelineDop();
+                            }
+                        }
+                    }
+                }
+
+                if (tabletSinkTotalDop < 0) {
+                    throw new UserException("tabletSinkTotalDop = " + String.valueOf(tabletSinkTotalDop) + " should be >= 0");
+                }
+
                 boolean isFirst = true;
                 for (List<FInstanceExecParam> fInstanceExecParamList : infightFInstanceExecParamList) {
                     TDescriptorTable descTable = new TDescriptorTable();
@@ -796,7 +818,17 @@ public class Coordinator {
                     Map<TUniqueId, TNetworkAddress> instanceId2Host =
                             fInstanceExecParamList.stream().collect(Collectors.toMap(f -> f.instanceId, f -> f.host));
                     List<TExecPlanFragmentParams> tParams =
-                            params.toThrift(instanceId2Host.keySet(), descTable, dbIds, enablePipelineEngine);
+                            params.toThrift(instanceId2Host.keySet(), descTable, dbIds, enablePipelineEngine,
+                                accTabletSinkDop, tabletSinkTotalDop);
+                    if (enablePipelineTableSinkDop) {
+                        for (FInstanceExecParam instanceExecParam : fInstanceExecParamList) {
+                            if (!forceSetTableSinkDop) {
+                                accTabletSinkDop += instanceExecParam.getPipelineDop();
+                            } else {
+                                accTabletSinkDop += fragment.getPipelineDop();
+                            }
+                        }
+                    }
                     List<Pair<BackendExecState, Future<PExecPlanFragmentResult>>> futures = Lists.newArrayList();
 
                     // This is a load process, and it is the first fragment.
@@ -1015,6 +1047,29 @@ public class Coordinator {
                     Map<TNetworkAddress, List<FInstanceExecParam>> requestsPerHost = params.instanceExecParams.stream()
                             .collect(Collectors.groupingBy(FInstanceExecParam::getHost, HashMap::new,
                                     Collectors.mapping(Function.identity(), Collectors.toList())));
+                    // if pipeline is enable and current fragment contain olap table sink, in fe we will 
+                    // calculate the number of all tablet sinks in advance and assign them to each fragment instance
+                    boolean enablePipelineTableSinkDop = enablePipelineEngine && fragment.hasOlapTableSink();
+                    boolean forceSetTableSinkDop = fragment.forceSetTableSinkDop();
+                    int tabletSinkTotalDop = 0;
+                    int accTabletSinkDop = 0;
+                    if (enablePipelineTableSinkDop) {
+                        for (Map.Entry<TNetworkAddress, List<FInstanceExecParam>> hostAndRequests : 
+                                    requestsPerHost.entrySet()) {
+                            List<FInstanceExecParam> requests = hostAndRequests.getValue();
+                            for (FInstanceExecParam request : requests) {
+                                if (!forceSetTableSinkDop) {
+                                    tabletSinkTotalDop += request.getPipelineDop();
+                                } else {
+                                    tabletSinkTotalDop += fragment.getPipelineDop();
+                                }
+                            }
+                        }
+                    }
+
+                    if (tabletSinkTotalDop < 0) {
+                        throw new UserException("tabletSinkTotalDop = " + String.valueOf(tabletSinkTotalDop) + " should be >= 0");
+                    }
 
                     for (Map.Entry<TNetworkAddress, List<FInstanceExecParam>> hostAndRequests : requestsPerHost.entrySet()) {
                         TNetworkAddress host = hostAndRequests.getKey();
@@ -1047,7 +1102,17 @@ public class Coordinator {
                                 .map(FInstanceExecParam::getInstanceId)
                                 .collect(Collectors.toSet());
                         TExecBatchPlanFragmentsParams tRequest =
-                                params.toThriftInBatch(curInstanceIds, host, curDescTable, dbIds, enablePipelineEngine);
+                                params.toThriftInBatch(curInstanceIds, host, curDescTable, dbIds, enablePipelineEngine, 
+                                    accTabletSinkDop, tabletSinkTotalDop);
+                        if (enablePipelineTableSinkDop) {
+                            for (FInstanceExecParam request : requests) {
+                                if (!forceSetTableSinkDop) {
+                                    accTabletSinkDop += request.getPipelineDop();
+                                } else {
+                                    accTabletSinkDop += fragment.getPipelineDop();
+                                }
+                            }
+                        }
                         TExecPlanFragmentParams tCommonParams = tRequest.getCommon_param();
                         List<TExecPlanFragmentParams> tUniqueParamsList = tRequest.getUnique_param_per_instance();
                         Preconditions.checkState(!tUniqueParamsList.isEmpty());
@@ -1884,7 +1949,8 @@ public class Coordinator {
                         parallelExecInstanceNum, pipelineDop, usePipeline, params);
                 computeBucketSeq2InstanceOrdinal(params, fragmentIdToBucketNumMap.get(fragment.getFragmentId()));
             } else {
-                boolean assignScanRangesPerDriverSeq = usePipeline && fragment.isAssignScanRangesPerDriverSeq();
+                boolean assignScanRangesPerDriverSeq = usePipeline && 
+                        (fragment.isAssignScanRangesPerDriverSeq() || fragment.isForceAssignScanRangesPerDriverSeq());
                 for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> tNetworkAddressMapEntry :
                         fragmentExecParamsMap.get(fragment.getFragmentId()).scanRangeAssignment.entrySet()) {
                     TNetworkAddress key = tNetworkAddressMapEntry.getKey();
@@ -1909,7 +1975,8 @@ public class Coordinator {
                             params.instanceExecParams.add(instanceParam);
 
                             boolean assignPerDriverSeq = assignScanRangesPerDriverSeq &&
-                                    enableAssignScanRangesPerDriverSeq(scanRangeParams, pipelineDop);
+                                    (enableAssignScanRangesPerDriverSeq(scanRangeParams, pipelineDop) 
+                                    || fragment.isForceAssignScanRangesPerDriverSeq());
                             if (!assignPerDriverSeq) {
                                 instanceParam.perNodeScanRanges.put(planNodeId, scanRangeParams);
                             } else {
@@ -2944,7 +3011,8 @@ public class Coordinator {
          */
         private void toThriftForCommonParams(TExecPlanFragmentParams commonParams,
                                              TNetworkAddress destHost, TDescriptorTable descTable,
-                                             boolean isEnablePipelineEngine) {
+                                             boolean isEnablePipelineEngine, int tabletSinkTotalDop) {
+            boolean enablePipelineTableSinkDop = isEnablePipelineEngine && fragment.hasOlapTableSink();
             commonParams.setProtocol_version(InternalServiceVersion.V1);
             commonParams.setFragment(fragment.toThrift());
             commonParams.setDesc_tbl(descTable);
@@ -2956,7 +3024,11 @@ public class Coordinator {
             commonParams.params.setQuery_id(queryId);
             commonParams.params.setInstances_number(hostToNumbers.get(destHost));
             commonParams.params.setDestinations(destinations);
-            commonParams.params.setNum_senders(instanceExecParams.size());
+            if (enablePipelineTableSinkDop) {
+                commonParams.params.setNum_senders(tabletSinkTotalDop);
+            } else {
+                commonParams.params.setNum_senders(instanceExecParams.size());
+            }
             commonParams.params.setPer_exch_num_senders(perExchNumSenders);
             if (runtimeFilterParams.isSetRuntime_filter_builder_number()) {
                 commonParams.params.setRuntime_filter_params(runtimeFilterParams);
@@ -3006,8 +3078,13 @@ public class Coordinator {
          * @param enablePipelineEngine Whether enable pipeline engine.
          */
         private void toThriftForUniqueParams(TExecPlanFragmentParams uniqueParams, int fragmentIndex,
-                                             FInstanceExecParam instanceExecParam, boolean enablePipelineEngine)
+                                             FInstanceExecParam instanceExecParam, boolean enablePipelineEngine,
+                                             int accTabletSinkDop, int curTabletSinkDop)
                 throws Exception {
+            // if pipeline is enable and current fragment contain olap table sink, in fe we will 
+            // calculate the number of all tablet sinks in advance and assign them to each fragment instance
+            boolean enablePipelineTableSinkDop = enablePipelineEngine && fragment.hasOlapTableSink();
+
             uniqueParams.setProtocol_version(InternalServiceVersion.V1);
             uniqueParams.setBackend_num(instanceExecParam.backendNum);
             if (enablePipelineEngine) {
@@ -3062,7 +3139,12 @@ public class Coordinator {
             uniqueParams.params.setPer_node_scan_ranges(scanRanges);
             uniqueParams.params.setNode_to_per_driver_seq_scan_ranges(instanceExecParam.nodeToPerDriverSeqScanRanges);
 
-            uniqueParams.params.setSender_id(fragmentIndex);
+            if (enablePipelineTableSinkDop) {
+                uniqueParams.params.setSender_id(accTabletSinkDop);
+                uniqueParams.params.setPipeline_sink_dop(curTabletSinkDop);
+            } else {
+                uniqueParams.params.setSender_id(fragmentIndex);
+            }
         }
 
         /**
@@ -3099,9 +3181,10 @@ public class Coordinator {
         }
 
         List<TExecPlanFragmentParams> toThrift(Set<TUniqueId> inFlightInstanceIds,
-                                               TDescriptorTable descTable,
-                                               Set<Long> dbIds,
-                                               boolean enablePipelineEngine) throws Exception {
+                                               TDescriptorTable descTable, Set<Long> dbIds,
+                                               boolean enablePipelineEngine, int accTabletSinkDop, 
+                                               int tabletSinkTotalDop) throws Exception {
+            boolean forceSetTableSinkDop = fragment.forceSetTableSinkDop();
             setBucketSeqToInstanceForRuntimeFilters();
 
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();
@@ -3110,23 +3193,36 @@ public class Coordinator {
                 if (!inFlightInstanceIds.contains(instanceExecParam.instanceId)) {
                     continue;
                 }
+                int curTabletSinkDop = 0;
+                if (forceSetTableSinkDop) {
+                    curTabletSinkDop = fragment.getPipelineDop();
+                } else {
+                    curTabletSinkDop = instanceExecParam.getPipelineDop();
+                }
                 TExecPlanFragmentParams params = new TExecPlanFragmentParams();
 
-                toThriftForCommonParams(params, instanceExecParam.getHost(), descTable, enablePipelineEngine);
-                toThriftForUniqueParams(params, i, instanceExecParam, enablePipelineEngine);
+                toThriftForCommonParams(params, instanceExecParam.getHost(), descTable, enablePipelineEngine, 
+                        tabletSinkTotalDop);
+                toThriftForUniqueParams(params, i, instanceExecParam, enablePipelineEngine,
+                        accTabletSinkDop, curTabletSinkDop);
 
                 paramsList.add(params);
+                accTabletSinkDop += curTabletSinkDop;
             }
             return paramsList;
         }
 
         TExecBatchPlanFragmentsParams toThriftInBatch(
                 Set<TUniqueId> inFlightInstanceIds, TNetworkAddress destHost, TDescriptorTable descTable,
-                Set<Long> dbIds, boolean enablePipelineEngine) throws Exception {
+                Set<Long> dbIds, boolean enablePipelineEngine, int accTabletSinkDop, 
+                int tabletSinkTotalDop) throws Exception {
+
+            boolean forceSetTableSinkDop = fragment.forceSetTableSinkDop();
+
             setBucketSeqToInstanceForRuntimeFilters();
 
             TExecPlanFragmentParams commonParams = new TExecPlanFragmentParams();
-            toThriftForCommonParams(commonParams, destHost, descTable, enablePipelineEngine);
+            toThriftForCommonParams(commonParams, destHost, descTable, enablePipelineEngine, tabletSinkTotalDop);
             fillRequiredFieldsToThrift(commonParams);
 
             List<TExecPlanFragmentParams> uniqueParamsList = Lists.newArrayList();
@@ -3135,12 +3231,20 @@ public class Coordinator {
                 if (!inFlightInstanceIds.contains(instanceExecParam.instanceId)) {
                     continue;
                 }
+                int curTabletSinkDop = 0;
+                if (forceSetTableSinkDop) {
+                    curTabletSinkDop = fragment.getPipelineDop();
+                } else {
+                    curTabletSinkDop = instanceExecParam.getPipelineDop();
+                }
 
                 TExecPlanFragmentParams uniqueParams = new TExecPlanFragmentParams();
-                toThriftForUniqueParams(uniqueParams, i, instanceExecParam, enablePipelineEngine);
+                toThriftForUniqueParams(uniqueParams, i, instanceExecParam, enablePipelineEngine, 
+                        accTabletSinkDop, curTabletSinkDop);
                 fillRequiredFieldsToThrift(uniqueParams);
 
                 uniqueParamsList.add(uniqueParams);
+                accTabletSinkDop += curTabletSinkDop;
             }
 
             TExecBatchPlanFragmentsParams request = new TExecBatchPlanFragmentsParams();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -265,6 +265,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // if the gc of any service is caused, you can set the value to 100 for testing.
     public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = "hive_partition_stats_sample_size";
 
+    public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
@@ -659,6 +660,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE)
     private int hivePartitionStatsSampleSize = 3000;
 
+    @VariableMgr.VarAttr(name = PIPELINE_SINK_DOP)
+    private int pipelineSinkDop = 0;
+
     @VariableMgr.VarAttr(name = JOIN_IMPLEMENTATION_MODE_V2, alias = JOIN_IMPLEMENTATION_MODE)
     private String joinImplementationMode = "auto"; // auto, merge, hash, nestloop
 
@@ -765,6 +769,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getHivePartitionStatsSampleSize() {
         return hivePartitionStatsSampleSize;
+    }
+
+    public int getPipelineSinkDop() {
+        return pipelineSinkDop;
+    }
+
+    public void setPipelineSinkDop(int dop) {
+        this.pipelineSinkDop = dop;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -11,6 +11,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.UpdateStmt;
@@ -85,12 +86,20 @@ public class UpdatePlanner {
             TWriteQuorumType writeQuorum = table.writeQuorum();
             DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, writeQuorum);
             execPlan.getFragments().get(0).setSink(dataSink);
-            // At present, we only support dop=1 for olap table sink.
-            // because tablet writing needs to know the number of senders in advance
-            // and guaranteed order of data writing
-            // It can be parallel only in some scenes, for easy use 1 dop now.
-            execPlan.getFragments().get(0).setPipelineDop(1);
             execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
+            if (isEnablePipeline && canUsePipeline) {
+                PlanFragment sinkFragment = execPlan.getFragments().get(0);
+                if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
+                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
+                } else {
+                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getPipelineSinkDop());
+                }
+                sinkFragment.setHasOlapTableSink();
+                sinkFragment.setForceSetTableSinkDop();
+                sinkFragment.setForceAssignScanRangesPerDriverSeq();
+            } else {
+                execPlan.getFragments().get(0).setPipelineDop(1);
+            }
             return execPlan;
         } finally {
             if (forceDisablePipeline) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -1,0 +1,1033 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.load;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.BrokerDesc;
+import com.starrocks.analysis.ColumnDef;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.load.BrokerFileGroup;
+import com.starrocks.load.Load;
+import com.starrocks.planner.FileScanNode;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.sql.ast.DataDescription;
+import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TBrokerFileStatus;
+import com.starrocks.thrift.TBrokerScanRangeParams;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TOpType;
+import com.starrocks.thrift.TPlanFragment;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeType;
+import com.starrocks.thrift.TPrimitiveType;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class LoadPlannerTest {
+    private long jobId;
+    private long txnId;
+    private TUniqueId loadId;
+    private BrokerDesc brokerDesc;
+
+    // config
+    private int loadParallelInstanceNum;
+    private int maxBrokerConcurrency;
+
+    // backends
+    private ImmutableMap<Long, Backend> idToBackend;
+
+    private static ConnectContext ctx;
+    private boolean strictMode = false;
+    private String timezone = TimeUtils.DEFAULT_TIME_ZONE;
+    private long timeoutS = 3600;
+    private long startTime = 0;
+    private boolean partialUpdate = false;
+    private Map<String, String> sessionVariables = null;
+    private long loadMemLimit = 1000000;
+    private long execMemLimit = 1000000;
+
+
+    @Mocked
+    Partition partition;
+    @Mocked
+    OlapTableSink sink;
+
+    @Before
+    public void setUp() throws IOException {
+        jobId = 1L;
+        txnId = 2L;
+        loadId = new TUniqueId(3, 4);
+        brokerDesc = new BrokerDesc("broker0", null);
+
+        loadParallelInstanceNum = Config.load_parallel_instance_num;
+        maxBrokerConcurrency = Config.max_broker_concurrency;
+
+        // backends
+        Map<Long, Backend> idToBackendTmp = Maps.newHashMap();
+        Backend b1 = new Backend(0L, "host0", 9050);
+        b1.setAlive(true);
+        idToBackendTmp.put(0L, b1);
+        Backend b2 = new Backend(1L, "host1", 9050);
+        b2.setAlive(true);
+        idToBackendTmp.put(1L, b2);
+        idToBackend = ImmutableMap.copyOf(idToBackendTmp);
+        ctx = UtFrameUtils.createDefaultCtx();
+    }
+
+    @After
+    public void tearDown() {
+        Config.load_parallel_instance_num = loadParallelInstanceNum;
+        Config.max_broker_concurrency = maxBrokerConcurrency;
+    }
+
+    @Test
+    public void testParallelInstance(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                                     @Injectable Database db, @Injectable OlapTable table) throws UserException {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        Column c1 = new Column("c1", Type.BIGINT, true);
+        columns.add(c1);
+        Column c2 = new Column("c2", Type.BIGINT, true);
+        columns.add(c2);
+        List<String> columnNames = Lists.newArrayList("c1", "c2");
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("c1");
+                result = columns.get(0);
+                table.getColumn("c2");
+                result = columns.get(1);
+            }
+        };
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1", "hdfs://127.0.0.1:9001/file2");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, columnNames, null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 268435456, true));
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file2", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // load_parallel_instance_num: 1
+        Config.load_parallel_instance_num = 1;
+        long startTime = System.currentTimeMillis();
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 2);
+
+        planner.plan();
+        Assert.assertEquals(1, planner.getScanNodes().size());
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(2, locationsList.size());
+
+        // load_parallel_instance_num: 2
+        Config.load_parallel_instance_num = 2;
+        planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 2);
+        planner.plan();
+        scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(4, locationsList.size());
+
+        // load_parallel_instance_num: 2, max_broker_concurrency: 3, non pipeline
+        Config.enable_pipeline_load = false;
+        ctx.getSessionVariable().setEnablePipelineEngine(false);
+        Config.load_parallel_instance_num = 2;
+        Config.max_broker_concurrency = 3;
+        planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 2);
+        planner.plan();
+        scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(3, locationsList.size());
+        Assert.assertEquals(1, planner.getFragments().get(0).getPipelineDop());
+        Assert.assertEquals(2, planner.getFragments().get(0).getParallelExecNum());
+
+        // load_parallel_instance_num: 2, max_broker_concurrency: 3, pipeline
+        ctx.getSessionVariable().setEnablePipelineEngine(true);
+        Config.enable_pipeline_load = true;
+        Config.load_parallel_instance_num = 2;
+        Config.max_broker_concurrency = 3;
+        planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 2);
+
+        planner.plan();
+        scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(3, locationsList.size());
+        Assert.assertEquals(2, planner.getFragments().get(0).getPipelineDop());
+        Assert.assertEquals(1, planner.getFragments().get(0).getParallelExecNum());
+    }
+
+    @Test
+    public void testVectorizedLoad(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                                   @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
+        columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
+        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
+
+        Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
+                Type.VARCHAR, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("k1");
+                result = columns.get(0);
+                table.getColumn("k2");
+                result = columns.get(1);
+                table.getColumn("k3");
+                result = columns.get(2);
+                table.getColumn("v");
+                result = columns.get(3);
+                table.getColumn("k33");
+                result = null;
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f1, f2);
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 1. check fragment
+        List<PlanFragment> fragments = planner.getFragments();
+        Assert.assertEquals(1, fragments.size());
+        PlanFragment fragment = fragments.get(0);
+        TPlanFragment tPlanFragment = fragment.toThrift();
+        List<TPlanNode> nodes = tPlanFragment.plan.nodes;
+        Assert.assertEquals(1, nodes.size());
+        TPlanNode tPlanNode = nodes.get(0);
+        Assert.assertEquals(TPlanNodeType.FILE_SCAN_NODE, tPlanNode.node_type);
+
+        // 2. check scan node column expr
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(1, locationsList.size());
+        TScanRangeLocations location = locationsList.get(0);
+        TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
+        Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;
+
+        // 2.1 check k1
+        TExpr k1Expr = exprOfDestSlot.get(0);
+        Assert.assertEquals(1, k1Expr.nodes.size());
+        TExprNode node = k1Expr.nodes.get(0);
+        Assert.assertEquals(TExprNodeType.SLOT_REF, node.node_type);
+        Assert.assertEquals(TPrimitiveType.TINYINT, node.type.types.get(0).scalar_type.type);
+
+        // 2.2 check k2 from path
+        TExpr k2Expr = exprOfDestSlot.get(1);
+        Assert.assertEquals(2, k2Expr.nodes.size());
+        TExprNode castNode = k2Expr.nodes.get(0);
+        Assert.assertEquals(TExprNodeType.CAST_EXPR, castNode.node_type);
+        Assert.assertEquals(TPrimitiveType.INT, castNode.fn.ret_type.types.get(0).scalar_type.type);
+        node = k2Expr.nodes.get(1);
+        Assert.assertEquals(TExprNodeType.SLOT_REF, node.node_type);
+        Assert.assertEquals(TPrimitiveType.VARCHAR, node.type.types.get(0).scalar_type.type);
+
+        // 2.3 check k3 mapping
+        TExpr k3Expr = exprOfDestSlot.get(2);
+        Assert.assertEquals(4, k3Expr.nodes.size());
+        node = k3Expr.nodes.get(0);
+        Assert.assertEquals(TExprNodeType.FUNCTION_CALL, node.node_type);
+        Assert.assertEquals("substr", node.fn.name.function_name);
+        node = k3Expr.nodes.get(1);
+        Assert.assertEquals(TExprNodeType.SLOT_REF, node.node_type);
+        Assert.assertEquals(TPrimitiveType.VARCHAR, node.type.types.get(0).scalar_type.type);
+        node = k3Expr.nodes.get(2);
+        Assert.assertEquals(TExprNodeType.INT_LITERAL, node.node_type);
+        Assert.assertEquals(1, node.int_literal.value);
+        node = k3Expr.nodes.get(3);
+        Assert.assertEquals(TExprNodeType.INT_LITERAL, node.node_type);
+        Assert.assertEquals(5, node.int_literal.value);
+    }
+
+    @Test
+    public void testPartialUpdatePlan(@Mocked GlobalStateMgr globalStateMgr,
+                                      @Mocked SystemInfoService systemInfoService,
+                                      @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
+        columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
+        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
+
+        Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
+                Type.VARCHAR, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                minTimes = 0;
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("k1");
+                result = columns.get(0);
+                table.getColumn("k2");
+                result = columns.get(1);
+                table.getColumn("k3");
+                result = columns.get(2);
+                table.getColumn("v");
+                result = columns.get(3);
+                table.getColumn("k33");
+                result = null;
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f1, f2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        brokerFileGroup.parse(db, desc);
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 1. check fragment
+        List<PlanFragment> fragments = planner.getFragments();
+        Assert.assertEquals(1, fragments.size());
+        PlanFragment fragment = fragments.get(0);
+        TPlanFragment tPlanFragment = fragment.toThrift();
+        List<TPlanNode> nodes = tPlanFragment.plan.nodes;
+        Assert.assertEquals(1, nodes.size());
+        TPlanNode tPlanNode = nodes.get(0);
+        Assert.assertEquals(TPlanNodeType.FILE_SCAN_NODE, tPlanNode.node_type);
+    }
+
+    @Test
+    public void testLoadWithOpColumnDefault(@Mocked GlobalStateMgr globalStateMgr,
+                                            @Mocked SystemInfoService systemInfoService,
+                                            @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
+        columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
+        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("pk");
+                result = columns.get(0);
+                table.getColumn("v1");
+                result = columns.get(1);
+                table.getColumn("v2");
+                result = columns.get(2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                result = null;
+            }
+        };
+
+        // column mappings
+        String sql =
+                "LOAD LABEL label0 (DATA INFILE('/path/file1') INTO TABLE t2 columns terminated by ',') with broker 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("/path/file1");
+        List<String> columnNames = Lists.newArrayList("pk", "v1", "v2");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "CSV", Lists.newArrayList(),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", ",");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "CSV");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("/path/file1", false, 128000000, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 2. check scan node column expr
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(1, locationsList.size());
+        TScanRangeLocations location = locationsList.get(0);
+        TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
+        Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;
+
+        // get last slot: id == 3
+        TExpr opExpr = exprOfDestSlot.get(3);
+        Assert.assertEquals(1, opExpr.nodes.size());
+        Assert.assertEquals(TExprNodeType.INT_LITERAL, opExpr.nodes.get(0).node_type);
+    }
+
+    @Test
+    public void testLoadWithOpColumnDelete(@Mocked GlobalStateMgr globalStateMgr,
+                                           @Mocked SystemInfoService systemInfoService,
+                                           @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
+        columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
+        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("pk");
+                result = columns.get(0);
+                table.getColumn("v1");
+                result = columns.get(1);
+                table.getColumn("v2");
+                result = columns.get(2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                result = null;
+            }
+        };
+
+        // column mappings
+        String sql =
+                "LOAD LABEL label0 (DATA INFILE('/path/file1') INTO TABLE t2 columns terminated by ',' " +
+                        "set ( __op = 'delete')) with broker 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("/path/file1");
+        List<String> columnNames = Lists.newArrayList("pk", "v1", "v2");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "CSV", Lists.newArrayList(),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", ",");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "CSV");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("/path/file1", false, 128000000, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 2. check scan node column expr
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(1, locationsList.size());
+        TScanRangeLocations location = locationsList.get(0);
+        TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
+        Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;
+
+        // get last slot: id == 3
+        TExpr opExpr = exprOfDestSlot.get(3);
+        Assert.assertEquals(1, opExpr.nodes.size());
+        Assert.assertEquals(TExprNodeType.INT_LITERAL, opExpr.nodes.get(0).node_type);
+        Assert.assertEquals(TOpType.DELETE.getValue(), opExpr.nodes.get(0).int_literal.value);
+    }
+
+    @Test
+    public void testLoadWithOpColumnExpr(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked SystemInfoService systemInfoService,
+                                         @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
+        columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
+        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+
+        Function f1 = new Function(new FunctionName("casttobigint"), new Type[] {Type.VARCHAR},
+                Type.BIGINT, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        Function f3 = new Function(new FunctionName("casttotinyint"), new Type[] {Type.VARCHAR},
+                Type.TINYINT, true);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("c0");
+                result = null;
+                table.getColumn("c1");
+                result = null;
+                table.getColumn("c2");
+                result = null;
+                table.getColumn("c3");
+                result = null;
+                result = columns.get(0);
+                table.getColumn("pk");
+                result = columns.get(0);
+                table.getColumn("v1");
+                result = columns.get(1);
+                table.getColumn("v2");
+                result = columns.get(2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                result = null;
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f2, f3);
+            }
+        };
+
+        // column mappings
+        String sql =
+                "LOAD LABEL label0 (DATA INFILE('/path/file1') INTO TABLE t2 columns terminated by ',' " +
+                        "(c0,c1,c2,c3) set (pk=c0, v1=c1, v2=c2, __op = c3)) with broker 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("/path/file1");
+        List<String> columnNames = Lists.newArrayList("c0", "c1", "c2", "c3");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "CSV", Lists.newArrayList(),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", ",");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "CSV");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("/path/file1", false, 128000000, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 2. check scan node column expr
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(1, locationsList.size());
+        TScanRangeLocations location = locationsList.get(0);
+        TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
+        Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;
+
+        // get last slot: id == 3
+        TExpr opExpr = exprOfDestSlot.get(3);
+        Assert.assertEquals(2, opExpr.nodes.size());
+        Assert.assertEquals(TExprNodeType.CAST_EXPR, opExpr.nodes.get(0).node_type);
+        Assert.assertEquals(TExprNodeType.SLOT_REF, opExpr.nodes.get(1).node_type);
+    }
+
+    @Test
+    public void testLoadWithOpAutoMapping(@Mocked GlobalStateMgr globalStateMgr,
+                                          @Mocked SystemInfoService systemInfoService,
+                                          @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("pk", Type.BIGINT, true, null, false,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("123")), ""));
+        columns.add(new Column("v1", Type.INT, false, null, false,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("231")), ""));
+        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("asdf")), ""));
+
+        Function f1 = new Function(new FunctionName("casttobigint"), new Type[] {Type.VARCHAR},
+                Type.BIGINT, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        Function f3 = new Function(new FunctionName("casttotinyint"), new Type[] {Type.VARCHAR},
+                Type.TINYINT, true);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                table.getColumn("pk");
+                result = columns.get(0);
+                table.getColumn("v1");
+                result = columns.get(1);
+                table.getColumn("v2");
+                result = columns.get(2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                result = null;
+                returns(f1, f2, f3);
+            }
+        };
+
+        // column mappings
+        String sql =
+                "LOAD LABEL label0 (DATA INFILE('/path/file1') INTO TABLE t2 columns terminated by ','" +
+                        " (pk,v1,v2,__op)) with broker 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("/path/file1");
+        List<String> columnNames = Lists.newArrayList("pk", "v1", "v2", "__op");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "CSV", Lists.newArrayList(),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", ",");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "CSV");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("/path/file1", false, 128000000, true));
+        fileStatusesList.add(fileStatusList);
+
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // 2. check scan node column expr
+        FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assert.assertEquals(1, locationsList.size());
+        TScanRangeLocations location = locationsList.get(0);
+        TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
+        Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;
+
+        TExpr opExpr = exprOfDestSlot.get(3);
+        Assert.assertEquals(1, opExpr.nodes.size());
+        Assert.assertEquals(TExprNodeType.SLOT_REF, opExpr.nodes.get(0).node_type);
+    }
+
+    @Test
+    public void testShuffle(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                            @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
+        columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
+        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
+
+        List<Column> keyColumns = Lists.newArrayList();
+        keyColumns.add(columns.get(0));
+        keyColumns.add(columns.get(1));
+        keyColumns.add(columns.get(2));
+
+        Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
+                Type.VARCHAR, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.UNIQUE_KEYS;
+                table.getDefaultReplicationNum();
+                result = 3;
+                table.getBaseIndexId();
+                result = 1;
+                table.getKeyColumnsByIndexId((long) 1);
+                result = keyColumns;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("k1");
+                result = columns.get(0);
+                table.getColumn("k2");
+                result = columns.get(1);
+                table.getColumn("k3");
+                result = columns.get(2);
+                table.getColumn("v");
+                result = columns.get(3);
+                table.getColumn("k33");
+                result = null;
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f1, f2);
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(sql,
+                ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // check fragment
+        List<PlanFragment> fragments = planner.getFragments();
+        Assert.assertEquals(2, fragments.size());
+    }
+
+    @Test
+    public void testAggShuffle(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                               @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
+        columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
+        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.REPLACE, false, null, ""));
+
+        List<Column> keyColumns = Lists.newArrayList();
+        keyColumns.add(columns.get(0));
+        keyColumns.add(columns.get(1));
+        keyColumns.add(columns.get(2));
+
+        Map<Long, List<Column>> indexSchema = Maps.newHashMap();
+        indexSchema.put((long) 1, columns);
+
+        Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
+                Type.VARCHAR, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                result = KeysType.AGG_KEYS;
+                table.getDefaultReplicationNum();
+                result = 3;
+                table.getBaseIndexId();
+                result = 1;
+                table.getIndexIdToSchema();
+                result = indexSchema;
+                table.getKeyColumnsByIndexId((long) 1);
+                result = keyColumns;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("k1");
+                result = columns.get(0);
+                table.getColumn("k2");
+                result = columns.get(1);
+                table.getColumn("k3");
+                result = columns.get(2);
+                table.getColumn("v");
+                result = columns.get(3);
+                table.getColumn("k33");
+                result = null;
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f1, f2);
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(sql,
+                ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.plan();
+
+        // check fragment
+        List<PlanFragment> fragments = planner.getFragments();
+        Assert.assertEquals(2, fragments.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -22,6 +22,7 @@ public class PipelineParallelismTest extends PlanTestBase {
     private int prevParallelExecInstanceNum = 0;
     private boolean prevEnablePipelineEngine = true;
     private int prevPipelineDop = 0;
+    private int pipelineSinkDop = 8;
 
     @Before
     public void setUp() {
@@ -39,6 +40,8 @@ public class PipelineParallelismTest extends PlanTestBase {
         connectContext.getSessionVariable().setParallelExecInstanceNum(parallelExecInstanceNum);
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
         connectContext.getSessionVariable().setPipelineDop(0);
+        connectContext.getSessionVariable().setPipelineSinkDop(pipelineSinkDop);
+
     }
 
     @After
@@ -104,8 +107,8 @@ public class PipelineParallelismTest extends PlanTestBase {
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // ParallelExecNum of fragment not 1. still can not use pipeline
-            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -131,7 +134,7 @@ public class PipelineParallelismTest extends PlanTestBase {
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
+            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -157,7 +160,7 @@ public class PipelineParallelismTest extends PlanTestBase {
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
+            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -249,6 +249,8 @@ struct TPlanFragmentExecParams {
   53: optional map<Types.TPlanNodeId, map<i32, list<TScanRangeParams>>> node_to_per_driver_seq_scan_ranges
 
   54: optional bool enable_exchange_perf
+
+  70: optional i32 pipeline_sink_dop
 }
 
 // Global query parameters assigned by the coordinator.


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12000

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

The current parallelism of the tablet sink in pipeline mode is always 1.
This one pr allows the parallelism to be adjusted.

The method is that FE will first pre-set the parallelism of the tablet sink,
and on the BE side, if it finds that the parallelism of the tablet sink operator
is not equal to the parallelism of the source operator,
then BE will convert the parallelism through the local passthourgh exchange.

For shuffle load service(primary table), because we have implemented single replica load,
lator we will disable shuffle load service by default, so here we always set its dop to be 1.
