### PR TITLE
[BugFix] Fix error when tablet perform drop and clone at same time (#12081)

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -990,6 +990,30 @@ Status TabletManager::delete_shutdown_tablet(int64_t tablet_id) {
     return Status::OK();
 }
 
+Status TabletManager::delete_shutdown_tablet_before_clone(int64_t tablet_id) {
+    std::unique_lock l(_get_tablets_shard_lock(tablet_id));
+    auto old_tablet_ptr = _get_tablet_unlocked(tablet_id, true, nullptr);
+    if (old_tablet_ptr != nullptr) {
+        if (old_tablet_ptr->tablet_state() == TabletState::TABLET_SHUTDOWN) {
+            // Must reset old_tablet_ptr, otherwise `delete_shutdown_tablet()` will never success.
+            old_tablet_ptr.reset();
+            Status st = delete_shutdown_tablet(tablet_id);
+            if (st.ok() || st.is_not_found()) {
+                LOG(INFO) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet:" << tablet_id;
+            } else {
+                LOG(WARNING) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet failed tablet:"
+                             << tablet_id << " st:" << st;
+                return st;
+            }
+        } else {
+            // normally this should not happen, unless in when doing clone, another create tablet task is performed
+            return Status::AlreadyExist(fmt::format(
+                    "delete_shutdown_tablet_before_clone error: tablet already exists tablet: {}", tablet_id));
+        }
+    }
+    return Status::OK();
+}
+
 void TabletManager::register_clone_tablet(int64_t tablet_id) {
     TabletsShard& shard = _get_tablets_shard(tablet_id);
     std::unique_lock wlock(shard.lock);
@@ -1388,25 +1412,6 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     }
 
     std::unique_lock l(_get_tablets_shard_lock(tablet_id));
-    // TODO: if old tablet exists, should do an atomic "replace_or_add" approach instead
-    auto old_tablet_ptr = _get_tablet_unlocked(tablet_id, true, nullptr);
-    if (old_tablet_ptr != nullptr) {
-        if (old_tablet_ptr->tablet_state() == TabletState::TABLET_SHUTDOWN) {
-            // Must reset old_tablet_ptr, otherwise `delete_shutdown_tablet()` will never success.
-            old_tablet_ptr.reset();
-            Status st = delete_shutdown_tablet(tablet_id);
-            if (st.ok() || st.is_not_found()) {
-                LOG(INFO) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet:" << tablet_id;
-            } else {
-                LOG(WARNING) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet failed tablet:"
-                             << tablet_id << " st:" << st;
-                return st;
-            }
-        } else {
-            return Status::InternalError("tablet already exist");
-        }
-    }
-
     RETURN_IF_ERROR(meta_store->write_batch(&wb));
 
     if (!tablet->init().ok()) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -145,6 +145,8 @@ public:
 
     Status delete_shutdown_tablet(int64_t tablet_id);
 
+    Status delete_shutdown_tablet_before_clone(int64_t tablet_id);
+
     MemTracker* tablet_meta_mem_tracker() { return _mem_tracker; }
 
 private:

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -174,6 +174,18 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
         auto clone_header_file = strings::Substitute("$0/$1.hdr", schema_hash_dir, tablet_id);
         auto clone_meta_file = strings::Substitute("$0/meta", schema_hash_dir);
 
+        // old tablet may not exists in tablet map, it may still in shutdown tablet map(tablet path not deleted)
+        // new tablet's path maybe the same as old tablet's path, so we need to clear that path before cloning
+        // new files into that directory.
+        // NOTE: there may be concurrent drop tablet operations going on, so current code is still not entirely safe,
+        //       to be safe requires a lock for the whole clone process, which is too heavy for now.
+        // TODO: the correct solution would be:
+        //       making create/drop/clone tablet operation atomic by introducing some kind of tablet lock that is
+        //       more lightweight than the current _get_tablets_shard_lock
+        //       or making the clone process inside lock more lightweight, for example, download files to a temp
+        //       path outside of lock, then do mvs inside lock
+        RETURN_IF_ERROR(tablet_manager->delete_shutdown_tablet_before_clone(tablet_id));
+
         status = _clone_copy(*store, schema_hash_dir, _error_msgs, nullptr);
         if (!status.ok()) {
             (void)FileUtils::remove_all(tablet_dir);


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/12041
Cherry-Pick: https://github.com/StarRocks/starrocks/pull/12081

This bug is related to #5052

When doing full clone, old tablet may not exists in tablet map, but it may still in shutdown tablet map(tablet path not deleted) new tablet's path maybe the same as old tablet's path, so we need to clear that path before cloning new files into that directory.

Note this solution is not optimal, the correct final solution would be:

making create/drop/clone tablet operation atomic by introducing some kind of tablet lock that is more lightweight than the current _get_tablets_shard_lock or making the clone process inside lock more lightweight, for example, download files to a temp path outside of lock, then do mvs inside lock

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
