### PR TITLE
[Enhancement] Support replicated_storage as tablet property & disable insert shuffle when enable replicated_storage

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -683,6 +683,8 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                 break;
             case TTabletMetaType::WRITE_QUORUM:
                 break;
+            case TTabletMetaType::REPLICATED_STORAGE:
+                break;
             case TTabletMetaType::ENABLE_PERSISTENT_INDEX:
                 LOG(INFO) << "update tablet:" << tablet->tablet_id()
                           << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -763,6 +763,9 @@ Status OlapTableSink::init(const TDataSink& t_sink) {
     if (table_sink.__isset.write_quorum_type) {
         _write_quorum_type = table_sink.write_quorum_type;
     }
+    if (table_sink.__isset.enable_replicated_storage) {
+        _enable_replicated_storage = table_sink.enable_replicated_storage;
+    }
     _schema = std::make_shared<OlapTableSchemaParam>();
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
     _vectorized_partition = _pool->add(new vectorized::OlapTablePartitionParam(_schema, table_sink.partition));
@@ -781,10 +784,6 @@ Status OlapTableSink::init(const TDataSink& t_sink) {
 
 Status OlapTableSink::prepare(RuntimeState* state) {
     _span->AddEvent("prepare");
-
-    if (state->query_options().__isset.enable_replicated_storage) {
-        _enable_replicated_storage = state->query_options().enable_replicated_storage;
-    }
 
     // profile must add to state's object pool
     _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -489,15 +489,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
             return Status::InvalidArgument("Invalid load_dop format");
         }
     }
-    if (!http_req->header(HTTP_ENABLE_REPLICATED_STORAGE).empty()) {
-        if (boost::iequals(http_req->header(HTTP_ENABLE_REPLICATED_STORAGE), "false")) {
-            request.__set_enable_replicated_storage(false);
-        } else if (boost::iequals(http_req->header(HTTP_ENABLE_REPLICATED_STORAGE), "true")) {
-            request.__set_enable_replicated_storage(true);
-        } else {
-            return Status::InvalidArgument("Invalid enable replicated storage flag format. Must be bool type");
-        }
-    }
     if (ctx->timeout_second != -1) {
         request.__set_timeout(ctx->timeout_second);
     }

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -51,7 +51,6 @@ static const std::string HTTP_STRIP_OUTER_ARRAY = "strip_outer_array";
 static const std::string HTTP_PARTIAL_UPDATE = "partial_update";
 static const std::string HTTP_TRANSMISSION_COMPRESSION_TYPE = "transmission_compression_type";
 static const std::string HTTP_LOAD_DOP = "load_dop";
-static const std::string HTTP_ENABLE_REPLICATED_STORAGE = "enable_replicated_storage";
 
 static const std::string HTTP_100_CONTINUE = "100-continue";
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -510,6 +510,7 @@ public class Alter {
                 Map<String, String> properties = alterClause.getProperties();
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX) ||
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM));
 
                 OlapTable olapTable = (OlapTable) db.getTable(tableName);
@@ -526,6 +527,9 @@ public class Alter {
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)) {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties,
                             TTabletMetaType.WRITE_QUORUM);
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
+                    ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties,
+                            TTabletMetaType.REPLICATED_STORAGE);
                 }
             } else {
                 throw new DdlException("Invalid alter opertion: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1120,6 +1120,8 @@ public class SchemaChangeHandler extends AlterHandler {
                     return null;
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)) {
                     return null;
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
+                    return null;
                 }
             }
 
