### PR TITLE
[Tool] Disable sysctl when building libevent

### DIFF
--- a/thirdparty/patches/libevent_on_free_cb.patch
+++ b/thirdparty/patches/libevent_on_free_cb.patch
@@ -69,3 +69,33 @@ index 4bf5b1f..0762cab 100644
  };
  
  #ifdef __cplusplus
+diff --git a/configure.ac b/configure.ac
+index e5088ac..7810b49 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -254,11 +254,6 @@ AC_CHECK_HEADERS([ \
+   errno.h \
+ ])
+ 
+-AC_CHECK_HEADERS(sys/sysctl.h, [], [], [
+-#ifdef HAVE_SYS_PARAM_H
+-#include <sys/param.h>
+-#endif
+-])
+ if test "x$ac_cv_header_sys_queue_h" = "xyes"; then
+ 	AC_MSG_CHECKING(for TAILQ_FOREACH in sys/queue.h)
+ 	AC_EGREP_CPP(yes,
+@@ -330,13 +325,6 @@ if test "x$ac_cv_header_sys_time_h" = "xyes"; then
+ )
+ fi
+ 
+-if test "x$ac_cv_header_sys_sysctl_h" = "xyes"; then
+-	AC_CHECK_DECLS([CTL_KERN, KERN_RANDOM, RANDOM_UUID, KERN_ARND], [], [],
+-	   [[#include <sys/types.h>
+-	     #include <sys/sysctl.h>]]
+-	)
+-fi
+-
+ AM_CONDITIONAL(BUILD_WIN32, test x$bwin32 = xtrue)
+ AM_CONDITIONAL(BUILD_CYGWIN, test x$cygwin = xtrue)
+ AM_CONDITIONAL(BUILD_MIDIPIX, test x$midipix = xtrue)


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：

Make the libevents library built on CentOS portable to Ubuntu.

## Problem Summary(Required) ：

When libevents is built on CentOS, it will detect sysctl libraries and try to make use of that.

Specifically, [`arc4random.c`](https://github.com/libevent/libevent/blob/3ec3b469b8d091837a1d1309ac0cdffa6a76e1d4/arc4random.c#L186) will use a different implementation when compiled with sysctl.

This causes a problem if we simply copy the `libevent.a` built on CentOS (the starrocks-dev-env docker is built by CentOS) to Ubuntu because Ubuntu does not have the sysctl libraries.

This will cause a linker error:

```
var/local/thirdparty/src/libevent-24236aed01798303745470e6c498bf606e88724a/./arc4random.c:192: undefined reference to `sysctl'
```

In this PR, we extend the libevent patch to disable sysctl when configuring the libevent library build. I have verified that the libevent library built on CentOS can now be ported to Ubuntu without linker error.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
