### PR TITLE
[Feature] Add cost time of hms thrift api to planner profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/CachingRemoteFileIO.java
@@ -64,7 +64,11 @@ public class CachingRemoteFileIO implements RemoteFileIO {
     }
 
     public Map<RemotePathKey, List<RemoteFileDesc>> getPresentRemoteFiles(List<RemotePathKey> paths) {
-        return cache.getAllPresent(paths);
+        if (fileIO instanceof CachingRemoteFileIO) {
+            return ((CachingRemoteFileIO) fileIO).getPresentRemoteFiles(paths);
+        } else {
+            return cache.getAllPresent(paths);
+        }
     }
 
     public List<RemotePathKey> getPresentPathKeyInCache(String basePath, boolean isRecursive) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/RemoteFileOperations.java
@@ -55,7 +55,9 @@ public class RemoteFileOperations {
         List<Future<Map<RemotePathKey, List<RemoteFileDesc>>>> futures = Lists.newArrayList();
         List<Map<RemotePathKey, List<RemoteFileDesc>>> result = Lists.newArrayList();
 
-        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getRemoteFiles", cacheMissSize)) {
+        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getRemoteFiles", String.format("%s partitions", cacheMissSize));
+
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getRemoteFiles")) {
             for (Partition partition : partitions) {
                 RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = executor.submit(() ->

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/CachingHiveMetastore.java
@@ -243,8 +243,12 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public Map<String, HivePartitionStats> getPresentPartitionsStatistics(List<HivePartitionName> partitions) {
-        return partitionStatsCache.getAllPresent(partitions).entrySet().stream()
-                .collect(Collectors.toMap(entry -> entry.getKey().getPartitionNames().get(), Map.Entry::getValue));
+        if (metastore instanceof CachingHiveMetastore) {
+            return ((CachingHiveMetastore) metastore).getPresentPartitionsStatistics(partitions);
+        } else {
+            return partitionStatsCache.getAllPresent(partitions).entrySet().stream()
+                    .collect(Collectors.toMap(entry -> entry.getKey().getPartitionNames().get(), Map.Entry::getValue));
+        }
     }
 
     private HivePartitionStats loadPartitionStatistics(HivePartitionName hivePartitionName) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -180,7 +180,9 @@ public class HiveMetaClient {
     public List<Partition> getPartitionsByNames(String dbName, String tblName, List<String> partitionNames) {
         int size = partitionNames.size();
         List<Partition> partitions;
-        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionsByNames", size);
+        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getPartitionsByNames", String.format("%s partitions", size));
+
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionsByNames");
                 AutoCloseClient client = getClient()) {
             partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, partitionNames);
             if (partitions.size() != partitionNames.size()) {
@@ -213,7 +215,9 @@ public class HiveMetaClient {
                                                                           List<String> partitionNames,
                                                                           List<String> columnNames) {
         int size = partitionNames.size();
-        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionColumnStatistics", size);
+        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getPartitionColumnStatistics", String.format("%s partitions", size));
+
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionColumnStatistics");
                 AutoCloseClient client = getClient()) {
             return client.hiveClient.getPartitionColumnStatistics(dbName, tableName, partitionNames, columnNames);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -210,18 +210,18 @@ public class HiveMetaClient {
 
     public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStats(String dbName,
                                                                           String tableName,
-                                                                          List<String> columns,
-                                                                          List<String> partitionNames) {
+                                                                          List<String> partitionNames,
+                                                                          List<String> columnNames) {
         int size = partitionNames.size();
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionColumnStatistics", size);
                 AutoCloseClient client = getClient()) {
-            return client.hiveClient.getPartitionColumnStatistics(dbName, tableName, columns, partitionNames);
+            return client.hiveClient.getPartitionColumnStatistics(dbName, tableName, partitionNames, columnNames);
         } catch (Exception e) {
             LOG.error("Failed to get partitions column statistics on [{}.{}]. partition size: {}, columns size: {}",
-                    dbName, tableName, partitionNames.size(), columns.size(), e);
+                    dbName, tableName, partitionNames.size(), columnNames.size(), e);
             throw new StarRocksConnectorException("Failed to get partitions column statistics on [%s.%s]." +
                     " partition size: %d, columns size: %d. msg: %s", dbName, tableName, partitionNames.size(),
-                    columns.size(), e.getMessage());
+                    columnNames.size(), e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastore.java
@@ -123,7 +123,6 @@ public class HiveMetastore implements IHiveMetastore {
         String dbName = hmsTbl.getDbName();
         String tblName = hmsTbl.getTableName();
         List<String> dataColumns = hmsTbl.getDataColumnNames();
-        List<String> partitionColumnNames = hmsTbl.getPartitionColumnNames();
         Map<String, Partition> partitions = getPartitionsByNames(hmsTbl.getDbName(), hmsTbl.getTableName(), partitionNames);
 
         Map<String, HiveCommonStats> partitionCommonStats = partitions.entrySet().stream()
@@ -134,7 +133,7 @@ public class HiveMetastore implements IHiveMetastore {
 
         ImmutableMap.Builder<String, HivePartitionStats> resultBuilder = ImmutableMap.builder();
         Map<String, List<ColumnStatisticsObj>> partitionNameToColumnStatsObj =
-                client.getPartitionColumnStats(dbName, tblName, partitionColumnNames, dataColumns);
+                client.getPartitionColumnStats(dbName, tblName, partitionNames, dataColumns);
 
         Map<String, Map<String, HiveColumnStats>> partitionColumnStats = HiveMetastoreApiConverter
                 .toPartitionColumnStatistics(partitionNameToColumnStatsObj, partitionRowNums);

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetastoreOperations.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.starrocks.external.PartitionUtil.executeInNewThread;
 
 public class HiveMetastoreOperations {
+    public static String BACKGROUND_THREAD_NAME_PREFIX = "background-get-partitions-statistics-";
     private final CachingHiveMetastore metastore;
     private final boolean enableCatalogLevelCache;
 
@@ -82,7 +83,7 @@ public class HiveMetastoreOperations {
                 return partitionStats;
             }
 
-            String backgroundThreadName = String.format("background-get-partitions-statistics-%s-%s-%s",
+            String backgroundThreadName = String.format(BACKGROUND_THREAD_NAME_PREFIX + "%s-%s-%s",
                     catalogName, dbName, tblName);
             executeInNewThread(backgroundThreadName, () -> metastore.getPartitionStatistics(table, partitionNames));
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
@@ -76,7 +76,6 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                         ImmutableList.of(), ImmutableList.copyOf(logs)));
             }
         } catch (Exception e) {
-            LOG.error("get file failed", e);
             throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s", pathKey);
         }
         return resultPartitions.put(pathKey, fileDescs).build();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hudi/HudiRemoteFileIO.java
@@ -21,6 +21,8 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class HudiRemoteFileIO implements RemoteFileIO {
+    private static final Logger LOG = LogManager.getLogger(HudiRemoteFileIO.class);
     private final Configuration configuration;
 
     // table location -> HoodieTableMetaClient
@@ -73,6 +76,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                         ImmutableList.of(), ImmutableList.copyOf(logs)));
             }
         } catch (Exception e) {
+            LOG.error("get file failed", e);
             throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s", pathKey);
         }
         return resultPartitions.put(pathKey, fileDescs).build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
@@ -157,9 +157,15 @@ public class PlannerProfile {
             ScopedTimer t = timers.get(key);
             p.addInfoString(name, String.format("%dms / %d", t.getTotalTime(), t.getTotalCount()));
         }
+    }
 
-        keys = new ArrayList<>(customProperties.keySet());
+    public void buildCustomProperties(RuntimeProfile parent) {
+        Map<String, RuntimeProfile> profilers = new HashMap<>();
+        profilers.put("", parent);
+
+        List<String> keys = new ArrayList<>(customProperties.keySet());
         Collections.sort(keys);
+
         for (String key : keys) {
             String prefix = getKeyPrefix(key);
             String name = key.substring(prefix.length());
@@ -171,6 +177,7 @@ public class PlannerProfile {
 
     public void build(RuntimeProfile parent) {
         buildTimers(parent);
+        buildCustomProperties(parent);
     }
 
     public void reset() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Add custom properties to PlannerProfile to count real partitions size.
- Print the time-cost of background requests with no connect context to fe.log

demo:
![image](https://user-images.githubusercontent.com/91597003/196400628-377487d8-44b0-49ca-bff9-eadb0c72d441.png)

The red box is the real size of thrift request partition. It‘s also the missing size of the cache about this query.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
