### PR TITLE
[BugFix] fix incorrect memory metrics of jemalloc

### DIFF
--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -209,7 +209,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("jemalloc_metadata_thp", &_memory_metrics->jemalloc_metadata_thp);
     registry->register_metric("jemalloc_resident_bytes", &_memory_metrics->jemalloc_resident_bytes);
     registry->register_metric("jemalloc_mapped_bytes", &_memory_metrics->jemalloc_mapped_bytes);
-    registry->register_metric("jemalloc_retained_bytes", &_memory_metrics->jemalloc_mapped_bytes);
+    registry->register_metric("jemalloc_retained_bytes", &_memory_metrics->jemalloc_retained_bytes);
 #endif
 
     registry->register_metric("process_mem_bytes", &_memory_metrics->process_mem_bytes);

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -258,7 +258,11 @@ void SystemMetrics::_update_memory_metrics() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
 #elif defined(USE_JEMALLOC)
-    size_t sz = sizeof(size_t);
+    // Update the statistics cached by mallctl.
+    uint64_t epoch = 1;
+    size_t sz = sizeof(epoch);
+    je_mallctl("epoch", &epoch, &sz, &epoch, sz);
+    sz = sizeof(size_t);
     if (je_mallctl("stats.allocated", &value, &sz, nullptr, 0) == 0) {
         _memory_metrics->jemalloc_allocated_bytes.set_value(value);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12349

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. fix a stupid bug that would cause the value of jemalloc_retained_bytes incorrect.
2. update the statistics cached by mallctl before get them, otherwise we won't get the latest results

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
