### PR TITLE
[BugFix] Persist offsets of all kafka partitions in Routine load if few are altered

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -125,6 +125,14 @@ public class KafkaProgress extends RoutineLoadProgress {
 
     // modify the partition offset of this progress.
     // throw exception is the specified partition does not exist in progress.
+    //
+    // `kafkaPartitionOffsets`, the parameter of this function, CAN BE MODIFIED to fit the actual value so that when
+    // all operations end, it will represent the actual offset of this job and will be persisted to the journal.
+    // All follower will replay this journal and load the actual offset of this job as well.
+    // For example:
+    //   if current offset is {0:11, 1:22, 2:33, 3:55}, the parameter `kafkaPartitionOffsets` is {0: 22, 2:44}
+    //   in this function, current offset is modified as {0: 22, 1: 22, 2:44, 3:55}
+    //   so is the parameter `kafkaPartitionOffsets`.
     public void modifyOffset(List<Pair<Integer, Long>> kafkaPartitionOffsets) throws DdlException {
         for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
             if (!partitionIdToOffset.containsKey(pair.first)) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
@@ -14,7 +14,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaProgressTest.java
@@ -4,6 +4,7 @@ package com.starrocks.load.routineload;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
@@ -12,6 +13,7 @@ import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,12 +43,26 @@ public class KafkaProgressTest {
         };
 
         KafkaProgress progress = new KafkaProgress();
-        // modify offset while paused
-        progress.modifyOffset(Arrays.asList(new Pair<>(3, 20L)));
+        // modify offset while paused when partition is not ready
+        try {
+            List<Pair<Integer, Long>> partitionToOffset = new ArrayList<>();
+            partitionToOffset.add(new Pair<>(3, 20L));
+            progress.modifyOffset(partitionToOffset);
+        } catch (DdlException e) {
+            Assert.assertEquals("The specified partition 3 is not in the consumed partitions", e.getMessage());
+        }
+
         progress.addPartitionOffset(new Pair<>(0, -1L));
         progress.addPartitionOffset(new Pair<>(1, -2L));
         progress.addPartitionOffset(new Pair<>(2, 10L));
+        progress.addPartitionOffset(new Pair<>(3, 10L));
         progress.convertOffset("127.0.0.1:9020", "topic", Maps.newHashMap());
+
+        List<Pair<Integer, Long>> partitionToOffset = new ArrayList<>();
+        partitionToOffset.add(new Pair<>(3, 20L));
+        progress.modifyOffset(partitionToOffset);
+        Assert.assertEquals(4, partitionToOffset.size());
+
         Assert.assertEquals(100L, (long) progress.getOffsetByPartition(0));
         Assert.assertEquals(1L, (long) progress.getOffsetByPartition(1));
         Assert.assertEquals(10L, (long) progress.getOffsetByPartition(2));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12221, actually fixes #7775 too..

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Alter routine load when partitions are not initialized will be rejected by master.
2. Alter routine load by alter the offsets of some of the partitions will end up persist offsets of all kafka partitions.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
