### PR TITLE
[Enhancement] generate min/max predicate from runtime filter & support `evaluate_with_filter`

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -757,6 +757,7 @@ CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 CONF_Bool(connector_dynamic_chunk_buffer_limiter_enable, "true");
+CONF_Bool(connector_min_max_predicate_from_runtime_filter_enable, "true");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -51,6 +51,7 @@ public:
         _runtime_filters = runtime_filters;
     }
     void set_read_limit(const uint64_t limit) { _read_limit = limit; }
+    Status parse_runtime_filters(RuntimeState* state);
 
 protected:
     int64_t _read_limit = -1; // no limit
@@ -58,7 +59,6 @@ protected:
     const vectorized::RuntimeFilterProbeCollector* _runtime_filters;
     RuntimeProfile* _runtime_profile;
     const TupleDescriptor* _tuple_desc = nullptr;
-
     void _init_chunk(vectorized::ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
 };
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -665,7 +665,7 @@ StatusOr<size_t> ExecNode::eval_conjuncts_into_filter(const std::vector<ExprCont
         return 0;
     }
     for (auto* ctx : ctxs) {
-        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk));
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate_with_filter(chunk, filter->data()));
         size_t true_count = vectorized::ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -168,7 +168,9 @@ Status ConnectorChunkSource::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ChunkSource::prepare(state));
     _runtime_state = state;
     _ck_acc.set_max_size(state->chunk_size());
-    _data_source->parse_runtime_filters(state);
+    if (config::connector_min_max_predicate_from_runtime_filter_enable) {
+        _data_source->parse_runtime_filters(state);
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -168,6 +168,7 @@ Status ConnectorChunkSource::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ChunkSource::prepare(state));
     _runtime_state = state;
     _ck_acc.set_max_size(state->chunk_size());
+    _data_source->parse_runtime_filters(state);
     return Status::OK();
 }
 

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -600,6 +600,10 @@ ColumnPtr Expr::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
     return nullptr;
 }
 
+ColumnPtr Expr::evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) {
+    return evaluate(context, ptr);
+}
+
 vectorized::ColumnRef* Expr::get_column_ref() {
     if (this->is_slotref()) {
         return down_cast<vectorized::ColumnRef*>(this);

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -370,6 +370,7 @@ Status Expr::create_vectorized_expr(starrocks::ObjectPool* pool, const starrocks
     case TExprNodeType::LIKE_PRED:
     case TExprNodeType::LITERAL_PRED:
     case TExprNodeType::TUPLE_IS_NULL_PRED:
+    case TExprNodeType::RUNTIME_FILTER_MIN_MAX_EXPR:
         break;
     }
     if (*expr == nullptr) {

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -191,6 +191,7 @@ public:
     virtual StatusOr<ColumnPtr> evaluate_const(ExprContext* context);
 
     virtual ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr);
+    virtual ColumnPtr evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter);
 
     // get the first column ref in expr
     vectorized::ColumnRef* get_column_ref();

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -118,8 +118,9 @@ public:
 
     // vector query engine
     StatusOr<ColumnPtr> evaluate(vectorized::Chunk* chunk);
+    StatusOr<ColumnPtr> evaluate_with_filter(vectorized::Chunk* chunk, uint8_t* filter);
 
-    StatusOr<ColumnPtr> evaluate(Expr* expr, vectorized::Chunk* chunk);
+    StatusOr<ColumnPtr> evaluate(Expr* expr, vectorized::Chunk* chunk, uint8_t* filter = nullptr);
 
 private:
     friend class Expr;

--- a/be/src/exprs/vectorized/binary_predicate.cpp
+++ b/be/src/exprs/vectorized/binary_predicate.cpp
@@ -57,7 +57,7 @@ public:
         auto l = _children[0]->evaluate(context, ptr);
         auto r = _children[1]->evaluate(context, ptr);
         return VectorizedStrictBinaryFunction<OP>::template evaluate<Type, TYPE_BOOLEAN>(l, r);
-    }    
+    }
 };
 
 template <PrimitiveType Type, typename OP>

--- a/be/src/exprs/vectorized/binary_predicate.cpp
+++ b/be/src/exprs/vectorized/binary_predicate.cpp
@@ -57,7 +57,7 @@ public:
         auto l = _children[0]->evaluate(context, ptr);
         auto r = _children[1]->evaluate(context, ptr);
         return VectorizedStrictBinaryFunction<OP>::template evaluate<Type, TYPE_BOOLEAN>(l, r);
