### PR TITLE
[BugFix] Add logic to handle case: when config type is array

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
@@ -302,7 +302,32 @@ public class ConfigBase {
             }
             String confVal;
             try {
-                confVal = String.valueOf(f.get(null));
+                if (f.getType().isArray()) {
+                    switch (f.getType().getSimpleName()) {
+                        case "short[]":
+                            confVal = Arrays.toString((short[]) f.get(null));
+                            break;
+                        case "int[]":
+                            confVal = Arrays.toString((int[]) f.get(null));
+                            break;
+                        case "long[]":
+                            confVal = Arrays.toString((long[]) f.get(null));
+                            break;
+                        case "double[]":
+                            confVal = Arrays.toString((double[]) f.get(null));
+                            break;
+                        case "boolean[]":
+                            confVal = Arrays.toString((boolean[]) f.get(null));
+                            break;
+                        case "String[]":
+                            confVal = Arrays.toString((String[]) f.get(null));
+                            break;
+                        default:
+                            throw new DdlException("Unknown type: " + f.getType().getSimpleName());
+                    }
+                } else {
+                    confVal = String.valueOf(f.get(null));
+                }
             } catch (IllegalArgumentException | IllegalAccessException e) {
                 throw new DdlException("Failed to get config '" + confKey + "'. err: " + e.getMessage());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
@@ -80,4 +80,37 @@ public class ConfigTest {
         Assert.assertEquals("4", configs.get(0).get(2));
         Assert.assertEquals(4, Config.tablet_sched_slot_num_per_path);
     }
+
+    private static class ConfigForArray extends ConfigBase {
+
+        @ConfField(mutable = true)
+        public static short[] prop_array_short = new short[] {1, 1};
+        @ConfField(mutable = true)
+        public static int[] prop_array_int = new int[] {2, 2};
+        @ConfField(mutable = true)
+        public static long[] prop_array_long = new long[] {3L, 3L};
+        @ConfField(mutable = true)
+        public static double[] prop_array_double = new double[] {1.1, 1.1};
+        @ConfField(mutable = true)
+        public static String[] prop_array_string = new String[] {"1", "2"};
+    }
+
+    @Test
+    public void testConfigArray() throws Exception {
+        ConfigForArray configForArray = new ConfigForArray();
+        URL resource = getClass().getClassLoader().getResource("conf/config_test3.properties");
+        configForArray.init(Paths.get(resource.toURI()).toFile().getAbsolutePath());
+        List<List<String>> configs = ConfigForArray.getConfigInfo(null);
+        Assert.assertEquals("[1, 1]", configs.get(0).get(2));
+        Assert.assertEquals("short[]", configs.get(0).get(3));
+        Assert.assertEquals("[2, 2]", configs.get(1).get(2));
+        Assert.assertEquals("int[]", configs.get(1).get(3));
+        Assert.assertEquals("[3, 3]", configs.get(2).get(2));
+        Assert.assertEquals("long[]", configs.get(2).get(3));
+        Assert.assertEquals("[1.1, 1.1]", configs.get(3).get(2));
+        Assert.assertEquals("double[]", configs.get(3).get(3));
+        Assert.assertEquals("[1, 2]", configs.get(4).get(2));
+        Assert.assertEquals("String[]", configs.get(4).get(3));
+        setUp();
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12114 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add logic to handle case: when config type is array, the previous logic will get some memory addresses, not the real value of the config
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
