### PR TITLE
[Enhancement] The exception message is unclear when creating the hive external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/TableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TableFactory.java
@@ -60,6 +60,11 @@ public class TableFactory {
         Map<String, String> properties = stmt.getProperties();
         long tableId = gsm.getNextId();
         Table table = getTableFromResourceMappingCatalog(properties, Table.TableType.HIVE, HIVE);
+        if (table == null) {
+            throw new DdlException("Can not find hive table "
+                    + properties.get(DB) + "." + properties.get(TABLE)
+                    + " from the resource " + properties.get(RESOURCE));
+        }
         HiveTable oHiveTable = (HiveTable) table;
 
         validateHiveColumnType(columns, oHiveTable);


### PR DESCRIPTION
… external table

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #12383

## Problem Summary(Required) ：
  The exception message is unclear when creating the hive table. If the hive table cannot be found, a NPE is thrown. And the exception information is `ERROR 1064 (HY000): Unexpected exception: null`. The user doesn't know what specific error happened.

  Before the change:
  ![image](https://user-images.githubusercontent.com/55134131/197345523-d772a23a-a668-4ff8-8f96-ab3c793e4516.png)

  After the change:
  ![after](https://user-images.githubusercontent.com/55134131/197346273-327f77ef-70d2-4f46-a9b6-c6f7ff6fe473.jpg)


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
