### PR TITLE
[Refactor] Give `ClientConfigure` a default region `aws-global` to prevent IMDS access

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -704,7 +704,7 @@ CONF_String(object_storage_access_key_id, "");
 CONF_String(object_storage_secret_access_key, "");
 CONF_String(object_storage_endpoint, "");
 // Tencent cos needs to add region information
-CONF_String(object_storage_region, "");
+CONF_String(object_storage_region, "aws-global");
 CONF_Int64(object_storage_max_connection, "102400");
 // Acccess object storage using https.
 // this options is applicable only if `object_storage_endpoint` is not specified.

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -74,16 +74,6 @@ public:
 
     S3ClientPtr new_client(const ClientConfiguration& config, const FSOptions& opts);
 
-    static ClientConfiguration& getClientConfig() {
-        // We cached config here and make a deep copy each time.Since aws sdk has changed the
-        // Aws::Client::ClientConfiguration default constructor to search for the region
-        // (where as before 1.8 it has been hard coded default of "us-east-1").
-        // Part of that change is looking through the ec2 metadata, which can take a long time.
-        // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
-        static ClientConfiguration instance;
-        return instance;
-    }
-
 private:
     S3ClientFactory();
 
@@ -149,7 +139,14 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
 }
 
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri, const FSOptions& opts) {
-    Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
+    Aws::Client::ClientConfiguration config = {
+            .endpoint = uri.endpoint().empty() ? config::object_storage_endpoint : uri.endpoint(),
+            .region = config::object_storage_region,
+            .maxConnextions = config::object_storage_max_connection,
+            .scheme = config::object_storage_endpoint_use_https ? Aws::Http::Scheme::HTTPS
+                                                                : config.scheme = Aws::Http::Scheme::HTTP,
+    };
+
     const THdfsProperties* hdfs_properties = opts.hdfs_properties();
     if (hdfs_properties != nullptr) {
         DCHECK(hdfs_properties->__isset.end_point);
@@ -168,21 +165,8 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri, const F
         } else {
             config.maxConnections = config::object_storage_max_connection;
         }
-    } else {
-        if (!uri.endpoint().empty()) {
-            config.endpointOverride = uri.endpoint();
-        } else if (!config::object_storage_endpoint.empty()) {
-            config.endpointOverride = config::object_storage_endpoint;
-        } else if (config::object_storage_endpoint_use_https) {
-            config.scheme = Aws::Http::Scheme::HTTPS;
-        } else {
-            config.scheme = Aws::Http::Scheme::HTTP;
-        }
-        if (!config::object_storage_region.empty()) {
-            config.region = config::object_storage_region;
-        }
-        config.maxConnections = config::object_storage_max_connection;
     }
+
     return S3ClientFactory::instance().new_client(config, opts);
 }
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -121,10 +121,6 @@ export_shared_envvars() {
     export UDF_RUNTIME_DIR=${STARROCKS_HOME}/lib/udf-runtime
     export LOG_DIR=${STARROCKS_HOME}/log
     export PID_DIR=`cd "$curdir"; pwd`
-
-    # https://github.com/aws/aws-cli/issues/5623
-    # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-    export AWS_EC2_METADATA_DISABLED=true
     # ===================================================================================
 }
 


### PR DESCRIPTION
…cess

Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Previous PR https://github.com/StarRocks/starrocks/pull/3912  introduces a static variable to prevent IMDS access. But we can prevent IDMS access by giving it a default region.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
