### PR TITLE
[cherry-pick] [branch-2.4] [Enhancement] Support adjust cachesize automatically (#11810)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -52,6 +52,18 @@ CONF_mInt64(tc_free_memory_rate, "0");
 // tcmalloc gc period, default 60, it should be between [1, 180]
 CONF_mInt64(tc_gc_period, "60");
 
+CONF_mBool(enable_auto_adjust_pagecache, "true");
+// Memory urget water level, if the memory usage exceeds this level, reduce the size of
+// the Pagecache immediately, it should be between (memory_high_level, 100].
+CONF_mInt64(memory_urgent_level, "85");
+// Memory high water level, if the memory usage exceeds this level, reduce the size of
+// the Pagecache slowly, it should be between [1, memory_urgent_level).
+CONF_mInt64(memory_high_level, "75");
+// Pagecache size adjust period, default 20, it should be between [1, 180].
+CONF_mInt64(pagecache_adjust_period, "20");
+// Sleep time in seconds between pagecache adjust iterations.
+CONF_mInt64(auto_adjust_pagecache_interval_seconds, "10");
+
 // Bound on the total amount of bytes allocated to thread caches.
 // This bound is not strict, so it is possible for the cache to go over this bound
 // in certain circumstances. The maximum value of this flag is capped to 1GB.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -55,6 +55,7 @@ void UpdateConfigAction::handle(HttpRequest* req) {
         });
         _config_callback.emplace("storage_page_cache_limit", [&]() {
             int64_t cache_limit = _exec_env->get_storage_page_cache_size();
+            cache_limit = _exec_env->check_storage_page_cache_size(cache_limit);
             StoragePageCache::instance()->set_capacity(cache_limit);
         });
     });

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -389,7 +389,10 @@ int64_t ExecEnv::get_storage_page_cache_size() {
     if (_mem_tracker->has_limit()) {
         mem_limit = _mem_tracker->limit();
     }
-    int64_t storage_cache_limit = ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+}
+
+int64_t ExecEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
     if (storage_cache_limit > MemInfo::physical_mem()) {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
                      << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
@@ -406,6 +409,7 @@ int64_t ExecEnv::get_storage_page_cache_size() {
 
 Status ExecEnv::_init_storage_page_cache() {
     int64_t storage_cache_limit = get_storage_page_cache_size();
+    storage_cache_limit = check_storage_page_cache_size(storage_cache_limit);
     StoragePageCache::create_global_cache(_page_cache_mem_tracker, storage_cache_limit);
 
     // TODO(zc): The current memory usage configuration is a bit confusing,

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -202,6 +202,7 @@ public:
     AgentServer* agent_server() const { return _agent_server; }
 
     int64_t get_storage_page_cache_size();
+    int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
 
 private:
     Status _init(const std::vector<StorePath>& store_paths);

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -37,6 +37,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/update_manager.h"
+#include "util/gc_helper.h"
 #include "util/thread.h"
 #include "util/time.h"
 
@@ -176,8 +177,102 @@ Status StorageEngine::start_bg_threads() {
         }
     }
 
+    if (!config::disable_storage_page_cache) {
+        _adjust_cache_thread = std::thread([this] { _adjust_pagecache_callback(nullptr); });
+        Thread::set_thread_name(_adjust_cache_thread, "adjust_cache");
+    }
+
     LOG(INFO) << "All backgroud threads of storage engine have started.";
     return Status::OK();
+}
+
+void evict_pagecache(StoragePageCache* cache, int64_t bytes_to_dec, std::atomic<bool>& stoped) {
+    if (bytes_to_dec > 0) {
+        int64_t bytes = bytes_to_dec;
+        while (bytes >= GCBYTES_ONE_STEP) {
+            // Evicting 1GB of data takes about 1 second, check if process have been canceled.
+            if (UNLIKELY(stoped)) {
+                return;
+            }
+            cache->adjust_capacity(-GCBYTES_ONE_STEP, kcacheMinSize);
+            bytes -= GCBYTES_ONE_STEP;
+        }
+        if (bytes > 0) {
+            cache->adjust_capacity(-bytes, kcacheMinSize);
+        }
+    }
+}
+
+void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
+#ifdef GOOGLE_PROFILER
+    ProfilerRegisterThread();
+#endif
+    int64_t cur_period = config::pagecache_adjust_period;
+    int64_t cur_interval = config::auto_adjust_pagecache_interval_seconds;
+    std::unique_ptr<GCHelper> dec_advisor = std::make_unique<GCHelper>(cur_period, cur_interval, MonoTime::Now());
+    std::unique_ptr<GCHelper> inc_advisor = std::make_unique<GCHelper>(cur_period, cur_interval, MonoTime::Now());
+    auto cache = StoragePageCache::instance();
+    while (!_bg_worker_stopped.load(std::memory_order_consume)) {
+        SLEEP_IN_BG_WORKER(cur_interval);
+        if (!config::enable_auto_adjust_pagecache) {
+            continue;
+        }
+        if (config::disable_storage_page_cache) {
+            continue;
+        }
+        MemTracker* memtracker = ExecEnv::GetInstance()->process_mem_tracker();
+        if (memtracker == nullptr || !memtracker->has_limit() || cache == nullptr) {
+            continue;
+        }
+        if (UNLIKELY(cur_period != config::pagecache_adjust_period ||
+                     cur_interval != config::auto_adjust_pagecache_interval_seconds)) {
+            cur_period = config::pagecache_adjust_period;
+            cur_interval = config::auto_adjust_pagecache_interval_seconds;
+            dec_advisor.reset(new GCHelper(cur_period, cur_interval, MonoTime::Now()));
+            inc_advisor.reset(new GCHelper(cur_period, cur_interval, MonoTime::Now()));
+            // We re-initialized advisor, just continue.
+            continue;
+        }
+
+        // Check config valid
+        int64_t memory_urgent_level = config::memory_urgent_level;
+        int64_t memory_high_level = config::memory_high_level;
+        if (UNLIKELY(!(memory_urgent_level > memory_high_level && memory_high_level >= 1 &&
+                       memory_urgent_level <= 100))) {
+            LOG(ERROR) << "memory water level config is illegal: memory_urgent_level=" << memory_urgent_level
+                       << " memory_high_level=" << memory_high_level;
+            continue;
+        }
+
+        int64_t memory_urgent = memtracker->limit() * memory_urgent_level / 100;
+        int64_t delta_urgent = memtracker->consumption() - memory_urgent;
+        int64_t memory_high = memtracker->limit() * memory_high_level / 100;
+        if (delta_urgent > 0) {
+            // Memory usage exceeds memory_urgent_level, reduce size immediately.
+            cache->adjust_capacity(-delta_urgent, kcacheMinSize);
+            size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), memory_urgent - memory_high);
+            evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _bg_worker_stopped);
+            continue;
+        }
+
+        int64_t delta_high = memtracker->consumption() - memory_high;
+        if (delta_high > 0) {
+            size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), delta_high);
+            evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _bg_worker_stopped);
+        } else {
+            int64_t max_cache_size = std::max(ExecEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
+            int64_t cur_cache_size = cache->get_capacity();
+            if (cur_cache_size >= max_cache_size) {
+                continue;
+            }
+            int64_t delta_cache = std::min(max_cache_size - cur_cache_size, std::abs(delta_high));
+            size_t bytes_to_inc = inc_advisor->bytes_should_gc(MonoTime::Now(), delta_cache);
+            if (bytes_to_inc > 0) {
+                cache->adjust_capacity(bytes_to_inc);
+            }
+        }
+    }
+    return nullptr;
 }
 
 void* StorageEngine::_fd_cache_clean_callback(void* arg) {

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -63,6 +63,18 @@ size_t StoragePageCache::get_capacity() {
     return _cache->get_capacity();
 }
 
+uint64_t StoragePageCache::get_lookup_count() {
+    return _cache->get_lookup_count();
+}
+
+uint64_t StoragePageCache::get_hit_count() {
+    return _cache->get_hit_count();
+}
+
+bool StoragePageCache::adjust_capacity(int64_t delta, size_t min_capacity) {
+    return _cache->adjust_capacity(delta, min_capacity);
+}
+
 bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle) {
     auto* lru_handle = _cache->lookup(key.encode());
     if (lru_handle == nullptr) {

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -97,6 +97,12 @@ public:
 
     size_t get_capacity();
 
+    uint64_t get_lookup_count();
+
+    uint64_t get_hit_count();
+
+    bool adjust_capacity(int64_t delta, size_t min_capacity = 0);
+
 private:
     static StoragePageCache* _s_instance;
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -516,6 +516,9 @@ void StorageEngine::stop() {
     if (_fd_cache_clean_thread.joinable()) {
         _fd_cache_clean_thread.join();
     }
+    if (_adjust_cache_thread.joinable()) {
+        _adjust_cache_thread.join();
+    }
     if (config::path_gc_check) {
         for (auto& thread : _path_scan_threads) {
             if (thread.joinable()) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -246,6 +246,8 @@ private:
 
     void* _tablet_checkpoint_callback(void* arg);
 
+    void* _adjust_pagecache_callback(void* arg);
+
     void _start_clean_fd_cache();
     Status _perform_cumulative_compaction(DataDir* data_dir);
     Status _perform_base_compaction(DataDir* data_dir);
@@ -311,6 +313,7 @@ private:
     std::vector<std::pair<int64_t, std::vector<std::pair<uint32_t, std::string>>>> _executed_repair_compaction_tasks;
     // threads to clean all file descriptor not actively in use
     std::thread _fd_cache_clean_thread;
+    std::thread _adjust_cache_thread;
     std::vector<std::thread> _path_gc_threads;
     // threads to scan disk paths
     std::vector<std::thread> _path_scan_threads;

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -182,6 +182,12 @@ public:
     virtual void set_capacity(size_t capacity) = 0;
     virtual size_t get_capacity() = 0;
 
+    virtual uint64_t get_lookup_count() = 0;
+    virtual uint64_t get_hit_count() = 0;
+
+    //  Decrease or increase cache capacity.
+    virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
+
 private:
     Cache(const Cache&) = delete;
     const Cache& operator=(const Cache&) = delete;
@@ -321,10 +327,17 @@ public:
     void get_cache_status(rapidjson::Document* document) override;
     void set_capacity(size_t capacity) override;
     size_t get_capacity() override;
+<<<<<<< HEAD
+=======
+    uint64_t get_lookup_count() override;
+    uint64_t get_hit_count() override;
+    bool adjust_capacity(int64_t delta, size_t min_capacity = 0) override;
+>>>>>>> 1a1ccac0c ([Enhancement] Support adjust cachesize automatically (#11810))
 
 private:
     static uint32_t _hash_slice(const CacheKey& s);
     static uint32_t _shard(uint32_t hash);
+    void _set_capacity(size_t capacity);
 
     LRUCache _shards[kNumShards];
     std::mutex _mutex;

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -98,6 +98,32 @@ TEST_F(StoragePageCacheTest, normal) {
         size_t ori = cache.get_capacity();
         cache.set_capacity(ori / 2);
         ASSERT_EQ(ori / 2, cache.get_capacity());
+        cache.set_capacity(ori);
+    }
+
+    // adjust capacity
+    {
+        size_t ori = cache.get_capacity();
+        for (int i = 1; i <= 10; i++) {
+            cache.adjust_capacity(32);
+            ASSERT_EQ(cache.get_capacity(), ori + 32 * i);
+        }
+        cache.set_capacity(ori);
+        for (int i = 1; i <= 10; i++) {
+            cache.adjust_capacity(-32);
+            ASSERT_EQ(cache.get_capacity(), ori - 32 * i);
+        }
+        cache.set_capacity(ori);
+
+        int64_t delta = ori;
+        ASSERT_FALSE(cache.adjust_capacity(-delta / 2, ori));
+        ASSERT_EQ(cache.get_capacity(), ori);
+        ASSERT_TRUE(cache.adjust_capacity(-delta / 2, ori / 4));
+        cache.set_capacity(ori);
+
+        // overflow
+        cache.set_capacity(kNumShards);
+        ASSERT_FALSE(cache.adjust_capacity(-2 * kNumShards, 0));
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The BE memory is used by many logics, such as queries, ingestions, compactions, pagecache, and so on. pagecache is enabled by default, and the user can adjust the maximum amount of memory. Furthermore, we would like to have a pagecache self-adjustment policy, so that when memory pressure is low, pagecache can buffer more data, and when memory pressure is high, Pagecache can buffer less data. pagecache can actively evict some data to ensure the running of BE.

This PR automatically resize the Pagecache by monitoring the current memory water level. Below is a test result with auto-tuning cachesize enabled. This test specifies a urgent water level of 30% and a high water level of 20%. The memory usage fluctuates between urgent and high water levels.
![image](https://user-images.githubusercontent.com/45813655/196202020-16154787-4f24-4bc7-b433-7a8597e2bc35.png)
If auto-tuning cachesize is turned off, memory usage is not constrained.
![image](https://user-images.githubusercontent.com/45813655/196202108-c2d7b290-2862-4ca3-9888-b31d48193dcc.png)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
