### PR TITLE
[BugFix] remain agg having filter when remove aggOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateAggRule.java
@@ -39,8 +39,6 @@ public class PushDownPredicateAggRule extends TransformationRule {
             List<ColumnRefOperator> columns = Utils.extractColumnRef(scalar);
 
             // push down predicate
-            // may be some problems. e.g. select count(*) from tbl having false return empty results.
-            // while select count(*) from (select * from tbl where false) t return one row with result of 0.
             if (groupColumns.containsAll(columns) && !columns.isEmpty()) {
                 // remove from filter
                 iter.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateAggRule.java
@@ -39,10 +39,12 @@ public class PushDownPredicateAggRule extends TransformationRule {
             List<ColumnRefOperator> columns = Utils.extractColumnRef(scalar);
 
             // push down predicate
+            // may be some problems. e.g. select count(*) from tbl having false return empty results.
+            // while select count(*) from (select * from tbl where false) t return one row with result of 0.
             if (groupColumns.containsAll(columns) && !columns.isEmpty()) {
                 // remove from filter
                 iter.remove();
-                // and to predicates
+                // add to push down predicates
                 pushDownPredicates.add(scalar);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -69,8 +69,9 @@ public class PushDownPredicateScanRule extends TransformationRule {
 
         // clone a new scan operator and rewrite predicate.
         Operator.Builder builder = OperatorBuilderFactory.build(logicalScanOperator);
-        LogicalScanOperator newScanOperator = (LogicalScanOperator) builder.withOperator(logicalScanOperator).build();
-        newScanOperator.setPredicate(predicates);
+        LogicalScanOperator newScanOperator = (LogicalScanOperator) builder.withOperator(logicalScanOperator)
+                .setPredicate(predicates)
+                .build();
         newScanOperator.buildColumnFilters(predicates);
         Map<ColumnRefOperator, ScalarOperator> projectMap =
                 newScanOperator.getOutputColumns().stream()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -146,6 +146,8 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
                 ScalarOperator rewrittenOperator = rewriter.rewrite(entry.getValue());
                 newProjectMap.put(entry.getKey(), rewrittenOperator);
             }
+        } else {
+            newProjectMap = projectMap;
         }
 
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(newProjectMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -15,6 +15,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -51,9 +52,6 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         OptExpression scanExpression = input.getInputs().get(0);
-        if (!(scanExpression.getOp() instanceof LogicalOlapScanOperator)) {
-            return false;
-        }
         LogicalOlapScanOperator scanOperator = (LogicalOlapScanOperator) scanExpression.getOp();
         if (scanOperator.getProjection() != null) {
             return false;
@@ -129,19 +127,28 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
             // in this case, CallOperator must have only one child ColumnRefOperator
             projectMap.put(entry.getKey(), entry.getValue().getChild(0));
         }
+
+        Map<ColumnRefOperator, ScalarOperator> newProjectMap = Maps.newHashMap();
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(projectMap);
+
+        OptExpression newChildOpt = input.inputAt(0);
+        if (aggregationOperator.getPredicate() != null) {
+            // rewrite the having predicate. replace the aggFunc by the columnRef
+            ScalarOperator newPredicate = rewriter.rewrite(aggregationOperator.getPredicate());
+            LogicalFilterOperator filterOperator = new LogicalFilterOperator(newPredicate);
+            newChildOpt = OptExpression.create(filterOperator, newChildOpt);
+        }
+
         if (aggregationOperator.getProjection() != null) {
-            Map<ColumnRefOperator, ScalarOperator> newProjectMap =
-                    Maps.newHashMap(aggregationOperator.getProjection().getColumnRefMap());
-            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(projectMap);
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry :
                     aggregationOperator.getProjection().getColumnRefMap().entrySet()) {
+                // rewrite the projection of this agg. replace the aggFunc by the columnRef
                 ScalarOperator rewrittenOperator = rewriter.rewrite(entry.getValue());
                 newProjectMap.put(entry.getKey(), rewrittenOperator);
             }
-            projectMap.clear();
-            projectMap.putAll(newProjectMap);
         }
-        LogicalProjectOperator projectOperator = new LogicalProjectOperator(projectMap);
-        return Lists.newArrayList(OptExpression.create(projectOperator, input.getInputs().get(0)));
+
+        LogicalProjectOperator projectOperator = new LogicalProjectOperator(newProjectMap);
+        return Lists.newArrayList(OptExpression.create(projectOperator, newChildOpt));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -137,10 +137,11 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
             ScalarOperator newPredicate = rewriter.rewrite(aggregationOperator.getPredicate());
             LogicalOlapScanOperator scanOperator = (LogicalOlapScanOperator) newChildOpt.getOp();
             LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
-            List<ScalarOperator> pushDownPredicates = Lists.newArrayList(newPredicate);
+            List<ScalarOperator> pushDownPredicates = Lists.newArrayList();
             if (scanOperator.getPredicate() != null) {
                 pushDownPredicates.add(scanOperator.getPredicate());
             }
+            pushDownPredicates.add(newPredicate);
             scanOperator = builder.withOperator(scanOperator)
                     .setPredicate(Utils.compoundAnd(pushDownPredicates))
                     .build();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -48,6 +48,7 @@ public class RemoveAggTest extends PlanTestBase {
         sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 having (max(v1) + min(v2)) is not null");
         sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 " +
                 "having ((max(v1) + min(v2)) is not null or k1 > 4)");
+        sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -25,6 +25,7 @@ public class RemoveAggTest extends PlanTestBase {
     @MethodSource("removeAggSqlCases")
     void removeAggTest(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         assertNotContains(plan, "AGGREGATE");
         assertContains(plan, "PREDICATES");
         assertContains(plan, "PREAGGREGATION: OFF");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 public class RemoveAggTest extends PlanTestBase {
@@ -26,6 +27,7 @@ public class RemoveAggTest extends PlanTestBase {
     void removeAggTest(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertNotContains(plan, "AGGREGATE");
+        assertContains(plan.toLowerCase(Locale.ROOT), "predicates");
         assertContains(plan, "PREAGGREGATION: OFF");
     }
 
@@ -40,7 +42,6 @@ public class RemoveAggTest extends PlanTestBase {
 
     private static Stream<Arguments> removeAggSqlCases() {
         List<String> sqlList = Lists.newArrayList();
-        sqlList.add("select max(v1) from test_agg group by k1, k2, k3;");
         sqlList.add("select max(v1) from test_agg group by k1, k2, k3 having(max(v1) = 1)");
         sqlList.add("select max(v1), min(v2) from test_agg group by k1, k2, k3 " +
                 "having (max(v1) > min(v2) or abs(max(v1)) is null)");
@@ -49,6 +50,7 @@ public class RemoveAggTest extends PlanTestBase {
         sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 " +
                 "having ((max(v1) + min(v2)) is not null or k1 > 4)");
         sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1");
+        sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1 and k2 < 1 and k1 + k2 >3");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Stream;
 
 public class RemoveAggTest extends PlanTestBase {
@@ -27,7 +26,7 @@ public class RemoveAggTest extends PlanTestBase {
     void removeAggTest(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertNotContains(plan, "AGGREGATE");
-        assertContains(plan.toLowerCase(Locale.ROOT), "predicates");
+        assertContains(plan, "PREDICATES");
         assertContains(plan, "PREAGGREGATION: OFF");
     }
 
@@ -42,15 +41,17 @@ public class RemoveAggTest extends PlanTestBase {
 
     private static Stream<Arguments> removeAggSqlCases() {
         List<String> sqlList = Lists.newArrayList();
-        sqlList.add("select max(v1) from test_agg group by k1, k2, k3 having(max(v1) = 1)");
+        sqlList.add("select max(v1) from test_agg group by k1, k2, k3 having (max(v1) = 1)");
         sqlList.add("select max(v1), min(v2) from test_agg group by k1, k2, k3 " +
                 "having (max(v1) > min(v2) or abs(max(v1)) is null)");
-        sqlList.add("select max(v1), min(v2), abs(123) from test_agg group by k1, k2, k3 having (max(v1) + min(v2) > sum(v3))");
+        sqlList.add("select max(v1), min(v2), abs(123) from test_agg group by k1, k2, k3" +
+                " having (max(v1) + min(v2) > sum(v3))");
         sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 having (max(v1) + min(v2)) is not null");
         sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 " +
                 "having ((max(v1) + min(v2)) is not null or k1 > 4)");
         sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1");
-        sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1 and k2 < 1 and k1 + k2 >3");
+        sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having k1 > 1 and k2 < 1 " +
+                "and k1 + k2 >3 and max(v1) = 1");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
@@ -61,6 +62,9 @@ public class RemoveAggTest extends PlanTestBase {
         sqlList.add("select max(v1) from test_agg group by k1");
         sqlList.add("select max(v1) from test_agg group by abs(k1), k1, k2, k3");
         sqlList.add("select hll_union_agg(h1) from test_agg group by k1, k2, k3");
+        sqlList.add("select max(v1) from t0 group by v2 having max(v1) > 2");
+        sqlList.add("select max(v1) from test_agg group by k1, k2, k3 having (min(v1) = 1)");
+        sqlList.add("select k1, k2 from test_agg group by k1, k2, k3 having max(v1) > 1 or min(v1) < 1");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -1,0 +1,66 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.plan;
+
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class RemoveAggTest extends PlanTestBase{
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("removeAggSqlCases")
+    void removeAggTest(String sql) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "AGGREGATE");
+        assertContains(plan, "PREAGGREGATION: OFF");
+    }
+
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("remainAggSqlCases")
+    void remainAggTest(String sql) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "AGGREGATE");
+    }
+
+
+    private static Stream<Arguments> removeAggSqlCases() {
+        List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select max(v1) from test_agg group by k1, k2, k3;");
+        sqlList.add("select max(v1) from test_agg group by k1, k2, k3 having(max(v1) = 1)");
+        sqlList.add("select max(v1), min(v2) from test_agg group by k1, k2, k3 " +
+                "having (max(v1) > min(v2) or abs(max(v1)) is null)");
+        sqlList.add("select max(v1), min(v2), abs(123) from test_agg group by k1, k2, k3 having (max(v1) + min(v2) > sum(v3))");
+        sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 having (max(v1) + min(v2)) is not null");
+        sqlList.add("select max(v1) + min(v2) from test_agg group by k1, k2, k3 " +
+                "having ((max(v1) + min(v2)) is not null or k1 > 4)");
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+
+    private static Stream<Arguments> remainAggSqlCases() {
+        List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select max(v1) from t0 group by v2");
+        sqlList.add("select min(v1) from test_agg group by k1, k2, k3");
+        sqlList.add("select max(v1) from test_agg group by k1");
+        sqlList.add("select max(v1) from test_agg group by abs(k1), k1, k2, k3");
+        sqlList.add("select hll_union_agg(h1) from test_agg group by k1, k2, k3");
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+
+
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RemoveAggTest.java
@@ -2,9 +2,9 @@
 
 package com.starrocks.sql.plan;
 
-
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class RemoveAggTest extends PlanTestBase{
+public class RemoveAggTest extends PlanTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -61,6 +61,8 @@ public class RemoveAggTest extends PlanTestBase{
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
-
-
+    @AfterAll
+    public static void afterClass() {
+        FeConstants.runningUnitTest = false;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11969

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When remove aggOperator, we should remain its having filter to avoid returning redundant rows.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
