### PR TITLE
[BugFix] Fix fencing failed when a new leader is elected

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -82,7 +82,7 @@ public class BDBHA implements HAProtocol {
 
         for (int i = 0; i < RETRY_TIME; i++) {
             try {
-                long myEpoch = getLargestEpoch(epochDb.getDb());
+                long myEpoch = getLargestEpoch(epochDb.getDb()) + 1;
                 LOG.info("start fencing, epoch number is {}", myEpoch);
                 Long key = myEpoch;
                 DatabaseEntry theKey = new DatabaseEntry();
@@ -116,7 +116,7 @@ public class BDBHA implements HAProtocol {
         OperationResult result = epochDB.get(null, key, data, Get.LAST,
                 new ReadOptions().setLockMode(LockMode.READ_COMMITTED));
         if (result == null) {
-            return 1L;
+            return 0L;
         } else {
             TupleBinding<Long> binding = TupleBinding.getPrimitiveBinding(Long.class);
             return binding.entryToObject(key);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12136

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Because of consistency bug in bdb(may arise when all node restart continuously), the data in epochDB may be discontinuous, so the `epochDB.count() + 1` can be an existing value, which will cause epochDb.putNoOverwrite failed. To fix bdb bug is difficulty, so we define the new epoch by `the largest value in epochDB + 1`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
