### PR TITLE
[Enhancement] rocksdb explicit set compression type to snappy

### DIFF
--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -75,9 +75,12 @@ Status KVStore::init(bool read_only) {
     // defined in olap_define.h
     std::vector<ColumnFamilyDescriptor> cf_descs(NUM_COLUMN_FAMILY_INDEX);
     cf_descs[0].name = DEFAULT_COLUMN_FAMILY;
+    cf_descs[0].options.compression = rocksdb::kSnappyCompression;
     cf_descs[1].name = STARROCKS_COLUMN_FAMILY;
+    cf_descs[1].options.compression = rocksdb::kSnappyCompression;
     cf_descs[2].name = META_COLUMN_FAMILY;
     cf_descs[2].options.prefix_extractor.reset(NewFixedPrefixTransform(PREFIX_LENGTH));
+    cf_descs[2].options.compression = rocksdb::kSnappyCompression;
     static_assert(NUM_COLUMN_FAMILY_INDEX == 3);
 
     rocksdb::Status s;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12583

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In rocksdb, the default compress type is snappy if snappy is installed in compile env. Or it will be no compression. This behavior is unstable, we should always want block to be compressed by snappy.
E.g, first time I compile be_a in machine A without snappy support, so the block be_a write is uncompress. And next time I compile be_b in machine B with snappy support，then be_b will not open rocksdb success because data compression type is uncorrect.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
