### PR TITLE
[BugFix] Fix use-after-free in when TabletScanner call destructor

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -436,7 +436,7 @@ Status OlapScanNode::_start_scan(RuntimeState* state) {
     OlapScanConjunctsManager& cm = _conjuncts_manager;
     cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
     cm.tuple_desc = _tuple_desc;
-    cm.obj_pool = &_obj_pool;
+    cm.obj_pool = _pool;
     cm.key_column_names = &_olap_scan_node.key_column_name;
     cm.runtime_filters = &_runtime_filter_collector;
     cm.runtime_state = state;
@@ -605,7 +605,7 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
             scanner_params.skip_aggregation = _olap_scan_node.is_preaggregation;
             scanner_params.need_agg_finalize = true;
             scanner_params.unused_output_columns = &_unused_output_columns;
-            auto* scanner = _obj_pool.add(new TabletScanner(this));
+            auto* scanner = _pool->add(new TabletScanner(this));
             RETURN_IF_ERROR(scanner->init(state, scanner_params));
             // Assume all scanners have the same schema.
             _chunk_schema = &scanner->chunk_schema();

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -147,7 +147,6 @@ private:
     OlapScanConjunctsManager _conjuncts_manager;
     DictOptimizeParser _dict_optimize_parser;
     const Schema* _chunk_schema = nullptr;
-    ObjectPool _obj_pool;
 
     int32_t _num_scanners = 0;
     int32_t _chunks_per_scanner = 10;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -146,7 +146,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     }
 
     ConjunctivePredicatesRewriter not_pushdown_predicate_rewriter(_predicates, *_params.global_dictmaps);
-    not_pushdown_predicate_rewriter.rewrite_predicate(&_parent->_obj_pool);
+    not_pushdown_predicate_rewriter.rewrite_predicate(&_pool);
 
     // Range
     for (auto key_range : *key_ranges) {
@@ -225,7 +225,7 @@ Status TabletScanner::_init_unused_output_columns(const std::vector<std::string>
 // mapping a slot-column-id to schema-columnid
 Status TabletScanner::_init_global_dicts() {
     const auto& global_dict_map = _runtime_state->get_query_global_dict_map();
-    auto global_dict = _parent->_obj_pool.add(new ColumnIdToGlobalDictMap());
+    auto global_dict = _pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     for (auto slot : _parent->_tuple_desc->slots()) {
         if (!slot->is_materialized()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
the same reason with #11396

## Problem Summary(Required) ：
ExecNode::pool is the same pool with runtime_state->_obj_pool;
when we OlapScanNode call destructor by RuntimeState. the destruct order is
```
~Expr
~ExprContext
~OlapScanNode()
~TabletScanner
~ExprContext(cloned)
```

so when cloned ExprContext call close() method. use-after-free will happen.

the solution is add TabletScanner to RuntimeState::obj_pool. then we can assure that TabletScanner is always call destructor before Expr

after this change the order will be
```
~TabletScanner
~ExprContext(cloned)
~Expr
~ExprContext
~OlapScanNode()
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
