### PR TITLE
[Enhancement] Add HTTP API pipeline_blocking_drivers

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -31,6 +31,7 @@ namespace pipeline {
 class PipelineDriver;
 using DriverPtr = std::shared_ptr<PipelineDriver>;
 using Drivers = std::vector<DriverPtr>;
+using IterateImmutableDriverFunc = std::function<void(DriverConstRawPtr)>;
 
 enum DriverState : uint32_t {
     NOT_READY = 0,
@@ -165,7 +166,9 @@ public:
     ~PipelineDriver();
 
     QueryContext* query_ctx() { return _query_ctx; }
+    const QueryContext* query_ctx() const { return _query_ctx; }
     FragmentContext* fragment_ctx() { return _fragment_ctx; }
+    const FragmentContext* fragment_ctx() const { return _fragment_ctx; }
     int32_t source_node_id() { return _source_node_id; }
     int32_t driver_id() const { return _driver_id; }
     DriverPtr clone() { return std::make_shared<PipelineDriver>(*this); }

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -225,6 +225,10 @@ void GlobalDriverExecutor::report_exec_state(FragmentContext* fragment_ctx, cons
     this->_exec_state_reporter->submit(std::move(report_task));
 }
 
+void GlobalDriverExecutor::iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const {
+    _blocked_driver_poller->iterate_immutable_driver(call);
+}
+
 void GlobalDriverExecutor::_update_profile_by_level(FragmentContext* fragment_ctx, bool done) {
     if (!done) {
         return;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -38,6 +38,8 @@ public:
     // to objects owned by FragmentContext.
     virtual void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) = 0;
 
+    virtual void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const = 0;
+
 protected:
     std::string _name;
 };
@@ -51,6 +53,8 @@ public:
     void submit(DriverRawPtr driver) override;
     void cancel(DriverRawPtr driver) override;
     void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) override;
+
+    void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const override;
 
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -22,6 +22,7 @@ using Pipelines = std::vector<PipelinePtr>;
 class PipelineDriver;
 using DriverPtr = std::shared_ptr<PipelineDriver>;
 using DriverRawPtr = PipelineDriver*;
+using DriverConstRawPtr = const PipelineDriver*;
 using Drivers = std::vector<DriverPtr>;
 class OperatorFactory;
 using OpFactoryPtr = std::shared_ptr<OperatorFactory>;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -32,7 +32,7 @@ public:
     ~QueryContext();
     void set_exec_env(ExecEnv* exec_env) { _exec_env = exec_env; }
     void set_query_id(const TUniqueId& query_id) { _query_id = query_id; }
-    TUniqueId query_id() { return _query_id; }
+    TUniqueId query_id() const { return _query_id; }
     void set_total_fragments(size_t total_fragments) { _total_fragments = total_fragments; }
 
     void increment_num_fragments() {

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -53,7 +53,8 @@ add_library(Webserver STATIC
   action/compaction_action.cpp
   action/update_config_action.cpp
   action/runtime_filter_cache_action.cpp
-  action/query_cache_action.cpp)
+  action/query_cache_action.cpp
+  action/pipeline_blocking_drivers_action.cpp)
 
 # target_link_libraries(Webserver pthread dl Util)
 #ADD_BE_TEST(integer-array-test)

--- a/be/src/http/action/pipeline_blocking_drivers_action.cpp
+++ b/be/src/http/action/pipeline_blocking_drivers_action.cpp
@@ -1,0 +1,150 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "http/action/pipeline_blocking_drivers_action.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <string>
+
+#include "common/logging.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+const static std::string HEADER_JSON = "application/json";
+const static std::string ACTION_KEY = "action";
+const static std::string ACTION_STAT = "stat";
+
+struct DriverInfo {
+    int32_t driver_id;
+    pipeline::DriverState state;
+    std::string driver_desc;
+
+    DriverInfo(int32_t driver_id, pipeline::DriverState state, std::string&& driver_desc)
+            : driver_id(driver_id), state(state), driver_desc(std::move(driver_desc)) {}
+};
+
+void PipelineBlockingDriversAction::handle(HttpRequest* req) {
+    VLOG_ROW << req->debug_string();
+    const auto& action = req->param(ACTION_KEY);
+    if (req->method() == HttpMethod::GET) {
+        if (action == ACTION_STAT) {
+            _handle_stat(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support GET method: '$0'", req->uri()));
+        }
+    } else {
+        _handle_error(req,
+                      strings::Substitute("Not support $0 method: '$1'", to_method_desc(req->method()), req->uri()));
+    }
+}
+
+void PipelineBlockingDriversAction::_handle(HttpRequest* req, std::function<void(rapidjson::Document&)> func) {
+    rapidjson::Document root;
+    root.SetObject();
+    func(root);
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    root.Accept(writer);
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
+    HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());
+}
+
+void PipelineBlockingDriversAction::_handle_stat(HttpRequest* req) {
+    _handle(req, [=](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+
+        using DriverInfoList = std::vector<DriverInfo>;
+        using FragmentMap = std::unordered_map<TUniqueId, DriverInfoList>;
+        using QueryMap = std::unordered_map<TUniqueId, FragmentMap>;
+
+        auto query_map_to_doc_func = [&allocator](const QueryMap& query_map) {
+            rapidjson::Document queries_obj;
+            queries_obj.SetArray();
+            for (const auto& [query_id, fragment_map] : query_map) {
+                rapidjson::Document fragments_obj;
+                fragments_obj.SetArray();
+                for (const auto& [fragment_id, driver_info_list] : fragment_map) {
+                    rapidjson::Document drivers_obj;
+                    drivers_obj.SetArray();
+                    for (const auto& driver_info : driver_info_list) {
+                        rapidjson::Document driver_obj;
+                        driver_obj.SetObject();
+
+                        driver_obj.AddMember("driver_id", rapidjson::Value(driver_info.driver_id), allocator);
+                        driver_obj.AddMember("state",
+                                             rapidjson::Value(ds_to_string(driver_info.state).c_str(), allocator),
+                                             allocator);
+                        driver_obj.AddMember("driver_desc",
+                                             rapidjson::Value(driver_info.driver_desc.c_str(), allocator), allocator);
+
+                        drivers_obj.PushBack(driver_obj, allocator);
+                    }
+
+                    rapidjson::Document fragment_obj;
+                    fragment_obj.SetObject();
+                    fragment_obj.AddMember("fragment_id", rapidjson::Value(print_id(fragment_id).c_str(), allocator),
+                                           allocator);
+                    fragment_obj.AddMember("drivers", drivers_obj, allocator);
+                    fragments_obj.PushBack(fragment_obj, allocator);
+                }
+
+                rapidjson::Document query_obj;
+                query_obj.SetObject();
+                query_obj.AddMember("query_id", rapidjson::Value(print_id(query_id).c_str(), allocator), allocator);
+                query_obj.AddMember("fragments", fragments_obj, allocator);
+                queries_obj.PushBack(query_obj, allocator);
+            }
+
+            return queries_obj;
+        };
+
+        auto iterate_func_generator = [](QueryMap& query_map) {
+            return [&query_map](pipeline::DriverConstRawPtr driver) {
+                TUniqueId query_id = driver->query_ctx()->query_id();
+                TUniqueId fragment_id = driver->fragment_ctx()->fragment_instance_id();
+                int32_t driver_id = driver->driver_id();
+                pipeline::DriverState state = driver->driver_state();
+                std::string driver_desc = driver->to_readable_string();
+
+                auto fragment_map_it = query_map.find(query_id);
+                if (fragment_map_it == query_map.end()) {
+                    fragment_map_it = query_map.emplace(query_id, FragmentMap()).first;
+                }
+                auto& fragment_map = fragment_map_it->second;
+                auto driver_list_it = fragment_map.find(fragment_id);
+                if (driver_list_it == fragment_map.end()) {
+                    driver_list_it = fragment_map.emplace(fragment_id, DriverInfoList()).first;
+                }
+                driver_list_it->second.emplace_back(driver_id, state, std::move(driver_desc));
+            };
+        };
+
+        QueryMap query_map_not_in_wg;
+        _exec_env->driver_executor()->iterate_immutable_blocking_driver(iterate_func_generator(query_map_not_in_wg));
+        rapidjson::Document queries_not_in_wg_obj = query_map_to_doc_func(query_map_not_in_wg);
+
+        QueryMap query_map_in_wg;
+        _exec_env->wg_driver_executor()->iterate_immutable_blocking_driver(iterate_func_generator(query_map_in_wg));
+        rapidjson::Document queries_in_wg_obj = query_map_to_doc_func(query_map_in_wg);
+
+        root.AddMember("queries_not_in_workgroup", queries_not_in_wg_obj, allocator);
+        root.AddMember("queries_in_workgroup", queries_in_wg_obj, allocator);
+    });
+}
+
+void PipelineBlockingDriversAction::_handle_error(HttpRequest* req, const std::string& err_msg) {
+    _handle(req, [err_msg](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        root.AddMember("error", rapidjson::Value(err_msg.c_str(), err_msg.size()), allocator);
+    });
+}
+
+} // namespace starrocks

