### PR TITLE
[Feature] Support glue hive metastore

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -591,7 +591,6 @@ under the License.
             <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -164,10 +164,6 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         return Joiner.on(":").join(hiveTableName, createTime);
     }
 
-    public static boolean isHudiTable(String inputFormat) {
-        return HudiTable.fromInputFormat(inputFormat) != HudiTable.HudiTableType.UNKNOWN;
-    }
-
     public static HudiTableType fromInputFormat(String inputFormat) {
         switch (inputFormat) {
             case COW_INPUT_FORMAT:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -3,21 +3,16 @@
 package com.starrocks.connector.delta;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.starrocks.common.Config;
 import com.starrocks.connector.ReentrantExecutor;
 import com.starrocks.external.hive.CachingHiveMetastore;
 import com.starrocks.external.hive.CachingHiveMetastoreConf;
 import com.starrocks.external.hive.HiveMetaClient;
 import com.starrocks.external.hive.HiveMetastore;
 import com.starrocks.external.hive.IHiveMetastore;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class DeltaLakeInternalMgr {
     private final String catalogName;
@@ -35,7 +30,7 @@ public class DeltaLakeInternalMgr {
 
     public IHiveMetastore createHiveMetastore() {
         // TODO(stephen): Abstract the creator class to construct hive meta client
-        HiveMetaClient metaClient = createHiveMetaClient();
+        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(properties);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName);
         IHiveMetastore baseHiveMetastore;
         if (!enableMetastoreCache) {
@@ -59,14 +54,6 @@ public class DeltaLakeInternalMgr {
         if (enableMetastoreCache && refreshHiveMetastoreExecutor != null) {
             refreshHiveMetastoreExecutor.shutdown();
         }
-    }
-
-    public HiveMetaClient createHiveMetaClient() {
-        HiveConf conf = new HiveConf();
-        conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
-        conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
-                String.valueOf(Config.hive_meta_store_timeout_s));
-        return new HiveMetaClient(conf);
     }
 
     public CachingHiveMetastoreConf getHiveMetastoreConf() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.starrocks.connector.hive.HiveConnector.DUMMY_THRIFT_URI;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HiveConnectorInternalMgr {
@@ -112,6 +113,13 @@ public class HiveConnectorInternalMgr {
 
     public HiveMetaClient createHiveMetaClient() {
         HiveConf conf = new HiveConf();
+
+        properties.forEach(conf::set);
+        if (!properties.containsKey(HIVE_METASTORE_URIS)) {
+            // set value for compatible with the rollback
+            properties.put(HIVE_METASTORE_URIS, DUMMY_THRIFT_URI);
+        }
+
         conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
         conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
                 String.valueOf(Config.hive_meta_store_timeout_s));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -15,15 +15,10 @@ import com.starrocks.external.hive.HiveMetastore;
 import com.starrocks.external.hive.HiveRemoteFileIO;
 import com.starrocks.external.hive.IHiveMetastore;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static com.starrocks.connector.hive.HiveConnector.DUMMY_THRIFT_URI;
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HiveConnectorInternalMgr {
     private final String catalogName;
@@ -69,7 +64,7 @@ public class HiveConnectorInternalMgr {
 
     public IHiveMetastore createHiveMetastore() {
         // TODO(stephen): Abstract the creator class to construct hive meta client
-        HiveMetaClient metaClient = createHiveMetaClient();
+        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(properties);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName);
         IHiveMetastore baseHiveMetastore;
         if (!enableMetastoreCache) {
@@ -109,21 +104,6 @@ public class HiveConnectorInternalMgr {
         }
 
         return baseRemoteFileIO;
-    }
-
-    public HiveMetaClient createHiveMetaClient() {
-        HiveConf conf = new HiveConf();
-
-        properties.forEach(conf::set);
-        if (!properties.containsKey(HIVE_METASTORE_URIS)) {
-            // set value for compatible with the rollback
-            properties.put(HIVE_METASTORE_URIS, DUMMY_THRIFT_URI);
-        }
-
-        conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
-        conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
-                String.valueOf(Config.hive_meta_store_timeout_s));
-        return new HiveMetaClient(conf);
     }
 
     public ExecutorService getPullRemoteFileExecutor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -15,14 +15,10 @@ import com.starrocks.external.hive.HiveMetastore;
 import com.starrocks.external.hive.IHiveMetastore;
 import com.starrocks.external.hudi.HudiRemoteFileIO;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HudiConnectorInternalMgr {
     private final String catalogName;
@@ -68,7 +64,7 @@ public class HudiConnectorInternalMgr {
 
     public IHiveMetastore createHiveMetastore() {
         // TODO(stephen): Abstract the creator class to construct hive meta client
-        HiveMetaClient metaClient = createHiveMetaClient();
+        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(properties);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName);
         IHiveMetastore baseHiveMetastore;
         if (!enableMetastoreCache) {
@@ -108,14 +104,6 @@ public class HudiConnectorInternalMgr {
         }
 
         return baseRemoteFileIO;
-    }
-
-    public HiveMetaClient createHiveMetaClient() {
-        HiveConf conf = new HiveConf();
-        conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
-        conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
-                String.valueOf(Config.hive_meta_store_timeout_s));
-        return new HiveMetaClient(conf);
     }
 
     public ExecutorService getPullRemoteFileExecutor() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
@@ -5,7 +5,6 @@ package com.starrocks.external.hive;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveMetaStoreTable;
-import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.external.PartitionUtil;
@@ -53,7 +52,7 @@ public class HiveMetastore implements IHiveMetastore {
             throw new StarRocksConnectorException("Table is missing storage descriptor");
         }
 
-        if (!HudiTable.isHudiTable(table.getSd().getInputFormat())) {
+        if (!HiveMetastoreApiConverter.isHudiTable(table.getSd().getInputFormat())) {
             return HiveMetastoreApiConverter.toHiveTable(table, catalogName);
         } else {
             return HiveMetastoreApiConverter.toHudiTable(table, catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
@@ -97,7 +97,7 @@ public class HiveMetastoreApiConverter {
     }
 
     public static HudiTable toHudiTable(Table table, String catalogName) {
-        String hudiBasePath = table.getSd().getLocation();
+        String hudiBasePath = ObjectStorageUtils.formatObjectStoragePath(table.getSd().getLocation());
         Configuration conf = new Configuration();
         HoodieTableMetaClient metaClient =
                 HoodieTableMetaClient.builder().setConf(conf).setBasePath(hudiBasePath).build();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
@@ -199,7 +199,7 @@ public class HiveMetastoreApiConverter {
                                                        Schema tableSchema) {
         Map<String, String> hudiProperties = Maps.newHashMap();
 
-        String hudiBasePath = metastoreTable.getSd().getLocation();
+        String hudiBasePath = ObjectStorageUtils.formatObjectStoragePath(metastoreTable.getSd().getLocation());
         if (!Strings.isNullOrEmpty(hudiBasePath)) {
             hudiProperties.put(HUDI_BASE_PATH, hudiBasePath);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
@@ -79,6 +79,10 @@ public class HiveMetastoreApiConverter {
                 .setFullSchema(toFullSchemasForHiveTable(table))
                 .setTableLocation(table.getSd().getLocation())
                 .setCreateTime(table.getCreateTime());
+
+        if (table.getParameters().get("spark.sql.sources.provider").equalsIgnoreCase("delta")) {
+            tableBuilder.setTableLocation(table.getSd().getSerdeInfo().getParameters().get("path"));
+        }
         return tableBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreApiConverter.java
@@ -65,7 +65,7 @@ public class HiveMetastoreApiConverter {
     }
 
     public static String toTableLocation(StorageDescriptor sd, Map<String, String> tableParams) {
-        Optional<Map<String, String>> tableParamsOptional = Optional.of(tableParams);
+        Optional<Map<String, String>> tableParamsOptional = Optional.ofNullable(tableParams);
         if (isDeltaLakeTable(tableParamsOptional.orElse(ImmutableMap.of()))) {
             return sd.getSerdeInfo().getParameters().get("path");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
@@ -9,7 +9,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.external.ObjectStorageUtils;
-import com.starrocks.external.PartitionUtil;
 import com.starrocks.external.RemoteFileBlockDesc;
 import com.starrocks.external.RemoteFileDesc;
 import com.starrocks.external.RemoteFileIO;
@@ -73,7 +72,8 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                 if (!isValidDataFile(locatedFileStatus)) {
                     continue;
                 }
-                String fileName = PartitionUtil.getSuffixName(pathKey.getPath(), locatedFileStatus.getPath().toString());
+                String fileName = locatedFileStatus.getPath().getName();
+
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<RemoteFileBlockDesc> fileBlockDescs = getRemoteFileBlockDesc(blockLocations);
                 fileDescs.add(new RemoteFileDesc(fileName, "", locatedFileStatus.getLen(),

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
@@ -73,7 +73,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                 if (!isValidDataFile(locatedFileStatus)) {
                     continue;
                 }
-                String fileName = PartitionUtil.getSuffixName(path, locatedFileStatus.getPath().toString());
+                String fileName = PartitionUtil.getSuffixName(pathKey.getPath(), locatedFileStatus.getPath().toString());
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<RemoteFileBlockDesc> fileBlockDescs = getRemoteFileBlockDesc(blockLocations);
                 fileDescs.add(new RemoteFileDesc(fileName, "", locatedFileStatus.getLen(),

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRemoteFileIO.java
@@ -73,7 +73,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                 if (!isValidDataFile(locatedFileStatus)) {
                     continue;
                 }
-                String fileName = PartitionUtil.getSuffixName(pathKey.getPath(), locatedFileStatus.getPath().toString());
+                String fileName = PartitionUtil.getSuffixName(path, locatedFileStatus.getPath().toString());
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<RemoteFileBlockDesc> fileBlockDescs = getRemoteFileBlockDesc(blockLocations);
                 fileDescs.add(new RemoteFileDesc(fileName, "", locatedFileStatus.getLen(),

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
@@ -1,0 +1,2106 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.starrocks.external.hive.glue.metastore.AWSGlueClientFactory;
+import com.starrocks.external.hive.glue.metastore.AWSGlueMetastore;
+import com.starrocks.external.hive.glue.metastore.AWSGlueMetastoreFactory;
+import com.starrocks.external.hive.glue.metastore.GlueMetastoreClientDelegate;
+import com.starrocks.external.hive.glue.util.ExpressionHelper;
+import com.starrocks.external.hive.glue.util.LoggingHelper;
+import com.starrocks.external.hive.glue.util.MetastoreClientUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.ValidTxnList;
+import org.apache.hadoop.hive.common.ValidWriteIdList;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.PartitionDropOptions;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.AggrStats;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.Catalog;
+import org.apache.hadoop.hive.metastore.api.CheckConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.CmRecycleRequest;
+import org.apache.hadoop.hive.metastore.api.CmRecycleResponse;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.CompactionResponse;
+import org.apache.hadoop.hive.metastore.api.CompactionType;
+import org.apache.hadoop.hive.metastore.api.ConfigValSecurityException;
+import org.apache.hadoop.hive.metastore.api.CreationMetadata;
+import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.DefaultConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.FindSchemasByColsResp;
+import org.apache.hadoop.hive.metastore.api.FindSchemasByColsRqst;
+import org.apache.hadoop.hive.metastore.api.FireEventRequest;
+import org.apache.hadoop.hive.metastore.api.FireEventResponse;
+import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.GetAllFunctionsResponse;
+import org.apache.hadoop.hive.metastore.api.GetOpenTxnsInfoResponse;
+import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
+import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
+import org.apache.hadoop.hive.metastore.api.HeartbeatTxnRangeResponse;
+import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
+import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.HiveObjectType;
+import org.apache.hadoop.hive.metastore.api.ISchema;
+import org.apache.hadoop.hive.metastore.api.InvalidInputException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.InvalidPartitionException;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.Materialization;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.MetadataPpdResult;
+import org.apache.hadoop.hive.metastore.api.NoSuchLockException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.NoSuchTxnException;
+import org.apache.hadoop.hive.metastore.api.NotNullConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
+import org.apache.hadoop.hive.metastore.api.NotificationEventsCountRequest;
+import org.apache.hadoop.hive.metastore.api.NotificationEventsCountResponse;
+import org.apache.hadoop.hive.metastore.api.OpenTxnsResponse;
+import org.apache.hadoop.hive.metastore.api.PartitionEventType;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
+import org.apache.hadoop.hive.metastore.api.PrimaryKeysRequest;
+import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
+import org.apache.hadoop.hive.metastore.api.RuntimeStat;
+import org.apache.hadoop.hive.metastore.api.SQLCheckConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLDefaultConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
+import org.apache.hadoop.hive.metastore.api.SQLNotNullConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
+import org.apache.hadoop.hive.metastore.api.SQLUniqueConstraint;
+import org.apache.hadoop.hive.metastore.api.SchemaVersion;
+import org.apache.hadoop.hive.metastore.api.SchemaVersionState;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
+import org.apache.hadoop.hive.metastore.api.ShowLocksRequest;
+import org.apache.hadoop.hive.metastore.api.ShowLocksResponse;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.hadoop.hive.metastore.api.TableValidWriteIds;
+import org.apache.hadoop.hive.metastore.api.TxnAbortedException;
+import org.apache.hadoop.hive.metastore.api.TxnOpenException;
+import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
+import org.apache.hadoop.hive.metastore.api.UniqueConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.hadoop.hive.metastore.api.UnknownPartitionException;
+import org.apache.hadoop.hive.metastore.api.UnknownTableException;
+import org.apache.hadoop.hive.metastore.api.WMFullResourcePlan;
+import org.apache.hadoop.hive.metastore.api.WMMapping;
+import org.apache.hadoop.hive.metastore.api.WMNullablePool;
+import org.apache.hadoop.hive.metastore.api.WMNullableResourcePlan;
+import org.apache.hadoop.hive.metastore.api.WMPool;
+import org.apache.hadoop.hive.metastore.api.WMResourcePlan;
+import org.apache.hadoop.hive.metastore.api.WMTrigger;
+import org.apache.hadoop.hive.metastore.api.WMValidateResourcePlanResponse;
+import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_COMMENT;
+import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+
+/**
+ * Modified from https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore
+ */
+
+public class AWSCatalogMetastoreClient implements IMetaStoreClient {
+    // TODO "hook" into Hive logging (hive or hive.metastore)
+    private static final Logger LOGGER = Logger.getLogger(AWSCatalogMetastoreClient.class);
+
+    private final HiveConf conf;
+    private final AWSGlue glueClient;
+    private final Warehouse wh;
+    private final GlueMetastoreClientDelegate glueMetastoreClientDelegate;
+    private final String catalogId;
+
+    private static final int BATCH_DELETE_PARTITIONS_THREADS_COUNT = 5;
+    static final String BATCH_DELETE_PARTITIONS_THREAD_POOL_NAME_FORMAT = "batch-delete-partitions-%d";
+    private static final ExecutorService BATCH_DELETE_PARTITIONS_THREAD_POOL = Executors.newFixedThreadPool(
+            BATCH_DELETE_PARTITIONS_THREADS_COUNT,
+            new ThreadFactoryBuilder()
+                    .setNameFormat(BATCH_DELETE_PARTITIONS_THREAD_POOL_NAME_FORMAT)
+                    .setDaemon(true).build()
+    );
+
+    private Map<String, String> currentMetaVars;
+
+    public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook) throws MetaException {
+        this.conf = conf;
+        glueClient = new AWSGlueClientFactory(this.conf).newClient();
+
+        // TODO preserve existing functionality for HiveMetaHook
+        wh = new Warehouse(this.conf);
+
+        AWSGlueMetastore glueMetastore = new AWSGlueMetastoreFactory().newMetastore(conf);
+        glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueMetastore, wh);
+
+        snapshotActiveConf();
+        catalogId = MetastoreClientUtils.getCatalogId(conf);
+        if (!doesDefaultDBExist()) {
+            createDefaultDatabase();
+        }
+    }
+
+    private boolean doesDefaultDBExist() throws MetaException {
+
+        try {
+            GetDatabaseRequest getDatabaseRequest =
+                    new GetDatabaseRequest().withName(DEFAULT_DATABASE_NAME).withCatalogId(
+                            catalogId);
+            glueClient.getDatabase(getDatabaseRequest);
+        } catch (EntityNotFoundException e) {
+            return false;
+        } catch (AmazonServiceException e) {
+            String msg = "Unable to verify existence of default database: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+        return true;
+    }
+
+    private void createDefaultDatabase() throws MetaException {
+        Database defaultDB = new Database();
+        defaultDB.setName(DEFAULT_DATABASE_NAME);
+        defaultDB.setDescription(DEFAULT_DATABASE_COMMENT);
+        defaultDB.setLocationUri(wh.getDefaultDatabasePath(DEFAULT_DATABASE_NAME).toString());
+
+        org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet principalPrivilegeSet
+                = new org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet();
+        principalPrivilegeSet.setRolePrivileges(
+                Maps.<String, List<org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo>>newHashMap());
+
+        defaultDB.setPrivileges(principalPrivilegeSet);
+
+        try {
+            createDatabase(defaultDB);
+        } catch (org.apache.hadoop.hive.metastore.api.AlreadyExistsException e) {
+            LOGGER.warn("database - default already exists. Ignoring..");
+        } catch (Exception e) {
+            LOGGER.error("Unable to create default database", e);
+        }
+    }
+
+    @Override
+    public void createDatabase(Database database) throws InvalidObjectException,
+            org.apache.hadoop.hive.metastore.api.AlreadyExistsException, MetaException, TException {
+        glueMetastoreClientDelegate.createDatabase(database);
+    }
+
+    @Override
+    public Database getDatabase(String name) throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getDatabase(name);
+    }
+
+    @Override
+    public Database getDatabase(String catalogName, String databaseName)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> getDatabases(String pattern) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getDatabases(pattern);
+    }
+
+    @Override
+    public List<String> getDatabases(String catName, String databasePattern) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> getAllDatabases() throws MetaException, TException {
+        return getDatabases(".*");
+    }
+
+    @Override
+    public List<String> getAllDatabases(String catName) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void alterDatabase(String databaseName, Database database) throws NoSuchObjectException, MetaException,
+            TException {
+        glueMetastoreClientDelegate.alterDatabase(databaseName, database);
+    }
+
+    @Override
+    public void alterDatabase(String catName, String dbName, Database newDb)
+            throws NoSuchObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void dropDatabase(String name) throws NoSuchObjectException, InvalidOperationException, MetaException,
+            TException {
+        dropDatabase(name, true, false, false);
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb) throws NoSuchObjectException,
+            InvalidOperationException, MetaException, TException {
+        dropDatabase(name, deleteData, ignoreUnknownDb, false);
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb, boolean cascade)
+            throws NoSuchObjectException, InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.dropDatabase(name, deleteData, ignoreUnknownDb, cascade);
+    }
+
+    @Override
+    public void dropDatabase(String catName, String dbName, boolean deleteData, boolean ignoreUnknownDb,
+                             boolean cascade)
+            throws NoSuchObjectException, InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition add_partition(
+            org.apache.hadoop.hive.metastore.api.Partition partition)
+            throws InvalidObjectException, org.apache.hadoop.hive.metastore.api.AlreadyExistsException, MetaException,
+            TException {
+        glueMetastoreClientDelegate.addPartitions(Lists.newArrayList(partition), false, true);
+        return partition;
+    }
+
+    @Override
+    public int add_partitions(List<org.apache.hadoop.hive.metastore.api.Partition> partitions)
+            throws InvalidObjectException, org.apache.hadoop.hive.metastore.api.AlreadyExistsException, MetaException,
+            TException {
+        return glueMetastoreClientDelegate.addPartitions(partitions, false, true).size();
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> add_partitions(
+            List<org.apache.hadoop.hive.metastore.api.Partition> partitions,
+            boolean ifNotExists,
+            boolean needResult
+    ) throws TException {
+        return glueMetastoreClientDelegate.addPartitions(partitions, ifNotExists, needResult);
+    }
+
+    @Override
+    public int add_partitions_pspec(
+            PartitionSpecProxy pSpec
+    ) throws InvalidObjectException, org.apache.hadoop.hive.metastore.api.AlreadyExistsException,
+            MetaException, TException {
+        return glueMetastoreClientDelegate.addPartitionsSpecProxy(pSpec);
+    }
+
+    @Override
+    public void alterFunction(String dbName, String functionName,
+                              org.apache.hadoop.hive.metastore.api.Function newFunction) throws InvalidObjectException,
+            MetaException, TException {
+        glueMetastoreClientDelegate.alterFunction(dbName, functionName, newFunction);
+    }
+
+    @Override
+    public void alterFunction(String catName, String dbName, String funcName, Function newFunction)
+            throws InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alter_partition(
+            String dbName,
+            String tblName,
+            org.apache.hadoop.hive.metastore.api.Partition partition
+    ) throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterPartitions(dbName, tblName, Lists.newArrayList(partition));
+    }
+
+    @Override
+    public void alter_partition(
+            String dbName,
+            String tblName,
+            org.apache.hadoop.hive.metastore.api.Partition partition,
+            EnvironmentContext environmentContext
+    ) throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterPartitions(dbName, tblName, Lists.newArrayList(partition));
+    }
+
+    @Override
+    public void alter_partition(String catName, String dbName, String tblName,
+                                org.apache.hadoop.hive.metastore.api.Partition newPart,
+                                EnvironmentContext environmentContext)
+            throws InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alter_partitions(
+            String dbName,
+            String tblName,
+            List<org.apache.hadoop.hive.metastore.api.Partition> partitions
+    ) throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterPartitions(dbName, tblName, partitions);
+    }
+
+    @Override
+    public void alter_partitions(
+            String dbName,
+            String tblName,
+            List<org.apache.hadoop.hive.metastore.api.Partition> partitions,
+            EnvironmentContext environmentContext
+    ) throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterPartitions(dbName, tblName, partitions);
+    }
+
+    @Override
+    public void alter_partitions(String catName, String dbName, String tblName,
+                                 List<org.apache.hadoop.hive.metastore.api.Partition> newParts,
+                                 EnvironmentContext environmentContext)
+            throws InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alter_table(String dbName, String tblName, org.apache.hadoop.hive.metastore.api.Table table)
+            throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterTable(dbName, tblName, table, null);
+    }
+
+    @Override
+    public void alter_table(String catName, String dbName, String tblName, Table newTable,
+                            EnvironmentContext envContext) throws InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alter_table(String dbName, String tblName, org.apache.hadoop.hive.metastore.api.Table table,
+                            boolean cascade)
+            throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterTable(dbName, tblName, table, null);
+    }
+
+    @Override
+    public void alter_table_with_environmentContext(
+            String dbName,
+            String tblName,
+            org.apache.hadoop.hive.metastore.api.Table table,
+            EnvironmentContext environmentContext
+    ) throws InvalidOperationException, MetaException, TException {
+        glueMetastoreClientDelegate.alterTable(dbName, tblName, table, environmentContext);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition appendPartition(String dbName, String tblName,
+                                                                          List<String> values)
+            throws InvalidObjectException, org.apache.hadoop.hive.metastore.api.AlreadyExistsException, MetaException,
+            TException {
+        return glueMetastoreClientDelegate.appendPartition(dbName, tblName, values);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition appendPartition(String catName, String dbName,
+                                                                          String tableName, List<String> partVals)
+            throws InvalidObjectException, AlreadyExistsException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition appendPartition(String dbName, String tblName,
+                                                                          String partitionName)
+            throws InvalidObjectException,
+            org.apache.hadoop.hive.metastore.api.AlreadyExistsException, MetaException, TException {
+        List<String> partVals = partitionNameToVals(partitionName);
+        return glueMetastoreClientDelegate.appendPartition(dbName, tblName, partVals);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition appendPartition(String catName, String dbName,
+                                                                          String tableName, String name)
+            throws InvalidObjectException, AlreadyExistsException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public boolean create_role(org.apache.hadoop.hive.metastore.api.Role role) throws MetaException, TException {
+        return glueMetastoreClientDelegate.createRole(role);
+    }
+
+    @Override
+    public boolean drop_role(String roleName) throws MetaException, TException {
+        return glueMetastoreClientDelegate.dropRole(roleName);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Role> list_roles(
+            String principalName, org.apache.hadoop.hive.metastore.api.PrincipalType principalType
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.listRoles(principalName, principalType);
+    }
+
+    @Override
+    public List<String> listRoleNames() throws MetaException, TException {
+        return glueMetastoreClientDelegate.listRoleNames();
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleResponse get_principals_in_role(
+            org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleRequest request) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getPrincipalsInRole(request);
+    }
+
+    @Override
+    public GetRoleGrantsForPrincipalResponse get_role_grants_for_principal(
+            GetRoleGrantsForPrincipalRequest request) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getRoleGrantsForPrincipal(request);
+    }
+
+    @Override
+    public boolean grant_role(
+            String roleName,
+            String userName,
+            org.apache.hadoop.hive.metastore.api.PrincipalType principalType,
+            String grantor, org.apache.hadoop.hive.metastore.api.PrincipalType grantorType,
+            boolean grantOption
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate
+                .grantRole(roleName, userName, principalType, grantor, grantorType, grantOption);
+    }
+
+    @Override
+    public boolean revoke_role(
+            String roleName,
+            String userName,
+            org.apache.hadoop.hive.metastore.api.PrincipalType principalType,
+            boolean grantOption
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.revokeRole(roleName, userName, principalType, grantOption);
+    }
+
+    @Override
+    public void cancelDelegationToken(String tokenStrForm) throws MetaException, TException {
+        glueMetastoreClientDelegate.cancelDelegationToken(tokenStrForm);
+    }
+
+    @Override
+    public String getTokenStrForm() throws IOException {
+        return glueMetastoreClientDelegate.getTokenStrForm();
+    }
+
+    @Override
+    public boolean addToken(String tokenIdentifier, String delegationToken) throws TException {
+        return glueMetastoreClientDelegate.addToken(tokenIdentifier, delegationToken);
+    }
+
+    @Override
+    public boolean removeToken(String tokenIdentifier) throws TException {
+        return glueMetastoreClientDelegate.removeToken(tokenIdentifier);
+    }
+
+    @Override
+    public String getToken(String tokenIdentifier) throws TException {
+        return glueMetastoreClientDelegate.getToken(tokenIdentifier);
+    }
+
+    @Override
+    public List<String> getAllTokenIdentifiers() throws TException {
+        return glueMetastoreClientDelegate.getAllTokenIdentifiers();
+    }
+
+    @Override
+    public int addMasterKey(String key) throws MetaException, TException {
+        return glueMetastoreClientDelegate.addMasterKey(key);
+    }
+
+    @Override
+    public void updateMasterKey(Integer seqNo, String key) throws NoSuchObjectException, MetaException, TException {
+        glueMetastoreClientDelegate.updateMasterKey(seqNo, key);
+    }
+
+    @Override
+    public boolean removeMasterKey(Integer keySeq) throws TException {
+        return glueMetastoreClientDelegate.removeMasterKey(keySeq);
+    }
+
+    @Override
+    public String[] getMasterKeys() throws TException {
+        return glueMetastoreClientDelegate.getMasterKeys();
+    }
+
+    @Override
+    public LockResponse checkLock(long lockId)
+            throws NoSuchTxnException, TxnAbortedException, NoSuchLockException, TException {
+        return glueMetastoreClientDelegate.checkLock(lockId);
+    }
+
+    @Override
+    public void close() {
+        currentMetaVars = null;
+    }
+
+    @Override
+    public void commitTxn(long txnId) throws NoSuchTxnException, TxnAbortedException, TException {
+        glueMetastoreClientDelegate.commitTxn(txnId);
+    }
+
+    @Override
+    public void replCommitTxn(long srcTxnid, String replPolicy)
+            throws NoSuchTxnException, TxnAbortedException, TException {
+
+    }
+
+    @Override
+    public void abortTxns(List<Long> txnIds) throws TException {
+        glueMetastoreClientDelegate.abortTxns(txnIds);
+    }
+
+    @Override
+    public long allocateTableWriteId(long txnId, String dbName, String tableName) throws TException {
+        return 0;
+    }
+
+    @Override
+    public void replTableWriteIdState(String validWriteIdList, String dbName, String tableName, List<String> partNames)
+            throws TException {
+
+    }
+
+    @Override
+    public List<TxnToWriteId> allocateTableWriteIdsBatch(List<Long> txnIds, String dbName, String tableName)
+            throws TException {
+        return null;
+    }
+
+    @Override
+    public List<TxnToWriteId> replAllocateTableWriteIdsBatch(String dbName, String tableName, String replPolicy,
+                                                             List<TxnToWriteId> srcTxnToWriteIdList) throws TException {
+        return null;
+    }
+
+    @Deprecated
+    public void compact(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType
+    ) throws TException {
+        glueMetastoreClientDelegate.compact(dbName, tblName, partitionName, compactionType);
+    }
+
+    @Deprecated
+    public void compact(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType,
+            Map<String, String> tblProperties
+    ) throws TException {
+        glueMetastoreClientDelegate.compact(dbName, tblName, partitionName, compactionType, tblProperties);
+    }
+
+    @Override
+    public CompactionResponse compact2(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType,
+            Map<String, String> tblProperties
+    ) throws TException {
+        return glueMetastoreClientDelegate.compact2(dbName, tblName, partitionName, compactionType, tblProperties);
+    }
+
+    @Override
+    public void createFunction(org.apache.hadoop.hive.metastore.api.Function function)
+            throws InvalidObjectException, MetaException, TException {
+        glueMetastoreClientDelegate.createFunction(function);
+    }
+
+    @Override
+    public void createTable(org.apache.hadoop.hive.metastore.api.Table tbl)
+            throws org.apache.hadoop.hive.metastore.api.AlreadyExistsException, InvalidObjectException, MetaException,
+            NoSuchObjectException, TException {
+        glueMetastoreClientDelegate.createTable(tbl);
+    }
+
+    @Override
+    public boolean deletePartitionColumnStatistics(
+            String dbName, String tableName, String partName, String colName
+    ) throws NoSuchObjectException, MetaException, InvalidObjectException,
+            TException, org.apache.hadoop.hive.metastore.api.InvalidInputException {
+        return glueMetastoreClientDelegate.deletePartitionColumnStatistics(dbName, tableName, partName, colName);
+    }
+
+    @Override
+    public boolean deletePartitionColumnStatistics(String catName, String dbName, String tableName, String partName,
+                                                   String colName)
+            throws NoSuchObjectException, MetaException, InvalidObjectException, TException, InvalidInputException {
+        return false;
+    }
+
+    @Override
+    public boolean deleteTableColumnStatistics(
+            String dbName, String tableName, String colName
+    ) throws NoSuchObjectException, MetaException, InvalidObjectException,
+            TException, org.apache.hadoop.hive.metastore.api.InvalidInputException {
+        return glueMetastoreClientDelegate.deleteTableColumnStatistics(dbName, tableName, colName);
+    }
+
+    @Override
+    public boolean deleteTableColumnStatistics(String catName, String dbName, String tableName, String colName)
+            throws NoSuchObjectException, MetaException, InvalidObjectException, TException, InvalidInputException {
+        return false;
+    }
+
+    @Override
+    public void dropFunction(String dbName, String functionName) throws MetaException, NoSuchObjectException,
+            InvalidObjectException, org.apache.hadoop.hive.metastore.api.InvalidInputException, TException {
+        glueMetastoreClientDelegate.dropFunction(dbName, functionName);
+    }
+
+    @Override
+    public void dropFunction(String catName, String dbName, String funcName)
+            throws MetaException, NoSuchObjectException, InvalidObjectException, InvalidInputException, TException {
+
+    }
+
+    @Override
+    public boolean dropPartition(String dbName, String tblName, List<String> values, boolean deleteData)
+            throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.dropPartition(dbName, tblName, values, false, deleteData, false);
+    }
+
+    @Override
+    public boolean dropPartition(String catName, String dbName, String tblName, List<String> partVals,
+                                 boolean deleteData) throws NoSuchObjectException, MetaException, TException {
+        return false;
+    }
+
+    @Override
+    public boolean dropPartition(String dbName, String tblName, List<String> values, PartitionDropOptions options)
+            throws TException {
+        return glueMetastoreClientDelegate
+                .dropPartition(dbName, tblName, values, options.ifExists, options.deleteData, options.purgeData);
+    }
+
+    @Override
+    public boolean dropPartition(String catName, String dbName, String tblName, List<String> partVals,
+                                 PartitionDropOptions options) throws NoSuchObjectException, MetaException, TException {
+        return false;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> dropPartitions(String dbName, String tblName,
+                List<org.apache.hadoop.hive.metastore.utils.ObjectPair<Integer, byte[]>> partExprs,
+                                                                               boolean deleteData, boolean ifExists)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> dropPartitions(String dbName, String tblName,
+            List<org.apache.hadoop.hive.metastore.utils.ObjectPair<Integer, byte[]>> partExprs,
+            boolean deleteData, boolean ifExists,
+            boolean needResults)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> dropPartitions(String dbName, String tblName,
+            List<org.apache.hadoop.hive.metastore.utils.ObjectPair<Integer, byte[]>> partExprs,
+            PartitionDropOptions options)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> dropPartitions(String catName, String dbName,
+            String tblName,
+            List<org.apache.hadoop.hive.metastore.utils.ObjectPair<Integer, byte[]>> partExprs,
+            PartitionDropOptions options)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public boolean dropPartition(String dbName, String tblName, String partitionName, boolean deleteData)
+            throws NoSuchObjectException, MetaException, TException {
+        List<String> values = partitionNameToVals(partitionName);
+        return glueMetastoreClientDelegate.dropPartition(dbName, tblName, values, false, deleteData, false);
+    }
+
+    @Override
+    public boolean dropPartition(String catName, String dbName, String tblName, String name, boolean deleteData)
+            throws NoSuchObjectException, MetaException, TException {
+        return false;
+    }
+
+    @Deprecated
+    public void dropTable(String tableName, boolean deleteData) throws MetaException, UnknownTableException, TException,
+            NoSuchObjectException {
+        dropTable(DEFAULT_DATABASE_NAME, tableName, deleteData, false);
+    }
+
+    @Override
+    public void dropTable(String dbname, String tableName) throws MetaException, TException, NoSuchObjectException {
+        dropTable(dbname, tableName, true, true, false);
+    }
+
+    @Override
+    public void dropTable(String catName, String dbName, String tableName, boolean deleteData,
+                          boolean ignoreUnknownTable, boolean ifPurge)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void truncateTable(String dbName, String tableName, List<String> partNames)
+            throws MetaException, TException {
+
+    }
+
+    @Override
+    public void truncateTable(String catName, String dbName, String tableName, List<String> partNames)
+            throws MetaException, TException {
+
+    }
+
+    @Override
+    public CmRecycleResponse recycleDirToCmPath(CmRecycleRequest request) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void dropTable(String dbname, String tableName, boolean deleteData, boolean ignoreUnknownTab)
+            throws MetaException, TException, NoSuchObjectException {
+        dropTable(dbname, tableName, deleteData, ignoreUnknownTab, false);
+    }
+
+    @Override
+    public void dropTable(String dbname, String tableName, boolean deleteData, boolean ignoreUnknownTab,
+                          boolean ifPurge)
+            throws MetaException, TException, NoSuchObjectException {
+        glueMetastoreClientDelegate.dropTable(dbname, tableName, deleteData, ignoreUnknownTab, ifPurge);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition exchange_partition(
+            Map<String, String> partitionSpecs,
+            String srcDb,
+            String srcTbl,
+            String dstDb,
+            String dstTbl
+    ) throws MetaException, NoSuchObjectException, InvalidObjectException, TException {
+        return glueMetastoreClientDelegate.exchangePartition(partitionSpecs, srcDb, srcTbl, dstDb, dstTbl);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition exchange_partition(Map<String, String> partitionSpecs,
+                                                                             String sourceCat, String sourceDb,
+                                                                             String sourceTable, String destCat,
+                                                                             String destdb, String destTableName)
+            throws MetaException, NoSuchObjectException, InvalidObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> exchange_partitions(
+            Map<String, String> partitionSpecs,
+            String sourceDb,
+            String sourceTbl,
+            String destDb,
+            String destTbl
+    ) throws MetaException, NoSuchObjectException, InvalidObjectException, TException {
+        return glueMetastoreClientDelegate.exchangePartitions(partitionSpecs, sourceDb, sourceTbl, destDb, destTbl);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> exchange_partitions(Map<String, String> partitionSpecs,
+                                                                                    String sourceCat, String sourceDb,
+                                                                                    String sourceTable, String destCat,
+                                                                                    String destdb, String destTableName)
+            throws MetaException, NoSuchObjectException, InvalidObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public AggrStats getAggrColStatsFor(String dbName, String tblName, List<String> colNames, List<String> partName)
+            throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getAggrColStatsFor(dbName, tblName, colNames, partName);
+    }
+
+    @Override
+    public AggrStats getAggrColStatsFor(String catName, String dbName, String tblName, List<String> colNames,
+                                        List<String> partNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> getAllTables(String dbname) throws MetaException, TException, UnknownDBException {
+        return getTables(dbname, ".*");
+    }
+
+    @Override
+    public List<String> getAllTables(String catName, String dbName)
+            throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public String getConfigValue(String name, String defaultValue) throws TException, ConfigValSecurityException {
+        if (!Pattern.matches("(hive|hdfs|mapred).*", name)) {
+            throw new ConfigValSecurityException(
+                    "For security reasons, the config key " + name + " cannot be accessed");
+        }
+
+        return conf.get(name, defaultValue);
+    }
+
+    @Override
+    public String getDelegationToken(
+            String owner, String renewerKerberosPrincipalName
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getDelegationToken(owner, renewerKerberosPrincipalName);
+    }
+
+    @Override
+    public List<FieldSchema> getFields(String db, String tableName) throws MetaException, TException,
+            UnknownTableException, UnknownDBException {
+        return glueMetastoreClientDelegate.getFields(db, tableName);
+    }
+
+    @Override
+    public List<FieldSchema> getFields(String catName, String db, String tableName)
+            throws MetaException, TException, UnknownTableException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Function getFunction(String dbName, String functionName)
+            throws MetaException, TException {
+        return glueMetastoreClientDelegate.getFunction(dbName, functionName);
+    }
+
+    @Override
+    public Function getFunction(String catName, String dbName, String funcName) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> getFunctions(String dbName, String pattern) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getFunctions(dbName, pattern);
+    }
+
+    @Override
+    public List<String> getFunctions(String catName, String dbName, String pattern) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public GetAllFunctionsResponse getAllFunctions() throws MetaException, TException {
+        throw new TException("method not implemented");
+    }
+
+    @Override
+    public String getMetaConf(String key) throws MetaException, TException {
+        ConfVars metaConfVar = HiveConf.getMetaConf(key);
+        if (metaConfVar == null) {
+            throw new MetaException("Invalid configuration key " + key);
+        }
+        return conf.get(key, metaConfVar.getDefaultValue());
+    }
+
+    @Override
+    public void createCatalog(Catalog catalog)
+            throws AlreadyExistsException, InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alterCatalog(String catalogName, Catalog newCatalog)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public Catalog getCatalog(String catName) throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> getCatalogs() throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void dropCatalog(String catName)
+            throws NoSuchObjectException, InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String dbName, String tblName,
+                                                                       List<String> values)
+            throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getPartition(dbName, tblName, values);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String catName, String dbName, String tblName,
+                                                                       List<String> partVals)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String dbName, String tblName,
+                                                                       String partitionName)
+            throws MetaException, UnknownTableException, NoSuchObjectException, TException {
+        return glueMetastoreClientDelegate.getPartition(dbName, tblName, partitionName);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String catName, String dbName, String tblName,
+                                                                       String name)
+            throws MetaException, UnknownTableException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> partitionNames,
+            List<String> columnNames
+    ) throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getPartitionColumnStatistics(dbName, tableName, partitionNames, columnNames);
+    }
+
+    @Override
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String catName, String dbName,
+                                                                               String tableName, List<String> partNames,
+                                                                               List<String> colNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartitionWithAuthInfo(
+            String databaseName, String tableName, List<String> values,
+            String userName, List<String> groupNames)
+            throws MetaException, UnknownTableException, NoSuchObjectException, TException {
+
+        // TODO move this into the service
+        org.apache.hadoop.hive.metastore.api.Partition partition = getPartition(databaseName, tableName, values);
+        org.apache.hadoop.hive.metastore.api.Table table = getTable(databaseName, tableName);
+        if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
+            String partName = Warehouse.makePartName(table.getPartitionKeys(), values);
+            HiveObjectRef obj = new HiveObjectRef();
+            obj.setObjectType(HiveObjectType.PARTITION);
+            obj.setDbName(databaseName);
+            obj.setObjectName(tableName);
+            obj.setPartValues(values);
+            org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet privilegeSet =
+                    this.get_privilege_set(obj, userName, groupNames);
+            partition.setPrivileges(privilegeSet);
+        }
+
+        return partition;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Partition getPartitionWithAuthInfo(String catName, String dbName,
+                                                                                   String tableName, List<String> pvals,
+                                                                                   String userName,
+                                                                                   List<String> groupNames)
+            throws MetaException, UnknownTableException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitionsByNames(
+            String databaseName, String tableName, List<String> partitionNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getPartitionsByNames(databaseName, tableName, partitionNames);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitionsByNames(String catName, String dbName,
+                                                                                     String tblName,
+                                                                                     List<String> partNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<FieldSchema> getSchema(String db, String tableName)
+            throws MetaException, TException, UnknownTableException,
+            UnknownDBException {
+        return glueMetastoreClientDelegate.getSchema(db, tableName);
+    }
+
+    @Override
+    public List<FieldSchema> getSchema(String catName, String db, String tableName)
+            throws MetaException, TException, UnknownTableException, UnknownDBException {
+        return null;
+    }
+
+    @Deprecated
+    public org.apache.hadoop.hive.metastore.api.Table getTable(String tableName)
+            throws MetaException, TException, NoSuchObjectException {
+        //this has been deprecated
+        return getTable(DEFAULT_DATABASE_NAME, tableName);
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.Table getTable(String dbName, String tableName)
+            throws MetaException, TException, NoSuchObjectException {
+        return glueMetastoreClientDelegate.getTable(dbName, tableName);
+    }
+
+    @Override
+    public Table getTable(String catName, String dbName, String tableName) throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<ColumnStatisticsObj> getTableColumnStatistics(String dbName, String tableName, List<String> colNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return glueMetastoreClientDelegate.getTableColumnStatistics(dbName, tableName, colNames);
+    }
+
+    @Override
+    public List<ColumnStatisticsObj> getTableColumnStatistics(String catName, String dbName, String tableName,
+                                                              List<String> colNames)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Table> getTableObjectsByName(String dbName,
+                                                                                  List<String> tableNames)
+            throws MetaException,
+            InvalidOperationException, UnknownDBException, TException {
+        List<org.apache.hadoop.hive.metastore.api.Table> hiveTables = Lists.newArrayList();
+        for (String tableName : tableNames) {
+            hiveTables.add(getTable(dbName, tableName));
+        }
+
+        return hiveTables;
+    }
+
+    @Override
+    public List<Table> getTableObjectsByName(String catName, String dbName, List<String> tableNames)
+            throws MetaException, InvalidOperationException, UnknownDBException, TException {
+        return null;
+    }
+
+    @Override
+    public Materialization getMaterializationInvalidationInfo(CreationMetadata cm, String validTxnList)
+            throws MetaException, InvalidOperationException, UnknownDBException, TException {
+        return null;
+    }
+
+    @Override
+    public void updateCreationMetadata(String dbName, String tableName, CreationMetadata cm)
+            throws MetaException, TException {
+
+    }
+
+    @Override
+    public void updateCreationMetadata(String catName, String dbName, String tableName, CreationMetadata cm)
+            throws MetaException, TException {
+
+    }
+
+    @Override
+    public List<String> getTables(String dbname, String tablePattern)
+            throws MetaException, TException, UnknownDBException {
+        return glueMetastoreClientDelegate.getTables(dbname, tablePattern);
+    }
+
+    @Override
+    public List<String> getTables(String catName, String dbName, String tablePattern)
+            throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public List<String> getTables(String dbname, String tablePattern, TableType tableType)
+            throws MetaException, TException, UnknownDBException {
+        return glueMetastoreClientDelegate.getTables(dbname, tablePattern, tableType);
+    }
+
+    @Override
+    public List<String> getTables(String catName, String dbName, String tablePattern, TableType tableType)
+            throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public List<String> getMaterializedViewsForRewriting(String dbName)
+            throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public List<String> getMaterializedViewsForRewriting(String catName, String dbName)
+            throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public List<TableMeta> getTableMeta(String dbPatterns, String tablePatterns, List<String> tableTypes)
+            throws MetaException, TException, UnknownDBException {
+        return glueMetastoreClientDelegate.getTableMeta(dbPatterns, tablePatterns, tableTypes);
+    }
+
+    @Override
+    public List<TableMeta> getTableMeta(String catName, String dbPatterns, String tablePatterns,
+                                        List<String> tableTypes) throws MetaException, TException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public ValidTxnList getValidTxns() throws TException {
+        return glueMetastoreClientDelegate.getValidTxns();
+    }
+
+    @Override
+    public ValidTxnList getValidTxns(long currentTxn) throws TException {
+        return glueMetastoreClientDelegate.getValidTxns(currentTxn);
+    }
+
+    @Override
+    public ValidWriteIdList getValidWriteIds(String fullTableName) throws TException {
+        return null;
+    }
+
+    @Override
+    public List<TableValidWriteIds> getValidWriteIds(List<String> tablesList, String validTxnList) throws TException {
+        return null;
+    }
+
+    @Override
+    public org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet get_privilege_set(
+            HiveObjectRef obj,
+            String user, List<String> groups
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.getPrivilegeSet(obj, user, groups);
+    }
+
+    @Override
+    public boolean grant_privileges(org.apache.hadoop.hive.metastore.api.PrivilegeBag privileges)
+            throws MetaException, TException {
+        return glueMetastoreClientDelegate.grantPrivileges(privileges);
+    }
+
+    @Override
+    public boolean revoke_privileges(
+            org.apache.hadoop.hive.metastore.api.PrivilegeBag privileges,
+            boolean grantOption
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.revokePrivileges(privileges, grantOption);
+    }
+
+    @Override
+    public boolean refresh_privileges(HiveObjectRef objToRefresh, String authorizer, PrivilegeBag grantPrivileges)
+            throws MetaException, TException {
+        return false;
+    }
+
+    @Override
+    public void heartbeat(long txnId, long lockId)
+            throws NoSuchLockException, NoSuchTxnException, TxnAbortedException, TException {
+        glueMetastoreClientDelegate.heartbeat(txnId, lockId);
+    }
+
+    @Override
+    public HeartbeatTxnRangeResponse heartbeatTxnRange(long min, long max) throws TException {
+        return glueMetastoreClientDelegate.heartbeatTxnRange(min, max);
+    }
+
+    @Override
+    public boolean isCompatibleWith(Configuration conf) {
+        return false;
+    }
+
+    @Override
+    public void setHiveAddedJars(String addedJars) {
+        //taken from HiveMetaStoreClient
+        HiveConf.setVar(conf, ConfVars.HIVEADDEDJARS, addedJars);
+    }
+
+    @Override
+    public boolean isLocalMetaStore() {
+        return false;
+    }
+
+    private void snapshotActiveConf() {
+        currentMetaVars = new HashMap<String, String>(HiveConf.metaVars.length);
+        for (ConfVars oneVar : HiveConf.metaVars) {
+            currentMetaVars.put(oneVar.varname, conf.get(oneVar.varname, ""));
+        }
+    }
+
+    @Override
+    public boolean isPartitionMarkedForEvent(String dbName, String tblName, Map<String, String> partKVs,
+                                             PartitionEventType eventType)
+            throws MetaException, NoSuchObjectException, TException, UnknownTableException, UnknownDBException,
+            UnknownPartitionException, InvalidPartitionException {
+        return glueMetastoreClientDelegate.isPartitionMarkedForEvent(dbName, tblName, partKVs, eventType);
+    }
+
+    @Override
+    public boolean isPartitionMarkedForEvent(String catName, String dbName, String tblName,
+                                             Map<String, String> partKVs, PartitionEventType eventType)
+            throws MetaException, NoSuchObjectException, TException, UnknownTableException, UnknownDBException,
+            UnknownPartitionException, InvalidPartitionException {
+        return false;
+    }
+
+    @Override
+    public List<String> listPartitionNames(String dbName, String tblName, short max)
+            throws MetaException, TException {
+        try {
+            return listPartitionNames(dbName, tblName, Collections.emptyList(), max);
+        } catch (NoSuchObjectException e) {
+            // For compatibility with Hive 1.0.0
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public List<String> listPartitionNames(String catName, String dbName, String tblName, int maxParts)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           List<String> values, short max)
+            throws MetaException, TException, NoSuchObjectException {
+        return glueMetastoreClientDelegate.listPartitionNames(databaseName, tableName, values, max);
+    }
+
+    @Override
+    public List<String> listPartitionNames(String catName, String dbName, String tblName, List<String> partVals,
+                                           int maxParts) throws MetaException, TException, NoSuchObjectException {
+        return null;
+    }
+
+    @Override
+    public PartitionValuesResponse listPartitionValues(PartitionValuesRequest request)
+            throws MetaException, TException, NoSuchObjectException {
+        return null;
+    }
+
+    @Override
+    public int getNumPartitionsByFilter(String dbName, String tableName, String filter)
+            throws MetaException, NoSuchObjectException, TException {
+        return glueMetastoreClientDelegate.getNumPartitionsByFilter(dbName, tableName, filter);
+    }
+
+    @Override
+    public int getNumPartitionsByFilter(String catName, String dbName, String tableName, String filter)
+            throws MetaException, NoSuchObjectException, TException {
+        return 0;
+    }
+
+    @Override
+    public PartitionSpecProxy listPartitionSpecs(String dbName, String tblName, int max) throws TException {
+        return glueMetastoreClientDelegate.listPartitionSpecs(dbName, tblName, max);
+    }
+
+    @Override
+    public PartitionSpecProxy listPartitionSpecs(String catName, String dbName, String tableName, int maxParts)
+            throws TException {
+        return null;
+    }
+
+    @Override
+    public PartitionSpecProxy listPartitionSpecsByFilter(String dbName, String tblName, String filter, int max)
+            throws MetaException, NoSuchObjectException, TException {
+        return glueMetastoreClientDelegate.listPartitionSpecsByFilter(dbName, tblName, filter, max);
+    }
+
+    @Override
+    public PartitionSpecProxy listPartitionSpecsByFilter(String catName, String dbName, String tblName, String filter,
+                                                         int maxParts)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitions(String dbName, String tblName, short max)
+            throws NoSuchObjectException, MetaException, TException {
+        return listPartitions(dbName, tblName, Collections.emptyList(), max);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitions(String catName, String dbName,
+                                                                               String tblName, int maxParts)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitions(
+            String databaseName,
+            String tableName,
+            List<String> values,
+            short max
+    ) throws NoSuchObjectException, MetaException, TException {
+        String expression = null;
+        if (values != null) {
+            org.apache.hadoop.hive.metastore.api.Table table = getTable(databaseName, tableName);
+            expression = ExpressionHelper.buildExpressionFromPartialSpecification(table, values);
+        }
+        return glueMetastoreClientDelegate.getPartitions(databaseName, tableName, expression, (long) max);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitions(String catName, String dbName,
+                                                                               String tblName, List<String> partVals,
+                                                                               int maxParts)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public boolean listPartitionsByExpr(
+            String databaseName,
+            String tableName,
+            byte[] expr,
+            String defaultPartitionName,
+            short max,
+            List<org.apache.hadoop.hive.metastore.api.Partition> result
+    ) throws TException {
+        checkNotNull(result, "The result argument cannot be null.");
+
+        String catalogExpression = ExpressionHelper.convertHiveExpressionToCatalogExpression(expr);
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions =
+                glueMetastoreClientDelegate.getPartitions(databaseName, tableName, catalogExpression, (long) max);
+        result.addAll(partitions);
+
+        return false;
+    }
+
+    @Override
+    public boolean listPartitionsByExpr(String catName, String dbName, String tblName, byte[] expr,
+                                        String defaultPartitionName, int maxParts,
+                                        List<org.apache.hadoop.hive.metastore.api.Partition> result) throws TException {
+        return false;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsByFilter(
+            String databaseName,
+            String tableName,
+            String filter,
+            short max
+    ) throws MetaException, NoSuchObjectException, TException {
+        // we need to replace double quotes with single quotes in the filter expression
+        // since server side does not accept double quote expressions.
+        if (StringUtils.isNotBlank(filter)) {
+            filter = ExpressionHelper.replaceDoubleQuoteWithSingleQuotes(filter);
+        }
+        return glueMetastoreClientDelegate.getPartitions(databaseName, tableName, filter, (long) max);
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsByFilter(String catName, String dbName,
+                                                                                       String tblName, String filter,
+                                                                                       int maxParts)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsWithAuthInfo(String database,
+                                                                                           String table, short maxParts,
+                                                                                           String user,
+                                                                                           List<String> groups)
+            throws MetaException, TException, NoSuchObjectException {
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions = listPartitions(database, table, maxParts);
+
+        for (org.apache.hadoop.hive.metastore.api.Partition p : partitions) {
+            HiveObjectRef obj = new HiveObjectRef();
+            obj.setObjectType(HiveObjectType.PARTITION);
+            obj.setDbName(database);
+            obj.setObjectName(table);
+            obj.setPartValues(p.getValues());
+            org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet set = this.get_privilege_set(obj, user, groups);
+            p.setPrivileges(set);
+        }
+
+        return partitions;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsWithAuthInfo(String catName,
+                                                                                           String dbName,
+                                                                                           String tableName,
+                                                                                           int maxParts,
+                                                                                           String userName,
+                                                                                           List<String> groupNames)
+            throws MetaException, TException, NoSuchObjectException {
+        return null;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsWithAuthInfo(String database,
+                                                                                           String table,
+                                                                                           List<String> partVals,
+                                                                                           short maxParts,
+                                                                                           String user,
+                                                                                           List<String> groups)
+            throws MetaException, TException, NoSuchObjectException {
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions =
+                listPartitions(database, table, partVals, maxParts);
+
+        for (org.apache.hadoop.hive.metastore.api.Partition p : partitions) {
+            HiveObjectRef obj = new HiveObjectRef();
+            obj.setObjectType(HiveObjectType.PARTITION);
+            obj.setDbName(database);
+            obj.setObjectName(table);
+            obj.setPartValues(p.getValues());
+            org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet set;
+            try {
+                set = get_privilege_set(obj, user, groups);
+            } catch (MetaException e) {
+                LOGGER.info(String.format("No privileges found for user: %s, "
+                        + "groups: [%s]", user, LoggingHelper.concatCollectionToStringForLogging(groups, ",")));
+                set = new org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet();
+            }
+            p.setPrivileges(set);
+        }
+
+        return partitions;
+    }
+
+    @Override
+    public List<org.apache.hadoop.hive.metastore.api.Partition> listPartitionsWithAuthInfo(String catName,
+                                                                                           String dbName,
+                                                                                           String tableName,
+                                                                                           List<String> partialPvals,
+                                                                                           int maxParts,
+                                                                                           String userName,
+                                                                                           List<String> groupNames)
+            throws MetaException, TException, NoSuchObjectException {
+        return null;
+    }
+
+    @Override
+    public List<String> listTableNamesByFilter(String dbName, String filter, short maxTables) throws MetaException,
+            TException, InvalidOperationException, UnknownDBException {
+        return glueMetastoreClientDelegate.listTableNamesByFilter(dbName, filter, maxTables);
+    }
+
+    @Override
+    public List<String> listTableNamesByFilter(String catName, String dbName, String filter, int maxTables)
+            throws TException, InvalidOperationException, UnknownDBException {
+        return null;
+    }
+
+    @Override
+    public List<HiveObjectPrivilege> list_privileges(
+            String principal,
+            org.apache.hadoop.hive.metastore.api.PrincipalType principalType,
+            HiveObjectRef objectRef
+    ) throws MetaException, TException {
+        return glueMetastoreClientDelegate.listPrivileges(principal, principalType, objectRef);
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest) throws NoSuchTxnException, TxnAbortedException, TException {
+        return glueMetastoreClientDelegate.lock(lockRequest);
+    }
+
+    @Override
+    public void markPartitionForEvent(
+            String dbName,
+            String tblName,
+            Map<String, String> partKVs,
+            PartitionEventType eventType
+    ) throws MetaException, NoSuchObjectException, TException, UnknownTableException, UnknownDBException,
+            UnknownPartitionException, InvalidPartitionException {
+        glueMetastoreClientDelegate.markPartitionForEvent(dbName, tblName, partKVs, eventType);
+    }
+
+    @Override
+    public void markPartitionForEvent(String catName, String dbName, String tblName, Map<String, String> partKVs,
+                                      PartitionEventType eventType)
+            throws MetaException, NoSuchObjectException, TException, UnknownTableException, UnknownDBException,
+            UnknownPartitionException, InvalidPartitionException {
+
+    }
+
+    @Override
+    public long openTxn(String user) throws TException {
+        return glueMetastoreClientDelegate.openTxn(user);
+    }
+
+    @Override
+    public List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user) throws TException {
+        return null;
+    }
+
+    @Override
+    public OpenTxnsResponse openTxns(String user, int numTxns) throws TException {
+        return glueMetastoreClientDelegate.openTxns(user, numTxns);
+    }
+
+    @Override
+    public Map<String, String> partitionNameToSpec(String name) throws MetaException, TException {
+        // Lifted from HiveMetaStore
+        if (name.length() == 0) {
+            return new HashMap<String, String>();
+        }
+        return Warehouse.makeSpecFromName(name);
+    }
+
+    @Override
+    public List<String> partitionNameToVals(String name) throws MetaException, TException {
+        return glueMetastoreClientDelegate.partitionNameToVals(name);
+    }
+
+    @Override
+    public void reconnect() throws MetaException {
+        // TODO reset active Hive confs for metastore glueClient
+        LOGGER.debug("reconnect() was called.");
+    }
+
+    @Override
+    public void renamePartition(String dbName, String tblName, List<String> partitionValues,
+                                org.apache.hadoop.hive.metastore.api.Partition newPartition)
+            throws InvalidOperationException, MetaException, TException {
+        throw new TException("method not implemented");
+    }
+
+    @Override
+    public void renamePartition(String catName, String dbname, String tableName, List<String> partVals,
+                                org.apache.hadoop.hive.metastore.api.Partition newPart)
+            throws InvalidOperationException, MetaException, TException {
+
+    }
+
+    @Override
+    public long renewDelegationToken(String tokenStrForm) throws MetaException, TException {
+        return glueMetastoreClientDelegate.renewDelegationToken(tokenStrForm);
+    }
+
+    @Override
+    public void rollbackTxn(long txnId) throws NoSuchTxnException, TException {
+        glueMetastoreClientDelegate.rollbackTxn(txnId);
+    }
+
+    @Override
+    public void replRollbackTxn(long srcTxnid, String replPolicy) throws NoSuchTxnException, TException {
+
+    }
+
+    @Override
+    public void setMetaConf(String key, String value) throws MetaException, TException {
+        ConfVars confVar = HiveConf.getMetaConf(key);
+        if (confVar == null) {
+            throw new MetaException("Invalid configuration key " + key);
+        }
+        String validate = confVar.validate(value);
+        if (validate != null) {
+            throw new MetaException("Invalid configuration value " + value + " for key " + key + " by " + validate);
+        }
+        conf.set(key, value);
+    }
+
+    @Override
+    public boolean setPartitionColumnStatistics(org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest request)
+            throws NoSuchObjectException, InvalidObjectException,
+            MetaException, TException, org.apache.hadoop.hive.metastore.api.InvalidInputException {
+        return glueMetastoreClientDelegate.setPartitionColumnStatistics(request);
+    }
+
+    @Override
+    public void flushCache() {
+        //no op
+    }
+
+    @Override
+    public Iterable<Map.Entry<Long, ByteBuffer>> getFileMetadata(List<Long> fileIds) throws TException {
+        return glueMetastoreClientDelegate.getFileMetadata(fileIds);
+    }
+
+    @Override
+    public Iterable<Map.Entry<Long, MetadataPpdResult>> getFileMetadataBySarg(
+            List<Long> fileIds,
+            ByteBuffer sarg,
+            boolean doGetFooters
+    ) throws TException {
+        return glueMetastoreClientDelegate.getFileMetadataBySarg(fileIds, sarg, doGetFooters);
+    }
+
+    @Override
+    public void clearFileMetadata(List<Long> fileIds) throws TException {
+        glueMetastoreClientDelegate.clearFileMetadata(fileIds);
+    }
+
+    @Override
+    public void putFileMetadata(List<Long> fileIds, List<ByteBuffer> metadata) throws TException {
+        glueMetastoreClientDelegate.putFileMetadata(fileIds, metadata);
+    }
+
+    @Override
+    public boolean isSameConfObj(Configuration c) {
+        return false;
+    }
+
+    @Override
+    public boolean cacheFileMetadata(String dbName, String tblName, String partName, boolean allParts)
+            throws TException {
+        return glueMetastoreClientDelegate.cacheFileMetadata(dbName, tblName, partName, allParts);
+    }
+
+    @Override
+    public List<SQLPrimaryKey> getPrimaryKeys(PrimaryKeysRequest primaryKeysRequest)
+            throws MetaException, NoSuchObjectException, TException {
+        // PrimaryKeys are currently unsupported
+        //return null to allow DESCRIBE (FORMATTED | EXTENDED)
+        return null;
+    }
+
+    @Override
+    public List<SQLForeignKey> getForeignKeys(ForeignKeysRequest foreignKeysRequest)
+            throws MetaException, NoSuchObjectException, TException {
+        // PrimaryKeys are currently unsupported
+        //return null to allow DESCRIBE (FORMATTED | EXTENDED)
+        return null;
+    }
+
+    @Override
+    public List<SQLUniqueConstraint> getUniqueConstraints(UniqueConstraintsRequest request)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<SQLNotNullConstraint> getNotNullConstraints(NotNullConstraintsRequest request)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<SQLDefaultConstraint> getDefaultConstraints(DefaultConstraintsRequest request)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public List<SQLCheckConstraint> getCheckConstraints(CheckConstraintsRequest request)
+            throws MetaException, NoSuchObjectException, TException {
+        return null;
+    }
+
+    @Override
+    public void createTableWithConstraints(Table tTbl, List<SQLPrimaryKey> primaryKeys, List<SQLForeignKey> foreignKeys,
+                                           List<SQLUniqueConstraint> uniqueConstraints,
+                                           List<SQLNotNullConstraint> notNullConstraints,
+                                           List<SQLDefaultConstraint> defaultConstraints,
+                                           List<SQLCheckConstraint> checkConstraints)
+            throws AlreadyExistsException, InvalidObjectException, MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void dropConstraint(
+            String dbName,
+            String tblName,
+            String constraintName
+    ) throws MetaException, NoSuchObjectException, TException {
+        glueMetastoreClientDelegate.dropConstraint(dbName, tblName, constraintName);
+    }
+
+    @Override
+    public void dropConstraint(String catName, String dbName, String tableName, String constraintName)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void addPrimaryKey(List<SQLPrimaryKey> primaryKeyCols)
+            throws MetaException, NoSuchObjectException, TException {
+        glueMetastoreClientDelegate.addPrimaryKey(primaryKeyCols);
+    }
+
+    @Override
+    public void addForeignKey(List<SQLForeignKey> foreignKeyCols)
+            throws MetaException, NoSuchObjectException, TException {
+        glueMetastoreClientDelegate.addForeignKey(foreignKeyCols);
+    }
+
+    @Override
+    public void addUniqueConstraint(List<SQLUniqueConstraint> uniqueConstraintCols)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void addNotNullConstraint(List<SQLNotNullConstraint> notNullConstraintCols)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void addDefaultConstraint(List<SQLDefaultConstraint> defaultConstraints)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public void addCheckConstraint(List<SQLCheckConstraint> checkConstraints)
+            throws MetaException, NoSuchObjectException, TException {
+
+    }
+
+    @Override
+    public String getMetastoreDbUuid() throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void createResourcePlan(WMResourcePlan resourcePlan, String copyFromName)
+            throws InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public WMFullResourcePlan getResourcePlan(String resourcePlanName)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public List<WMResourcePlan> getAllResourcePlans() throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void dropResourcePlan(String resourcePlanName) throws NoSuchObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public WMFullResourcePlan alterResourcePlan(String resourcePlanName, WMNullableResourcePlan resourcePlan,
+                                                boolean canActivateDisabled, boolean isForceDeactivate,
+                                                boolean isReplace)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public WMFullResourcePlan getActiveResourcePlan() throws MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public WMValidateResourcePlanResponse validateResourcePlan(String resourcePlanName)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void createWMTrigger(WMTrigger trigger) throws InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alterWMTrigger(WMTrigger trigger)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void dropWMTrigger(String resourcePlanName, String triggerName)
+            throws NoSuchObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public List<WMTrigger> getTriggersForResourcePlan(String resourcePlan)
+            throws NoSuchObjectException, MetaException, TException {
+        return null;
+    }
+
+    @Override
+    public void createWMPool(WMPool pool)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void alterWMPool(WMNullablePool pool, String poolPath)
+            throws NoSuchObjectException, InvalidObjectException, TException {
+
+    }
+
+    @Override
+    public void dropWMPool(String resourcePlanName, String poolPath) throws TException {
+
+    }
+
+    @Override
+    public void createOrUpdateWMMapping(WMMapping mapping, boolean isUpdate) throws TException {
+
+    }
+
+    @Override
+    public void dropWMMapping(WMMapping mapping) throws TException {
+
+    }
+
+    @Override
+    public void createOrDropTriggerToPoolMapping(String resourcePlanName, String triggerName, String poolPath,
+                                                 boolean shouldDrop)
+            throws AlreadyExistsException, NoSuchObjectException, InvalidObjectException, MetaException, TException {
+
+    }
+
+    @Override
+    public void createISchema(ISchema schema) throws TException {
+
+    }
+
+    @Override
+    public void alterISchema(String catName, String dbName, String schemaName, ISchema newSchema) throws TException {
+
+    }
+
+    @Override
+    public ISchema getISchema(String catName, String dbName, String name) throws TException {
+        return null;
+    }
+
+    @Override
+    public void dropISchema(String catName, String dbName, String name) throws TException {
+
+    }
+
+    @Override
+    public void addSchemaVersion(SchemaVersion schemaVersion) throws TException {
+
+    }
+
+    @Override
+    public SchemaVersion getSchemaVersion(String catName, String dbName, String schemaName, int version)
+            throws TException {
+        return null;
+    }
+
+    @Override
+    public SchemaVersion getSchemaLatestVersion(String catName, String dbName, String schemaName) throws TException {
+        return null;
+    }
+
+    @Override
+    public List<SchemaVersion> getSchemaAllVersions(String catName, String dbName, String schemaName)
+            throws TException {
+        return null;
+    }
+
+    @Override
+    public void dropSchemaVersion(String catName, String dbName, String schemaName, int version) throws TException {
+
+    }
+
+    @Override
+    public FindSchemasByColsResp getSchemaByCols(FindSchemasByColsRqst rqst) throws TException {
+        return null;
+    }
+
+    @Override
+    public void mapSchemaVersionToSerde(String catName, String dbName, String schemaName, int version, String serdeName)
+            throws TException {
+
+    }
+
+    @Override
+    public void setSchemaVersionState(String catName, String dbName, String schemaName, int version,
+                                      SchemaVersionState state) throws TException {
+
+    }
+
+    @Override
+    public void addSerDe(SerDeInfo serDeInfo) throws TException {
+
+    }
+
+    @Override
+    public SerDeInfo getSerDe(String serDeName) throws TException {
+        return null;
+    }
+
+    @Override
+    public LockResponse lockMaterializationRebuild(String dbName, String tableName, long txnId) throws TException {
+        return null;
+    }
+
+    @Override
+    public boolean heartbeatLockMaterializationRebuild(String dbName, String tableName, long txnId) throws TException {
+        return false;
+    }
+
+    @Override
+    public void addRuntimeStat(RuntimeStat stat) throws TException {
+
+    }
+
+    @Override
+    public List<RuntimeStat> getRuntimeStats(int maxWeight, int maxCreateTime) throws TException {
+        return null;
+    }
+
+    @Override
+    public ShowCompactResponse showCompactions() throws TException {
+        return glueMetastoreClientDelegate.showCompactions();
+    }
+
+    @Override
+    public void addDynamicPartitions(long txnId, long writeId, String dbName, String tableName, List<String> partNames)
+            throws TException {
+
+    }
+
+    @Override
+    public void addDynamicPartitions(long txnId, long writeId, String dbName, String tableName, List<String> partNames,
+                                     DataOperationType operationType) throws TException {
+
+    }
+
+    @Override
+    public void insertTable(org.apache.hadoop.hive.metastore.api.Table table, boolean overwrite) throws MetaException {
+        glueMetastoreClientDelegate.insertTable(table, overwrite);
+    }
+
+    @Override
+    public NotificationEventResponse getNextNotification(
+            long lastEventId, int maxEvents, NotificationFilter notificationFilter) throws TException {
+        return glueMetastoreClientDelegate.getNextNotification(lastEventId, maxEvents, notificationFilter);
+    }
+
+    @Override
+    public CurrentNotificationEventId getCurrentNotificationEventId() throws TException {
+        return glueMetastoreClientDelegate.getCurrentNotificationEventId();
+    }
+
+    @Override
+    public NotificationEventsCountResponse getNotificationEventsCount(NotificationEventsCountRequest rqst)
+            throws TException {
+        return null;
+    }
+
+    @Override
+    public FireEventResponse fireListenerEvent(FireEventRequest fireEventRequest) throws TException {
+        return glueMetastoreClientDelegate.fireListenerEvent(fireEventRequest);
+    }
+
+    @Override
+    public ShowLocksResponse showLocks() throws TException {
+        return glueMetastoreClientDelegate.showLocks();
+    }
+
+    @Override
+    public ShowLocksResponse showLocks(ShowLocksRequest showLocksRequest) throws TException {
+        return glueMetastoreClientDelegate.showLocks(showLocksRequest);
+    }
+
+    @Override
+    public GetOpenTxnsInfoResponse showTxns() throws TException {
+        return glueMetastoreClientDelegate.showTxns();
+    }
+
+    @Deprecated
+    public boolean tableExists(String tableName) throws MetaException, TException, UnknownDBException {
+        //this method has been deprecated;
+        return tableExists(DEFAULT_DATABASE_NAME, tableName);
+    }
+
+    @Override
+    public boolean tableExists(String databaseName, String tableName) throws MetaException, TException,
+            UnknownDBException {
+        return glueMetastoreClientDelegate.tableExists(databaseName, tableName);
+    }
+
+    @Override
+    public boolean tableExists(String catName, String dbName, String tableName)
+            throws MetaException, TException, UnknownDBException {
+        return false;
+    }
+
+    @Override
+    public void unlock(long lockId) throws NoSuchLockException, TxnOpenException, TException {
+        glueMetastoreClientDelegate.unlock(lockId);
+    }
+
+    @Override
+    public boolean updatePartitionColumnStatistics(
+            org.apache.hadoop.hive.metastore.api.ColumnStatistics columnStatistics)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException,
+            org.apache.hadoop.hive.metastore.api.InvalidInputException {
+        return glueMetastoreClientDelegate.updatePartitionColumnStatistics(columnStatistics);
+    }
+
+    @Override
+    public boolean updateTableColumnStatistics(org.apache.hadoop.hive.metastore.api.ColumnStatistics columnStatistics)
+            throws NoSuchObjectException, InvalidObjectException, MetaException, TException,
+            org.apache.hadoop.hive.metastore.api.InvalidInputException {
+        return glueMetastoreClientDelegate.updateTableColumnStatistics(columnStatistics);
+    }
+
+    @Override
+    public void validatePartitionNameCharacters(List<String> partVals) throws TException, MetaException {
+        try {
+            String partitionValidationRegex = conf.getVar(ConfVars.METASTORE_PARTITION_NAME_WHITELIST_PATTERN);
+            Pattern partitionValidationPattern = Strings.isNullOrEmpty(partitionValidationRegex) ? null
+                    : Pattern.compile(partitionValidationRegex);
+            MetaStoreUtils.validatePartitionNameCharacters(partVals, partitionValidationPattern);
+        } catch (Exception e) {
+            throw new MetaException(e.getMessage());
+        }
+    }
+
+    private Path constructRenamedPath(Path defaultNewPath, Path currentPath) {
+        URI currentUri = currentPath.toUri();
+
+        return new Path(currentUri.getScheme(), currentUri.getAuthority(),
+                defaultNewPath.toUri().getPath());
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
@@ -159,7 +159,7 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
     private Map<String, String> currentMetaVars;
 
-    public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook) throws MetaException {
+    public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook, Boolean allowEmbedded) throws MetaException {
         this.conf = conf;
         glueClient = new AWSGlueClientFactory(this.conf).newClient();
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/AWSCatalogMetastoreClient.java
@@ -159,14 +159,14 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
     private Map<String, String> currentMetaVars;
 
-    public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook, Boolean allowEmbedded) throws MetaException {
-        this.conf = conf;
+    public AWSCatalogMetastoreClient(Configuration conf, HiveMetaHookLoader hook, Boolean allowEmbedded) throws MetaException {
+        this.conf = new HiveConf(conf, AWSCatalogMetastoreClient.class);
         glueClient = new AWSGlueClientFactory(this.conf).newClient();
 
         // TODO preserve existing functionality for HiveMetaHook
         wh = new Warehouse(this.conf);
 
-        AWSGlueMetastore glueMetastore = new AWSGlueMetastoreFactory().newMetastore(conf);
+        AWSGlueMetastore glueMetastore = new AWSGlueMetastoreFactory().newMetastore(this.conf);
         glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueMetastore, wh);
 
         snapshotActiveConf();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/CatalogToHiveConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/CatalogToHiveConverter.java
@@ -1,0 +1,402 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.converters;
+
+import com.amazonaws.services.glue.model.ErrorDetail;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Order;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.ResourceType;
+import org.apache.hadoop.hive.metastore.api.ResourceUri;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.SkewedInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
+public class CatalogToHiveConverter {
+
+    private static final Logger LOGGER = Logger.getLogger(CatalogToHiveConverter.class);
+
+    private static final ImmutableMap<String, HiveException> EXCEPTION_MAP =
+            ImmutableMap.<String, HiveException>builder()
+                    .put("AlreadyExistsException", new HiveException() {
+                        public TException get(String msg) {
+                            return new AlreadyExistsException(msg);
+                        }
+                    })
+                    .put("InvalidInputException", new HiveException() {
+                        public TException get(String msg) {
+                            return new InvalidObjectException(msg);
+                        }
+                    })
+                    .put("InternalServiceException", new HiveException() {
+                        public TException get(String msg) {
+                            return new MetaException(msg);
+                        }
+                    })
+                    .put("ResourceNumberLimitExceededException", new HiveException() {
+                        public TException get(String msg) {
+                            return new MetaException(msg);
+                        }
+                    })
+                    .put("OperationTimeoutException", new HiveException() {
+                        public TException get(String msg) {
+                            return new MetaException(msg);
+                        }
+                    })
+                    .put("EntityNotFoundException", new HiveException() {
+                        public TException get(String msg) {
+                            return new NoSuchObjectException(msg);
+                        }
+                    })
+                    .build();
+
+    interface HiveException {
+        TException get(String msg);
+    }
+
+    public static TException wrapInHiveException(Throwable e) {
+        return getHiveException(e.getClass().getSimpleName(), e.getMessage());
+    }
+
+    public static TException errorDetailToHiveException(ErrorDetail errorDetail) {
+        return getHiveException(errorDetail.getErrorCode(), errorDetail.getErrorMessage());
+    }
+
+    private static TException getHiveException(String errorName, String errorMsg) {
+        if (EXCEPTION_MAP.containsKey(errorName)) {
+            return EXCEPTION_MAP.get(errorName).get(errorMsg);
+        } else {
+            LOGGER.warn("Hive Exception type not found for " + errorName);
+            return new MetaException(errorMsg);
+        }
+    }
+
+    public static Database convertDatabase(com.amazonaws.services.glue.model.Database catalogDatabase) {
+        Database hiveDatabase = new Database();
+        hiveDatabase.setName(catalogDatabase.getName());
+        hiveDatabase.setDescription(catalogDatabase.getDescription());
+        String location = catalogDatabase.getLocationUri();
+        hiveDatabase.setLocationUri(location == null ? "" : location);
+        hiveDatabase.setParameters(firstNonNull(catalogDatabase.getParameters(), Maps.<String, String>newHashMap()));
+        return hiveDatabase;
+    }
+
+    public static FieldSchema convertFieldSchema(com.amazonaws.services.glue.model.Column catalogFieldSchema) {
+        FieldSchema hiveFieldSchema = new FieldSchema();
+        hiveFieldSchema.setType(catalogFieldSchema.getType());
+        hiveFieldSchema.setName(catalogFieldSchema.getName());
+        hiveFieldSchema.setComment(catalogFieldSchema.getComment());
+
+        return hiveFieldSchema;
+    }
+
+    public static List<FieldSchema> convertFieldSchemaList(
+            List<com.amazonaws.services.glue.model.Column> catalogFieldSchemaList) {
+        List<FieldSchema> hiveFieldSchemaList = new ArrayList<>();
+        if (catalogFieldSchemaList == null) {
+            return hiveFieldSchemaList;
+        }
+        for (com.amazonaws.services.glue.model.Column catalogFieldSchema : catalogFieldSchemaList) {
+            hiveFieldSchemaList.add(convertFieldSchema(catalogFieldSchema));
+        }
+
+        return hiveFieldSchemaList;
+    }
+
+    public static Table convertTable(com.amazonaws.services.glue.model.Table catalogTable, String dbname) {
+        Table hiveTable = new Table();
+        hiveTable.setDbName(dbname);
+        hiveTable.setTableName(catalogTable.getName());
+        Date createTime = catalogTable.getCreateTime();
+        hiveTable.setCreateTime(createTime == null ? 0 : (int) (createTime.getTime() / 1000));
+        hiveTable.setOwner(catalogTable.getOwner());
+        Date lastAccessedTime = catalogTable.getLastAccessTime();
+        hiveTable.setLastAccessTime(lastAccessedTime == null ? 0 : (int) (lastAccessedTime.getTime() / 1000));
+        hiveTable.setRetention(catalogTable.getRetention());
+        hiveTable.setSd(convertStorageDescriptor(catalogTable.getStorageDescriptor()));
+        hiveTable.setPartitionKeys(convertFieldSchemaList(catalogTable.getPartitionKeys()));
+        // Hive may throw a NPE during dropTable if the parameter map is null.
+        Map<String, String> parameterMap = catalogTable.getParameters();
+        if (parameterMap == null) {
+            parameterMap = Maps.newHashMap();
+        }
+        hiveTable.setParameters(parameterMap);
+        hiveTable.setViewOriginalText(catalogTable.getViewOriginalText());
+        hiveTable.setViewExpandedText(catalogTable.getViewExpandedText());
+        hiveTable.setTableType(catalogTable.getTableType());
+
+        return hiveTable;
+    }
+
+    public static TableMeta convertTableMeta(com.amazonaws.services.glue.model.Table catalogTable, String dbName) {
+        TableMeta tableMeta = new TableMeta();
+        tableMeta.setDbName(dbName);
+        tableMeta.setTableName(catalogTable.getName());
+        tableMeta.setTableType(catalogTable.getTableType());
+        if (catalogTable.getParameters().containsKey("comment")) {
+            tableMeta.setComments(catalogTable.getParameters().get("comment"));
+        }
+        return tableMeta;
+    }
+
+    public static StorageDescriptor convertStorageDescriptor(
+            com.amazonaws.services.glue.model.StorageDescriptor catalogSd) {
+        StorageDescriptor hiveSd = new StorageDescriptor();
+        hiveSd.setCols(convertFieldSchemaList(catalogSd.getColumns()));
+        hiveSd.setLocation(catalogSd.getLocation());
+        hiveSd.setInputFormat(catalogSd.getInputFormat());
+        hiveSd.setOutputFormat(catalogSd.getOutputFormat());
+        hiveSd.setCompressed(catalogSd.getCompressed());
+        hiveSd.setNumBuckets(catalogSd.getNumberOfBuckets());
+        hiveSd.setSerdeInfo(convertSerDeInfo(catalogSd.getSerdeInfo()));
+        hiveSd.setBucketCols(firstNonNull(catalogSd.getBucketColumns(), Lists.<String>newArrayList()));
+        hiveSd.setSortCols(convertOrderList(catalogSd.getSortColumns()));
+        hiveSd.setParameters(firstNonNull(catalogSd.getParameters(), Maps.<String, String>newHashMap()));
+        hiveSd.setSkewedInfo(convertSkewedInfo(catalogSd.getSkewedInfo()));
+        hiveSd.setStoredAsSubDirectories(catalogSd.getStoredAsSubDirectories());
+
+        return hiveSd;
+    }
+
+    public static Order convertOrder(com.amazonaws.services.glue.model.Order catalogOrder) {
+        Order hiveOrder = new Order();
+        hiveOrder.setCol(catalogOrder.getColumn());
+        hiveOrder.setOrder(catalogOrder.getSortOrder());
+
+        return hiveOrder;
+    }
+
+    public static List<Order> convertOrderList(List<com.amazonaws.services.glue.model.Order> catalogOrderList) {
+        List<Order> hiveOrderList = new ArrayList<>();
+        if (catalogOrderList == null) {
+            return hiveOrderList;
+        }
+        for (com.amazonaws.services.glue.model.Order catalogOrder : catalogOrderList) {
+            hiveOrderList.add(convertOrder(catalogOrder));
+        }
+
+        return hiveOrderList;
+    }
+
+    public static SerDeInfo convertSerDeInfo(com.amazonaws.services.glue.model.SerDeInfo catalogSerDeInfo) {
+        SerDeInfo hiveSerDeInfo = new SerDeInfo();
+        hiveSerDeInfo.setName(catalogSerDeInfo.getName());
+        hiveSerDeInfo.setParameters(firstNonNull(catalogSerDeInfo.getParameters(), Maps.<String, String>newHashMap()));
+        hiveSerDeInfo.setSerializationLib(catalogSerDeInfo.getSerializationLibrary());
+
+        return hiveSerDeInfo;
+    }
+
+    public static SkewedInfo convertSkewedInfo(com.amazonaws.services.glue.model.SkewedInfo catalogSkewedInfo) {
+        if (catalogSkewedInfo == null) {
+            return null;
+        }
+
+        SkewedInfo hiveSkewedInfo = new SkewedInfo();
+        hiveSkewedInfo.setSkewedColNames(
+                firstNonNull(catalogSkewedInfo.getSkewedColumnNames(), Lists.<String>newArrayList()));
+        hiveSkewedInfo.setSkewedColValues(convertSkewedValue(catalogSkewedInfo.getSkewedColumnValues()));
+        hiveSkewedInfo
+                .setSkewedColValueLocationMaps(convertSkewedMap(catalogSkewedInfo.getSkewedColumnValueLocationMaps()));
+        return hiveSkewedInfo;
+    }
+
+    public static Partition convertPartition(com.amazonaws.services.glue.model.Partition src) {
+        Partition tgt = new Partition();
+        Date createTime = src.getCreationTime();
+        if (createTime != null) {
+            tgt.setCreateTime((int) (createTime.getTime() / 1000));
+            tgt.setCreateTimeIsSet(true);
+        } else {
+            tgt.setCreateTimeIsSet(false);
+        }
+        String dbName = src.getDatabaseName();
+        if (dbName != null) {
+            tgt.setDbName(dbName);
+            tgt.setDbNameIsSet(true);
+        } else {
+            tgt.setDbNameIsSet(false);
+        }
+        Date lastAccessTime = src.getLastAccessTime();
+        if (lastAccessTime != null) {
+            tgt.setLastAccessTime((int) (lastAccessTime.getTime() / 1000));
+            tgt.setLastAccessTimeIsSet(true);
+        } else {
+            tgt.setLastAccessTimeIsSet(false);
+        }
+        Map<String, String> params = src.getParameters();
+
+        // A null parameter map causes Hive to throw a NPE
+        // so ensure we do not return a Partition object with a null parameter map.
+        if (params == null) {
+            params = Maps.newHashMap();
+        }
+
+        tgt.setParameters(params);
+        tgt.setParametersIsSet(true);
+
+        String tableName = src.getTableName();
+        if (tableName != null) {
+            tgt.setTableName(tableName);
+            tgt.setTableNameIsSet(true);
+        } else {
+            tgt.setTableNameIsSet(false);
+        }
+
+        List<String> values = src.getValues();
+        if (values != null) {
+            tgt.setValues(values);
+            tgt.setValuesIsSet(true);
+        } else {
+            tgt.setValuesIsSet(false);
+        }
+
+        com.amazonaws.services.glue.model.StorageDescriptor sd = src.getStorageDescriptor();
+        if (sd != null) {
+            StorageDescriptor hiveSd = convertStorageDescriptor(sd);
+            tgt.setSd(hiveSd);
+            tgt.setSdIsSet(true);
+        } else {
+            tgt.setSdIsSet(false);
+        }
+
+        return tgt;
+    }
+
+    public static List<Partition> convertPartitions(List<com.amazonaws.services.glue.model.Partition> src) {
+        if (src == null) {
+            return null;
+        }
+
+        List<Partition> target = Lists.newArrayList();
+        for (com.amazonaws.services.glue.model.Partition partition : src) {
+            target.add(convertPartition(partition));
+        }
+        return target;
+    }
+
+    public static List<String> convertStringToList(final String s) {
+        if (s == null) {
+            return null;
+        }
+        List<String> listString = new ArrayList<>();
+        for (int i = 0; i < s.length(); ) {
+            StringBuilder length = new StringBuilder();
+            for (int j = i; j < s.length(); j++) {
+                if (s.charAt(j) != '$') {
+                    length.append(s.charAt(j));
+                } else {
+                    int lengthOfString = Integer.valueOf(length.toString());
+                    listString.add(s.substring(j + 1, j + 1 + lengthOfString));
+                    i = j + 1 + lengthOfString;
+                    break;
+                }
+            }
+        }
+        return listString;
+    }
+
+    @Nonnull
+    public static Map<List<String>, String> convertSkewedMap(final @Nullable Map<String, String> catalogSkewedMap) {
+        Map<List<String>, String> skewedMap = new HashMap<>();
+        if (catalogSkewedMap == null) {
+            return skewedMap;
+        }
+
+        for (String coralKey : catalogSkewedMap.keySet()) {
+            skewedMap.put(convertStringToList(coralKey), catalogSkewedMap.get(coralKey));
+        }
+        return skewedMap;
+    }
+
+    @Nonnull
+    public static List<List<String>> convertSkewedValue(final @Nullable List<String> catalogSkewedValue) {
+        List<List<String>> skewedValues = new ArrayList<>();
+        if (catalogSkewedValue == null) {
+            return skewedValues;
+        }
+
+        for (String skewValue : catalogSkewedValue) {
+            skewedValues.add(convertStringToList(skewValue));
+        }
+        return skewedValues;
+    }
+
+    public static PrincipalType convertPrincipalType(
+            com.amazonaws.services.glue.model.PrincipalType catalogPrincipalType) {
+        if (catalogPrincipalType == null) {
+            return null;
+        }
+
+        if (catalogPrincipalType == com.amazonaws.services.glue.model.PrincipalType.GROUP) {
+            return PrincipalType.GROUP;
+        } else if (catalogPrincipalType == com.amazonaws.services.glue.model.PrincipalType.USER) {
+            return PrincipalType.USER;
+        } else if (catalogPrincipalType == com.amazonaws.services.glue.model.PrincipalType.ROLE) {
+            return PrincipalType.ROLE;
+        }
+        throw new RuntimeException("Unknown principal type:" + catalogPrincipalType.name());
+    }
+
+    public static Function convertFunction(final String dbName,
+                                           final com.amazonaws.services.glue.model.UserDefinedFunction catalogFunction) {
+        if (catalogFunction == null) {
+            return null;
+        }
+        Function hiveFunction = new Function();
+        hiveFunction.setClassName(catalogFunction.getClassName());
+        hiveFunction.setCreateTime((int) (catalogFunction.getCreateTime().getTime() / 1000));
+        hiveFunction.setDbName(dbName);
+        hiveFunction.setFunctionName(catalogFunction.getFunctionName());
+        hiveFunction.setFunctionType(FunctionType.JAVA);
+        hiveFunction.setOwnerName(catalogFunction.getOwnerName());
+        hiveFunction.setOwnerType(convertPrincipalType(
+                com.amazonaws.services.glue.model.PrincipalType.fromValue(catalogFunction.getOwnerType())));
+        hiveFunction.setResourceUris(convertResourceUriList(catalogFunction.getResourceUris()));
+        return hiveFunction;
+    }
+
+    public static List<ResourceUri> convertResourceUriList(
+            final List<com.amazonaws.services.glue.model.ResourceUri> catalogResourceUriList) {
+        if (catalogResourceUriList == null) {
+            return null;
+        }
+        List<ResourceUri> hiveResourceUriList = new ArrayList<>();
+        for (com.amazonaws.services.glue.model.ResourceUri catalogResourceUri : catalogResourceUriList) {
+            ResourceUri hiveResourceUri = new ResourceUri();
+            hiveResourceUri.setUri(catalogResourceUri.getUri());
+            if (catalogResourceUri.getResourceType() != null) {
+                hiveResourceUri.setResourceType(ResourceType.valueOf(catalogResourceUri.getResourceType()));
+            }
+            hiveResourceUriList.add(hiveResourceUri);
+        }
+
+        return hiveResourceUriList;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/ConverterUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/ConverterUtils.java
@@ -1,0 +1,24 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.converters;
+
+import com.amazonaws.services.glue.model.Table;
+import com.google.gson.Gson;
+
+public class ConverterUtils {
+
+    public static final String INDEX_DEFERRED_REBUILD = "DeferredRebuild";
+    public static final String INDEX_TABLE_NAME = "IndexTableName";
+    public static final String INDEX_HANDLER_CLASS = "IndexHandlerClass";
+    public static final String INDEX_DB_NAME = "DbName";
+    public static final String INDEX_ORIGIN_TABLE_NAME = "OriginTableName";
+    private static final Gson GSON = new Gson();
+
+    public static String catalogTableToString(final Table table) {
+        return GSON.toJson(table);
+    }
+
+    public static Table stringToCatalogTable(final String input) {
+        return GSON.fromJson(input, Table.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/GlueInputConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/GlueInputConverter.java
@@ -1,0 +1,98 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.converters;
+
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class provides methods to convert Hive/Catalog objects to Input objects used
+ * for Glue API parameters
+ */
+public final class GlueInputConverter {
+
+    public static DatabaseInput convertToDatabaseInput(Database hiveDatabase) {
+        return convertToDatabaseInput(HiveToCatalogConverter.convertDatabase(hiveDatabase));
+    }
+
+    public static DatabaseInput convertToDatabaseInput(com.amazonaws.services.glue.model.Database database) {
+        DatabaseInput input = new DatabaseInput();
+
+        input.setName(database.getName());
+        input.setDescription(database.getDescription());
+        input.setLocationUri(database.getLocationUri());
+        input.setParameters(database.getParameters());
+
+        return input;
+    }
+
+    public static TableInput convertToTableInput(Table hiveTable) {
+        return convertToTableInput(HiveToCatalogConverter.convertTable(hiveTable));
+    }
+
+    public static TableInput convertToTableInput(com.amazonaws.services.glue.model.Table table) {
+        TableInput tableInput = new TableInput();
+
+        tableInput.setRetention(table.getRetention());
+        tableInput.setPartitionKeys(table.getPartitionKeys());
+        tableInput.setTableType(table.getTableType());
+        tableInput.setName(table.getName());
+        tableInput.setOwner(table.getOwner());
+        tableInput.setLastAccessTime(table.getLastAccessTime());
+        tableInput.setStorageDescriptor(table.getStorageDescriptor());
+        tableInput.setParameters(table.getParameters());
+        tableInput.setViewExpandedText(table.getViewExpandedText());
+        tableInput.setViewOriginalText(table.getViewOriginalText());
+
+        return tableInput;
+    }
+
+    public static PartitionInput convertToPartitionInput(Partition src) {
+        return convertToPartitionInput(HiveToCatalogConverter.convertPartition(src));
+    }
+
+    public static PartitionInput convertToPartitionInput(com.amazonaws.services.glue.model.Partition src) {
+        PartitionInput partitionInput = new PartitionInput();
+
+        partitionInput.setLastAccessTime(src.getLastAccessTime());
+        partitionInput.setParameters(src.getParameters());
+        partitionInput.setStorageDescriptor(src.getStorageDescriptor());
+        partitionInput.setValues(src.getValues());
+
+        return partitionInput;
+    }
+
+    public static List<PartitionInput> convertToPartitionInputs(
+            Collection<com.amazonaws.services.glue.model.Partition> parts) {
+        List<PartitionInput> inputList = new ArrayList<>();
+
+        for (com.amazonaws.services.glue.model.Partition part : parts) {
+            inputList.add(convertToPartitionInput(part));
+        }
+        return inputList;
+    }
+
+    public static UserDefinedFunctionInput convertToUserDefinedFunctionInput(Function hiveFunction) {
+        UserDefinedFunctionInput functionInput = new UserDefinedFunctionInput();
+
+        functionInput.setClassName(hiveFunction.getClassName());
+        functionInput.setFunctionName(hiveFunction.getFunctionName());
+        functionInput.setOwnerName(hiveFunction.getOwnerName());
+        if (hiveFunction.getOwnerType() != null) {
+            functionInput.setOwnerType(hiveFunction.getOwnerType().name());
+        }
+        functionInput.setResourceUris(HiveToCatalogConverter.covertResourceUriList(hiveFunction.getResourceUris()));
+        return functionInput;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/HiveToCatalogConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/converters/HiveToCatalogConverter.java
@@ -1,0 +1,222 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.converters;
+
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.Order;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.ResourceUri;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.SkewedInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HiveToCatalogConverter {
+
+    public static com.amazonaws.services.glue.model.Database convertDatabase(Database hiveDatabase) {
+        com.amazonaws.services.glue.model.Database catalogDatabase = new com.amazonaws.services.glue.model.Database();
+        catalogDatabase.setName(hiveDatabase.getName());
+        catalogDatabase.setDescription(hiveDatabase.getDescription());
+        catalogDatabase.setLocationUri(hiveDatabase.getLocationUri());
+        catalogDatabase.setParameters(hiveDatabase.getParameters());
+        return catalogDatabase;
+    }
+
+    public static com.amazonaws.services.glue.model.Table convertTable(
+            Table hiveTable) {
+        com.amazonaws.services.glue.model.Table catalogTable = new com.amazonaws.services.glue.model.Table();
+        catalogTable.setRetention(hiveTable.getRetention());
+        catalogTable.setPartitionKeys(convertFieldSchemaList(hiveTable.getPartitionKeys()));
+        catalogTable.setTableType(hiveTable.getTableType());
+        catalogTable.setName(hiveTable.getTableName());
+        catalogTable.setOwner(hiveTable.getOwner());
+        catalogTable.setCreateTime(new Date((long) hiveTable.getCreateTime() * 1000));
+        catalogTable.setLastAccessTime(new Date((long) hiveTable.getLastAccessTime() * 1000));
+        catalogTable.setStorageDescriptor(convertStorageDescriptor(hiveTable.getSd()));
+        catalogTable.setParameters(hiveTable.getParameters());
+        catalogTable.setViewExpandedText(hiveTable.getViewExpandedText());
+        catalogTable.setViewOriginalText(hiveTable.getViewOriginalText());
+
+        return catalogTable;
+    }
+
+    public static com.amazonaws.services.glue.model.StorageDescriptor convertStorageDescriptor(
+            StorageDescriptor hiveSd) {
+        com.amazonaws.services.glue.model.StorageDescriptor catalogSd =
+                new com.amazonaws.services.glue.model.StorageDescriptor();
+        catalogSd.setNumberOfBuckets(hiveSd.getNumBuckets());
+        catalogSd.setCompressed(hiveSd.isCompressed());
+        catalogSd.setParameters(hiveSd.getParameters());
+        catalogSd.setBucketColumns(hiveSd.getBucketCols());
+        catalogSd.setColumns(convertFieldSchemaList(hiveSd.getCols()));
+        catalogSd.setInputFormat(hiveSd.getInputFormat());
+        catalogSd.setLocation(hiveSd.getLocation());
+        catalogSd.setOutputFormat(hiveSd.getOutputFormat());
+        catalogSd.setSerdeInfo(convertSerDeInfo(hiveSd.getSerdeInfo()));
+        catalogSd.setSkewedInfo(convertSkewedInfo(hiveSd.getSkewedInfo()));
+        catalogSd.setSortColumns(convertOrderList(hiveSd.getSortCols()));
+        catalogSd.setStoredAsSubDirectories(hiveSd.isStoredAsSubDirectories());
+
+        return catalogSd;
+    }
+
+    public static com.amazonaws.services.glue.model.Column convertFieldSchema(
+            FieldSchema hiveFieldSchema) {
+        com.amazonaws.services.glue.model.Column catalogFieldSchema =
+                new com.amazonaws.services.glue.model.Column();
+        catalogFieldSchema.setComment(hiveFieldSchema.getComment());
+        catalogFieldSchema.setName(hiveFieldSchema.getName());
+        catalogFieldSchema.setType(hiveFieldSchema.getType());
+
+        return catalogFieldSchema;
+    }
+
+    public static List<com.amazonaws.services.glue.model.Column> convertFieldSchemaList(
+            List<FieldSchema> hiveFieldSchemaList) {
+        List<com.amazonaws.services.glue.model.Column> catalogFieldSchemaList =
+                new ArrayList<com.amazonaws.services.glue.model.Column>();
+        for (FieldSchema hiveFs : hiveFieldSchemaList) {
+            catalogFieldSchemaList.add(convertFieldSchema(hiveFs));
+        }
+
+        return catalogFieldSchemaList;
+    }
+
+    public static com.amazonaws.services.glue.model.SerDeInfo convertSerDeInfo(
+            SerDeInfo hiveSerDeInfo) {
+        com.amazonaws.services.glue.model.SerDeInfo catalogSerDeInfo =
+                new com.amazonaws.services.glue.model.SerDeInfo();
+        catalogSerDeInfo.setName(hiveSerDeInfo.getName());
+        catalogSerDeInfo.setParameters(hiveSerDeInfo.getParameters());
+        catalogSerDeInfo.setSerializationLibrary(hiveSerDeInfo.getSerializationLib());
+
+        return catalogSerDeInfo;
+    }
+
+    public static com.amazonaws.services.glue.model.SkewedInfo convertSkewedInfo(SkewedInfo hiveSkewedInfo) {
+        if (hiveSkewedInfo == null) {
+            return null;
+        }
+        com.amazonaws.services.glue.model.SkewedInfo catalogSkewedInfo =
+                new com.amazonaws.services.glue.model.SkewedInfo()
+                        .withSkewedColumnNames(hiveSkewedInfo.getSkewedColNames())
+                        .withSkewedColumnValues(convertSkewedValue(hiveSkewedInfo.getSkewedColValues()))
+                        .withSkewedColumnValueLocationMaps(
+                                convertSkewedMap(hiveSkewedInfo.getSkewedColValueLocationMaps()));
+        return catalogSkewedInfo;
+    }
+
+    public static com.amazonaws.services.glue.model.Order convertOrder(Order hiveOrder) {
+        com.amazonaws.services.glue.model.Order order = new com.amazonaws.services.glue.model.Order();
+        order.setColumn(hiveOrder.getCol());
+        order.setSortOrder(hiveOrder.getOrder());
+
+        return order;
+    }
+
+    public static List<com.amazonaws.services.glue.model.Order> convertOrderList(List<Order> hiveOrderList) {
+        if (hiveOrderList == null) {
+            return null;
+        }
+        List<com.amazonaws.services.glue.model.Order> catalogOrderList = new ArrayList<>();
+        for (Order hiveOrder : hiveOrderList) {
+            catalogOrderList.add(convertOrder(hiveOrder));
+        }
+
+        return catalogOrderList;
+    }
+
+    public static com.amazonaws.services.glue.model.Partition convertPartition(Partition src) {
+        com.amazonaws.services.glue.model.Partition tgt = new com.amazonaws.services.glue.model.Partition();
+
+        tgt.setDatabaseName(src.getDbName());
+        tgt.setTableName(src.getTableName());
+        tgt.setCreationTime(new Date((long) src.getCreateTime() * 1000));
+        tgt.setLastAccessTime(new Date((long) src.getLastAccessTime() * 1000));
+        tgt.setParameters(src.getParameters());
+        tgt.setStorageDescriptor(convertStorageDescriptor(src.getSd()));
+        tgt.setValues(src.getValues());
+
+        return tgt;
+    }
+
+    public static String convertListToString(final List<String> list) {
+        if (list == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < list.size(); i++) {
+            String currentString = list.get(i);
+            sb.append(currentString.length() + "$" + currentString);
+        }
+
+        return sb.toString();
+    }
+
+    public static Map<String, String> convertSkewedMap(final Map<List<String>, String> coreSkewedMap) {
+        if (coreSkewedMap == null) {
+            return null;
+        }
+        Map<String, String> catalogSkewedMap = new HashMap<>();
+        for (List<String> coreKey : coreSkewedMap.keySet()) {
+            catalogSkewedMap.put(convertListToString(coreKey), coreSkewedMap.get(coreKey));
+        }
+        return catalogSkewedMap;
+    }
+
+    public static List<String> convertSkewedValue(final List<List<String>> coreSkewedValue) {
+        if (coreSkewedValue == null) {
+            return null;
+        }
+        List<String> catalogSkewedValue = new ArrayList<>();
+        for (int i = 0; i < coreSkewedValue.size(); i++) {
+            catalogSkewedValue.add(convertListToString(coreSkewedValue.get(i)));
+        }
+
+        return catalogSkewedValue;
+    }
+
+    public static com.amazonaws.services.glue.model.UserDefinedFunction convertFunction(final Function hiveFunction) {
+        if (hiveFunction == null) {
+            return null;
+        }
+        com.amazonaws.services.glue.model.UserDefinedFunction catalogFunction =
+                new com.amazonaws.services.glue.model.UserDefinedFunction();
+        catalogFunction.setClassName(hiveFunction.getClassName());
+        catalogFunction.setFunctionName(hiveFunction.getFunctionName());
+        catalogFunction.setCreateTime(new Date((long) (hiveFunction.getCreateTime()) * 1000));
+        catalogFunction.setOwnerName(hiveFunction.getOwnerName());
+        if (hiveFunction.getOwnerType() != null) {
+            catalogFunction.setOwnerType(hiveFunction.getOwnerType().name());
+        }
+        catalogFunction.setResourceUris(covertResourceUriList(hiveFunction.getResourceUris()));
+        return catalogFunction;
+    }
+
+    public static List<com.amazonaws.services.glue.model.ResourceUri> covertResourceUriList(
+            final List<ResourceUri> hiveResourceUriList) {
+        if (hiveResourceUriList == null) {
+            return null;
+        }
+        List<com.amazonaws.services.glue.model.ResourceUri> catalogResourceUriList = new ArrayList<>();
+        for (ResourceUri hiveResourceUri : hiveResourceUriList) {
+            com.amazonaws.services.glue.model.ResourceUri catalogResourceUri =
+                    new com.amazonaws.services.glue.model.ResourceUri();
+            catalogResourceUri.setUri(hiveResourceUri.getUri());
+            if (hiveResourceUri.getResourceType() != null) {
+                catalogResourceUri.setResourceType(hiveResourceUri.getResourceType().name());
+            }
+            catalogResourceUriList.add(catalogResourceUri);
+        }
+        return catalogResourceUriList;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AKSKCredentialsProviderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AKSKCredentialsProviderFactory.java
@@ -1,0 +1,32 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class AKSKCredentialsProviderFactory implements AWSCredentialsProviderFactory {
+
+    public static final String AWS_ACCESS_KEY_CONF_VAR = "hive.aws_session_access_id";
+    public static final String AWS_SECRET_KEY_CONF_VAR = "hive.aws_session_secret_key";
+
+    @Override
+    public AWSCredentialsProvider buildAWSCredentialsProvider(HiveConf hiveConf) {
+
+        checkArgument(hiveConf != null, "hiveConf cannot be null.");
+
+        String accessKey = hiveConf.get(AWS_ACCESS_KEY_CONF_VAR);
+        String secretKey = hiveConf.get(AWS_SECRET_KEY_CONF_VAR);
+
+        checkArgument(accessKey != null, AWS_ACCESS_KEY_CONF_VAR + " must be set.");
+        checkArgument(secretKey != null, AWS_SECRET_KEY_CONF_VAR + " must be set.");
+
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return new AWSStaticCredentialsProvider(credentials);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSCredentialsProviderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSCredentialsProviderFactory.java
@@ -1,0 +1,11 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+public interface AWSCredentialsProviderFactory {
+
+    AWSCredentialsProvider buildAWSCredentialsProvider(HiveConf hiveConf);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueClientFactory.java
@@ -1,0 +1,102 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.log4j.Logger;
+
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_CATALOG_CREDENTIALS_PROVIDER_FACTORY_CLASS;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_CONNECTION_TIMEOUT;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_ENDPOINT;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_MAX_CONNECTIONS;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_MAX_RETRY;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_SOCKET_TIMEOUT;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_REGION;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.DEFAULT_CONNECTION_TIMEOUT;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.DEFAULT_MAX_CONNECTIONS;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.DEFAULT_MAX_RETRY;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.DEFAULT_SOCKET_TIMEOUT;
+
+public final class AWSGlueClientFactory implements GlueClientFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(AWSGlueClientFactory.class);
+
+    private final HiveConf conf;
+
+    public AWSGlueClientFactory(HiveConf conf) {
+        Preconditions.checkNotNull(conf, "HiveConf cannot be null");
+        this.conf = conf;
+    }
+
+    @Override
+    public AWSGlue newClient() throws MetaException {
+        try {
+            AWSGlueClientBuilder glueClientBuilder = AWSGlueClientBuilder.standard()
+                    .withCredentials(getAWSCredentialsProvider(conf));
+
+            String regionStr = getProperty(AWS_REGION, conf);
+            String glueEndpoint = getProperty(AWS_GLUE_ENDPOINT, conf);
+
+            // ClientBuilder only allows one of EndpointConfiguration or Region to be set
+            if (StringUtils.isNotBlank(glueEndpoint)) {
+                LOGGER.info("Setting glue service endpoint to " + glueEndpoint);
+                glueClientBuilder
+                        .setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(glueEndpoint, null));
+            } else if (StringUtils.isNotBlank(regionStr)) {
+                LOGGER.info("Setting region to : " + regionStr);
+                glueClientBuilder.setRegion(regionStr);
+            } else {
+                Region currentRegion = Regions.getCurrentRegion();
+                if (currentRegion != null) {
+                    LOGGER.info("Using region from ec2 metadata : " + currentRegion.getName());
+                    glueClientBuilder.setRegion(currentRegion.getName());
+                } else {
+                    LOGGER.info("No region info found, using SDK default region: us-east-1");
+                }
+            }
+
+            glueClientBuilder.setClientConfiguration(buildClientConfiguration(conf));
+            return glueClientBuilder.build();
+        } catch (Exception e) {
+            String message = "Unable to build AWSGlueClient: " + e;
+            LOGGER.error(message);
+            throw new MetaException(message);
+        }
+    }
+
+    private AWSCredentialsProvider getAWSCredentialsProvider(HiveConf conf) {
+        Class<? extends AWSCredentialsProviderFactory> providerFactoryClass = conf
+                .getClass(AWS_CATALOG_CREDENTIALS_PROVIDER_FACTORY_CLASS,
+                        AKSKCredentialsProviderFactory.class).asSubclass(
+                        AWSCredentialsProviderFactory.class);
+        AWSCredentialsProviderFactory provider = ReflectionUtils.newInstance(
+                providerFactoryClass, conf);
+        return provider.buildAWSCredentialsProvider(conf);
+    }
+
+    private ClientConfiguration buildClientConfiguration(HiveConf hiveConf) {
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+                .withMaxErrorRetry(hiveConf.getInt(AWS_GLUE_MAX_RETRY, DEFAULT_MAX_RETRY))
+                .withMaxConnections(hiveConf.getInt(AWS_GLUE_MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS))
+                .withConnectionTimeout(hiveConf.getInt(AWS_GLUE_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT))
+                .withSocketTimeout(hiveConf.getInt(AWS_GLUE_SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT));
+        return clientConfiguration;
+    }
+
+    private static String getProperty(String propertyName, HiveConf conf) {
+        return Strings.isNullOrEmpty(System.getProperty(propertyName)) ?
+                conf.get(propertyName) : System.getProperty(propertyName);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastore.java
@@ -1,0 +1,76 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.thrift.TException;
+
+import java.util.List;
+
+/**
+ * This is the accessor interface for using AWS Glue as a metastore.
+ * The generic AWSGlue interface{@link com.amazonaws.services.glue.AWSGlue}
+ * has a number of methods that are irrelevant for clients using Glue only
+ * as a metastore.
+ * Think of this interface as a wrapper over AWSGlue. This additional layer
+ * of abstraction achieves the following -
+ * a) Hides the non-metastore related operations present in AWSGlue
+ * b) Hides away the batching and pagination related limitations of AWSGlue
+ */
+public interface AWSGlueMetastore {
+
+    void createDatabase(DatabaseInput databaseInput);
+
+    Database getDatabase(String dbName);
+
+    List<Database> getAllDatabases();
+
+    void updateDatabase(String databaseName, DatabaseInput databaseInput);
+
+    void deleteDatabase(String dbName);
+
+    void createTable(String dbName, TableInput tableInput);
+
+    Table getTable(String dbName, String tableName);
+
+    List<Table> getTables(String dbname, String tablePattern);
+
+    void updateTable(String dbName, TableInput tableInput);
+
+    void deleteTable(String dbName, String tableName);
+
+    Partition getPartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                         List<PartitionValueList> partitionsToGet);
+
+    List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                  long max) throws TException;
+
+    void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                         PartitionInput partitionInput);
+
+    void deletePartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<PartitionError> createPartitions(String dbName, String tableName,
+                                          List<PartitionInput> partitionInputs);
+
+    void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput);
+
+    UserDefinedFunction getUserDefinedFunction(String dbName, String functionName);
+
+    List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern);
+
+    void deleteUserDefinedFunction(String dbName, String functionName);
+
+    void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreBaseDecorator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreBaseDecorator.java
@@ -1,0 +1,135 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.thrift.TException;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AWSGlueMetastoreBaseDecorator implements AWSGlueMetastore {
+
+    private final AWSGlueMetastore awsGlueMetastore;
+
+    public AWSGlueMetastoreBaseDecorator(AWSGlueMetastore awsGlueMetastore) {
+        checkNotNull(awsGlueMetastore, "awsGlueMetastore can not be null");
+        this.awsGlueMetastore = awsGlueMetastore;
+    }
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        awsGlueMetastore.createDatabase(databaseInput);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        return awsGlueMetastore.getDatabase(dbName);
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        return awsGlueMetastore.getAllDatabases();
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        awsGlueMetastore.updateDatabase(databaseName, databaseInput);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        awsGlueMetastore.deleteDatabase(dbName);
+    }
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.createTable(dbName, tableInput);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        return awsGlueMetastore.getTable(dbName, tableName);
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        return awsGlueMetastore.getTables(dbname, tablePattern);
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.updateTable(dbName, tableInput);
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        awsGlueMetastore.deleteTable(dbName, tableName);
+    }
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        return awsGlueMetastore.getPartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName, List<PartitionValueList> partitionsToGet) {
+        return awsGlueMetastore.getPartitionsByNames(dbName, tableName, partitionsToGet);
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression, long max) throws TException {
+        return awsGlueMetastore.getPartitions(dbName, tableName, expression, max);
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues, PartitionInput partitionInput) {
+        awsGlueMetastore.updatePartition(dbName, tableName, partitionValues, partitionInput);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        awsGlueMetastore.deletePartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName, List<PartitionInput> partitionInputs) {
+        return awsGlueMetastore.createPartitions(dbName, tableName, partitionInputs);
+    }
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.createUserDefinedFunction(dbName, functionInput);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        return awsGlueMetastore.getUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        return awsGlueMetastore.getUserDefinedFunctions(dbName, pattern);
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        awsGlueMetastore.deleteUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.updateUserDefinedFunction(dbName, functionName, functionInput);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreCacheDecorator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreCacheDecorator.java
@@ -1,0 +1,281 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+
+public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorator {
+
+    private static final Logger LOGGER = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
+
+    private final HiveConf conf;
+
+    private final boolean databaseCacheEnabled;
+
+    private final boolean tableCacheEnabled;
+
+    private final String databasesCacheKey = "*";
+
+    @VisibleForTesting
+    protected Cache<String, Database> databaseCache;
+    @VisibleForTesting
+    protected Cache<TableIdentifier, Table> tableCache;
+    @VisibleForTesting
+    protected Cache<String, List<String>> databasesCache;
+
+    public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
+        this(conf, awsGlueMetastore, Ticker.systemTicker());
+    }
+
+    public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore, Ticker ticker) {
+        super(awsGlueMetastore);
+        checkNotNull(conf, "conf can not be null");
+        this.conf = conf;
+
+        databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        if (databaseCacheEnabled) {
+            int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
+            int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
+
+            //initialize database cache
+            databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+                    .ticker(ticker)
+                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+            databasesCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+                    .ticker(ticker)
+                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            databaseCache = null;
+            databasesCache = null;
+        }
+
+        tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        if (tableCacheEnabled) {
+            int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
+            int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
+
+            //initialize table cache
+            tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
+                    .ticker(ticker)
+                    .expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            tableCache = null;
+        }
+
+        LOGGER.info("Constructed");
+    }
+
+    private void validateConfigValueIsGreaterThanZero(String configName, int value) {
+        checkArgument(value > 0, String.format("Invalid value for Hive Config %s. " +
+                "Provide a value greater than zero", configName));
+
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        Database result;
+        if (databaseCacheEnabled) {
+            Database valueFromCache = databaseCache.getIfPresent(dbName);
+            if (valueFromCache != null) {
+                LOGGER.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
+                result = valueFromCache;
+            } else {
+                LOGGER.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
+                result = super.getDatabase(dbName);
+                databaseCache.put(dbName, result);
+            }
+        } else {
+            result = super.getDatabase(dbName);
+        }
+        return result;
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        List<Database> allDatabases;
+        if (databaseCacheEnabled) {
+            List<String> databaseNames = databasesCache.getIfPresent(databasesCacheKey);
+            if (databaseNames != null) {
+                List<Database> databases = new ArrayList<>();
+                for (String name : databaseNames) {
+                    Database valueFromCache = databaseCache.getIfPresent(name);
+                    if (valueFromCache != null) {
+                        databases.add(valueFromCache);
+                    } else {
+                        LOGGER.info(
+                                "Cannot get database from database cache, cache miss for operation [getAllDatabases].");
+                        databasesCache.invalidateAll();
+                        allDatabases = super.getAllDatabases();
+                        cacheAllDatabases(allDatabases);
+                        return allDatabases;
+                    }
+                }
+                LOGGER.info("Cache hit for operation [getAllDatabases]");
+                allDatabases = databases;
+            } else {
+                LOGGER.info("Cache miss for operation [getAllDatabases]");
+                allDatabases = super.getAllDatabases();
+                cacheAllDatabases(allDatabases);
+                return allDatabases;
+            }
+        } else {
+            allDatabases = super.getAllDatabases();
+        }
+        return allDatabases;
+    }
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        super.createDatabase(databaseInput);
+        if (databaseCacheEnabled) {
+            databasesCache.invalidateAll();
+        }
+    }
+
+    @Override
+    public void updateDatabase(String dbName, DatabaseInput databaseInput) {
+        super.updateDatabase(dbName, databaseInput);
+        if (databaseCacheEnabled) {
+            purgeDatabaseFromCache(dbName);
+            databasesCache.invalidateAll();
+        }
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        super.deleteDatabase(dbName);
+        if (databaseCacheEnabled) {
+            purgeDatabaseFromCache(dbName);
+            databasesCache.invalidateAll();
+        }
+    }
+
+    private void purgeDatabaseFromCache(String dbName) {
+        databaseCache.invalidate(dbName);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        Table result;
+        if (tableCacheEnabled) {
+            TableIdentifier key = new TableIdentifier(dbName, tableName);
+            Table valueFromCache = tableCache.getIfPresent(key);
+            if (valueFromCache != null) {
+                LOGGER.info("Cache hit for operation [getTable] on key [" + key + "]");
+                result = valueFromCache;
+            } else {
+                LOGGER.info("Cache miss for operation [getTable] on key [" + key + "]");
+                result = super.getTable(dbName, tableName);
+                tableCache.put(key, result);
+            }
+        } else {
+            result = super.getTable(dbName, tableName);
+        }
+        return result;
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        super.updateTable(dbName, tableInput);
+        if (tableCacheEnabled) {
+            purgeTableFromCache(dbName, tableInput.getName());
+        }
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        super.deleteTable(dbName, tableName);
+        if (tableCacheEnabled) {
+            purgeTableFromCache(dbName, tableName);
+        }
+    }
+
+    private void purgeTableFromCache(String dbName, String tableName) {
+        TableIdentifier key = new TableIdentifier(dbName, tableName);
+        tableCache.invalidate(key);
+    }
+
+    private void cacheAllDatabases(List<Database> allDatabases) {
+        List<String> allNames = new ArrayList<>();
+        for (Database db : allDatabases) {
+            databaseCache.put(db.getName(), db);
+            allNames.add(db.getName());
+        }
+        databasesCache.put(databasesCacheKey, allNames);
+    }
+
+    static class TableIdentifier {
+        private final String dbName;
+        private final String tableName;
+
+        public TableIdentifier(String dbName, String tableName) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+        }
+
+        public String getDbName() {
+            return dbName;
+        }
+
+        public String getTableName() {
+            return tableName;
+        }
+
+        @Override
+        public String toString() {
+            return "TableIdentifier{" +
+                    "dbName='" + dbName + '\'' +
+                    ", tableName='" + tableName + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TableIdentifier that = (TableIdentifier) o;
+            return Objects.equals(dbName, that.dbName) &&
+                    Objects.equals(tableName, that.tableName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tableName);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/AWSGlueMetastoreFactory.java
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.services.glue.AWSGlue;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.starrocks.external.hive.glue.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+
+public class AWSGlueMetastoreFactory {
+
+    public AWSGlueMetastore newMetastore(HiveConf conf) throws MetaException {
+        AWSGlue glueClient = new AWSGlueClientFactory(conf).newClient();
+        AWSGlueMetastore defaultMetastore = new DefaultAWSGlueMetastore(conf, glueClient);
+        if (isCacheEnabled(conf)) {
+            return new AWSGlueMetastoreCacheDecorator(conf, defaultMetastore);
+        }
+        return defaultMetastore;
+    }
+
+    private boolean isCacheEnabled(HiveConf conf) {
+        boolean databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        boolean tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        return (databaseCacheEnabled || tableCacheEnabled);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultAWSCredentialsProviderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultAWSCredentialsProviderFactory.java
@@ -1,0 +1,17 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+public class DefaultAWSCredentialsProviderFactory implements
+        AWSCredentialsProviderFactory {
+
+    @Override
+    public AWSCredentialsProvider buildAWSCredentialsProvider(HiveConf hiveConf) {
+        return new DefaultAWSCredentialsProviderChain();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultAWSGlueMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultAWSGlueMetastore.java
@@ -1,0 +1,409 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionResult;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.CreateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.DeleteUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabaseResult;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetDatabasesResult;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetPartitionsResult;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.GetTablesResult;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsResult;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Segment;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.amazonaws.services.glue.model.UpdateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.starrocks.external.hive.glue.util.MetastoreClientUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.thrift.TException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
+
+    public static final int BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE = 1000;
+    /**
+     * Based on the maxResults parameter at https://docs.aws.amazon.com/glue/latest/webapi/API_GetPartitions.html
+     */
+    public static final int GET_PARTITIONS_MAX_SIZE = 1000;
+    /**
+     * Maximum number of Glue Segments. A segment defines a non-overlapping region of a table's partitions,
+     * allowing multiple requests to be executed in parallel.
+     */
+    public static final int DEFAULT_NUM_PARTITION_SEGMENTS = 5;
+    /**
+     * Currently the upper limit allowed by Glue is 10.
+     * https://docs.aws.amazon.com/glue/latest/webapi/API_Segment.html
+     */
+    public static final int MAX_NUM_PARTITION_SEGMENTS = 10;
+    public static final String NUM_PARTITION_SEGMENTS_CONF = "aws.glue.partition.num.segments";
+    public static final String CUSTOM_EXECUTOR_FACTORY_CONF = "hive.metastore.executorservice.factory.class";
+
+    private final HiveConf conf;
+    private final AWSGlue glueClient;
+    private final String catalogId;
+    private final ExecutorService executorService;
+    private final int numPartitionSegments;
+
+    protected ExecutorService getExecutorService(HiveConf hiveConf) {
+        Class<? extends ExecutorServiceFactory> executorFactoryClass = hiveConf
+                .getClass(CUSTOM_EXECUTOR_FACTORY_CONF,
+                        DefaultExecutorServiceFactory.class).asSubclass(
+                        ExecutorServiceFactory.class);
+        ExecutorServiceFactory factory = ReflectionUtils.newInstance(
+                executorFactoryClass, hiveConf);
+        return factory.getExecutorService(hiveConf);
+    }
+
+    public DefaultAWSGlueMetastore(HiveConf conf, AWSGlue glueClient) {
+        checkNotNull(conf, "Hive Config cannot be null");
+        checkNotNull(glueClient, "glueClient cannot be null");
+        this.numPartitionSegments = conf.getInt(NUM_PARTITION_SEGMENTS_CONF, DEFAULT_NUM_PARTITION_SEGMENTS);
+        checkArgument(numPartitionSegments <= MAX_NUM_PARTITION_SEGMENTS,
+                String.format("Hive Config [%s] can't exceed %d", NUM_PARTITION_SEGMENTS_CONF, MAX_NUM_PARTITION_SEGMENTS));
+        this.conf = conf;
+        this.glueClient = glueClient;
+        this.catalogId = MetastoreClientUtils.getCatalogId(conf);
+        this.executorService = getExecutorService(conf);
+    }
+
+    // ======================= Database =======================
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest().withDatabaseInput(databaseInput)
+                .withCatalogId(catalogId);
+        glueClient.createDatabase(createDatabaseRequest);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        GetDatabaseRequest getDatabaseRequest = new GetDatabaseRequest().withCatalogId(catalogId).withName(dbName);
+        GetDatabaseResult result = glueClient.getDatabase(getDatabaseRequest);
+        return result.getDatabase();
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        List<Database> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetDatabasesRequest getDatabasesRequest = new GetDatabasesRequest().withNextToken(nextToken).withCatalogId(
+                    catalogId);
+            GetDatabasesResult result = glueClient.getDatabases(getDatabasesRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getDatabaseList());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        UpdateDatabaseRequest updateDatabaseRequest = new UpdateDatabaseRequest().withName(databaseName)
+                .withDatabaseInput(databaseInput).withCatalogId(catalogId);
+        glueClient.updateDatabase(updateDatabaseRequest);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        DeleteDatabaseRequest deleteDatabaseRequest = new DeleteDatabaseRequest().withName(dbName).withCatalogId(
+                catalogId);
+        glueClient.deleteDatabase(deleteDatabaseRequest);
+    }
+
+    // ======================== Table ========================
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        CreateTableRequest createTableRequest = new CreateTableRequest().withTableInput(tableInput)
+                .withDatabaseName(dbName).withCatalogId(catalogId);
+        glueClient.createTable(createTableRequest);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        GetTableResult result = glueClient.getTable(getTableRequest);
+        return result.getTable();
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        List<Table> ret = new ArrayList<>();
+        String nextToken = null;
+        do {
+            GetTablesRequest getTablesRequest = new GetTablesRequest().withDatabaseName(dbname)
+                    .withExpression(tablePattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetTablesResult result = glueClient.getTables(getTablesRequest);
+            ret.addAll(result.getTableList());
+            nextToken = result.getNextToken();
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        UpdateTableRequest updateTableRequest = new UpdateTableRequest().withDatabaseName(dbName)
+                .withTableInput(tableInput).withCatalogId(catalogId);
+        glueClient.updateTable(updateTableRequest);
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        DeleteTableRequest deleteTableRequest = new DeleteTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        glueClient.deleteTable(deleteTableRequest);
+    }
+
+    // =========================== Partition ===========================
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        GetPartitionRequest request = new GetPartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        return glueClient.getPartition(request).getPartition();
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                                List<PartitionValueList> partitionsToGet) {
+
+        List<List<PartitionValueList>> batchedPartitionsToGet = Lists.partition(partitionsToGet,
+                BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE);
+        List<Future<BatchGetPartitionResult>> batchGetPartitionFutures = Lists.newArrayList();
+
+        for (List<PartitionValueList> batch : batchedPartitionsToGet) {
+            final BatchGetPartitionRequest request = new BatchGetPartitionRequest()
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withPartitionsToGet(batch)
+                    .withCatalogId(catalogId);
+            batchGetPartitionFutures.add(this.executorService.submit(new Callable<BatchGetPartitionResult>() {
+                @Override
+                public BatchGetPartitionResult call() throws Exception {
+                    return glueClient.batchGetPartition(request);
+                }
+            }));
+        }
+
+        List<Partition> result = Lists.newArrayList();
+        try {
+            for (Future<BatchGetPartitionResult> future : batchGetPartitionFutures) {
+                result.addAll(future.get().getPartitions());
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return result;
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                         long max) throws TException {
+        if (max == 0) {
+            return Collections.emptyList();
+        }
+        if (max < 0 || max > GET_PARTITIONS_MAX_SIZE) {
+            return getPartitionsParallel(dbName, tableName, expression, max);
+        } else {
+            // We don't need to get too many partitions, so just do it serially.
+            return getCatalogPartitions(dbName, tableName, expression, max, null);
+        }
+    }
+
+    private List<Partition> getPartitionsParallel(
+            final String databaseName,
+            final String tableName,
+            final String expression,
+            final long max) throws TException {
+        // Prepare the segments
+        List<Segment> segments = Lists.newArrayList();
+        for (int i = 0; i < numPartitionSegments; i++) {
+            segments.add(new Segment()
+                    .withSegmentNumber(i)
+                    .withTotalSegments(numPartitionSegments));
+        }
+        // Submit Glue API calls in parallel using the thread pool.
+        // We could convert this into a parallelStream after upgrading to JDK 8 compiler base.
+        List<Future<List<Partition>>> futures = Lists.newArrayList();
+        for (final Segment segment : segments) {
+            futures.add(this.executorService.submit(new Callable<List<Partition>>() {
+                @Override
+                public List<Partition> call() throws Exception {
+                    return getCatalogPartitions(databaseName, tableName, expression, max, segment);
+                }
+            }));
+        }
+
+        // Get the results
+        List<Partition> partitions = Lists.newArrayList();
+        try {
+            for (Future<List<Partition>> future : futures) {
+                List<Partition> segmentPartitions = future.get();
+                if (partitions.size() + segmentPartitions.size() >= max && max > 0) {
+                    // Extract the required number of partitions from the segment and we're done.
+                    long remaining = max - partitions.size();
+                    partitions.addAll(segmentPartitions.subList(0, (int) remaining));
+                    break;
+                } else {
+                    partitions.addAll(segmentPartitions);
+                }
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return partitions;
+    }
+
+
+    private List<Partition> getCatalogPartitions(String databaseName, String tableName, String expression,
+                                                 long max, Segment segment) {
+        List<Partition> partitions = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetPartitionsRequest request = new GetPartitionsRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withExpression(expression)
+                    .withNextToken(nextToken)
+                    .withCatalogId(catalogId)
+                    .withSegment(segment);
+            GetPartitionsResult res = glueClient.getPartitions(request);
+            List<Partition> list = res.getPartitions();
+            if ((partitions.size() + list.size()) >= max && max > 0) {
+                long remaining = max - partitions.size();
+                partitions.addAll(list.subList(0, (int) remaining));
+                break;
+            }
+            partitions.addAll(list);
+            nextToken = res.getNextToken();
+        } while (nextToken != null);
+        return partitions;
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                                PartitionInput partitionInput) {
+        UpdatePartitionRequest updatePartitionRequest = new UpdatePartitionRequest().withDatabaseName(dbName)
+                .withTableName(tableName).withPartitionValueList(partitionValues)
+                .withPartitionInput(partitionInput).withCatalogId(catalogId);
+        glueClient.updatePartition(updatePartitionRequest);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        DeletePartitionRequest request = new DeletePartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        glueClient.deletePartition(request);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName,
+                                                 List<PartitionInput> partitionInputs) {
+        BatchCreatePartitionRequest request =
+                new BatchCreatePartitionRequest().withDatabaseName(dbName)
+                .withTableName(tableName).withCatalogId(catalogId)
+                .withPartitionInputList(partitionInputs);
+        return glueClient.batchCreatePartition(request).getErrors();
+    }
+
+    // ====================== User Defined Function ======================
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        CreateUserDefinedFunctionRequest createUserDefinedFunctionRequest = new CreateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionInput(functionInput).withCatalogId(catalogId);
+        glueClient.createUserDefinedFunction(createUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        GetUserDefinedFunctionRequest getUserDefinedFunctionRequest = new GetUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        return glueClient.getUserDefinedFunction(getUserDefinedFunctionRequest).getUserDefinedFunction();
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        List<UserDefinedFunction> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetUserDefinedFunctionsRequest getUserDefinedFunctionsRequest = new GetUserDefinedFunctionsRequest()
+                    .withDatabaseName(dbName).withPattern(pattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetUserDefinedFunctionsResult result = glueClient.getUserDefinedFunctions(getUserDefinedFunctionsRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getUserDefinedFunctions());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        DeleteUserDefinedFunctionRequest deleteUserDefinedFunctionRequest = new DeleteUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        glueClient.deleteUserDefinedFunction(deleteUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        UpdateUserDefinedFunctionRequest updateUserDefinedFunctionRequest = new UpdateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withFunctionInput(functionInput)
+                .withCatalogId(catalogId);
+        glueClient.updateUserDefinedFunction(updateUserDefinedFunctionRequest);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultExecutorServiceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/DefaultExecutorServiceFactory.java
@@ -1,0 +1,24 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
+    private static final int NUM_EXECUTOR_THREADS = 5;
+
+    private static final ExecutorService GLUE_METASTORE_DELEGATE_THREAD_POOL = Executors.newFixedThreadPool(
+            NUM_EXECUTOR_THREADS, new ThreadFactoryBuilder()
+                    .setNameFormat(GlueMetastoreClientDelegate.GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT)
+                    .setDaemon(true).build()
+    );
+
+    @Override
+    public ExecutorService getExecutorService(HiveConf conf) {
+        return GLUE_METASTORE_DELEGATE_THREAD_POOL;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/ExecutorServiceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/ExecutorServiceFactory.java
@@ -1,0 +1,14 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.util.concurrent.ExecutorService;
+
+/*
+ * Interface for creating an ExecutorService
+ */
+public interface ExecutorServiceFactory {
+    public ExecutorService getExecutorService(HiveConf conf);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/GlueClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/GlueClientFactory.java
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.services.glue.AWSGlue;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+/***
+ * Interface for creating Glue AWS Client
+ */
+public interface GlueClientFactory {
+
+    AWSGlue newClient() throws MetaException;
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/GlueMetastoreClientDelegate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/metastore/GlueMetastoreClientDelegate.java
@@ -1,0 +1,1626 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.metastore;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.glue.model.Column;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.external.hive.glue.converters.CatalogToHiveConverter;
+import com.starrocks.external.hive.glue.converters.GlueInputConverter;
+import com.starrocks.external.hive.glue.converters.HiveToCatalogConverter;
+import com.starrocks.external.hive.glue.util.BatchCreatePartitionsHelper;
+import com.starrocks.external.hive.glue.util.ExpressionHelper;
+import com.starrocks.external.hive.glue.util.MetastoreClientUtils;
+import com.starrocks.external.hive.glue.util.PartitionKey;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.common.ValidTxnList;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.AggrStats;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.CompactionResponse;
+import org.apache.hadoop.hive.metastore.api.CompactionType;
+import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.FireEventRequest;
+import org.apache.hadoop.hive.metastore.api.FireEventResponse;
+import org.apache.hadoop.hive.metastore.api.GetOpenTxnsInfoResponse;
+import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
+import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
+import org.apache.hadoop.hive.metastore.api.HeartbeatTxnRangeResponse;
+import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
+import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.MetadataPpdResult;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
+import org.apache.hadoop.hive.metastore.api.OpenTxnsResponse;
+import org.apache.hadoop.hive.metastore.api.PartitionEventType;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.Role;
+import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
+import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
+import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
+import org.apache.hadoop.hive.metastore.api.ShowLocksRequest;
+import org.apache.hadoop.hive.metastore.api.ShowLocksResponse;
+import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.hadoop.hive.metastore.api.UnknownTableException;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.starrocks.external.hive.glue.util.MetastoreClientUtils.deepCopyMap;
+import static com.starrocks.external.hive.glue.util.MetastoreClientUtils.isExternalTable;
+import static com.starrocks.external.hive.glue.util.MetastoreClientUtils.makeDirs;
+import static com.starrocks.external.hive.glue.util.MetastoreClientUtils.validateGlueTable;
+import static com.starrocks.external.hive.glue.util.MetastoreClientUtils.validateTableObject;
+import static org.apache.hadoop.hive.metastore.HiveMetaStore.PUBLIC;
+import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
+
+/***
+ * Delegate Class to provide all common functionality
+ * between Spark-hive version, Hive and Presto clients
+ *
+ */
+public class GlueMetastoreClientDelegate {
+
+    private static final Logger LOGGER = Logger.getLogger(GlueMetastoreClientDelegate.class);
+
+    private static final List<Role> IMPLICIT_ROLES = Lists.newArrayList(new Role(PUBLIC, 0, PUBLIC));
+    public static final int MILLISECOND_TO_SECOND_FACTOR = 1000;
+    public static final Long NO_MAX = -1L;
+    public static final String MATCH_ALL = ".*";
+
+    public static final String INDEX_PREFIX = "index_prefix";
+
+    private static final int BATCH_CREATE_PARTITIONS_MAX_REQUEST_SIZE = 100;
+
+    public static final String CUSTOM_EXECUTOR_FACTORY_CONF = "hive.metastore.executorservice.factory.class";
+
+    static final String GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT = "glue-metastore-delegate-%d";
+
+    private final ExecutorService executorService;
+    private final AWSGlueMetastore glueMetastore;
+    private final HiveConf conf;
+    private final Warehouse wh;
+    private final String catalogId;
+
+    public static final String CATALOG_ID_CONF = "hive.metastore.glue.catalogid";
+    public static final String NUM_PARTITION_SEGMENTS_CONF = "aws.glue.partition.num.segments";
+
+    protected ExecutorService getExecutorService() {
+        Class<? extends ExecutorServiceFactory> executorFactoryClass = this.conf
+                .getClass(CUSTOM_EXECUTOR_FACTORY_CONF,
+                        DefaultExecutorServiceFactory.class).asSubclass(
+                        ExecutorServiceFactory.class);
+        ExecutorServiceFactory factory = ReflectionUtils.newInstance(
+                executorFactoryClass, conf);
+        return factory.getExecutorService(conf);
+    }
+
+    public GlueMetastoreClientDelegate(HiveConf conf, AWSGlueMetastore glueMetastore,
+                                       Warehouse wh) throws MetaException {
+        checkNotNull(conf, "Hive Config cannot be null");
+        checkNotNull(glueMetastore, "glueMetastore cannot be null");
+        checkNotNull(wh, "Warehouse cannot be null");
+
+        this.conf = conf;
+        this.glueMetastore = glueMetastore;
+        this.wh = wh;
+        this.executorService = getExecutorService();
+
+        // TODO - May be validate catalogId confirms to AWS AccountId too.
+        catalogId = MetastoreClientUtils.getCatalogId(conf);
+    }
+
+    // ======================= Database =======================
+
+    public void createDatabase(org.apache.hadoop.hive.metastore.api.Database database) throws TException {
+        checkNotNull(database, "database cannot be null");
+
+        if (StringUtils.isEmpty(database.getLocationUri())) {
+            database.setLocationUri(wh.getDefaultDatabasePath(database.getName()).toString());
+        } else {
+            database.setLocationUri(wh.getDnsPath(new Path(database.getLocationUri())).toString());
+        }
+        Path dbPath = new Path(database.getLocationUri());
+        boolean madeDir = makeDirs(wh, dbPath);
+
+        try {
+            DatabaseInput catalogDatabase = GlueInputConverter.convertToDatabaseInput(database);
+            glueMetastore.createDatabase(catalogDatabase);
+        } catch (AmazonServiceException e) {
+            if (madeDir) {
+                wh.deleteDir(dbPath, true, database);
+            }
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to create database: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public org.apache.hadoop.hive.metastore.api.Database getDatabase(String name) throws TException {
+        checkArgument(StringUtils.isNotEmpty(name), "name cannot be null or empty");
+
+        try {
+            Database catalogDatabase = glueMetastore.getDatabase(name);
+            return CatalogToHiveConverter.convertDatabase(catalogDatabase);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get database object: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public List<String> getDatabases(String pattern) throws TException {
+        // Special handling for compatibility with Hue that passes "*" instead of ".*"
+        if (pattern == null || pattern.equals("*")) {
+            pattern = MATCH_ALL;
+        }
+
+        try {
+            List<String> ret = new ArrayList<>();
+
+            List<Database> allDatabases = glueMetastore.getAllDatabases();
+
+            //filter by pattern
+            for (Database db : allDatabases) {
+                String name = db.getName();
+                if (Pattern.matches(pattern, name)) {
+                    ret.add(name);
+                }
+            }
+            return ret;
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get databases: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public void alterDatabase(String databaseName, org.apache.hadoop.hive.metastore.api.Database database)
+            throws TException {
+        checkArgument(StringUtils.isNotEmpty(databaseName), "databaseName cannot be null or empty");
+        checkNotNull(database, "database cannot be null");
+
+        try {
+            DatabaseInput catalogDatabase = GlueInputConverter.convertToDatabaseInput(database);
+            glueMetastore.updateDatabase(databaseName, catalogDatabase);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to alter database: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb, boolean cascade)
+            throws TException {
+        checkArgument(StringUtils.isNotEmpty(name), "name cannot be null or empty");
+
+        String dbLocation;
+        org.apache.hadoop.hive.metastore.api.Database db = getDatabase(name);
+        try {
+            List<String> tables = getTables(name, MATCH_ALL);
+            boolean isEmptyDatabase = tables.isEmpty();
+
+            dbLocation = db.getLocationUri();
+
+            // TODO: handle cascade
+            if (isEmptyDatabase || cascade) {
+                glueMetastore.deleteDatabase(name);
+            } else {
+                throw new InvalidOperationException("Database " + name + " is not empty.");
+            }
+        } catch (NoSuchObjectException e) {
+            if (ignoreUnknownDb) {
+                return;
+            } else {
+                throw e;
+            }
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to drop database: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+
+        if (deleteData) {
+            try {
+                wh.deleteDir(new Path(dbLocation), true, db);
+            } catch (Exception e) {
+                LOGGER.error("Unable to remove database directory " + dbLocation, e);
+            }
+        }
+    }
+
+    public boolean databaseExists(String dbName) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+
+        try {
+            getDatabase(dbName);
+        } catch (NoSuchObjectException e) {
+            return false;
+        } catch (AmazonServiceException e) {
+            throw new TException(e);
+        } catch (Exception e) {
+            throw new MetaException(e.getMessage());
+        }
+        return true;
+    }
+
+    // ======================== Table ========================
+
+    public void createTable(org.apache.hadoop.hive.metastore.api.Table tbl) throws TException {
+        checkNotNull(tbl, "tbl cannot be null");
+        boolean dirCreated = validateNewTableAndCreateDirectory(tbl);
+        try {
+            // Glue Server side does not set DDL_TIME. Set it here for the time being.
+            // TODO: Set DDL_TIME parameter in Glue service
+            tbl.setParameters(deepCopyMap(tbl.getParameters()));
+            tbl.getParameters().put(hive_metastoreConstants.DDL_TIME,
+                    Long.toString(System.currentTimeMillis() / MILLISECOND_TO_SECOND_FACTOR));
+
+            TableInput tableInput = GlueInputConverter.convertToTableInput(tbl);
+            glueMetastore.createTable(tbl.getDbName(), tableInput);
+        } catch (AmazonServiceException e) {
+            if (dirCreated) {
+                Path tblPath = new Path(tbl.getSd().getLocation());
+                wh.deleteDir(tblPath, true, getDatabase(tbl.getDbName()));
+            }
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to create table: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public boolean tableExists(String databaseName, String tableName) throws TException {
+        checkArgument(StringUtils.isNotEmpty(databaseName), "databaseName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+
+        if (!databaseExists(databaseName)) {
+            throw new UnknownDBException("Database: " + databaseName + " does not exist.");
+        }
+        try {
+            glueMetastore.getTable(databaseName, tableName);
+            return true;
+        } catch (EntityNotFoundException e) {
+            return false;
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to check table exist: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public org.apache.hadoop.hive.metastore.api.Table getTable(String dbName, String tableName) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+
+        try {
+            Table table = glueMetastore.getTable(dbName, tableName);
+            validateGlueTable(table);
+            return CatalogToHiveConverter.convertTable(table, dbName);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get table: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public List<String> getTables(String dbname, String tablePattern) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbname), "dbName cannot be null or empty");
+
+        List<String> names = Lists.newArrayList();
+        try {
+            List<Table> tables = glueMetastore.getTables(dbname, tablePattern);
+            for (Table catalogTable : tables) {
+                names.add(catalogTable.getName());
+            }
+            return names;
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get tables: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public List<TableMeta> getTableMeta(
+            String dbPatterns,
+            String tablePatterns,
+            List<String> tableTypes
+    ) throws TException {
+        List<TableMeta> tables = new ArrayList<>();
+        List<String> databases = getDatabases(dbPatterns);
+        for (String dbName : databases) {
+            String nextToken = null;
+            List<Table> dbTables = glueMetastore.getTables(dbName, tablePatterns);
+            for (Table catalogTable : dbTables) {
+                if (tableTypes == null ||
+                        tableTypes.isEmpty() ||
+                        tableTypes.contains(catalogTable.getTableType())) {
+                    tables.add(CatalogToHiveConverter.convertTableMeta(catalogTable, dbName));
+                }
+            }
+        }
+        return tables;
+    }
+
+    /*
+     * Hive reference: https://github.com/apache/hive/blob/rel/release-2.3.0/metastore/src/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java#L88
+     */
+    public void alterTable(
+            String dbName,
+            String oldTableName,
+            org.apache.hadoop.hive.metastore.api.Table newTable,
+            EnvironmentContext environmentContext
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(oldTableName), "oldTableName cannot be null or empty");
+        checkNotNull(newTable, "newTable cannot be null");
+
+        if (isCascade(environmentContext)) {
+            throw new UnsupportedOperationException("Cascade for alter_table is not supported");
+        }
+
+        if (!oldTableName.equals(newTable.getTableName())) {
+            throw new UnsupportedOperationException("Table rename is not supported");
+        }
+
+        validateTableObject(newTable, conf);
+        if (!tableExists(dbName, oldTableName)) {
+            throw new UnknownTableException("Table: " + oldTableName + " does not exists");
+        }
+
+        // If table properties has EXTERNAL set, update table type accordinly
+        // mimics Hive's ObjectStore#convertToMTable, added in HIVE-1329
+        boolean isExternal = Boolean.parseBoolean(newTable.getParameters().get("EXTERNAL"));
+        if (MANAGED_TABLE.toString().equals(newTable.getTableType()) && isExternal) {
+            newTable.setTableType(EXTERNAL_TABLE.toString());
+        } else if (EXTERNAL_TABLE.toString().equals(newTable.getTableType()) && !isExternal) {
+            newTable.setTableType(MANAGED_TABLE.toString());
+        }
+
+        try {
+            TableInput newTableInput = GlueInputConverter.convertToTableInput(newTable);
+            glueMetastore.updateTable(dbName, newTableInput);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to alter table: " + oldTableName;
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    private boolean isCascade(EnvironmentContext environmentContext) {
+        return environmentContext != null &&
+                environmentContext.isSetProperties() &&
+                StatsSetupConst.TRUE.equals(environmentContext.getProperties().get(StatsSetupConst.CASCADE));
+    }
+
+    public void dropTable(
+            String dbName,
+            String tableName,
+            boolean deleteData,
+            boolean ignoreUnknownTbl,
+            boolean ifPurge
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+
+        if (!tableExists(dbName, tableName)) {
+            if (!ignoreUnknownTbl) {
+                throw new UnknownTableException("Cannot find table: " + dbName + "." + tableName);
+            } else {
+                return;
+            }
+        }
+
+        org.apache.hadoop.hive.metastore.api.Table tbl = getTable(dbName, tableName);
+        String tblLocation = tbl.getSd().getLocation();
+        boolean isExternal = isExternalTable(tbl);
+        dropPartitionsForTable(dbName, tableName, deleteData && !isExternal);
+
+        try {
+            glueMetastore.deleteTable(dbName, tableName);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to drop table: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+
+        if (StringUtils.isNotEmpty(tblLocation) && deleteData && !isExternal) {
+            Path tblPath = new Path(tblLocation);
+            try {
+                wh.deleteDir(tblPath, true, ifPurge, getDatabase(dbName));
+            } catch (Exception e) {
+                LOGGER.error("Unable to remove table directory " + tblPath, e);
+            }
+        }
+    }
+
+    private void dropPartitionsForTable(String dbName, String tableName, boolean deleteData) throws TException {
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitionsToDelete =
+                getPartitions(dbName, tableName, null, NO_MAX);
+        for (org.apache.hadoop.hive.metastore.api.Partition part : partitionsToDelete) {
+            dropPartition(dbName, tableName, part.getValues(), true, deleteData, false);
+        }
+    }
+
+    public List<String> getTables(String dbname, String tablePattern, TableType tableType) throws TException {
+        throw new UnsupportedOperationException("getTables with TableType is not supported");
+    }
+
+    public List<String> listTableNamesByFilter(String dbName, String filter, short maxTables) throws TException {
+        throw new UnsupportedOperationException("listTableNamesByFilter is not supported");
+    }
+
+    /**
+     * @return boolean
+     * true  -> directory created
+     * false -> directory not created
+     */
+    public boolean validateNewTableAndCreateDirectory(org.apache.hadoop.hive.metastore.api.Table tbl)
+            throws TException {
+        checkNotNull(tbl, "tbl cannot be null");
+        if (tableExists(tbl.getDbName(), tbl.getTableName())) {
+            throw new AlreadyExistsException("Table " + tbl.getTableName() + " already exists.");
+        }
+        validateTableObject(tbl, conf);
+
+        if (TableType.VIRTUAL_VIEW.toString().equals(tbl.getTableType())) {
+            // we don't need to create directory for virtual views
+            return false;
+        }
+
+        tbl.getSd().setLocation(wh.getDnsPath(new Path(tbl.getSd().getLocation())).toString());
+        Path tblPath = new Path(tbl.getSd().getLocation());
+        return makeDirs(wh, tblPath);
+    }
+
+    // =========================== Partition ===========================
+
+    public org.apache.hadoop.hive.metastore.api.Partition appendPartition(
+            String dbName,
+            String tblName,
+            List<String> values
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
+        checkNotNull(values, "partition values cannot be null");
+        org.apache.hadoop.hive.metastore.api.Table table = getTable(dbName, tblName);
+        checkNotNull(table.getSd(), "StorageDescriptor cannot be null for Table " + tblName);
+        org.apache.hadoop.hive.metastore.api.Partition partition = buildPartitionFromValues(table, values);
+        addPartitions(Lists.newArrayList(partition), false, true);
+        return partition;
+    }
+
+    /**
+     * Taken from HiveMetaStore#append_partition_common
+     */
+    private org.apache.hadoop.hive.metastore.api.Partition buildPartitionFromValues(
+            org.apache.hadoop.hive.metastore.api.Table table, List<String> values) throws MetaException {
+        org.apache.hadoop.hive.metastore.api.Partition partition = new org.apache.hadoop.hive.metastore.api.Partition();
+        partition.setDbName(table.getDbName());
+        partition.setTableName(table.getTableName());
+        partition.setValues(values);
+        partition.setSd(table.getSd().deepCopy());
+
+        Path partLocation =
+                new Path(table.getSd().getLocation(), Warehouse.makePartName(table.getPartitionKeys(), values));
+        partition.getSd().setLocation(partLocation.toString());
+
+        long timeInSecond = System.currentTimeMillis() / MILLISECOND_TO_SECOND_FACTOR;
+        partition.setCreateTime((int) timeInSecond);
+        partition.putToParameters(hive_metastoreConstants.DDL_TIME, Long.toString(timeInSecond));
+        return partition;
+    }
+
+    public List<org.apache.hadoop.hive.metastore.api.Partition> addPartitions(
+            List<org.apache.hadoop.hive.metastore.api.Partition> partitions,
+            boolean ifNotExists,
+            boolean needResult
+    ) throws TException {
+        checkNotNull(partitions, "partitions cannot be null");
+        List<Partition> partitionsCreated =
+                batchCreatePartitions(partitions, ifNotExists);
+        if (!needResult) {
+            return null;
+        }
+        return CatalogToHiveConverter.convertPartitions(partitionsCreated);
+    }
+
+    private List<Partition> batchCreatePartitions(
+            final List<org.apache.hadoop.hive.metastore.api.Partition> hivePartitions,
+            final boolean ifNotExists
+    ) throws TException {
+        if (hivePartitions.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        final String dbName = hivePartitions.get(0).getDbName();
+        final String tableName = hivePartitions.get(0).getTableName();
+        org.apache.hadoop.hive.metastore.api.Table tbl = getTable(dbName, tableName);
+        validateInputForBatchCreatePartitions(tbl, hivePartitions);
+
+        List<Partition> catalogPartitions = Lists.newArrayList();
+        Map<PartitionKey, Path> addedPath = Maps.newHashMap();
+        try {
+            for (org.apache.hadoop.hive.metastore.api.Partition partition : hivePartitions) {
+                Path location = getPartitionLocation(tbl, partition);
+                boolean partDirCreated = false;
+                if (location != null) {
+                    partition.getSd().setLocation(location.toString());
+                    partDirCreated = makeDirs(wh, location);
+                }
+                Partition catalogPartition = HiveToCatalogConverter.convertPartition(partition);
+                catalogPartitions.add(catalogPartition);
+                if (partDirCreated) {
+                    addedPath.put(new PartitionKey(catalogPartition), new Path(partition.getSd().getLocation()));
+                }
+            }
+        } catch (MetaException e) {
+            for (Path path : addedPath.values()) {
+                deletePath(path);
+            }
+            throw e;
+        }
+
+        List<Future<BatchCreatePartitionsHelper>> batchCreatePartitionsFutures = Lists.newArrayList();
+        for (int i = 0; i < catalogPartitions.size(); i += BATCH_CREATE_PARTITIONS_MAX_REQUEST_SIZE) {
+            int j = Math.min(i + BATCH_CREATE_PARTITIONS_MAX_REQUEST_SIZE, catalogPartitions.size());
+            final List<Partition> partitionsOnePage = catalogPartitions.subList(i, j);
+
+            batchCreatePartitionsFutures.add(this.executorService.submit(new Callable<BatchCreatePartitionsHelper>() {
+                @Override
+                public BatchCreatePartitionsHelper call() throws Exception {
+                    return new BatchCreatePartitionsHelper(glueMetastore, dbName, tableName, catalogId,
+                            partitionsOnePage, ifNotExists)
+                            .createPartitions();
+                }
+            }));
+        }
+
+        TException tException = null;
+        List<Partition> partitionsCreated = Lists.newArrayList();
+        for (Future<BatchCreatePartitionsHelper> future : batchCreatePartitionsFutures) {
+            try {
+                BatchCreatePartitionsHelper batchCreatePartitionsHelper = future.get();
+                partitionsCreated.addAll(batchCreatePartitionsHelper.getPartitionsCreated());
+                tException = tException == null ? batchCreatePartitionsHelper.getFirstTException() : tException;
+                deletePathForPartitions(batchCreatePartitionsHelper.getPartitionsFailed(), addedPath);
+            } catch (Exception e) {
+                LOGGER.error("Exception thrown by BatchCreatePartitions thread pool. ", e);
+            }
+        }
+
+        if (tException != null) {
+            throw tException;
+        }
+        return partitionsCreated;
+    }
+
+    private void validateInputForBatchCreatePartitions(
+            org.apache.hadoop.hive.metastore.api.Table tbl,
+            List<org.apache.hadoop.hive.metastore.api.Partition> hivePartitions) {
+        checkNotNull(tbl.getPartitionKeys(), "Partition keys cannot be null");
+        for (org.apache.hadoop.hive.metastore.api.Partition partition : hivePartitions) {
+            checkArgument(tbl.getDbName().equals(partition.getDbName()), "Partitions must be in the same DB");
+            checkArgument(tbl.getTableName().equals(partition.getTableName()), "Partitions must be in the same table");
+            checkNotNull(partition.getValues(), "Partition values cannot be null");
+            checkArgument(tbl.getPartitionKeys().size() == partition.getValues().size(),
+                    "Number of table partition keys must match number of partition values");
+        }
+    }
+
+    private void deletePathForPartitions(List<Partition> partitions, Map<PartitionKey, Path> addedPath) {
+        for (Partition partition : partitions) {
+            Path path = addedPath.get(new PartitionKey(partition));
+            if (path != null) {
+                deletePath(path);
+            }
+        }
+    }
+
+    private void deletePath(Path path) {
+        try {
+            wh.deleteDir(path, true, false, false);
+        } catch (MetaException e) {
+            LOGGER.error("Warehouse delete directory failed. ", e);
+        }
+    }
+
+    /**
+     * Taken from HiveMetastore#createLocationForAddedPartition
+     */
+    private Path getPartitionLocation(
+            org.apache.hadoop.hive.metastore.api.Table tbl,
+            org.apache.hadoop.hive.metastore.api.Partition part) throws MetaException {
+        Path partLocation = null;
+        String partLocationStr = null;
+        if (part.getSd() != null) {
+            partLocationStr = part.getSd().getLocation();
+        }
+
+        if (StringUtils.isEmpty(partLocationStr)) {
+            // set default location if not specified and this is
+            // a physical table partition (not a view)
+            if (tbl.getSd().getLocation() != null) {
+                partLocation = new Path(tbl.getSd().getLocation(),
+                        Warehouse.makePartName(tbl.getPartitionKeys(), part.getValues()));
+            }
+        } else {
+            if (tbl.getSd().getLocation() == null) {
+                throw new MetaException("Cannot specify location for a view partition");
+            }
+            partLocation = wh.getDnsPath(new Path(partLocationStr));
+        }
+        return partLocation;
+    }
+
+    public List<String> listPartitionNames(
+            String databaseName,
+            String tableName,
+            List<String> values,
+            short max
+    ) throws TException {
+        String expression = null;
+        org.apache.hadoop.hive.metastore.api.Table table = getTable(databaseName, tableName);
+        if (values != null) {
+            expression = ExpressionHelper.buildExpressionFromPartialSpecification(table, values);
+        }
+
+        List<String> names = Lists.newArrayList();
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions =
+                getPartitions(databaseName, tableName, expression, max);
+        for (org.apache.hadoop.hive.metastore.api.Partition p : partitions) {
+            names.add(Warehouse.makePartName(table.getPartitionKeys(), p.getValues()));
+        }
+        return names;
+    }
+
+    public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitionsByNames(
+            String databaseName,
+            String tableName,
+            List<String> partitionNames
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(databaseName), "databaseName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+        checkNotNull(partitionNames, "partitionNames cannot be null");
+
+        List<PartitionValueList> partitionsToGet = Lists.newArrayList();
+        for (String partitionName : partitionNames) {
+            partitionsToGet.add(new PartitionValueList().withValues(partitionNameToVals(partitionName)));
+        }
+        try {
+            List<Partition> partitions =
+                    glueMetastore.getPartitionsByNames(databaseName, tableName, partitionsToGet);
+
+            return CatalogToHiveConverter.convertPartitions(partitions);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get partition by names: " + StringUtils.join(partitionNames, "/");
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String dbName, String tblName,
+                                                                       String partitionName)
+            throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(partitionName), "partitionName cannot be null or empty");
+        List<String> values = partitionNameToVals(partitionName);
+        return getPartition(dbName, tblName, values);
+    }
+
+    public org.apache.hadoop.hive.metastore.api.Partition getPartition(String dbName, String tblName,
+                                                                       List<String> values) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
+        checkNotNull(values, "values cannot be null");
+
+        Partition partition;
+        try {
+            partition = glueMetastore.getPartition(dbName, tblName, values);
+            if (partition == null) {
+                LOGGER.debug(
+                        "No partitions were return for dbName = " + dbName + ", tblName = " + tblName + ", values = " +
+                                values);
+                return null;
+            }
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get partition with values: " + StringUtils.join(values, "/");
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+        return CatalogToHiveConverter.convertPartition(partition);
+    }
+
+    public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitions(
+            String databaseName,
+            String tableName,
+            String filter,
+            long max
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(databaseName), "databaseName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+        List<Partition> partitions = getCatalogPartitions(databaseName, tableName, filter, max);
+        return CatalogToHiveConverter.convertPartitions(partitions);
+    }
+
+    public List<Partition> getCatalogPartitions(
+            final String databaseName,
+            final String tableName,
+            final String expression,
+            final long max
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(databaseName), "databaseName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
+        try {
+            return glueMetastore.getPartitions(databaseName, tableName, expression, max);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get partitions with expression: " + expression;
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    public boolean dropPartition(
+            String dbName,
+            String tblName,
+            List<String> values,
+            boolean ifExist,
+            boolean deleteData,
+            boolean purgeData
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
+        checkNotNull(values, "values cannot be null");
+
+        org.apache.hadoop.hive.metastore.api.Partition partition = null;
+        try {
+            partition = getPartition(dbName, tblName, values);
+        } catch (NoSuchObjectException e) {
+            if (ifExist) {
+                return true;
+            }
+        }
+
+        try {
+            glueMetastore.deletePartition(dbName, tblName, partition.getValues());
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to drop partition with values: " + StringUtils.join(values, "/");
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+
+        performDropPartitionPostProcessing(dbName, tblName, partition, deleteData, purgeData);
+        return true;
+    }
+
+    private void performDropPartitionPostProcessing(
+            String dbName,
+            String tblName,
+            org.apache.hadoop.hive.metastore.api.Partition partition,
+            boolean deleteData,
+            boolean ifPurge
+    ) throws TException {
+        if (deleteData && partition.getSd() != null && partition.getSd().getLocation() != null) {
+            Path partPath = new Path(partition.getSd().getLocation());
+            org.apache.hadoop.hive.metastore.api.Table table = getTable(dbName, tblName);
+            if (isExternalTable(table)) {
+                //Don't delete external table data
+                return;
+            }
+            boolean mustPurge = isMustPurge(table, ifPurge);
+            wh.deleteDir(partPath, true, mustPurge, getDatabase(dbName));
+            try {
+                List<String> values = partition.getValues();
+                deleteParentRecursive(partPath.getParent(), values.size() - 1, mustPurge);
+            } catch (IOException e) {
+                throw new MetaException(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Taken from HiveMetaStore#isMustPurge
+     */
+    private boolean isMustPurge(org.apache.hadoop.hive.metastore.api.Table table, boolean ifPurge) {
+        return (ifPurge || "true".equalsIgnoreCase(table.getParameters().get("auto.purge")));
+    }
+
+    /**
+     * Taken from HiveMetaStore#deleteParentRecursive
+     */
+    private void deleteParentRecursive(Path parent, int depth, boolean mustPurge) throws IOException, MetaException {
+        if (depth > 0 && parent != null && wh.isWritable(parent) && wh.isEmpty(parent)) {
+            wh.deleteDir(parent, true, mustPurge, false);
+            deleteParentRecursive(parent.getParent(), depth - 1, mustPurge);
+        }
+    }
+
+    public void alterPartitions(
+            String dbName,
+            String tblName,
+            List<org.apache.hadoop.hive.metastore.api.Partition> partitions
+    ) throws TException {
+        checkArgument(StringUtils.isNotEmpty(dbName), "dbName cannot be null or empty");
+        checkArgument(StringUtils.isNotEmpty(tblName), "tblName cannot be null or empty");
+        checkNotNull(partitions, "partitions cannot be null");
+
+        for (org.apache.hadoop.hive.metastore.api.Partition part : partitions) {
+            part.setParameters(deepCopyMap(part.getParameters()));
+            if (part.getParameters().get(hive_metastoreConstants.DDL_TIME) == null ||
+                    Integer.parseInt(part.getParameters().get(hive_metastoreConstants.DDL_TIME)) == 0) {
+                part.putToParameters(hive_metastoreConstants.DDL_TIME,
+                        Long.toString(System.currentTimeMillis() / MILLISECOND_TO_SECOND_FACTOR));
+            }
+
+            PartitionInput partitionInput = GlueInputConverter.convertToPartitionInput(part);
+
+            try {
+                glueMetastore.updatePartition(dbName, tblName, part.getValues(), partitionInput);
+            } catch (AmazonServiceException e) {
+                throw CatalogToHiveConverter.wrapInHiveException(e);
+            } catch (Exception e) {
+                String msg = "Unable to alter partition: ";
+                LOGGER.error(msg, e);
+                throw new MetaException(msg + e);
+            }
+        }
+    }
+
+    /**
+     * Taken from HiveMetaStore#partition_name_to_vals
+     */
+    public List<String> partitionNameToVals(String name) throws TException {
+        checkNotNull(name, "name cannot be null");
+        if (name.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        LinkedHashMap<String, String> map = Warehouse.makeSpecFromName(name);
+        List<String> vals = Lists.newArrayList();
+        vals.addAll(map.values());
+        return vals;
+    }
+
+    // ======================= Roles & Privilege =======================
+
+    public boolean createRole(Role role) throws TException {
+        throw new UnsupportedOperationException("createRole is not supported");
+    }
+
+    public boolean dropRole(String roleName) throws TException {
+        throw new UnsupportedOperationException("dropRole is not supported");
+    }
+
+    public List<Role> listRoles(
+            String principalName,
+            PrincipalType principalType
+    ) throws TException {
+        // All users belong to public role implicitly, add that role
+        // Bring logic from Hive's ObjectStore
+        // https://code.amazon.com/packages/Aws157Hive/blobs/48f6e30080df475ffe54c39f70dd134268e30358/
+        // --/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L4208
+        if (principalType == PrincipalType.USER) {
+            return IMPLICIT_ROLES;
+        } else {
+            throw new UnsupportedOperationException(
+                    "listRoles is only supported for " + PrincipalType.USER + " Principal type");
+        }
+    }
+
+    public List<String> listRoleNames() throws TException {
+        // return PUBLIC role as implicit role to prevent unnecessary failure,
+        // even though Glue doesn't support Role API yet
+        // https://code.amazon.com/packages/Aws157Hive/blobs/48f6e30080df475ffe54c39f70dd134268e30358/
+        // --/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L4325
+        return Lists.newArrayList(PUBLIC);
+    }
+
+    public org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleResponse getPrincipalsInRole(
+            org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleRequest request
+    ) throws TException {
+        throw new UnsupportedOperationException("getPrincipalsInRole is not supported");
+    }
+
+    public GetRoleGrantsForPrincipalResponse getRoleGrantsForPrincipal(
+            GetRoleGrantsForPrincipalRequest request
+    ) throws TException {
+        throw new UnsupportedOperationException("getRoleGrantsForPrincipal is not supported");
+    }
+
+    public boolean grantRole(
+            String roleName,
+            String userName,
+            PrincipalType principalType,
+            String grantor, PrincipalType grantorType,
+            boolean grantOption
+    ) throws TException {
+        throw new UnsupportedOperationException("grantRole is not supported");
+    }
+
+    public boolean revokeRole(
+            String roleName,
+            String userName,
+            PrincipalType principalType,
+            boolean grantOption
+    ) throws TException {
+        throw new UnsupportedOperationException("revokeRole is not supported");
+    }
+
+    public boolean revokePrivileges(
+            org.apache.hadoop.hive.metastore.api.PrivilegeBag privileges,
+            boolean grantOption
+    ) throws TException {
+        throw new UnsupportedOperationException("revokePrivileges is not supported");
+    }
+
+    public boolean grantPrivileges(org.apache.hadoop.hive.metastore.api.PrivilegeBag privileges)
+            throws TException {
+        throw new UnsupportedOperationException("grantPrivileges is not supported");
+    }
+
+    public org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet getPrivilegeSet(
+            HiveObjectRef objectRef,
+            String user, List<String> groups
+    ) throws TException {
+        // getPrivilegeSet is NOT yet supported.
+        // return null not to break due to optional info
+        // Hive return null when every condition fail
+        // https://code.amazon.com/packages/Aws157Hive/blobs/c1ced60e67765d27086b3621255cd843947c151e/
+        // --/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java#L5237
+        return null;
+    }
+
+    public List<HiveObjectPrivilege> listPrivileges(
+            String principal,
+            PrincipalType principalType,
+            HiveObjectRef objectRef
+    ) throws TException {
+        throw new UnsupportedOperationException("listPrivileges is not supported");
+    }
+
+    // ========================== Statistics ==========================
+
+    public boolean deletePartitionColumnStatistics(
+            String dbName,
+            String tableName,
+            String partName,
+            String colName
+    ) throws TException {
+        throw new UnsupportedOperationException("deletePartitionColumnStatistics is not supported");
+    }
+
+    public boolean deleteTableColumnStatistics(
+            String dbName,
+            String tableName,
+            String colName
+    ) throws TException {
+        throw new UnsupportedOperationException("deleteTableColumnStatistics is not supported");
+    }
+
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> partitionNames, List<String> columnNames
+    ) throws TException {
+        throw new UnsupportedOperationException("getPartitionColumnStatistics is not supported");
+    }
+
+    public List<ColumnStatisticsObj> getTableColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> colNames
+    ) throws TException {
+        throw new UnsupportedOperationException("getTableColumnStatistics is not supported");
+    }
+
+    public boolean updatePartitionColumnStatistics(
+            org.apache.hadoop.hive.metastore.api.ColumnStatistics columnStatistics
+    ) throws TException {
+        throw new UnsupportedOperationException("updatePartitionColumnStatistics is not supported");
+    }
+
+    public boolean updateTableColumnStatistics(
+            org.apache.hadoop.hive.metastore.api.ColumnStatistics columnStatistics
+    ) throws TException {
+        throw new UnsupportedOperationException("updateTableColumnStatistics is not supported");
+    }
+
+    public AggrStats getAggrColStatsFor(
+            String dbName,
+            String tblName,
+            List<String> colNames,
+            List<String> partName
+    ) throws TException {
+        throw new UnsupportedOperationException("getAggrColStatsFor is not supported");
+    }
+
+    public void cancelDelegationToken(String tokenStrForm) throws TException {
+        throw new UnsupportedOperationException("cancelDelegationToken is not supported");
+    }
+
+    public String getTokenStrForm() throws IOException {
+        throw new UnsupportedOperationException("getTokenStrForm is not supported");
+    }
+
+    public boolean addToken(String tokenIdentifier, String delegationToken) throws TException {
+        throw new UnsupportedOperationException("addToken is not supported");
+    }
+
+    public boolean removeToken(String tokenIdentifier) throws TException {
+        throw new UnsupportedOperationException("removeToken is not supported");
+    }
+
+    public String getToken(String tokenIdentifier) throws TException {
+        throw new UnsupportedOperationException("getToken is not supported");
+    }
+
+    public List<String> getAllTokenIdentifiers() throws TException {
+        throw new UnsupportedOperationException("getAllTokenIdentifiers is not supported");
+    }
+
+    public int addMasterKey(String key) throws TException {
+        throw new UnsupportedOperationException("addMasterKey is not supported");
+    }
+
+    public void updateMasterKey(Integer seqNo, String key) throws TException {
+        throw new UnsupportedOperationException("updateMasterKey is not supported");
+    }
+
+    public boolean removeMasterKey(Integer keySeq) throws TException {
+        throw new UnsupportedOperationException("removeMasterKey is not supported");
+    }
+
+    public String[] getMasterKeys() throws TException {
+        throw new UnsupportedOperationException("getMasterKeys is not supported");
+    }
+
+    public LockResponse checkLock(long lockId) throws TException {
+        throw new UnsupportedOperationException("checkLock is not supported");
+    }
+
+    public void commitTxn(long txnId) throws TException {
+        throw new UnsupportedOperationException("commitTxn is not supported");
+    }
+
+    public void abortTxns(List<Long> txnIds) throws TException {
+        throw new UnsupportedOperationException("abortTxns is not supported");
+    }
+
+    public void compact(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType
+    ) throws TException {
+        throw new UnsupportedOperationException("compact is not supported");
+    }
+
+    public void compact(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType,
+            Map<String, String> tblProperties
+    ) throws TException {
+        throw new UnsupportedOperationException("compact is not supported");
+    }
+
+    public CompactionResponse compact2(
+            String dbName,
+            String tblName,
+            String partitionName,
+            CompactionType compactionType,
+            Map<String, String> tblProperties
+    ) throws TException {
+        throw new UnsupportedOperationException("compact2 is not supported");
+    }
+
+    public ValidTxnList getValidTxns() throws TException {
+        throw new UnsupportedOperationException("getValidTxns is not supported");
+    }
+
+    public ValidTxnList getValidTxns(long currentTxn) throws TException {
+        throw new UnsupportedOperationException("getValidTxns is not supported");
+    }
+
+    public org.apache.hadoop.hive.metastore.api.Partition exchangePartition(
+            Map<String, String> partitionSpecs,
+            String srcDb,
+            String srcTbl,
+            String dstDb,
+            String dstTbl
+    ) throws TException {
+        throw new UnsupportedOperationException("exchangePartition not yet supported.");
+    }
+
+    public List<org.apache.hadoop.hive.metastore.api.Partition> exchangePartitions(
+            Map<String, String> partitionSpecs,
+            String sourceDb,
+            String sourceTbl,
+            String destDb,
+            String destTbl
+    ) throws TException {
+        throw new UnsupportedOperationException("exchangePartitions is not yet supported");
+    }
+
+    public String getDelegationToken(
+            String owner,
+            String renewerKerberosPrincipalName
+    ) throws TException {
+        throw new UnsupportedOperationException("getDelegationToken is not supported");
+    }
+
+    public void heartbeat(long txnId, long lockId) throws TException {
+        throw new UnsupportedOperationException("heartbeat is not supported");
+    }
+
+    public HeartbeatTxnRangeResponse heartbeatTxnRange(long min, long max) throws TException {
+        throw new UnsupportedOperationException("heartbeatTxnRange is not supported");
+    }
+
+    public boolean isPartitionMarkedForEvent(
+            String dbName,
+            String tblName,
+            Map<String, String> partKVs,
+            PartitionEventType eventType
+    ) throws TException {
+        throw new UnsupportedOperationException("isPartitionMarkedForEvent is not supported");
+    }
+
+    public int getNumPartitionsByFilter(
+            String dbName,
+            String tableName,
+            String filter
+    ) throws TException {
+        throw new UnsupportedOperationException("getNumPartitionsByFilter is not supported.");
+    }
+
+    public PartitionSpecProxy listPartitionSpecs(
+            String dbName,
+            String tblName,
+            int max
+    ) throws TException {
+        throw new UnsupportedOperationException("listPartitionSpecs is not supported.");
+    }
+
+    public PartitionSpecProxy listPartitionSpecsByFilter(
+            String dbName,
+            String tblName,
+            String filter,
+            int max
+    ) throws TException {
+        throw new UnsupportedOperationException("listPartitionSpecsByFilter is not supported");
+    }
+
+    public LockResponse lock(LockRequest lockRequest) throws TException {
+        throw new UnsupportedOperationException("lock is not supported");
+    }
+
+    public void markPartitionForEvent(
+            String dbName,
+            String tblName,
+            Map<String, String> partKeyValues,
+            PartitionEventType eventType
+    ) throws TException {
+        throw new UnsupportedOperationException("markPartitionForEvent is not supported");
+    }
+
+    public long openTxn(String user) throws TException {
+        throw new UnsupportedOperationException("openTxn is not supported");
+    }
+
+    public OpenTxnsResponse openTxns(String user, int numTxns) throws TException {
+        throw new UnsupportedOperationException("openTxns is not supported");
+    }
+
+    public long renewDelegationToken(String tokenStrForm) throws TException {
+        throw new UnsupportedOperationException("renewDelegationToken is not supported");
+    }
+
+    public void rollbackTxn(long txnId) throws TException {
+        throw new UnsupportedOperationException("rollbackTxn is not supported");
+    }
+
+    public void createTableWithConstraints(
+            org.apache.hadoop.hive.metastore.api.Table table,
+            List<SQLPrimaryKey> primaryKeys,
+            List<SQLForeignKey> foreignKeys
+    ) throws AlreadyExistsException, TException {
+        throw new UnsupportedOperationException("createTableWithConstraints is not supported");
+    }
+
+    public void dropConstraint(
+            String dbName,
+            String tblName,
+            String constraintName
+    ) throws TException {
+        throw new UnsupportedOperationException("dropConstraint is not supported");
+    }
+
+    public void addPrimaryKey(List<SQLPrimaryKey> primaryKeyCols) throws TException {
+        throw new UnsupportedOperationException("addPrimaryKey is not supported");
+    }
+
+    public void addForeignKey(List<SQLForeignKey> foreignKeyCols) throws TException {
+        throw new UnsupportedOperationException("addForeignKey is not supported");
+    }
+
+    public ShowCompactResponse showCompactions() throws TException {
+        throw new UnsupportedOperationException("showCompactions is not supported");
+    }
+
+    public void addDynamicPartitions(
+            long txnId,
+            String dbName,
+            String tblName,
+            List<String> partNames
+    ) throws TException {
+        throw new UnsupportedOperationException("addDynamicPartitions is not supported");
+    }
+
+    public void addDynamicPartitions(
+            long txnId,
+            String dbName,
+            String tblName,
+            List<String> partNames,
+            DataOperationType operationType
+    ) throws TException {
+        throw new UnsupportedOperationException("addDynamicPartitions is not supported");
+    }
+
+    public void insertTable(org.apache.hadoop.hive.metastore.api.Table table, boolean overwrite) throws MetaException {
+        throw new UnsupportedOperationException("insertTable is not supported");
+    }
+
+    public NotificationEventResponse getNextNotification(
+            long lastEventId,
+            int maxEvents,
+            IMetaStoreClient.NotificationFilter notificationFilter
+    ) throws TException {
+        throw new UnsupportedOperationException("getNextNotification is not supported");
+    }
+
+    public CurrentNotificationEventId getCurrentNotificationEventId() throws TException {
+        throw new UnsupportedOperationException("getCurrentNotificationEventId is not supported");
+    }
+
+    public FireEventResponse fireListenerEvent(FireEventRequest fireEventRequest) throws TException {
+        throw new UnsupportedOperationException("fireListenerEvent is not supported");
+    }
+
+    public ShowLocksResponse showLocks() throws TException {
+        throw new UnsupportedOperationException("showLocks is not supported");
+    }
+
+    public ShowLocksResponse showLocks(ShowLocksRequest showLocksRequest) throws TException {
+        throw new UnsupportedOperationException("showLocks is not supported");
+    }
+
+    public GetOpenTxnsInfoResponse showTxns() throws TException {
+        throw new UnsupportedOperationException("showTxns is not supported");
+    }
+
+    public void unlock(long lockId) throws TException {
+        throw new UnsupportedOperationException("unlock is not supported");
+    }
+
+    public Iterable<Map.Entry<Long, ByteBuffer>> getFileMetadata(List<Long> fileIds) throws TException {
+        throw new UnsupportedOperationException("getFileMetadata is not supported");
+    }
+
+    public Iterable<Map.Entry<Long, MetadataPpdResult>> getFileMetadataBySarg(
+            List<Long> fileIds,
+            ByteBuffer sarg,
+            boolean doGetFooters
+    ) throws TException {
+        throw new UnsupportedOperationException("getFileMetadataBySarg is not supported");
+    }
+
+    public void clearFileMetadata(List<Long> fileIds) throws TException {
+        throw new UnsupportedOperationException("clearFileMetadata is not supported");
+    }
+
+    public void putFileMetadata(List<Long> fileIds, List<ByteBuffer> metadata) throws TException {
+        throw new UnsupportedOperationException("putFileMetadata is not supported");
+    }
+
+    public boolean setPartitionColumnStatistics(
+            org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest request
+    ) throws TException {
+        throw new UnsupportedOperationException("setPartitionColumnStatistics is not supported");
+    }
+
+    public boolean cacheFileMetadata(
+            String dbName,
+            String tblName,
+            String partName,
+            boolean allParts
+    ) throws TException {
+        throw new UnsupportedOperationException("cacheFileMetadata is not supported");
+    }
+
+    public int addPartitionsSpecProxy(PartitionSpecProxy pSpec) throws TException {
+        throw new UnsupportedOperationException("addPartitionsSpecProxy is unsupported");
+    }
+
+    public void setUGI(String username) throws TException {
+        throw new UnsupportedOperationException("setUGI is unsupported");
+    }
+
+    /**
+     * Gets the user defined function in a database stored in metastore and
+     * converts back to Hive function.
+     *
+     * @param dbName
+     * @param functionName
+     * @return
+     * @throws MetaException
+     * @throws TException
+     */
+    public org.apache.hadoop.hive.metastore.api.Function getFunction(String dbName, String functionName)
+            throws TException {
+        try {
+            UserDefinedFunction userDefinedFunction = glueMetastore.getUserDefinedFunction(dbName, functionName);
+            return CatalogToHiveConverter.convertFunction(dbName, userDefinedFunction);
+        } catch (AmazonServiceException e) {
+            LOGGER.error(e);
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get Function: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Gets user defined functions that match a pattern in database stored in
+     * metastore and converts back to Hive function.
+     *
+     * @param dbName
+     * @param pattern
+     * @return
+     * @throws MetaException
+     * @throws TException
+     */
+    public List<String> getFunctions(String dbName, String pattern) throws TException {
+        try {
+            List<String> functionNames = Lists.newArrayList();
+            List<UserDefinedFunction> functions =
+                    glueMetastore.getUserDefinedFunctions(dbName, pattern);
+            for (UserDefinedFunction catalogFunction : functions) {
+                functionNames.add(catalogFunction.getFunctionName());
+            }
+            return functionNames;
+        } catch (AmazonServiceException e) {
+            LOGGER.error(e);
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get Functions: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Creates a new user defined function in the metastore.
+     *
+     * @param function
+     * @throws InvalidObjectException
+     * @throws MetaException
+     * @throws TException
+     */
+    public void createFunction(org.apache.hadoop.hive.metastore.api.Function function) throws InvalidObjectException,
+            TException {
+        try {
+            UserDefinedFunctionInput functionInput = GlueInputConverter.convertToUserDefinedFunctionInput(function);
+            glueMetastore.createUserDefinedFunction(function.getDbName(), functionInput);
+        } catch (AmazonServiceException e) {
+            LOGGER.error(e);
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to create Function: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Drops a user defined function in the database stored in metastore.
+     *
+     * @param dbName
+     * @param functionName
+     * @throws MetaException
+     * @throws NoSuchObjectException
+     * @throws InvalidObjectException
+     * @throws org.apache.hadoop.hive.metastore.api.InvalidInputException
+     * @throws TException
+     */
+    public void dropFunction(String dbName, String functionName) throws NoSuchObjectException,
+            InvalidObjectException, org.apache.hadoop.hive.metastore.api.InvalidInputException, TException {
+        try {
+            glueMetastore.deleteUserDefinedFunction(dbName, functionName);
+        } catch (AmazonServiceException e) {
+            LOGGER.error(e);
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to drop Function: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Updates a user defined function in a database stored in the metastore.
+     *
+     * @param dbName
+     * @param functionName
+     * @param newFunction
+     * @throws InvalidObjectException
+     * @throws MetaException
+     * @throws TException
+     */
+    public void alterFunction(String dbName, String functionName,
+                              org.apache.hadoop.hive.metastore.api.Function newFunction)
+            throws InvalidObjectException, MetaException,
+            TException {
+        try {
+            UserDefinedFunctionInput functionInput = GlueInputConverter.convertToUserDefinedFunctionInput(newFunction);
+            glueMetastore.updateUserDefinedFunction(dbName, functionName, functionInput);
+        } catch (AmazonServiceException e) {
+            LOGGER.error(e);
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to alter Function: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Fetches the fields for a table in a database.
+     *
+     * @param db
+     * @param tableName
+     * @return
+     * @throws MetaException
+     * @throws TException
+     * @throws UnknownTableException
+     * @throws UnknownDBException
+     */
+    public List<FieldSchema> getFields(String db, String tableName) throws MetaException, TException,
+            UnknownTableException, UnknownDBException {
+        try {
+            Table table = glueMetastore.getTable(db, tableName);
+            return CatalogToHiveConverter.convertFieldSchemaList(table.getStorageDescriptor().getColumns());
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get field from table: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Fetches the schema for a table in a database.
+     *
+     * @param db
+     * @param tableName
+     * @return
+     * @throws MetaException
+     * @throws TException
+     * @throws UnknownTableException
+     * @throws UnknownDBException
+     */
+    public List<FieldSchema> getSchema(String db, String tableName) throws TException,
+            UnknownTableException, UnknownDBException {
+        try {
+            Table table = glueMetastore.getTable(db, tableName);
+            List<Column> schemas = table.getStorageDescriptor().getColumns();
+            if (table.getPartitionKeys() != null && !table.getPartitionKeys().isEmpty()) {
+                schemas.addAll(table.getPartitionKeys());
+            }
+            return CatalogToHiveConverter.convertFieldSchemaList(schemas);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        } catch (Exception e) {
+            String msg = "Unable to get field from table: ";
+            LOGGER.error(msg, e);
+            throw new MetaException(msg + e);
+        }
+    }
+
+    /**
+     * Updates the partition values for a table in database stored in metastore.
+     *
+     * @param databaseName
+     * @param tableName
+     * @param partitionValues
+     * @param newPartition
+     * @throws InvalidOperationException
+     * @throws MetaException
+     * @throws TException
+     */
+    public void renamePartitionInCatalog(String databaseName, String tableName, List<String> partitionValues,
+                                         org.apache.hadoop.hive.metastore.api.Partition newPartition)
+            throws InvalidOperationException,
+            TException {
+        try {
+            PartitionInput partitionInput = GlueInputConverter.convertToPartitionInput(newPartition);
+            glueMetastore.updatePartition(databaseName, tableName, partitionValues, partitionInput);
+        } catch (AmazonServiceException e) {
+            throw CatalogToHiveConverter.wrapInHiveException(e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/AWSGlueConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/AWSGlueConfig.java
@@ -1,0 +1,36 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.ClientConfiguration;
+
+public final class AWSGlueConfig {
+
+    private AWSGlueConfig() {
+    }
+
+    public static final String AWS_GLUE_ENDPOINT = "aws.glue.endpoint";
+    public static final String AWS_REGION = "aws.region";
+    public static final String AWS_CATALOG_CREDENTIALS_PROVIDER_FACTORY_CLASS
+            = "aws.catalog.credentials.provider.factory.class";
+
+    public static final String AWS_GLUE_MAX_RETRY = "aws.glue.max-error-retries";
+    public static final int DEFAULT_MAX_RETRY = 5;
+
+    public static final String AWS_GLUE_MAX_CONNECTIONS = "aws.glue.max-connections";
+    public static final int DEFAULT_MAX_CONNECTIONS = ClientConfiguration.DEFAULT_MAX_CONNECTIONS;
+
+    public static final String AWS_GLUE_CONNECTION_TIMEOUT = "aws.glue.connection-timeout";
+    public static final int DEFAULT_CONNECTION_TIMEOUT = ClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
+
+    public static final String AWS_GLUE_SOCKET_TIMEOUT = "aws.glue.socket-timeout";
+    public static final int DEFAULT_SOCKET_TIMEOUT = ClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
+
+    public static final String AWS_GLUE_DB_CACHE_ENABLE = "aws.glue.cache.db.enable";
+    public static final String AWS_GLUE_DB_CACHE_SIZE = "aws.glue.cache.db.size";
+    public static final String AWS_GLUE_DB_CACHE_TTL_MINS = "aws.glue.cache.db.ttl-mins";
+
+    public static final String AWS_GLUE_TABLE_CACHE_ENABLE = "aws.glue.cache.table.enable";
+    public static final String AWS_GLUE_TABLE_CACHE_SIZE = "aws.glue.cache.table.size";
+    public static final String AWS_GLUE_TABLE_CACHE_TTL_MINS = "aws.glue.cache.table.ttl-mins";
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/BatchCreatePartitionsHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/BatchCreatePartitionsHelper.java
@@ -1,0 +1,135 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.google.common.collect.Lists;
+import com.starrocks.external.hive.glue.converters.CatalogToHiveConverter;
+import com.starrocks.external.hive.glue.converters.GlueInputConverter;
+import com.starrocks.external.hive.glue.metastore.AWSGlueMetastore;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.external.hive.glue.util.PartitionUtils.isInvalidUserInputException;
+
+public final class BatchCreatePartitionsHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(BatchCreatePartitionsHelper.class);
+
+    private final AWSGlueMetastore glueClient;
+    private final String databaseName;
+    private final String tableName;
+    private final List<Partition> partitions;
+    private final boolean ifNotExists;
+    private Map<PartitionKey, Partition> partitionMap;
+    private List<Partition> partitionsFailed;
+    private TException firstTException;
+    private String catalogId;
+
+    public BatchCreatePartitionsHelper(AWSGlueMetastore glueClient, String databaseName, String tableName,
+                                       String catalogId,
+                                       List<Partition> partitions, boolean ifNotExists) {
+        this.glueClient = glueClient;
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.catalogId = catalogId;
+        this.partitions = partitions;
+        this.ifNotExists = ifNotExists;
+    }
+
+    public BatchCreatePartitionsHelper createPartitions() {
+        partitionMap = PartitionUtils.buildPartitionMap(partitions);
+        partitionsFailed = Lists.newArrayList();
+
+        try {
+            List<PartitionError> result =
+                    glueClient.createPartitions(databaseName, tableName,
+                            GlueInputConverter.convertToPartitionInputs(partitionMap.values()));
+            processResult(result);
+        } catch (Exception e) {
+            LOGGER.error("Exception thrown while creating partitions in DataCatalog: ", e);
+            firstTException = CatalogToHiveConverter.wrapInHiveException(e);
+            if (isInvalidUserInputException(e)) {
+                setAllFailed();
+            } else {
+                checkIfPartitionsCreated();
+            }
+        }
+        return this;
+    }
+
+    private void setAllFailed() {
+        partitionsFailed = partitions;
+        partitionMap.clear();
+    }
+
+    private void processResult(List<PartitionError> partitionErrors) {
+        if (partitionErrors == null || partitionErrors.isEmpty()) {
+            return;
+        }
+
+        LOGGER.error(String.format("BatchCreatePartitions failed to create %d out of %d partitions. \n",
+                partitionErrors.size(), partitionMap.size()));
+
+        for (PartitionError partitionError : partitionErrors) {
+            Partition partitionFailed = partitionMap.remove(new PartitionKey(partitionError.getPartitionValues()));
+
+            TException exception = CatalogToHiveConverter.errorDetailToHiveException(partitionError.getErrorDetail());
+            if (ifNotExists && exception instanceof AlreadyExistsException) {
+                // AlreadyExistsException is allowed, so we shouldn't add the partition to partitionsFailed list
+                continue;
+            }
+            LOGGER.error(exception);
+            if (firstTException == null) {
+                firstTException = exception;
+            }
+            partitionsFailed.add(partitionFailed);
+        }
+    }
+
+    private void checkIfPartitionsCreated() {
+        for (Partition partition : partitions) {
+            if (!partitionExists(partition)) {
+                partitionsFailed.add(partition);
+                partitionMap.remove(new PartitionKey(partition));
+            }
+        }
+    }
+
+    private boolean partitionExists(Partition partition) {
+
+        try {
+            Partition partitionReturned = glueClient.getPartition(databaseName, tableName, partition.getValues());
+            return partitionReturned != null; //probably always true here
+        } catch (EntityNotFoundException e) {
+            // here we assume namespace and table exist. It is assured by calling "isInvalidUserInputException" method above
+            return false;
+        } catch (Exception e) {
+            LOGGER.error(String.format("Get partition request %s failed. ",
+                    StringUtils.join(partition.getValues(), "/")), e);
+            // partition status unknown, we assume that the partition was not created
+            return false;
+        }
+    }
+
+    public TException getFirstTException() {
+        return firstTException;
+    }
+
+    public Collection<Partition> getPartitionsCreated() {
+        return partitionMap.values();
+    }
+
+    public List<Partition> getPartitionsFailed() {
+        return partitionsFailed;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/BatchDeletePartitionsHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/BatchDeletePartitionsHelper.java
@@ -1,0 +1,125 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchDeletePartitionRequest;
+import com.amazonaws.services.glue.model.BatchDeletePartitionResult;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.ErrorDetail;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionResult;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.starrocks.external.hive.glue.converters.CatalogToHiveConverter;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public final class BatchDeletePartitionsHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(BatchDeletePartitionsHelper.class);
+
+    private final AWSGlue client;
+    private final String namespaceName;
+    private final String tableName;
+    private final String catalogId;
+    private final List<Partition> partitions;
+    private Map<PartitionKey, Partition> partitionMap;
+    private TException firstTException;
+
+    public BatchDeletePartitionsHelper(AWSGlue client, String namespaceName, String tableName,
+                                       String catalogId, List<Partition> partitions) {
+        this.client = client;
+        this.namespaceName = namespaceName;
+        this.tableName = tableName;
+        this.catalogId = catalogId;
+        this.partitions = partitions;
+    }
+
+    public BatchDeletePartitionsHelper deletePartitions() {
+        partitionMap = PartitionUtils.buildPartitionMap(partitions);
+
+        BatchDeletePartitionRequest request = new BatchDeletePartitionRequest().withDatabaseName(namespaceName)
+                .withTableName(tableName).withCatalogId(catalogId)
+                .withPartitionsToDelete(PartitionUtils.getPartitionValuesList(partitionMap));
+
+        try {
+            BatchDeletePartitionResult result = client.batchDeletePartition(request);
+            processResult(result);
+        } catch (Exception e) {
+            LOGGER.error("Exception thrown while deleting partitions in DataCatalog: ", e);
+            firstTException = CatalogToHiveConverter.wrapInHiveException(e);
+            if (PartitionUtils.isInvalidUserInputException(e)) {
+                setAllFailed();
+            } else {
+                checkIfPartitionsDeleted();
+            }
+        }
+        return this;
+    }
+
+    private void setAllFailed() {
+        partitionMap.clear();
+    }
+
+    private void processResult(final BatchDeletePartitionResult batchDeletePartitionsResult) {
+        List<PartitionError> partitionErrors = batchDeletePartitionsResult.getErrors();
+        if (partitionErrors == null || partitionErrors.isEmpty()) {
+            return;
+        }
+
+        LOGGER.error(String.format("BatchDeletePartitions failed to delete %d out of %d partitions. \n",
+                partitionErrors.size(), partitionMap.size()));
+
+        for (PartitionError partitionError : partitionErrors) {
+            partitionMap.remove(new PartitionKey(partitionError.getPartitionValues()));
+            ErrorDetail errorDetail = partitionError.getErrorDetail();
+            LOGGER.error(errorDetail.toString());
+            if (firstTException == null) {
+                firstTException = CatalogToHiveConverter.errorDetailToHiveException(errorDetail);
+            }
+        }
+    }
+
+    private void checkIfPartitionsDeleted() {
+        for (Partition partition : partitions) {
+            if (!partitionDeleted(partition)) {
+                partitionMap.remove(new PartitionKey(partition));
+            }
+        }
+    }
+
+    private boolean partitionDeleted(Partition partition) {
+        GetPartitionRequest request = new GetPartitionRequest()
+                .withDatabaseName(partition.getDatabaseName())
+                .withTableName(partition.getTableName())
+                .withPartitionValues(partition.getValues())
+                .withCatalogId(catalogId);
+
+        try {
+            GetPartitionResult result = client.getPartition(request);
+            Partition partitionReturned = result.getPartition();
+            return partitionReturned == null; //probably always false
+        } catch (EntityNotFoundException e) {
+            // here we assume namespace and table exist. It is assured by calling "isInvalidUserInputException" method above
+            return true;
+        } catch (Exception e) {
+            LOGGER.error(String.format("Get partition request %s failed. ", request.toString()), e);
+            // Partition status unknown, we assume that the partition was not deleted
+            return false;
+        }
+    }
+
+    public TException getFirstTException() {
+        return firstTException;
+    }
+
+    public Collection<Partition> getPartitionsDeleted() {
+        return partitionMap.values();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/ExpressionHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/ExpressionHelper.java
@@ -1,0 +1,202 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNot;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility methods for constructing the string representation of query expressions used by Catalog service
+ */
+public final class ExpressionHelper {
+
+    private static final String HIVE_STRING_TYPE_NAME = "string";
+    private static final String HIVE_IN_OPERATOR = "IN";
+    private static final String HIVE_NOT_IN_OPERATOR = "NOT IN";
+    private static final String HIVE_NOT_OPERATOR = "not";
+
+    // TODO "hook" into Hive logging (hive or hive.metastore)
+    private static final Logger LOGGER = Logger.getLogger(ExpressionHelper.class);
+
+    private static final List<String> QUOTED_TYPES =
+            ImmutableList.of("string", "char", "varchar", "date", "datetime", "timestamp");
+    private static final Joiner JOINER = Joiner.on(" AND ");
+
+    /*
+     * The method below is used to rewrite the hive expression tree to quote the timestamp values.
+     * An example of this would be hive providing us as query as follows:
+     * ((strCol = 'test') and (timestamp = 1969-12-31 16:02:03.456))
+     *
+     * this will be rewritten by the method to:
+     * ((strCol = 'test') and (timestamp = '1969-12-31 16:02:03.456'))
+     *
+     * Notice the way the timestamp is quoted.
+     *
+     * In order to perform this operation we recursively navigate the ExpressionTree
+     * given to us by hive and switch the type to 'string' whenever we encounter a node type
+     * of type 'timestamp'
+     *
+     * When we call the getExprTree method of the modified expression tree, the timestamp values are
+     * properly quoted.
+     *
+     * This method also rewrites the expression string for "NOT IN" expression.
+     * Hive converts the expression "<colName> NOT IN (<List of values>)"  to "(not (<colName>) IN (<List of values>))".
+     * But in DataCatalog service, the parsing is done based on the original expression (which contains NOT IN).
+     * So, we need to rewrite the expression if NOT IN was used.
+     * */
+    public static String convertHiveExpressionToCatalogExpression(byte[] exprBytes) throws MetaException {
+        ExprNodeGenericFuncDesc exprTree = deserializeExpr(exprBytes);
+        Set<String> columnNamesInNotInExpression = Sets.newHashSet();
+        fieldEscaper(exprTree.getChildren(), exprTree, columnNamesInNotInExpression);
+        String expression = rewriteExpressionForNotIn(exprTree.getExprString(), columnNamesInNotInExpression);
+        return expression;
+    }
+
+    private static ExprNodeGenericFuncDesc deserializeExpr(byte[] exprBytes) throws MetaException {
+        ExprNodeGenericFuncDesc expr = null;
+        try {
+            expr = SerializationUtilities.deserializeExpressionFromKryo(exprBytes);
+        } catch (Exception ex) {
+            LOGGER.error("Failed to deserialize the expression", ex);
+            throw new MetaException(ex.getMessage());
+        }
+        if (expr == null) {
+            throw new MetaException("Failed to deserialize expression - ExprNodeDesc not present");
+        }
+        return expr;
+    }
+
+    //Helper method that recursively switches the type of the node, this is used
+    //by the convertHiveExpressionToCatalogExpression
+    private static void fieldEscaper(List<ExprNodeDesc> exprNodes, ExprNodeDesc parent,
+                                     Set<String> columnNamesInNotInExpression) {
+        if (exprNodes == null || exprNodes.isEmpty()) {
+            return;
+        } else {
+            for (ExprNodeDesc nodeDesc : exprNodes) {
+                String nodeType = nodeDesc.getTypeString().toLowerCase();
+                if (QUOTED_TYPES.contains(nodeType)) {
+                    PrimitiveTypeInfo tInfo = new PrimitiveTypeInfo();
+                    tInfo.setTypeName(HIVE_STRING_TYPE_NAME);
+                    nodeDesc.setTypeInfo(tInfo);
+                }
+                addColumnNamesOfNotInExpressionToSet(nodeDesc, parent, columnNamesInNotInExpression);
+                fieldEscaper(nodeDesc.getChildren(), nodeDesc, columnNamesInNotInExpression);
+            }
+        }
+    }
+
+    /*
+     * Method to extract the names of columns that are involved in NOT IN expression. Only one column is allowed to be
+     * used in NOT IN expression. So, ExprNodeDesc.getCols() would return only 1 column.
+     *
+     * @param childNode
+     * @param parentNode
+     * @param columnsInNotInExpression
+     */
+    private static void addColumnNamesOfNotInExpressionToSet(ExprNodeDesc childNode, ExprNodeDesc parentNode,
+                                                             Set<String> columnsInNotInExpression) {
+        if (parentNode instanceof ExprNodeGenericFuncDesc &&
+                childNode instanceof ExprNodeGenericFuncDesc) {
+            ExprNodeGenericFuncDesc parentFuncNode = (ExprNodeGenericFuncDesc) parentNode;
+            ExprNodeGenericFuncDesc childFuncNode = (ExprNodeGenericFuncDesc) childNode;
+            if (parentFuncNode.getGenericUDF() instanceof GenericUDFOPNot &&
+                    childFuncNode.getGenericUDF() instanceof GenericUDFIn) {
+                // The current parent child pair represents a "NOT IN" expression. Add name of the column to the set.
+                columnsInNotInExpression.addAll(childFuncNode.getCols());
+            }
+        }
+    }
+
+    private static String rewriteExpressionForNotIn(String expression, Set<String> columnsInNotInExpression) {
+        for (String columnName : columnsInNotInExpression) {
+            if (columnName != null) {
+                String hiveExpression = getHiveCompatibleNotInExpression(columnName);
+                hiveExpression = escapeParentheses(hiveExpression);
+                String catalogExpression = getCatalogCompatibleNotInExpression(columnName);
+                catalogExpression = escapeParentheses(catalogExpression);
+                expression = expression.replaceAll(hiveExpression, catalogExpression);
+            }
+        }
+        return expression;
+    }
+
+    // return "not (<columnName>) IN ("
+    private static String getHiveCompatibleNotInExpression(String columnName) {
+        return String.format("%s (%s) %s (", HIVE_NOT_OPERATOR, columnName, HIVE_IN_OPERATOR);
+    }
+
+    // return "(<columnName>) NOT IN ("
+    private static String getCatalogCompatibleNotInExpression(String columnName) {
+        return String.format("(%s) %s (", columnName, HIVE_NOT_IN_OPERATOR);
+    }
+
+    /*
+     * Escape the parentheses so that they are considered literally and not as part of regular expression. In the updated
+     * expression , we need "\\(" as the output. So, the first four '\' generate '\\' and the last two '\' generate a '('
+     */
+    private static String escapeParentheses(String expression) {
+        expression = expression.replaceAll("\\(", "\\\\\\(");
+        expression = expression.replaceAll("\\)", "\\\\\\)");
+        return expression;
+    }
+
+    public static String buildExpressionFromPartialSpecification(org.apache.hadoop.hive.metastore.api.Table table,
+                                                                 List<String> partitionValues) throws MetaException {
+
+        List<org.apache.hadoop.hive.metastore.api.FieldSchema> partitionKeys = table.getPartitionKeys();
+
+        if (partitionValues == null || partitionValues.isEmpty()) {
+            return null;
+        }
+
+        if (partitionKeys == null || partitionValues.size() > partitionKeys.size()) {
+            throw new MetaException("Incorrect number of partition values: " + partitionValues);
+        }
+
+        partitionKeys = partitionKeys.subList(0, partitionValues.size());
+        List<String> predicates = new LinkedList<>();
+        for (int i = 0; i < partitionValues.size(); i++) {
+            if (!Strings.isNullOrEmpty(partitionValues.get(i))) {
+                predicates.add(buildPredicate(partitionKeys.get(i), partitionValues.get(i)));
+            }
+        }
+
+        return JOINER.join(predicates);
+    }
+
+    private static String buildPredicate(org.apache.hadoop.hive.metastore.api.FieldSchema schema, String value) {
+        if (isQuotedType(schema.getType())) {
+            return String.format("(%s='%s')", schema.getName(), escapeSingleQuotes(value));
+        } else {
+            return String.format("(%s=%s)", schema.getName(), value);
+        }
+    }
+
+    private static String escapeSingleQuotes(String s) {
+        return s.replaceAll("'", "\\\\'");
+    }
+
+    private static boolean isQuotedType(String type) {
+        return QUOTED_TYPES.contains(type);
+    }
+
+    public static String replaceDoubleQuoteWithSingleQuotes(String s) {
+        return s.replaceAll("\"", "\'");
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/HiveTableValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/HiveTableValidator.java
@@ -1,0 +1,69 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.services.glue.model.InvalidInputException;
+import com.amazonaws.services.glue.model.Table;
+import org.apache.hadoop.hive.metastore.TableType;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
+
+public enum HiveTableValidator {
+
+    REQUIRED_PROPERTIES_VALIDATOR {
+        public void validate(Table table) {
+            String missingProperty = null;
+
+            if (notApplicableTableType(table)) {
+                return;
+            }
+
+            if (table.getTableType() == null) {
+                missingProperty = "TableType";
+            } else if (table.getStorageDescriptor() == null) {
+                missingProperty = "StorageDescriptor";
+            } else if (table.getStorageDescriptor().getInputFormat() == null) {
+                missingProperty = "StorageDescriptor#InputFormat";
+            } else if (table.getStorageDescriptor().getOutputFormat() == null) {
+                missingProperty = "StorageDescriptor#OutputFormat";
+            } else if (table.getStorageDescriptor().getSerdeInfo() == null) {
+                missingProperty = "StorageDescriptor#SerdeInfo";
+            } else if (table.getStorageDescriptor().getSerdeInfo().getSerializationLibrary() == null) {
+                missingProperty = "StorageDescriptor#SerdeInfo#SerializationLibrary";
+            }
+
+            if (missingProperty != null) {
+                throw new InvalidInputException(
+                        String.format("%s cannot be null for table: %s", missingProperty, table.getName()));
+            }
+        }
+    };
+
+    public abstract void validate(Table table);
+
+    private static boolean notApplicableTableType(Table table) {
+        if (isNotManagedOrExternalTable(table) ||
+                isStorageHandlerType(table)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isNotManagedOrExternalTable(Table table) {
+        if (table.getTableType() != null &&
+                TableType.valueOf(table.getTableType()) != TableType.MANAGED_TABLE &&
+                TableType.valueOf(table.getTableType()) != TableType.EXTERNAL_TABLE) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isStorageHandlerType(Table table) {
+        if (table.getParameters() != null && table.getParameters().containsKey(META_TABLE_STORAGE) &&
+                isNotEmpty(table.getParameters().get(META_TABLE_STORAGE))) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/LoggingHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/LoggingHelper.java
@@ -1,0 +1,40 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import java.util.Collection;
+
+public class LoggingHelper {
+
+    private static final int MAX_LOG_STRING_LEN = 2000;
+
+    private LoggingHelper() {
+    }
+
+    public static String concatCollectionToStringForLogging(Collection<String> collection, String delimiter) {
+        if (collection == null) {
+            return "";
+        }
+        if (delimiter == null) {
+            delimiter = ",";
+        }
+        StringBuilder bldr = new StringBuilder();
+        int totalLen = 0;
+        int delimiterSize = delimiter.length();
+        for (String str : collection) {
+            if (totalLen > MAX_LOG_STRING_LEN) {
+                break;
+            }
+            if (str.length() + totalLen > MAX_LOG_STRING_LEN) {
+                bldr.append(str.subSequence(0, (MAX_LOG_STRING_LEN - totalLen)));
+                break;
+            } else {
+                bldr.append(str);
+                bldr.append(delimiter);
+                totalLen += str.length() + delimiterSize;
+            }
+        }
+        return bldr.toString();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/MetastoreClientUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/MetastoreClientUtils.java
@@ -1,0 +1,118 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.google.common.collect.Maps;
+import com.starrocks.external.hive.glue.metastore.GlueMetastoreClientDelegate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+
+public final class MetastoreClientUtils {
+    private MetastoreClientUtils() {
+        // static util class should not be instantiated
+    }
+
+    /**
+     * @return boolean
+     * true -> if directory was able to be created.
+     * false -> if directory already exists.
+     * @throws MetaException if directory could not be created.
+     */
+    public static boolean makeDirs(Warehouse wh, Path path) throws MetaException {
+        checkNotNull(wh, "Warehouse cannot be null");
+        checkNotNull(path, "Path cannot be null");
+
+        boolean madeDir = false;
+        if (!wh.isDir(path)) {
+            if (!wh.mkdirs(path)) {
+                throw new MetaException("Unable to create path: " + path);
+            }
+            madeDir = true;
+        }
+        return madeDir;
+    }
+
+    /**
+     * Taken from HiveMetaStore#create_table_core
+     * https://github.com/apache/hive/blob/rel/release-2.3.0/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java#L1370-L1383
+     */
+    public static void validateTableObject(Table table, Configuration conf) throws InvalidObjectException {
+        checkNotNull(table, "table cannot be null");
+        checkNotNull(table.getSd(), "Table#StorageDescriptor cannot be null");
+
+        String validate = MetaStoreUtils.validateTblColumns(table.getSd().getCols());
+        if (validate != null) {
+            throw new InvalidObjectException("Invalid column " + validate);
+        }
+
+        if (table.getPartitionKeys() != null) {
+            validate = MetaStoreUtils.validateTblColumns(table.getPartitionKeys());
+            if (validate != null) {
+                throw new InvalidObjectException("Invalid partition column " + validate);
+            }
+        }
+    }
+
+    /**
+     * Should be used when getting table from Glue that may have been created by
+     * users manually or through Crawlers. Validates that table contains properties required by Hive/Spark.
+     *
+     * @param table
+     */
+    public static void validateGlueTable(com.amazonaws.services.glue.model.Table table) {
+        checkNotNull(table, "table cannot be null");
+
+        for (HiveTableValidator validator : HiveTableValidator.values()) {
+            validator.validate(table);
+        }
+    }
+
+    public static <K, V> Map<K, V> deepCopyMap(Map<K, V> originalMap) {
+        Map<K, V> deepCopy = Maps.newHashMap();
+        if (originalMap == null) {
+            return deepCopy;
+        }
+
+        for (Map.Entry<K, V> entry : originalMap.entrySet()) {
+            deepCopy.put(entry.getKey(), entry.getValue());
+        }
+        return deepCopy;
+    }
+
+    /**
+     * Mimics MetaStoreUtils.isExternalTable
+     * Additional logic: check Table#getTableType to see if isExternalTable
+     */
+    public static boolean isExternalTable(Table table) {
+        if (table == null) {
+            return false;
+        }
+
+        Map<String, String> params = table.getParameters();
+        String paramsExternalStr = params == null ? null : params.get("EXTERNAL");
+        if (paramsExternalStr != null) {
+            return "TRUE".equalsIgnoreCase(paramsExternalStr);
+        }
+
+        return table.getTableType() != null && EXTERNAL_TABLE.name().equalsIgnoreCase(table.getTableType());
+    }
+
+    public static String getCatalogId(Configuration conf) {
+        if (StringUtils.isNotEmpty(conf.get(GlueMetastoreClientDelegate.CATALOG_ID_CONF))) {
+            return conf.get(GlueMetastoreClientDelegate.CATALOG_ID_CONF);
+        }
+        // This case defaults to using the caller's account Id as Catalog Id.
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/PartitionKey.java
@@ -1,0 +1,41 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.services.glue.model.Partition;
+
+import java.util.List;
+
+public class PartitionKey {
+
+    private final List<String> partitionValues;
+    private final int hashCode;
+
+    public PartitionKey(Partition partition) {
+        this(partition.getValues());
+    }
+
+    public PartitionKey(List<String> partitionValues) {
+        if (partitionValues == null) {
+            throw new IllegalArgumentException("Partition values cannot be null");
+        }
+        this.partitionValues = partitionValues;
+        this.hashCode = partitionValues.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other != null && other instanceof PartitionKey
+                && this.partitionValues.equals(((PartitionKey) other).partitionValues));
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    List<String> getValues() {
+        return partitionValues;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/glue/util/PartitionUtils.java
@@ -1,0 +1,38 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.external.hive.glue.util;
+
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.InvalidInputException;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+
+public final class PartitionUtils {
+
+    public static Map<PartitionKey, Partition> buildPartitionMap(final List<Partition> partitions) {
+        Map<PartitionKey, Partition> partitionValuesMap = Maps.newHashMap();
+        for (Partition partition : partitions) {
+            partitionValuesMap.put(new PartitionKey(partition), partition);
+        }
+        return partitionValuesMap;
+    }
+
+    public static List<PartitionValueList> getPartitionValuesList(final Map<PartitionKey, Partition> partitionMap) {
+        List<PartitionValueList> partitionValuesList = Lists.newArrayList();
+        for (Map.Entry<PartitionKey, Partition> entry : partitionMap.entrySet()) {
+            partitionValuesList.add(new PartitionValueList().withValues(entry.getValue().getValues()));
+        }
+        return partitionValuesList;
+    }
+
+    public static boolean isInvalidUserInputException(Exception e) {
+        // exceptions caused by invalid requests, in which case we know all partitions creation failed
+        return e instanceof EntityNotFoundException || e instanceof InvalidInputException;
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#12249 
In This PR, we support create hive type catalog whcih metasotre type is glue,  you can create the catalog like this
```
CREATE EXTERNAL CATALOG glue_catalog
PROPERTIES(
  "type"="hive", 
  "hive.metastore.type"="glue",
  "hive.aws_session_access_id" = "xxxxxx",
  "hive.aws_session_secret_key" = "xxxxxxxxxxxx",
  "aws.glue.endpoint"="https://glue.region.amazonaws.com"
);
```
If the data file is stored in S3, also need S3 configuration, refer to https://docs.starrocks.io/zh-cn/latest/using_starrocks/External_table#aws-s3tencent-cloud-cos%E6%94%AF%E6%8C%81  


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
