### PR TITLE
[BugFix] Colocate join with different number of buckets

### DIFF
--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -412,31 +412,23 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
 
     auto rhs_operators = child(1)->decompose_to_pipeline(context);
     auto lhs_operators = child(0)->decompose_to_pipeline(context);
-    size_t num_right_partitions;
-    size_t num_left_partitions;
     if (_distribution_mode == TJoinDistributionMode::BROADCAST) {
-        num_right_partitions = 1;
         // Broadcast join need only create one hash table, because all the HashJoinProbeOperators
         // use the same hash table with their own different probe states.
         rhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), rhs_operators);
 
-        num_left_partitions = context->degree_of_parallelism();
         bool force_local_passthrough = false;
         lhs_operators = context->maybe_interpolate_local_passthrough_exchange(
-                runtime_state(), lhs_operators, num_left_partitions, force_local_passthrough);
+                runtime_state(), lhs_operators, context->degree_of_parallelism(), force_local_passthrough);
     } else {
         // "col NOT IN (NULL, val1, val2)" always returns false, so hash join should
         // return empty result in this case. Hash join cannot be divided into multiple
         // partitions in this case. Otherwise, NULL value in right table will only occur
         // in some partition hash table, and other partition hash table can output chunk.
         if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
-            num_left_partitions = num_right_partitions = 1;
-
             rhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), rhs_operators);
             lhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), lhs_operators);
         } else {
-            num_left_partitions = num_right_partitions = context->degree_of_parallelism();
-
             // Both HashJoin{Build, Probe}Operator are parallelized
             // There are two ways of shuffle
             // 1. If previous op is ExchangeSourceOperator and its partition type is HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED
@@ -471,12 +463,16 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
         }
     }
 
+    size_t num_right_partitions = down_cast<SourceOperatorFactory*>(rhs_operators[0].get())->degree_of_parallelism();
+    size_t num_left_partitions = down_cast<SourceOperatorFactory*>(lhs_operators[0].get())->degree_of_parallelism();
+
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();
     HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           _row_descriptor, child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(),
                           _build_runtime_filters, _output_slots, _distribution_mode);
-    auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param, num_left_partitions);
+    auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(
+            param, std::max(num_left_partitions, num_right_partitions));
 
     // add placeholder into RuntimeFilterHub, HashJoinBuildOperator will generate runtime filters and fill it,
     // Operators consuming the runtime filters will inspect this placeholder.

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -416,10 +416,8 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
         // Broadcast join need only create one hash table, because all the HashJoinProbeOperators
         // use the same hash table with their own different probe states.
         rhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), rhs_operators);
-
-        bool force_local_passthrough = false;
-        lhs_operators = context->maybe_interpolate_local_passthrough_exchange(
-                runtime_state(), lhs_operators, context->degree_of_parallelism(), force_local_passthrough);
+        lhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), lhs_operators,
+                                                                              context->degree_of_parallelism());
     } else {
         // "col NOT IN (NULL, val1, val2)" always returns false, so hash join should
         // return empty result in this case. Hash join cannot be divided into multiple

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -463,6 +463,8 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
 
     size_t num_right_partitions = down_cast<SourceOperatorFactory*>(rhs_operators[0].get())->degree_of_parallelism();
     size_t num_left_partitions = down_cast<SourceOperatorFactory*>(lhs_operators[0].get())->degree_of_parallelism();
+    // For non-broadcast join, the number of left and right partitions must be the same.
+    DCHECK(_distribution_mode == TJoinDistributionMode::BROADCAST || num_right_partitions == num_left_partitions);
 
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();
     HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2196,6 +2196,16 @@ public class Coordinator {
                     });
                 }
 
+                // ScanNode with scanId in BE uses maxDriverSeq+1 in nodeToPerDriverSeqScanRanges[scanId] as pipelineDop.
+                // PipelineDop of all the ScanNodes in the fragment should be the same regardless of the difference of
+                // each ScanNode's tablets, so maxDriverSeq=pipelineDop-1 is forced to set to empty list if it is absent.
+                if (assignPerDriverSeq && instanceParam.pipelineDop > 0) {
+                    int maxDriverSeq = instanceParam.pipelineDop - 1;
+                    instanceParam.nodeToPerDriverSeqScanRanges.forEach((scanId, perDriverSeqScanRanges) -> {
+                        perDriverSeqScanRanges.computeIfAbsent(maxDriverSeq, k -> new ArrayList<>());
+                    });
+                }
+
                 params.instanceExecParams.add(instanceParam);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2196,14 +2196,12 @@ public class Coordinator {
                     });
                 }
 
-                // ScanNode with scanId in BE uses maxDriverSeq+1 in nodeToPerDriverSeqScanRanges[scanId] as pipelineDop.
-                // PipelineDop of all the ScanNodes in the fragment should be the same regardless of the difference of
-                // each ScanNode's tablets, so maxDriverSeq=pipelineDop-1 is forced to set to empty list if it is absent.
-                if (assignPerDriverSeq && instanceParam.pipelineDop > 0) {
-                    int maxDriverSeq = instanceParam.pipelineDop - 1;
-                    instanceParam.nodeToPerDriverSeqScanRanges.forEach((scanId, perDriverSeqScanRanges) ->
-                            perDriverSeqScanRanges.computeIfAbsent(maxDriverSeq, k -> new ArrayList<>())
-                    );
+                if (assignPerDriverSeq) {
+                    instanceParam.nodeToPerDriverSeqScanRanges.forEach((scanId, perDriverSeqScanRanges) -> {
+                        for (int driverSeq = 0; driverSeq < instanceParam.pipelineDop; ++driverSeq) {
+                            perDriverSeqScanRanges.computeIfAbsent(driverSeq, k -> new ArrayList<>());
+                        }
+                    });
                 }
 
                 params.instanceExecParams.add(instanceParam);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2201,9 +2201,9 @@ public class Coordinator {
                 // each ScanNode's tablets, so maxDriverSeq=pipelineDop-1 is forced to set to empty list if it is absent.
                 if (assignPerDriverSeq && instanceParam.pipelineDop > 0) {
                     int maxDriverSeq = instanceParam.pipelineDop - 1;
-                    instanceParam.nodeToPerDriverSeqScanRanges.forEach((scanId, perDriverSeqScanRanges) -> {
-                        perDriverSeqScanRanges.computeIfAbsent(maxDriverSeq, k -> new ArrayList<>());
-                    });
+                    instanceParam.nodeToPerDriverSeqScanRanges.forEach((scanId, perDriverSeqScanRanges) ->
+                            perDriverSeqScanRanges.computeIfAbsent(maxDriverSeq, k -> new ArrayList<>())
+                    );
                 }
 
                 params.instanceExecParams.add(instanceParam);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1338.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
ScanNode with `scanId` in BE uses `maxDriverSeq+1` in `nodeToPerDriverSeqScanRanges[scanId]` as pipelineDop.
PipelineDop of all the ScanNodes in the fragment should be the same regardless of the difference of each ScanNode's tablets, so `maxDriverSeq=pipelineDop-1` is forced to set to empty list if it is absent.

For example, as for t1 colocate join t2, where t1 has 1 bucket and t2 has 2 buckets.
Before this PR, dop of driver including t1 and t2 are 1 and 2, respectively. However, they should all be 2.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