--- a/be/src/http/action/pipeline_blocking_drivers_action.h
+++ b/be/src/http/action/pipeline_blocking_drivers_action.h
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
+#include "http/http_handler.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class PipelineBlockingDriversAction : public HttpHandler {
+public:
+    explicit PipelineBlockingDriversAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+    ~PipelineBlockingDriversAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    void _handle(HttpRequest* req, std::function<void(rapidjson::Document& root)> func);
+    // Returns information about the blocking drivers with the following format:
+    // {
+    //      "queries_not_in_workgroup": [{
+    //          "query_id": "str",
+    //          "fragments": [{
+    //              "fragment_id": "str",
+    //              "drivers": [{
+    //                  "driver_id": "int",
+    //                  "state": "str",
+    //                  "driver_desc": "str"
+    //              }]
+    //          }]
+    //      }],
+    //      "queries_in_workgroup": []
+    // }
+    void _handle_stat(HttpRequest* req);
+    void _handle_error(HttpRequest* req, const std::string& error_msg);
+
+private:
+    ExecEnv* _exec_env;
+};
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -29,6 +29,7 @@
 #include "http/action/health_action.h"
 #include "http/action/meta_action.h"
 #include "http/action/metrics_action.h"
+#include "http/action/pipeline_blocking_drivers_action.h"
 #include "http/action/pprof_actions.h"
 #include "http/action/query_cache_action.h"
 #include "http/action/reload_tablet_action.h"
