### PR TITLE
[BugFix] fix topn offset issue

### DIFF
--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -68,12 +68,12 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
         if (_topn_type == TTopNType::ROW_NUMBER && _limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
             chunks_sorter = std::make_unique<ChunksSorterHeapSort>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, _offset, _limit);
+                    _sort_keys, 0, _limit + _offset);
         } else {
             size_t max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, _offset, _limit, _topn_type, max_buffered_chunks);
+                    _sort_keys, 0, _limit + _offset, _topn_type, max_buffered_chunks);
         }
     } else {
         chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(runtime_state(),

--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
@@ -117,6 +117,17 @@ Status ChunksSorterHeapSort::done(RuntimeState* state) {
             result_chunk->append_safe(*ref_chunk, rid, 1);
         }
         _merged_segment.init(_sort_exprs, result_chunk);
+        // Skip top OFFSET rows
+        if (_offset > 0) {
+            if (_offset > _merged_segment.chunk->num_rows()) {
+                _merged_segment.clear();
+                _next_output_row = 0;
+            } else {
+                _next_output_row += _offset;
+            }
+        } else {
+            _next_output_row = 0;
+        }
     }
     _sort_heap.reset();
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9698 in non-pipeline engine

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. `ChunksSorterHeapSort` doesn't handle offset in `done` stage and the queries will get a wrong result in non-pipeline engine when limit <= `USE_HEAP_SORTER_LIMIT_SZ`(1024).
2. in pipeline engine, the dop of `PartitionSortSinkOperator` may greater than 1, so there may multiple `ChunksSorter`. we should handle offset in the final `SortContext` instead of passing it into the `ChunksSorter`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
