### PR TITLE
[BugFix] fix compatibility issue when upgrading version

### DIFF
--- a/be/src/exec/vectorized/cross_join_node.h
+++ b/be/src/exec/vectorized/cross_join_node.h
@@ -68,7 +68,7 @@ private:
     void _init_row_desc();
     void _init_chunk(ChunkPtr* chunk);
 
-    TJoinOp::type _join_op;
+    TJoinOp::type _join_op = TJoinOp::CROSS_JOIN;
     std::vector<ExprContext*> _join_conjuncts;
     std::string _sql_join_conjuncts;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


- In 2.4, the `CrossJoinNode::_join_op` would be initialized according to PlanNode. 
- But in 2.3, the PlanNode does not contain this field, so it would not be initialized
- As result, the join op may be `LEFT_OUTER`, even if it's a CrossJoin plan

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
