### PR TITLE
[BugFix] Add recognization for date and datetime

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -103,6 +103,10 @@ public class AnalyzeFunctionTest {
 
         analyzeFail("select time_slice(th, interval 1 second, FCEILK) from tall",
                 "time_slice must use FLOOR/CEIL as third parameter");
+
+        analyzeSuccess("select time_slice('2022-04-26 19:01:03', interval 5 day)");
+        analyzeSuccess("select time_slice('2022-04-26', interval 5 day)");
+        analyzeSuccess("select time_slice('2022-04-', interval 5 day)");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes to recognize DATETIME from text:
```
mysql> select time_slice('2022-04-26 19:01:07', interval 5 second);
+-------------------------------------------------------------+
| time_slice('2022-04-26 19:01:07', INTERVAL 5 second, floor) |
+-------------------------------------------------------------+
| 2022-04-26 19:01:05                                         |
+-------------------------------------------------------------+
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
