### PR TITLE
[Enhancement] Add a configuration item to control data checksum for block cache

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -13,9 +13,13 @@ struct DirSpace {
 };
 
 struct CacheOptions {
+    // basic
     size_t mem_space_size;
     std::vector<DirSpace> disk_spaces;
+
+    // advanced
     size_t block_size;
+    bool checksum;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -25,6 +25,7 @@ Status FbCacheLib::init(const CacheOptions& options) {
             nvmConfig.navyConfig.setRaidFiles(files, options.disk_spaces[0].size, false);
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
+        nvmConfig.navyConfig.blockCache().setDataChecksum(options.checksum);
         config.enableNvmCache(nvmConfig);
     }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -866,6 +866,7 @@ CONF_Int64(block_cache_disk_size, "0");
 CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
+CONF_Bool(block_cache_checksum_enable, "true");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -187,6 +187,7 @@ int main(int argc, char** argv) {
             }
         }
         cache_options.block_size = starrocks::config::block_cache_block_size;
+        cache_options.checksum = starrocks::config::block_cache_checksum_enable;
         cache->init(cache_options);
     }
 #endif


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add a configuration item `block_cache_checksum_enable` to expose the checksum switch for block cache, which enable/disable data checksum when read/write. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
