### PR TITLE
[BugFix] fix alter table in new publish; add detail error message for load/insert publish timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1473,6 +1473,15 @@ public class StmtExecutor {
         }
 
         String errMsg = "";
+        if (txnStatus.equals(TransactionStatus.COMMITTED)) {
+            String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
+                    .getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
+            LOG.warn("txn {} publish timeout {}", transactionId, timeoutInfo);
+            if (timeoutInfo.length() > 120) {
+                timeoutInfo = timeoutInfo.substring(0, 120) + "...";
+            }
+            errMsg = "Publish timeout " + timeoutInfo;
+        }
         try {
             context.getGlobalStateMgr().getLoadManager().recordFinishedOrCacnelledLoadJob(jobId,
                     EtlJobType.INSERT,

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -965,11 +965,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
         try {
-            if (!loadTxnCommitImpl(request)) {
-                // committed success but not visible
-                status.setStatus_code(TStatusCode.PUBLISH_TIMEOUT);
-                status.addToError_msgs("Publish timeout. The data will be visible after a while");
-            }
+            loadTxnCommitImpl(request, status);
         } catch (UserException e) {
             LOG.warn("failed to commit txn_id: {}: {}", request.getTxnId(), e.getMessage());
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
@@ -984,7 +980,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     // return true if commit success and publish success, return false if publish timeout
-    private boolean loadTxnCommitImpl(TLoadTxnCommitRequest request) throws UserException {
+    private void loadTxnCommitImpl(TLoadTxnCommitRequest request, TStatus status) throws UserException {
         String cluster = request.getCluster();
         if (Strings.isNullOrEmpty(cluster)) {
             cluster = SystemInfoService.DEFAULT_CLUSTER;
@@ -1015,17 +1011,26 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
                 timeoutMs, attachment);
         if (!ret) {
-            return ret;
+            // committed success but not visible
+            status.setStatus_code(TStatusCode.PUBLISH_TIMEOUT);
+            String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
+                    .getTxnPublishTimeoutDebugInfo(db.getId(), request.getTxnId());
+            LOG.warn("txn {} publish timeout {}", request.getTxnId(), timeoutInfo);
+            if (timeoutInfo.length() > 120) {
+                timeoutInfo = timeoutInfo.substring(0, 120) + "...";
+            }
+            status.addToError_msgs("Publish timeout. The data will be visible after a while" + timeoutInfo);
+            return;
         }
         // if commit and publish is success, load can be regarded as success
         MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
         if (null == attachment) {
-            return ret;
+            return;
         }
         // collect table-level metrics
         Table tbl = db.getTable(request.getTbl());
         if (null == tbl) {
-            return ret;
+            return;
         }
         TableMetricsEntity entity = TableMetricsRegistry.getInstance().getMetricsEntity(tbl.getId());
         switch (request.txnCommitAttachment.getLoadType()) {
@@ -1053,7 +1058,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             default:
                 break;
         }
-        return ret;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1658,4 +1658,17 @@ public class DatabaseTransactionMgr {
         LOG.info("finish transaction {} successfully", transactionState);
     }
 
+    public String getTxnPublishTimeoutDebugInfo(long txnId) {
+        TransactionState transactionState;
+        readLock();
+        try {
+            transactionState = unprotectedGetTransactionState(txnId);
+        } finally {
+            readUnlock();
+        }
+        if (transactionState == null) {
+            return "";
+        }
+        return transactionState.getPublishTimeoutDebugInfo();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -740,4 +740,12 @@ public class GlobalTransactionMgr implements Writable {
         write(dos);
         return checksum;
     }
+
+    public String getTxnPublishTimeoutDebugInfo(long dbId, long txnId) {
+        DatabaseTransactionMgr dbTransactionMgr = dbIdToDatabaseTransactionMgrs.get(dbId);
+        if (dbTransactionMgr == null) {
+            return "";
+        }
+        return dbTransactionMgr.getTxnPublishTimeoutDebugInfo(txnId);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
@@ -36,6 +36,19 @@ public class TransactionChecker {
         return true;
     }
 
+    // return abnormal tablets/replicas which is causing this txn unfinished
+    public String debugInfo() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("errors:");
+        int totalTablet = 0;
+        for (PartitionChecker p : partitions) {
+            p.debugInfo(sb);
+            totalTablet += p.tablets.size();
+        }
+        sb.append(String.format(" #partition:%d #tablet:%d", partitions.size(), totalTablet));
+        return sb.toString();
+    }
+
     static class PartitionChecker {
         long partitionId;
         long version;
@@ -55,6 +68,12 @@ public class TransactionChecker {
                 }
             }
             return true;
+        }
+
+        void debugInfo(StringBuilder sb) {
+            for (LocalTablet t : tablets) {
+                t.getAbnormalReplicaInfos(version, quorum, sb);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -926,6 +926,14 @@ public class TransactionState implements Writable {
         return ret;
     }
 
+    public String getPublishTimeoutDebugInfo() {
+        if (finishChecker != null) {
+            return finishChecker.debugInfo();
+        } else {
+            return getErrMsg();
+        }
+    }
+
     public void setFinishState(TxnFinishState finishState) {
         this.finishState = finishState;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR fixes a bug in publish version check logic when alter table is undergoing. When alter table is in progress, the newly created alter tablet cannot achieve the desired version for publish task, so when checking for publish reach quorum conditions, should consider tablets under schemachange normal, so txn during schemachange can publish normally.
This PR also add more detailed error to client return message when publish is timeout for new publish mechanism. 

The error message will change from
```
"Message": "Publish timeout. The data will be visible after a while",
```
to something like:
```
"Message": "Publish timeout. The data will be visible after a while errors:  {tablet:31027 quorum:1 version:4 #replica:1 err:[be:192.168.100.72,version:3,ALTER]} #partition:1 #tablet:2",
```

Fixes: #11841
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
