### PR TITLE
[BugFix]Use re2 when pattern is empty

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -2660,7 +2660,7 @@ Status StringFunctions::regexp_replace_prepare(starrocks_udf::FunctionContext* c
     state->pattern = pattern_str;
 
     std::string search_string;
-    if (RE2::FullMatch(pattern_str, SUBSTRING_RE, &search_string)) {
+    if (pattern_str.size() && RE2::FullMatch(pattern_str, SUBSTRING_RE, &search_string)) {
         state->use_hyperscan = true;
         state->size_of_pattern = pattern.size;
         std::string re_pattern(pattern.data, pattern.size);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes testRegexpReplace1

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

