### PR TITLE
[Cherry-pick-2.2][BugFix] Fix report sync tablet version bugfix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -547,14 +547,6 @@ public class ReportHandler extends Daemon {
                                     ((metaVersion < backendVersion) ||
                                             (metaVersion == backendVersion && replica.isBad()))) {
 
-                                // This is just a optimization for the old compatibility
-                                // The init version in FE is (1-0), in BE is (2-0)
-                                // If the BE report version is (2-0), we just update the replica's version in
-                                // Master FE,
-                                // and no need to write edit log, to save some time.
-                                // TODO(cmy): This will be removed later.
-                                boolean isInitVersion = metaVersion == 1 && backendVersion == 2;
-
                                 if (backendReportVersion < Catalog.getCurrentSystemInfo()
                                         .getBackendReportVersion(backendId)) {
                                     continue;
@@ -566,7 +558,7 @@ public class ReportHandler extends Daemon {
                                 // to FE
                                 replica.updateRowCount(backendVersion, dataSize, rowCount);
 
-                                if (replica.getLastFailedVersion() < 0 && !isInitVersion) {
+                                if (replica.getLastFailedVersion() < 0) {
                                     // last failed version < 0 means this replica becomes health after sync,
                                     // so we write an edit log to sync this operation
                                     replica.setBad(false);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12491

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
There is version old code logic: if be report version is 2 and fe meta version is 1, the sync operation will not be written to bdb log, which will cause inconsistency bug. As the comment shows, these code should be removed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
