### PR TITLE
[BugFix] fix race condition of workgroup scheduling

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -303,8 +303,9 @@ bool WorkGroupDriverQueue::should_yield(const DriverRawPtr driver, int64_t unacc
 
     // Return true, if the minimum-vruntime workgroup is not current workgroup anymore.
     auto* wg_entity = driver->workgroup()->driver_sched_entity();
-    return _min_wg_entity.load() != wg_entity &&
-           _min_vruntime_ns.load() < wg_entity->vruntime_ns() + unaccounted_runtime_ns / wg_entity->cpu_limit();
+    auto* min_entity = _min_wg_entity.load();
+    return min_entity != wg_entity && min_entity &&
+           min_entity->vruntime_ns() < wg_entity->vruntime_ns() + unaccounted_runtime_ns / wg_entity->cpu_limit();
 }
 
 bool WorkGroupDriverQueue::_throttled(const workgroup::WorkGroupDriverSchedEntity* wg_entity,
@@ -336,10 +337,8 @@ void WorkGroupDriverQueue::_put_back(const DriverRawPtr driver) {
 void WorkGroupDriverQueue::_update_min_wg() {
     auto* min_wg_entity = _take_next_wg();
     if (min_wg_entity == nullptr) {
-        _min_vruntime_ns = std::numeric_limits<int64_t>::max();
         _min_wg_entity = nullptr;
     } else {
-        _min_vruntime_ns = min_wg_entity->vruntime_ns();
         _min_wg_entity = min_wg_entity;
     }
 }

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -202,8 +202,7 @@ private:
 
     size_t _sum_cpu_limit = 0;
 
-    // Cache the minimum vruntime and entity, used to check should_yield() without lock.
-    std::atomic<int64_t> _min_vruntime_ns = std::numeric_limits<int64_t>::max();
+    // Cache the minimum entity, used to check should_yield() without lock.
     std::atomic<workgroup::WorkGroupDriverSchedEntity*> _min_wg_entity = nullptr;
 
     // Hard bandwidth control to non-short-query workgroups.

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -124,8 +124,9 @@ bool WorkGroupScanTaskQueue::should_yield(const WorkGroup* wg, int64_t unaccount
 
     // Return true, if the minimum-vruntime workgroup is not current workgroup anymore.
     auto* wg_entity = _sched_entity(wg);
-    return _min_wg_entity.load() != wg_entity &&
-           _min_vruntime_ns.load() < wg_entity->vruntime_ns() + unaccounted_runtime_ns / wg_entity->cpu_limit();
+    auto* min_entity = _min_wg_entity.load();
+    return min_entity != wg_entity && min_entity &&
+           min_entity->vruntime_ns() < wg_entity->vruntime_ns() + unaccounted_runtime_ns / wg_entity->cpu_limit();
 }
 
 bool WorkGroupScanTaskQueue::_throttled(const workgroup::WorkGroupScanSchedEntity* wg_entity,
@@ -144,10 +145,8 @@ bool WorkGroupScanTaskQueue::_throttled(const workgroup::WorkGroupScanSchedEntit
 void WorkGroupScanTaskQueue::_update_min_wg() {
     auto* min_wg_entity = _take_next_wg();
     if (min_wg_entity == nullptr) {
-        _min_vruntime_ns = std::numeric_limits<int64_t>::max();
         _min_wg_entity = nullptr;
     } else {
-        _min_vruntime_ns = min_wg_entity->vruntime_ns();
         _min_wg_entity = min_wg_entity;
     }
 }

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -138,8 +138,7 @@ private:
 
     size_t _sum_cpu_limit = 0;
 
-    // Cache the minimum vruntime and entity, used to check should_yield() without lock.
-    std::atomic<int64_t> _min_vruntime_ns = std::numeric_limits<int64_t>::max();
+    // Cache the minimum entity, used to check should_yield() without lock.
     std::atomic<workgroup::WorkGroupScanSchedEntity*> _min_wg_entity = nullptr;
 
     // Hard bandwidth control to non-short-query workgroups.


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`min_vruntime` and `min_wg_entity` are two variables, updating them introduce race condition.

As result, running a single query could introduce unexpected workgroup preempt.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
