### PR TITLE
[Docs] Remove /bin/sh when starting binary

### DIFF
--- a/docs/administration/Build_in_docker.md
+++ b/docs/administration/Build_in_docker.md
@@ -24,7 +24,7 @@ docker pull starrocks/dev-env:{version}
   # Run git clone starrocks in any path which in the container
   git clone https://github.com/StarRocks/starrocks.git
   cd starrocks
-  sh build.sh
+  ./build.sh
   ```
 
 - Run the container by mounting the local path (**recommended**)
@@ -41,7 +41,7 @@ docker pull starrocks/dev-env:{version}
   
   docker exec -it {container-name} /bin/bash
   cd /root/starrocks
-  sh build.sh
+  ./build.sh
   ```
 
 ## Third party tool

--- a/docs/administration/Cluster_administration.md
+++ b/docs/administration/Cluster_administration.md
@@ -26,7 +26,7 @@ Before you set up an FE, configure the `meta_dir` parameter and the communicatio
 After you complete the previous configurations, perform the following steps to start the FE:
 
 1. Navigate to the deployment directory of the FE.
-2. Run `sh bin/start_fe.sh --daemon` to start the FE.
+2. Run `./bin/start_fe.sh --daemon` to start the FE.
 
 You can deploy multiple FEs to ensure high availability. Typically, you can deploy three FEs: one leader FE and two follower FEs.
 
@@ -68,7 +68,7 @@ Navigate to the deployment directory of the Compute Node and start the Compute N
 
 ```shell
 cd StarRocks-x.x.x/be
-sh bin/start_cn.sh --daemon
+./bin/start_cn.sh --daemon
 ```
 
 ### Check the health status of a cluster
@@ -87,9 +87,9 @@ After the Compute Nodes are started properly, you need to set the system variabl
 
 To stop a cluster, you need to stop all the FEs and BEs in the cluster:
 
-- Go to the deployment directory of each FE and run `sh bin/stop_fe.sh`.
+- Go to the deployment directory of each FE and run `./bin/stop_fe.sh`.
 
-- Go to the deployment directory of each BE and run `sh bin/stop_be.sh`.
+- Go to the deployment directory of each BE and run `./bin/stop_be.sh`.
 
 #### Stop a Compute Node
 
@@ -97,7 +97,7 @@ Navigate to the deployment directory of the Compute Node and stop the Compute No
 
 ```shell
 cd StarRocks-x.x.x/be
-sh bin/stop_cn.sh
+./bin/stop_cn.sh
 ```
 
 ### Upgrade a cluster
@@ -124,7 +124,7 @@ StarRocks can perform a rolling upgrade, which allows you to first upgrade the B
 ```Plain%20Text
 cd be_work_dir
 
-sh bin/stop_be.sh
+./bin/stop_be.sh
 
 mv lib lib.bak 
 
@@ -134,7 +134,7 @@ cp -r /tmp/StarRocks-SE-x.x.x/be/lib  .
 
 cp -r /tmp/StarRocks-SE-x.x.x/be/bin  .  
 
-sh bin/start_be.sh --daemon
+./bin/start_be.sh --daemon
 
 ps aux | grep starrocks_be
 ```
@@ -144,7 +144,7 @@ ps aux | grep starrocks_be
 ```Plain%20Text
 cd fe_work_dir
 
-sh bin/stop_fe.sh
+./bin/stop_fe.sh
 
 mv lib lib.bak 
 
@@ -154,7 +154,7 @@ cp -r /tmp/StarRocks-SE-x.x.x/fe/lib  .
 
 cp -r /tmp/StarRocks-SE-x.x.x/fe/bin  .
 
-sh bin/start_fe.sh --daemon
+./bin/start_fe.sh --daemon
 
 ps aux | grep StarRocksFE
 ```
@@ -164,7 +164,7 @@ ps aux | grep StarRocksFE
 Since the Compute Node node is stateless, you only need to replace the binary file and restart the process. We recommend to stop it gracefully.
 
 ```shell
-sh bin/stop_cn.sh --graceful
+./bin/stop_cn.sh --graceful
 ```
 
 By using this method, the Compute Node waits until the currently running task finishes before exiting the process.
@@ -182,9 +182,9 @@ cp -r /tmp/StarRocks-SE-x.x.x/apache_hdfs_broker/lib  .
 
 cp -r /tmp/StarRocks-SE-x.x.x/apache_hdfs_broker/bin  .
 
-sh bin/stop_broker.sh
+./bin/stop_broker.sh
 
-sh bin/start_broker.sh --daemon
+./bin/start_broker.sh --daemon
 
 ps aux | grep broker
 ```
@@ -221,9 +221,9 @@ mv lib.bak lib
 
 mv bin.bak bin 
 
-sh bin/stop_fe.sh
+./bin/stop_fe.sh
 
-sh bin/start_fe.sh --daemon
+./bin/start_fe.sh --daemon
 
 ps aux | grep StarRocksFe
 ```
