### PR TITLE
[BugFix] Fix NPE when broker_addresses of export sink is empty.

### DIFF
--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -121,6 +121,10 @@ Status ExportSinkIOBuffer::_open_file_writer(int timeout_ms) {
             ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(file_path, FSOptions(&_t_export_sink)));
             ASSIGN_OR_RETURN(output_file, fs->new_writable_file(options, file_path));
         } else {
+            if (_t_export_sink.broker_addresses.empty()) {
+                LOG(WARNING) << "ExportSink broker_addresses empty";
+                return Status::InternalError("ExportSink broker_addresses empty");
+            }
             const TNetworkAddress& broker_addr = _t_export_sink.broker_addresses[0];
             BrokerFileSystem fs_broker(broker_addr, _t_export_sink.properties, timeout_ms);
             ASSIGN_OR_RETURN(output_file, fs_broker.new_writable_file(options, file_path));

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -123,6 +123,10 @@ Status ExportSink::open_file_writer(int timeout_ms) {
             ASSIGN_OR_RETURN(output_file, fs->new_writable_file(options, file_path));
             break;
         } else {
+            if (_t_export_sink.broker_addresses.empty()) {
+                LOG(WARNING) << "ExportSink broker_addresses empty";
+                return Status::InternalError("ExportSink broker_addresses empty");
+            }
             const TNetworkAddress& broker_addr = _t_export_sink.broker_addresses[0];
             BrokerFileSystem fs_broker(broker_addr, _t_export_sink.properties, timeout_ms);
             ASSIGN_OR_RETURN(output_file, fs_broker.new_writable_file(options, file_path));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12301

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

![img_v2_71cf8537-4c28-40d5-85b0-2347ab692d0g](https://user-images.githubusercontent.com/16617323/196896607-4b7dcd5c-fad7-4828-bc20-49536beb096a.jpg)