### PR TITLE
[Enhancement] Support larger length in Hive string type.

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -287,11 +287,12 @@ public:
         std::stringstream ss;
         ss << "[";
         size_t size = this->size();
-        for (int i = 0; i < size - 1; ++i) {
-            ss << debug_item(i) << ", ";
-        }
-        if (size > 0) {
-            ss << debug_item(size - 1);
+        for(size_t i = 0; i < size; i++) {
+            if (i == size - 1) {
+                ss << debug_item(i);
+            } else {
+                ss << debug_item(i) << ", ";
+            }
         }
         ss << "]";
         return ss.str();

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -285,14 +285,17 @@ public:
 
     std::string debug_string() const override {
         std::stringstream ss;
-        ss << "[";
         size_t size = this->size();
-        for (size_t i = 0; i < size; i++) {
-            if (i == size - 1) {
-                ss << debug_item(i);
-            } else {
-                ss << debug_item(i) << ", ";
-            }
+        if (size == 0) {
+            return "[]";
+        }
+
+        ss << "[";
+        for (size_t i = 0; i < size - 1; i++) {
+            ss << debug_item(i) << ", ";
+        }
+        if (size > 0) {
+            ss << debug_item(size - 1);
         }
         ss << "]";
         return ss.str();

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -287,7 +287,7 @@ public:
         std::stringstream ss;
         ss << "[";
         size_t size = this->size();
-        for(size_t i = 0; i < size; i++) {
+        for (size_t i = 0; i < size; i++) {
             if (i == size - 1) {
                 ss << debug_item(i);
             } else {

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -272,7 +272,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
                 if (!_converters[j]->read_string(column, field, options)) {
                     LOG(WARNING) << "Converter encountered an error for field " << field.to_string() << ", index "
                                  << index << ", column " << _scanner_params.materialize_slots[j]->debug_string();
-                    error_msg = strings::Substitute("CSV parse column [$0] failed, more details plz see be log.",
+                    error_msg = strings::Substitute("CSV parse column [$0] failed, more details please see be log.",
                                                     _scanner_params.materialize_slots[j]->debug_string());
                     chunk->get()->set_num_rows(num_rows);
                     has_error = true;

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -221,6 +221,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     options.array_hive_collection_delimiter = _collection_delimiter;
     options.array_hive_mapkey_delimiter = _mapkey_delimiter;
     options.array_hive_nested_level = 1;
+    options.invalid_field_as_null = false;
 
     for (size_t num_rows = chunk->get()->num_rows(); num_rows < chunk_size; /**/) {
         status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
@@ -250,6 +251,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
 
         bool has_error = false;
+        std::string error_msg;
         int num_materialize_columns = _scanner_params.materialize_slots.size();
         int field_size = fields.size();
         if (_scanner_params.hive_column_names->size() != field_size) {
@@ -270,6 +272,8 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
                 if (!_converters[j]->read_string(column, field, options)) {
                     LOG(WARNING) << "Converter encountered an error for field " << field.to_string() << ", index "
                                  << index << ", column " << _scanner_params.materialize_slots[j]->debug_string();
+                    error_msg = strings::Substitute("CSV parse column [$0] failed, more details plz see be log.",
+                                                    _scanner_params.materialize_slots[j]->debug_string());
                     chunk->get()->set_num_rows(num_rows);
                     has_error = true;
                     break;
@@ -301,6 +305,8 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
                     column->append(*data_column, 0, 1);
                 }
             }
+        } else {
+            return Status::InternalError(error_msg);
         }
     }
     return chunk->get()->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");

--- a/be/src/formats/csv/binary_converter.cpp
+++ b/be/src/formats/csv/binary_converter.cpp
@@ -47,6 +47,7 @@ bool BinaryConverter::read_string(Column* column, Slice s, const Options& option
     }
 
     if (UNLIKELY((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
+        LOG(WARNING) << "Column [" << column->get_name() << "]'s length exceed max varchar length.";
         return false;
     }
     down_cast<BinaryColumn*>(column)->append(s);
@@ -91,6 +92,7 @@ bool BinaryConverter::read_quoted_string(Column* column, Slice s, const Options&
     size_t ext_size = new_size - old_size;
     if (UNLIKELY((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
         bytes.resize(old_size);
+        LOG(WARNING) << "Column [" << column->get_name() << "]'s length exceed max varchar length.";
         return false;
     }
     offsets.push_back(bytes.size());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -50,9 +50,9 @@ public class ScalarType extends Type implements Cloneable {
     // precision that is supported by the smallest decimal type in the BE (4 bytes).
     public static final int DEFAULT_PRECISION = 9;
     public static final int DEFAULT_SCALE = 0; // SQL standard
-    // Longest supported VARCHAR and CHAR, chosen to match Hive.
-    public static final int DEFAULT_STRING_LENGTH = 65533;
     public static final int MAX_VARCHAR_LENGTH = 1048576;
+    // Longest supported VARCHAR and CHAR, chosen to match Hive.
+    public static final int DEFAULT_STRING_LENGTH = MAX_VARCHAR_LENGTH;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)
     public static final int MAX_HLL_LENGTH = 16385;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -958,19 +958,19 @@ public class ExpressionTest extends PlanTestBase {
         String plan;
         sql = "select cast(cast(id_date as string) as boolean) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(CAST(9: id_date AS VARCHAR(65533)) AS BOOLEAN)");
+        assertContains(plan, "CAST(CAST(9: id_date AS VARCHAR(1048576)) AS BOOLEAN)");
 
         sql = "select cast(cast(id_date as datetime) as string) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(CAST(9: id_date AS DATETIME) AS VARCHAR(65533))");
+        assertContains(plan, "CAST(CAST(9: id_date AS DATETIME) AS VARCHAR(1048576))");
 
         sql = "select cast(cast(id_date as boolean) as string) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(CAST(9: id_date AS BOOLEAN) AS VARCHAR(65533))");
+        assertContains(plan, "CAST(CAST(9: id_date AS BOOLEAN) AS VARCHAR(1048576))");
 
         sql = "select cast(cast(id_datetime as string) as date) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(CAST(8: id_datetime AS VARCHAR(65533)) AS DATE)");
+        assertContains(plan, "CAST(CAST(8: id_datetime AS VARCHAR(1048576)) AS DATE)");
 
         sql = "select cast(cast(t1d as int) as boolean) from test_all_type;";
         plan = getFragmentPlan(sql);
@@ -1005,7 +1005,7 @@ public class ExpressionTest extends PlanTestBase {
         String plan;
         sql = "select cast(cast(t1c as bigint) as string) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(3: t1c AS VARCHAR(65533))");
+        assertContains(plan, "CAST(3: t1c AS VARCHAR(1048576))");
 
         sql = "select cast(cast(t1c as bigint) as int) from test_all_type;";
         plan = getFragmentPlan(sql);
@@ -1017,11 +1017,11 @@ public class ExpressionTest extends PlanTestBase {
 
         sql = "select cast(cast(id_bool as bigint) as string) from test_bool;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+        assertContains(plan, "CAST(11: id_bool AS VARCHAR(1048576))");
 
         sql = "select cast(cast(id_bool as boolean) as string) from test_bool;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+        assertContains(plan, "CAST(11: id_bool AS VARCHAR(1048576))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2070,7 +2070,7 @@ public class JoinTest extends PlanTestBase {
         assertContains(plan, "|  equal join conjunct: 1: v1 = 4: v4");
         assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: CAST(1: v1 AS VARCHAR(65533)) = CAST(1: v1 AS VARCHAR(1048576))\n" +
+                "     PREDICATES: CAST(1: v1 AS VARCHAR(1048576)) = CAST(1: v1 AS VARCHAR(1048576))\n" +
                 "     partitions=0/1\n");
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Our original design is to convert string to varchar(65533), but actually, we can provide larger varchar length.

In this pr, I do the following things:
1. In CSV, if there is an error in parsing a column, an error will be reported directly, instead of converted as a null column.
2. Support larger length for Hive string type.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
