### PR TITLE
[Enhancement] Add replicated storage blacklist mechanism

### DIFF
--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -176,6 +176,7 @@ private:
     std::map<int64_t, std::vector<PTabletWithPartition>> _index_tablets_map;
 
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
+    std::vector<TTabletFailInfo> _tablet_fail_infos;
 
     AddBatchCounter _add_batch_counter;
     int64_t _serialize_batch_ns = 0;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -283,6 +283,9 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
                 params.commitInfos.push_back(info);
             }
         }
+        if (!runtime_state->tablet_fail_infos().empty()) {
+            params.__set_failInfos(runtime_state->tablet_fail_infos());
+        }
 
         // Send new errors to coordinator
         runtime_state->get_unreported_errors(&(params.error_log));

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -370,6 +370,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
     _is_replicated_storage = params.is_replicated_storage();
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
+    std::vector<int64_t> failed_tablet_ids;
     for (const PTabletWithPartition& tablet : params.tablets()) {
         vectorized::DeltaWriterOptions options;
         options.tablet_id = tablet.tablet_id();
@@ -383,20 +384,33 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.index_id = _index_id;
         options.node_id = _node_id;
         options.timeout_ms = params.timeout_ms();
-        options.is_replicated_storage = params.is_replicated_storage();
         options.write_quorum = params.write_quorum();
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);
             }
+            if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
+                options.replica_state = vectorized::Primary;
+            } else {
+                options.replica_state = vectorized::Secondary;
+            }
+        } else {
+            options.replica_state = vectorized::Peer;
         }
         options.merge_condition = params.merge_condition();
 
         auto res = AsyncDeltaWriter::open(options, _mem_tracker);
-        RETURN_IF_ERROR(res.status());
-        auto writer = std::move(res).value();
-        _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
-        tablet_ids.emplace_back(tablet.tablet_id());
+        if (res.status().ok()) {
+            auto writer = std::move(res).value();
+            _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
+            tablet_ids.emplace_back(tablet.tablet_id());
+        } else {
+            if (options.replica_state == vectorized::Secondary) {
+                failed_tablet_ids.emplace_back(tablet.tablet_id());
+            } else {
+                return res.status();
+            }
+        }
     }
     _s_tablet_writer_count += _delta_writers.size();
     DCHECK_EQ(_delta_writers.size(), params.tablets_size());
@@ -407,9 +421,12 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
     }
     std::stringstream ss;
     ss << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(params.id()) << " open delta writer: ";
-
     for (auto& [tablet_id, delta_writer] : _delta_writers) {
         ss << "[" << tablet_id << ":" << delta_writer->replica_state() << "]";
+    }
+    ss << " failed_tablets: ";
+    for (auto& tablet_id : failed_tablet_ids) {
+        ss << tablet_id << ",";
     }
     LOG(INFO) << ss.str();
     return Status::OK();
@@ -485,14 +502,31 @@ StatusOr<std::shared_ptr<LocalTabletsChannel::WriteContext>> LocalTabletsChannel
     return std::move(context);
 }
 