@@ -217,6 +218,11 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/query_cache/{action}", query_cache_action);
     _ev_http_server->register_handler(HttpMethod::PUT, "/api/query_cache/{action}", query_cache_action);
     _http_handlers.emplace_back(query_cache_action);
+
+    PipelineBlockingDriversAction* pipeline_driver_poller_action = new PipelineBlockingDriversAction(_env);
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/pipeline_blocking_drivers/{action}",
+                                      pipeline_driver_poller_action);
+    _http_handlers.emplace_back(pipeline_driver_poller_action);
 
     RETURN_IF_ERROR(_ev_http_server->start());
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Note that, the thread `PipelinerDiverPoller` uses a local blocking queue. To get information from the blocking queue, expose this local blocking queue, and use a read-write lock to avoid race condition.

Add HTTP GET API `/api/pipeline_blocking_drivers/stat` to fetch information about blocking drivers.
It will return a JSON with the following format:
```json
{
    "queries_not_in_workgroup": [{
        "query_id": "str",
        "fragments": [{
            "fragment_id": "str",
            "drivers": [{
                "driver_id": "int",
                "state": "str",
                "driver_desc": "driver=addr, status=str, operator-chain: [op1->op2->op3]"
            }]
        }]
    }],
    "queries_in_workgroup": []
}
```

An example for the BugFix #12454 is as follows:
```json
{
    "queries_not_in_workgroup": [
        {
            "query_id": "0fe350d9-550b-11ed-8e38-00163e00accc",
            "fragments": [
                {
                    "fragment_id": "0fe350d9-550b-11ed-8e38-00163e00accd",
                    "drivers": [
                        {
                            "driver_id": 4,
                            "state": "PRECONDITION_BLOCK",
                            "driver_desc": "driver=0x7f7a769ecb10, status=PRECONDITION_BLOCK, operator-chain: [olap_scan_prepare_0_0x7f7a769eb710(O) -> noop_sink_0_0x7f7a769ec110(O)]"
                        },
                        {
                            "driver_id": 9,
                            "state": "PRECONDITION_BLOCK",
                            "driver_desc": "driver=0x7f7a740c1190, status=PRECONDITION_BLOCK, operator-chain: [olap_scan_0_0x7f7a71d53310(O) -> chunk_accumulate_0_0x7f7a75958110(O) -> hash_join_probe_2_0x7f7a75958d90(O)(HashJoiner=0x7f7a757a9b90) -> chunk_accumulate_2_0x7f7a740a7790(O) -> project_3_0x7f7a740a9590(O) -> hash_join_probe_5_0x7f7a740a9f90(O)(HashJoiner=0x7f7a757acd90) -> chunk_accumulate_5_0x7f7a740aa990(O) -> project_6_0x7f7a740ab390(O) -> aggregate_blocking_sink_7_0x7f7a740abd90(O)]"
                        },
                        {
                            "driver_id": 10,
                            "state": "INPUT_EMPTY",
                            "driver_desc": "driver=0x7f7a740c2810, status=INPUT_EMPTY, operator-chain: [aggregate_blocking_source_7_0x7f7a740c1690(O) -> exchange_sink_8_0x7f7aa7345810(O)]"
                        }
                    ]
                }
            ]
        }
    ],
    "queries_in_workgroup": []
}
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
