### PR TITLE
[Feature] Add bitmap/hll type for lead/lag

### DIFF
--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -516,8 +516,9 @@ public:
         //so here are the separate processing function percentile_approx
         if (name == "percentile_approx") {
             return AggregateFactory::MakePercentileApproxAggregateFunction();
+        } else if (name == "lead" || name == "lag") {
+            return AggregateFactory::MakeLeadLagWindowFunction<ArgPT>();
         }
-
         return nullptr;
     }
 
@@ -1120,7 +1121,11 @@ AggregateFuncResolver::AggregateFuncResolver() {
     ADD_ALL_TYPE("first_value", true);
     ADD_ALL_TYPE("last_value", true);
     ADD_ALL_TYPE("lead", true);
+    add_object_mapping<TYPE_OBJECT, TYPE_OBJECT, true>("lead");
+    add_object_mapping<TYPE_HLL, TYPE_HLL, true>("lead");
     ADD_ALL_TYPE("lag", true);
+    add_object_mapping<TYPE_OBJECT, TYPE_OBJECT, true>("lag");
+    add_object_mapping<TYPE_HLL, TYPE_HLL, true>("lag");
 
     add_object_mapping<TYPE_HLL, TYPE_HLL>("hll_union");
     add_object_mapping<TYPE_HLL, TYPE_HLL>("hll_raw_agg");

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -404,7 +404,8 @@ class WindowFunnelAggregateFunction final
     using TimestampType = typename WindowFunnelState<PT>::TimestampType;
 
 public:
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state, size_t row_num) const {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(columns[2]->is_constant());
 
         this->data(state).window_size = down_cast<const Int64Column*>(columns[0])->get_data()[0];

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.thrift.TAggregateExpr;
@@ -458,5 +459,15 @@ public class FunctionCallExpr extends Expr {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public Expr uncheckedCastTo(Type targetType) throws AnalysisException {
+        Type type = getFn().getReturnType();
+	if (!type.equals(targetType)) {
+            return super.uncheckedCastTo(targetType);
+        } else {
+            return this;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -229,6 +229,7 @@ public class FunctionSet {
     public static final String HLL_UNION = "hll_union";
     public static final String HLL_RAW_AGG = "hll_raw_agg";
     public static final String HLL_RAW = "hll_raw";
+    public static final String HLL_EMPTY = "hll_empty";
     public static final String NDV = "ndv";
     public static final String NDV_NO_FINALIZE = "ndv_no_finalize";
     public static final String MULTI_DISTINCT_COUNT = "multi_distinct_count";
@@ -474,6 +475,8 @@ public class FunctionSet {
                     .add(FunctionSet.UTC_TIMESTAMP)
                     .add(FunctionSet.MD5_SUM)
                     .add(FunctionSet.MD5_SUM_NUMERIC)
+                    .add(FunctionSet.BITMAP_EMPTY)
+                    .add(FunctionSet.HLL_EMPTY)
                     .build();
 
     public static final Set<String> decimalRoundFunctions =
@@ -534,14 +537,13 @@ public class FunctionSet {
                 || functionName.equalsIgnoreCase(LAG)) {
             final ScalarType descArgType = (ScalarType) descArgTypes[0];
             final ScalarType candicateArgType = (ScalarType) candicateArgTypes[0];
-            // Bitmap, HLL, PERCENTILE type don't allow cast
-            if (descArgType.isOnlyMetricType()) {
-                return false;
-            }
             if (functionName.equalsIgnoreCase(LEAD) ||
                     functionName.equalsIgnoreCase(LAG)) {
                 // lead and lag function respect first arg type
                 return descArgType.isNull() || descArgType.matchesType(candicateArgType);
+            } else if (descArgType.isOnlyMetricType()) {
+                // Bitmap, HLL, PERCENTILE type don't allow cast
+                return false;
             } else {
                 // The implementations of hex for string and int are different.
                 return descArgType.isStringType() || !candicateArgType.isStringType();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -51,11 +51,15 @@ public class AnalyticAnalyzer {
 
         for (Expr e : analyticExpr.getFnCall().getChildren()) {
             if (e.getType().isBitmapType() &&
-                    !analyticFunction.getFn().functionName().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)) {
-                throw new SemanticException("bitmap type could only used for bitmap_union_count window function");
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.BITMAP_UNION_COUNT) &&
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.LAG)) {
+                throw new SemanticException("bitmap type could only used for bitmap_union_count/lead/lag window function");
             } else if (e.getType().isHllType() &&
-                    !analyticFunction.getFn().functionName().equalsIgnoreCase(AnalyticExpr.HLL_UNION_AGG)) {
-                throw new SemanticException("hll type could only used for hll_union_agg window function");
+                    !analyticFunction.getFn().functionName().equals(AnalyticExpr.HLL_UNION_AGG) &&
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.LAG)) {
+                throw new SemanticException("hll type could only used for hll_union_agg/lead/lag window function");
             } else if (e.getType().isPercentile()) {
                 throw new SemanticException("window functions don't support percentile type");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -117,7 +117,6 @@ public class WindowTransformer {
                     throw new SemanticException("Convert type error in offset fn(default value); old_type="
                             + callExpr.getChild(2).getType() + " new_type=" + callExpr.getChild(0).getType());
                 }
-
                 if (callExpr.getChild(2) instanceof CastExpr) {
                     throw new SemanticException(
                             "The third parameter of `" + callExpr.getFn().getFunctionName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -118,7 +118,6 @@ public class WindowTransformer {
                             + callExpr.getChild(2).getType() + " new_type=" + callExpr.getChild(0).getType());
                 }
 
-                // Allow bitmap_empty/hll_empty as third paramter of LEAD/LAG.
                 if (callExpr.getChild(2) instanceof CastExpr) {
                     throw new SemanticException(
                             "The third parameter of `" + callExpr.getFn().getFunctionName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -117,6 +117,8 @@ public class WindowTransformer {
                     throw new SemanticException("Convert type error in offset fn(default value); old_type="
                             + callExpr.getChild(2).getType() + " new_type=" + callExpr.getChild(0).getType());
                 }
+
+                // Allow bitmap_empty/hll_empty as third paramter of LEAD/LAG.
                 if (callExpr.getChild(2) instanceof CastExpr) {
                     throw new SemanticException(
                             "The third parameter of `" + callExpr.getFn().getFunctionName().getFunction() +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -108,6 +108,41 @@ public class WindowTest extends PlanTestBase {
     }
 
     @Test
+    public void testLeadAndLagWithBitmapAndHll() throws Exception {
+        String sql = "select lead(id2, 1, bitmap_empty()) OVER () from bitmap_table";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "lead(2: id2, 1, bitmap_empty())");
+
+        sql = "select lead(id2, 1, null) OVER () from bitmap_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lead(2: id2, 1, null)");
+
+        sql = "select lag(id2, 1, bitmap_empty()) OVER () from bitmap_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lag(2: id2, 1, bitmap_empty())");
+
+        sql = "select lag(id2, 1, null) OVER () from bitmap_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lag(2: id2, 1, null)");
+
+        sql = "select lead(id2, 1, hll_empty()) OVER () from hll_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lead(2: id2, 1, hll_empty())");
+
+        sql = "select lead(id2, 1, null) OVER () from hll_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lead(2: id2, 1, null)");
+
+        sql = "select lag(id2, 1, hll_empty()) OVER () from hll_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lag(2: id2, 1, hll_empty())");
+
+        sql = "select lag(id2, 1, null) OVER () from hll_table";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "lag(2: id2, 1, null)");
+    }
+
+    @Test
     public void testWindowWithAgg() throws Exception {
         String sql = "SELECT v1, sum(v2),  sum(v2) over (ORDER BY v1) AS `rank` FROM t0 group BY v1, v2";
         String plan = getFragmentPlan(sql);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add **bitmap/hll** type for **lead/lag**,
now we can use case like following:
```
select bitmap_to_string(user_id), bitmap_to_string(lead(user_id, 1, bitmap_empty()) over (partition by dt order by page)) as next_id_float from pv_bitmap order by page;
+---------------------------+---------------+
| bitmap_to_string(user_id) | next_id_float |
+---------------------------+---------------+
| 1                         | 2             |
| 2                         | 3             |
| 3                         | 4             |
| 4                         | 4222          |
| 4222                      |               |
+---------------------------+---------------+

mysql> select bitmap_to_string(user_id), bitmap_to_string(lead(user_id, 1, null) over (partition by dt order by page)) as next_id_float from pv_bitmap order by page;
+---------------------------+---------------+
| bitmap_to_string(user_id) | next_id_float |
+---------------------------+---------------+
| 1                         | 2             |
| 2                         | 3             |
| 3                         | 4             |
| 4                         | 4222          |
| 4222                      | NULL          |
+---------------------------+---------------+
```