### PR TITLE
[BugFix]catch all exceptions from driver process

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -119,7 +119,8 @@ void GlobalDriverExecutor::_worker_thread() {
                 _finalize_driver(driver, runtime_state, driver->driver_state());
                 continue;
             }
-            auto maybe_state = TRY_CATCH_ALL(driver->process(runtime_state, worker_id));
+            StatusOr<DriverState> maybe_state;
+            TRY_CATCH_ALL(maybe_state, driver->process(runtime_state, worker_id));
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -119,7 +119,7 @@ void GlobalDriverExecutor::_worker_thread() {
                 _finalize_driver(driver, runtime_state, driver->driver_state());
                 continue;
             }
-            auto maybe_state = driver->process(runtime_state, worker_id);
+            auto maybe_state = TRY_CATCH_ALL(driver->process(runtime_state, worker_id));
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -120,7 +120,11 @@ void GlobalDriverExecutor::_worker_thread() {
                 continue;
             }
             StatusOr<DriverState> maybe_state;
+#ifdef NDEBUG
             TRY_CATCH_ALL(maybe_state, driver->process(runtime_state, worker_id));
+#else
+            maybe_state = driver->process(runtime_state, worker_id);
+#endif
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
 

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -272,12 +272,12 @@ private:
         try {                                                                            \
             SCOPED_SET_CATCHED(true);                                                    \
             { result = stmt; }                                                           \
-        } catch (std::bad_alloc const& e) {                                              \
-            result = Status::InternalError(fmt::format("Internal error: {}", e.what())); \
         } catch (std::runtime_error const& e) {                                          \
             result = Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));   \
         } catch (std::exception const& e) {                                              \
-            result = Status::Unknown(fmt::format("Unknown error: {}", e.what()));        \
+            result = Status::InternalError(fmt::format("Internal error: {}", e.what())); \
+        } catch (...) {                                                                  \
+            result = Status::Unknown("Unknown error");                                   \
         }                                                                                \
     } while (0)
 } // namespace starrocks

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -267,17 +267,17 @@ private:
         TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
-#define TRY_CATCH_ALL(stmt)                                                            \
-    do {                                                                               \
-        try {                                                                          \
-            SCOPED_SET_CATCHED(true);                                                  \
-            { stmt; }                                                                  \
-        } catch (std::bad_alloc const& e) {                                            \
-            return Status::InternalError(fmt::format("Internal error: {}", e.what())); \
-        } catch (std::runtime_error const& e) {                                        \
-            return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));   \
-        } catch (const std::exception& e) {                                            \
-            return Status::Unknown(fmt::format("Unknown error: {}", e.what()));        \
-        }                                                                              \
+#define TRY_CATCH_ALL(result, stmt)                                                      \
+    do {                                                                                 \
+        try {                                                                            \
+            SCOPED_SET_CATCHED(true);                                                    \
+            { result = stmt; }                                                           \
+        } catch (std::bad_alloc const& e) {                                              \
+            result = Status::InternalError(fmt::format("Internal error: {}", e.what())); \
+        } catch (std::runtime_error const& e) {                                          \
+            result = Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));   \
+        } catch (std::exception const& e) {                                              \
+            result = Status::Unknown(fmt::format("Unknown error: {}", e.what()));        \
+        }                                                                                \
     } while (0)
 } // namespace starrocks

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -267,4 +267,17 @@ private:
         TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
+#define TRY_CATCH_ALL(stmt)                                                            \
+    do {                                                                               \
+        try {                                                                          \
+            SCOPED_SET_CATCHED(true);                                                  \
+            { stmt; }                                                                  \
+        } catch (std::bad_alloc const& e) {                                            \
+            return Status::InternalError(fmt::format("Internal error: {}", e.what())); \
+        } catch (std::runtime_error const& e) {                                        \
+            return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));   \
+        } catch (const std::exception& e) {                                            \
+            return Status::Unknown(fmt::format("Unknown error: {}", e.what()));        \
+        }                                                                              \
+    } while (0)
 } // namespace starrocks


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/12308

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are many potential exceptions when running sql, which may result from bugs or some other reasons. whatever, BE should not crash, so we should catch all exceptions for processing drivers.

result for the first problem in the issue
```
mysql> select exchange_speed(pv) from t group by siteid;
ERROR 1064 (HY000): Internal error: std::bad_alloc
```

the second should add some checks for some potential wrong codes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature [check by manual]
- [ ] I have added user document for my new feature or new function
