### PR TITLE
[Enhancement] accumulate chunk into full one in connector chunk source

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,6 +754,7 @@ CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
+CONF_Bool(connector_chunk_source_accumulate_enable, "true");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,7 +754,7 @@ CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
-CONF_Bool(connector_chunk_source_accumulate_enable, "true");
+CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -14,22 +14,16 @@ Status ChunkAccumulateOperator::push_chunk(RuntimeState* state, const vectorized
 }
 
 StatusOr<vectorized::ChunkPtr> ChunkAccumulateOperator::pull_chunk(RuntimeState*) {
-    // If there isn't more input chunk and _out_chunk has been outputted, output _in_chunk this time.
-    if (_is_finished && _acc.output_chunk() == nullptr) {
-        return std::move(_acc.staging_chunk());
-    }
-
-    return std::move(_acc.output_chunk());
+    return std::move(_acc.pull());
 }
 
 Status ChunkAccumulateOperator::set_finishing(RuntimeState* state) {
-    _is_finished = true;
-
+    _acc.finalize();
     return Status::OK();
 }
 
 Status ChunkAccumulateOperator::set_finished(RuntimeState*) {
-    _is_finished = true;
+    _acc.finalize();
     _acc.reset();
 
     return Status::OK();

--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -37,8 +37,7 @@ Status ChunkAccumulateOperator::set_finished(RuntimeState*) {
 
 Status ChunkAccumulateOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
-    _in_chunk = nullptr;
-    _out_chunk = nullptr;
+    _acc.reset();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "exec/pipeline/operator.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks {
 
@@ -21,9 +22,13 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    bool has_output() const override { return _out_chunk != nullptr || (_is_finished && _in_chunk != nullptr); }
-    bool need_input() const override { return !_is_finished && _out_chunk == nullptr; }
-    bool is_finished() const override { return _is_finished && _in_chunk == nullptr && _out_chunk == nullptr; }
+    bool has_output() const override {
+        return _acc.output_chunk() != nullptr || (_is_finished && _acc.staging_chunk() != nullptr);
+    }
+    bool need_input() const override { return !_is_finished && _acc.output_chunk() == nullptr; }
+    bool is_finished() const override {
+        return _is_finished && _acc.staging_chunk() == nullptr && _acc.output_chunk() == nullptr;
+    }
 
     Status set_finishing(RuntimeState* state) override;
     Status set_finished(RuntimeState* state) override;
@@ -31,12 +36,8 @@ public:
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
-    static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
-    static constexpr size_t LOW_WATERMARK_BYTES = 256 * 1024 * 1024; // 256MB.
-
     bool _is_finished = false;
-    vectorized::ChunkPtr _in_chunk = nullptr;
-    vectorized::ChunkPtr _out_chunk = nullptr;
+    ChunkPipelineAccumulator _acc;
 };
 
 class ChunkAccumulateOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -22,13 +22,9 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    bool has_output() const override {
-        return _acc.output_chunk() != nullptr || (_is_finished && _acc.staging_chunk() != nullptr);
-    }
-    bool need_input() const override { return !_is_finished && _acc.output_chunk() == nullptr; }
-    bool is_finished() const override {
-        return _is_finished && _acc.staging_chunk() == nullptr && _acc.output_chunk() == nullptr;
-    }
+    bool has_output() const override { return _acc.has_output(); }
+    bool need_input() const override { return _acc.need_input(); }
+    bool is_finished() const override { return _acc.is_finished(); }
 
     Status set_finishing(RuntimeState* state) override;
     Status set_finished(RuntimeState* state) override;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -219,7 +219,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, vectorized::ChunkP
         _rows_read += (*chunk)->num_rows();
         return Status::OK();
     }
