### PR TITLE
[Enhancement] add cache metrics

### DIFF
--- a/be/src/exec/query_cache/cache_manager.cpp
+++ b/be/src/exec/query_cache/cache_manager.cpp
@@ -29,7 +29,7 @@ StatusOr<CacheValue> CacheManager::probe(const std::string& key) {
         return CACHE_MISS;
     }
     DeferOp defer([this, handle]() { _cache.release(handle); });
-    CacheValue cache_value = *reinterpret_cast<CacheValue*>(_cache.value(handle));
+    CacheValue cache_value(*reinterpret_cast<CacheValue*>(_cache.value(handle)));
     return cache_value;
 }
 

--- a/be/src/exec/query_cache/cache_manager.cpp
+++ b/be/src/exec/query_cache/cache_manager.cpp
@@ -49,5 +49,12 @@ size_t CacheManager::hit_count() {
     return _cache.get_hit_count();
 }
 
+void CacheManager::invalidate_all() {
+    auto old_capacity = _cache.get_capacity();
+    // set capacity of cache to zero, the cache shall prune all cache entries.
+    _cache.set_capacity(0);
+    _cache.set_capacity(old_capacity);
+}
+
 } // namespace query_cache
 } // namespace starrocks

--- a/be/src/exec/query_cache/cache_manager.cpp
+++ b/be/src/exec/query_cache/cache_manager.cpp
@@ -41,5 +41,13 @@ size_t CacheManager::capacity() {
     return _cache.get_capacity();
 }
 
+size_t CacheManager::lookup_count() {
+    return _cache.get_lookup_count();
+}
+
+size_t CacheManager::hit_count() {
+    return _cache.get_hit_count();
+}
+
 } // namespace query_cache
 } // namespace starrocks

--- a/be/src/exec/query_cache/cache_manager.h
+++ b/be/src/exec/query_cache/cache_manager.h
@@ -40,6 +40,8 @@ public:
     StatusOr<CacheValue> probe(const std::string& key);
     size_t memory_usage();
     size_t capacity();
+    size_t lookup_count();
+    size_t hit_count();
 
 private:
     ShardedLRUCache _cache;

--- a/be/src/exec/query_cache/cache_manager.h
+++ b/be/src/exec/query_cache/cache_manager.h
@@ -69,6 +69,8 @@ public:
     size_t capacity();
     size_t lookup_count();
     size_t hit_count();
+    // vacuum cache by invalidate all cache entries
+    void invalidate_all();
 
 private:
     ShardedLRUCache _cache;

--- a/be/src/exec/query_cache/cache_manager.h
+++ b/be/src/exec/query_cache/cache_manager.h
@@ -6,6 +6,7 @@
 
 #include "column/chunk.h"
 #include "common/status.h"
+#include "gutil/strings/substitute.h"
 #include "util/lru_cache.h"
 #include "util/slice.h"
 
