### PR TITLE
[Enhancement] use memory_usage instead of bytes_usage to account the memory usage of cache entry

### DIFF
--- a/be/src/exec/query_cache/cache_manager.h
+++ b/be/src/exec/query_cache/cache_manager.h
@@ -26,7 +26,7 @@ struct CacheValue {
     size_t size() {
         size_t value_size = 0;
         for (auto& chk : result) {
-            value_size += chk->bytes_usage();
+            value_size += chk->memory_usage();
         }
         return value_size;
     }

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -95,11 +95,13 @@ struct PerLaneBuffer {
                 chunks[next_gc_chunk_idx++].reset();
             }
             ++next_gc_chunk_idx;
+            return std::move(chunks[next_chunk_idx++]);
+        } else {
+            // CRITICAL(by satanson): The method is invoked when cloning chunk, when query cache enabled, chunk
+            // may be accessed by multi-thread, so we must clone a chunk when pull chunk from cache operator.
+            ChunkPtr chunk = std::move(chunks[next_chunk_idx++]->clone_unique());
+            return chunk;
         }
-        // CRITICAL(by satanson): The method is invoked when cloning chunk, when query cache enabled, chunk
-        // may be accessed by multi-thread, so we must clone a chunk when pull chunk from cache operator.
-        ChunkPtr chunk = std::move(chunks[next_chunk_idx++]->clone_unique());
-        return chunk;
     }
 };
 


### PR DESCRIPTION
…

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
Two fixes:
1. use Chunk::memory_usage instead of Chunk::byte_usage to account the size of the chunk more exactly.
2. when the Chunk need not to be populate into the query cache, pulling chunk from cache operator need not clone the chunk.