### PR TITLE
[Enhancement][Deps] Don't build hyperscan unit tests

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -738,7 +738,7 @@ build_fmt() {
     mkdir -p build
     cd build
     $CMAKE_CMD -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR} ../ \
-            -DCMAKE_INSTALL_LIBDIR=lib64 -G "${CMAKE_GENERATOR}" -DFMT_TEST=NO
+            -DCMAKE_INSTALL_LIBDIR=lib64 -G "${CMAKE_GENERATOR}" -DFMT_TEST=OFF
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
@@ -802,7 +802,8 @@ build_hyperscan() {
     cd $TP_SOURCE_DIR/$HYPERSCAN_SOURCE
     export PATH=$TP_INSTALL_DIR/bin:$PATH
     $CMAKE_CMD -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR} -DBOOST_ROOT=$STARROCKS_THIRDPARTY/installed/include \
-          -DCMAKE_CXX_COMPILER=$STARROCKS_GCC_HOME/bin/g++ -DCMAKE_C_COMPILER=$STARROCKS_GCC_HOME/bin/gcc  -DCMAKE_INSTALL_LIBDIR=lib
+          -DCMAKE_CXX_COMPILER=$STARROCKS_GCC_HOME/bin/g++ -DCMAKE_C_COMPILER=$STARROCKS_GCC_HOME/bin/gcc  -DCMAKE_INSTALL_LIBDIR=lib \
+          -DBUILD_EXAMPLES=OFF -DBUILD_UNIT=OFF
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
@@ -971,10 +972,10 @@ build_streamvbyte() {
     make install
 }
 
-export CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess -fPIC -g -I${TP_INCLUDE_DIR}"
-export CPPFLAGS=$CXXFLAGS
+export CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess -fPIC -g"
+export CPPFLAGS="-I ${TP_INCLUDE_DIR}"
 # https://stackoverflow.com/questions/42597685/storage-size-of-timespec-isnt-known
-export CFLAGS="-O3 -fno-omit-frame-pointer -std=c99 -fPIC -g -D_POSIX_C_SOURCE=199309L -I${TP_INCLUDE_DIR}"
+export CFLAGS="-O3 -fno-omit-frame-pointer -std=c99 -fPIC -g -D_POSIX_C_SOURCE=199309L"
 
 build_libevent
 build_zlib

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -410,5 +410,14 @@ fi
 cd -
 echo "Finished patching $STREAMVBYTE_SOURCE"
 
+# patch hyperscan
+cd $TP_SOURCE_DIR/$HYPERSCAN_SOURCE
+if [ ! -f $PATCHED_MARK ] && [ $HYPERSCAN_SOURCE = "hyperscan-5.4.0" ]; then
+    patch -p1 < $TP_PATCH_DIR/hyperscan-5.4.0.patch
+    touch $PATCHED_MARK
+fi
+cd -
+echo "Finished patching $HYPERSCAN_SOURCE"
+
 cd -
 

--- a/thirdparty/patches/hyperscan-5.4.0.patch
+++ b/thirdparty/patches/hyperscan-5.4.0.patch
@@ -1,0 +1,24 @@
+diff -rupN hyperscan-5.4.0.orig/CMakeLists.txt hyperscan-5.4.0/CMakeLists.txt
+--- hyperscan-5.4.0.orig/CMakeLists.txt 2022-10-26 16:40:46.498384371 +0000
++++ hyperscan-5.4.0/CMakeLists.txt      2022-10-26 16:44:28.947137907 +0000
+@@ -482,7 +482,11 @@ if (CORRECT_PCRE_VERSION AND PCRE_BUILD_
+     set(BUILD_CHIMERA TRUE)
+ endif()
+
+-add_subdirectory(unit)
++option(BUILD_UNIT "Build Hyperscan unit test (default TRUE)" TRUE)
++if (BUILD_UNIT)
++    add_subdirectory(unit)
++endif()
++
+ if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
+     add_subdirectory(tools)
+ endif()
+@@ -534,7 +538,6 @@ if (CORRECT_PCRE_VERSION AND PCRE_BUILD_
+     set(BUILD_CHIMERA TRUE)
+ endif()
+
+-add_subdirectory(unit)
+ if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
+     add_subdirectory(tools)
+ endif()


### PR DESCRIPTION
Because hyperscan include a legency google test in their code base, some compilation errors will happend when compiling them. And this project is not active anymore, so I patch their CMake files to disable its unit tests.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
