### PR TITLE
[Tool] Add patches and scripts to compile StarRocks on Ubuntu

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -380,6 +380,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} $ENV{STARROCKS_CXX_LINKER_
 #  -pthread: enable multithreaded malloc
 #  -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG: enable nanosecond precision for boost
 #  -fno-omit-frame-pointers: Keep frame pointer for functions in register
+#  -no-pie: Disable Position Independent Executables (PIE) as certain libraries cannot be linked against PIE executables.
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall -Wno-sign-compare -Wno-unknown-pragmas -pthread -Wno-register")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-strict-aliasing -fno-omit-frame-pointer")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=gnu++17 -D__STDC_FORMAT_MACROS")
@@ -387,6 +388,7 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-deprecated -Wno-vla -Wno-comment"
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=return-type -Werror=switch")
+set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -no-pie")
 if (${USE_STAROS} STREQUAL "ON")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DUSE_STAROS")
 endif()

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <new>
 #include <numeric>
+#include <optional>
 #include <roaring/roaring.hh>
 #include <stdexcept>
 #include <string>

--- a/be/src/util/priority_queue_inl.h
+++ b/be/src/util/priority_queue_inl.h
@@ -17,7 +17,7 @@ inline bool PriorityQueue<NUM_PRIORITY, T, Container>::empty() const noexcept {
 template <int NUM_PRIORITY, class T, class Container>
 inline typename PriorityQueue<NUM_PRIORITY, T, Container>::size_type PriorityQueue<NUM_PRIORITY, T, Container>::size()
         const noexcept {
-    size_t sz = 0;
+    std::size_t sz = 0;
     for (const auto& q : _queues) {
         sz += q.size();
     }

--- a/be/test/storage/rowset/frame_of_reference_page_test.cpp
+++ b/be/test/storage/rowset/frame_of_reference_page_test.cpp
@@ -88,7 +88,11 @@ public:
 
         for (uint i = 0; i < size; i++) {
             if (src[i] != values[i]) {
-                FAIL() << "Fail at index " << i << " inserted=" << src[i] << " got=" << values[i];
+                // Change the logging because g++-11 complains about ambiguous overload:
+                // In template: use of overloaded operator '<<' is ambiguous (with operand types 'std::basic_stringstream<char>' and 'const __int128')
+
+                // FAIL() << "Fail at index " << i << " inserted=" << src[i] << " got=" << values[i];
+                FAIL() << "Fail at index " << i;
             }
         }
 

--- a/thirdparty/build-thirdparty-ubuntu.sh
+++ b/thirdparty/build-thirdparty-ubuntu.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#################################################################################
+# This script will
+# 1. Check prerequisite libraries. Including:
+#    cmake byacc flex automake libtool binutils-dev libiberty-dev bison
+# 2. Compile and install all thirdparties which are downloaded
+#    using *download-thirdparty-ubuntu.sh*.
+#
+# This script will run *download-thirdparty-ubuntu.sh* once again
+# to check if all thirdparties have been downloaded, unpacked and patched.
+#################################################################################
+set -e
+
+curdir=`dirname "$0"`
+curdir=`cd "$curdir"; pwd`
+
+export STARROCKS_HOME=$curdir/..
+export TP_DIR=$curdir
+
+# include custom environment variables
+if [[ -f ${STARROCKS_HOME}/env.sh ]]; then
+    . ${STARROCKS_HOME}/env.sh
+fi
+
+if [[ ! -f ${TP_DIR}/download-thirdparty-ubuntu.sh ]]; then
+    echo "Download thirdparty script is missing".
+    exit 1
+fi
+
+if [ ! -f ${TP_DIR}/vars-ubuntu.sh ]; then
+    echo "vars-ubuntu.sh is missing".
+    exit 1
+fi
+. ${TP_DIR}/vars-ubuntu.sh
+
+cd $TP_DIR
+
+# Download thirdparties.
+${TP_DIR}/download-thirdparty-ubuntu.sh
+
+export C_INCLUDE_PATH=${TP_INCLUDE_DIR}:${C_INCLUDE_PATH}
+export CPLUS_INCLUDE_PATH=${TP_INCLUDE_DIR}:${CPLUS_INCLUDE_PATH}
+export LD_LIBRARY_PATH=$TP_DIR/installed/lib:$LD_LIBRARY_PATH
+
+# set COMPILER
+if [[ ! -z ${STARROCKS_GCC_HOME} ]]; then
+    export CC=${STARROCKS_GCC_HOME}/bin/gcc
+    export CPP=${STARROCKS_GCC_HOME}/bin/cpp
+    export CXX=${STARROCKS_GCC_HOME}/bin/g++
+else
+    echo "STARROCKS_GCC_HOME environment variable is not set"
+    exit 1
+fi
+
+# prepare installed prefix
+mkdir -p ${TP_DIR}/installed
+
+check_prerequest() {
+    local CMD=$1
+    local NAME=$2
+    if ! $CMD; then
+        echo $NAME is missing
+        exit 1
+    else
+        echo $NAME is found
+    fi
+}
+
+# sudo apt-get install cmake
+# sudo yum install cmake
+check_prerequest "${CMAKE_CMD} --version" "cmake"
+
+# sudo apt-get install byacc
+# sudo yum install byacc
+# check_prerequest "byacc -V" "byacc"
+
+# sudo apt-get install flex
+# sudo yum install flex
+check_prerequest "flex -V" "flex"
+
+# sudo apt-get install automake
+# sudo yum install automake
+check_prerequest "automake --version" "automake"
+
+# sudo apt-get install libtool
+# sudo yum install libtool
+check_prerequest "libtoolize --version" "libtool"
+
+BUILD_SYSTEM=${BUILD_SYSTEM:-make}
+
+# sudo apt-get install binutils-dev
+# sudo yum install binutils-devel
+#check_prerequest "locate libbfd.a" "binutils-dev"
+
+# sudo apt-get install libiberty-dev
+# no need in centos 7.1
+#check_prerequest "locate libiberty.a" "libiberty-dev"
+
+# sudo apt-get install bison
+# sudo yum install bison
+#check_prerequest "bison --version" "bison"
+
+#########################
+# build all thirdparties
+#########################
+
+
+# Name of cmake build directory in each thirdpary project.
+# Do not use `build`, because many projects contained a file named `BUILD`
+# and if the filesystem is not case sensitive, `mkdir` will fail.
+BUILD_DIR=starrocks_build
+MACHINE_TYPE=$(uname -m)
+
+check_if_source_exist() {
+    if [ -z $1 ]; then
+        echo "dir should specified to check if exist."
+        exit 1
+    fi
+
+    if [ ! -d $TP_SOURCE_DIR/$1 ];then
+        echo "$TP_SOURCE_DIR/$1 does not exist."
+        exit 1
+    fi
+    echo "===== begin build $1"
+}
+
+check_if_archieve_exist() {
+    if [ -z $1 ]; then
+        echo "archieve should specified to check if exist."
+        exit 1
+    fi
+
+    if [ ! -f $TP_SOURCE_DIR/$1 ];then
+        echo "$TP_SOURCE_DIR/$1 does not exist."
+        exit 1
+    fi
+}
+
+export TP_DEPLOY_DIR=/var/local/thirdparty/installed
+
+# libevent
+build_libevent() {
+    check_if_source_exist $LIBEVENT_SOURCE
+    cd $TP_SOURCE_DIR/$LIBEVENT_SOURCE
+    if [ ! -f configure ]; then
+        ./autogen.sh
+    fi
+
+    LDFLAGS="-L${TP_LIB_DIR}" \
+    ./configure --prefix=$TP_INSTALL_DIR --enable-shared=no --disable-samples --disable-libevent-regress
+    make -j$PARALLEL
+    make install
+
+    cp $TP_INSTALL_DIR/lib/libevent*.a $TP_DEPLOY_DIR/lib
+    cp $TP_INSTALL_DIR/lib/libevent*.la $TP_DEPLOY_DIR/lib
+    echo "Deployed libevent to $TP_DEPLOY_DIR"
+}
+
+# brpc
+build_brpc() {
+    check_if_source_exist $BRPC_SOURCE
+
+    cd $TP_SOURCE_DIR/$BRPC_SOURCE
+    sh config_brpc.sh --headers="$TP_DEPLOY_DIR/include usr/include" --libs="$TP_DEPLOY_DIR/bin $TP_DEPLOY_DIR/lib /usr/lib" --with-glog
+    make -j$PARALLEL
+    cp $TP_SOURCE_DIR/$BRPC_SOURCE/output/lib/libbrpc.a $TP_DEPLOY_DIR/lib64
+    echo "Deployed libbrpc.a to $TP_DEPLOY_DIR/lib64"
+}
+
+export CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess -fPIC -g -I${TP_INCLUDE_DIR}"
+export CPPFLAGS=$CXXFLAGS
+# https://stackoverflow.com/questions/42597685/storage-size-of-timespec-isnt-known
+export CFLAGS="-O3 -fno-omit-frame-pointer -std=c99 -fPIC -g -D_POSIX_C_SOURCE=199309L -I${TP_INCLUDE_DIR}"
+
+build_libevent
+build_brpc
+
+echo "Finished to build all thirdparties"
+

--- a/thirdparty/copy_from_docker.sh
+++ b/thirdparty/copy_from_docker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+STARROCKS_BRANCH=2.4
+
+docker create --name temp-sr-dev-env-$STARROCKS_BRANCH starrocks/dev-env:branch-$STARROCKS_BRANCH
+mkdir -p /var/local/thirdparty
+docker cp temp-sr-dev-env-$STARROCKS_BRANCH:/var/local/thirdparty/installed /var/local/thirdparty
+docker rm temp-sr-dev-env-$STARROCKS_BRANCH

--- a/thirdparty/download-thirdparty-ubuntu.sh
+++ b/thirdparty/download-thirdparty-ubuntu.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#set -e
+################################################################
+# This script will download all thirdparties and java libraries
+# which are defined in *vars-ubuntu.sh*, unpack patch them if necessary.
+# You can run this script multi-times.
+# Things will only be downloaded, unpacked and patched once.
+################################################################
+
+curdir=`dirname "$0"`
+curdir=`cd "$curdir"; pwd`
+
+if [[ -z "${STARROCKS_HOME}" ]]; then
+    STARROCKS_HOME=$curdir/..
+fi
+
+# include custom environment variables
+if [[ -f ${STARROCKS_HOME}/custom_env.sh ]]; then
+    . ${STARROCKS_HOME}/custom_env.sh
+fi
+
+if [[ -z "${TP_DIR}" ]]; then
+    TP_DIR=$curdir
+fi
+
+if [ ! -f ${TP_DIR}/vars-ubuntu.sh ]; then
+    echo "vars-ubuntu.sh is missing".
+    exit 1
+fi
+. ${TP_DIR}/vars-ubuntu.sh
+
+mkdir -p ${TP_DIR}/src
+
+md5sum_bin=md5sum
+if ! command -v ${md5sum_bin} >/dev/null 2>&1; then
+    echo "Warn: md5sum is not installed"
+    md5sum_bin=""
+fi
+
+md5sum_func() {
+    local FILENAME=$1
+    local DESC_DIR=$2
+    local MD5SUM=$3
+
+    if [ "$md5sum_bin" == "" ]; then
+       return 0
+    else
+       md5=`md5sum "$DESC_DIR/$FILENAME"`
+       if [ "$md5" != "$MD5SUM  $DESC_DIR/$FILENAME" ]; then
+           echo "$DESC_DIR/$FILENAME md5sum check failed!"
+           echo -e "except-md5 $MD5SUM \nactual-md5 $md5"
+           return 1
+       fi
+    fi
+
+    return 0
+}
+
+download_func() {
+    local FILENAME=$1
+    local DOWNLOAD_URL=$2
+    local DESC_DIR=$3
+    local MD5SUM=$4
+
+    if [ -z "$FILENAME" ]; then
+        echo "Error: No file name specified to download"
+        exit 1
+    fi
+    if [ -z "$DOWNLOAD_URL" ]; then
+        echo "Error: No download url specified for $FILENAME"
+        exit 1
+    fi
+    if [ -z "$DESC_DIR" ]; then
+        echo "Error: No dest dir specified for $FILENAME"
+        exit 1
+    fi
+
+
+    SUCCESS=0
+    for attemp in 1 2; do
+        if [ -r "$DESC_DIR/$FILENAME" ]; then
+            if md5sum_func $FILENAME $DESC_DIR $MD5SUM; then
+                echo "Archive $FILENAME already exist."
+                SUCCESS=1
+                break;
+            fi
+            echo "Archive $FILENAME will be removed and download again."
+            rm -f "$DESC_DIR/$FILENAME"
+        else
+            echo "Downloading $FILENAME from $DOWNLOAD_URL to $DESC_DIR"
+            wget --no-check-certificate $DOWNLOAD_URL -O $DESC_DIR/$FILENAME
+            if [ "$?"x == "0"x ]; then
+                if md5sum_func $FILENAME $DESC_DIR $MD5SUM; then
+                    SUCCESS=1
+                    echo "Success to download $FILENAME"
+                    break;
+                fi
+                echo "Archive $FILENAME will be removed and download again."
+                rm -f "$DESC_DIR/$FILENAME"
+            else
+                echo "Failed to download $FILENAME. attemp: $attemp"
+            fi
+        fi
+    done
+
+    if [ $SUCCESS -ne 1 ]; then
+        echo "Failed to download $FILENAME"
+    fi
+    return $SUCCESS
+}
+
+# download thirdparty archives
+echo "===== Downloading thirdparty archives..."
+for TP_ARCH in ${TP_ARCHIVES[*]}
+do
+    NAME=$TP_ARCH"_NAME"
+    MD5SUM=$TP_ARCH"_MD5SUM"
+    if test "x$REPOSITORY_URL" = x; then
+        URL=$TP_ARCH"_DOWNLOAD"
+        download_func ${!NAME} ${!URL} $TP_SOURCE_DIR ${!MD5SUM}
+        if [ "$?"x == "0"x ]; then
+            echo "Failed to download ${!NAME}"
+            exit 1
+        fi
+    else
+        URL="${REPOSITORY_URL}/${!NAME}"
+        download_func ${!NAME} ${URL} $TP_SOURCE_DIR ${!MD5SUM}
+        if [ "$?x" == "0x" ]; then
+            #try to download from home
+            URL=$TP_ARCH"_DOWNLOAD"
+            download_func ${!NAME} ${!URL} $TP_SOURCE_DIR ${!MD5SUM}
+            if [ "$?x" == "0x" ]; then
+                echo "Failed to download ${!NAME}"
+                exit 1 # download failed again exit.
+            fi
+        fi
+    fi
+done
+echo "===== Downloading thirdparty archives...done"
+
+# check if all tp archievs exists
+echo "===== Checking all thirdpart archives..."
+for TP_ARCH in ${TP_ARCHIVES[*]}
+do
+    NAME=$TP_ARCH"_NAME"
+    if [ ! -r $TP_SOURCE_DIR/${!NAME} ]; then
+        echo "Failed to fetch ${!NAME}"
+        exit 1
+    fi
+done
+echo "===== Checking all thirdpart archives...done"
+
+# unpacking thirdpart archives
+echo "===== Unpacking all thirdparty archives..."
+TAR_CMD="tar"
+UNZIP_CMD="unzip"
+SUFFIX_TGZ="\.(tar\.gz|tgz)$"
+SUFFIX_XZ="\.tar\.xz$"
+SUFFIX_ZIP="\.zip$"
+SUFFIX_BZ2="\.bz2$"
+# temporary directory for unpacking
+# package is unpacked in tmp_dir and then renamed.
+mkdir -p $TP_SOURCE_DIR/tmp_dir
+for TP_ARCH in ${TP_ARCHIVES[*]}
+do
+    NAME=$TP_ARCH"_NAME"
+    SOURCE=$TP_ARCH"_SOURCE"
+
+    if [ -z "${!SOURCE}" ]; then
+        continue
+    fi
+
+    if [ ! -d $TP_SOURCE_DIR/${!SOURCE} ]; then
+        if [[ "${!NAME}" =~ $SUFFIX_TGZ  ]]; then
+            echo "$TP_SOURCE_DIR/${!NAME}"
+            echo "$TP_SOURCE_DIR/${!SOURCE}"
+            if ! $TAR_CMD xzf "$TP_SOURCE_DIR/${!NAME}" -C $TP_SOURCE_DIR/tmp_dir; then
+                echo "Failed to untar ${!NAME}"
+                exit 1
+            fi
+        elif [[ "${!NAME}" =~ $SUFFIX_XZ ]]; then
+            echo "$TP_SOURCE_DIR/${!NAME}"
+            echo "$TP_SOURCE_DIR/${!SOURCE}"
+            if ! $TAR_CMD xJf "$TP_SOURCE_DIR/${!NAME}" -C $TP_SOURCE_DIR/tmp_dir; then
+                echo "Failed to untar ${!NAME}"
+                exit 1
+            fi
+        elif [[ "${!NAME}" =~ $SUFFIX_ZIP ]]; then
+            if ! $UNZIP_CMD "$TP_SOURCE_DIR/${!NAME}" -d $TP_SOURCE_DIR/tmp_dir; then
+                echo "Failed to unzip ${!NAME}"
+                exit 1
+            fi
+        elif [[ "${!NAME}" =~ $SUFFIX_BZ2 ]]; then
+            echo "$TP_SOURCE_DIR/${!NAME}"
+            echo "$TP_SOURCE_DIR/${!SOURCE}"
+            if ! $TAR_CMD jxvf "$TP_SOURCE_DIR/${!NAME}" -C $TP_SOURCE_DIR/tmp_dir; then
+                echo "Failed to untar ${!NAME}"
+                exit 1
+            fi
+        else
+            echo "nothing has been done with ${!NAME}"
+            continue
+        fi
+        mv $TP_SOURCE_DIR/tmp_dir/* $TP_SOURCE_DIR/${!SOURCE}
+    else
+        echo "${!SOURCE} already unpacked."
+    fi
+done
+rm -r $TP_SOURCE_DIR/tmp_dir
+echo "===== Unpacking all thirdparty archives...done"
+
+echo "===== Patching thirdparty archives..."
+
+###################################################################################
+# PATCHED_MARK is a empty file which will be created in some thirdparty source dir
+# only after that thirdparty source is patched.
+# This is to avoid duplicated patch.
+###################################################################################
+PATCHED_MARK="patched_mark"
+
+
+# libevent patch
+cd $TP_SOURCE_DIR/$LIBEVENT_SOURCE
+if [ ! -f $PATCHED_MARK ]; then
+    patch -p1 < $TP_PATCH_DIR/libevent_on_free_cb.patch
+    touch $PATCHED_MARK
+fi
+cd -
+echo "Finished patching $LIBEVENT_SOURCE"
+
+# brpc patch
+cd $TP_SOURCE_DIR/$BRPC_SOURCE
+if [ ! -f $PATCHED_MARK ]; then
+    patch -p1 < $TP_PATCH_DIR/brpc-0.9.7-ubuntu.patch
+    touch $PATCHED_MARK
+fi
+cd -
+echo "Finished patching $BRPC_SOURCE"

--- a/thirdparty/patches/brpc-0.9.7-ubuntu.patch
+++ b/thirdparty/patches/brpc-0.9.7-ubuntu.patch
@@ -1,0 +1,540 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 057695af..bfc9fe4f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,7 +108,7 @@ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG
+ if(WITH_MESALINK)
+     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DUSE_MESALINK")
+ endif()
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
+ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEBUG_SYMBOL} ${THRIFT_CPP_FLAG}")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ set(CMAKE_C_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer")
+diff --git a/Makefile b/Makefile
+index 3538e47c..dd0434f1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -20,10 +20,9 @@ include config.mk
+ 
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-# 3. Removed -Werror: Not block compilation for non-vital warnings, especially when the
++# 2. Removed -Werror: Not block compilation for non-vital warnings, especially when the
+ #    code is tested on newer systems. If the code is used in production, add -Werror back
+-CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DNDEBUG -DBRPC_REVISION=\"$(shell ./tools/get_brpc_revision.sh .)\"
++CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DNDEBUG -DBRPC_REVISION=\"$(shell ./tools/get_brpc_revision.sh .)\"
+ CXXFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
+ CFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer
+ DEBUG_CXXFLAGS = $(filter-out -DNDEBUG,$(CXXFLAGS)) -DUNIT_TEST -DBVAR_NOT_LINK_DEFAULT_VARIABLES
+diff --git a/config_brpc.sh b/config_brpc.sh
+index 1720031f..03785535 100755
+--- a/config_brpc.sh
++++ b/config_brpc.sh
+@@ -315,6 +315,10 @@ append_to_output "STATIC_LINKINGS=$STATIC_LINKINGS"
+ append_to_output "DYNAMIC_LINKINGS=$DYNAMIC_LINKINGS"
+ CPPFLAGS="-DBRPC_WITH_GLOG=$WITH_GLOG -DGFLAGS_NS=$GFLAGS_NS"
+ 
++# Avoid over-optimizations of TLS variables by GCC>=4.8
++# See: https://github.com/apache/incubator-brpc/issues/1693
++CPPFLAGS="${CPPFLAGS} -D__const__=__unused__"
++
+ if [ ! -z "$DEBUGSYMBOLS" ]; then
+     CPPFLAGS="${CPPFLAGS} $DEBUGSYMBOLS"
+ fi
+diff --git a/example/BUILD b/example/BUILD
+index ee2c6ffd..d688749d 100644
+--- a/example/BUILD
++++ b/example/BUILD
+@@ -16,7 +16,7 @@
+ COPTS = [
+     "-D__STDC_FORMAT_MACROS",
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/example/asynchronous_echo_c++/CMakeLists.txt b/example/asynchronous_echo_c++/CMakeLists.txt
+index 18fec20e..4a118b19 100644
+--- a/example/asynchronous_echo_c++/CMakeLists.txt
++++ b/example/asynchronous_echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/auto_concurrency_limiter/CMakeLists.txt b/example/auto_concurrency_limiter/CMakeLists.txt
+index ef20bf0a..88b78427 100644
+--- a/example/auto_concurrency_limiter/CMakeLists.txt
++++ b/example/auto_concurrency_limiter/CMakeLists.txt
+@@ -70,7 +70,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/backup_request_c++/CMakeLists.txt b/example/backup_request_c++/CMakeLists.txt
+index d247bc15..fc39ba3c 100644
+--- a/example/backup_request_c++/CMakeLists.txt
++++ b/example/backup_request_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cancel_c++/CMakeLists.txt b/example/cancel_c++/CMakeLists.txt
+index 26f2581b..ea611e03 100644
+--- a/example/cancel_c++/CMakeLists.txt
++++ b/example/cancel_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cascade_echo_c++/CMakeLists.txt b/example/cascade_echo_c++/CMakeLists.txt
+index 24d9249a..6ca2e25d 100644
+--- a/example/cascade_echo_c++/CMakeLists.txt
++++ b/example/cascade_echo_c++/CMakeLists.txt
+@@ -80,7 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/dynamic_partition_echo_c++/CMakeLists.txt b/example/dynamic_partition_echo_c++/CMakeLists.txt
+index 5a268a6c..8df3ad62 100644
+--- a/example/dynamic_partition_echo_c++/CMakeLists.txt
++++ b/example/dynamic_partition_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/echo_c++/CMakeLists.txt b/example/echo_c++/CMakeLists.txt
+index 4e6f5231..d7babd7f 100644
+--- a/example/echo_c++/CMakeLists.txt
++++ b/example/echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++/Makefile b/example/echo_c++/Makefile
+index 710cc7ed..fddde8cb 100644
+--- a/example/echo_c++/Makefile
++++ b/example/echo_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../..
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/grpc_c++/CMakeLists.txt b/example/grpc_c++/CMakeLists.txt
+index 5f9032e1..49010e96 100644
+--- a/example/grpc_c++/CMakeLists.txt
++++ b/example/grpc_c++/CMakeLists.txt
+@@ -75,7 +75,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/http_c++/CMakeLists.txt b/example/http_c++/CMakeLists.txt
+index 388b58c2..34f3050f 100644
+--- a/example/http_c++/CMakeLists.txt
++++ b/example/http_c++/CMakeLists.txt
+@@ -86,7 +86,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/http_c++/Makefile b/example/http_c++/Makefile
+index dc9d430f..51545655 100644
+--- a/example/http_c++/Makefile
++++ b/example/http_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/memcache_c++/CMakeLists.txt b/example/memcache_c++/CMakeLists.txt
+index 2554b829..85b4affc 100644
+--- a/example/memcache_c++/CMakeLists.txt
++++ b/example/memcache_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/memcache_c++/Makefile b/example/memcache_c++/Makefile
+index 2579f68f..03b3d4cd 100644
+--- a/example/memcache_c++/Makefile
++++ b/example/memcache_c++/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRS+=$(BRPC_PATH)/output/include
+ LIBS+=$(BRPC_PATH)/output/lib
+ HDRPATHS = $(addprefix -I, $(HDRS))
+diff --git a/example/multi_threaded_echo_c++/CMakeLists.txt b/example/multi_threaded_echo_c++/CMakeLists.txt
+index c68010dc..4a7291c4 100644
+--- a/example/multi_threaded_echo_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/multi_threaded_echo_c++/Makefile b/example/multi_threaded_echo_c++/Makefile
+index 558b77c3..cd344f98 100644
+--- a/example/multi_threaded_echo_c++/Makefile
++++ b/example/multi_threaded_echo_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../..
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/multi_threaded_echo_fns_c++/CMakeLists.txt b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+index 148490a0..8345076e 100644
+--- a/example/multi_threaded_echo_fns_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/nshead_extension_c++/CMakeLists.txt b/example/nshead_extension_c++/CMakeLists.txt
+index 72c9b418..b0b93a23 100644
+--- a/example/nshead_extension_c++/CMakeLists.txt
++++ b/example/nshead_extension_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/nshead_pb_extension_c++/CMakeLists.txt b/example/nshead_pb_extension_c++/CMakeLists.txt
+index 82c055ba..448c7070 100644
+--- a/example/nshead_pb_extension_c++/CMakeLists.txt
++++ b/example/nshead_pb_extension_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/parallel_echo_c++/CMakeLists.txt b/example/parallel_echo_c++/CMakeLists.txt
+index 65b25153..b24bb41f 100644
+--- a/example/parallel_echo_c++/CMakeLists.txt
++++ b/example/parallel_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/partition_echo_c++/CMakeLists.txt b/example/partition_echo_c++/CMakeLists.txt
+index fecdfa0c..25d98dbe 100644
+--- a/example/partition_echo_c++/CMakeLists.txt
++++ b/example/partition_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/redis_c++/CMakeLists.txt b/example/redis_c++/CMakeLists.txt
+index f1bafece..a7b008b5 100644
+--- a/example/redis_c++/CMakeLists.txt
++++ b/example/redis_c++/CMakeLists.txt
+@@ -90,7 +90,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/redis_c++/Makefile b/example/redis_c++/Makefile
+index 4ba9505f..7c94e195 100644
+--- a/example/redis_c++/Makefile
++++ b/example/redis_c++/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRS+=$(BRPC_PATH)/output/include
+ LIBS+=$(BRPC_PATH)/output/lib
+ HDRPATHS = $(addprefix -I, $(HDRS))
+diff --git a/example/selective_echo_c++/CMakeLists.txt b/example/selective_echo_c++/CMakeLists.txt
+index 74135282..7d65c775 100644
+--- a/example/selective_echo_c++/CMakeLists.txt
++++ b/example/selective_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/session_data_and_thread_local/CMakeLists.txt b/example/session_data_and_thread_local/CMakeLists.txt
+index 120f92e2..28ba0356 100644
+--- a/example/session_data_and_thread_local/CMakeLists.txt
++++ b/example/session_data_and_thread_local/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/streaming_echo_c++/CMakeLists.txt b/example/streaming_echo_c++/CMakeLists.txt
+index 57fe261e..34e041d7 100644
+--- a/example/streaming_echo_c++/CMakeLists.txt
++++ b/example/streaming_echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/thrift_extension_c++/Makefile b/example/thrift_extension_c++/Makefile
+index 980b2085..47b381fd 100644
+--- a/example/thrift_extension_c++/Makefile
++++ b/example/thrift_extension_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -g -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -g -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/src/bthread/mutex.cpp b/src/bthread/mutex.cpp
+index 441bc6c8..75c5b66f 100644
+--- a/src/bthread/mutex.cpp
++++ b/src/bthread/mutex.cpp
+@@ -44,7 +44,7 @@
+ #include "bthread/log.h"
+ 
+ extern "C" {
+-extern void* _dl_sym(void* handle, const char* symbol, void* caller);
++extern void* __attribute__((weak)) _dl_sym(void* handle, const char* symbol, void* caller);  
+ }
+ 
+ namespace bthread {
+@@ -408,8 +408,14 @@ static void init_sys_mutex_lock() {
+ #if defined(OS_LINUX)
+     // TODO: may need dlvsym when GLIBC has multiple versions of a same symbol.
+     // http://blog.fesnel.com/blog/2009/08/25/preloading-with-multiple-symbol-versions
+-    sys_pthread_mutex_lock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_lock", (void*)init_sys_mutex_lock);
+-    sys_pthread_mutex_unlock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_unlock", (void*)init_sys_mutex_lock);
++    if (_dl_sym) {
++        sys_pthread_mutex_lock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_lock", (void*)init_sys_mutex_lock);
++        sys_pthread_mutex_unlock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_unlock", (void*)init_sys_mutex_lock);
++    } else {
++        // _dl_sym may be undefined reference in some system, fallback to dlsym
++        sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
++        sys_pthread_mutex_unlock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_unlock");
++    }  
+ #elif defined(OS_MACOSX)
+     // TODO: look workaround for dlsym on mac
+     sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
+diff --git a/src/butil/errno.h b/src/butil/errno.h
+index 0390a840..14856eeb 100644
+--- a/src/butil/errno.h
++++ b/src/butil/errno.h
+@@ -22,7 +22,12 @@
+ #ifndef BUTIL_BAIDU_ERRNO_H
+ #define BUTIL_BAIDU_ERRNO_H
+ 
+-#define __const__
++#ifndef __const__
++// Avoid over-optimizations of TLS variables by GCC>=4.8
++// See: https://github.com/apache/incubator-brpc/issues/1693
++#define __const__ __unused__
++#endif
++
+ #include <errno.h>                           // errno
+ #include "butil/macros.h"                     // BAIDU_CONCAT
+ 
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 7c274ef5..2b00c7fa 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -52,7 +52,7 @@ else()
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -g -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ use_cxx11()
+ 
+diff --git a/test/Makefile b/test/Makefile
+index 9a63dc1a..231c6456 100644
+--- a/test/Makefile
++++ b/test/Makefile
+@@ -18,7 +18,7 @@
+ NEED_GPERFTOOLS=1
+ NEED_GTEST=1
+ include ../config.mk
+-CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES --include sstream_workaround.h
++CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES --include sstream_workaround.h
+ CXXFLAGS=$(CPPFLAGS) -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
+ 
+ #required by butil/crc32.cc to boost performance for 10x
+diff --git a/tools/parallel_http/Makefile b/tools/parallel_http/Makefile
+index 5b866470..a57c5d5f 100644
+--- a/tools/parallel_http/Makefile
++++ b/tools/parallel_http/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_press/Makefile b/tools/rpc_press/Makefile
+index c1d866d0..8cae3033 100644
+--- a/tools/rpc_press/Makefile
++++ b/tools/rpc_press/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_replay/Makefile b/tools/rpc_replay/Makefile
+index fcd5eb6f..8f4eadde 100644
+--- a/tools/rpc_replay/Makefile
++++ b/tools/rpc_replay/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_view/Makefile b/tools/rpc_view/Makefile
+index c654cfd5..13f026cb 100644
+--- a/tools/rpc_view/Makefile
++++ b/tools/rpc_view/Makefile
+@@ -19,8 +19,7 @@ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/trackme_server/Makefile b/tools/trackme_server/Makefile
+index 79e8536d..5bdd53f8 100644
+--- a/tools/trackme_server/Makefile
++++ b/tools/trackme_server/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a

--- a/thirdparty/vars-ubuntu.sh
+++ b/thirdparty/vars-ubuntu.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+############################################################
+# You may have to set variables bellow,
+# which are used for compiling thirdparties and starrocks itself.
+############################################################
+
+# --job param for *make*
+PARALLEL=$[$(nproc)/4+1]
+
+###################################################
+# DO NOT change variables bellow unless you known
+# what you are doing.
+###################################################
+
+# thirdparties will be downloaded and unpacked here
+export TP_SOURCE_DIR=$TP_DIR/src
+
+# thirdparties will be installed to here
+export TP_INSTALL_DIR=$TP_DIR/installed
+
+# patches for all thirdparties
+export TP_PATCH_DIR=$TP_DIR/patches
+
+# header files of all thirdparties will be intalled to here
+export TP_INCLUDE_DIR=$TP_INSTALL_DIR/include
+
+# libraries of all thirdparties will be intalled to here
+export TP_LIB_DIR=$TP_INSTALL_DIR/lib
+
+# all java libraries will be unpacked to here
+export TP_JAR_DIR=$TP_INSTALL_DIR/lib/jar
+
+#####################################################
+# Download url, filename and unpacked filename
+# of all thirdparties
+#####################################################
+
+# libevent
+# the last release version of libevent is 2.1.8, which was released on 26 Jan 2017, that is too old.
+# so we use the master version of libevent, which is downloaded on 22 Jun 2018, with commit 24236aed01798303745470e6c498bf606e88724a
+LIBEVENT_DOWNLOAD="https://github.com/libevent/libevent/archive/24236ae.zip"
+LIBEVENT_NAME=libevent-24236aed01798303745470e6c498bf606e88724a.zip
+LIBEVENT_SOURCE=libevent-24236aed01798303745470e6c498bf606e88724a
+LIBEVENT_MD5SUM="c6c4e7614f03754b8c67a17f68177649"
+
+# brpc
+BRPC_DOWNLOAD="https://github.com/apache/incubator-brpc/archive/0.9.7.tar.gz"
+BRPC_NAME=incubator-brpc-0.9.7.tar.gz
+BRPC_SOURCE=incubator-brpc-0.9.7
+BRPC_MD5SUM="a5b79339d139d1c55d39689c0a69bcef"
+
+TP_ARCHIVES="LIBEVENT BRPC"


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：

Fixes building StarRocks on Ubuntu 22.04.

## Problem Summary(Required) ：

Currently, StarRocks developers often use the [starrocks-dev-env](https://hub.docker.com/r/starrocks/dev-env) docker container to build and run StarRocks. The docker container is based off CentOS. It has been a long-standing issue in the community that building StarRocks on Ubuntu or MacOS does not work out of the box. Building StarRocks in the docker container has several limitations:
- Using IDE such as CLion with docker container is hard. Although [remote development](https://www.jetbrains.com/help/clion/remote-projects-support.html) can be set up, but the IDE delay is high and several features do not work as in local development.
- Docker container is run as the root user. They produce files as root and often cause file permission issues when trying to access and modify the files outside of the container.
- Developers typically have tools and scripts in their local development. Docker environment makes reusing those tools difficult.

This PR includes a few patches and scripts to successfully build StarRocks (both FE, BE and starrocks-test) on Ubuntu 22.04.

The high-level steps are:
- Pull starrocks-dev-env docker image
- Copy the `/var/local/thirdparty` files to local (Ubuntu)
- Run `thirdparty/build-thirdparty-ubuntu.sh` to rebuild `libbrpc` and `libevents` natively on Ubuntu.
- Run `./build.sh` with the right flags.

Notable mentions on the patches:
- Set compilation option `STARROCKS_CXX_COMMON_FLAGS="-no-pie"` otherwise the linker complained about  `(libhdfs.a) `relocation R_X86_64_32 against .rodata.str1.1' can not be used when making a PIE object`
- Recompile `libevents` on Ubuntu, otherwise linker complained about `undefined reference: sysctl` on this [line](https://github.com/libevent/libevent/blob/8f47d8de281b877450474734594fdc0a60ee35d1/arc4random.c#L204).
- Recompile `libbrpc` with patches on Ubuntu, otherwise linker complained about `undefined reference to _dl_sym'`
  - The libbrpc patch is basically https://github.com/apache/incubator-brpc/pull/1783 https://github.com/apache/incubator-brpc/pull/1784. The libbrpc compilation issue has been fixed in the main, but StarRocks is still using an older version 0.9.7 so we need the patch.
- A few minor fixes in StarRocks code to make the code compile with g++-11 on Ubuntu.

The PR added a few additional scripts to assist the Ubuntu build:
- `vars-ubuntu.sh`
- `down-thirdparty-ubuntu.sh`
- `build-thirdparty-ubuntu.sh`

These scripts are modified from the existing scripts.


## How to build on Ubuntu?

1. Copy /var/local/thirdparty from starrocks-dev-env docker
	```
    cd thirdparty
	sudo ./copy_from_docker.sh
	sudo chown -R $USERNAME /var/local/thirdparty
	```

2. Rebuild libbrpc and libevents on Ubuntu
	```
	cd thirdparty
    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64  STARROCKS_GCC_HOME=/usr ./build-thirdparty-ubuntu.sh
	```
3. Build StarRocks BE
	```
	STARROCKS_CXX_COMMON_FLAGS="-no-pie" STARROCKS_GCC_HOME=/usr JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 STARROCKS_THIRDPARTY=/var/local/thirdparty ./build.sh --be
	```

4. Run StarRocks BE
	```
	LD_LIBRARY_PATH=/usr/lib/jvm/java-11-openjdk-amd64/lib/server output/be/start_be.sh
	```

For more details on how to build FE and how to set up CLion and IntelliJ on StarRocks on Ubuntu, please refer to this documentation: https://docs.google.com/document/d/1RzUweJ9NlN8pbuadwBFoROGmqhs3Z4ZCTh73TdQAH6k/


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
