### PR TITLE
[Tool] add --debug option to build.sh to allow attaching debuggers to the FE process

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -25,6 +25,7 @@ OPTS=$(getopt \
   -l 'daemon' \
   -l 'helper:' \
   -l 'host_type:' \
+  -l 'debug' \
   -- "$@")
 
 eval set -- "$OPTS"
@@ -32,15 +33,19 @@ eval set -- "$OPTS"
 RUN_DAEMON=0
 HELPER=
 HOST_TYPE=
+ENABLE_DEBUGGER=
 while true; do
     case "$1" in
         --daemon) RUN_DAEMON=1 ; shift ;;
         --helper) HELPER=$2 ; shift 2 ;;
         --host_type) HOST_TYPE=$2 ; shift 2 ;;
+        --debug) ENABLE_DEBUGGER=1 ; shift ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
     esac
 done
+
+echo $ENABLE_DEBUGGER
 
 export STARROCKS_HOME=`cd "$curdir/.."; pwd`
 
@@ -81,6 +86,14 @@ if [[ "$JAVA_VERSION" -gt 8 ]]; then
     fi 
     final_java_opt=$JAVA_OPTS_FOR_JDK_9
 fi
+
+if [ ${ENABLE_DEBUGGER} -eq 1 ]; then
+    # Allow attaching debuggers to the FE process:
+    # https://www.jetbrains.com/help/idea/attaching-to-local-process.html
+    final_java_opt="${final_java_opt} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+    echo $final_java_opt
+fi
+echo $final_java_opt
 
 if [ ! -d $LOG_DIR ]; then
     mkdir -p $LOG_DIR


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：

Allow attaching debuggers (e.g. from IDEA) to a running FE process.

## Problem Summary(Required) ：

We will add the following VM option to allow attaching debuggers when `--debug` is passed to the FE start script. per https://www.jetbrains.com/help/idea/attaching-to-local-process.html.

```-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005```

```
./start_fe.sh --daemon --debug
```




## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
