### PR TITLE
[BugFix] Fix getSortKeyIdxes() potential null pointer.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -263,9 +263,11 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not modify key column: " + modColumn.getName() + " for primary key table");
             }
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());
-            for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
-                if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
-                    throw new DdlException("Can not drop sort column in primary data model table");
+            if (indexMeta.getSortKeyIdxes() != null) {
+                for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
+                    if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
+                        throw new DdlException("Can not drop sort column in primary data model table");
+                    }
                 }
             }
             if (modColumn.getAggregationType() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -266,7 +266,7 @@ public class SchemaChangeHandler extends AlterHandler {
             if (indexMeta.getSortKeyIdxes() != null) {
                 for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                     if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
-                        throw new DdlException("Can not drop sort column in primary data model table");
+                        throw new DdlException("Can not modify sort column in primary data model table");
                     }
                 }
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12548

```
CREATE TABLE `primary_table_without_null` (
                        `k1` int NOT NULL,
                        `v2` date NULL,
                        `v3` datetime NULL,
                        `v4` varchar(20) NULL,
                        `v5` boolean NULL,
                        `v6` tinyint NULL,
                        `v7` smallint NULL,
                        `v8` int NULL,
                        `v9` bigint NULL,
                        `v10` largeint NULL,
                        `v11` float NULL,
                        `v12` double NULL,
                        `v13` decimal(27,9) NULL
                    ) ENGINE=OLAP
                    PRIMARY KEY(`k1`)
                    COMMENT "OLAP"
                    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
                    PROPERTIES (
                        "replication_num" = "3",
                        "storage_format" = "v2"
                    );
ALTER TABLE primary_table_without_null MODIFY COLUMN v2 datetime,MODIFY COLUMN v3 date, MODIFY COLUMN v6 smallint, MODIFY COLUMN v7 INT,MODIFY COLUMN v8 BIGINT,MODIFY COLUMN v9 LARGEINT,MODIFY COLUMN v10 VARCHAR(40), MODIFY COLUMN v11 double;
execute sql error and messages: (1064, 'Unexpected exception: null'), and time is: 2022-10-26 03:33:15
```

```
mysql> select current_version();
+----------------------+
| current_version()    |
+----------------------+
| MAIN-RELEASE 7fbd664 |
+----------------------+
1 row in set (0.01 sec)
```

```
2022-10-26 10:05:52,157 WARN (starrocks-mysql-nio-pool-127|12741) [StmtExecutor.handleDdlStmt():1095] DDL statement(ALTER TABLE primary_table_without_null MODIFY COLUMN v2 datetime,MODIFY COLUMN v3 date, MODIFY COLUMN v6 smallint, MODIFY COLUMN v7 INT,MODIFY COLUMN v8 BIGINT,MODIFY COLUMN v9 LARGEINT,MODIFY COLUMN v10 VARCHAR(40), MODIFY COLUMN v11 double) process failed.
java.lang.NullPointerException: null
        at com.starrocks.alter.SchemaChangeHandler.processModifyColumn(SchemaChangeHandler.java:266) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.SchemaChangeHandler.analyzeAndCreateJob(SchemaChangeHandler.java:1145) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.SchemaChangeHandler.process(SchemaChangeHandler.java:1170) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.Alter.processAlterTable(Alter.java:420) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.alterTable(LocalMetastore.java:3130) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.alterTable(GlobalStateMgr.java:2755) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitAlterTableStatement$13(DDLStmtExecutor.java:283) ~[starrocks-fe.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterTableStatement(DDLStmtExecutor.java:282) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterTableStatement(DDLStmtExecutor.java:122) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AlterTableStmt.accept(AlterTableStmt.java:33) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:108) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:1073) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:471) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:305) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:420) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:666) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]
```