### PR TITLE
[UT] refactor hive plan ut framework to support join operator with different catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -39,7 +39,7 @@ public class MetadataMgr {
         this.connectorMgr = connectorMgr;
     }
 
-    private Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
+    protected Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
         if (CatalogMgr.isInternalCatalog(catalogName)) {
             return Optional.of(localMetastore);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/MockedMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/MockedMetadataMgr.java
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.connector;
+
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.MetadataMgr;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MockedMetadataMgr extends MetadataMgr {
+    private final Map<String, ConnectorMetadata> metadatas = new HashMap<>();
+    private final LocalMetastore localMetastore;
+
+    public MockedMetadataMgr(LocalMetastore localMetastore, ConnectorMgr connectorMgr) {
+        super(localMetastore, connectorMgr);
+        this.localMetastore = localMetastore;
+    }
+
+    public void registerMockedMetadata(String catalogName, ConnectorMetadata metadata) {
+        metadatas.put(catalogName, metadata);
+    }
+
+    @Override
+    public Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
+        if (CatalogMgr.isInternalCatalog(catalogName)) {
+            return Optional.of(localMetastore);
+        } else {
+            return Optional.ofNullable(metadatas.get(catalogName));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -5,18 +5,24 @@ package com.starrocks.sql.plan;
 import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
-import com.starrocks.external.MockedMetadataMgrForHive;
+import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.BeforeClass;
 
 import java.util.Map;
 
-public class HivePlanTestBase extends PlanTestBase {
+public class ConnectorPlanTestBase extends PlanTestBase {
+    private static MockedMetadataMgr metadataMgr = null;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
+        GlobalStateMgr gsmMgr = connectContext.getGlobalStateMgr();
+        metadataMgr = new MockedMetadataMgr(gsmMgr.getLocalMetastore(), gsmMgr.getConnectorMgr());
+        gsmMgr.setMetadataMgr(metadataMgr);
+
         mockHiveCatalog();
     }
 
@@ -27,8 +33,7 @@ public class HivePlanTestBase extends PlanTestBase {
         properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
         GlobalStateMgr.getCurrentState().getCatalogMgr().createCatalog("hive", "hive0", "", properties);
 
-        GlobalStateMgr gsmMgr = connectContext.getGlobalStateMgr();
-        MockedMetadataMgrForHive metadataMgr = new MockedMetadataMgrForHive(gsmMgr.getLocalMetastore(), gsmMgr.getConnectorMgr());
-        gsmMgr.setMetadataMgr(metadataMgr);
+        MockedHiveMetadata mockedHiveMetadata = new MockedHiveMetadata();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME, mockedHiveMetadata);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -7,7 +7,7 @@ import com.starrocks.server.GlobalStateMgr;
 import org.junit.Before;
 import org.junit.Test;
 
-public class HivePartitionPruneTest extends HivePlanTestBase {
+public class HivePartitionPruneTest extends ConnectorPlanTestBase {
     @Before
     public void setUp() throws DdlException {
         GlobalStateMgr.getCurrentState().changeCatalogDb(connectContext, "hive0.partitioned_db");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveTPCHPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveTPCHPlanTest.java
@@ -9,10 +9,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class HiveTPCHPlanTest extends HivePlanTestBase {
+public class HiveTPCHPlanTest extends ConnectorPlanTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
-        HivePlanTestBase.beforeClass();
+        ConnectorPlanTestBase.beforeClass();
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
         GlobalStateMgr.getCurrentState().changeCatalogDb(connectContext, "hive0.tpch");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Any external catalog query ut could extends ConnectorPlanTestBase.
- ConnectorPlanTestBase could init MockedConnectorMetadata.
- Register MockedConnectorMetadata to MoeckedMetadataMgr.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