-void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRowsetInfo* info) {
+void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRowsetInfo* committed_info,
+                                             const FailedRowsetInfo* failed_info) {
     _context->update_status(st);
-    if (info != nullptr) {
+    if (failed_info != nullptr) {
+        PTabletInfo tablet_info;
+        tablet_info.set_tablet_id(failed_info->tablet_id);
+        // unused but it's required field of protobuf
+        tablet_info.set_schema_hash(0);
+        _context->add_failed_tablet_info(&tablet_info);
+
+        // committed tablets from seconary replica
+        if (failed_info->replicate_token) {
+            const auto failed_tablet_infos = failed_info->replicate_token->failed_tablet_infos();
+            for (const auto& failed_tablet_info : *failed_tablet_infos) {
+                _context->add_failed_tablet_info(failed_tablet_info.get());
+            }
+        }
+    }
+    if (committed_info != nullptr) {
         // committed tablets from primary replica
         PTabletInfo tablet_info;
-        tablet_info.set_tablet_id(info->tablet->tablet_id());
-        tablet_info.set_schema_hash(info->tablet->schema_hash());
-        const auto& rowset_global_dict_columns_valid_info = info->rowset_writer->global_dict_columns_valid_info();
+        tablet_info.set_tablet_id(committed_info->tablet->tablet_id());
+        tablet_info.set_schema_hash(committed_info->tablet->schema_hash());
+        const auto& rowset_global_dict_columns_valid_info =
+                committed_info->rowset_writer->global_dict_columns_valid_info();
         for (const auto& item : rowset_global_dict_columns_valid_info) {
             if (item.second) {
                 tablet_info.add_valid_dict_cache_columns(item.first);
@@ -503,8 +537,8 @@ void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRo
         _context->add_committed_tablet_info(&tablet_info);
 
         // committed tablets from seconary replica
-        if (info->replicate_token) {
-            const auto replicated_tablet_infos = info->replicate_token->replicated_tablet_infos();
+        if (committed_info->replicate_token) {
+            const auto replicated_tablet_infos = committed_info->replicate_token->replicated_tablet_infos();
             for (const auto& synced_tablet_info : *replicated_tablet_infos) {
                 _context->add_committed_tablet_info(synced_tablet_info.get());
             }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -287,9 +287,18 @@ public:
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }
 
     void append_tablet_commit_infos(std::vector<TTabletCommitInfo>& commit_info) {
-        std::lock_guard<std::mutex> l(_tablet_commit_infos_lock);
+        std::lock_guard<std::mutex> l(_tablet_infos_lock);
         _tablet_commit_infos.insert(_tablet_commit_infos.end(), std::make_move_iterator(commit_info.begin()),
                                     std::make_move_iterator(commit_info.end()));
+    }
+
+    const std::vector<TTabletFailInfo>& tablet_fail_infos() const { return _tablet_fail_infos; }
+
+    std::vector<TTabletFailInfo>& tablet_fail_infos() { return _tablet_fail_infos; }
+
+    void append_tablet_fail_infos(TTabletFailInfo fail_info) {
+        std::lock_guard<std::mutex> l(_tablet_infos_lock);
+        _tablet_fail_infos.emplace_back(std::move(fail_info));
     }
 
     // get mem limit for load channel
@@ -417,8 +426,9 @@ private:
 
     std::string _error_log_file_path;
     std::ofstream* _error_log_file = nullptr; // error file path, absolute path
-    std::mutex _tablet_commit_infos_lock;
+    std::mutex _tablet_infos_lock;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
+    std::vector<TTabletFailInfo> _tablet_fail_infos;
 
     // prohibit copies
     RuntimeState(const RuntimeState&) = delete;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -228,6 +228,7 @@ public:
     std::unique_ptr<PulsarLoadInfo> pulsar_info;
 
     std::vector<TTabletCommitInfo> commit_infos;
+    std::vector<TTabletFailInfo> fail_infos;
 
     std::mutex lock;
 

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -27,6 +27,7 @@ namespace starrocks::vectorized {
 
 class AsyncDeltaWriterRequest;
 class CommittedRowsetInfo;
+class FailedRowsetInfo;
 class AsyncDeltaWriterCallback;
 class AsyncDeltaWriterSegmentRequest;
 
@@ -111,6 +112,12 @@ public:
     const ReplicateToken* replicate_token;
 };
 
+class FailedRowsetInfo {
+public:
+    const int64_t tablet_id;
+    const ReplicateToken* replicate_token;
+};
+
 class AsyncDeltaWriterRequest {
 public:
     // nullptr means no record to write
@@ -135,7 +142,7 @@ public:
     // st != Status::OK means either the writes or the commit failed.
     // st == Status::OK && info != nullptr means commit succeeded.
     // st == Status::OK && info == nullptr means the writes succeeded with no commit.
-    virtual void run(const Status& st, const CommittedRowsetInfo* info) = 0;
+    virtual void run(const Status& st, const CommittedRowsetInfo* info, const FailedRowsetInfo* failed_info) = 0;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -83,15 +83,7 @@ void DeltaWriter::_garbage_collection() {
 Status DeltaWriter::_init() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
 
-    if (_opt.is_replicated_storage) {
-        if (_opt.replicas.size() > 0 && _opt.replicas[0].node_id() == _opt.node_id) {
-            _replica_state = Primary;
-        } else {
-            _replica_state = Secondary;
-        }
-    } else {
-        _replica_state = Peer;
-    }
+    _replica_state = _opt.replica_state;
 
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
     _tablet = tablet_mgr->get_tablet(_opt.tablet_id, false);
@@ -125,8 +117,8 @@ Status DeltaWriter::_init() {
         }
     }
     if (_tablet->version_count() > config::tablet_max_versions) {
-        auto msg = fmt::format("Too many versions. tablet_id: {}, version_count: {}, limit: {}", _opt.tablet_id,
-                               _tablet->version_count(), config::tablet_max_versions);
+        auto msg = fmt::format("Too many versions. tablet_id: {}, version_count: {}, limit: {}, replica_state: {}",
+                               _opt.tablet_id, _tablet->version_count(), config::tablet_max_versions, _replica_state);
         LOG(ERROR) << msg;
         Status st = Status::ServiceUnavailable(msg);
         _set_state(kUninitialized, st);

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -26,6 +26,14 @@ namespace vectorized {
 class MemTable;
 class MemTableSink;
 
+enum ReplicaState {
+    // peer storage engine
+    Peer,
+    // replicated storage engine
+    Primary,
+    Secondary,
+};
+
 struct DeltaWriterOptions {
     int64_t tablet_id;
     int32_t schema_hash;
@@ -38,19 +46,11 @@ struct DeltaWriterOptions {
     Span parent_span;
     int64_t index_id;
     int64_t node_id;
-    bool is_replicated_storage = false;
     std::vector<PNetworkAddress> replicas;
     int64_t timeout_ms;
     WriteQuorumTypePB write_quorum;
     std::string merge_condition;
-};
-
-enum ReplicaState {
-    // peer storage engine
-    Peer,
-    // replicated storage engine
-    Primary,
-    Secondary,
+    ReplicaState replica_state;
 };
 
 enum State {

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -58,6 +58,9 @@ Status SegmentFlushToken::submit(brpc::Controller* cntl, const PTabletWriterAddS
         }
         if (!st.ok()) {
             writer->abort(true);
+            auto* tablet_info = response->add_failed_tablet_vec();
+            tablet_info->set_tablet_id(writer->tablet()->tablet_id());
+            tablet_info->set_node_id(writer->node_id());
         }
         st.to_protobuf(response->mutable_status());
         done->Run();

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -33,10 +33,12 @@ public:
     ~ReplicateChannel();
 
     Status sync_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
-                        std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos);
+                        std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
+                        std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
 
     Status async_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
-                         std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos);
+                         std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
+                         std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
 
     void cancel();
 
@@ -47,7 +49,8 @@ public:
 private:
     Status _init();
     void _send_request(SegmentPB* segment, butil::IOBuf& data, bool eos);
-    Status _wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos);
+    Status _wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
+                          std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
 
     const DeltaWriterOptions* _opt;
     const std::string _host;
@@ -92,6 +95,8 @@ public:
         return &_replicated_tablet_infos;
     }
 
+    const std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos() const { return &_failed_tablet_infos; }
+
 private:
     friend class SegmentReplicateTask;
 
@@ -108,6 +113,7 @@ private:
     std::vector<std::unique_ptr<ReplicateChannel>> _replicate_channels;
 
     std::vector<std::unique_ptr<PTabletInfo>> _replicated_tablet_infos;
+    std::vector<std::unique_ptr<PTabletInfo>> _failed_tablet_infos;
 
     std::unique_ptr<FileSystem> _fs;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -207,8 +207,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     // return map of (BE id -> path hash) of normal replicas
-    public Multimap<Long, Long> getNormalReplicaBackendPathMap(int clusterId) {
-        Multimap<Long, Long> map = HashMultimap.create();
+    public Multimap<Replica, Long> getNormalReplicaBackendPathMap(int clusterId) {
+        Multimap<Replica, Long> map = HashMultimap.create();
         SystemInfoService infoService = GlobalStateMgr.getCurrentState().getOrCreateSystemInfo(clusterId);
         for (Replica replica : replicas) {
             if (replica.isBad()) {
@@ -218,7 +218,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             ReplicaState state = replica.getState();
             if (infoService.checkBackendAlive(replica.getBackendId())
                     && (state == ReplicaState.NORMAL || state == ReplicaState.ALTER)) {
-                map.put(replica.getBackendId(), replica.getPathHash());
+                map.put(replica, replica.getPathHash());
             }
         }
         return map;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -160,6 +160,9 @@ public class Replica implements Writable {
      */
     private boolean deferReplicaDeleteToNextReport = true;
 
+    // if lastWriteFail is true, we can not use it as replicated storage primary replica
+    private volatile boolean lastWriteFail = false;
+
     public Replica() {
     }
 
@@ -197,6 +200,14 @@ public class Replica implements Writable {
         } else {
             this.lastSuccessVersion = lastSuccessVersion;
         }
+    }
+
+    public void setLastWriteFail(boolean lastWriteFail) {
+        this.lastWriteFail = lastWriteFail;
+    }
+
+    public boolean getLastWriteFail() {
+        return this.lastWriteFail;
     }
 
     public void setLastFailedTime(long lastFailedTime) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -344,7 +344,7 @@ public class CompactionScheduler extends Daemon {
         VisibleStateWaiter waiter;
         db.writeLock();
         try {
-            waiter = transactionMgr.commitTransaction(db.getId(), context.getTxnId(), commitInfoList);
+            waiter = transactionMgr.commitTransaction(db.getId(), context.getTxnId(), commitInfoList, Lists.newArrayList());
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -178,6 +178,7 @@ public class LakeDeleteJob extends DeleteJob {
         }
 
         return GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, timeoutMs);
+                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Lists.newArrayList(),
+                        timeoutMs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -115,6 +115,7 @@ import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMeta;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
@@ -1141,6 +1142,7 @@ public class LeaderImpl {
             boolean ret = GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
                     db, request.getTxn_id(),
                     TabletCommitInfo.fromThrift(request.getCommit_infos()),
+                    TabletFailInfo.fromThrift(request.getFail_infos()),
                     timeoutMs, attachment);
             if (!ret) {
                 TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -365,7 +365,8 @@ public class OlapDeleteJob extends DeleteJob {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
         }
-        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, tabletCommitInfos, timeoutMs,
+        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, tabletCommitInfos,
+                Lists.newArrayList(), timeoutMs,
                 new InsertTxnCommitAttachment());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -323,7 +323,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                     .add("msg", "Load job try to commit txn")
                     .build());
             GlobalStateMgr.getCurrentGlobalTransactionMgr().commitTransaction(
-                    dbId, transactionId, commitInfos,
+                    dbId, transactionId, commitInfos, failInfos,
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
                             finishTimestamp, state, failMsg));
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
@@ -366,6 +366,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             loadingStatus.setTrackingUrl(attachment.getTrackingUrl());
         }
         commitInfos.addAll(attachment.getCommitInfoList());
+        failInfos.addAll(attachment.getFailInfoList());
         progress = (int) ((double) finishedTaskIds.size() / idToTasks.size() * 100);
         if (progress == 100) {
             loadingStatus.getLoadStatistic().setLoadFinish();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -22,6 +22,7 @@
 package com.starrocks.load.loadv2;
 
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 
 import java.util.List;
 import java.util.Map;
@@ -31,13 +32,15 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
     private Map<String, String> counters;
     private String trackingUrl;
     private List<TabletCommitInfo> commitInfoList;
+    private List<TabletFailInfo> failInfoList;
 
     public BrokerLoadingTaskAttachment(long taskId, Map<String, String> counters, String trackingUrl,
-                                       List<TabletCommitInfo> commitInfoList) {
+                                       List<TabletCommitInfo> commitInfoList, List<TabletFailInfo> failInfoList) {
         super(taskId);
         this.trackingUrl = trackingUrl;
         this.counters = counters;
         this.commitInfoList = commitInfoList;
+        this.failInfoList = failInfoList;
     }
 
     public String getCounter(String key) {
@@ -54,5 +57,9 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     public List<TabletCommitInfo> getCommitInfoList() {
         return commitInfoList;
+    }
+
+    public List<TabletFailInfo> getFailInfoList() {
+        return failInfoList;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -47,6 +47,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +76,7 @@ public abstract class BulkLoadJob extends LoadJob {
     // include broker desc and data desc
     protected BrokerFileGroupAggInfo fileGroupAggInfo = new BrokerFileGroupAggInfo();
     protected List<TabletCommitInfo> commitInfos = Lists.newArrayList();
+    protected List<TabletFailInfo> failInfos = Lists.newArrayList();
 
     // sessionVariable's name -> sessionVariable's value
     // we persist these sessionVariables due to the session is not available when replaying the job.

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -42,6 +42,7 @@ import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -189,7 +190,8 @@ public class LoadLoadingTask extends LoadTask {
                 attachment = new BrokerLoadingTaskAttachment(signature,
                         curCoordinator.getLoadCounters(),
                         curCoordinator.getTrackingUrl(),
-                        TabletCommitInfo.fromThrift(curCoordinator.getCommitInfos()));
+                        TabletCommitInfo.fromThrift(curCoordinator.getCommitInfos()),
+                        TabletFailInfo.fromThrift(curCoordinator.getFailInfos()));
             } else {
                 throw new LoadException(status.getErrorMsg());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -697,7 +697,7 @@ public class SparkLoadJob extends BulkLoadJob {
         db.writeLock();
         try {
             GlobalStateMgr.getCurrentGlobalTransactionMgr().commitTransaction(
-                    dbId, transactionId, commitInfos,
+                    dbId, transactionId, commitInfos, Lists.newArrayList(),
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
                             finishTimestamp, state, failMsg));
         } catch (TabletQuorumFailedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -35,6 +35,7 @@ import com.starrocks.thrift.TStreamLoadChannel;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionCommitFailedException;
 import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
@@ -835,13 +836,14 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
 
     public void unprotectedPrepareTxn() throws UserException {
         List<TabletCommitInfo> commitInfos = TabletCommitInfo.fromThrift(coord.getCommitInfos());
+        List<TabletFailInfo> failInfos = TabletFailInfo.fromThrift(coord.getFailInfos());
         finishPreparingTimeMs = System.currentTimeMillis();
         StreamLoadTxnCommitAttachment txnCommitAttachment = new StreamLoadTxnCommitAttachment(
                 beforeLoadTimeMs, startLoadingTimeMs, startPreparingTimeMs, finishPreparingTimeMs,
                 endTimeMs, numRowsNormal, numRowsAbnormal, numRowsUnselected, numLoadBytesTotal,
                 trackingUrl);
         GlobalStateMgr.getCurrentGlobalTransactionMgr().prepareTransaction(dbId, 
-                txnId, commitInfos, txnCommitAttachment);
+                txnId, commitInfos, failInfos, txnCommitAttachment);
     }
 
     public boolean checkNeedRemove(long currentMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -132,6 +132,7 @@ import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionCommitFailedException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
@@ -1369,7 +1370,8 @@ public class StmtExecutor {
                                 database.getId(),
                                 transactionId,
                                 TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking_url = "
-                                        + coord.getTrackingUrl()
+                                        + coord.getTrackingUrl(),
+                                TabletFailInfo.fromThrift(coord.getFailInfos())
                         );
                     }
                     context.getState().setError("Insert has filtered data in strict mode, txn_id = " +
@@ -1416,6 +1418,7 @@ public class StmtExecutor {
                         database,
                         transactionId,
                         TabletCommitInfo.fromThrift(coord.getCommitInfos()),
+                        TabletFailInfo.fromThrift(coord.getFailInfos()),
                         context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000,
                         new InsertTxnCommitAttachment(loadedRows))) {
                     txnStatus = TransactionStatus.VISIBLE;
@@ -1447,7 +1450,8 @@ public class StmtExecutor {
                 } else {
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
                             database.getId(), transactionId,
-                            t.getMessage() == null ? "Unknown reason" : t.getMessage());
+                            t.getMessage() == null ? "Unknown reason" : t.getMessage(),
+                            TabletFailInfo.fromThrift(coord.getFailInfos()));
                 }
             } catch (Exception abortTxnException) {
                 // just print a log if abort txn failed. This failure do not need to pass to user.
@@ -1456,7 +1460,7 @@ public class StmtExecutor {
             }
 
             // if not using old load usage pattern, error will be returned directly to user
-            StringBuilder sb = new StringBuilder(t.getMessage());
+            StringBuilder sb = new StringBuilder(t.getMessage() == null ? "Unknown reason" : t.getMessage());
             if (coord != null && !Strings.isNullOrEmpty(coord.getTrackingUrl())) {
                 sb.append(". url: ").append(coord.getTrackingUrl());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -158,6 +158,7 @@ import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUpdateResourceUsageResponse;
 import com.starrocks.thrift.TUserPrivDesc;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionNotFoundException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
@@ -1014,6 +1015,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         boolean ret = GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
                 db, request.getTxnId(),
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
+                TabletFailInfo.fromThrift(request.getFailInfos()),
                 timeoutMs, attachment);
         if (!ret) {
             // committed success but not visible
@@ -1122,6 +1124,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         GlobalStateMgr.getCurrentGlobalTransactionMgr().prepareTransaction(
                 db.getId(), request.getTxnId(),
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
+                TabletFailInfo.fromThrift(request.getFailInfos()),
                 attachment);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -76,6 +76,9 @@ public class ComputeNode implements IComputable, Writable {
     @SerializedName("starletPort")
     private volatile int starletPort;
 
+    @SerializedName("lastWriteFail")
+    private volatile boolean lastWriteFail = false;
+
     private volatile int numRunningQueries = 0;
     private volatile long memLimitBytes = 0;
     private volatile long memUsedBytes = 0;
@@ -117,6 +120,14 @@ public class ComputeNode implements IComputable, Writable {
         this.ownerClusterName = "";
         this.backendState = Backend.BackendState.free.ordinal();
         this.decommissionType = DecommissionType.SystemDecommission.ordinal();
+    }
+
+    public void setLastWriteFail(boolean lastWriteFail) {
+        this.lastWriteFail = lastWriteFail;
+    }
+
+    public boolean getLastWriteFail() {
+        return this.lastWriteFail;
     }
 
     public int getStarletPort() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -42,7 +42,8 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     }
 
     @Override
-    public void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets) throws TransactionException {
+    public void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
+            List<TabletFailInfo> failedTablets) throws TransactionException {
         Preconditions.checkState(txnState.getTransactionStatus() != TransactionStatus.COMMITTED);
         if (table.getState() == OlapTable.OlapTableState.RESTORE) {
             throw new TransactionCommitFailedException("Cannot write RESTORE state table \"" + table.getName() + "\"");
@@ -112,7 +113,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     }
 
     @Override
-    public void postAbort(TransactionState txnState) {
+    public void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets) {
         Map<Long, List<Long>> tabletGroup = null;
         Database db = GlobalStateMgr.getCurrentState().getDb(txnState.getDbId());
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletFailInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletFailInfo.java
@@ -1,0 +1,62 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.transaction;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.starrocks.common.io.Writable;
+import com.starrocks.thrift.TTabletFailInfo;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+
+public class TabletFailInfo implements Writable {
+
+    private long tabletId;
+    private long backendId;
+
+    public TabletFailInfo(long tabletId, long backendId) {
+        super();
+        this.tabletId = tabletId;
+        this.backendId = backendId;
+    }
+
+    public long getTabletId() {
+        return tabletId;
+    }
+
+    public long getBackendId() {
+        return backendId;
+    }
+
+    public static List<TabletFailInfo> fromThrift(List<TTabletFailInfo> tTabletFailInfos) {
+        List<TabletFailInfo> failInfos = Lists.newArrayList();
+        if (tTabletFailInfos != null) {
+            for (TTabletFailInfo tTabletFailInfo : tTabletFailInfos) {
+                failInfos.add(new TabletFailInfo(tTabletFailInfo.getTabletId(),
+                        tTabletFailInfo.getBackendId()));
+
+            }
+        }
+        return failInfos;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        out.writeLong(tabletId);
+        out.writeLong(backendId);
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        tabletId = in.readLong();
+        backendId = in.readLong();
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListener.java
@@ -8,7 +8,8 @@ import java.util.List;
 // Used to check if a transaction can be committed and save some information in the TransactionState.
 public interface TransactionStateListener {
     // This method is called by the FE master before changing the in-memory TransactionState to COMMITTED.
-    void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets) throws TransactionException;
+    void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
+            List<TabletFailInfo> failedTablets) throws TransactionException;
 
     // This method is called by the FE master after changing the in-memory TransactionState to COMMITTED and before writing
     // the edit log.
@@ -20,5 +21,5 @@ public interface TransactionStateListener {
     // This method is called by the FE master after changed the TransactionState to ABORTED and *AFTER* released the writer
     // lock of the DatabaseTransactionMgr.
     // It's *unsafe* to access mutable fields of txnState inside this function.
-    void postAbort(TransactionState txnState);
+    void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -202,7 +202,7 @@ public class DeleteTest {
                     }
                 };
 
-                globalTransactionMgr.commitAndPublishTransaction(db, anyLong, (List) any, anyLong);
+                globalTransactionMgr.commitAndPublishTransaction(db, anyLong, (List) any, (List) any, anyLong);
                 result = true;
 
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -37,6 +37,7 @@ import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TxnCommitAttachment;
@@ -359,6 +360,7 @@ public class DeleteHandlerTest {
             {
                 try {
                     globalTransactionMgr.commitTransaction(anyLong, anyLong, (List<TabletCommitInfo>) any,
+                            (List<TabletFailInfo>) any,
                             (TxnCommitAttachment) any);
                 } catch (UserException e) {
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -63,6 +63,7 @@ import com.starrocks.task.PushTask;
 import com.starrocks.thrift.TEtlState;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import mockit.Expectations;
@@ -386,7 +387,7 @@ public class SparkLoadJobTest {
                 AgentTaskExecutor.submit((AgentBatchTask) any);
                 GlobalStateMgr.getCurrentGlobalTransactionMgr();
                 result = transactionMgr;
-                transactionMgr.commitTransaction(dbId, transactionId, (List<TabletCommitInfo>) any,
+                transactionMgr.commitTransaction(dbId, transactionId, (List<TabletCommitInfo>) any, (List<TabletFailInfo>) any,
                         (LoadJobFinalOperation) any);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -345,7 +345,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY, false);
+        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY, true);
         TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
         System.out.println(param);
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -730,7 +730,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets, null);
+        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                        Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         assertEquals(TransactionStatus.PREPARED, transactionState.getTransactionStatus());
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -208,6 +208,7 @@ message PTabletWriterAddBatchResult {
     repeated PTabletInfo tablet_vec = 2;
     optional int64 execution_time_us = 3;
     optional int64 wait_lock_time_us = 4;
+    repeated PTabletInfo failed_tablet_vec = 5;
 };
 
 message PTabletWriterAddSegmentRequest {
@@ -224,6 +225,7 @@ message PTabletWriterAddSegmentResult {
     optional StatusPB status = 1;
     optional int64 execution_time_us = 2;
     repeated PTabletInfo tablet_vec = 3;
+    repeated PTabletInfo failed_tablet_vec = 4;
 };
 
 // Tablet writer cancel.

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -452,6 +452,8 @@ struct TReportExecStatusParams {
   19: optional i64 source_load_bytes
 
   20: optional InternalService.TLoadJobType load_type
+
+  21: optional list<Types.TTabletFailInfo> failInfos
 }
 
 struct TFeResult {
@@ -664,6 +666,7 @@ struct TLoadTxnCommitRequest {
     10: optional i64 auth_code
     11: optional TTxnCommitAttachment txnCommitAttachment
     12: optional i64 thrift_rpc_timeout_ms
+    13: optional list<Types.TTabletFailInfo> failInfos
 }
 
 struct TLoadTxnCommitResult {
@@ -681,6 +684,7 @@ struct TLoadTxnRollbackRequest {
     8: optional string reason
     9: optional i64 auth_code
     10: optional TTxnCommitAttachment txnCommitAttachment
+    11: optional list<Types.TTabletFailInfo> failInfos
 }
 
 struct TLoadTxnRollbackResult {
@@ -961,6 +965,7 @@ struct TCommitRemoteTxnRequest {
     4: optional i32 commit_timeout_ms
     5: optional list<Types.TTabletCommitInfo> commit_infos
     6: optional TTxnCommitAttachment commit_attachment
+    7: optional list<Types.TTabletFailInfo> fail_infos
 }
 
 struct TCommitRemoteTxnResponse {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -409,6 +409,11 @@ struct TTabletCommitInfo {
     4: optional list<string> valid_dict_cache_columns
 }
 
+struct TTabletFailInfo {
+    1: optional i64 tabletId
+    2: optional i64 backendId
+}
+
 enum TLoadType {
     MANUAL_LOAD,
     ROUTINE_LOAD,


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, StarRocks will randomly select a replica as the `primary replica` of replicated storage during data load. If the primary replica fails for any reason, the entire load will fail.
Of course, when selecting the primary replica, we will exclude the nodes whose backend status is `not alive`, but this is far from enough. For example, the version of the replica `exceeds the limit`, the fluctuation of network delay and other anomalies are currently unaware. because the subsequent load may still be selected, this problematic replica caused subsequent load to continue to fail.
So we added a blacklist mechanism to avoid selecting those problematic replicas as primary replicas. When they are successfully loaded as secondary replicas, they will be removed from the blacklist.
At the same time, we use a `greedy strategy` to keep the primary replica distribution as balanced as possible between backends.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
