### PR TITLE
[Enhancement] Fix log printing in BE

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -145,8 +145,8 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
 
     if (master_info.__isset.backend_ip) {
         if (master_info.backend_ip != BackendOptions::get_localhost()) {
-            LOG(INFO) << master_info.backend_ip << " not equal to to backend localhost "
-                      << BackendOptions::get_localhost();
+            LOG(WARNING) << master_info.backend_ip << " not equal to to backend localhost "
+                         << BackendOptions::get_localhost();
             bool fe_saved_is_valid_ip = is_valid_ip(master_info.backend_ip);
             if (fe_saved_is_valid_ip && is_valid_ip(BackendOptions::get_localhost())) {
                 return Status::InternalError("FE saved address not match backend address");

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -74,7 +74,7 @@ bool BackendOptions::init() {
         LOG(INFO) << "fail to find one valid non-loopback address, use loopback address.";
         _s_localhost = loopback;
     }
-    LOG(INFO) << "local host" << _s_localhost;
+    LOG(INFO) << "localhost " << _s_localhost;
     return true;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes a typo in the log introduced by #9318, and changed a log output location for better debugging in BE

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

* Fixed the log output for BE IP: `backend_options.cpp:77] local host192.168.145.1`
* Moved the log about a mismatched BE IP address into the WARNING log, instead of INFO, for a better debugging experience.
   ```
   I1024 15:36:38.188383 248318 heartbeat_server.cpp:148] 172.17.0.1 not equal to to backend localhost 192.168.145.1
   W1024 15:36:38.188386 248318 heartbeat_server.cpp:74] Fail to handle heartbeat: Internal error: FE saved address not match backend address cached master info: TMasterInfo(network_address=TNetworkAddress(hostname=, port=0), cluster_id=-1, epoch=0, token=<null>, backend_ip=<null>, http_port=<null>, heartbeat_flags=<null>, backend_id=<null>) received master info: TMasterInfo(network_address=TNetworkAddress(hostname=172.17.0.1, port=9020), cluster_id=452026703, epoch=3, token=c2de331e-6628-4f77-92cc-913a61aa40f8, backend_ip=172.17.0.1, http_port=8030, heartbeat_flags=0, backend_id=10020)
   ```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
