### PR TITLE
[BugFix] fix unstable ut in colocate test

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -423,6 +423,7 @@ public class ColocateTableBalancerTest {
                 minTimes = 0;
             }
         };
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", Type.INT));
@@ -481,6 +482,7 @@ public class ColocateTableBalancerTest {
             }
         };
 
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         // all buckets are on different be
         List<Long> allAvailBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
         Set<Long> unavailBackendIds = Sets.newHashSet(9L);
@@ -591,6 +593,7 @@ public class ColocateTableBalancerTest {
             }
         };
 
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         Set<Long> unavailableBeIds = Deencapsulation
                 .invoke(balancer, "getUnavailableBeIdsInGroup", infoService, colocateTableIndex, groupId);
         System.out.println(unavailableBeIds);
@@ -667,6 +670,7 @@ public class ColocateTableBalancerTest {
             }
         };
 
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         List<Long> availableBeIds = Deencapsulation.invoke(balancer, "getAvailableBeIds", infoService);
         Assert.assertArrayEquals(new long[] {2L, 4L}, availableBeIds.stream().mapToLong(i -> i).sorted().toArray());
     }
@@ -713,6 +717,7 @@ public class ColocateTableBalancerTest {
                 minTimes = 0;
             }
         };
+        GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", Type.INT));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getIdToBackend()
   on mock instance: com.starrocks.system.SystemInfoService@4fef2259
Caused by: Missing invocations
	at com.starrocks.system.SystemInfoService.getIdToBackend(SystemInfoService.java)
	at com.starrocks.system.HeartbeatMgr.runAfterCatalogReady(HeartbeatMgr.java:120)
	at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:60)
	at com.starrocks.common.util.Daemon.run(Daemon.java:115)
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
