### PR TITLE
[Enhancement] support to read cache in any size instead of whole block

### DIFF
--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -53,6 +53,7 @@ StatusOr<size_t> FbCacheLib::read_cache(const std::string& key, char* value, siz
     if (!handle) {
         return Status::NotFound("not found cachelib item");
     }
+    DCHECK((off + size) <= handle->getSize());
     std::memcpy(value, (char*)handle->getMemory() + off, size);
     if (handle->hasChainedItem()) {
     }

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -45,7 +45,7 @@ Status FbCacheLib::write_cache(const std::string& key, const char* value, size_t
     return Status::OK();
 }
 
-StatusOr<size_t> FbCacheLib::read_cache(const std::string& key, char* value) {
+StatusOr<size_t> FbCacheLib::read_cache(const std::string& key, char* value, size_t off, size_t size) {
     // TODO:
     // 1. check chain item
     // 2. replace with async methods
@@ -53,21 +53,10 @@ StatusOr<size_t> FbCacheLib::read_cache(const std::string& key, char* value) {
     if (!handle) {
         return Status::NotFound("not found cachelib item");
     }
-    size_t size = handle->getSize();
-    std::memcpy(value, handle->getMemory(), size);
+    std::memcpy(value, (char*)handle->getMemory() + off, size);
     if (handle->hasChainedItem()) {
     }
     return size;
-}
-
-Status FbCacheLib::read_cache_zero_copy(const std::string& key, const char** buf) {
-    auto handle = _cache->find(key);
-    if (handle) {
-        *buf = (const char*)(handle->getMemory());
-        return Status::OK();
-    } else {
-        return Status::NotFound("not found cachelib item");
-    }
 }
 
 Status FbCacheLib::remove_cache(const std::string& key) {

--- a/be/src/block_cache/fb_cachelib.h
+++ b/be/src/block_cache/fb_cachelib.h
@@ -22,9 +22,7 @@ public:
 
     Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) override;
 
-    StatusOr<size_t> read_cache(const std::string& key, char* value) override;
-
-    Status read_cache_zero_copy(const std::string& key, const char** buf) override;
+    StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) override;
 
     Status remove_cache(const std::string& key) override;
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -19,9 +19,7 @@ public:
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.
-    virtual StatusOr<size_t> read_cache(const std::string& key, char* value) = 0;
-
-    virtual Status read_cache_zero_copy(const std::string& key, const char** buf) = 0;
+    virtual StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) = 0;
 
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove_cache(const std::string& key) = 0;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -81,6 +81,7 @@ StatusOr<int64_t> CacheInputStream::read(void* out, int64_t count) {
 
         if (!can_zero_copy) {
             memcpy(p, src + shift, size);
+            _stats.read_cache_bytes += size;
         }
         p += size;
         _offset += size;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -30,31 +30,31 @@ CacheInputStream::CacheInputStream(const std::string& filename, std::shared_ptr<
 StatusOr<int64_t> CacheInputStream::read(void* out, int64_t count) {
     BlockCache* cache = BlockCache::instance();
     const int64_t BLOCK_SIZE = cache->block_size();
-    int64_t end = _offset + count;
-    int64_t start_block_id = _offset / BLOCK_SIZE;
-    int64_t end_block_id = (end - 1) / BLOCK_SIZE;
-
     char* p = static_cast<char*>(out);
     char* pe = p + count;
 
-    for (int64_t i = start_block_id; i <= end_block_id; i++) {
-        int64_t off = i * BLOCK_SIZE;
-        int64_t size = std::min(BLOCK_SIZE, end - off);
-        int64_t load_size = std::min(BLOCK_SIZE, _size - off);
-
-        // handle data alignment for first block
-        int64_t shift = 0;
-        if (i == start_block_id) {
-            shift = _offset - start_block_id * BLOCK_SIZE;
-            DCHECK(size > shift);
-        }
-
-        // VLOG_FILE << "[CacheInputStream] offset = " << _offset << ", count = " << count << ", block_id = " << i
-        //           << ", off = " << off << " , load_size = " << load_size << ", shift = " << shift
-        //           << ", p + BLOCK_SIZE = " << (void*)(p + BLOCK_SIZE) << ", pe = " << (void*)pe << "\n"
-        //           << get_stack_trace();
-
+    auto read_one_block = [&](size_t offset, size_t size) {
         StatusOr<size_t> res;
+
+        DCHECK(size <= BLOCK_SIZE);
+        {
+            SCOPED_RAW_TIMER(&_stats.read_cache_ns);
+            res = cache->read_cache(_cache_key, _offset, size, p);
+            if (res.ok()) {
+                _stats.read_cache_count += 1;
+                _stats.read_cache_bytes += size;
+                p += size;
+                _offset += size;
+                return Status::OK();
+            }
+        }
+        if (!res.status().is_not_found()) Status::NotFound("");
+        DCHECK(res.status().is_not_found());
+
+        int64_t block_id = offset / BLOCK_SIZE;
+        int64_t block_offset = block_id * BLOCK_SIZE;
+        int64_t shift = offset - block_offset;
+
         char* src = nullptr;
         bool can_zero_copy = false;
         if ((p + BLOCK_SIZE <= pe) && (shift == 0)) {
@@ -64,41 +64,42 @@ StatusOr<int64_t> CacheInputStream::read(void* out, int64_t count) {
             src = _buffer.data();
         }
 
-        // try to read from cache first.
-        {
-            SCOPED_RAW_TIMER(&_stats.read_cache_ns);
-            res = cache->read_cache(_cache_key, off, load_size, src);
-            if (res.ok()) {
-                _stats.read_cache_count += 1;
-            }
-        }
         // if not found, read from stream and write back to cache.
-        if (res.status().is_not_found()) {
-            RETURN_IF_ERROR(_stream->read_at_fully(off, src, load_size));
-            {
-                SCOPED_RAW_TIMER(&_stats.write_cache_ns);
-                Status r = cache->write_cache(_cache_key, off, load_size, src);
-                if (r.ok()) {
-                    _stats.write_cache_count += 1;
-                    _stats.write_cache_bytes += load_size;
-                } else {
-                    LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
-                }
+        int64_t load_size = std::min(BLOCK_SIZE, _size - block_offset);
+        RETURN_IF_ERROR(_stream->read_at_fully(block_offset, src, load_size));
+        {
+            SCOPED_RAW_TIMER(&_stats.write_cache_ns);
+            Status r = cache->write_cache(_cache_key, block_offset, load_size, src);
+            if (r.ok()) {
+                _stats.write_cache_count += 1;
+                _stats.write_cache_bytes += load_size;
+            } else {
+                LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
+                return r;
             }
-        } else if (!res.ok()) {
-            return res;
-        } else {
-            _stats.read_cache_bytes += load_size;
         }
 
         if (!can_zero_copy) {
-            src += shift;
-            size -= shift;
-            memcpy(p, src, size);
+            memcpy(p, src + shift, size);
         }
         p += size;
+        _offset += size;
+        return Status::OK();
+    };
+
+    int64_t end_offset = _offset + count;
+    int64_t start_block_id = _offset / BLOCK_SIZE;
+    int64_t end_block_id = (end_offset - 1) / BLOCK_SIZE;
+    // VLOG_FILE << "[XXX] CacheInputStream read _offset = " << _offset << ", count = " << count;
+    for (int64_t i = start_block_id; i <= end_block_id; i++) {
+        size_t off = std::max(_offset, i * BLOCK_SIZE);
+        size_t end = std::min((i + 1) * BLOCK_SIZE, end_offset);
+        size_t size = end - off;
+        // VLOG_FILE << "[XXX] Cache inputStream read_one_block. off = " << off << ", size = " << size;
+        Status st = read_one_block(off, size);
+        if (!st.ok()) return st;
     }
-    _offset += count;
+    DCHECK(p == pe);
     return count;
 }
 #else

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -147,28 +147,12 @@ Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offse
         return Status::RuntimeError("bad construction of shared buffer");
     }
 
-    int head_pad = 0;
-    if (_enable_block_cache) {
-        head_pad = sb.offset % config::block_cache_block_size;
-        if (sb.buffer.capacity() == 0) {
-            // we allocate enough room aligned with `block_cache_block_size`
-            // so cache_input_stream can use this buffer and do zero copy.
-            int tail_pad = (head_pad + sb.size) % config::block_cache_block_size;
-            if (tail_pad > 0) {
-                tail_pad = config::block_cache_block_size - tail_pad;
-            }
-            sb.buffer.reserve(sb.size + head_pad + tail_pad);
-            RETURN_IF_ERROR(
-                    _file->read_at_fully(sb.offset - head_pad, sb.buffer.data(), sb.size + head_pad + tail_pad));
-        }
-    } else {
-        if (sb.buffer.capacity() == 0) {
-            sb.buffer.reserve(sb.size);
-            RETURN_IF_ERROR(_file->read_at_fully(sb.offset, sb.buffer.data(), sb.size));
-        }
+    if (sb.buffer.capacity() == 0) {
+        sb.buffer.reserve(sb.size);
+        RETURN_IF_ERROR(_file->read_at_fully(sb.offset, sb.buffer.data(), sb.size));
     }
 
-    *buffer = sb.buffer.data() + head_pad + offset - sb.offset;
+    *buffer = sb.buffer.data() + offset - sb.offset;
     return Status::OK();
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to support read cache from cachelib in any size instead of a whole block, which leads to read amplification.

With this PR, ssbflat/q01 read bytes can be reduced from 6.62GB down to 3.89GB.(block_cache_size=1M).

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
