### PR TITLE
[Enhancement] add variable `enable_populate_block_cache`

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -60,6 +60,9 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.use_scan_block_cache) {
         _use_block_cache &= state->query_options().use_scan_block_cache;
     }
+    if (state->query_options().__isset.enable_populate_block_cache) {
+        _enable_populate_block_cache = state->query_options().enable_populate_block_cache;
+    }
 
     RETURN_IF_ERROR(_init_conjunct_ctxs(state));
     _init_tuples_and_slots(state);
@@ -290,6 +293,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         scanner_params.deletes.emplace_back(&delete_file);
     }
     scanner_params.use_block_cache = _use_block_cache;
+    scanner_params.enable_populate_block_cache = _enable_populate_block_cache;
 
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -67,6 +67,7 @@ private:
     RuntimeState* _runtime_state = nullptr;
     vectorized::HdfsScanner* _scanner = nullptr;
     bool _use_block_cache = false;
+    bool _enable_populate_block_cache = false;
 
     // ============ conjuncts =================
     std::vector<ExprContext*> _min_max_conjunct_ctxs;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -199,6 +199,7 @@ Status HdfsScanner::open_random_access_file() {
 
     if (_scanner_params.use_block_cache && _compression_type == CompressionTypePB::NO_COMPRESSION) {
         _cache_input_stream = std::make_shared<io::CacheInputStream>(_raw_file->filename(), input_stream);
+        _cache_input_stream->enable_populate_cache(_scanner_params.enable_populate_block_cache);
         _file = std::make_unique<RandomAccessFile>(_cache_input_stream, _raw_file->filename());
         _scanner_ctx.enable_block_cache = true;
     } else {

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -199,7 +199,7 @@ Status HdfsScanner::open_random_access_file() {
 
     if (_scanner_params.use_block_cache && _compression_type == CompressionTypePB::NO_COMPRESSION) {
         _cache_input_stream = std::make_shared<io::CacheInputStream>(_raw_file->filename(), input_stream);
-        _cache_input_stream->enable_populate_cache(_scanner_params.enable_populate_block_cache);
+        _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
         _file = std::make_unique<RandomAccessFile>(_cache_input_stream, _raw_file->filename());
         _scanner_ctx.enable_block_cache = true;
     } else {

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -133,9 +133,10 @@ struct HdfsScannerParams {
 
     std::vector<const TIcebergDeleteFile*> deletes;
 
-    bool use_block_cache = false;
-
     bool is_lazy_materialization_slot(SlotId slot_id) const;
+
+    bool use_block_cache = false;
+    bool enable_populate_block_cache = false;
 };
 
 struct HdfsScannerContext {

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -69,7 +69,8 @@ StatusOr<int64_t> CacheInputStream::read(void* out, int64_t count) {
         // if not found, read from stream and write back to cache.
         int64_t load_size = std::min(BLOCK_SIZE, _size - block_offset);
         RETURN_IF_ERROR(_stream->read_at_fully(block_offset, src, load_size));
-        {
+
+        if (_enable_populate_cache) {
             SCOPED_RAW_TIMER(&_stats.write_cache_ns);
             Status r = cache->write_cache(_cache_key, block_offset, load_size, src);
             if (r.ok()) {

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -35,7 +35,7 @@ public:
 
     const Stats& stats() { return _stats; }
 
-    void enable_populate_cache(bool v) { _enable_populate_cache = v; }
+    void set_enable_populate_cache(bool v) { _enable_populate_cache = v; }
 
 private:
     std::string _cache_key;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -35,6 +35,8 @@ public:
 
     const Stats& stats() { return _stats; }
 
+    void enable_populate_cache(bool v) { _enable_populate_cache = v; }
+
 private:
     std::string _cache_key;
     std::string _filename;
@@ -44,6 +46,7 @@ private:
     Stats _stats;
     int64_t _size;
     int64_t _block_size;
+    bool _enable_populate_cache = false;
 };
 
 } // namespace starrocks::io

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2302,6 +2302,8 @@ public class Coordinator {
                     scanNode instanceof HudiScanNode || scanNode instanceof DeltaLakeScanNode) {
                 if (connectContext != null) {
                     queryOptions.setUse_scan_block_cache(connectContext.getSessionVariable().getUseScanBlockCache());
+                    queryOptions.setEnable_populate_block_cache(
+                            connectContext.getSessionVariable().getEnablePopulateBlockCache());
                 }
                 HDFSBackendSelector selector =
                         new HDFSBackendSelector(scanNode, locations, assignment, addressToBackendID, usedBackendIDs,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -287,6 +287,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SORT_AGGREGATE = "enable_sort_aggregate";
 
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
+    public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
 
 
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
@@ -709,6 +710,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_SCAN_BLOCK_CACHE)
     private boolean useScanBlockCache = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
+    private boolean enablePopulateBlockCache = true;
+
     public boolean getUseScanBlockCache() {
         return useScanBlockCache;
     }
@@ -724,6 +728,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
     private long queryCacheEntryMaxRows = 409600;
+    
+    public boolean getEnablePopulateBlockCache() {
+        return enablePopulateBlockCache;
+    }
 
     public void setCboCTEMaxLimit(int cboCTEMaxLimit) {
         this.cboCTEMaxLimit = cboCTEMaxLimit;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -197,6 +197,8 @@ struct TQueryOptions {
   67: optional bool enable_pipeline_query_statistic = false;
 
   68: optional i32 transmission_encode_level;
+  
+  69: optional bool enable_populate_block_cache;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This session variable `enable_populate_block_cache` can control if to populate block cache or not.

If user know some queries are just large scan job and will trash block cache, user can disable populate bock cache.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
