### PR TITLE
[BugFix] when the path contains(),replaceFirst not work

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/PartitionUtil.java
@@ -198,7 +198,8 @@ public class PartitionUtil {
                     "dirPath " + dirPath + " should be prefix of filePath " + filePath);
         }
 
-        String name = filePath.replaceFirst(dirPath, "");
+        //we had checked the startsWith, so just get substring
+        String name = filePath.substring(dirPath.length());
         if (name.startsWith("/")) {
             name = name.substring(1);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/external/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/PartitionUtilTest.java
@@ -56,6 +56,7 @@ public class PartitionUtilTest {
     public void testGetSuffixName() {
         Assert.assertEquals("file", getSuffixName("/path/", "/path/file"));
         Assert.assertEquals("file", getSuffixName("/path", "/path/file"));
+        Assert.assertEquals("file", getSuffixName("/dt=(a)/", "/dt=(a)/file"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12641 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
repalceFirst will use the first param as regex, so when the path contains (), it will not work.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
