### PR TITLE
[BugFix][cherry-pick][Branch-2.2] Fix nullable column update rows not set _has_null and Fix be crash when flush mem table is null

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -165,6 +165,8 @@ Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
         const auto& c = down_cast<const NullableColumn&>(src);
         RETURN_IF_ERROR(_null_column->update_rows(*c._null_column, indexes));
         RETURN_IF_ERROR(_data_column->update_rows(*c._data_column, indexes));
+        // update rows may convert between null and not null, so we need count every times
+        _has_null = SIMD::count_nonzero(_null_column->get_data());
     } else {
         auto new_null_column = NullColumn::create();
         new_null_column->get_data().insert(new_null_column->get_data().end(), replace_num, 0);

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -243,6 +243,10 @@ Status DeltaWriter::close() {
 }
 
 Status DeltaWriter::_flush_memtable_async() {
+    // _mem_table is nullptr means write() has not been called
+    if (_mem_table == nullptr) {
+        return Status::OK();
+    }
     RETURN_IF_ERROR(_mem_table->finalize());
     return _flush_token->submit(std::move(_mem_table));
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
