### PR TITLE
[BugFix] remove unnecessary null aware anti join 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
@@ -49,8 +49,10 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
         // NOT IN to ANTI-JOIN or NULL_AWARE_LEFT_ANTI_JOIN
         OptExpression joinExpression;
         if (ipo.isNotIn()) {
-            //@TODO: if will can filter null, use left-anti-join
-            joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN,
+            boolean operandsNullable = bpo.getChildren().stream().anyMatch(ScalarOperator::isNullable);
+            JoinOperator joinType = operandsNullable ?
+                    JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN : JoinOperator.LEFT_ANTI_JOIN;
+            joinExpression = new OptExpression(new LogicalJoinOperator(joinType,
                     Utils.compoundAnd(bpo, Utils.compoundAnd(apply.getCorrelationConjuncts(), apply.getPredicate()))));
         } else {
             joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.LEFT_SEMI_JOIN,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -527,4 +527,13 @@ public class SubqueryTest extends PlanTestBase {
                 "  |  <slot 4> : 4: v7\n" +
                 "  |  <slot 8> : 5: v8 + 1");
     }
+
+    @Test
+    public void testTransformNAAJ() throws Exception {
+        String sql = "select * from t0_not_null where v1 not in (select v2 from t0_not_null)";
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "NULL AWARE LEFT ANTI JOIN");
+        assertContains(plan, "LEFT ANTI JOIN");
+
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When  `select * from tblA where colA not in (select colB from tblB)` colA and colB both not null, we can transform this subquery to normal anti join instead null aware anti join, which helps simplify the be processing.  

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
