### PR TITLE
[Enhancement] reduce jdbc connections

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -825,7 +825,16 @@ CONF_String(dependency_librdkafka_debug, "all");
 // max loop count when be waiting its fragments finish
 CONF_Int64(loop_count_wait_fragments_finish, "0");
 
+// the maximum number of connections in the connection pool for a single jdbc url
 CONF_Int16(jdbc_connection_pool_size, "8");
+// the minimum number of idle connections that connection pool tries to maintain.
+// if the idle connections dip below this value and the total connections in the pool are less than jdbc_connection_pool_size,
+// the connection pool will make a best effort to add additional connections quickly.
+CONF_Int16(jdbc_minimum_idle_connections, "1");
+// the maximum amount of time that a connection is allowed to sit idle in the pool.
+// this setting only applies when jdbc_minimum_idle_connections is less than jdbc_connection_pool_size.
+// The minimum allowed value is 10000(10 seconds).
+CONF_Int32(jdbc_connection_idle_timeout_ms, "600000");
 
 // Now, only get_info is processed by _async_thread_pool, and only needs a small number of threads.
 // The default value is set as the THREAD_POOL_SIZE of RoutineLoadTaskScheduler of FE.

--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -97,7 +97,7 @@ Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
 
     jmethodID constructor = env->GetMethodID(
             scan_context_cls, "<init>",
-            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V");
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIII)V");
     jstring driver_class_name = env->NewStringUTF(_scan_ctx.driver_class_name.c_str());
     LOCAL_REF_GUARD_ENV(env, driver_class_name);
     jstring jdbc_url = env->NewStringUTF(_scan_ctx.jdbc_url.c_str());
@@ -110,9 +110,21 @@ Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
     LOCAL_REF_GUARD_ENV(env, sql);
     int statement_fetch_size = state->chunk_size();
     int connection_pool_size = config::jdbc_connection_pool_size;
+    if (UNLIKELY(connection_pool_size <= 0)) {
+        connection_pool_size = DEFAULT_JDBC_CONNECTION_POOL_SIZE;
+    }
+    int minimum_idle_connections = config::jdbc_minimum_idle_connections;
+    if (UNLIKELY(minimum_idle_connections < 0 || minimum_idle_connections > connection_pool_size)) {
+        minimum_idle_connections = connection_pool_size;
+    }
+    int idle_timeout_ms = config::jdbc_connection_idle_timeout_ms;
+    if (UNLIKELY(idle_timeout_ms < MINIMUM_ALLOWED_JDBC_CONNECTION_IDLE_TIMEOUT_MS)) {
+        idle_timeout_ms = MINIMUM_ALLOWED_JDBC_CONNECTION_IDLE_TIMEOUT_MS;
+    }
 
-    auto scan_ctx = env->NewObject(scan_context_cls, constructor, driver_class_name, jdbc_url, user, passwd, sql,
-                                   statement_fetch_size, connection_pool_size);
+    auto scan_ctx =
+            env->NewObject(scan_context_cls, constructor, driver_class_name, jdbc_url, user, passwd, sql,
+                           statement_fetch_size, connection_pool_size, minimum_idle_connections, idle_timeout_ms);
     _jdbc_scan_context = env->NewGlobalRef(scan_ctx);
     LOCAL_REF_GUARD_ENV(env, scan_ctx);
     CHECK_JAVA_EXCEPTION(env, "construct JDBCScanContext failed")

--- a/be/src/exec/vectorized/jdbc_scanner.h
+++ b/be/src/exec/vectorized/jdbc_scanner.h
@@ -111,5 +111,8 @@ private:
     static constexpr const char* JDBC_SCAN_CONTEXT_CLASS_NAME = "com/starrocks/jdbcbridge/JDBCScanContext";
     static constexpr const char* JDBC_SCANNER_CLASS_NAME = "com/starrocks/jdbcbridge/JDBCScanner";
     static constexpr const char* JDBC_UTIL_CLASS_NAME = "com/starrocks/jdbcbridge/JDBCUtil";
+
+    static const int32_t DEFAULT_JDBC_CONNECTION_POOL_SIZE = 8;
+    static const int32_t MINIMUM_ALLOWED_JDBC_CONNECTION_IDLE_TIMEOUT_MS = 10000;
 };
 } // namespace starrocks::vectorized

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanContext.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanContext.java
@@ -11,10 +11,13 @@ public class JDBCScanContext {
 
     private int statementFetchSize;
     private int connectionPoolSize;
+    private int minimumIdleConnections;
+    private int connectionIdleTimeoutMs;
 
     public JDBCScanContext() {}
     public JDBCScanContext(String driverClassName, String jdbcURL, String user, String password,
-                           String sql, int statementFetchSize, int connectionPoolSize) {
+                           String sql, int statementFetchSize, int connectionPoolSize,
+                           int minimumIdleConnections, int connectionIdleTimeoutMs) {
         this.driverClassName = driverClassName;
         this.jdbcURL = jdbcURL;
         this.user = user;
@@ -22,6 +25,8 @@ public class JDBCScanContext {
         this.sql = sql;
         this.statementFetchSize = statementFetchSize;
         this.connectionPoolSize = connectionPoolSize;
+        this.minimumIdleConnections = minimumIdleConnections;
+        this.connectionIdleTimeoutMs = connectionIdleTimeoutMs;
     }
 
     public void setDriverClassName(String driverClassName) {
@@ -74,6 +79,14 @@ public class JDBCScanContext {
 
     public int getConnectionPoolSize() {
         return connectionPoolSize;
+    }
+
+    public int getMinimumIdleConnections() {
+        return minimumIdleConnections;
+    }
+
+    public int getConnectionIdleTimeoutMs() {
+        return connectionIdleTimeoutMs;
     }
 
 }

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -32,13 +32,15 @@ public class JDBCScanner {
 
     public void open() throws Exception {
 
-        dataSource = DataSourceCache.getInstance().getSource(driverLocation, () -> {
+        dataSource = DataSourceCache.getInstance().getSource(scanContext.getJdbcURL(), () -> {
             HikariConfig config = new HikariConfig();
             config.setDriverClassName(scanContext.getDriverClassName());
             config.setJdbcUrl(scanContext.getJdbcURL());
             config.setUsername(scanContext.getUser());
             config.setPassword(scanContext.getPassword());
             config.setMaximumPoolSize(scanContext.getConnectionPoolSize());
+            config.setMinimumIdle(scanContext.getMinimumIdleConnections());
+            config.setIdleTimeout(scanContext.getConnectionIdleTimeoutMs());
             dataSource = new HikariDataSource(config);
             return dataSource;
         });


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12083

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In order to avoid frequent connection creation, BE introduced `DataSourceCache` to maintain  a dedicated connection pool for each jdbc data source. In the previous implementation, we use jdbc driver location to identify the jdbc data source. If the user create multiple jdbc resource with the same jdbc url, there will be multiple connection pools for the same jdbc resource.

Here I changed to directly use jdbc url to identify jdbc data source to reduce jdbc connections.
In addition to this, two new configurations are added to control the number of idle connections in the connection pool.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
