### PR TITLE
[BugFix] Fix BE crash when runtime filter push down to storage layer

### DIFF
--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -59,6 +59,11 @@ struct RuntimeColumnPredicateBuilder {
             std::vector<TCondition> filters;
             range.to_olap_filter(filters);
 
+            // if runtime filter generate an empty range we could return directly
+            if (range.is_empty_value_range()) {
+                return Status::EndOfFile("EOF, Filter by always false runtime filter");
+            }
+
             for (auto& f : filters) {
                 std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
                 p->set_index_filter_only(f.is_index_filter_only);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
introduced by #11505 

## Problem Summary(Required) ：
when runtime filter build from an empty hash table. the value of 'min' of runtime filter will be greater than 'max' in RuntimeFilter. In this case. we will return an null ColumnPredicate which will make BE crash

```patch
    ColumnPredicate* pred = nullptr;
+   if range is empty. condition.condition_values.size() will be 0. we will return an empty ColumnPredicate
    if ((condition.condition_op == "*=" || condition.condition_op == "=") && condition.condition_values.size() == 1) {
        pred = new_column_eq_predicate(type_info, index, condition.condition_values[0]);
    } else if (condition.condition_op == "!=" && condition.condition_values.size() == 1) {
        pred = new_column_ne_predicate(type_info, index, condition.condition_values[0]);
    } else if (condition.condition_op == "<<") {
    ......
    return nullptr;
```
```

            for (auto& f : filters) {
                std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
                p->set_index_filter_only(f.is_index_filter_only);
                preds.emplace_back(std::move(p));
            }
```
```
query_id:880b9fba-4939-11ed-92c8-00163e21e302, fragment_instance:880b9fba-4939-11ed-92c8-00163e21e30f
*** Aborted at 1665474696 (unix time) try "date -d @1665474696" if you are using GNU date ***
PC: @          0x21c014f starrocks::type_dispatch_predicate<>()
*** SIGSEGV (@0x1c) received by PID 441480 (TID 0x7f23629cf700) from PID 28; stack trace: ***
    @          0x4c44632 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f2432657b20 (unknown)
    @          0x21c014f starrocks::type_dispatch_predicate<>()
    @          0x21c0f1c starrocks::vectorized::OlapRuntimeScanRangePruner::_update()
    @          0x21af030 starrocks::vectorized::SegmentIterator::_try_to_update_ranges_by_runtime_filter()
    @          0x21b76a7 starrocks::vectorized::SegmentIterator::do_get_next()
    @          0x27a78d5 starrocks::SegmentIteratorWrapper::do_get_next()
    @          0x277d7a3 starrocks::vectorized::TimedChunkIterator::do_get_next()
    @          0x251cdde starrocks::vectorized::TabletReader::do_get_next()
    @          0x32a603b starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage()
    @          0x32a670b starrocks::pipeline::OlapChunkSource::_read_chunk()
    @          0x32a0544 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x315b281 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS1_12RuntimeStateEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x3200c65 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x2967cd5 starrocks::ThreadPool::dispatch_thread()
    @          0x29631ba starrocks::Thread::supervise_thread()
    @     0x7f243264d14a start_thread
    @     0x7f2431beedc3 __GI___clone
    @                0x0 (unknown)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
