### PR TITLE
[Enhancement] Pipeline profile refine

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1133,29 +1133,12 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             }
             counter0->set(merged_value);
 
-            bool update_min_max = false;
-            if (already_merged) {
-                update_min_max = true;
-            } else {
-                // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-                const auto diff = max_value - min_value;
-                if (is_average_type(counter0->type())) {
-                    if ((diff > 5'000'000L && diff > merged_value / 5.0)) {
-                        update_min_max = true;
-                    }
-                } else {
-                    // All sum type counters will have extra info (min value and max value)
-                    update_min_max = true;
-                }
-            }
-            if (update_min_max) {
-                auto* min_counter =
-                        profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
-                auto* max_counter =
-                        profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
-                min_counter->set(min_value);
-                max_counter->set(max_value);
-            }
+            auto* min_counter =
+                    profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name), type, name);
+            auto* max_counter =
+                    profile0->add_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name), type, name);
+            min_counter->set(min_value);
+            max_counter->set(max_value);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -215,8 +215,10 @@ public class RuntimeProfileTest {
         Assert.assertEquals(2000000000L, mergedTime1.getValue());
         Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
         Counter mergedMaxOfTime1 = mergedProfile.getCounter("__MAX_OF_time1");
-        Assert.assertNull(mergedMinOfTime1);
-        Assert.assertNull(mergedMaxOfTime1);
+        Assert.assertNotNull(mergedMinOfTime1);
+        Assert.assertNotNull(mergedMaxOfTime1);
+        Assert.assertEquals(2000000000L, mergedMinOfTime1.getValue());
+        Assert.assertEquals(2000000000L, mergedMaxOfTime1.getValue());
 
         Counter mergedTime2 = mergedProfile.getCounter("time2");
         Assert.assertEquals(1000000000L, mergedTime2.getValue());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Changelist

1. Fix the stupid bug of `OverheadTime` because the metric is rarely concerned under normal circumstances
2. Add `DriverPrepareTime` and `FragmentInstancePrepareTime`
3. Fix merge problem of time metrics
    * Before, it might get stupid result with average greater than the max value
    ```
    # first merge, min/max is not saved if values do not differ much
    (1000, 1000, 1000) -> 1000 
    (10, 20, 30) -> 20[MIN=10, MAX=30]

    # second merge
    (1000, 20[MIN=10, MAX=30]) -> 510[MIN=10, MAX=30]
    ```
    * After
    ```
    # first merge, always keep min and max no matter how much they differ
    (1000, 1000, 1000) -> 1000[MIN=1000, MAX=1000]
    (10, 20, 30) -> 20[MIN=10, MAX=30]

    # second merge
    (1000[MIN=1000, MAX=1000], 20[MIN=10, MAX=30]) -> 510[MIN=10, MAX=1000]
    ```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
