### PR TITLE
[BugFix] Fix join reorder bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
@@ -54,8 +54,13 @@ public class ReplaceColumnRefRewriter {
             // Rewiring predicate shouldn't change the origin project columnRefMap
 
             ScalarOperator mapperOperator = operatorMap.get(column).clone();
-            for (int i = 0; i < mapperOperator.getChildren().size() && isRecursively; ++i) {
-                mapperOperator.setChild(i, mapperOperator.getChild(i).accept(this, null));
+            if (isRecursively) {
+                while (mapperOperator.getChildren().isEmpty() && operatorMap.containsKey(mapperOperator)) {
+                    mapperOperator = operatorMap.get(mapperOperator).clone();
+                }
+                for (int i = 0; i < mapperOperator.getChildren().size(); ++i) {
+                    mapperOperator.setChild(i, mapperOperator.getChild(i).accept(this, null));
+                }
             }
             return mapperOperator;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriterTest.java
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class ReplaceColumnRefRewriterTest {
+    @Test
+    public void testRecursiveWithoutChildren() {
+        Map<ColumnRefOperator, ScalarOperator> operatorMap = Maps.newHashMap();
+        ColumnRefOperator columnRef1 = createColumnRef(1);
+        ColumnRefOperator columnRef2 = createColumnRef(2);
+        ColumnRefOperator columnRef3 = createColumnRef(3);
+        operatorMap.put(columnRef1, columnRef2);
+        operatorMap.put(columnRef2, columnRef3);
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(operatorMap, true);
+        ColumnRefOperator source = createColumnRef(1);
+        ScalarOperator target = rewriter.rewrite(source);
+        Assert.assertTrue(target instanceof ColumnRefOperator);
+        ColumnRefOperator rewritten = (ColumnRefOperator) target;
+        Assert.assertEquals(3, rewritten.getId());
+    }
+
+    @Test
+    public void testRecursiveWithChildren() {
+        Map<ColumnRefOperator, ScalarOperator> operatorMap = Maps.newHashMap();
+        ColumnRefOperator columnRef1 = createColumnRef(1);
+        ColumnRefOperator columnRef2 = createColumnRef(2);
+        ColumnRefOperator columnRef3 = createColumnRef(3);
+
+        BinaryPredicateOperator binary = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ, columnRef2,
+                ConstantOperator.createInt(1));
+
+        operatorMap.put(columnRef1, binary);
+        operatorMap.put(columnRef2, columnRef3);
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(operatorMap, true);
+        ColumnRefOperator source = createColumnRef(1);
+        ScalarOperator target = rewriter.rewrite(source);
+        Assert.assertTrue(target instanceof BinaryPredicateOperator);
+        BinaryPredicateOperator rewritten = (BinaryPredicateOperator) target;
+
+        BinaryPredicateOperator result = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ, columnRef3,
+                ConstantOperator.createInt(1));
+        Assert.assertEquals(result, rewritten);
+    }
+
+    ColumnRefOperator createColumnRef(int id) {
+        return new ColumnRefOperator(id, Type.INT, "ref" + id, false);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10208 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix join reorder bug. The bug comes from that join reorder makes use of MultiJoinNode to generate the projection map of reordered join and here mapping should be recursive. but ColumnRefOperator is incorrectly recursively processed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