-    }
+    }    
 };
 
 template <PrimitiveType Type, typename OP>

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -179,9 +179,7 @@ public:
         if (!lhs->is_constant()) {
             if (filter) {
                 for (int row = 0; row < size; ++row) {
-                    if (filter[row]) {
-                        data3[row] = check_value_existence<use_array>(data[row]);
-                    }
+                    data3[row] = (filter[row] && check_value_existence<use_array>(data[row]));
                 }
             } else {
                 for (int row = 0; row < size; ++row) {

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -241,6 +241,9 @@ public:
             for (int row = 0; row < size; ++row) {
                 if (filter[row]) {
                     update_row(row);
+                } else {
+                    // any value will be OK since we don't use it.
+                    builder.append_null();
                 }
             }
         } else {

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -645,6 +645,11 @@ public:
             return result;
         }
 
+        // NOTE(yan): make sure following code can be compiled into SIMD instructions:
+        // in original version, we use
+        // 1. memcpy filter -> res
+        // 2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
+        // but they can not be compiled into SIMD instructions.
         if (col->is_nullable()) {
             auto tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
             uint8_t* __restrict__ null_data = tmp->null_column_data().data();

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -646,9 +646,7 @@ public:
         }
 
         if (filter != nullptr) {
-            for (int i = 0; i < size; i++) {
-                res[i] = res[i] & filter[i];
-            }
+            memcpy(res, filter, size);
         }
 
         if (col->is_nullable()) {
@@ -656,12 +654,12 @@ public:
             uint8_t* null_data = tmp->null_column_data().data();
             CppType* data = ColumnHelper::cast_to_raw<Type>(tmp->data_column())->get_data().data();
             for (int i = 0; i < size; i++) {
-                res[i] = res[i] & (null_data[i] | (data[i] >= _min_value && data[i] <= _max_value));
+                res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
             }
         } else {
             CppType* data = ColumnHelper::cast_to_raw<Type>(col)->get_data().data();
             for (int i = 0; i < size; i++) {
-                res[i] = res[i] & (data[i] >= _min_value && data[i] <= _max_value);
+                res[i] = res[i] && (data[i] >= _min_value && data[i] <= _max_value);
             }
         }
 

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -647,8 +647,8 @@ public:
 
         // NOTE(yan): make sure following code can be compiled into SIMD instructions:
         // in original version, we use
-        // 1. memcpy filter -> res
-        // 2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
+        //   1. memcpy filter -> res
+        //   2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
         // but they can not be compiled into SIMD instructions.
         if (col->is_nullable()) {
             auto tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
@@ -657,6 +657,7 @@ public:
             for (int i = 0; i < size; i++) {
                 res[i] = (data[i] >= _min_value && data[i] <= _max_value);
             }
+            // we take null as true value.
             for (int i = 0; i < size; i++) {
                 res[i] = res[i] | null_data[i];
             }
@@ -667,11 +668,12 @@ public:
             }
         }
 
-        if (filter != nullptr) {
-            for (int i = 0; i < size; i++) {
-                res[i] = res[i] & filter[i];
-            }
-        }
+        // NOTE(yan): filter can be used optionally.
+        // if (filter != nullptr) {
+        //     for (int i = 0; i < size; i++) {
+        //         res[i] = res[i] & filter[i];
+        //     }
+        // }
 
         return result;
     }

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -620,11 +620,16 @@ class MinMaxPredicate : public Expr {
 public:
     using CppType = RunTimeCppType<Type>;
     MinMaxPredicate(SlotId slot_id, const CppType& min_value, const CppType& max_value)
-            : Expr(TypeDescriptor(Type), false), _slot_id(slot_id), _min_value(min_value), _max_value(max_value) {}
+            : Expr(TypeDescriptor(Type), false), _slot_id(slot_id), _min_value(min_value), _max_value(max_value) {
+        _node_type = TExprNodeType::RUNTIME_FILTER_MIN_MAX_EXPR;
+    }
     ~MinMaxPredicate() override = default;
     Expr* clone(ObjectPool* pool) const override {
         return pool->add(new MinMaxPredicate<Type>(_slot_id, _min_value, _max_value));
     }
+
+    bool is_constant() const override { return false; }
+    bool is_bound(const std::vector<TupleId>& tuple_ids) const override { return false; }
 
     ColumnPtr evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
         const vectorized::ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -49,6 +49,10 @@ public:
 
     static bool filter_zonemap_with_min_max(PrimitiveType type, const JoinRuntimeFilter* filter,
                                             const Column* min_column, const Column* max_column);
+
+    // create min/max predicate from filter.
+    static void create_min_max_value_predicate(ObjectPool* pool, SlotId slot_id, PrimitiveType slot_type,
+                                               const JoinRuntimeFilter* filter, Expr** min_max_predicate);
 };
 
 // how to generate & publish this runtime filter

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -163,7 +163,8 @@ private:
     //
     // col_int   | col_map
     // 7         | {"abc-123":-327}
-    std::string _file_map_char_key_path = "./be/test/exec/test_data/parquet_scanner/file_reader_test_map_char_key.parquet";
+    std::string _file_map_char_key_path =
+            "./be/test/exec/test_data/parquet_scanner/file_reader_test_map_char_key.parquet";
 
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;

--- a/build.sh
+++ b/build.sh
@@ -52,12 +52,6 @@ if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/include/pulsar/Client.h ]]; then
     ${STARROCKS_HOME}/thirdparty/build-thirdparty.sh
 fi
 