-    _ck_acc.reset();    
+    _ck_acc.reset();
     return Status::EndOfFile("");
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -198,7 +198,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, vectorized::ChunkP
         if (_status.ok()) {
             if (tmp->num_rows() == 0) continue;
             _ck_acc.push(std::move(tmp));
-            if (config::connector_chunk_source_accumulate_enable) {
+            if (config::connector_chunk_source_accumulate_chunk_enable) {
                 if (_ck_acc.has_output()) break;
             } else {
                 _ck_acc.finalize();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -7,6 +7,8 @@
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "exec/pipeline/scan/scan_operator.h"
 #include "exec/workgroup/work_group_fwd.h"
+#include "storage/chunk_helper.h"
+
 
 namespace starrocks {
 
@@ -89,6 +91,8 @@ private:
 
     // =========================
     RuntimeState* _runtime_state = nullptr;
+    ChunkAccumulator _ck_acc;
+    Status _status = Status::OK();
     bool _opened = false;
     bool _closed = false;
     uint64_t _rows_read = 0;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -9,7 +9,6 @@
 #include "exec/workgroup/work_group_fwd.h"
 #include "storage/chunk_helper.h"
 
-
 namespace starrocks {
 
 class ScanNode;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -90,7 +90,7 @@ private:
 
     // =========================
     RuntimeState* _runtime_state = nullptr;
-    ChunkAccumulator _ck_acc;
+    ChunkPipelineAccumulator _ck_acc;
     Status _status = Status::OK();
     bool _opened = false;
     bool _closed = false;

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -480,4 +480,27 @@ void ChunkPipelineAccumulator::reset() {
     _out_chunk.reset();
 }
 
+void ChunkPipelineAccumulator::finalize() {
+    _finalized = true;
+}
+
+vectorized::ChunkPtr& ChunkPipelineAccumulator::pull() {
+    if (_finalized && _out_chunk == nullptr) {
+        return _in_chunk;
+    }
+    return _out_chunk;
+}
+
+bool ChunkPipelineAccumulator::has_output() const {
+    return _out_chunk != nullptr || (_finalized && _in_chunk != nullptr);
+}
+
+bool ChunkPipelineAccumulator::need_input() const {
+    return !_finalized && _out_chunk == nullptr;
+}
+
+bool ChunkPipelineAccumulator::is_finished() const {
+    return _finalized && _out_chunk == nullptr && _in_chunk == nullptr;
+}
+
 } // namespace starrocks

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -96,11 +96,13 @@ public:
     ChunkPipelineAccumulator() = default;
     void set_max_size(size_t max_size) { _max_size = max_size; }
     void push(const vectorized::ChunkPtr& chunk);
-    vectorized::ChunkPtr& output_chunk() { return _out_chunk; }
-    vectorized::ChunkPtr& staging_chunk() { return _in_chunk; }
-    const vectorized::ChunkPtr& output_chunk() const { return _out_chunk; }
-    const vectorized::ChunkPtr& staging_chunk() const { return _in_chunk; }
+    vectorized::ChunkPtr& pull();
+    void finalize();
     void reset();
+
+    bool has_output() const;
+    bool need_input() const;
+    bool is_finished() const;
 
 private:
     static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
@@ -108,6 +110,7 @@ private:
     vectorized::ChunkPtr _in_chunk = nullptr;
     vectorized::ChunkPtr _out_chunk = nullptr;
     size_t _max_size = 4096;
+    bool _finalized = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -91,4 +91,23 @@ private:
     std::deque<vectorized::ChunkPtr> _output;
 };
 
+class ChunkPipelineAccumulator {
+public:
+    ChunkPipelineAccumulator() = default;
+    void set_max_size(size_t max_size) { _max_size = max_size; }
+    void push(const vectorized::ChunkPtr& chunk);
+    vectorized::ChunkPtr& output_chunk() { return _out_chunk; }
+    vectorized::ChunkPtr& staging_chunk() { return _in_chunk; }
+    const vectorized::ChunkPtr& output_chunk() const { return _out_chunk; }
+    const vectorized::ChunkPtr& staging_chunk() const { return _in_chunk; }
+    void reset();
+
+private:
+    static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
+    static constexpr size_t LOW_WATERMARK_BYTES = 256 * 1024 * 1024; // 256MB.
+    vectorized::ChunkPtr _in_chunk = nullptr;
+    vectorized::ChunkPtr _out_chunk = nullptr;
+    size_t _max_size = 4096;
+};
+
 } // namespace starrocks

--- a/be/test/exprs/vectorized/decimal_binary_function_test.cpp
+++ b/be/test/exprs/vectorized/decimal_binary_function_test.cpp
@@ -479,7 +479,8 @@ void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_
         Columns columns = prepare_nullable_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
         test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
-                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size, std::vector<bool>());
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
+                std::vector<bool>());
     }
 }
 template <PrimitiveType Type, typename Op, bool check_overflow>
