### PR TITLE
[BugFix] Fix error when tablet perform drop and clone at same time (#12081)

### DIFF
--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -142,6 +142,8 @@ public:
 
     Status delete_shutdown_tablet(int64_t tablet_id);
 
+    Status delete_shutdown_tablet_before_clone(int64_t tablet_id);
+
     MemTracker* tablet_meta_mem_tracker() { return _mem_tracker; }
 
     // return true if all tablets visited

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -218,6 +218,18 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
         auto clone_header_file = strings::Substitute("$0/$1.hdr", schema_hash_dir, tablet_id);
         auto clone_meta_file = strings::Substitute("$0/meta", schema_hash_dir);
 
+        // old tablet may not exists in tablet map, it may still in shutdown tablet map(tablet path not deleted)
+        // new tablet's path maybe the same as old tablet's path, so we need to clear that path before cloning
+        // new files into that directory.
+        // NOTE: there may be concurrent drop tablet operations going on, so current code is still not entirely safe,
+        //       to be safe requires a lock for the whole clone process, which is too heavy for now.
+        // TODO: the correct solution would be:
+        //       making create/drop/clone tablet operation atomic by introducing some kind of tablet lock that is
+        //       more lightweight than the current _get_tablets_shard_lock
+        //       or making the clone process inside lock more lightweight, for example, download files to a temp
+        //       path outside of lock, then do mvs inside lock
+        RETURN_IF_ERROR(tablet_manager->delete_shutdown_tablet_before_clone(tablet_id));
+
         status = _clone_copy(*store, schema_hash_dir, _error_msgs, nullptr);
         if (!status.ok()) {
             (void)fs::remove_all(tablet_dir);


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/12041
Cherry-Pick: #12081

This bug is related to #5052

When doing full clone, old tablet may not exists in tablet map, but it may still in shutdown tablet map(tablet path not deleted) new tablet's path maybe the same as old tablet's path, so we need to clear that path before cloning new files into that directory.

Note this solution is not optimal, the correct final solution would be:

making create/drop/clone tablet operation atomic by introducing some kind of tablet lock that is more lightweight than the current _get_tablets_shard_lock or making the clone process inside lock more lightweight, for example, download files to a temp path outside of lock, then do mvs inside lock

