### PR TITLE
[Refactor] disable DCHECK(!_close)in ExprContext::evaluate() as some expr are shared by multi threads

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -187,6 +187,7 @@ StatusOr<ColumnPtr> ExprContext::evaluate(vectorized::Chunk* chunk) {
 StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk) {
     DCHECK(_prepared);
     DCHECK(_opened);
+    // as may be shared by multi threads, this check may fail
     // DCHECK(!_closed);
 #ifndef NDEBUG
     if (chunk != nullptr) {

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -187,7 +187,7 @@ StatusOr<ColumnPtr> ExprContext::evaluate(vectorized::Chunk* chunk) {
 StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk) {
     DCHECK(_prepared);
     DCHECK(_opened);
-    DCHECK(!_closed);
+    // DCHECK(!_closed);
 #ifndef NDEBUG
     if (chunk != nullptr) {
         chunk->check_or_die();


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksBenchmark/issues/267

in DEBUG model, ExprContext::evaluate() check !_close, but some exprContext are shared by multiple threads, if some threads close it first, other threads check failed by accadence.
for example, `SortExecExprs` has many expressiones that are shared by many pipeline instances. The issue is resulted from the shared pointer of `_sort_tuple_slot_expr_ctxs `.

or we should add a deep copy function to `SortExecExprs`.

https://github.com/StarRocks/starrocks/blob/7f5e84ac5f64441c93d098282405dff77bc24e30/be/src/exec/sort_exec_exprs.h#L67-L78

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
