### PR TITLE
[Refactor] Filter resource mapping catalog when executing show catalogs.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -294,7 +294,7 @@ public class CatalogMgr {
             try {
                 for (Map.Entry<String, Catalog> entry : catalogs.entrySet()) {
                     Catalog catalog = entry.getValue();
-                    if (catalog == null) {
+                    if (catalog == null || isResourceMappingCatalog(catalog.getName())) {
                         continue;
                     }
                     catalog.getProcNodeData(result);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Every hive/hudi resource will create a non-persist inside catalog which named "resourceMappingCatalog".  We shouldn't display resourceMappingCatalog when executing show catalogs.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
