### PR TITLE
[Cherry-pick-2.1][BugFix]Fix olap external table meta synchronization bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
@@ -808,7 +808,7 @@ public class RollupJob extends AlterJob {
                         tablet.clearReplica();
                         for (Replica copiedReplica : copiedReplicas) {
                             Replica replica = invertedIndex.getReplica(tablet.getId(), copiedReplica.getBackendId());
-                            tablet.addReplica(replica, true);
+                            tablet.addReplica(replica, false);
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -837,7 +837,7 @@ public class RestoreJob extends AbstractJob {
                 long newTabletId = catalog.getNextId();
                 Tablet newTablet = new Tablet(newTabletId);
                 // add tablet to index, but not add to TabletInvertedIndex
-                remoteIdx.addTablet(newTablet, null /* tablet meta */, true /* is restore */);
+                remoteIdx.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
 
                 // replicas
                 List<Long> beIds = Catalog.getCurrentSystemInfo().seqChooseBackendIds(restoreReplicationNum, true,
@@ -852,7 +852,7 @@ public class RestoreJob extends AbstractJob {
                     long newReplicaId = catalog.getNextId();
                     Replica newReplica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
                             visibleVersion, schemaHash);
-                    newTablet.addReplica(newReplica, true /* is restore */);
+                    newTablet.addReplica(newReplica, false/* update inverted index */);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -474,12 +474,12 @@ public class ExternalOlapTable extends OlapTable {
                             replica.setLastFailedTime(replicaMeta.getLast_failed_time());
                             // forbidden repair for external table
                             replica.setNeedFurtherRepair(false);
-                            tablet.addReplica(replica, true);
+                            tablet.addReplica(replica, false);
                         }
                         TabletMeta tabletMeta = new TabletMeta(tTabletMeta.getDb_id(), tTabletMeta.getTable_id(),
-                                                            tTabletMeta.getPartition_id(), tTabletMeta.getIndex_id(),
-                                                            tTabletMeta.getOld_schema_hash(), tTabletMeta.getStorage_medium());
-                        index.addTablet(tablet, tabletMeta);
+                                tTabletMeta.getPartition_id(), tTabletMeta.getIndex_id(),
+                                tTabletMeta.getOld_schema_hash(), tTabletMeta.getStorage_medium());
+                        index.addTablet(tablet, tabletMeta, false);
                     }
                     if (indexMeta.getPartition_id() == partition.getId()) {
                         if (index.getId() != baseIndexId) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -145,13 +145,13 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public void addTablet(Tablet tablet, TabletMeta tabletMeta) {
-        addTablet(tablet, tabletMeta, false);
+        addTablet(tablet, tabletMeta, true);
     }
 
-    public void addTablet(Tablet tablet, TabletMeta tabletMeta, boolean isRestore) {
+    public void addTablet(Tablet tablet, TabletMeta tabletMeta, boolean updateInvertedIndex) {
         idToTablets.put(tablet.getId(), tablet);
         tablets.add(tablet);
-        if (!isRestore) {
+        if (updateInvertedIndex) {
             Catalog.getCurrentInvertedIndex().addTablet(tablet.getId(), tabletMeta);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -489,7 +489,7 @@ public class OlapTable extends Table {
                 for (int i = 0; i < tabletNum; i++) {
                     long newTabletId = catalog.getNextId();
                     Tablet newTablet = new Tablet(newTabletId);
-                    idx.addTablet(newTablet, null /* tablet meta */, true /* is restore */);
+                    idx.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
 
                     // replicas
                     List<Long> beIds = Catalog.getCurrentSystemInfo()
@@ -505,7 +505,7 @@ public class OlapTable extends Table {
                         long newReplicaId = catalog.getNextId();
                         Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
                                 partition.getVisibleVersion(), schemaHash);
-                        newTablet.addReplica(replica, true /* is restore */);
+                        newTablet.addReplica(replica, false/* update inverted index */);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -137,17 +137,17 @@ public class Tablet extends MetaObject implements Writable {
         return delete || !hasBackend;
     }
 
-    public void addReplica(Replica replica, boolean isRestore) {
+    public void addReplica(Replica replica, boolean updateInvertedIndex) {
         if (deleteRedundantReplica(replica.getBackendId(), replica.getVersion())) {
             replicas.add(replica);
-            if (!isRestore) {
+            if (updateInvertedIndex) {
                 Catalog.getCurrentInvertedIndex().addReplica(id, replica);
             }
         }
     }
 
     public void addReplica(Replica replica) {
-        addReplica(replica, false);
+        addReplica(replica, true);
     }
 
     public List<Replica> getReplicas() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/starrocks/StarRocksRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/starrocks/StarRocksRepository.java
@@ -11,7 +11,6 @@ import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.MasterDaemon;
-import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.meta.MetaContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,7 +69,7 @@ public class StarRocksRepository extends MasterDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
-        if (Catalog.getCurrentCatalog().getRole() != FrontendNodeType.FOLLOWER) {
+        if (!Catalog.getCurrentCatalog().isMaster()) {
             return;
         }
         for (ExternalOlapTable table : srTables.values()) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
@@ -164,8 +164,8 @@ public class TabletTest {
         // normal replica
         Replica normalReplica = new Replica(2L, 10002L,
                 9L, -1, 10L, 10L, ReplicaState.NORMAL, -1L, 9L);
-        tablet.addReplica(versionIncompleteReplica, true);
-        tablet.addReplica(normalReplica, true);
+        tablet.addReplica(versionIncompleteReplica, false);
+        tablet.addReplica(normalReplica, false);
         Assert.assertEquals(Tablet.TabletStatus.COLOCATE_REDUNDANT,
                 tablet.getColocateHealthStatus(9, 1, Sets.newHashSet(10002L)));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -561,6 +561,6 @@ public class DiskAndTabletLoadReBalancerTest {
         replica.setPathHash(pathHash);
         invertedIndex.addReplica(tabletId, replica);
         Tablet tablet1 = new Tablet(tabletId, Lists.newArrayList(replica));
-        materializedIndex.addTablet(tablet1, tabletMeta, false);
+        materializedIndex.addTablet(tablet1, tabletMeta, true);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -39,7 +39,7 @@ public class ConsistencyCheckerTest {
 
         TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 1111, medium);
         Tablet tablet = new Tablet(tabletId, Lists.newArrayList(replica));
-        materializedIndex.addTablet(tablet, tabletMeta, true);
+        materializedIndex.addTablet(tablet, tabletMeta, false);
         PartitionInfo partitionInfo = new PartitionInfo();
         DataProperty dataProperty = new DataProperty(medium);
         partitionInfo.addPartition(partitionId, dataProperty, (short) 3, false);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12367

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The tablet of the external OLAP table should not be added to TabletInvertedIndex; it will replace the local tablet if they have the same id, which will cause some inconsistency bugs.
Besides, this PR changes the param from isRestore to updateInvertedIndex, which makes the param more visible. And there is no need to cache the OLAP external table metadata in the non-leader node, so if the current node is not a leader, do nothing.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