@@ -23,6 +24,32 @@ struct CacheValue {
     int64_t populate_time;
     int64_t version;
     CacheResult result;
+
+    CacheValue(int64_t populate_time, int64_t cache_version, CacheResult&& cache_result)
+            : latest_hit_time(0),
+              hit_count(0),
+              populate_time(populate_time),
+              version(cache_version),
+              result(cache_result) {}
+
+    CacheValue(const CacheValue& that)
+            : latest_hit_time(that.latest_hit_time),
+              hit_count(that.hit_count),
+              populate_time(that.populate_time),
+              version(that.version),
+              result(that.result) {}
+
+    CacheValue& operator=(const CacheValue& that) {
+        this->latest_hit_time = that.latest_hit_time;
+        this->hit_count = that.hit_count;
+        this->populate_time = that.populate_time;
+        this->version = that.version;
+        this->result = that.result;
+        return *this;
+    }
+
+    ~CacheValue() { result.clear(); }
+
     size_t size() {
         size_t value_size = 0;
         for (auto& chk : result) {

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -348,14 +348,14 @@ void CacheOperator::populate_cache(int64_t tablet_id) {
     const std::string cache_key = _cache_param.digest + cache_key_suffix_it->second;
     int64_t current = GetMonoTimeMicros();
     auto chunks = remap_chunks(buffer->chunks, _cache_param.slot_remapping);
-    CacheValue value{0, 0, current, buffer->required_version, std::move(chunks)};
+    CacheValue cache_value(current, buffer->required_version, std::move(chunks));
     // If the cache implementation is global, populate method must be asynchronous and try its best to
     // update the cache.
     _cache_populate_bytes_counter->update(buffer->num_bytes);
     _cache_populate_chunks_counter->update(buffer->chunks.size());
     _cache_populate_rows_counter->update(buffer->num_rows);
     _populate_tablets.insert(tablet_id);
-    _cache_mgr->populate(cache_key, value);
+    _cache_mgr->populate(cache_key, cache_value);
     buffer->state = PLBS_POPULATE;
 }
 

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(Webserver STATIC
   action/compaction_action.cpp
   action/update_config_action.cpp
   action/runtime_filter_cache_action.cpp
-)
+  action/query_cache_action.cpp)
 
 # target_link_libraries(Webserver pthread dl Util)
 #ADD_BE_TEST(integer-array-test)

--- a/be/src/http/action/query_cache_action.cpp
+++ b/be/src/http/action/query_cache_action.cpp
@@ -1,0 +1,99 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "http/action/query_cache_action.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <string>
+
+#include "common/logging.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+const static std::string HEADER_JSON = "application/json";
+const static std::string ACTION_KEY = "action";
+const static std::string ACTION_STAT = "stat";
+const static std::string ACTION_INVALIDATE_ALL = "invalidate_all";
+
+void QueryCacheAction::handle(HttpRequest* req) {
+    LOG(INFO) << req->debug_string();
+    const auto& action = req->param(ACTION_KEY);
+    if (req->method() == HttpMethod::GET) {
+        if (action == ACTION_STAT) {
+            _handle_stat(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support GET method: '$0'", req->uri()));
+        }
+    } else if (req->method() == HttpMethod::PUT) {
+        if (action == ACTION_INVALIDATE_ALL) {
+            _handle_invalidate_all(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support PUT method: '$0'", req->uri()));
+        }
+    } else {
+        _handle_error(req,
+                      strings::Substitute("Not support $0 method: '$1'", to_method_desc(req->method()), req->uri()));
+    }
+}
+void QueryCacheAction::_handle(HttpRequest* req, std::function<void(rapidjson::Document&)> func) {
+    rapidjson::Document root;
+    root.SetObject();
+    func(root);
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    root.Accept(writer);
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
+    HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());
+}
+void QueryCacheAction::_handle_stat(HttpRequest* req) {
+    auto cache_mgr = _exec_env->cache_mgr();
+    _handle(req, [=](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        if (cache_mgr == nullptr) {
+            root.AddMember("error", rapidjson::StringRef("Cache Manager is nullptr"), allocator);
+            return;
+        }
+        auto capacity = cache_mgr->capacity();
+        auto usage = cache_mgr->memory_usage();
+        auto usage_ratio = capacity == 0 ? 0.0 : double(usage) / double(capacity);
+        auto lookup_count = cache_mgr->lookup_count();
+        auto hit_count = cache_mgr->hit_count();
+        auto hit_ratio = lookup_count == 0 ? 0.0 : double(hit_count) / double(lookup_count);
+
+        root.AddMember("capacity", rapidjson::Value(capacity), allocator);
+        root.AddMember("usage", rapidjson::Value(usage), allocator);
+        root.AddMember("usage_ratio", rapidjson::Value(usage_ratio), allocator);
+        root.AddMember("lookup_count", rapidjson::Value(lookup_count), allocator);
+        root.AddMember("hit_count", rapidjson::Value(hit_count), allocator);
+        root.AddMember("hit_ratio", rapidjson::Value(hit_ratio), allocator);
+    });
+}
+
+void QueryCacheAction::_handle_invalidate_all(HttpRequest* req) {
+    auto cache_mgr = _exec_env->cache_mgr();
+    _handle(req, [&](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        if (cache_mgr == nullptr) {
+            root.AddMember("error", rapidjson::StringRef("Cache Manager is nullptr"), allocator);
+            return;
+        }
+        cache_mgr->invalidate_all();
+        root.AddMember("status", rapidjson::StringRef("OK"), allocator);
+    });
+}
+
+void QueryCacheAction::_handle_error(HttpRequest* req, const std::string& err_msg) {
+    _handle(req, [err_msg](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        root.AddMember("error", rapidjson::Value(err_msg.c_str(), err_msg.size()), allocator);
+    });
+}
+
+} // namespace starrocks

--- a/be/src/http/action/query_cache_action.cpp
+++ b/be/src/http/action/query_cache_action.cpp
@@ -23,7 +23,7 @@ const static std::string ACTION_STAT = "stat";
 const static std::string ACTION_INVALIDATE_ALL = "invalidate_all";
 
 void QueryCacheAction::handle(HttpRequest* req) {
-    LOG(INFO) << req->debug_string();
+    VLOG_ROW << req->debug_string();
     const auto& action = req->param(ACTION_KEY);
     if (req->method() == HttpMethod::GET) {
         if (action == ACTION_STAT) {

--- a/be/src/http/action/query_cache_action.h
+++ b/be/src/http/action/query_cache_action.h
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
+#include "http/http_handler.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class QueryCacheAction : public HttpHandler {
+public:
+    explicit QueryCacheAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+    ~QueryCacheAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    void _handle(HttpRequest* req, std::function<void(rapidjson::Document& root)> func);
+    void _handle_stat(HttpRequest* req);
+    void _handle_invalidate_all(HttpRequest* req);
+    void _handle_error(HttpRequest* req, const std::string& error_msg);
+    ExecEnv* _exec_env;
+};
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -30,6 +30,7 @@
 #include "http/action/meta_action.h"
 #include "http/action/metrics_action.h"
 #include "http/action/pprof_actions.h"
+#include "http/action/query_cache_action.h"
 #include "http/action/reload_tablet_action.h"
 #include "http/action/restore_tablet_action.h"
 #include "http/action/runtime_filter_cache_action.h"
@@ -211,6 +212,11 @@ Status HttpServiceBE::start() {
     CompactRocksDbMetaAction* compact_rocksdb_meta_action = new CompactRocksDbMetaAction(_env);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/compact_rocksdb_meta", compact_rocksdb_meta_action);
     _http_handlers.emplace_back(compact_rocksdb_meta_action);
+
+    QueryCacheAction* query_cache_action = new QueryCacheAction(_env);
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/query_cache/{action}", query_cache_action);
+    _ev_http_server->register_handler(HttpMethod::PUT, "/api/query_cache/{action}", query_cache_action);
+    _http_handlers.emplace_back(query_cache_action);
 
     RETURN_IF_ERROR(_ev_http_server->start());
     return Status::OK();

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -176,14 +176,13 @@ public:
     // leveldb may change prune() to a pure abstract method.
     virtual void prune() {}
 
-    virtual size_t get_memory_usage() = 0;
     virtual void get_cache_status(rapidjson::Document* document) = 0;
 
     virtual void set_capacity(size_t capacity) = 0;
     virtual size_t get_capacity() = 0;
-
-    virtual uint64_t get_lookup_count() = 0;
-    virtual uint64_t get_hit_count() = 0;
+    virtual size_t get_memory_usage() = 0;
+    virtual size_t get_lookup_count() = 0;
+    virtual size_t get_hit_count() = 0;
 
     //  Decrease or increase cache capacity.
     virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
@@ -323,9 +322,9 @@ public:
     Slice value_slice(Handle* handle) override;
     uint64_t new_id() override;
     void prune() override;
-    size_t get_memory_usage() override;
     void get_cache_status(rapidjson::Document* document) override;
     void set_capacity(size_t capacity) override;
+    size_t get_memory_usage() override;
     size_t get_capacity() override;
     uint64_t get_lookup_count() override;
     uint64_t get_hit_count() override;
@@ -335,6 +334,7 @@ private:
     static uint32_t _hash_slice(const CacheKey& s);
     static uint32_t _shard(uint32_t hash);
     void _set_capacity(size_t capacity);
+    size_t _get_stat(size_t (LRUCache::*mem_fun)());
 
     LRUCache _shards[kNumShards];
     std::mutex _mutex;

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -631,6 +631,9 @@ void SystemMetrics::_update_snmp_metrics() {
 
 void SystemMetrics::_update_query_cache_metrics() {
     auto* cache_mgr = ExecEnv::GetInstance()->cache_mgr();
+    if (UNLIKELY(cache_mgr == nullptr)) {
+        return;
+    }
     auto capacity = cache_mgr->capacity();
     auto usage = cache_mgr->memory_usage();
     auto lookup_count = cache_mgr->lookup_count();

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -98,6 +98,16 @@ public:
     METRIC_DEFINE_INT_GAUGE(fd_num_used, MetricUnit::NOUNIT);
 };
 
+class QueryCacheMetrics {
+public:
+    METRIC_DEFINE_INT_GAUGE(query_cache_capacity, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(query_cache_usage, MetricUnit::BYTES);
+    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_usage_ratio, MetricUnit::PERCENT);
+    METRIC_DEFINE_INT_GAUGE(query_cache_lookup_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(query_cache_hit_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_hit_ratio, MetricUnit::PERCENT);
+};
+
 SystemMetrics::SystemMetrics() = default;
 
 SystemMetrics::~SystemMetrics() {
@@ -129,6 +139,7 @@ void SystemMetrics::install(MetricRegistry* registry, const std::set<std::string
     _install_net_metrics(registry, network_interfaces);
     _install_fd_metrics(registry);
     _install_snmp_metrics(registry);
+    _install_query_cache_metrics(registry);
     _registry = registry;
 }
 
@@ -139,6 +150,7 @@ void SystemMetrics::update() {
     _update_net_metrics();
     _update_fd_metrics();
     _update_snmp_metrics();
+    _update_query_cache_metrics();
 }
 
 void SystemMetrics::_install_cpu_metrics(MetricRegistry* registry) {
@@ -617,10 +629,36 @@ void SystemMetrics::_update_snmp_metrics() {
     fclose(fp);
 }
 
+void SystemMetrics::_update_query_cache_metrics() {
+    auto* cache_mgr = ExecEnv::GetInstance()->cache_mgr();
+    auto capacity = cache_mgr->capacity();
+    auto usage = cache_mgr->memory_usage();
+    auto lookup_count = cache_mgr->lookup_count();
+    auto hit_count = cache_mgr->hit_count();
+    auto usage_ratio = (capacity == 0L) ? 0.0 : double(usage) / double(capacity);
+    auto hit_ratio = (lookup_count == 0L) ? 0.0 : double(hit_count) / double(lookup_count);
+    _query_cache_metrics->query_cache_capacity.set_value(capacity);
+    _query_cache_metrics->query_cache_usage.set_value(usage);
+    _query_cache_metrics->query_cache_usage_ratio.set_value(usage_ratio);
+    _query_cache_metrics->query_cache_lookup_count.set_value(lookup_count);
+    _query_cache_metrics->query_cache_hit_count.set_value(hit_count);
+    _query_cache_metrics->query_cache_hit_ratio.set_value(hit_ratio);
+}
+
 void SystemMetrics::_install_fd_metrics(MetricRegistry* registry) {
     _fd_metrics = std::make_unique<FileDescriptorMetrics>();
     registry->register_metric("fd_num_limit", &_fd_metrics->fd_num_limit);
     registry->register_metric("fd_num_used", &_fd_metrics->fd_num_used);
+}
+
+void SystemMetrics::_install_query_cache_metrics(starrocks::MetricRegistry* registry) {
+    _query_cache_metrics = std::make_unique<QueryCacheMetrics>();
+    registry->register_metric("query_cache_capacity", &_query_cache_metrics->query_cache_capacity);
+    registry->register_metric("query_cache_usage", &_query_cache_metrics->query_cache_usage);
+    registry->register_metric("query_cache_usage_ratio", &_query_cache_metrics->query_cache_usage_ratio);
+    registry->register_metric("query_cache_lookup_count", &_query_cache_metrics->query_cache_lookup_count);
+    registry->register_metric("query_cache_hit_count", &_query_cache_metrics->query_cache_hit_count);
+    registry->register_metric("query_cache_hit_ratio", &_query_cache_metrics->query_cache_hit_ratio);
 }
 
 void SystemMetrics::_update_fd_metrics() {

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -29,6 +29,7 @@ class DiskMetrics;
 class NetMetrics;
 class FileDescriptorMetrics;
 class SnmpMetrics;
+class QueryCacheMetrics;
 
 class MemoryMetrics {
 public:
@@ -134,7 +135,12 @@ private:
     void _update_fd_metrics();
 
     void _install_snmp_metrics(MetricRegistry* registry);
+
     void _update_snmp_metrics();
+
+    void _install_query_cache_metrics(MetricRegistry* registry);
+
+    void _update_query_cache_metrics();
 
 private:
     static const char* const _s_hook_name;
@@ -144,6 +150,7 @@ private:
     std::map<std::string, DiskMetrics*> _disk_metrics;
     std::map<std::string, NetMetrics*> _net_metrics;
     std::unique_ptr<FileDescriptorMetrics> _fd_metrics;
+    std::unique_ptr<QueryCacheMetrics> _query_cache_metrics;
     int _proc_net_dev_version = 0;
     std::unique_ptr<SnmpMetrics> _snmp_metrics;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

This pr add restful api for query cache management and monitoring.
1. monitoring: 
```
curl -s  http://${be_host}:${be_http_port}/metrics |grep query_cache

# TYPE starrocks_be_query_cache_capacity gauge
starrocks_be_query_cache_capacity 536870912
# TYPE starrocks_be_query_cache_hit_count gauge
starrocks_be_query_cache_hit_count 5084393
# TYPE starrocks_be_query_cache_hit_ratio gauge
starrocks_be_query_cache_hit_ratio 0.984098
# TYPE starrocks_be_query_cache_lookup_count gauge
starrocks_be_query_cache_lookup_count 5166553
# TYPE starrocks_be_query_cache_usage gauge
starrocks_be_query_cache_usage 0
# TYPE starrocks_be_query_cache_usage_ratio gauge
starrocks_be_query_cache_usage_ratio 0.000000
```
2. query cache management
```
## show stat of query cache
curl  http://${be_host}:${be_http_port}/api/query_cache/stat
{
    "capacity": 536870912,
    "usage": 0,
    "usage_ratio": 0.0,
    "lookup_count": 5025124,
    "hit_count": 4943720,
    "hit_ratio": 0.983800598751394
}

## clear cache by invaliating all cache entries.
curl  -XPUT http://${be_host}:${be_http_port}/api/query_cache/invalidate_all

{
    "status": "OK"
}

```