### PR TITLE
[BugFix] Fix ChunkAccummulatorOperator::reset() error and should_cache suppress interpolate_passthrough

### DIFF
--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -30,7 +30,6 @@ Status ChunkAccumulateOperator::set_finished(RuntimeState*) {
 }
 
 Status ChunkAccumulateOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
-    _is_finished = false;
     _acc.reset();
 
     return Status::OK();

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -32,7 +32,6 @@ public:
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
-    bool _is_finished = false;
     ChunkPipelineAccumulator _acc;
 };
 

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -255,12 +255,12 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     size_t degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
 
-    if (_tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough) {
+    auto should_cache = context->should_interpolate_cache_operator(operators_with_sink[0], id());
+    if (!should_cache && _tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough) {
         operators_with_sink = context->maybe_interpolate_local_passthrough_exchange(
                 runtime_state(), operators_with_sink, degree_of_parallelism, true);
     }
 
-    auto should_cache = context->should_interpolate_cache_operator(operators_with_sink[0], id());
     auto operators_generator = [this, should_cache, &context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -477,6 +477,7 @@ void ChunkPipelineAccumulator::push(const vectorized::ChunkPtr& chunk) {
 }
 
 void ChunkPipelineAccumulator::reset() {
+    _finalized = false;
     _in_chunk.reset();
     _out_chunk.reset();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function

1. Bug introduced from https://github.com/StarRocks/starrocks/pull/12268
2. interpolate_passthrough overrides enable_query_cache introduced from https://github.com/StarRocks/starrocks/pull/12117