@@ -501,7 +502,8 @@ void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_
         Columns columns = prepare_const_nullable_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
         test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
-                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size, std::vector<bool>());
+                DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
+                std::vector<bool>());
     }
 }
 template <PrimitiveType Type, typename Op, bool check_overflow>
@@ -3008,7 +3010,7 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x32) {
     test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL32, TYPE_DECIMAL128, MulOp32x32_128>(test_cases, 9, 2, 9, 2,
                                                                                                 38, 4);
     test_decimal_fast_mul_help<TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp32x64_128>(test_cases, 9, 2, 9, 2,
-                                                                                               38, 4);
+                                                                                                38, 4);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x64) {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -820,7 +820,7 @@ TEST_F(RowsetTest, SegmentWriteTest) {
 
         butil::IOBuf data;
         auto buf = new uint8[seg_info->data_size()];
-        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
 
         ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
         auto st = segment_rowset_writer->flush_segment(*seg_info, data);

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -259,7 +259,7 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     auto metrics = instance->metrics();
     metrics->collect(&visitor);
     LOG(INFO) << "\n" << visitor.to_string();
-    
+
     auto lookup_metric = metrics->get_metric("page_cache_lookup_count");
     ASSERT_TRUE(lookup_metric != nullptr);
     auto hit_metric = metrics->get_metric("page_cache_hit_count");
@@ -285,7 +285,7 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     metrics->collect(&visitor);
     ASSERT_STREQ("1025", lookup_metric->to_string().c_str());
     ASSERT_STREQ("1", hit_metric->to_string().c_str());
-    ASSERT_STREQ(std::to_string(cache->get_capacity()).c_str(), capacity_metric->to_string().c_str());   
+    ASSERT_STREQ(std::to_string(cache->get_capacity()).c_str(), capacity_metric->to_string().c_str());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

ssb-100g with block cache, optimized version can save almost 1000ms. 



  | ssbflat(before) | after | ssb(before) | after
-- | -- | -- | -- | --
Q01 | 444 | 350 | 683 | 612
Q02 | 419 | 328 | 645 | 574
Q03 | 460 | 414 | 588 | 559
Q04 | 628 | 445 | 878 | 845
Q05 | 478 | 360 | 729 | 723
Q06 | 335 | 276 | 699 | 693
Q07 | 920 | 666 | 1372 | 1396
Q08 | 817 | 601 | 823 | 807
Q09 | 298 | 275 | 741 | 737
Q10 | 219 | 222 | 762 | 667
Q11 | 861 | 608 | 1573 | 1577
Q12 | 1027 | 748 | 1310 | 1168
Q13 | 958 | 738 | 1210 | 1095
SUM | 7864 | 6031 | 12013 | 11453

tpch-100g with block cache.

  | tpch(before) | after
-- | -- | --
Q01 | 3654 | 3655
Q02 | 513 | 478
Q03 | 2425 | 2293
Q04 | 1150 | 1069
Q05 | 1904 | 1874
Q06 | 896 | 774
Q07 | 1726 | 1682
Q08 | 1577 | 1530
Q09 | 4756 | 4699
Q10 | 2764 | 2590
Q11 | 380 | 379
Q12 | 1366 | 1204
Q13 | 2761 | 2796
Q14 | 1119 | 971
Q15 | 996 | 845
Q16 | 3535 | 3615
Q17 | 1869 | 1775
Q18 | 10364 | 10369
Q19 | 1173 | 1000
Q20 | 1220 | 1181
Q21 | 3513 | 3509
Q22 | 678 | 691
SUM | 50339 | 48979





## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
