### PR TITLE
[Feature] Support query queue

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -51,6 +51,7 @@ const uint32_t REPORT_TASK_WORKER_COUNT = 1;
 const uint32_t REPORT_DISK_STATE_WORKER_COUNT = 1;
 const uint32_t REPORT_OLAP_TABLE_WORKER_COUNT = 1;
 const uint32_t REPORT_WORKGROUP_WORKER_COUNT = 1;
+const uint32_t REPORT_RESOURCE_USAGE_WORKER_COUNT = 1;
 
 class AgentServer::Impl {
 public:
@@ -101,6 +102,7 @@ private:
     std::unique_ptr<ReportDiskStateTaskWorkerPool> _report_disk_state_workers;
     std::unique_ptr<ReportOlapTableTaskWorkerPool> _report_tablet_workers;
     std::unique_ptr<ReportWorkgroupTaskWorkerPool> _report_workgroup_workers;
+    std::unique_ptr<ReportResourceUsageTaskWorkerPool> _report_resource_usage_workers;
 };
 
 void AgentServer::Impl::init_or_die() {
@@ -209,6 +211,8 @@ void AgentServer::Impl::init_or_die() {
     CREATE_AND_START_POOL(_report_disk_state_workers, ReportDiskStateTaskWorkerPool, REPORT_DISK_STATE_WORKER_COUNT)
     CREATE_AND_START_POOL(_report_tablet_workers, ReportOlapTableTaskWorkerPool, REPORT_OLAP_TABLE_WORKER_COUNT)
     CREATE_AND_START_POOL(_report_workgroup_workers, ReportWorkgroupTaskWorkerPool, REPORT_WORKGROUP_WORKER_COUNT)
+    CREATE_AND_START_POOL(_report_resource_usage_workers, ReportResourceUsageTaskWorkerPool,
+                          REPORT_RESOURCE_USAGE_WORKER_COUNT)
 #undef CREATE_AND_START_POOL
 }
 
@@ -241,6 +245,7 @@ AgentServer::Impl::~Impl() {
     STOP_POOL(REPORT_DISK_STATE, _report_disk_state_workers);
     STOP_POOL(REPORT_OLAP_TABLE, _report_tablet_workers);
     STOP_POOL(REPORT_WORKGROUP, _report_workgroup_workers);
+    STOP_POOL(REPORT_WORKGROUP, _report_resource_usage_workers);
 #undef STOP_POOL
 }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -716,6 +716,8 @@ void* ReportResourceUsageTaskWorkerPool::_worker_thread_callback(void* arg_this)
         resource_usage.__set_num_running_queries(ExecEnv::GetInstance()->query_context_mgr()->size());
         resource_usage.__set_mem_used_bytes(ExecEnv::GetInstance()->process_mem_tracker()->consumption());
         resource_usage.__set_mem_limit_bytes(ExecEnv::GetInstance()->process_mem_tracker()->limit());
+        worker_pool_this->_cpu_usage_recorder.update_interval();
+        resource_usage.__set_cpu_used_permille(worker_pool_this->_cpu_usage_recorder.cpu_used_permille());
         request.__set_resource_usage(std::move(resource_usage));
 
         TMasterResult result;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -201,4 +201,18 @@ private:
     }
 };
 
+class ReportResourceUsageTaskWorkerPool : public TaskWorkerPool<AgentTaskRequestWithoutReqBody> {
+public:
+    ReportResourceUsageTaskWorkerPool(ExecEnv* env, int worker_num) : TaskWorkerPool(env, worker_num) {
+        _callback_function = _worker_thread_callback;
+    }
+
+private:
+    static void* _worker_thread_callback(void* arg_this);
+
+    AgentTaskRequestPtr _convert_task(const TAgentTaskRequest& task, time_t recv_time) override {
+        return std::make_shared<AgentTaskRequestWithoutReqBody>(task, recv_time);
+    }
+};
+
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -36,6 +36,7 @@
 #include "gen_cpp/HeartbeatService_types.h"
 #include "storage/olap_define.h"
 #include "storage/storage_engine.h"
+#include "util/cpu_usage_info.h"
 #include "util/threadpool.h"
 
 namespace starrocks {
@@ -213,6 +214,9 @@ private:
     AgentTaskRequestPtr _convert_task(const TAgentTaskRequest& task, time_t recv_time) override {
         return std::make_shared<AgentTaskRequestWithoutReqBody>(task, recv_time);
     }
+
+private:
+    CpuUsageRecorder _cpu_usage_recorder;
 };
 
 } // namespace starrocks

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -135,6 +135,8 @@ CONF_mInt32(report_disk_state_interval_seconds, "60");
 CONF_mInt32(report_tablet_interval_seconds, "60");
 // The interval time(seconds) for agent report workgroup to FE.
 CONF_mInt32(report_workgroup_interval_seconds, "5");
+// The interval time (millisecond) for agent report resource usage to FE.
+CONF_mInt32(report_resource_usage_interval_ms, "1000");
 // The max download speed(KB/s).
 CONF_mInt32(max_download_speed_kbps, "50000");
 // The download low speed limit(KB/s).

--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRC_FILES
     ${GEN_CPP_DIR}/HeartbeatService_constants.cpp
     ${GEN_CPP_DIR}/HeartbeatService.cpp
     ${GEN_CPP_DIR}/WorkGroup_types.cpp
