### PR TITLE
[BugFix] HeartbeatResponse add prop aliveStatus

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -98,6 +98,8 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
                 HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
             if (hbResponse.aliveStatus != null) {
+                // The metadata before the upgrade does not contain hbResponse.aliveStatus,
+                // in which case the alive status needs to be handled according to the original logic
                 isAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
                 heartbeatRetryTimes = 0;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -63,7 +63,7 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
      * handle Broker's heartbeat response.
      * return true if alive state is changed.
      */
-    public boolean handleHbResponse(BrokerHbResponse hbResponse) {
+    public boolean handleHbResponse(BrokerHbResponse hbResponse, boolean isReplay) {
         boolean isChanged = false;
         if (hbResponse.getStatus() == HbStatus.OK) {
             if (!isAlive) {
@@ -89,10 +89,15 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
             // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
             // if this heartbeat is not synchronized to the follower, 
-            // that will cause the Follower and master’s memory to be inconsistent
+            // that will cause the Follower and leader’s memory to be inconsistent
             isChanged = true;
         }
-
+        if (!isReplay) {
+            hbResponse.aliveStatus = isAlive;
+        } else {
+            isAlive = hbResponse.aliveStatus;
+            heartbeatRetryTimes = 0;
+        }
         return isChanged;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FsBroker.java
@@ -29,6 +29,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.BrokerHbResponse;
+import com.starrocks.system.HeartbeatResponse;
 import com.starrocks.system.HeartbeatResponse.HbStatus;
 
 import java.io.DataInput;
@@ -93,10 +94,13 @@ public class FsBroker implements Writable, Comparable<FsBroker> {
             isChanged = true;
         }
         if (!isReplay) {
-            hbResponse.aliveStatus = isAlive;
+            hbResponse.aliveStatus = isAlive ?
+                HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
-            isAlive = hbResponse.aliveStatus;
-            heartbeatRetryTimes = 0;
+            if (hbResponse.aliveStatus != null) {
+                isAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
+                heartbeatRetryTimes = 0;
+            }
         }
         return isChanged;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -432,10 +432,13 @@ public class ComputeNode implements IComputable, Writable {
             isChanged = true;
         }
         if (!isReplay) {
-            hbResponse.aliveStatus = isAlive.get();
+            hbResponse.aliveStatus = isAlive.get() ?
+                HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
-            isAlive.getAndSet(hbResponse.aliveStatus);
-            heartbeatRetryTimes = 0;
+            if (hbResponse.aliveStatus != null) {
+                isAlive.getAndSet(hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE);
+                heartbeatRetryTimes = 0;
+            }
         }
         return isChanged;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -360,7 +360,7 @@ public class ComputeNode implements IComputable, Writable {
      * handle Compute node's heartbeat response.
      * return true if any port changed, or alive state is changed.
      */
-    public boolean handleHbResponse(BackendHbResponse hbResponse) {
+    public boolean handleHbResponse(BackendHbResponse hbResponse, boolean isReplay) {
         boolean isChanged = false;
         if (hbResponse.getStatus() == HeartbeatResponse.HbStatus.OK) {
             if (!this.version.equals(hbResponse.getVersion())) {
@@ -428,10 +428,15 @@ public class ComputeNode implements IComputable, Writable {
             // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
             // if this heartbeat is not synchronized to the follower, 
-            // that will cause the Follower and master’s memory to be inconsistent
+            // that will cause the Follower and leader’s memory to be inconsistent
             isChanged = true;
         }
-
+        if (!isReplay) {
+            hbResponse.aliveStatus = isAlive.get();
+        } else {
+            isAlive.getAndSet(hbResponse.aliveStatus);
+            heartbeatRetryTimes = 0;
+        }
         return isChanged;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -436,6 +436,8 @@ public class ComputeNode implements IComputable, Writable {
                 HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
             if (hbResponse.aliveStatus != null) {
+                // The metadata before the upgrade does not contain hbResponse.aliveStatus,
+                // in which case the alive status needs to be handled according to the original logic
                 isAlive.getAndSet(hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE);
                 heartbeatRetryTimes = 0;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -158,10 +158,13 @@ public class Frontend implements Writable {
             isChanged = true;
         }
         if (!isReplay) {
-            hbResponse.aliveStatus = isAlive;
+            hbResponse.aliveStatus = isAlive ?
+                HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
-            isAlive = hbResponse.aliveStatus;
-            heartbeatRetryTimes = 0;
+            if (hbResponse.aliveStatus != null) {
+                isAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
+                heartbeatRetryTimes = 0;
+            }
         }
         return isChanged;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -154,8 +154,14 @@ public class Frontend implements Writable {
             // this heartbeat info also need to be synced to follower.
             // Since the failed heartbeat info also modifies fe's memory, (this.heartbeatRetryTimes++;)
             // if this heartbeat is not synchronized to the follower, 
-            // that will cause the Follower and master’s memory to be inconsistent
+            // that will cause the Follower and leader’s memory to be inconsistent
             isChanged = true;
+        }
+        if (!isReplay) {
+            hbResponse.aliveStatus = isAlive;
+        } else {
+            isAlive = hbResponse.aliveStatus;
+            heartbeatRetryTimes = 0;
         }
         return isChanged;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -162,6 +162,8 @@ public class Frontend implements Writable {
                 HeartbeatResponse.AliveStatus.ALIVE : HeartbeatResponse.AliveStatus.NOT_ALIVE;
         } else {
             if (hbResponse.aliveStatus != null) {
+                // The metadata before the upgrade does not contain hbResponse.aliveStatus,
+                // in which case the alive status needs to be handled according to the original logic
                 isAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
                 heartbeatRetryTimes = 0;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -216,7 +216,7 @@ public class HeartbeatMgr extends LeaderDaemon {
                     computeNode = nodeMgr.getComputeNode(hbResponse.getBeId());
                 }
                 if (computeNode != null) {
-                    boolean isChanged = computeNode.handleHbResponse(hbResponse);
+                    boolean isChanged = computeNode.handleHbResponse(hbResponse, isReplay);
                     if (hbResponse.getStatus() != HbStatus.OK) {
                         // invalid all connections cached in ClientPool
                         ClientPool.backendPool.clearPool(new TNetworkAddress(computeNode.getHost(), computeNode.getBePort()));
@@ -243,7 +243,7 @@ public class HeartbeatMgr extends LeaderDaemon {
                 FsBroker broker = GlobalStateMgr.getCurrentState().getBrokerMgr().getBroker(
                         hbResponse.getName(), hbResponse.getHost(), hbResponse.getPort());
                 if (broker != null) {
-                    boolean isChanged = broker.handleHbResponse(hbResponse);
+                    boolean isChanged = broker.handleHbResponse(hbResponse, isReplay);
                     if (hbResponse.getStatus() != HbStatus.OK) {
                         // invalid all connections cached in ClientPool
                         ClientPool.brokerPool.clearPool(new TNetworkAddress(broker.ip, broker.port));

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
@@ -57,6 +57,9 @@ public class HeartbeatResponse implements Writable {
     @SerializedName(value = "hbTime")
     protected long hbTime;
 
+    @SerializedName(value = "as")
+    public boolean aliveStatus;
+
     public HeartbeatResponse(Type type) {
         this.type = type;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
@@ -57,7 +57,7 @@ public class HeartbeatResponse implements Writable {
     @SerializedName(value = "hbTime")
     protected long hbTime;
 
-    @SerializedName(value = "as")
+    @SerializedName(value = "aliveStatus")
     public boolean aliveStatus;
 
     public HeartbeatResponse(Type type) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatResponse.java
@@ -44,6 +44,10 @@ public class HeartbeatResponse implements Writable {
         OK, BAD
     }
 
+    public enum AliveStatus {
+        ALIVE, NOT_ALIVE
+    }
+
     @SerializedName(value = "type")
     protected Type type;
     protected boolean isTypeRead = false;
@@ -58,7 +62,7 @@ public class HeartbeatResponse implements Writable {
     protected long hbTime;
 
     @SerializedName(value = "aliveStatus")
-    public boolean aliveStatus;
+    public AliveStatus aliveStatus;
 
     public HeartbeatResponse(Type type) {
         this.type = type;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
@@ -36,7 +36,7 @@ public class ExportRelativeStmtTest {
         FsBroker fsBroker = new FsBroker("127.0.0.1", 8118);
         long time = System.currentTimeMillis();
         BrokerHbResponse hbResponse = new BrokerHbResponse("broker", "127.0.0.1", 8118, time);
-        fsBroker.handleHbResponse(hbResponse);
+        fsBroker.handleHbResponse(hbResponse, false);
         GlobalStateMgr.getCurrentState().getBrokerMgr().replayAddBrokers("broker", Lists.newArrayList(fsBroker));
         String originStmt = "EXPORT TABLE tall TO \"hdfs://hdfs_host:port/a/b/c/\" " +
                 "WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
@@ -234,7 +234,7 @@ public class BackendTest {
         Backend be = new Backend();
         BackendHbResponse hbResponse = new BackendHbResponse(1, 9060, 8040, 8060, 8090,
                 System.currentTimeMillis(), "1.0", 64);
-        boolean isChanged = be.handleHbResponse(hbResponse);
+        boolean isChanged = be.handleHbResponse(hbResponse, false);
         Assert.assertTrue(isChanged);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
@@ -60,7 +60,7 @@ public class FsBrokerTest {
         FsBroker fsBroker = new FsBroker("127.0.0.1", 8118);
         long time = System.currentTimeMillis();
         BrokerHbResponse hbResponse = new BrokerHbResponse("broker", "127.0.0.1", 8118, time);
-        fsBroker.handleHbResponse(hbResponse);
+        fsBroker.handleHbResponse(hbResponse, false);
         fsBroker.write(dos);
         dos.flush();
         dos.close();
@@ -88,7 +88,7 @@ public class FsBrokerTest {
         FsBroker fsBroker = new FsBroker("127.0.0.1", 8118);
         long time = System.currentTimeMillis();
         BrokerHbResponse hbResponse = new BrokerHbResponse("broker", "127.0.0.1", 8118, "got exception");
-        fsBroker.handleHbResponse(hbResponse);
+        fsBroker.handleHbResponse(hbResponse, false);
         fsBroker.write(dos);
         dos.flush();
         dos.close();

--- a/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/FsBrokerTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.FsBroker;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.system.BrokerHbResponse;
+import com.starrocks.system.HeartbeatResponse;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -104,5 +105,20 @@ public class FsBrokerTest {
         Assert.assertEquals(-1, readBroker.lastStartTime);
         Assert.assertEquals(-1, readBroker.lastUpdateTime);
         dis.close();
+    }
+
+    @Test
+    public void testBrokerAlive() throws Exception {
+
+        FsBroker fsBroker = new FsBroker("127.0.0.1", 8118);
+        long time = System.currentTimeMillis();
+        BrokerHbResponse hbResponse = new BrokerHbResponse("broker", "127.0.0.1", 8118, "got exception");
+
+        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.ALIVE;
+        fsBroker.handleHbResponse(hbResponse, true);
+        Assert.assertTrue(fsBroker.isAlive);
+        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.NOT_ALIVE;
+        fsBroker.handleHbResponse(hbResponse, true);
+        Assert.assertFalse(fsBroker.isAlive);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -132,7 +132,7 @@ public class PrivilegeCheckerTest {
         FsBroker fsBroker = new FsBroker("127.0.0.1", 8118);
         long time = System.currentTimeMillis();
         BrokerHbResponse hbResponse = new BrokerHbResponse("broker", "127.0.0.1", 8118, time);
-        fsBroker.handleHbResponse(hbResponse);
+        fsBroker.handleHbResponse(hbResponse, false);
         GlobalStateMgr.getCurrentState().getBrokerMgr().replayAddBrokers("broker", Lists.newArrayList(fsBroker));
 
         TablePattern db1TablePattern = new TablePattern("*", "*");

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -16,6 +16,13 @@ public class ComputeNodeTest {
         ComputeNode node = new ComputeNode();
         boolean needSync = node.handleHbResponse(hbResponse, false);
         Assert.assertTrue(needSync);
+
+        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.ALIVE;
+        node.handleHbResponse(hbResponse, true);
+        Assert.assertTrue(node.isAlive());
+        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.NOT_ALIVE;
+        node.handleHbResponse(hbResponse, true);
+        Assert.assertFalse(node.isAlive());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -14,7 +14,7 @@ public class ComputeNodeTest {
         hbResponse.status = HbStatus.BAD;
 
         ComputeNode node = new ComputeNode();
-        boolean needSync = node.handleHbResponse(hbResponse);
+        boolean needSync = node.handleHbResponse(hbResponse, false);
         Assert.assertTrue(needSync);
     }
 
@@ -25,7 +25,7 @@ public class ComputeNodeTest {
         hbResponse.status = HbStatus.OK;
         hbResponse.setRebootTime(1000L);
         ComputeNode node = new ComputeNode();
-        boolean needSync = node.handleHbResponse(hbResponse);
+        boolean needSync = node.handleHbResponse(hbResponse, false);
         Assert.assertTrue(node.getLastStartTime() == 1000000L);    
         Assert.assertTrue(needSync);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12473 

Prop 'heartbeatRetryTimes' makes node alive status which stored in follower wrong, the alive of nodes in Follower depends on the calculation of heartbeatRetryTimes, which is not accurate, this PR adds a new prop 'aliveStatus' in HeartbeatResponse and uses 'aliveStatus' to decide node alive status which stored in follower

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
