### PR TITLE
[Enhancement]Fix Conversion warning for gcc(#12071)

### DIFF
--- a/be/src/gutil/strings/numbers.cc
+++ b/be/src/gutil/strings/numbers.cc
@@ -611,7 +611,7 @@ bool safe_strto32(const char* startptr, const int buffer_size, int32* value) {
     return safe_int_internal<int32>(startptr, startptr + buffer_size, 10, value);
 }
 
-bool safe_strto64(const char* startptr, const int buffer_size, int64* value) {
+bool safe_strto64(const char* startptr, const int64 buffer_size, int64* value) {
     return safe_int_internal<int64>(startptr, startptr + buffer_size, 10, value);
 }
 

--- a/be/src/gutil/strings/numbers.h
+++ b/be/src/gutil/strings/numbers.h
@@ -59,7 +59,7 @@ bool safe_strtod(const string& str, double* value);
 
 // Parses buffer_size many characters from startptr into value.
 bool safe_strto32(const char* startptr, int buffer_size, int32* value);
-bool safe_strto64(const char* startptr, int buffer_size, int64* value);
+bool safe_strto64(const char* startptr, int64 buffer_size, int64* value);
 
 // Parses with a fixed base between 2 and 36. For base 16, leading "0x" is ok.
 // If base is set to 0, its value is inferred from the beginning of str:

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -28,7 +28,7 @@ void CompactionTask::run() {
     _task_info.start_time = UnixMillis();
     scoped_refptr<Trace> trace(new Trace);
     SCOPED_CLEANUP({
-        uint64_t time_s = _watch.elapsed_time() / 1e9;
+        uint64_t time_s = _watch.elapsed_time() / 1000000000;
         if (time_s > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -609,7 +609,7 @@ void StorageEngine::compaction_check() {
         LOG(INFO) << "start to check compaction";
         size_t num = _compaction_check_one_round();
         stop_watch.stop();
-        LOG(INFO) << num << " tablets checked. time elapse:" << stop_watch.elapsed_time() / 1e9 << " seconds."
+        LOG(INFO) << num << " tablets checked. time elapse:" << stop_watch.elapsed_time() / 1000000000 << " seconds."
                   << " compaction checker will be scheduled again in " << checker_one_round_sleep_time_s << " seconds";
         std::unique_lock<std::mutex> lk(_checker_mutex);
         _checker_cv.wait_for(lk, std::chrono::seconds(checker_one_round_sleep_time_s),
@@ -648,7 +648,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1000000000 > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });
@@ -691,7 +691,7 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int3
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1000000000 > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });
@@ -730,7 +730,7 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1000000000 > config::compaction_trace_threshold) {
             LOG(WARNING) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1129,7 +1129,7 @@ size_t Tablet::num_rows() {
     }
 }
 
-int Tablet::version_count() const {
+size_t Tablet::version_count() const {
     if (_updates) {
         return _updates->version_count();
     } else {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -95,7 +95,7 @@ public:
 
     size_t tablet_footprint(); // disk space occupied by tablet
     size_t num_rows();
-    int version_count() const;
+    size_t version_count() const;
     Version max_version() const;
 
     // propreties encapsulated in TabletSchema

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -67,7 +67,7 @@ static void get_shutdown_tablets(std::ostream& os, void*) {
 
 bvar::PassiveStatus<std::string> g_shutdown_tablets("starrocks_shutdown_tablets", get_shutdown_tablets, nullptr);
 
-TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
+TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
         : _tablets_shards(tablet_map_lock_shard_size),
           _tablets_shards_mask(tablet_map_lock_shard_size - 1),
           _last_update_stat_ms(0) {
@@ -145,8 +145,8 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     // the shard where the target tablet is located need to be locked.
     // In order to prevent deadlock, the order of locking needs to be fixed.
     if (request.__isset.base_tablet_id && request.base_tablet_id > 0) {
-        int shard_idx = _get_tablets_shard_idx(tablet_id);
-        int base_shard_idx = _get_tablets_shard_idx(request.base_tablet_id);
+        int64_t shard_idx = _get_tablets_shard_idx(tablet_id);
+        int64_t base_shard_idx = _get_tablets_shard_idx(request.base_tablet_id);
 
         if (shard_idx == base_shard_idx) {
             wlock.lock();

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -59,7 +59,7 @@ enum TabletDropFlag {
 // please uniformly name the method in "xxx_unlocked()" mode
 class TabletManager {
 public:
-    explicit TabletManager(int32_t tablet_map_lock_shard_size);
+    explicit TabletManager(int64_t tablet_map_lock_shard_size);
     ~TabletManager() = default;
 
     // The param stores holds all candidate data_dirs for this tablet.
@@ -179,7 +179,7 @@ private:
     private:
         constexpr static int kNumShard = 128;
 
-        int _shard(int64_t tablet_id) { return tablet_id % kNumShard; }
+        int64_t _shard(int64_t tablet_id) { return tablet_id % kNumShard; }
 
         SpinLock _latches[kNumShard];
         std::unordered_set<int64_t> _locks[kNumShard];
@@ -222,14 +222,14 @@ private:
 
     TabletsShard& _get_tablets_shard(TTabletId tabletId);
 
-    int32_t _get_tablets_shard_idx(TTabletId tabletId) const { return tabletId & _tablets_shards_mask; }
+    int64_t _get_tablets_shard_idx(TTabletId tabletId) const { return tabletId & _tablets_shards_mask; }
 
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
 
     std::vector<TabletsShard> _tablets_shards;
-    const int32_t _tablets_shards_mask;
+    const int64_t _tablets_shards_mask;
     LockTable _schema_change_lock_tbl;
 
     // Protect _partition_tablet_map, should not be obtained before _tablet_map_lock to avoid deadlock

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -116,7 +116,7 @@ public:
     int64_t tablet_id() const;
     void set_tablet_id(int64_t tablet_id) { _tablet_id = tablet_id; }
     int32_t schema_hash() const;
-    int16_t shard_id() const;
+    int32_t shard_id() const;
     void set_shard_id(int32_t shard_id);
     int64_t creation_time() const;
     void set_creation_time(int64_t creation_time);
@@ -246,7 +246,7 @@ inline int32_t TabletMeta::schema_hash() const {
     return _schema_hash;
 }
 
-inline int16_t TabletMeta::shard_id() const {
+inline int32_t TabletMeta::shard_id() const {
     return _shard_id;
 }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2154,7 +2154,7 @@ RowsetSharedPtr TabletUpdates::get_delta_rowset(int64_t version) const {
     if (version < _edit_version_infos[0]->version.major() || _edit_version_infos.back()->version.major() < version) {
         return nullptr;
     }
-    int idx_hint = version - _edit_version_infos[0]->version.major();
+    int64_t idx_hint = version - _edit_version_infos[0]->version.major();
     for (auto i = idx_hint; i < _edit_version_infos.size(); i++) {
         const auto& vi = _edit_version_infos[i];
         if (vi->version.major() < version) {

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -76,7 +76,7 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
               << ", tablet=" << tablet->full_name() << ", dest_store=" << _dest_store->path();
 
     // 1. lock and check
-    int32_t end_version = -1;
+    int64_t end_version = -1;
     std::vector<RowsetSharedPtr> consistent_rowsets;
     uint64_t shard = 0;
     std::string schema_hash_path;
@@ -231,7 +231,7 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
                 res = Status::NotFound(fmt::format("Not found version in tablet. tablet: {}", tablet->tablet_id()));
                 break;
             }
-            int32_t new_end_version = max_version->end_version();
+            int64_t new_end_version = max_version->end_version();
             if (end_version != new_end_version) {
                 LOG(WARNING) << "Version does not match. src_version: " << end_version
                              << ", dst_version: " << new_end_version;

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -41,7 +41,7 @@
 
 namespace starrocks {
 
-TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, int32_t store_num)
+TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, uint32_t store_num)
         : _txn_map_shard_size(txn_map_shard_size), _txn_shard_size(txn_shard_size) {
     DCHECK_GT(_txn_map_shard_size, 0);
     DCHECK_GT(_txn_shard_size, 0);

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -67,7 +67,7 @@ struct TabletTxnInfo {
 // txn manager is used to manage mapping between tablet and txns
 class TxnManager {
 public:
-    TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, int32_t store_num);
+    TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, uint32_t store_num);
 
     ~TxnManager() = default;
 

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -52,7 +52,7 @@ public:
     uint64_t get_elapse_time_us() {
         struct timeval now;
         gettimeofday(&now, nullptr);
-        return (uint64_t)((now.tv_sec - _begin_time.tv_sec) * 1e6 + (now.tv_usec - _begin_time.tv_usec));
+        return (uint64_t)((now.tv_sec - _begin_time.tv_sec) * 1000000 + (now.tv_usec - _begin_time.tv_usec));
     }
 
     double get_elapse_second() { return get_elapse_time_us() / 1000000.0; }

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -96,10 +96,10 @@ std::string get_version_string(bool compact) {
     return ss.str();
 }
 
-std::string hexdump(const char* buf, int len) {
+std::string hexdump(const char* buf, size_t len) {
     std::stringstream ss;
     ss << std::hex << std::uppercase;
-    for (int i = 0; i < len; ++i) {
+    for (size_t i = 0; i < len; ++i) {
         ss << std::setfill('0') << std::setw(2) << ((uint16_t)buf[i] & 0xff);
     }
     return ss.str();

--- a/be/src/util/debug_util.h
+++ b/be/src/util/debug_util.h
@@ -50,6 +50,6 @@ std::string get_short_version();
 // Returns "<program short name> version <GetBuildVersion(compact)>"
 std::string get_version_string(bool compact);
 
-std::string hexdump(const char* buf, int len);
+std::string hexdump(const char* buf, size_t len);
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12071

## Problem Summary(Required) ：
Problem:
If we enable Wconversion for compiling in gcc, we will get a lot warning for it. This issue is mainly remove part of warning from the code.

Solution:
We will use more reasonable variable type in the code, except for:
1. The modification will cause performance drop.
2. Some small-length variables come from third-party libraries, so we can only ensure that our code is safe when we used it.
3. Some functions logically need to do this type conversion.
4. From the semantics of the function, there will be no overflow.
