### PR TITLE
[BugFix] start_fe.sh unary operator expected error

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -33,7 +33,7 @@ eval set -- "$OPTS"
 RUN_DAEMON=0
 HELPER=
 HOST_TYPE=
-ENABLE_DEBUGGER=
+ENABLE_DEBUGGER=0
 while true; do
     case "$1" in
         --daemon) RUN_DAEMON=1 ; shift ;;

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -45,8 +45,6 @@ while true; do
     esac
 done
 
-echo $ENABLE_DEBUGGER
-
 export STARROCKS_HOME=`cd "$curdir/.."; pwd`
 
 # compatible with DORIS_HOME: DORIS_HOME still be using in config on the user side, so set DORIS_HOME to the meaningful value in case of wrong envs.


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix a bug introduced by https://github.com/StarRocks/starrocks/pull/12432.
```
$ ./bin/start_fe.sh --daemon
./bin/start_fe.sh: line 90: [: -eq: unary operator expected
```
It's because the default of ENABLE_DEBUGGER is unset.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
