### PR TITLE
[BugFix] disable use_broker for old FE

### DIFF
--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -183,7 +183,7 @@ struct TUploadReq {
     4: optional map<string, string> broker_prop
     // If use_broker is set, we will write hdfs thourgh broker
     // If use_broker is not set, we will write through libhdfs/S3 directly
-    5: optional bool use_broker = false
+    5: optional bool use_broker
     // hdfs_write_buffer_size_kb for writing through lib hdfs directly
     6: optional i32 hdfs_write_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties
@@ -197,7 +197,7 @@ struct TDownloadReq {
     4: optional map<string, string> broker_prop
     // If use_broker is set, we will write hdfs thourgh broker
     // If use_broker is not set, we will write through libhdfs/S3 directly
-    5: optional bool use_broker = false
+    5: optional bool use_broker
     // hdfs_read_buffer_size_kb for writing through lib hdfs directly
     6: optional i32 hdfs_read_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -56,7 +56,7 @@ struct TResultFileSinkOptions {
     7: optional map<string, string> broker_properties // only for remote file.
     // If use_broker is set, we will write hdfs thourgh broker
     // If use_broker is not set, we will write through libhdfs/S3 directly
-    8: optional bool use_broker = false
+    8: optional bool use_broker
     // hdfs_write_buffer_size_kb for writing through lib hdfs directly
     9: optional i32 hdfs_write_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties
@@ -138,7 +138,7 @@ struct TExportSink {
 
     // If use_broker is set, we will write hdfs thourgh broker
     // If use_broker is not set, we will write through libhdfs/S3 directly
-    7: optional bool use_broker = false
+    7: optional bool use_broker
     // hdfs_write_buffer_size_kb for writing through lib hdfs directly
     8: optional i32 hdfs_write_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -213,7 +213,7 @@ struct TBrokerScanRangeParams {
     13: optional bool non_blocking_read;
     // If use_broker is set, we will read hdfs thourgh broker
     // If use_broker is not set, we will read through libhdfs/S3 directly
-    14: optional bool use_broker = false
+    14: optional bool use_broker
     // hdfs_read_buffer_size_kb for reading through lib hdfs directly
     15: optional i32 hdfs_read_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties


### PR DESCRIPTION
if fe's version is 2.3 and be's version is 2.4, although fe doesn't set use_broker in thrift, be will still set the default value of use_broker to be false, which enable without broker, this is not the expected behaviour

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12143

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