+    ${GEN_CPP_DIR}/ResourceUsage_types.cpp
     ${GEN_CPP_DIR}/WorkGroup_constants.cpp
     ${GEN_CPP_DIR}/HeartbeatService_types.cpp
     ${GEN_CPP_DIR}/InternalService_constants.cpp

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -37,6 +37,7 @@ set(UTIL_FILES
   compression/stream_compression.cpp
   coding.cpp
   cpu_info.cpp
+  cpu_usage_info.cpp
   crc32c.cpp
   date_func.cpp
   dynamic_util.cpp

--- a/be/src/util/cpu_usage_info.cpp
+++ b/be/src/util/cpu_usage_info.cpp
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "util/cpu_usage_info.h"
+
+#include <glog/logging.h>
+
+#include <cstdio>
+#include <thread>
+
+#include "util/defer_op.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+const int CpuUsageRecorder::NUM_HARDWARE_CORES = std::thread::hardware_concurrency();
+const int CpuUsageRecorder::SECOND_CLOCK_TICK = sysconf(_SC_CLK_TCK);
+
+CpuUsageRecorder::CpuUsageRecorder() : _timestamp{0, MonotonicNanos()}, _proc_time{0, _get_proc_time()} {}
+
+CpuUsageRecorder::~CpuUsageRecorder() {
+    if (_line_ptr != nullptr) {
+        free(_line_ptr);
+    }
+}
+
+void CpuUsageRecorder::update_interval() {
+    _curr_idx = (_curr_idx + 1) % 2;
+    _proc_time[_curr_idx] = _get_proc_time();
+    _timestamp[_curr_idx] = MonotonicNanos();
+}
+
+int CpuUsageRecorder::cpu_used_permille() const {
+    if (_curr_idx == ABSENT_INDEX) {
+        // Haven't called update_interval.
+        return 0;
+    }
+    int prev_idx = (_curr_idx + 1) % 2;
+    return (_proc_time[_curr_idx] - _proc_time[prev_idx]) * 1000'000'000L / SECOND_CLOCK_TICK * 1000 /
+           NUM_HARDWARE_CORES / (_timestamp[_curr_idx] - _timestamp[prev_idx]);
+}
+
+uint64_t CpuUsageRecorder::_get_proc_time() {
+    FILE* fp = fopen("/proc/self/stat", "r");
+    if (fp == nullptr) {
+        LOG(WARNING) << "open /proc/self/stat failed";
+        return 0;
+    }
+    DeferOp close_fp([fp] { fclose(fp); });
+
+    if (getline(&_line_ptr, &_line_buf_size, fp) < 0) {
+        LOG(WARNING) << "getline from /proc/self/stat failed";
+        return 0;
+    }
+
+    uint64_t utime = 0;
+    uint64_t stime = 0;
+    sscanf(_line_ptr, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu", &utime, &stime);
+    return utime + stime;
+}
+
+} // namespace starrocks

--- a/be/src/util/cpu_usage_info.h
+++ b/be/src/util/cpu_usage_info.h
@@ -1,0 +1,38 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace starrocks {
+
+/// Record the cpu usage percentage at an interval.
+/// The interval is between the last two invocations of update_interval
+/// or from constructor to the first invocation of update_interval.
+/// It is not thread-safe.
+class CpuUsageRecorder {
+public:
+    CpuUsageRecorder();
+    ~CpuUsageRecorder();
+
+    void update_interval();
+    int cpu_used_permille() const;
+
+private:
+    uint64_t _get_proc_time();
+
+private:
+    static const int NUM_HARDWARE_CORES;
+    static const int SECOND_CLOCK_TICK;
+    static constexpr int ABSENT_INDEX = -1;
+
+    char* _line_ptr = nullptr;
+    size_t _line_buf_size = 0;
+
+    int _curr_idx = ABSENT_INDEX;
+    int64_t _timestamp[2];
+    uint64_t _proc_time[2];
+};
+
+} // namespace starrocks

--- a/be/src/util/cpu_usage_info.h
+++ b/be/src/util/cpu_usage_info.h
@@ -17,6 +17,7 @@ public:
     ~CpuUsageRecorder();
 
     void update_interval();
+    // Return the cpu usage ratio in parts per thousand at an interval.
     int cpu_used_permille() const;
 
 private:
@@ -30,6 +31,8 @@ private:
     char* _line_ptr = nullptr;
     size_t _line_buf_size = 0;
 
+    // Record the latest two time points, where the current recorded point is at `_curr_idx`,
+    // and the previous recorded point is at `(_curr_idx+1)%2`.
     int _curr_idx = ABSENT_INDEX;
     int64_t _timestamp[2];
     uint64_t _proc_time[2];

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -82,6 +82,8 @@ public:
     METRIC_DEFINE_INT_COUNTER(report_task_requests_failed, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_workgroup_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_workgroup_requests_failed, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(report_resource_usage_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(report_resource_usage_requests_failed, MetricUnit::REQUESTS);
 
     METRIC_DEFINE_INT_COUNTER(schema_change_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(schema_change_requests_failed, MetricUnit::REQUESTS);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -301,6 +301,7 @@ set(EXEC_FILES
         ./util/starrocks_metrics_test.cpp
         ./util/system_metrics_test.cpp
         ./util/ratelimit_test.cpp
+        ./util/cpu_usage_info_test.cpp
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
         )

--- a/be/test/util/cpu_usage_info_test.cpp
+++ b/be/test/util/cpu_usage_info_test.cpp
@@ -1,0 +1,21 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "util/cpu_usage_info.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/parallel_test.h"
+
+namespace starrocks {
+
+PARALLEL_TEST(CpuUsageRecorderTest, normal) {
+    CpuUsageRecorder recorder;
+    ASSERT_EQ(0, recorder.cpu_used_permille());
+
+    recorder.update_interval();
+    int cpu_used_permille = recorder.cpu_used_permille();
+    ASSERT_GE(cpu_used_permille, 0);
+    ASSERT_LE(cpu_used_permille, 1000);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -187,6 +187,7 @@ under the License.
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -183,6 +183,13 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
         <dependency>
             <groupId>com.baidu</groupId>

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -57,7 +57,7 @@ public class BackendsProcDir implements ProcDirInterface {
                 .add("Alive").add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
                 .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
                 .add("MaxDiskUsedPct").add("ErrMsg").add("Version").add("Status").add("DataTotalCapacity")
-                .add("DataUsedPct").add("CpuCores");
+                .add("DataUsedPct").add("CpuCores").add("NumRunningQueries").add("MemUsedPct");
         if (Config.integrate_starmgr) {
             builder.add("StarletPort").add("WorkerId");
         }
@@ -175,6 +175,11 @@ public class BackendsProcDir implements ProcDirInterface {
 
             // Num CPU cores
             backendInfo.add(BackendCoreStat.getCoresOfBe(backendId));
+
+            backendInfo.add(backend.getNumRunningQueries());
+            double memUsedPct = backend.getMemUsedPct();
+            backendInfo.add(String.format("%.2f", memUsedPct * 100) + " %");
+
             if (Config.integrate_starmgr) {
                 backendInfo.add(String.valueOf(backend.getStarletPort()));
                 long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByBackendId(backendId);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -57,7 +57,7 @@ public class BackendsProcDir implements ProcDirInterface {
                 .add("Alive").add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
                 .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
                 .add("MaxDiskUsedPct").add("ErrMsg").add("Version").add("Status").add("DataTotalCapacity")
-                .add("DataUsedPct").add("CpuCores").add("NumRunningQueries").add("MemUsedPct");
+                .add("DataUsedPct").add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct");
         if (Config.integrate_starmgr) {
             builder.add("StarletPort").add("WorkerId");
         }
@@ -179,6 +179,7 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(backend.getNumRunningQueries());
             double memUsedPct = backend.getMemUsedPct();
             backendInfo.add(String.format("%.2f", memUsedPct * 100) + " %");
+            backendInfo.add(String.format("%.1f", backend.getCpuUsedPermille() / 10.0) + " %");
 
             if (Config.integrate_starmgr) {
                 backendInfo.add(String.valueOf(backend.getStarletPort()));

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -488,7 +488,8 @@ public class ReportHandler extends Daemon {
         LOG.debug("begin to handle resource usage report from backend {}", backendId);
         long start = System.currentTimeMillis();
         boolean isChanged = QueryQueueManager.getInstance().updateResourceUsage(
-                backendId, usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes());
+                backendId, usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes(),
+                usage.getCpu_used_permille());
         if (isChanged) {
             GlobalStateMgr.getCurrentState().updateResourceUsage(backendId, usage);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -487,12 +487,10 @@ public class ReportHandler extends Daemon {
     private static void resourceUsageReport(long backendId, TResourceUsage usage) {
         LOG.debug("begin to handle resource usage report from backend {}", backendId);
         long start = System.currentTimeMillis();
-        boolean isChanged = QueryQueueManager.getInstance().updateResourceUsage(
+        QueryQueueManager.getInstance().updateResourceUsage(
                 backendId, usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes(),
                 usage.getCpu_used_permille());
-        if (isChanged) {
-            GlobalStateMgr.getCurrentState().updateResourceUsage(backendId, usage);
-        }
+        GlobalStateMgr.getCurrentState().updateResourceUsage(backendId, usage);
         LOG.debug("finished to handle resource usage report from backend {}, cost: {} ms",
                 backendId, (System.currentTimeMillis() - start));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -81,6 +81,14 @@ public class ResultSink extends DataSink {
         return sinkType == TResultSinkType.FILE;
     }
 
+    public boolean isQuerySink() {
+        return sinkType == TResultSinkType.MYSQL_PROTOCAL;
+    }
+
+    public boolean isStatisticSink() {
+        return sinkType == TResultSinkType.STATISTIC;
+    }
+
     public boolean needBroker() {
         return fileSinkOptions.isSetUse_broker() && fileSinkOptions.use_broker;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -100,6 +100,8 @@ public class AuditEvent {
     public double planCpuCosts = 0.0;
     @AuditField(value = "PlanMemCost")
     public double planMemCosts = 0.0;
+    @AuditField(value = "PendingTimeMs")
+    public long pendingTimeMs = 0;
 
     public static class AuditEventBuilder {
 
@@ -232,6 +234,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setPlanMemCosts(double memCosts) {
             auditEvent.planMemCosts = memCosts;
+            return this;
+        }
+
+        public AuditEventBuilder setPendingTimeMs(long pendingTimeMs) {
+            auditEvent.pendingTimeMs = pendingTimeMs;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -629,7 +629,16 @@ public class Coordinator {
         return fragments;
     }
 
+    public boolean isLoadType() {
+        return queryOptions.getQuery_type() == TQueryType.LOAD;
+    }
+
+    public List<ScanNode> getScanNodes() {
+        return scanNodes;
+    }
+
     public void exec() throws Exception {
+        QueryQueueManager.getInstance().maybeWait(connectContext, this);
         prepareExec();
         deliverExecFragments();
     }
@@ -834,8 +843,7 @@ public class Coordinator {
                     // This is a load process, and it is the first fragment.
                     // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
                     // so that we can check these backends' state when joining this Coordinator
-                    boolean needCheckBackendState =
-                            queryOptions.getQuery_type() == TQueryType.LOAD && profileFragmentId == 0;
+                    boolean needCheckBackendState = isLoadType() && profileFragmentId == 0;
 
                     for (TExecPlanFragmentParams tParam : tParams) {
                         // TODO: pool of pre-formatted BackendExecStates?
@@ -1120,8 +1128,7 @@ public class Coordinator {
                         // this is a load process, and it is the first fragment.
                         // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
                         // so that we can check these backends' state when joining this Coordinator
-                        boolean needCheckBackendState =
-                                queryOptions.getQuery_type() == TQueryType.LOAD && profileFragmentId == 0;
+                        boolean needCheckBackendState = isLoadType() && profileFragmentId == 0;
 
                         // Create ExecState for each fragment instance.
                         List<BackendExecState> execStates = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -82,6 +82,8 @@ public class CoordinatorMonitor {
                 }
 
                 deadBackendIDs.clear();
+
+                QueryQueueManager.getInstance().maybeNotify();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -46,7 +46,9 @@ public final class GlobalVariable {
     public static final String DEFAULT_ROWSET_TYPE = "default_rowset_type";
     public static final String CHARACTER_SET_DATABASE = "character_set_database";
 
-    public static final String QUERY_QUEUE_ENABLE = "query_queue_enable";
+    public static final String QUERY_QUEUE_SELECT_ENABLE = "query_queue_select_enable";
+    public static final String QUERY_QUEUE_STATISTIC_ENABLE = "query_queue_statistic_enable";
+    public static final String QUERY_QUEUE_INSERT_ENABLE = "query_queue_insert_enable";
     public static final String QUERY_QUEUE_CONCURRENCY_HARD_LIMIT = "query_queue_concurrency_hard_limit";
     public static final String QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT = "query_queue_mem_used_pct_hard_limit";
     public static final String QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT = "query_queue_cpu_used_permille_hard_limit";
@@ -111,8 +113,12 @@ public final class GlobalVariable {
      * The queries only using schema meta will never been queued, because a MySQL client will
      * query schema meta after the connection is established.
      */
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_ENABLE, flag = VariableMgr.GLOBAL)
-    private static boolean queryQueueEnable = false;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_SELECT_ENABLE, flag = VariableMgr.GLOBAL)
+    private static boolean queryQueueSelectEnable = false;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_STATISTIC_ENABLE, flag = VariableMgr.GLOBAL)
+    private static boolean queryQueueStatisticEnable = false;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_INSERT_ENABLE, flag = VariableMgr.GLOBAL)
+    private static boolean queryQueueInsertEnable = false;
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_HARD_LIMIT, flag = VariableMgr.GLOBAL)
     private static int queryQueueConcurrencyHardLimit = 0;
@@ -128,12 +134,28 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = QUERY_QUEUE_MAX_QUEUED_QUERIES, flag = VariableMgr.GLOBAL)
     private static int queryQueueMaxQueuedQueries = 1024;
 
-    public static boolean isQueryQueueEnable() {
-        return queryQueueEnable;
+    public static boolean isQueryQueueSelectEnable() {
+        return queryQueueSelectEnable;
     }
 
-    public static void setQueryQueueEnable(boolean queryQueueEnable) {
-        GlobalVariable.queryQueueEnable = queryQueueEnable;
+    public static void setQueryQueueSelectEnable(boolean queryQueueSelectEnable) {
+        GlobalVariable.queryQueueSelectEnable = queryQueueSelectEnable;
+    }
+
+    public static boolean isQueryQueueStatisticEnable() {
+        return queryQueueStatisticEnable;
+    }
+
+    public static void setQueryQueueStatisticEnable(boolean queryQueueStatisticEnable) {
+        GlobalVariable.queryQueueStatisticEnable = queryQueueStatisticEnable;
+    }
+
+    public static boolean isQueryQueueInsertEnable() {
+        return queryQueueInsertEnable;
+    }
+
+    public static void setQueryQueueInsertEnable(boolean queryQueueInsertEnable) {
+        GlobalVariable.queryQueueInsertEnable = queryQueueInsertEnable;
     }
 
     public static boolean isQueryQueueConcurrencyHardLimitEffective() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -110,18 +110,18 @@ public final class GlobalVariable {
      * The queries only using schema meta will never been queued, because a MySQL client will
      * query schema meta after the connection is established.
      */
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_ENABLE, flag = VariableMgr.GLOBAL | VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_ENABLE, flag = VariableMgr.GLOBAL)
     private static boolean queryQueueEnable = false;
     // Effective iff it is positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_HARD_LIMIT, flag = VariableMgr.GLOBAL | VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_HARD_LIMIT, flag = VariableMgr.GLOBAL)
     private static int queryQueueConcurrencyHardLimit = 0;
     // Effective iff it is positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT, flag = VariableMgr.GLOBAL | VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT, flag = VariableMgr.GLOBAL)
     private static double queryQueueMemUsedPctHardLimit = 0;
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_PENDING_TIMEOUT_SECOND, flag = VariableMgr.GLOBAL | VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_PENDING_TIMEOUT_SECOND, flag = VariableMgr.GLOBAL)
     private static int queryQueuePendingTimeoutSecond = 300;
     // Unlimited iff it is non-positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_MAX_QUEUED_QUERIES, flag = VariableMgr.GLOBAL | VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_MAX_QUEUED_QUERIES, flag = VariableMgr.GLOBAL)
     private static int queryQueueMaxQueuedQueries = 1024;
 
     public static boolean isQueryQueueEnable() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -49,6 +49,7 @@ public final class GlobalVariable {
     public static final String QUERY_QUEUE_ENABLE = "query_queue_enable";
     public static final String QUERY_QUEUE_CONCURRENCY_HARD_LIMIT = "query_queue_concurrency_hard_limit";
     public static final String QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT = "query_queue_mem_used_pct_hard_limit";
+    public static final String QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT = "query_queue_cpu_used_permille_hard_limit";
     public static final String QUERY_QUEUE_PENDING_TIMEOUT_SECOND = "query_queue_pending_timeout_second";
     public static final String QUERY_QUEUE_MAX_QUEUED_QUERIES = "query_queue_max_queued_queries";
 
@@ -118,6 +119,9 @@ public final class GlobalVariable {
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT, flag = VariableMgr.GLOBAL)
     private static double queryQueueMemUsedPctHardLimit = 0;
+    // Effective iff it is positive.
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT, flag = VariableMgr.GLOBAL)
+    private static long queryQueueCpuUsedPermilleHardLimit = 0;
     @VariableMgr.VarAttr(name = QUERY_QUEUE_PENDING_TIMEOUT_SECOND, flag = VariableMgr.GLOBAL)
     private static int queryQueuePendingTimeoutSecond = 300;
     // Unlimited iff it is non-positive.
@@ -154,6 +158,18 @@ public final class GlobalVariable {
 
     public static void setQueryQueueMemUsedPctHardLimit(double queryQueueMemUsedPctHardLimit) {
         GlobalVariable.queryQueueMemUsedPctHardLimit = queryQueueMemUsedPctHardLimit;
+    }
+
+    public static boolean isQueryQueueCpuUsedPermilleHardLimitEffective() {
+        return queryQueueCpuUsedPermilleHardLimit > 0;
+    }
+
+    public static double getQueryQueueCpuUsedPermilleHardLimit() {
+        return queryQueueCpuUsedPermilleHardLimit;
+    }
+
+    public static void setQueryQueueCpuUsedPermilleHardLimit(long queryQueueCpuUsedPermilleHardLimit) {
+        GlobalVariable.queryQueueCpuUsedPermilleHardLimit = queryQueueCpuUsedPermilleHardLimit;
     }
 
     public static int getQueryQueuePendingTimeoutSecond() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -51,9 +51,9 @@ public final class GlobalVariable {
     public static final String QUERY_QUEUE_INSERT_ENABLE = "query_queue_insert_enable";
     public static final String QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS =
             "query_queue_fresh_resource_usage_interval_ms";
-    public static final String QUERY_QUEUE_CONCURRENCY_HARD_LIMIT = "query_queue_concurrency_hard_limit";
-    public static final String QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT = "query_queue_mem_used_pct_hard_limit";
-    public static final String QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT = "query_queue_cpu_used_permille_hard_limit";
+    public static final String QUERY_QUEUE_CONCURRENCY_LIMIT = "query_queue_concurrency_limit";
+    public static final String QUERY_QUEUE_MEM_USED_PCT_LIMIT = "query_queue_mem_used_pct_limit";
+    public static final String QUERY_QUEUE_CPU_USED_PERMILLE_LIMIT = "query_queue_cpu_used_permille_limit";
     public static final String QUERY_QUEUE_PENDING_TIMEOUT_SECOND = "query_queue_pending_timeout_second";
     public static final String QUERY_QUEUE_MAX_QUEUED_QUERIES = "query_queue_max_queued_queries";
 
@@ -101,8 +101,8 @@ public final class GlobalVariable {
     /**
      * Query will be pending when BE is overloaded, if `queryQueueEnable` is true.
      * <p>
-     * If the number of running queries of any BE `exceeds queryQueueConcurrencyHardLimit`,
-     * or memory usage rate of any BE exceeds `queryQueueMemUsedPctHardLimit`,
+     * If the number of running queries of any BE `exceeds queryQueueConcurrencyLimit`,
+     * or memory usage rate of any BE exceeds `queryQueueMemUsedPctLimit`,
      * the current query will be pending or failed:
      * - if the number of pending queries in this FE exceeds `queryQueueMaxQueuedQueries`,
      * the query will be failed.
@@ -125,14 +125,14 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS, flag = VariableMgr.GLOBAL)
     private static long queryQueueResourceUsageIntervalMs = 5000;
     // Effective iff it is positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_HARD_LIMIT, flag = VariableMgr.GLOBAL)
-    private static int queryQueueConcurrencyHardLimit = 0;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_LIMIT, flag = VariableMgr.GLOBAL)
+    private static int queryQueueConcurrencyLimit = 0;
     // Effective iff it is positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT, flag = VariableMgr.GLOBAL)
-    private static double queryQueueMemUsedPctHardLimit = 0;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_LIMIT, flag = VariableMgr.GLOBAL)
+    private static double queryQueueMemUsedPctLimit = 0;
     // Effective iff it is positive.
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT, flag = VariableMgr.GLOBAL)
-    private static int queryQueueCpuUsedPermilleHardLimit = 0;
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_CPU_USED_PERMILLE_LIMIT, flag = VariableMgr.GLOBAL)
+    private static int queryQueueCpuUsedPermilleLimit = 0;
     @VariableMgr.VarAttr(name = QUERY_QUEUE_PENDING_TIMEOUT_SECOND, flag = VariableMgr.GLOBAL)
     private static int queryQueuePendingTimeoutSecond = 300;
     // Unlimited iff it is non-positive.
@@ -171,40 +171,40 @@ public final class GlobalVariable {
         GlobalVariable.queryQueueResourceUsageIntervalMs = queryQueueResourceUsageIntervalMs;
     }
 
-    public static boolean isQueryQueueConcurrencyHardLimitEffective() {
-        return queryQueueConcurrencyHardLimit > 0;
+    public static boolean isQueryQueueConcurrencyLimitEffective() {
+        return queryQueueConcurrencyLimit > 0;
     }
 
-    public static int getQueryQueueConcurrencyHardLimit() {
-        return queryQueueConcurrencyHardLimit;
+    public static int getQueryQueueConcurrencyLimit() {
+        return queryQueueConcurrencyLimit;
     }
 
-    public static void setQueryQueueConcurrencyHardLimit(int queryQueueConcurrencyHardLimit) {
-        GlobalVariable.queryQueueConcurrencyHardLimit = queryQueueConcurrencyHardLimit;
+    public static void setQueryQueueConcurrencyLimit(int queryQueueConcurrencyLimit) {
+        GlobalVariable.queryQueueConcurrencyLimit = queryQueueConcurrencyLimit;
     }
 
-    public static boolean isQueryQueueMemUsedPctHardLimitEffective() {
-        return queryQueueMemUsedPctHardLimit > 0;
+    public static boolean isQueryQueueMemUsedPctLimitEffective() {
+        return queryQueueMemUsedPctLimit > 0;
     }
 
-    public static double getQueryQueueMemUsedPctHardLimit() {
-        return queryQueueMemUsedPctHardLimit;
+    public static double getQueryQueueMemUsedPctLimit() {
+        return queryQueueMemUsedPctLimit;
     }
 
-    public static void setQueryQueueMemUsedPctHardLimit(double queryQueueMemUsedPctHardLimit) {
-        GlobalVariable.queryQueueMemUsedPctHardLimit = queryQueueMemUsedPctHardLimit;
+    public static void setQueryQueueMemUsedPctLimit(double queryQueueMemUsedPctLimit) {
+        GlobalVariable.queryQueueMemUsedPctLimit = queryQueueMemUsedPctLimit;
     }
 
-    public static boolean isQueryQueueCpuUsedPermilleHardLimitEffective() {
-        return queryQueueCpuUsedPermilleHardLimit > 0;
+    public static boolean isQueryQueueCpuUsedPermilleLimitEffective() {
+        return queryQueueCpuUsedPermilleLimit > 0;
     }
 
-    public static int getQueryQueueCpuUsedPermilleHardLimit() {
-        return queryQueueCpuUsedPermilleHardLimit;
+    public static int getQueryQueueCpuUsedPermilleLimit() {
+        return queryQueueCpuUsedPermilleLimit;
     }
 
-    public static void setQueryQueueCpuUsedPermilleHardLimit(int queryQueueCpuUsedPermilleHardLimit) {
-        GlobalVariable.queryQueueCpuUsedPermilleHardLimit = queryQueueCpuUsedPermilleHardLimit;
+    public static void setQueryQueueCpuUsedPermilleLimit(int queryQueueCpuUsedPermilleLimit) {
+        GlobalVariable.queryQueueCpuUsedPermilleLimit = queryQueueCpuUsedPermilleLimit;
     }
 
     public static int getQueryQueuePendingTimeoutSecond() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -49,6 +49,8 @@ public final class GlobalVariable {
     public static final String QUERY_QUEUE_SELECT_ENABLE = "query_queue_select_enable";
     public static final String QUERY_QUEUE_STATISTIC_ENABLE = "query_queue_statistic_enable";
     public static final String QUERY_QUEUE_INSERT_ENABLE = "query_queue_insert_enable";
+    public static final String QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS =
+            "query_queue_fresh_resource_usage_interval_ms";
     public static final String QUERY_QUEUE_CONCURRENCY_HARD_LIMIT = "query_queue_concurrency_hard_limit";
     public static final String QUERY_QUEUE_MEM_USED_PCT_HARD_LIMIT = "query_queue_mem_used_pct_hard_limit";
     public static final String QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT = "query_queue_cpu_used_permille_hard_limit";
@@ -119,6 +121,9 @@ public final class GlobalVariable {
     private static boolean queryQueueStatisticEnable = false;
     @VariableMgr.VarAttr(name = QUERY_QUEUE_INSERT_ENABLE, flag = VariableMgr.GLOBAL)
     private static boolean queryQueueInsertEnable = false;
+    // Use the resource usage, only when the duration from the last report is within this interval.
+    @VariableMgr.VarAttr(name = QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS, flag = VariableMgr.GLOBAL)
+    private static long queryQueueResourceUsageIntervalMs = 5000;
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_HARD_LIMIT, flag = VariableMgr.GLOBAL)
     private static int queryQueueConcurrencyHardLimit = 0;
@@ -127,7 +132,7 @@ public final class GlobalVariable {
     private static double queryQueueMemUsedPctHardLimit = 0;
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_CPU_USED_PERMILLE_HARD_LIMIT, flag = VariableMgr.GLOBAL)
-    private static long queryQueueCpuUsedPermilleHardLimit = 0;
+    private static int queryQueueCpuUsedPermilleHardLimit = 0;
     @VariableMgr.VarAttr(name = QUERY_QUEUE_PENDING_TIMEOUT_SECOND, flag = VariableMgr.GLOBAL)
     private static int queryQueuePendingTimeoutSecond = 300;
     // Unlimited iff it is non-positive.
@@ -158,6 +163,14 @@ public final class GlobalVariable {
         GlobalVariable.queryQueueInsertEnable = queryQueueInsertEnable;
     }
 
+    public static long getQueryQueueResourceUsageIntervalMs() {
+        return queryQueueResourceUsageIntervalMs;
+    }
+
+    public static void setQueryQueueResourceUsageIntervalMs(long queryQueueResourceUsageIntervalMs) {
+        GlobalVariable.queryQueueResourceUsageIntervalMs = queryQueueResourceUsageIntervalMs;
+    }
+
     public static boolean isQueryQueueConcurrencyHardLimitEffective() {
         return queryQueueConcurrencyHardLimit > 0;
     }
@@ -186,11 +199,11 @@ public final class GlobalVariable {
         return queryQueueCpuUsedPermilleHardLimit > 0;
     }
 
-    public static double getQueryQueueCpuUsedPermilleHardLimit() {
+    public static int getQueryQueueCpuUsedPermilleHardLimit() {
         return queryQueueCpuUsedPermilleHardLimit;
     }
 
-    public static void setQueryQueueCpuUsedPermilleHardLimit(long queryQueueCpuUsedPermilleHardLimit) {
+    public static void setQueryQueueCpuUsedPermilleHardLimit(int queryQueueCpuUsedPermilleHardLimit) {
         GlobalVariable.queryQueueCpuUsedPermilleHardLimit = queryQueueCpuUsedPermilleHardLimit;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -77,7 +77,8 @@ public class QueryQueueManager {
         }
     }
 
-    public boolean updateResourceUsage(long backendId, int numRunningQueries, long memLimitBytes, long memUsedBytes) {
+    public boolean updateResourceUsage(long backendId, int numRunningQueries, long memLimitBytes, long memUsedBytes,
+                                       int cpuUsedPermille) {
         Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
         if (backend == null) {
             LOG.warn("backend doesn't exist. id: {}", backendId);
@@ -87,7 +88,8 @@ public class QueryQueueManager {
         try {
             lock.lock();
 
-            boolean isChanged = backend.updateResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes);
+            boolean isChanged =
+                    backend.updateResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
             if (isChanged) {
                 LOG.debug("resource usage from backend {} has changed", backendId);
                 maybeNotifyAfterLock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -1,0 +1,184 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.qe;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.UserException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class QueryQueueManager {
+    private static final Logger LOG = LogManager.getLogger(QueryQueueManager.class);
+
+    private static class PendingQueryInfo {
+        private final ConnectContext connectCtx;
+        private final ReentrantLock lock;
+        private final Condition condition;
+        private boolean isCancelled = false;
+
+        private PendingQueryInfo(ConnectContext connectCtx, ReentrantLock lock) {
+            Preconditions.checkState(connectCtx != null);
+            this.connectCtx = connectCtx;
+            this.lock = lock;
+            this.condition = this.lock.newCondition();
+        }
+
+        public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+            Preconditions.checkState(lock.isHeldByCurrentThread());
+            return condition.await(timeout, unit);
+        }
+
+        public void signalAfterLock() {
+            Preconditions.checkState(lock.isHeldByCurrentThread());
+            condition.signal();
+        }
+
+        public void cancelAfterLock() {
+            Preconditions.checkState(lock.isHeldByCurrentThread());
+            isCancelled = true;
+            signalAfterLock();
+        }
+    }
+
+    private static class SingletonHolder {
+        private static final QueryQueueManager INSTANCE = new QueryQueueManager();
+    }
+
+    public static QueryQueueManager getInstance() {
+        return QueryQueueManager.SingletonHolder.INSTANCE;
+    }
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Map<ConnectContext, PendingQueryInfo> pendingQueryInfoMap = new ConcurrentHashMap<>();
+
+    public void cancelQuery(ConnectContext connectCtx) {
+        if (connectCtx == null) {
+            return;
+        }
+
+        try {
+            lock.lock();
+
+            PendingQueryInfo queryInfo = pendingQueryInfoMap.get(connectCtx);
+            if (queryInfo != null) {
+                queryInfo.cancelAfterLock();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean updateResourceUsage(long backendId, int numRunningQueries, long memLimitBytes, long memUsedBytes) {
+        Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
+        if (backend == null) {
+            LOG.warn("backend doesn't exist. id: {}", backendId);
+            return false;
+        }
+
+        try {
+            lock.lock();
+
+            boolean isChanged = backend.updateResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes);
+            if (isChanged) {
+                LOG.debug("resource usage from backend {} has changed", backendId);
+                maybeNotifyAfterLock();
+            }
+            return isChanged;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Public for test.
+    public void maybeNotifyAfterLock() {
+        Preconditions.checkState(lock.isHeldByCurrentThread());
+
+        if (pendingQueryInfoMap.isEmpty()) {
+            return;
+        }
+        if (needWait()) {
+            return;
+        }
+
+        for (PendingQueryInfo queryInfo : pendingQueryInfoMap.values()) {
+            queryInfo.signalAfterLock();
+        }
+    }
+
+    // For test.
+    public void maybeNotify() {
+        try {
+            lock.lock();
+            maybeNotifyAfterLock();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void maybeWait(ConnectContext connectCtx) throws UserException, InterruptedException {
+        if (!GlobalVariable.isQueryQueueEnable()) {
+            return;
+        }
+
+        if (!needWait()) {
+            return;
+        }
+
+        long startMs = System.currentTimeMillis();
+        long timeoutMs = startMs + GlobalVariable.getQueryQueuePendingTimeoutSecond() * 1000L;
+        PendingQueryInfo queryInfo = new PendingQueryInfo(connectCtx, lock);
+
+        try {
+            lock.lock();
+
+            if (GlobalVariable.isQueryQueueMaxQueuedQueriesEffective() &&
+                    pendingQueryInfoMap.size() >= GlobalVariable.getQueryQueueMaxQueuedQueries()) {
+                throw new UserException("Need pend but exceed query queue capacity");
+            }
+
+            queryInfo.connectCtx.setPending(true);
+            pendingQueryInfoMap.put(queryInfo.connectCtx, queryInfo);
+
+            while (needWait()) {
+                long currentMs = System.currentTimeMillis();
+                if (currentMs >= timeoutMs) {
+                    throw new UserException("Pending timeout");
+                }
+
+                boolean timeout = !queryInfo.await(timeoutMs - currentMs, TimeUnit.MILLISECONDS);
+                if (timeout) {
+                    throw new UserException("Pending timeout");
+                }
+
+                if (queryInfo.isCancelled) {
+                    throw new UserException("Cancelled");
+                }
+            }
+        } finally {
+            queryInfo.connectCtx.auditEventBuilder.setPendingTimeMs(System.currentTimeMillis() - startMs);
+            queryInfo.connectCtx.setPending(false);
+            pendingQueryInfoMap.remove(queryInfo.connectCtx);
+
+            lock.unlock();
+        }
+    }
+
+    public boolean needWait() {
+        return GlobalStateMgr.getCurrentSystemInfo().getBackends().stream()
+                .anyMatch(ComputeNode::isResourceOverloaded);
+    }
+
+    public int numPendingQueries() {
+        return pendingQueryInfoMap.size();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -168,7 +168,6 @@ public class QueryQueueManager {
         }
     }
 
-    // For test.
     public void maybeNotify() {
         try {
             lock.lock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -115,7 +115,7 @@ public class QueryQueueManager {
         }
 
         long startMs = System.currentTimeMillis();
-        long timeoutMs = startMs + GlobalVariable.getQueryQueuePendingTimeoutSecond() * 1000L;
+        long timeoutMs;
         PendingQueryInfo info = new PendingQueryInfo(connectCtx, lock, coord);
 
         try {
@@ -131,6 +131,7 @@ public class QueryQueueManager {
             pendingQueryInfoMap.put(info.connectCtx, info);
 
             while (enableCheckQueue(coord) && !canRunMore()) {
+                timeoutMs = startMs + GlobalVariable.getQueryQueuePendingTimeoutSecond() * 1000L;
                 long currentMs = System.currentTimeMillis();
                 if (currentMs >= timeoutMs) {
                     throw new UserException("Pending timeout");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -71,7 +71,6 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
-import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.privilege.PrivilegeException;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.QueryStatisticsItemPB;
@@ -719,12 +718,6 @@ public class StmtExecutor {
         QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(),
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
 
-        //  The queries only using schema meta will never been queued, because a MySQL client will
-        //  query schema meta after the connection is established.
-        boolean needQueue = !(scanNodes.isEmpty() || scanNodes.stream().allMatch(SchemaScanNode.class::isInstance));
-        if (needQueue) {
-            QueryQueueManager.getInstance().maybeWait(ConnectContext.get());
-        }
         coord.exec();
 
         // send result

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -71,6 +71,7 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.privilege.PrivilegeException;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.QueryStatisticsItemPB;
@@ -718,6 +719,12 @@ public class StmtExecutor {
         QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(),
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
 
+        //  The queries only using schema meta will never been queued, because a MySQL client will
+        //  query schema meta after the connection is established.
+        boolean needQueue = !(scanNodes.isEmpty() || scanNodes.stream().allMatch(SchemaScanNode.class::isInstance));
+        if (needQueue) {
+            QueryQueueManager.getInstance().maybeWait(ConnectContext.get());
+        }
         coord.exec();
 
         // send result

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -230,6 +230,7 @@ import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TRefreshTableRequest;
 import com.starrocks.thrift.TRefreshTableResponse;
+import com.starrocks.thrift.TResourceUsage;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
@@ -3144,6 +3145,10 @@ public class GlobalStateMgr {
 
     public void replayTruncateTable(TruncateTableInfo info) {
         localMetastore.replayTruncateTable(info);
+    }
+
+    public void updateResourceUsage(long backendId, TResourceUsage usage) {
+        nodeMgr.updateResourceUsage(backendId, usage);
     }
 
     public void setConfig(AdminSetConfigStmt stmt) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -70,6 +70,7 @@ import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.QueryQueueManager;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
@@ -137,6 +138,7 @@ import com.starrocks.thrift.TRefreshTableResponse;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TReportExecStatusResult;
 import com.starrocks.thrift.TReportRequest;
+import com.starrocks.thrift.TResourceUsage;
 import com.starrocks.thrift.TSetConfigRequest;
 import com.starrocks.thrift.TSetConfigResponse;
 import com.starrocks.thrift.TShowVariableRequest;
@@ -152,6 +154,8 @@ import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTaskInfo;
 import com.starrocks.thrift.TTaskRunInfo;
 import com.starrocks.thrift.TUpdateExportTaskStatusRequest;
+import com.starrocks.thrift.TUpdateResourceUsageRequest;
+import com.starrocks.thrift.TUpdateResourceUsageResponse;
 import com.starrocks.thrift.TUserPrivDesc;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TransactionNotFoundException;
@@ -1409,5 +1413,17 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TGetTablesInfoResponse getTablesInfo(TGetTablesInfoRequest request) throws TException {
 
         return InformationSchemaDataSource.generateTablesInfoResponse(request);
+    }
+
+    @Override
+    public TUpdateResourceUsageResponse updateResourceUsage(TUpdateResourceUsageRequest request) throws TException {
+        TResourceUsage usage = request.getResource_usage();
+        QueryQueueManager.getInstance().updateResourceUsage(request.getBackend_id(),
+                usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes());
+
+        TUpdateResourceUsageResponse res = new TUpdateResourceUsageResponse();
+        TStatus status = new TStatus(TStatusCode.OK);
+        res.setStatus(status);
+        return res;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1419,7 +1419,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TUpdateResourceUsageResponse updateResourceUsage(TUpdateResourceUsageRequest request) throws TException {
         TResourceUsage usage = request.getResource_usage();
         QueryQueueManager.getInstance().updateResourceUsage(request.getBackend_id(),
-                usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes());
+                usage.getNum_running_queries(), usage.getMem_limit_bytes(), usage.getMem_used_bytes(),
+                usage.getCpu_used_permille());
 
         TUpdateResourceUsageResponse res = new TUpdateResourceUsageResponse();
         TStatus status = new TStatus(TStatusCode.OK);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowProcesslistStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowProcesslistStmt.java
@@ -21,6 +21,7 @@ public class ShowProcesslistStmt extends ShowStmt {
                     .addColumn(new Column("Time", ScalarType.createType(PrimitiveType.INT)))
                     .addColumn(new Column("State", ScalarType.createVarchar(64)))
                     .addColumn(new Column("Info", ScalarType.createVarchar(32 * 1024)))
+                    .addColumn(new Column("IsPending", ScalarType.createVarchar(16)))
                     .build();
     private final boolean isShowFull;
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -79,6 +79,7 @@ public class ComputeNode implements IComputable, Writable {
     private volatile int numRunningQueries = 0;
     private volatile long memLimitBytes = 0;
     private volatile long memUsedBytes = 0;
+    private volatile int cpuUsedPermille = 0;
 
     public ComputeNode() {
         this.host = "";
@@ -289,7 +290,12 @@ public class ComputeNode implements IComputable, Writable {
         return ((double) memUsedBytes) / memLimitBytes;
     }
 
-    public boolean updateResourceUsage(int numRunningQueries, long memLimitBytes, long memUsedBytes) {
+    public int getCpuUsedPermille() {
+        return cpuUsedPermille;
+    }
+
+    public boolean updateResourceUsage(int numRunningQueries, long memLimitBytes, long memUsedBytes,
+                                       int cpuUsedPermille) {
         boolean isChanged = false;
         if (numRunningQueries != this.numRunningQueries) {
             this.numRunningQueries = numRunningQueries;
@@ -301,6 +307,10 @@ public class ComputeNode implements IComputable, Writable {
         }
         if (memUsedBytes != this.memUsedBytes) {
             this.memUsedBytes = memUsedBytes;
+            isChanged = true;
+        }
+        if (cpuUsedPermille != this.cpuUsedPermille) {
+            this.cpuUsedPermille = cpuUsedPermille;
             isChanged = true;
         }
         return isChanged;
@@ -486,6 +496,11 @@ public class ComputeNode implements IComputable, Writable {
 
         if (GlobalVariable.isQueryQueueConcurrencyHardLimitEffective() &&
                 numRunningQueries >= GlobalVariable.getQueryQueueConcurrencyHardLimit()) {
+            return true;
+        }
+
+        if (GlobalVariable.isQueryQueueCpuUsedPermilleHardLimitEffective() &&
+                cpuUsedPermille >= GlobalVariable.getQueryQueueCpuUsedPermilleHardLimit()) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -486,10 +486,6 @@ public class ComputeNode implements IComputable, Writable {
     }
 
     public boolean isResourceOverloaded() {
-        if (!GlobalVariable.isQueryQueueEnable()) {
-            return false;
-        }
-
         if (!isAvailable()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -485,17 +485,17 @@ public class ComputeNode implements IComputable, Writable {
             return false;
         }
 
-        if (GlobalVariable.isQueryQueueConcurrencyHardLimitEffective() &&
-                numRunningQueries >= GlobalVariable.getQueryQueueConcurrencyHardLimit()) {
+        if (GlobalVariable.isQueryQueueConcurrencyLimitEffective() &&
+                numRunningQueries >= GlobalVariable.getQueryQueueConcurrencyLimit()) {
             return true;
         }
 
-        if (GlobalVariable.isQueryQueueCpuUsedPermilleHardLimitEffective() &&
-                cpuUsedPermille >= GlobalVariable.getQueryQueueCpuUsedPermilleHardLimit()) {
+        if (GlobalVariable.isQueryQueueCpuUsedPermilleLimitEffective() &&
+                cpuUsedPermille >= GlobalVariable.getQueryQueueCpuUsedPermilleLimit()) {
             return true;
         }
 
-        return GlobalVariable.isQueryQueueMemUsedPctHardLimitEffective() &&
-                getMemUsedPct() >= GlobalVariable.getQueryQueueMemUsedPctHardLimit();
+        return GlobalVariable.isQueryQueueMemUsedPctLimitEffective() &&
+                getMemUsedPct() >= GlobalVariable.getQueryQueueMemUsedPctLimit();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowProcesslistStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowProcesslistStmtTest.java
@@ -27,7 +27,7 @@ public class ShowProcesslistStmtTest {
         ShowProcesslistStmt stmt = (ShowProcesslistStmt)UtFrameUtils.parseStmtWithNewParser(originStmt, connectContext);
         ShowResultSetMetaData metaData = stmt.getMetaData();
         Assert.assertNotNull(metaData);
-        Assert.assertEquals(9, metaData.getColumnCount());
+        Assert.assertEquals(10, metaData.getColumnCount());
         Assert.assertEquals("Id", metaData.getColumn(0).getName());
         Assert.assertEquals("User", metaData.getColumn(1).getName());
         Assert.assertEquals("Host", metaData.getColumn(2).getName());
@@ -37,5 +37,6 @@ public class ShowProcesslistStmtTest {
         Assert.assertEquals("Time", metaData.getColumn(6).getName());
         Assert.assertEquals("State", metaData.getColumn(7).getName());
         Assert.assertEquals("Info", metaData.getColumn(8).getName());
+        Assert.assertEquals("IsPending", metaData.getColumn(9).getName());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -69,11 +69,13 @@ public class ReportHandlerTest {
         handler.testHandleSetTabletEnablePersistentIndex(backendId, backendTablets);
     }
 
-    private TResourceUsage genResourceUsage(int numRunningQueries, long memLimitBytes, long memUsedBytes) {
+    private TResourceUsage genResourceUsage(int numRunningQueries, long memLimitBytes, long memUsedBytes,
+                                            int cpuUsedPermille) {
         TResourceUsage usage = new TResourceUsage();
         usage.setNum_running_queries(numRunningQueries);
         usage.setMem_limit_bytes(memLimitBytes);
         usage.setMem_used_bytes(memUsedBytes);
+        usage.setCpu_used_permille(cpuUsedPermille);
         return usage;
     }
 
@@ -86,6 +88,7 @@ public class ReportHandlerTest {
         int numRunningQueries = 1;
         long memLimitBytes = 3;
         long memUsedBytes = 2;
+        int cpuUsedPermille = 300;
         new Expectations(systemInfoService, queryQueueManager) {
             {
                 queryQueueManager.maybeNotifyAfterLock();
@@ -102,12 +105,13 @@ public class ReportHandlerTest {
             }
         };
 
-        TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes);
+        TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
         // Sync to FE followers and notify pending queries, because resource usage is changed.
         ReportHandler.testHandleResourceUsageReport(backendId, resourceUsage);
         Assert.assertEquals(numRunningQueries, backend.getNumRunningQueries());
         Assert.assertEquals(memLimitBytes, backend.getMemLimitBytes());
         Assert.assertEquals(memUsedBytes, backend.getMemUsedBytes());
+        Assert.assertEquals(cpuUsedPermille, backend.getCpuUsedPermille());
         // Don't sync and notify, because resource usage isn't changed.
         ReportHandler.testHandleResourceUsageReport(backendId, resourceUsage);
         // Don't sync and notify, because this BE doesn't exist.

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -106,14 +106,12 @@ public class ReportHandlerTest {
         };
 
         TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
-        // Sync to FE followers and notify pending queries, because resource usage is changed.
+        // Sync to FE followers and notify pending queries.
         ReportHandler.testHandleResourceUsageReport(backendId, resourceUsage);
         Assert.assertEquals(numRunningQueries, backend.getNumRunningQueries());
         Assert.assertEquals(memLimitBytes, backend.getMemLimitBytes());
         Assert.assertEquals(memUsedBytes, backend.getMemUsedBytes());
         Assert.assertEquals(cpuUsedPermille, backend.getCpuUsedPermille());
-        // Don't sync and notify, because resource usage isn't changed.
-        ReportHandler.testHandleResourceUsageReport(backendId, resourceUsage);
         // Don't sync and notify, because this BE doesn't exist.
         ReportHandler.testHandleResourceUsageReport(/* Not Exist */ 1, resourceUsage);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -121,7 +121,7 @@ public class ConnectContextTest {
         Assert.assertNotNull(ctx.toThreadInfo());
         long currentTimeMillis = System.currentTimeMillis();
         List<String> row = ctx.toThreadInfo().toRow(currentTimeMillis, false);
-        Assert.assertEquals(9, row.size());
+        Assert.assertEquals(10, row.size());
         Assert.assertEquals("101", row.get(0));
         Assert.assertEquals("testUser", row.get(1));
         Assert.assertEquals("127.0.0.1:12345", row.get(2));
@@ -131,6 +131,7 @@ public class ConnectContextTest {
         Assert.assertEquals(Long.toString((currentTimeMillis - ctx.getConnectionStartTime()) / 1000), row.get(6));
         Assert.assertEquals("OK", row.get(7));
         Assert.assertEquals("", row.get(8));
+        Assert.assertEquals("false", row.get(9));
 
         // Start time
         ctx.setStartTime();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -1,0 +1,192 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.qe;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.UserException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import mockit.Expectations;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class QueryQueueManagerTest {
+
+    private boolean queryQueueEnable;
+    private int queryQueueConcurrencyHardLimit;
+    private double queryQueueMemUsedPctHardLimit;
+    private int queryQueuePendingTimeoutSecond;
+    private int queryQueueMaxQueuedQueries;
+
+    @Before
+    public void before() {
+        queryQueueEnable = GlobalVariable.isQueryQueueEnable();
+        queryQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyHardLimit();
+        queryQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctHardLimit();
+        queryQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
+        queryQueueMaxQueuedQueries = GlobalVariable.getQueryQueueMaxQueuedQueries();
+    }
+
+    @After
+    public void after() {
+        // Reset query queue configs.
+        GlobalVariable.setQueryQueueEnable(queryQueueEnable);
+        GlobalVariable.setQueryQueueConcurrencyHardLimit(queryQueueConcurrencyHardLimit);
+        GlobalVariable.setQueryQueueMemUsedPctHardLimit(queryQueueMemUsedPctHardLimit);
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(queryQueuePendingTimeoutSecond);
+        GlobalVariable.setQueryQueueMaxQueuedQueries(queryQueueMaxQueuedQueries);
+    }
+
+    private void mockResourceOverloaded() {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        new Expectations(manager) {
+            {
+                manager.needWait();
+                result = true;
+            }
+        };
+    }
+
+    private void mockResourceNotOverloaded() {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        new Expectations(manager) {
+            {
+                manager.needWait();
+                result = false;
+            }
+        };
+    }
+
+    @Test
+    public void testNotWait() throws UserException, InterruptedException {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        ConnectContext connectCtx = new ConnectContext();
+
+        // Case 1: Disable query_queue.
+        GlobalVariable.setQueryQueueEnable(false);
+        manager.maybeWait(connectCtx);
+        Assert.assertEquals(0, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
+        Assert.assertEquals(0, manager.numPendingQueries());
+
+        // Case 2: Enable query_queue but resource isn't overloaded.
+        GlobalVariable.setQueryQueueEnable(true);
+        mockResourceNotOverloaded();
+        manager.maybeWait(connectCtx);
+        Assert.assertEquals(0, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
+        Assert.assertEquals(0, manager.numPendingQueries());
+    }
+
+    @Test
+    public void testWait() throws InterruptedException {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        ConnectContext connectCtx1 = new ConnectContext();
+        ConnectContext connectCtx2 = new ConnectContext();
+
+        mockResourceOverloaded();
+
+        // Case 1: Pending timeout.
+        GlobalVariable.setQueryQueueEnable(true);
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(1);
+        Thread thread = new Thread(() -> {
+            Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> {
+                Assert.assertThrows("Pending timeout", UserException.class, () -> manager.maybeWait(connectCtx1));
+                return true;
+            });
+            Assert.assertEquals(0, manager.numPendingQueries());
+        });
+        thread.start();
+        thread.join();
+
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(300);
+        GlobalVariable.setQueryQueueMaxQueuedQueries(1);
+        thread = new Thread(() -> {
+            // Case 3: Cancel the query, when it is pending.
+            Assert.assertThrows("Cancelled", UserException.class, () -> manager.maybeWait(connectCtx1));
+            Assert.assertEquals(0, manager.numPendingQueries());
+        });
+        thread.start();
+
+        // Case 2: exceed query queue capacity.
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).until(connectCtx1::isPending);
+        Assert.assertThrows("Need pend but exceed query queue capacity", UserException.class,
+                () -> manager.maybeWait(connectCtx2));
+
+        // Case 3: Cancel the query, when it is pending.
+        manager.cancelQuery(connectCtx1);
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> !connectCtx1.isPending());
+
+        // Case 4: wait first, and then wakeup and don't wait anymore after resource isn't overloaded.
+        thread = new Thread(() -> {
+            try {
+                manager.maybeWait(connectCtx1);
+                Assert.assertEquals(0, manager.numPendingQueries());
+            } catch (UserException | InterruptedException e) {
+                Assert.fail("Unexpected exception");
+            }
+        });
+        thread.start();
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).until(connectCtx1::isPending);
+        mockResourceNotOverloaded();
+        manager.maybeNotify();
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> !connectCtx1.isPending());
+        // noneffective.
+        manager.maybeNotify();
+    }
+
+    @Test
+    public void testNeedWait() {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        SystemInfoService service = GlobalStateMgr.getCurrentSystemInfo();
+        Backend be1 = new Backend();
+        be1.setAlive(true);
+        be1.setId(1);
+        Backend be2 = new Backend();
+        be2.setAlive(true);
+        be2.setId(2);
+        new Expectations(service) {
+            {
+                service.getBackends();
+                result = ImmutableList.of(be1, be2);
+            }
+            {
+                service.getBackend(be2.getId());
+                result = be2;
+            }
+        };
+
+        // Case 1: disable query_queue.
+        GlobalVariable.setQueryQueueEnable(false);
+        Assert.assertFalse(manager.needWait());
+
+        // Case 2: enable query_queue, but min_concurrency and min_mem_used_pct not effective.
+        GlobalVariable.setQueryQueueEnable(true);
+        GlobalVariable.setQueryQueueConcurrencyHardLimit(0);
+        GlobalVariable.setQueryQueueMemUsedPctHardLimit(0);
+        Assert.assertFalse(manager.needWait());
+
+        GlobalVariable.setQueryQueueConcurrencyHardLimit(3);
+        GlobalVariable.setQueryQueueMemUsedPctHardLimit(0.3);
+        // Case 3: exceed concurrency threshold.
+        manager.updateResourceUsage(be2.getId(), 3, 10, 0);
+        Assert.assertTrue(manager.needWait());
+
+        // Case 4: exceed memory threshold.
+        manager.updateResourceUsage(be2.getId(), 0, 10, 4);
+        Assert.assertTrue(manager.needWait());
+
+        // Case 5: BE isn't alive after resource overload.
+        be2.setAlive(false);
+        Assert.assertFalse(manager.needWait());
+
+        // Case 6: don't exceed concurrency and memory threshold.
+        be2.setAlive(true);
+        manager.updateResourceUsage(be2.getId(), 2, 10, 2);
+        Assert.assertFalse(manager.needWait());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -168,25 +168,31 @@ public class QueryQueueManagerTest {
         GlobalVariable.setQueryQueueEnable(true);
         GlobalVariable.setQueryQueueConcurrencyHardLimit(0);
         GlobalVariable.setQueryQueueMemUsedPctHardLimit(0);
+        GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(0);
         Assert.assertFalse(manager.needWait());
 
         GlobalVariable.setQueryQueueConcurrencyHardLimit(3);
         GlobalVariable.setQueryQueueMemUsedPctHardLimit(0.3);
+        GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(400);
         // Case 3: exceed concurrency threshold.
-        manager.updateResourceUsage(be2.getId(), 3, 10, 0);
+        manager.updateResourceUsage(be2.getId(), 3, 10, 0, 200);
         Assert.assertTrue(manager.needWait());
 
         // Case 4: exceed memory threshold.
-        manager.updateResourceUsage(be2.getId(), 0, 10, 4);
+        manager.updateResourceUsage(be2.getId(), 0, 10, 4, 200);
         Assert.assertTrue(manager.needWait());
 
-        // Case 5: BE isn't alive after resource overload.
+        // Case 5: exceed CPU threshold.
+        manager.updateResourceUsage(be2.getId(), 0, 10, 2, 500);
+        Assert.assertTrue(manager.needWait());
+
+        // Case 6: BE isn't alive after resource overload.
         be2.setAlive(false);
         Assert.assertFalse(manager.needWait());
 
-        // Case 6: don't exceed concurrency and memory threshold.
+        // Case 7: don't exceed concurrency and memory threshold.
         be2.setAlive(true);
-        manager.updateResourceUsage(be2.getId(), 2, 10, 2);
+        manager.updateResourceUsage(be2.getId(), 2, 10, 2, 200);
         Assert.assertFalse(manager.needWait());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -4,60 +4,95 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.UserException;
+import com.starrocks.planner.ExportSink;
+import com.starrocks.planner.MysqlTableSink;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.ResultSink;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TResultSinkType;
 import mockit.Expectations;
+import mockit.Mocked;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class QueryQueueManagerTest {
+    @Mocked
+    private Coordinator coordinator;
 
-    private boolean queryQueueEnable;
-    private int queryQueueConcurrencyHardLimit;
-    private double queryQueueMemUsedPctHardLimit;
-    private int queryQueuePendingTimeoutSecond;
-    private int queryQueueMaxQueuedQueries;
+    private boolean taskQueueEnable;
+    private int taskQueueConcurrencyHardLimit;
+    private double taskQueueMemUsedPctHardLimit;
+    private int taskQueuePendingTimeoutSecond;
+    private int taskQueueMaxQueuedQueries;
 
     @Before
     public void before() {
-        queryQueueEnable = GlobalVariable.isQueryQueueEnable();
-        queryQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyHardLimit();
-        queryQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctHardLimit();
-        queryQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
-        queryQueueMaxQueuedQueries = GlobalVariable.getQueryQueueMaxQueuedQueries();
+        taskQueueEnable = GlobalVariable.isQueryQueueSelectEnable();
+        taskQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyHardLimit();
+        taskQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctHardLimit();
+        taskQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
+        taskQueueMaxQueuedQueries = GlobalVariable.getQueryQueueMaxQueuedQueries();
     }
 
     @After
     public void after() {
         // Reset query queue configs.
-        GlobalVariable.setQueryQueueEnable(queryQueueEnable);
-        GlobalVariable.setQueryQueueConcurrencyHardLimit(queryQueueConcurrencyHardLimit);
-        GlobalVariable.setQueryQueueMemUsedPctHardLimit(queryQueueMemUsedPctHardLimit);
-        GlobalVariable.setQueryQueuePendingTimeoutSecond(queryQueuePendingTimeoutSecond);
-        GlobalVariable.setQueryQueueMaxQueuedQueries(queryQueueMaxQueuedQueries);
+        GlobalVariable.setQueryQueueSelectEnable(taskQueueEnable);
+        GlobalVariable.setQueryQueueConcurrencyHardLimit(taskQueueConcurrencyHardLimit);
+        GlobalVariable.setQueryQueueMemUsedPctHardLimit(taskQueueMemUsedPctHardLimit);
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(taskQueuePendingTimeoutSecond);
+        GlobalVariable.setQueryQueueMaxQueuedQueries(taskQueueMaxQueuedQueries);
     }
 
-    private void mockResourceOverloaded() {
+    private void mockNotCanRunMore() {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.needWait();
+                manager.canRunMore();
+                result = false;
+            }
+        };
+    }
+
+    private void mockCanRunMore() {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        new Expectations(manager) {
+            {
+                manager.canRunMore();
                 result = true;
             }
         };
     }
 
-    private void mockResourceNotOverloaded() {
+    private void mockCoordinatorNeedCheckQueue() {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.needWait();
+                manager.needCheckQueue((Coordinator) any);
+                result = true;
+            }
+        };
+    }
+
+    private void mockCoordinatorNotNeedCheckQueue() {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+        new Expectations(manager) {
+            {
+                manager.needCheckQueue((Coordinator) any);
                 result = false;
             }
         };
@@ -68,18 +103,21 @@ public class QueryQueueManagerTest {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         ConnectContext connectCtx = new ConnectContext();
 
-        // Case 1: Disable query_queue.
-        GlobalVariable.setQueryQueueEnable(false);
-        manager.maybeWait(connectCtx);
+        // Case 1: Coordinator needn't check queue.
+        mockCoordinatorNotNeedCheckQueue();
+        GlobalVariable.setQueryQueueSelectEnable(true);
+        manager.maybeWait(connectCtx, coordinator);
         Assert.assertEquals(0, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
         Assert.assertEquals(0, manager.numPendingQueries());
 
-        // Case 2: Enable query_queue but resource isn't overloaded.
-        GlobalVariable.setQueryQueueEnable(true);
-        mockResourceNotOverloaded();
-        manager.maybeWait(connectCtx);
+        // Case 2: Coordinator need check queue but resource isn't overloaded.
+        mockCoordinatorNeedCheckQueue();
+        GlobalVariable.setQueryQueueSelectEnable(true);
+        mockCanRunMore();
+        manager.maybeWait(connectCtx, coordinator);
         Assert.assertEquals(0, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
         Assert.assertEquals(0, manager.numPendingQueries());
+
     }
 
     @Test
@@ -88,14 +126,15 @@ public class QueryQueueManagerTest {
         ConnectContext connectCtx1 = new ConnectContext();
         ConnectContext connectCtx2 = new ConnectContext();
 
-        mockResourceOverloaded();
+        mockCoordinatorNeedCheckQueue();
+        mockNotCanRunMore();
 
         // Case 1: Pending timeout.
-        GlobalVariable.setQueryQueueEnable(true);
+        GlobalVariable.setQueryQueueSelectEnable(true);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(1);
         Thread thread = new Thread(() -> {
             Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> {
-                Assert.assertThrows("Pending timeout", UserException.class, () -> manager.maybeWait(connectCtx1));
+                Assert.assertThrows("Pending timeout", UserException.class, () -> manager.maybeWait(connectCtx1, coordinator));
                 return true;
             });
             Assert.assertEquals(0, manager.numPendingQueries());
@@ -107,7 +146,7 @@ public class QueryQueueManagerTest {
         GlobalVariable.setQueryQueueMaxQueuedQueries(1);
         thread = new Thread(() -> {
             // Case 3: Cancel the query, when it is pending.
-            Assert.assertThrows("Cancelled", UserException.class, () -> manager.maybeWait(connectCtx1));
+            Assert.assertThrows("Cancelled", UserException.class, () -> manager.maybeWait(connectCtx1, coordinator));
             Assert.assertEquals(0, manager.numPendingQueries());
         });
         thread.start();
@@ -115,7 +154,7 @@ public class QueryQueueManagerTest {
         // Case 2: exceed query queue capacity.
         Awaitility.await().atMost(1, TimeUnit.SECONDS).until(connectCtx1::isPending);
         Assert.assertThrows("Need pend but exceed query queue capacity", UserException.class,
-                () -> manager.maybeWait(connectCtx2));
+                () -> manager.maybeWait(connectCtx2, coordinator));
 
         // Case 3: Cancel the query, when it is pending.
         manager.cancelQuery(connectCtx1);
@@ -124,7 +163,7 @@ public class QueryQueueManagerTest {
         // Case 4: wait first, and then wakeup and don't wait anymore after resource isn't overloaded.
         thread = new Thread(() -> {
             try {
-                manager.maybeWait(connectCtx1);
+                manager.maybeWait(connectCtx1, coordinator);
                 Assert.assertEquals(0, manager.numPendingQueries());
             } catch (UserException | InterruptedException e) {
                 Assert.fail("Unexpected exception");
@@ -132,7 +171,7 @@ public class QueryQueueManagerTest {
         });
         thread.start();
         Awaitility.await().atMost(1, TimeUnit.SECONDS).until(connectCtx1::isPending);
-        mockResourceNotOverloaded();
+        mockCanRunMore();
         manager.maybeNotify();
         Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> !connectCtx1.isPending());
         // noneffective.
@@ -140,7 +179,7 @@ public class QueryQueueManagerTest {
     }
 
     @Test
-    public void testNeedWait() {
+    public void testCanRunMore() {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         SystemInfoService service = GlobalStateMgr.getCurrentSystemInfo();
         Backend be1 = new Backend();
@@ -160,39 +199,147 @@ public class QueryQueueManagerTest {
             }
         };
 
-        // Case 1: disable query_queue.
-        GlobalVariable.setQueryQueueEnable(false);
-        Assert.assertFalse(manager.needWait());
-
-        // Case 2: enable query_queue, but min_concurrency and min_mem_used_pct not effective.
-        GlobalVariable.setQueryQueueEnable(true);
+        // Case 1: enable query_queue, but min_concurrency and min_mem_used_pct not effective.
         GlobalVariable.setQueryQueueConcurrencyHardLimit(0);
         GlobalVariable.setQueryQueueMemUsedPctHardLimit(0);
         GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(0);
-        Assert.assertFalse(manager.needWait());
+        Assert.assertTrue(manager.canRunMore());
 
         GlobalVariable.setQueryQueueConcurrencyHardLimit(3);
         GlobalVariable.setQueryQueueMemUsedPctHardLimit(0.3);
         GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(400);
-        // Case 3: exceed concurrency threshold.
+        // Case 2: exceed concurrency threshold.
         manager.updateResourceUsage(be2.getId(), 3, 10, 0, 200);
-        Assert.assertTrue(manager.needWait());
+        Assert.assertFalse(manager.canRunMore());
 
-        // Case 4: exceed memory threshold.
+        // Case 3: exceed memory threshold.
         manager.updateResourceUsage(be2.getId(), 0, 10, 4, 200);
-        Assert.assertTrue(manager.needWait());
+        Assert.assertFalse(manager.canRunMore());
 
-        // Case 5: exceed CPU threshold.
+        // Case 4: exceed CPU threshold.
         manager.updateResourceUsage(be2.getId(), 0, 10, 2, 500);
-        Assert.assertTrue(manager.needWait());
+        Assert.assertFalse(manager.canRunMore());
 
-        // Case 6: BE isn't alive after resource overload.
+        // Case 5: BE isn't alive after resource overload.
         be2.setAlive(false);
-        Assert.assertFalse(manager.needWait());
+        Assert.assertTrue(manager.canRunMore());
 
-        // Case 7: don't exceed concurrency and memory threshold.
+        // Case 6: don't exceed concurrency and memory threshold.
         be2.setAlive(true);
         manager.updateResourceUsage(be2.getId(), 2, 10, 2, 200);
-        Assert.assertFalse(manager.needWait());
+        Assert.assertTrue(manager.canRunMore());
+    }
+
+    @Test
+    public void testCoordinatorNeedCheckQueue(@Mocked SchemaScanNode schemaScanNode,
+                                              @Mocked OlapScanNode olapScanNode,
+                                              @Mocked PlanFragment fragment,
+                                              @Mocked OlapTableSink olapTableSink,
+                                              @Mocked MysqlTableSink mysqlTableSink,
+                                              @Mocked ExportSink exportSink) {
+        QueryQueueManager manager = QueryQueueManager.getInstance();
+
+        // 1. Load type.
+        new Expectations(coordinator) {
+            {
+                coordinator.isLoadType();
+                result = true;
+            }
+        };
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+
+        // 2. ScanNodes is empty.
+        List<ScanNode> scanNodes = new ArrayList<>();
+        new Expectations(coordinator) {
+            {
+                coordinator.isLoadType();
+                result = false;
+            }
+
+            {
+                coordinator.getScanNodes();
+                result = scanNodes;
+            }
+        };
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+
+        // 3. ScanNodes only contain SchemaNode.
+        scanNodes.add(schemaScanNode);
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+
+        // 4. Insert to MySQL table.
+        scanNodes.add(olapScanNode);
+        new Expectations(coordinator, fragment) {
+            {
+                coordinator.getFragments();
+                result = ImmutableList.of(fragment);
+            }
+            {
+                fragment.getSink();
+                result = mysqlTableSink;
+            }
+        };
+        GlobalVariable.setQueryQueueInsertEnable(false);
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+        GlobalVariable.setQueryQueueInsertEnable(true);
+        Assert.assertTrue(manager.needCheckQueue(coordinator));
+
+        // 5. Insert to OLAP table.
+        new Expectations(coordinator, fragment) {
+            {
+                fragment.getSink();
+                result = olapTableSink;
+            }
+        };
+        GlobalVariable.setQueryQueueInsertEnable(false);
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+        GlobalVariable.setQueryQueueInsertEnable(true);
+        Assert.assertTrue(manager.needCheckQueue(coordinator));
+
+        // 6. Query for select.
+        PlanNodeId nodeId = new PlanNodeId(0);
+        ResultSink queryResultSink = new ResultSink(nodeId, TResultSinkType.MYSQL_PROTOCAL);
+        new Expectations(coordinator, fragment) {
+            {
+                fragment.getSink();
+                result = queryResultSink;
+            }
+        };
+        GlobalVariable.setQueryQueueSelectEnable(false);
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+        GlobalVariable.setQueryQueueSelectEnable(true);
+        Assert.assertTrue(manager.needCheckQueue(coordinator));
+
+        // 7. Query for statistic.
+        ResultSink statisticResultSink = new ResultSink(nodeId, TResultSinkType.STATISTIC);
+        new Expectations(coordinator, fragment) {
+            {
+                fragment.getSink();
+                result = statisticResultSink;
+            }
+        };
+        GlobalVariable.setQueryQueueStatisticEnable(false);
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+        GlobalVariable.setQueryQueueStatisticEnable(true);
+        Assert.assertTrue(manager.needCheckQueue(coordinator));
+
+        // 8. Query for outfile.
+        ResultSink fileResultSink = new ResultSink(nodeId, TResultSinkType.FILE);
+        new Expectations(coordinator, fragment) {
+            {
+                fragment.getSink();
+                result = fileResultSink;
+            }
+        };
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
+
+        // 9. Export.
+        new Expectations(coordinator, fragment) {
+            {
+                fragment.getSink();
+                result = exportSink;
+            }
+        };
+        Assert.assertFalse(manager.needCheckQueue(coordinator));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -42,8 +42,8 @@ public class QueryQueueManagerTest {
     @Before
     public void before() {
         taskQueueEnable = GlobalVariable.isQueryQueueSelectEnable();
-        taskQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyHardLimit();
-        taskQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctHardLimit();
+        taskQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
+        taskQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctLimit();
         taskQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
         taskQueueMaxQueuedQueries = GlobalVariable.getQueryQueueMaxQueuedQueries();
     }
@@ -52,8 +52,8 @@ public class QueryQueueManagerTest {
     public void after() {
         // Reset query queue configs.
         GlobalVariable.setQueryQueueSelectEnable(taskQueueEnable);
-        GlobalVariable.setQueryQueueConcurrencyHardLimit(taskQueueConcurrencyHardLimit);
-        GlobalVariable.setQueryQueueMemUsedPctHardLimit(taskQueueMemUsedPctHardLimit);
+        GlobalVariable.setQueryQueueConcurrencyLimit(taskQueueConcurrencyHardLimit);
+        GlobalVariable.setQueryQueueMemUsedPctLimit(taskQueueMemUsedPctHardLimit);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(taskQueuePendingTimeoutSecond);
         GlobalVariable.setQueryQueueMaxQueuedQueries(taskQueueMaxQueuedQueries);
     }
@@ -232,14 +232,14 @@ public class QueryQueueManagerTest {
         };
 
         // Case 1: enable query_queue, but min_concurrency and min_mem_used_pct not effective.
-        GlobalVariable.setQueryQueueConcurrencyHardLimit(0);
-        GlobalVariable.setQueryQueueMemUsedPctHardLimit(0);
-        GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(0);
+        GlobalVariable.setQueryQueueConcurrencyLimit(0);
+        GlobalVariable.setQueryQueueMemUsedPctLimit(0);
+        GlobalVariable.setQueryQueueCpuUsedPermilleLimit(0);
         Assert.assertTrue(manager.canRunMore());
 
-        GlobalVariable.setQueryQueueConcurrencyHardLimit(3);
-        GlobalVariable.setQueryQueueMemUsedPctHardLimit(0.3);
-        GlobalVariable.setQueryQueueCpuUsedPermilleHardLimit(400);
+        GlobalVariable.setQueryQueueConcurrencyLimit(3);
+        GlobalVariable.setQueryQueueMemUsedPctLimit(0.3);
+        GlobalVariable.setQueryQueueCpuUsedPermilleLimit(400);
         // Case 2: exceed concurrency threshold.
         manager.updateResourceUsage(be2.getId(), 3, 10, 0, 200);
         Assert.assertFalse(manager.canRunMore());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -682,15 +682,17 @@ public class ShowExecutorTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
-        Assert.assertEquals(25, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(27, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("BackendId", resultSet.getMetaData().getColumn(0).getName());
-        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(23).getName());
-        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(24).getName());
+        Assert.assertEquals("NumRunningQueries", resultSet.getMetaData().getColumn(23).getName());
+        Assert.assertEquals("MemUsedPct", resultSet.getMetaData().getColumn(24).getName());
+        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(25).getName());
+        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(26).getName());
 
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("1", resultSet.getString(0));
         Assert.assertEquals("0", resultSet.getString(23));
-        Assert.assertEquals("5", resultSet.getString(24));
+        Assert.assertEquals("5", resultSet.getString(26));
 
         Config.integrate_starmgr = false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -682,17 +682,18 @@ public class ShowExecutorTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
-        Assert.assertEquals(27, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(28, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("BackendId", resultSet.getMetaData().getColumn(0).getName());
         Assert.assertEquals("NumRunningQueries", resultSet.getMetaData().getColumn(23).getName());
         Assert.assertEquals("MemUsedPct", resultSet.getMetaData().getColumn(24).getName());
-        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(25).getName());
-        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(26).getName());
+        Assert.assertEquals("CpuUsedPct", resultSet.getMetaData().getColumn(25).getName());
+        Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(26).getName());
+        Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(27).getName());
 
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("1", resultSet.getString(0));
         Assert.assertEquals("0", resultSet.getString(23));
-        Assert.assertEquals("5", resultSet.getString(26));
+        Assert.assertEquals("5", resultSet.getString(27));
 
         Config.integrate_starmgr = false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -234,14 +234,12 @@ public class FrontendServiceImplTest {
         TUpdateResourceUsageRequest request = genUpdateResourceUsageRequest(
                 backendId, numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
 
-        //Notify pending queries, because resource usage is changed.
+        // Notify pending queries.
         impl.updateResourceUsage(request);
         Assert.assertEquals(numRunningQueries, backend.getNumRunningQueries());
         Assert.assertEquals(memLimitBytes, backend.getMemLimitBytes());
         Assert.assertEquals(memUsedBytes, backend.getMemUsedBytes());
         Assert.assertEquals(cpuUsedPermille, backend.getCpuUsedPermille());
-        // Don't notify, because resource usage isn't changed.
-        impl.updateResourceUsage(request);
         // Don't notify, because this BE doesn't exist.
         request.setBackend_id(/* Not Exist */ 1);
         impl.updateResourceUsage(request);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -286,6 +286,14 @@ under the License.
                 <scope>test</scope>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.2.0</version>
+                <scope>test</scope>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
             <dependency>
                 <groupId>com.baidu</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -286,14 +286,6 @@ under the License.
                 <scope>test</scope>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
-            <dependency>
-                <groupId>org.awaitility</groupId>
-                <artifactId>awaitility</artifactId>
-                <version>4.2.0</version>
-                <scope>test</scope>
-            </dependency>
-
             <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
             <dependency>
                 <groupId>com.baidu</groupId>

--- a/gensrc/script/vectorized/gen_vectorized_functions.py
+++ b/gensrc/script/vectorized/gen_vectorized_functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """

--- a/gensrc/script/vectorized/gen_vectorized_functions.py
+++ b/gensrc/script/vectorized/gen_vectorized_functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # encoding: utf-8
 
 """

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -34,6 +34,7 @@ include "Exprs.thrift"
 include "RuntimeProfile.thrift"
 include "MasterService.thrift"
 include "AgentService.thrift"
+include "ResourceUsage.thrift"
 
 // These are supporting structs for JniFrontend.java, which serves as the glue
 // between our C++ execution environment and the Java frontend.
@@ -1021,6 +1022,15 @@ struct TGetTablesInfoResponse {
     1: optional list<TTableInfo> tables_infos
 }
 
+struct TUpdateResourceUsageRequest {
+    1: optional i64 backend_id 
+    2: optional ResourceUsage.TResourceUsage resource_usage
+}
+
+struct TUpdateResourceUsageResponse {
+    1: optional Status.TStatus status
+}
+
 struct TTableInfo {
     1: optional string table_catalog
     2: optional string table_schema
@@ -1099,5 +1109,7 @@ service FrontendService {
     TAbortRemoteTxnResponse  abortRemoteTxn(1: TAbortRemoteTxnRequest request)
 
     TSetConfigResponse setConfig(1: TSetConfigRequest request)
+
+    TUpdateResourceUsageResponse updateResourceUsage(1: TUpdateResourceUsageRequest request)
 }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -27,6 +27,7 @@ include "InternalService.thrift"
 include "Types.thrift"
 include "Status.thrift"
 include "WorkGroup.thrift"
+include "ResourceUsage.thrift"
 
 struct TTabletInfo {
     1: required Types.TTabletId tablet_id
@@ -93,7 +94,7 @@ struct TPluginInfo {
 
 struct TReportRequest {
     1: required Types.TBackend backend
-    2: optional i64 report_version
+    2: optional i64 report_version // Required
     3: optional map<Types.TTaskType, set<i64>> tasks // string signature
     4: optional map<Types.TTabletId, TTablet> tablets
     5: optional map<string, TDisk> disks // string root_path
@@ -104,6 +105,7 @@ struct TReportRequest {
     8: optional i64 tablet_max_compaction_score
     // active workgroup on this backend
     9: optional list<WorkGroup.TWorkGroup> active_workgroups
+    10: optional ResourceUsage.TResourceUsage resource_usage
 }
 
 struct TMasterResult {

--- a/gensrc/thrift/ResourceUsage.thrift
+++ b/gensrc/thrift/ResourceUsage.thrift
@@ -1,0 +1,10 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+namespace cpp starrocks
+namespace java com.starrocks.thrift
+
+struct TResourceUsage {
+    1: optional i32 num_running_queries
+    2: optional i64 mem_limit_bytes
+    3: optional i64 mem_used_bytes
+}

--- a/gensrc/thrift/ResourceUsage.thrift
+++ b/gensrc/thrift/ResourceUsage.thrift
@@ -7,4 +7,5 @@ struct TResourceUsage {
     1: optional i32 num_running_queries
     2: optional i64 mem_limit_bytes
     3: optional i64 mem_used_bytes
+    4: optional i32 cpu_used_permille;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Query will be pending when BE is overloaded, if `query_queue_enable` is true.

If the number of running queries of any BE `exceeds query_queue_min_concurrency` or memory usage rate of any BE exceeds `query_queue_min_mem_used_pct`, the current query will be pending or failed:
- if the number of pending queries in this FE exceeds `query_queue_capacity`, the query will be failed.
- otherwise, the query will be pending until all the BEs aren't overloaded anymore or timeout `query_queue_pending_timeout_second`.

Every BE reports at interval `report_resource_usage_interval_ms` (1s by default) the resources containing the number of running queries and memory usage rate to the FE leader. And the FE leader synchronizes the resource usage info to FE followers by RPC.

The queries only using schema meta will never been queued, because a MySQL client will query schema meta after the connection is established.

## Related Behaviour Modification
- `show backends` shows `NumRunningQueries` and `MemUsedPct`.
- `show prcesslist` shows whether the connection is pending in the field `IsPending`.
- `audit.log` shows the pending time of a query.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