@@ -1238,6 +1240,11 @@ public class SchemaChangeHandler extends AlterHandler {
             TWriteQuorumType writeQuorum = WriteQuorum
                     .findTWriteQuorumByName(properties.get(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM));
             if (writeQuorum == olapTable.writeQuorum()) {
+                return;
+            }
+        } else if (metaType == TTabletMetaType.REPLICATED_STORAGE) {
+            metaValue = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE));
+            if (metaValue == olapTable.enableReplicatedStorage()) {
                 return;
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -328,6 +328,7 @@ public class ExternalOlapTable extends OlapTable {
             tableProperty.buildInMemory();
             tableProperty.buildDynamicProperty();
             tableProperty.buildWriteQuorum();
+            tableProperty.buildReplicatedStorage();
 
             indexes = null;
             if (meta.isSetIndex_infos()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1644,6 +1644,23 @@ public class OlapTable extends Table implements GsonPostProcessable {
         tableProperty.buildEnablePersistentIndex();
     }
 
+    public Boolean enableReplicatedStorage() {
+        if (tableProperty != null) {
+            return tableProperty.enableReplicatedStorage();
+        }
+        return false;
+    }
+
+    public void setEnableReplicatedStorage(boolean enableReplicatedStorage) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty
+                .modifyTableProperties(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
+                        Boolean.valueOf(enableReplicatedStorage).toString());
+        tableProperty.buildReplicatedStorage();
+    }
+
     public TWriteQuorumType writeQuorum() {
         if (tableProperty != null) {
             return tableProperty.writeQuorum();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -82,6 +82,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // the default write quorum
     private TWriteQuorumType writeQuorum = TWriteQuorumType.MAJORITY;
 
+    // the default disable replicated storage
+    private boolean enableReplicatedStorage = false;
+
     // 1. This table has been deleted. if hasDelete is false, the BE segment must don't have deleteConditions.
     //    If hasDelete is true, the BE segment maybe have deleteConditions because compaction.
     // 2. Before checkpoint, we relay delete job journal log to persist.
@@ -122,6 +125,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 break;
             case OperationType.OP_MODIFY_WRITE_QUORUM:
                 buildWriteQuorum();
+                break;
+            case OperationType.OP_MODIFY_REPLICATED_STORAGE:
+                buildReplicatedStorage();
                 break;
             default:
                 break;
@@ -175,6 +181,13 @@ public class TableProperty implements Writable, GsonPostProcessable {
                         WriteQuorum.MAJORITY));
         return this;
     }
+
+    public TableProperty buildReplicatedStorage() {
+        enableReplicatedStorage = Boolean
+                .parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE, "false"));
+        return this;
+    }
+
     public TableProperty buildEnablePersistentIndex() {
         enablePersistentIndex = Boolean.parseBoolean(
                 properties.getOrDefault(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "false"));
@@ -219,6 +232,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TWriteQuorumType writeQuorum() {
         return writeQuorum;
+    }
+
+    public boolean enableReplicatedStorage() {
+        return enableReplicatedStorage;
     }
 
     public TStorageFormat getStorageFormat() {
@@ -272,5 +289,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildCompressionType();
         buildWriteQuorum();
         buildPartitionTTL();
+        buildReplicatedStorage();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -90,6 +90,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_WRITE_QUORUM = "write_quorum";
 
+    public static final String PROPERTIES_REPLICATED_STORAGE = "replicated_storage";
+
     public static final String PROPERTIES_TABLET_TYPE = "tablet_type";
 
     public static final String PROPERTIES_STRICT_RANGE = "strict_range";

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -581,6 +581,7 @@ public class JournalEntity implements Writable {
             case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
             case OperationType.OP_MODIFY_REPLICATION_NUM:
             case OperationType.OP_MODIFY_WRITE_QUORUM:
+            case OperationType.OP_MODIFY_REPLICATED_STORAGE:
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX: {
                 data = ModifyTablePropertyOperationLog.read(in);
                 isRead = true;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -96,7 +96,6 @@ public abstract class BulkLoadJob extends LoadJob {
             SessionVariable var = ConnectContext.get().getSessionVariable();
             sessionVariables.put(SessionVariable.SQL_MODE, Long.toString(var.getSqlMode()));
             sessionVariables.put(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, var.getloadTransmissionCompressionType());
-            sessionVariables.put(SessionVariable.ENABLE_REPLICATED_STORAGE, Boolean.toString(var.getEnableReplicatedStorage()));
         } else {
             sessionVariables.put(SessionVariable.SQL_MODE, String.valueOf(SqlModeHelper.MODE_DEFAULT));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -263,7 +263,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             sessionVariables.put(SessionVariable.SQL_MODE, Long.toString(var.getSqlMode()));
             sessionVariables.put(SessionVariable.EXEC_MEM_LIMIT, Long.toString(var.getMaxExecMemByte()));
             sessionVariables.put(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, var.getloadTransmissionCompressionType());
-            sessionVariables.put(SessionVariable.ENABLE_REPLICATED_STORAGE, Boolean.toString(var.getEnableReplicatedStorage()));
         } else {
             sessionVariables.put(SessionVariable.SQL_MODE, String.valueOf(SqlModeHelper.MODE_DEFAULT));
             sessionVariables.put(SessionVariable.EXEC_MEM_LIMIT, Long.toString(SessionVariable.DEFAULT_EXEC_MEM_LIMIT));

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -702,6 +702,7 @@ public class EditLog {
                 case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
                 case OperationType.OP_MODIFY_REPLICATION_NUM:
                 case OperationType.OP_MODIFY_WRITE_QUORUM:
+                case OperationType.OP_MODIFY_REPLICATED_STORAGE:
                 case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
                             (ModifyTablePropertyOperationLog) journal.getData();
@@ -1432,6 +1433,10 @@ public class EditLog {
 
     public void logModifyWriteQuorum(ModifyTablePropertyOperationLog info) {
         logEdit(OperationType.OP_MODIFY_WRITE_QUORUM, info);
+    }
+
+    public void logModifyReplicatedStorage(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_MODIFY_REPLICATED_STORAGE, info);
     }
 
     public void logReplaceTempPartition(ReplacePartitionOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -199,6 +199,7 @@ public class OperationType {
     public static final short OP_ERASE_MULTI_TABLES = 10004;
     public static final short OP_MODIFY_ENABLE_PERSISTENT_INDEX = 10005;
     public static final short OP_MODIFY_WRITE_QUORUM = 10006;
+    public static final short OP_MODIFY_REPLICATED_STORAGE = 10007;
 
     // statistic 10010 ~ 10020
     public static final short OP_ADD_ANALYZER_JOB = 10010;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -103,13 +103,15 @@ public class OlapTableSink extends DataSink {
 
     private boolean enablePipelineLoad;
     private TWriteQuorumType writeQuorum;
+    private boolean enableReplicatedStorage;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
-                         TWriteQuorumType writeQuorum) {
-        this(dstTable, tupleDescriptor, partitionIds, true, writeQuorum);
+            TWriteQuorumType writeQuorum, boolean enableReplicatedStorage) {
+        this(dstTable, tupleDescriptor, partitionIds, true, writeQuorum, enableReplicatedStorage);
     }
 
-    public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds, boolean enablePipelineLoad, TWriteQuorumType writeQuorum) {
+    public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
+            boolean enablePipelineLoad, TWriteQuorumType writeQuorum, boolean enableReplicatedStorage) {
         this.dstTable = dstTable;
         this.tupleDescriptor = tupleDescriptor;
         Preconditions.checkState(!CollectionUtils.isEmpty(partitionIds));
@@ -117,6 +119,7 @@ public class OlapTableSink extends DataSink {
         this.clusterId = dstTable.getClusterId();
         this.enablePipelineLoad = enablePipelineLoad;
         this.writeQuorum = writeQuorum;
+        this.enableReplicatedStorage = enableReplicatedStorage;
     }
 
     public void init(TUniqueId loadId, long txnId, long dbId, long loadChannelTimeoutS)
@@ -135,6 +138,7 @@ public class OlapTableSink extends DataSink {
         tSink.setIs_lake_table(dstTable.isLakeTable());
         tSink.setKeys_type(dstTable.getKeysType().toThrift());
         tSink.setWrite_quorum_type(writeQuorum);
+        tSink.setEnable_replicated_storage(enableReplicatedStorage);
         tDataSink = new TDataSink(TDataSinkType.DATA_SPLIT_SINK);
         tDataSink.setType(TDataSinkType.OLAP_TABLE_SINK);
         tDataSink.setOlap_table_sink(tSink);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -159,7 +159,8 @@ public class StreamLoadPlanner {
         TWriteQuorumType writeQuorum = destTable.writeQuorum();
 
         List<Long> partitionIds = getAllPartitionIds();
-        OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds, writeQuorum);
+        OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds, writeQuorum,
+                destTable.enableReplicatedStorage());
         olapTableSink.init(loadId, streamLoadTask.getTxnId(), db.getId(), streamLoadTask.getTimeout());
         olapTableSink.complete();
 
@@ -205,7 +206,6 @@ public class StreamLoadPlanner {
         queryOptions.setQuery_type(TQueryType.LOAD);
         queryOptions.setQuery_timeout(streamLoadTask.getTimeout());
         queryOptions.setLoad_transmission_compression_type(streamLoadTask.getTransmisionCompressionType());
-        queryOptions.setEnable_replicated_storage(streamLoadTask.getEnableReplicatedStorage());
 
         // Disable load_dop for LakeTable temporary, because BE's `LakeTabletsChannel` does not support
         // parallel send from a single sender.
@@ -230,7 +230,7 @@ public class StreamLoadPlanner {
         LOG.info("load job id: {} tx id {} parallel {} compress {} replicated {} quorum {}", loadId,
                 streamLoadTask.getTxnId(),
                 queryOptions.getLoad_dop(),
-                queryOptions.getLoad_transmission_compression_type(), streamLoadTask.getEnableReplicatedStorage(),
+                queryOptions.getLoad_transmission_compression_type(), destTable.enableReplicatedStorage(),
                 writeQuorum);
         return params;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -340,10 +340,6 @@ public class Coordinator {
                 this.queryOptions.setLoad_transmission_compression_type(loadCompressionType);
             }
         }
-        if (sessionVariables.containsKey(SessionVariable.ENABLE_REPLICATED_STORAGE)) {
-            this.queryOptions.setEnable_replicated_storage(
-                    Boolean.parseBoolean(sessionVariables.get(SessionVariable.ENABLE_REPLICATED_STORAGE)));
-        }
         String nowString = DATE_FORMAT.format(Instant.ofEpochMilli(startTime).atZone(ZoneId.of(timezone)));
         this.queryGlobals.setNow_string(nowString);
         this.queryGlobals.setTimestamp_ms(startTime);
@@ -383,10 +379,6 @@ public class Coordinator {
                 if (loadCompressionType != null) {
                     this.queryOptions.setLoad_transmission_compression_type(loadCompressionType);
                 }
-            }
-            if (sessionVariables.containsKey(SessionVariable.ENABLE_REPLICATED_STORAGE)) {
-                this.queryOptions.setEnable_replicated_storage(
-                        Boolean.parseBoolean(sessionVariables.get(SessionVariable.ENABLE_REPLICATED_STORAGE)));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -244,7 +244,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // higher compression ratio may be chosen to use more CPU and make the overall query time lower.
     public static final String TRANSMISSION_COMPRESSION_TYPE = "transmission_compression_type";
     public static final String LOAD_TRANSMISSION_COMPRESSION_TYPE = "load_transmission_compression_type";
-    public static final String ENABLE_REPLICATED_STORAGE = "enable_replicated_storage";
 
     public static final String RUNTIME_JOIN_FILTER_PUSH_DOWN_LIMIT = "runtime_join_filter_push_down_limit";
     public static final String ENABLE_GLOBAL_RUNTIME_FILTER = "enable_global_runtime_filter";
@@ -625,9 +624,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = LOAD_TRANSMISSION_COMPRESSION_TYPE)
     private String loadTransmissionCompressionType = "NO_COMPRESSION";
-
-    @VariableMgr.VarAttr(name = ENABLE_REPLICATED_STORAGE)
-    private boolean enableReplicatedStorage = false;
 
     @VariableMgr.VarAttr(name = RUNTIME_JOIN_FILTER_PUSH_DOWN_LIMIT)
     private long runtimeJoinFilterPushDownLimit = 1024000;
@@ -1349,10 +1345,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.parseTokensLimit = parseTokensLimit;
     }
 
-    public boolean getEnableReplicatedStorage() {
-        return enableReplicatedStorage;
-    }
-
     public boolean isEnableQueryCache() {
         return isEnablePipelineEngine() && enableQueryCache;
     }
@@ -1415,8 +1407,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         if (loadCompressionType != null) {
             tResult.setLoad_transmission_compression_type(loadCompressionType);
         }
-
-        tResult.setEnable_replicated_storage(enableReplicatedStorage);
 
         tResult.setRuntime_join_filter_pushdown_limit(runtimeJoinFilterPushDownLimit);
         final int global_runtime_filter_wait_timeout = 20;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2166,6 +2166,14 @@ public class GlobalStateMgr {
                     .append("\" = \"");
             sb.append(olapTable.enablePersistentIndex()).append("\"");
 
+            // replicated_storage
+            if (olapTable.enableReplicatedStorage()) {
+                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                        .append(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)
+                        .append("\" = \"");
+                sb.append(olapTable.enableReplicatedStorage()).append("\"");
+            }
+
             // write quorum
             if (olapTable.writeQuorum() != TWriteQuorumType.MAJORITY) {
                 sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_WRITE_QUORUM)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -26,7 +26,6 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
-import com.starrocks.thrift.TWriteQuorumType;
 
 import java.util.List;
 
@@ -89,8 +88,8 @@ public class DeletePlanner {
             for (Partition partition : table.getPartitions()) {
                 partitionIds.add(partition.getId());
             }
-            TWriteQuorumType writeQuorum = table.writeQuorum();
-            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, writeQuorum);
+            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, table.writeQuorum(),
+                    table.enableReplicatedStorage());
             execPlan.getFragments().get(0).setSink(dataSink);
             if (isEnablePipeline && canUsePipeline) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -27,7 +27,6 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
-import com.starrocks.thrift.TWriteQuorumType;
 
 import java.util.List;
 import java.util.Optional;
@@ -83,8 +82,8 @@ public class UpdatePlanner {
             for (Partition partition : table.getPartitions()) {
                 partitionIds.add(partition.getId());
             }
-            TWriteQuorumType writeQuorum = table.writeQuorum();
-            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, writeQuorum);
+            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, table.writeQuorum(),
+                    table.enableReplicatedStorage());
             execPlan.getFragments().get(0).setSink(dataSink);
             execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
             if (isEnablePipeline && canUsePipeline) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -170,6 +170,15 @@ public class AlterTableStatementAnalyzer {
                 }
                 clause.setNeedTableStable(false);
                 clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
+                if (!properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("true") &&
+                        !properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("false")) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE +
+                                    " must be bool type(false/true)");
+                }
+                clause.setNeedTableStable(false);
+                clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLET_TYPE)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Alter tablet type not supported");
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/StreamLoadTask.java
@@ -258,9 +258,6 @@ public class StreamLoadTask {
         if (request.isSetLoad_dop()) {
             loadParallelRequestNum = request.getLoad_dop();
         }
-        if (request.isSetEnable_replicated_storage()) {
-            enableReplicatedStorage = request.isEnable_replicated_storage();
-        }
     }
 
     public static StreamLoadTask fromRoutineLoadJob(RoutineLoadJob routineLoadJob) {
@@ -304,10 +301,6 @@ public class StreamLoadTask {
         if (routineLoadJob.getSessionVariables().containsKey(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE)) {
             compressionType = CompressionUtils.findTCompressionByName(
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
-        }
-        if (routineLoadJob.getSessionVariables().containsKey(SessionVariable.ENABLE_REPLICATED_STORAGE)) {
-            enableReplicatedStorage = Boolean
-                    .parseBoolean(routineLoadJob.getSessionVariables().get(SessionVariable.ENABLE_REPLICATED_STORAGE));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -127,7 +127,7 @@ public class OlapTableSinkTest {
             result = partition;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L), TWriteQuorumType.MAJORITY, false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -164,7 +164,7 @@ public class OlapTableSinkTest {
             result = p1;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), TWriteQuorumType.MAJORITY, false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         try {
             sink.complete();
@@ -187,7 +187,8 @@ public class OlapTableSinkTest {
             result = null;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId),
+                TWriteQuorumType.MAJORITY, false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
@@ -260,7 +261,8 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY,
+                false);
         TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
         System.out.println(param);
 
@@ -343,7 +345,7 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId), TWriteQuorumType.MAJORITY, false);
         TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
         System.out.println(param);
 
@@ -387,7 +389,8 @@ public class OlapTableSinkTest {
             result = listPartitionInfo;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L), TWriteQuorumType.MAJORITY,
+                false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
 
@@ -421,7 +424,8 @@ public class OlapTableSinkTest {
             result = listPartitionInfo;
         }};
 
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L), TWriteQuorumType.MAJORITY);
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L), TWriteQuorumType.MAJORITY,
+                false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -285,7 +285,8 @@ enum TTabletMetaType {
     PARTITIONID,
     INMEMORY,
     ENABLE_PERSISTENT_INDEX,
-    WRITE_QUORUM
+    WRITE_QUORUM,
+    REPLICATED_STORAGE
 }
 
 struct TTabletMetaInfo {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -167,6 +167,7 @@ struct TOlapTableSink {
     16: optional string txn_trace_parent
     17: optional Types.TKeysType keys_type
     18: optional Types.TWriteQuorumType write_quorum_type
+    19: optional bool enable_replicated_storage
 }
 
 struct TDataSink {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -592,7 +592,6 @@ struct TStreamLoadPutRequest {
     27: optional bool partial_update
     28: optional string transmission_compression_type
     29: optional i32 load_dop
-    30: optional bool enable_replicated_storage
     // only valid when file type is CSV
     50: optional string rowDelimiter
 }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -190,8 +190,6 @@ struct TQueryOptions {
 
   64: optional TLoadJobType load_job_type
 
-  65: optional bool enable_replicated_storage;
-
   66: optional bool use_scan_block_cache;
 
   67: optional bool enable_pipeline_query_statistic = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
User can set `replicated_storage` to specify table's storage engine when create/alter table.

### CREATE TABLE
```sql
CREATE TABLE my_table
(
    k1 TINYINT,
    k2 DECIMAL(10, 2) DEFAULT "10.5",
    v1 CHAR(10) REPLACE,
    v2 INT SUM
)
ENGINE = olap
AGGREGATE KEY(k1, k2)
DISTRIBUTED BY HASH(k1) BUCKETS 10
PROPERTIES ("replicated_storage" = "true");
```
### ALTER TABLE
```sql
ALTER TABLE my_table
SET ("replicated_storage" = "false");
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
