### PR TITLE
[BugFix] release rowset id while remove rowset of primary key tablet

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2584,6 +2584,7 @@ void TabletUpdates::_remove_unused_rowsets() {
             skipped_rowsets.emplace_back(std::move(rowset));
             continue;
         }
+        StorageEngine::instance()->release_rowset_id(rowset->rowset_id());
         rowset->close();
         rowset->set_need_delete_file();
         auto ost = rowset->remove();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2584,9 +2584,9 @@ void TabletUpdates::_remove_unused_rowsets() {
             skipped_rowsets.emplace_back(std::move(rowset));
             continue;
         }
-        StorageEngine::instance()->release_rowset_id(rowset->rowset_id());
         rowset->close();
         rowset->set_need_delete_file();
+        StorageEngine::instance()->release_rowset_id(rowset->rowset_id());
         auto ost = rowset->remove();
         VLOG(1) << "remove rowset " << _tablet.tablet_id() << "@" << rowset->rowset_meta()->get_rowset_seg_id() << "@"
                 << rowset->rowset_id() << ": " << ost << " tablet:" << _tablet.tablet_id();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

While finish compaction of primarykey, we don't release the rowset id of expired rowset which cause memory leak.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