@@ -241,9 +241,9 @@ mv lib.bak lib
 
 mv bin.bak bin
 
-sh bin/stop_be.sh
+./bin/stop_be.sh
 
-sh bin/start_be.sh --daemon
+./bin/start_be.sh --daemon
 
 ps aux | grep starrocks_be
 ```
@@ -261,9 +261,9 @@ mv lib.bak lib
 
 mv bin.bak bin
 
-sh bin/stop_broker.sh
+./bin/stop_broker.sh
 
-sh bin/start_broker.sh --daemon
+./bin/start_broker.sh --daemon
 
 ps aux | grep broker
 ```
@@ -324,8 +324,8 @@ The FE metadata is critical and an abnormal upgrade may cause data loss. We reco
 4. Set `metadata_failure_recovery` in the **fe.conf** file to `true`.
 5. Copy the metadata directory of the leader FE in the production environment to your test environment.
 6. Set the `cluster_id` configuration item in the **meta/image/VERSION** file to 123456.
-7. In your test environment, run `sh bin/start_fe.sh` to start the test FE.
+7. In your test environment, run `./bin/start_fe.sh` to start the test FE.
 8. View the **fe.log** file of the test FE to check whether the restart is successful.
-9. If the restart is successful, run `sh bin/stop_fe.sh` to stop the test FE.
+9. If the restart is successful, run `./bin/stop_fe.sh` to stop the test FE.
 
 The step 2 through 6 aim to prevent the test FE from connecting to the production environment after a restart.

--- a/docs/administration/Metadata_recovery.md
+++ b/docs/administration/Metadata_recovery.md
@@ -59,7 +59,7 @@ The restoration steps vary for each FE based on the role of an FE. We recommend 
 We recommend that you restore a follower FE. Perform the following steps to restore a follower FE:
 
 1. Set `metadata_failure_recovery` in the **fe.conf** file to `true` to delete the metadata of other FEs in BDBJE except for the metadata of the FE that needs to be restored. In this way, the FE cannot connect with other FEs and starts as a standalone FE.
-2. Run `sh bin/start_fe.sh --deamon` to start the FE, which works as the leader FE. You can see `transfer from XXXX to MASTER` in the **fe.log** log.
+2. Run `./bin/start_fe.sh --deamon` to start the FE, which works as the leader FE. You can see `transfer from XXXX to MASTER` in the **fe.log** log.
 3. You can send queries to the FE to check whether the FE is started successfully. If an error occurs, view the log of the FE and troubleshoot the error based on the log data and then restart the FE. If no error occurs, you can run the `show frontends` command to check the details of all the FEs that are added to your StarRocks cluster before. The current FE is the leader FE.
 4. Delete `metadata_failure_recovery=true` from the **fe.conf** file or change `true` to `false`. Then restart the FE. Otherwise, the metadata of BDBJE is deleted when you restart the FE, and other FEs cannot work properly.
 
@@ -71,7 +71,7 @@ Perform the following steps to restore an observer FE:
 
 2. Set `metadata_failure_recovery` in the **fe.conf** file of the FE to `true` to delete the metadata of other FEs in BDBJE except for the metadata of the FE that needs to be restored. In this way, the FE cannot connect with other FEs and starts as a standalone FE.
 
-3. Run `sh bin/start_fe.sh --deamon` to start the FE, which works as the leader FE. You can see `transfer from XXXX to MASTER` in the **fe.log** log.
+3. Run `./bin/start_fe.sh --deamon` to start the FE, which works as the leader FE. You can see `transfer from XXXX to MASTER` in the **fe.log** log.
 
 4. You can send queries to the FE to check whether the FE is started successfully. If an error occurs, view the log of the FE and troubleshoot the error based on the log data and then restart the FE. If no error occurs, you can run the `show frontends` command to check the details of all the FEs that are added to your StarRocks cluster before.
 

--- a/docs/administration/deploy_broker.md
+++ b/docs/administration/deploy_broker.md
@@ -32,7 +32,7 @@ Specify the Broker configuration file **conf/apache_hdfs_broker.conf**. Because 
 Run the following command to start Broker.
 
 ```bash
-sh ./apache_hdfs_broker/bin/start_broker.sh --daemon
+./apache_hdfs_broker/bin/start_broker.sh --daemon
 ```
 
 ## Add a Broker to cluster

--- a/docs/administration/deploy_cn.md
+++ b/docs/administration/deploy_cn.md
@@ -61,7 +61,7 @@ mysql> ALTER SYSTEM DROP COMPUTE NODE "host:port";
 Run the following command to start the CN node.
 
 ```shell
-sh bin/start_cn.sh --daemon
+./bin/start_cn.sh --daemon
 ```
 
 ## Verify if CN node starts

