### PR TITLE
[BugFix] Fix colocate balancer not handling bad replica case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -590,29 +590,36 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
     /**
      * Check colocate table's tablet health
-     * 1. Mismatch:
-     * backends set:       1,2,3
+     * <p>
+     * 1. Mismatch:<p>
+     * backends set:       1,2,3<p>
      * tablet replicas:    1,2,5
      * <p>
-     * backends set:       1,2,3
+     * backends set:       1,2,3<p>
      * tablet replicas:    1,2
      * <p>
-     * backends set:       1,2,3
+     * backends set:       1,2,3<p>
      * tablet replicas:    1,2,4,5
      * <p>
-     * 2. Version incomplete:
+     * 2. Version incomplete:<p>
      * backend matched, but some replica's version is incomplete
      * <p>
-     * 3. Redundant:
-     * backends set:       1,2,3
+     * 3. Redundant:<p>
+     * backends set:       1,2,3<p>
      * tablet replicas:    1,2,3,4
      * <p>
+     * 4. Replica bad:<p>
+     * If a replica is marked bad, we need to migrate it and all the other replicas corresponding to the same bucket
+     * index in the colocate group to another backend, but the backend where the bad replica sits on may still be
+     * available, so the backend set won't be changed by ColocateBalancer, so we need to learn this state and update
+     * the backend set to replace the backend that has the bad replica. In order to be in consistent with the current
+     * logic, we return COLOCATE_MISMATCH not REPLICA_MISSING.
+     * <p></p>
      * No need to check if backend is available. We consider all backends in 'backendsSet' are available,
      * If not, unavailable backends will be relocated by ColocateTableBalancer first.
      */
     public TabletStatus getColocateHealthStatus(long visibleVersion,
                                                 int replicationNum, Set<Long> backendsSet) {
-
         // 1. check if replicas' backends are mismatch
         Set<Long> replicaBackendIds = getBackendIds();
         for (Long backendId : backendsSet) {
@@ -627,6 +634,10 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             // this kind of replica should be drooped.
             if (!backendsSet.contains(replica.getBackendId())) {
                 continue;
+            }
+
+            if (replica.isBad()) {
+                return TabletStatus.COLOCATE_MISMATCH;
             }
 
             if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -776,6 +776,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
         List<Long> badReplicaIdList = Lists.newArrayList();
         Set<Long> unavailableBeIdsInGroup = getUnavailableBeIdsInGroup(infoService, colocateIndex, groupId);
         List<Long> availableBeIds = getAvailableBeIds(infoService);
+        Set<Long> removedBackendIdSet = Sets.newHashSet();
         boolean isBackendSetChanged = false;
 
         // Traverse all replicas of the tablet to check if we need to replace backend of bad replica.
@@ -798,8 +799,10 @@ public class ColocateTableBalancer extends LeaderDaemon {
                 int idx = backendWithReplicaNum.size() - 1;
                 while (idx >= 0) {
                     long chosenBackendId = backendWithReplicaNum.get(idx).getKey();
-                    if (chosenBackendId != backendId && !currentBackendsSet.contains(chosenBackendId)) {
+                    if (chosenBackendId != backendId && !currentBackendsSet.contains(chosenBackendId) &&
+                            !removedBackendIdSet.contains(chosenBackendId)) {
                         replaceBackendId = chosenBackendId;
+                        removedBackendIdSet.add(backendId);
                         break;
                     }
                     idx--;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -22,6 +22,7 @@
 package com.starrocks.clone;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -35,6 +36,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.clone.TabletSchedCtx.Priority;
 import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
@@ -71,6 +73,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
      * Only for unit test purpose.
      */
     public static boolean disableRepairPrecedence = false;
+    public static boolean ignoreSingleReplicaCheck = false;
 
     public static ColocateTableBalancer getInstance() {
         if (INSTANCE == null) {
@@ -328,6 +331,12 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                             LOG.debug("get unhealthy tablet {} in colocate table. status: {}",
                                                     tablet.getId(),
                                                     st);
+
+                                            // If tablet has bad replica, `getColocateHealthStatus()` will also return
+                                            // COLOCATE_MISMATCH, we need to replace the backend which owns the bad
+                                            // replica.
+                                            adjustBackendSetIfReplicaBad(idx, tablet, st, groupId,
+                                                    ignoreSingleReplicaCheck);
 
                                             TabletSchedCtx tabletCtx = new TabletSchedCtx(
                                                     TabletSchedCtx.Type.REPAIR,
@@ -743,6 +752,74 @@ public class ColocateTableBalancer extends LeaderDaemon {
             return Sets.newHashSet(info.getLastBackendsPerBucketSeq().get(ctx.getTabletOrderIdx()));
         } else {
             return Sets.newHashSet();
+        }
+    }
+
+    void adjustBackendSetIfReplicaBad(int tabletOrderIdx, LocalTablet tablet, TabletStatus st, GroupId groupId,
+                                      boolean ignoreSingleReplicaCheck) {
+        if (st != TabletStatus.COLOCATE_MISMATCH) {
+            return;
+        }
+
+        List<Replica> replicas = tablet.getImmutableReplicas();
+        if (!ignoreSingleReplicaCheck && replicas.size() <= 1) {
+            return;
+        }
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        SystemInfoService infoService = GlobalStateMgr.getCurrentSystemInfo();
+        ClusterLoadStatistic statistic = globalStateMgr.getTabletScheduler().getLoadStatistic();
+        ColocateTableIndex colocateIndex = globalStateMgr.getColocateTableIndex();
+
+        Set<Long> currentBackendsSet = colocateIndex.getTabletBackendsByGroup(groupId, tabletOrderIdx);
+        Set<Long> savedBackendSet = ImmutableSet.copyOf(currentBackendsSet);
+        List<Long> badReplicaIdList = Lists.newArrayList();
+        Set<Long> unavailableBeIdsInGroup = getUnavailableBeIdsInGroup(infoService, colocateIndex, groupId);
+        List<Long> availableBeIds = getAvailableBeIds(infoService);
+        boolean isBackendSetChanged = false;
+
+        // Traverse all replicas of the tablet to check if we need to replace backend of bad replica.
+        for (Replica replica : replicas) {
+            long backendId = replica.getBackendId();
+            if (replica.isBad() && currentBackendsSet.contains(backendId)) {
+                badReplicaIdList.add(replica.getId());
+                long replaceBackendId = -1;
+                List<List<Long>> backendsPerBucketSeq =
+                        Lists.newArrayList(colocateIndex.getBackendsPerBucketSeq(groupId));
+                List<Long> flatBackendsPerBucketSeq =
+                        backendsPerBucketSeq.stream().flatMap(List::stream).collect(Collectors.toList());
+                // Get the aggregated number of replicas per backend and sort it in desc order, if we have to replace
+                // some backend in the current backend set, we will choose the backend with the least number
+                // of replicas first. The returned list only contains available backend.
+                List<Map.Entry<Long, Long>> backendWithReplicaNum =
+                        getSortedBackendReplicaNumPairs(availableBeIds, unavailableBeIdsInGroup, statistic,
+                                flatBackendsPerBucketSeq);
+
+                int idx = backendWithReplicaNum.size() - 1;
+                while (idx >= 0) {
+                    long chosenBackendId = backendWithReplicaNum.get(idx).getKey();
+                    if (chosenBackendId != backendId && !currentBackendsSet.contains(chosenBackendId)) {
+                        replaceBackendId = chosenBackendId;
+                        break;
+                    }
+                    idx--;
+                }
+
+                if (replaceBackendId != -1) {
+                    currentBackendsSet.add(replaceBackendId);
+                    currentBackendsSet.remove(backendId);
+                    isBackendSetChanged = true;
+                }
+            }
+        }
+
+        if (isBackendSetChanged) {
+            // Backend set changed, update metadata in ColocateIndex, ColocateBalancer will arrange tablet migration
+            // based on the new backend set.
+            colocateIndex.setBackendsSetByIdxForGroup(groupId, tabletOrderIdx, currentBackendsSet);
+            LOG.info("backend set changed because of bad replica, tablet id: {}, bad replica: {}," +
+                    " old backend set: {}, new backend set: {}",
+                    tablet.getId(), badReplicaIdList, savedBackendSet, currentBackendsSet);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -831,20 +831,26 @@ public class ColocateTableBalancerTest {
         LocalTablet tablet = (LocalTablet) partitions.get(0).getBaseIndex().getTablets().get(0);
         tablet.getImmutableReplicas().get(0).setBad(true);
         ColocateTableBalancer colocateTableBalancer = ColocateTableBalancer.getInstance();
-        Config.tablet_sched_repair_delay_factor_second = -1;
-        // the created pseudo min cluster can only have backend on the same host, so we can only create table with
-        // single replica, we need to open this test switch to test the behavior of bad replica balance
-        ColocateTableBalancer.ignoreSingleReplicaCheck = true;
-        // call twice to trigger the real balance action
-        colocateTableBalancer.runAfterCatalogReady();
-        colocateTableBalancer.runAfterCatalogReady();
+        long oldVal = Config.tablet_sched_repair_delay_factor_second;
+        try {
+            Config.tablet_sched_repair_delay_factor_second = -1;
+            // the created pseudo min cluster can only have backend on the same host, so we can only create table with
+            // single replica, we need to open this test switch to test the behavior of bad replica balance
+            ColocateTableBalancer.ignoreSingleReplicaCheck = true;
+            // call twice to trigger the real balance action
+            colocateTableBalancer.runAfterCatalogReady();
+            colocateTableBalancer.runAfterCatalogReady();
 
-        // get backend list after set bad
-        List<List<Long>> backendListAfter =
-                colocateTableIndex.getBackendsPerBucketSeq(colocateTableIndex.getGroup(table.getId()));
-        System.out.println(backendListAfter);
-        // backend set changed because of bad replica
-        Assert.assertFalse(backendListBefore.equals(backendListAfter));
+            // get backend list after set bad
+            List<List<Long>> backendListAfter =
+                    colocateTableIndex.getBackendsPerBucketSeq(colocateTableIndex.getGroup(table.getId()));
+            System.out.println(backendListAfter);
+            // backend set changed because of bad replica
+            Assert.assertNotEquals(backendListBefore, backendListAfter);
+        } finally {
+            Config.tablet_sched_repair_delay_factor_second = oldVal;
+        }
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.clone;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -29,6 +30,7 @@ import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -83,10 +85,6 @@ public class ColocateTableBalancerTest {
         UtFrameUtils.createMinStarRocksCluster();
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(ctx);
-        starRocksAssert.withDatabase("db1").useDatabase("db1")
-                .withTable("CREATE TABLE db1.tbl(id INT NOT NULL) " +
-                        "distributed by hash(`id`) buckets 3 " +
-                        "properties('replication_num' = '1', 'colocate_with' = 'group1');");
     }
 
     @Before
@@ -768,7 +766,12 @@ public class ColocateTableBalancerTest {
     }
 
     @Test
-    public void test1MatchGroup() {
+    public void test1MatchGroup() throws Exception {
+        starRocksAssert.withDatabase("db1").useDatabase("db1")
+                .withTable("CREATE TABLE db1.tbl(id INT NOT NULL) " +
+                        "distributed by hash(`id`) buckets 3 " +
+                        "properties('replication_num' = '1', 'colocate_with' = 'group1');");
+
         Database database = GlobalStateMgr.getCurrentState().getDb("db1");
         OlapTable table = (OlapTable) database.getTable("tbl");
         addTabletsToScheduler("db1", "tbl", false);
@@ -803,6 +806,45 @@ public class ColocateTableBalancerTest {
         colocateTableBalancer.runAfterCatalogReady();
         long after = stat.counterColocateBalanceRound.get();
         Assert.assertEquals(before + 1, after);
+    }
+
+    @Test
+    public void test3RepairWithBadReplica() throws Exception {
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
+        starRocksAssert.withDatabase("db3").useDatabase("db3")
+                .withTable("CREATE TABLE db3.tbl3(id INT NOT NULL) " +
+                        "distributed by hash(`id`) buckets 1 " +
+                        "properties('replication_num' = '1', 'colocate_with' = 'group3');");
+
+        Database database = GlobalStateMgr.getCurrentState().getDb("db3");
+        OlapTable table = (OlapTable) database.getTable("tbl3");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+
+        // get backend list before set bad
+        List<List<Long>> backendListBefore = ImmutableList.copyOf(
+                colocateTableIndex.getBackendsPerBucketSeq(colocateTableIndex.getGroup(table.getId())));
+        System.out.println(backendListBefore);
+
+        List<Partition> partitions = Lists.newArrayList(table.getPartitions());
+        LocalTablet tablet = (LocalTablet) partitions.get(0).getBaseIndex().getTablets().get(0);
+        tablet.getImmutableReplicas().get(0).setBad(true);
+        ColocateTableBalancer colocateTableBalancer = ColocateTableBalancer.getInstance();
+        Config.tablet_sched_repair_delay_factor_second = -1;
+        // the created pseudo min cluster can only have backend on the same host, so we can only create table with
+        // single replica, we need to open this test switch to test the behavior of bad replica balance
+        ColocateTableBalancer.ignoreSingleReplicaCheck = true;
+        // call twice to trigger the real balance action
+        colocateTableBalancer.runAfterCatalogReady();
+        colocateTableBalancer.runAfterCatalogReady();
+
+        // get backend list after set bad
+        List<List<Long>> backendListAfter =
+                colocateTableIndex.getBackendsPerBucketSeq(colocateTableIndex.getGroup(table.getId()));
+        System.out.println(backendListAfter);
+        // backend set changed because of bad replica
+        Assert.assertFalse(backendListBefore.equals(backendListAfter));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12461

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If a replica is marked bad, we need to migrate it and all the other replicas corresponding to the same bucket
index in the colocate group to another backend, but the backend where the bad replica sits on may still be
available, so the backend set won't be changed by ColocateBalancer, so we need to learn this state and update
the backend set to replace the backend that has the bad replica. In order to be in consistent with the current
logic, we return COLOCATE_MISMATCH not REPLICA_MISSING in `getColocateHealthStatus()`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
