### PR TITLE
[Enhancement] Avoid reserve oversize memory for chunk generated by agg operators

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -327,6 +327,8 @@ Status Aggregator::_reset_state(RuntimeState* state) {
     _num_input_rows = 0;
     _is_sink_complete = false;
     _it_hash.reset();
+    _num_rows_processed = 0;
+
     {
         typeof(_buffer) empty_buffer;
         _buffer.swap(empty_buffer);
@@ -534,7 +536,7 @@ Status Aggregator::_evaluate_const_columns(int i) {
 
 void Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
     // TODO(kks): we should approve memory allocate here
-    vectorized::Columns agg_result_column = _create_agg_result_columns();
+    vectorized::Columns agg_result_column = _create_agg_result_columns(1);
     auto use_intermediate = _use_intermediate_as_output();
     if (!use_intermediate) {
         _finalize_to_chunk(_single_agg_state, agg_result_column);
@@ -560,6 +562,7 @@ void Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
         result_chunk->append_column(std::move(agg_result_column[i]), tuple_desc->slots()[i]->id());
     }
     ++_num_rows_returned;
+    ++_num_rows_processed;
     *chunk = std::move(result_chunk);
     _is_ht_eos = true;
 }
@@ -593,7 +596,9 @@ void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
     }
 
     if (!_agg_fn_ctxs.empty()) {
-        vectorized::Columns agg_result_column = _create_agg_result_columns();
+        DCHECK(!_group_by_columns.empty());
+        const auto num_rows = _group_by_columns[0]->size();
+        vectorized::Columns agg_result_column = _create_agg_result_columns(num_rows);
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             size_t id = _group_by_columns.size() + i;
             auto slot_id = slots[id]->id();
@@ -610,6 +615,7 @@ void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
 
     _num_pass_through_rows += result_chunk->num_rows();
     _num_rows_returned += result_chunk->num_rows();
+    _num_rows_processed += result_chunk->num_rows();
     *chunk = std::move(result_chunk);
     COUNTER_SET(_pass_through_row_count, _num_pass_through_rows);
 }
@@ -695,7 +701,7 @@ Status Aggregator::check_has_error() {
 
 // When need finalize, create column by result type
 // otherwise, create column by serde type
-vectorized::Columns Aggregator::_create_agg_result_columns() {
+vectorized::Columns Aggregator::_create_agg_result_columns(size_t num_rows) {
     vectorized::Columns agg_result_columns(_agg_fn_types.size());
     auto use_intermediate = _use_intermediate_as_output();
 
@@ -705,24 +711,24 @@ vectorized::Columns Aggregator::_create_agg_result_columns() {
             // we need to create a not-nullable column.
             agg_result_columns[i] = vectorized::ColumnHelper::create_column(
                     _agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child & _agg_fn_types[i].is_nullable);
-            agg_result_columns[i]->reserve(_state->chunk_size());
+            agg_result_columns[i]->reserve(num_rows);
         }
     } else {
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
             agg_result_columns[i] = vectorized::ColumnHelper::create_column(_agg_fn_types[i].serde_type,
                                                                             _agg_fn_types[i].has_nullable_child);
-            agg_result_columns[i]->reserve(_state->chunk_size());
+            agg_result_columns[i]->reserve(num_rows);
         }
     }
     return agg_result_columns;
 }
 
-vectorized::Columns Aggregator::_create_group_by_columns() {
+vectorized::Columns Aggregator::_create_group_by_columns(size_t num_rows) {
     vectorized::Columns group_by_columns(_group_by_types.size());
     for (size_t i = 0; i < _group_by_types.size(); ++i) {
         group_by_columns[i] =
                 vectorized::ColumnHelper::create_column(_group_by_types[i].result_type, _group_by_types[i].is_nullable);
-        group_by_columns[i]->reserve(_state->chunk_size());
+        group_by_columns[i]->reserve(num_rows);
     }
     return group_by_columns;
 }

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -262,6 +262,7 @@ private:
 
     int64_t _limit = -1;
     int64_t _num_rows_returned = 0;
+    int64_t _num_rows_processed = 0;
 
     // only used in pipeline engine
     std::atomic<bool> _is_sink_complete = false;
@@ -392,8 +393,10 @@ public:
         auto it = std::any_cast<RawHashTableIterator>(_it_hash);
         auto end = _state_allocator.end();
 
-        vectorized::Columns group_by_columns = _create_group_by_columns();
-        vectorized::Columns agg_result_columns = _create_agg_result_columns();
+        const auto hash_map_size = _hash_map_variant.size();
+        auto num_rows = std::min<size_t>(hash_map_size - _num_rows_processed, chunk_size);
+        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
+        vectorized::Columns agg_result_columns = _create_agg_result_columns(num_rows);
 
         auto use_intermediate = _use_intermediate_as_output();
         int32_t read_index = 0;
@@ -478,6 +481,7 @@ public:
             }
         }
         _num_rows_returned += read_index;
+        _num_rows_processed += read_index;
         *chunk = std::move(_result_chunk);
     }
 
@@ -487,8 +491,9 @@ public:
         using Iterator = typename HashSetWithKey::Iterator;
         auto it = std::any_cast<Iterator>(_it_hash);
         auto end = hash_set.hash_set.end();
-
-        vectorized::Columns group_by_columns = _create_group_by_columns();
+        const auto hash_set_size = _hash_set_variant.size();
+        auto num_rows = std::min<size_t>(hash_set_size - _num_rows_processed, chunk_size);
+        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
 
         // Computer group by columns and aggregate result column
         int32_t read_index = 0;
@@ -539,6 +544,7 @@ public:
             }
         }
         _num_rows_returned += read_index;
+        _num_rows_processed += read_index;
         *chunk = std::move(result_chunk);
     }
 
@@ -565,8 +571,8 @@ private:
     Status _evaluate_const_columns(int i);
 
     // Create new aggregate function result column by type
-    vectorized::Columns _create_agg_result_columns();
-    vectorized::Columns _create_group_by_columns();
+    vectorized::Columns _create_agg_result_columns(size_t num_rows);
+    vectorized::Columns _create_group_by_columns(size_t num_rows);
 
     void _serialize_to_chunk(vectorized::ConstAggDataPtr __restrict state,
                              const vectorized::Columns& agg_result_columns);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

Runtime three times of query cache tests in daily, the result has proved that memory leak in cache is reduced.

```
+==============+=======+=======+=====================+
| Test         | VIRT  | RES   | cache usage(jeprof) |
+==============+=======+=======+=====================+
| mem_leak     | 85.5g | 13.6g | 44g                 |
| no_leak(1st) | 27.4g | 3.7g  | 499m                |
| no_leak(2nd) | 28.2g | 4.5g  | 983m                |
| no_leak(3rd) | 37.5g | 6.9g  | 1254m               |
+--------------+-------+-------+---------------------+
```
The memory(cache usage) is increased sightly.