--- a/docs/administration/enable_fqdn.md
+++ b/docs/administration/enable_fqdn.md
@@ -27,7 +27,7 @@ Therefore, to start the nodes via FQDNs, you DO NOT need to specify the property
 Alternatively, if you want to start the cluster with IP address access, you still have to specify the property `priority_networks` in the corresponding FE and BE configuration files before starting the nodes. Besides, because the IP address access is not adopted by default, you must start the FE nodes by running the following commands:
 
 ```Shell
-sh bin/start_fe.sh --host_type IP --daemon
+./bin/start_fe.sh --host_type IP --daemon
 ```
 
 The property `--host_type` specifies the way of access that is used to start the node. The valid value includes `FQDN` and `IP`. You only need to specify this property ONCE when you start the node for the first time.
@@ -49,7 +49,7 @@ You need to enable FQDN access for all the non-Leader Follower FE nodes before e
 1. Navigate to the deployment directory of the FE node, and run the following command to stop the FE node.
 
   ```Shell
-  sh bin/stop_fe.sh --daemon
+  ./bin/stop_fe.sh --daemon
   ```
 
 2. Execute the following statement via your MySQL client to check the `Alive` status of the FE node that you have stopped. Wait until the `Alive` status becomes `false`.
@@ -67,7 +67,7 @@ You need to enable FQDN access for all the non-Leader Follower FE nodes before e
 4. Run the following command to start the FE node with FQDN access.
 
   ```Shell
-  sh bin/start_fe.sh --host_type FQDN --daemon
+  ./bin/start_fe.sh --host_type FQDN --daemon
   ```
 
   The property `--host_type` specifies the way of access that is used to start the node. The valid value includes `FQDN` and `IP`. You only need to specify this property ONCE when you restart the node after you modified the node.
@@ -91,7 +91,7 @@ After all non-Leader FE nodes have been modified and restarted successfully, you
 1. Navigate to the deployment directory of the Leader FE node, and run the following command to stop the Leader FE node.
 
   ```Shell
-  sh bin/stop_fe.sh --daemon
+  ./bin/stop_fe.sh --daemon
   ```
 
 2. Execute the following statement via your MySQL client to check if there is a new Leader FE node that has been elected for the cluster.
@@ -111,7 +111,7 @@ After all non-Leader FE nodes have been modified and restarted successfully, you
 4. Run the following command to start the FE node with FQDN access.
 
   ```Shell
-  sh bin/start_fe.sh --host_type FQDN --daemon
+  ./bin/start_fe.sh --host_type FQDN --daemon
   ```
 
   The property `--host_type` specifies the way of access that is used to start the node. The valid value includes `FQDN` and `IP`. You only need to specify this property ONCE when you restart the node after you modified the node.

--- a/docs/faq/Others.md
+++ b/docs/faq/Others.md
@@ -184,7 +184,7 @@ If you execute the DROP TABLE statement to delete a table, StarRocks takes a whi
 
 ## How to view the current version of StarRocks?
 
-Run the `select current_version();` command or the CLI command `sh bin/show_fe_version.sh` to view the current version.
+Run the `select current_version();` command or the CLI command `./bin/show_fe_version.sh` to view the current version.
 
 ## How to set the memory size of an FE?
 

--- a/docs/quick_start/Deploy.md
+++ b/docs/quick_start/Deploy.md
@@ -123,7 +123,7 @@ Having installed StarRocks, you need to start the FE node. FE is the front layer
 5. Start FE node.
 
   ```Plain
-  sh fe/bin/start_fe.sh --daemon
+  ./fe/bin/start_fe.sh --daemon
   ```
 
 6. Verify if the FE node is started successfully.
@@ -194,7 +194,7 @@ After FE node is started, you need to start the BE node. BE is the executing lay
 4. Start BE node.
 
   ```Plain
-  sh be/bin/start_be.sh --daemon
+  ./be/bin/start_be.sh --daemon
   ```
 
 5. Verify if the BE node is started successfully.
@@ -312,13 +312,13 @@ You can stop the StarRocks cluster by running the following commands.
 1. Stop the FE node.
 
   ```Plain
-  sh fe/bin/stop_fe.sh --daemon
+  ./fe/bin/stop_fe.sh --daemon
   ```
 
 2. Stop the BE node.
 
   ```Plain
-  sh be/bin/stop_be.sh --daemon
+  ./be/bin/stop_be.sh --daemon
   ```
 
 ## Troubleshooting


### PR DESCRIPTION
/bin/sh is used by Centos, /bin/bash is used by Ubuntu. So remove the /bin/sh to make the script more general.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
