### PR TITLE
[Refactor] Remove compiler warning

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -34,7 +34,7 @@ inline const char* assemble_state(TStatusCode::type code, Slice msg, Slice ctx) 
     return result;
 }
 
-const char* Status::copy_state(const char* state) const {
+const char* Status::copy_state(const char* state) {
     uint16_t len1;
     uint16_t len2;
     strings::memcpy_inlined(&len1, state, sizeof(len1));
@@ -45,7 +45,7 @@ const char* Status::copy_state(const char* state) const {
     return result;
 }
 
-const char* Status::copy_state_with_extra_ctx(const char* state, Slice ctx) const {
+const char* Status::copy_state_with_extra_ctx(const char* state, Slice ctx) {
     uint16_t len1;
     uint16_t len2;
     strings::memcpy_inlined(&len1, state, sizeof(len1));

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -243,8 +243,8 @@ public:
     Status clone_and_append_context(const char* filename, int line, const char* expr) const;
 
 private:
-    const char* copy_state(const char* state) const;
-    const char* copy_state_with_extra_ctx(const char* state, Slice ctx) const;
+    static const char* copy_state(const char* state);
+    static const char* copy_state_with_extra_ctx(const char* state, Slice ctx);
 
     // Indicates whether this Status was the rhs of a move operation.
     static bool is_moved_from(const char* state);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

The compiler will complain
```
/home/disk1/zc/code/starrocks/be/src/common/status.h: In member function ‘void starrocks::stream_load::NodeChannel::_cancel(int64_t, const starrocks::Status&)’:
/home/disk1/zc/code/starrocks/be/src/common/status.h:246:17: note: by argument 1 of type ‘const starrocks::Status*’ to ‘const char* starrocks::Status::copy_state(const char*) const’ declared here
  246 |     const char* copy_state(const char* state) const noexcept;
      |                 ^~~~~~~~~~
```

This is because copy_state is a member function which should not be used in initialization function.
I changed it to a static function in the PR.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
