### PR TITLE
[Refactor] Remove unused PlanFragmentExecutor get_next function

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -306,22 +306,6 @@ void PlanFragmentExecutor::send_report(bool done) {
     _report_status_cb(status, profile(), done || !status.ok());
 }
 
-Status PlanFragmentExecutor::get_next(vectorized::ChunkPtr* chunk) {
-    VLOG_FILE << "GetNext(): instance_id=" << _runtime_state->fragment_instance_id();
-    Status status = _get_next_internal_vectorized(chunk);
-    update_status(status);
-
-    if (_done) {
-        LOG(INFO) << "Finished executing fragment query_id=" << print_id(_query_id)
-                  << " instance_id=" << print_id(_runtime_state->fragment_instance_id());
-        // Query is done, return the thread token
-        release_thread_token();
-        send_report(true);
-    }
-
-    return status;
-}
-
 Status PlanFragmentExecutor::_get_next_internal_vectorized(vectorized::ChunkPtr* chunk) {
     // If there is a empty chunk, we continue to read next chunk
     // If we set chunk to nullptr, means this fragment read done

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -75,13 +75,11 @@ public:
     typedef std::function<void(const Status& status, RuntimeProfile* profile, bool done)> report_status_callback;
 
     // if report_status_cb is not empty, is used to report the accumulated profile
-    // information periodically during execution (open() or get_next()).
+    // information periodically during execution open().
     PlanFragmentExecutor(ExecEnv* exec_env, report_status_callback report_status_cb);
 
-    // Closes the underlying plan fragment and frees up all resources allocated
-    // in open()/get_next().
-    // It is an error to delete a PlanFragmentExecutor with a report callback
-    // before open()/get_next() (depending on whether the fragment has a sink)
+    // Closes the underlying plan fragment and frees up all resources allocated in open()
+    // It is an error to delete a PlanFragmentExecutor with a report callback before open()
     // indicated that execution is finished.
     ~PlanFragmentExecutor();
 
@@ -93,21 +91,17 @@ public:
     // The query will be aborted (MEM_LIMIT_EXCEEDED) if it goes over that limit.
     Status prepare(const TExecPlanFragmentParams& request);
 
-    // Start execution. Call this prior to get_next().
+    // Start execution.
     // If this fragment has a sink, open() will send all rows produced
     // by the fragment to that sink. Therefore, open() may block until
-    // all rows are produced (and a subsequent call to get_next() will not return
-    // any rows).
+    // all rows are produced
     // This also starts the status-reporting thread, if the interval flag
     // is > 0 and a callback was specified in the c'tor.
     // If this fragment has a sink, report_status_cb will have been called for the final
     // time when open() returns, and the status-reporting thread will have been stopped.
     Status open();
 
-    Status get_next(vectorized::ChunkPtr* chunk);
-
-    // Closes the underlying plan fragment and frees up all resources allocated
-    // in open()/get_next().
+    // Closes the underlying plan fragment and frees up all resources allocated in open()
     void close();
 
     // Initiate cancellation. Must not be called until after prepare() returned.
@@ -150,7 +144,7 @@ private:
     // profile reporting-related
     report_status_callback _report_status_cb;
 
-    // true if _plan->get_next() indicated that it's done
+    // true if _plan->_get_next_internal_vectorized() indicated that it's done
     bool _done;
 
     // true if prepare() returned OK


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
PlanFragmentExecutor::get_next() is useless and can be confusing 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