-WITH_BLOCK_CACHE=OFF
-if [[ "${WITH_BLOCK_CACHE}" == "ON" && ! -f ${STARROCKS_THIRDPARTY}/installed/cachelib/lib/libcachelib_allocator.a ]]; then
-    echo "Thirdparty libraries need to be build ..."
-    ${STARROCKS_HOME}/thirdparty/build-thirdparty.sh
-fi
-
 PARALLEL=$[$(nproc)/4+1]
 
 # Check args
@@ -128,11 +122,22 @@ if [[ -z $(grep -o 'sse[^ ]*' /proc/cpuinfo) ]]; then
     USE_SSE4_2=OFF
 fi
 
+if [[ -z ${WITH_BLOCK_CACHE} ]]; then
+	WITH_BLOCK_CACHE=OFF
+fi
+
+if [[ "${WITH_BLOCK_CACHE}" == "ON" && ! -f ${STARROCKS_THIRDPARTY}/installed/cachelib/lib/libcachelib_allocator.a ]]; then
+    echo "WITH_BLOCK_CACHE=ON but missing depdency libraries(cachelib)"
+    exit 1
+fi
+
 if [[ -z ${ENABLE_QUERY_DEBUG_TRACE} ]]; then
 	ENABLE_QUERY_DEBUG_TRACE=OFF
 fi
 
-USE_JEMALLOC=ON
+if [[ -z ${USE_JEMALLOC} ]]; then
+    USE_JEMALLOC=ON
+fi
 
 HELP=0
 if [ $# == 1 ] ; then
@@ -197,6 +202,8 @@ echo "Get params:
     USE_AVX2            -- $USE_AVX2
     PARALLEL            -- $PARALLEL
     ENABLE_QUERY_DEBUG_TRACE -- $ENABLE_QUERY_DEBUG_TRACE
+    WITH_BLOCK_CACHE    -- $WITH_BLOCK_CACHE
+    USE_JEMALLOC        -- $USE_JEMALLOC
 "
 
 # Clean and build generated code

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -65,6 +65,7 @@ enum TExprNodeType {
   CLONE_EXPR,
   LAMBDA_FUNCTION_EXPR,
   SUBFIELD_EXPR,
+  RUNTIME_FILTER_MIN_MAX_EXPR,
 }
 
 //enum TAggregationOp {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR introduces two things:
1. `evaluate_with_filter` in expr.
2.  generate min/max predicate from runtime filter.

---

About point 1, we can think about a case that. If we have two predicates:
1.  a > 10 (light weight operation)
2. function(b) > 100 ( heavy weight operation)

If we don't have `evaluate_with_filter`, for every tuple we have to run `function(b) > 100` even this tuple has been filtered by `a > 10`.   But with `evaluate_with_filter`, we can avoid running `function(b) > 100` if tuple has been filtered by `a > 10`.

Right now I only implement `evaluate_with_filter` in `VectorizedInConstPredicate`. I guess we can implement it in more exprs.

And with this ability, we can keep optimizing predicates by ordering them: to put light weight predicates before heavy weight predicates. 

---

SSB-100G with block cache

The intention of this PR is to optimize Q01, and it works for other queries too. For some queries, there is negative effect because of `MinMaxPredicate`, but the overall effect is positive.



  | ssbflat(before) | after | ssb(before) | after
-- | -- | -- | -- | --
Q01 | 350 | 355 | 612 | 423
Q02 | 328 | 331 | 574 | 363
Q03 | 414 | 423 | 559 | 343
Q04 | 445 | 445 | 845 | 887
Q05 | 360 | 357 | 723 | 785
Q06 | 276 | 269 | 693 | 757
Q07 | 666 | 671 | 1396 | 1393
Q08 | 601 | 605 | 807 | 902
Q09 | 275 | 279 | 737 | 844
Q10 | 222 | 231 | 667 | 497
Q11 | 608 | 613 | 1577 | 1640
Q12 | 748 | 740 | 1168 | 1099
Q13 | 738 | 732 | 1095 | 982
SUM | 6031 | 6051 | 11453 | 10915

tpch-100g block cache



  | tpch(before) | after
-- | -- | --
Q01 | 3655 | 3665
Q02 | 478 | 483
Q03 | 2293 | 2327
Q04 | 1069 | 1096
Q05 | 1874 | 1790
Q06 | 774 | 783
Q07 | 1682 | 1661
Q08 | 1530 | 1451
Q09 | 4699 | 4779
Q10 | 2590 | 2569
Q11 | 379 | 383
Q12 | 1204 | 1224
Q13 | 2796 | 2799
Q14 | 971 | 973
Q15 | 845 | 849
Q16 | 3615 | 3574
Q17 | 1775 | 1723
Q18 | 10369 | 10263
Q19 | 1000 | 1001
Q20 | 1181 | 1151
Q21 | 3509 | 3512
Q22 | 691 | 689
SUM | 48979 | 48745





## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
