### PR TITLE
[Feature] Make ES supports custom timezone.

### DIFF
--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -93,7 +93,8 @@ Status ESDataSource::_build_conjuncts() {
     _predicate_idx.reserve(conjunct_sz);
 
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
-        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _runtime_state, _pool));
+        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc,
+                                                            _runtime_state->timezone(), _pool));
         predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list(true);
         if (status.ok()) {

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -93,8 +93,8 @@ Status ESDataSource::_build_conjuncts() {
     _predicate_idx.reserve(conjunct_sz);
 
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
-        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc,
-                                                            _runtime_state->timezone(), _pool));
+        EsPredicate* predicate =
+                _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _runtime_state->timezone(), _pool));
         predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list(true);
         if (status.ok()) {

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -93,7 +93,7 @@ Status ESDataSource::_build_conjuncts() {
     _predicate_idx.reserve(conjunct_sz);
 
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
-        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _pool));
+        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _runtime_state, _pool));
         predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list(true);
         if (status.ok()) {

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -118,8 +118,11 @@ std::string VExtLiteral::_value_to_string(ColumnPtr& column) {
 
 EsPredicate::EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, const std::string& timezone,
                          ObjectPool* pool)
-        : _context(context), _tuple_desc(tuple_desc),
-          _es_query_status(Status::OK()), _timezone(timezone), _pool(pool) {}
+        : _context(context),
+          _tuple_desc(tuple_desc),
+          _es_query_status(Status::OK()),
+          _timezone(timezone),
+          _pool(pool) {}
 
 EsPredicate::~EsPredicate() {
     for (auto& _disjunct : _disjuncts) {
@@ -353,14 +356,13 @@ Status build_inpred_values(const Predicate* pred, bool& is_not_in, Func&& func) 
     return Status::OK();
 }
 
-#define BUILD_INPRED_VALUES(TYPE)                                                                                    \
-    case TYPE: {                                                                                                     \
-        RETURN_IF_ERROR(build_inpred_values<TYPE>(pred, is_not_in, [&](auto& v) {                                    \
-            in_pred_values.emplace_back(new VExtLiteral(slot_desc->type().type,                                      \
-                                                        vectorized::ColumnHelper::create_const_column<TYPE>(v, 1),   \
-                                                        _timezone)); \
-        }));                                                                                                         \
-        break;                                                                                                       \
+#define BUILD_INPRED_VALUES(TYPE)                                                                                   \
+    case TYPE: {                                                                                                    \
+        RETURN_IF_ERROR(build_inpred_values<TYPE>(pred, is_not_in, [&](auto& v) {                                   \
+            in_pred_values.emplace_back(new VExtLiteral(                                                            \
+                    slot_desc->type().type, vectorized::ColumnHelper::create_const_column<TYPE>(v, 1), _timezone)); \
+        }));                                                                                                        \
+        break;                                                                                                      \
     }
 
 Status EsPredicate::_build_in_predicate(const Expr* conjunct, bool* handled) {

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -42,7 +42,6 @@
 #include "runtime/string_value.h"
 #include "service/backend_options.h"
 #include "util/runtime_profile.h"
-#include "util/timezone_utils.h"
 
 namespace starrocks {
 
@@ -61,7 +60,7 @@ static constexpr bool is_type_in() {
     return (std::is_same_v<T, Ts> || ...);
 }
 
-VExtLiteral::VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column, RuntimeState* runtime_state) {
+VExtLiteral::VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column, const std::string& timezone) {
     DCHECK(!column->empty());
     // We need to convert the predicate column into the corresponding string.
     // Some types require special handling, because the default behavior of Datum may not match the behavior of ES.
@@ -74,7 +73,12 @@ VExtLiteral::VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column, Runti
         DCHECK(!viewer.is_null(0));
         vectorized::TimestampValue datetime_value = viewer.value(0);
         // Use timezone variable from FE
-        int64_t offsets = TimezoneUtils::to_utc_offset(runtime_state->timezone_obj());
+        cctz::time_zone timezone_obj;
+        if (!TimezoneUtils::find_cctz_time_zone(timezone, timezone_obj)) {
+            // Use default +8 timezone instead.
+            TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj);
+        }
+        int64_t offsets = TimezoneUtils::to_utc_offset(timezone_obj);
         _value = std::to_string((datetime_value.to_unix_second() - offsets) * 1000);
     } else if (type == TYPE_BOOLEAN) {
         vectorized::ColumnViewer<TYPE_BOOLEAN> viewer(column);
@@ -112,10 +116,10 @@ std::string VExtLiteral::_value_to_string(ColumnPtr& column) {
     return res;
 }
 
-EsPredicate::EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, RuntimeState* runtime_state,
+EsPredicate::EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, const std::string& timezone,
                          ObjectPool* pool)
         : _context(context), _tuple_desc(tuple_desc),
-          _es_query_status(Status::OK()), _runtime_state(runtime_state), _pool(pool) {}
+          _es_query_status(Status::OK()), _timezone(timezone), _pool(pool) {}
 
 EsPredicate::~EsPredicate() {
     for (auto& _disjunct : _disjuncts) {
@@ -219,7 +223,7 @@ Status EsPredicate::_build_binary_predicate(const Expr* conjunct, bool* handled)
 
         // how to process literal
         ASSIGN_OR_RETURN(auto expr_value, _context->evaluate(expr, nullptr));
-        auto literal = _pool->add(new VExtLiteral(expr->type().type, std::move(expr_value), _runtime_state));
+        auto literal = _pool->add(new VExtLiteral(expr->type().type, std::move(expr_value), _timezone));
         std::string col = slot_desc->col_name();
 
         // ES does not support non-bool literal pushdown for bool type
@@ -251,7 +255,7 @@ Status EsPredicate::_build_functioncall_predicate(const Expr* conjunct, bool* ha
             }
             Expr* expr = conjunct->get_child(1);
             ASSIGN_OR_RETURN(auto expr_value, _context->evaluate(expr, nullptr));
-            auto literal = _pool->add(new VExtLiteral(expr->type().type, std::move(expr_value), _runtime_state));
+            auto literal = _pool->add(new VExtLiteral(expr->type().type, std::move(expr_value), _timezone));
             std::vector<ExtLiteral*> query_conditions;
             query_conditions.emplace_back(literal);
             std::vector<ExtColumnDesc> cols;
@@ -319,7 +323,7 @@ Status EsPredicate::_build_functioncall_predicate(const Expr* conjunct, bool* ha
             }
 
             ASSIGN_OR_RETURN(auto expr_col, _context->evaluate(expr, nullptr));
-            auto literal = _pool->add(new VExtLiteral(type, std::move(expr_col), _runtime_state));
+            auto literal = _pool->add(new VExtLiteral(type, std::move(expr_col), _timezone));
             ExtPredicate* predicate = new ExtLikePredicate(TExprNodeType::LIKE_PRED, col, slot_desc->type(), literal);
 
             _disjuncts.push_back(predicate);
@@ -354,7 +358,7 @@ Status build_inpred_values(const Predicate* pred, bool& is_not_in, Func&& func) 
         RETURN_IF_ERROR(build_inpred_values<TYPE>(pred, is_not_in, [&](auto& v) {                                    \
             in_pred_values.emplace_back(new VExtLiteral(slot_desc->type().type,                                      \
                                                         vectorized::ColumnHelper::create_const_column<TYPE>(v, 1),   \
-                                                        _runtime_state)); \
+                                                        _timezone)); \
         }));                                                                                                         \
         break;                                                                                                       \
     }
@@ -435,7 +439,7 @@ Status EsPredicate::_build_compound_predicate(const Expr* conjunct, bool* handle
         if (conjunct->op() == TExprOpcode::COMPOUND_AND) {
             std::vector<EsPredicate*> conjuncts;
             for (int i = 0; i < conjunct->get_num_children(); ++i) {
-                EsPredicate* predicate = _pool->add(new EsPredicate(_context, _tuple_desc, _runtime_state, _pool));
+                EsPredicate* predicate = _pool->add(new EsPredicate(_context, _tuple_desc, _timezone, _pool));
                 predicate->set_field_context(_field_context);
                 Status status = predicate->_vec_build_disjuncts_list(conjunct->children()[i]);
                 if (status.ok()) {

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include "cctz/time_zone.h"
+#include "util/timezone_utils.h"
 #include "column/vectorized_fwd.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Opcodes_types.h"
@@ -47,7 +49,8 @@ public:
 // for vectorized call
 class VExtLiteral : public ExtLiteral {
 public:
-    VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column, RuntimeState* runtime_state);
+    VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column,
+                const std::string& timezone = TimezoneUtils::default_time_zone);
 
     VExtLiteral() = default;
     const std::string& to_string() const override { return _value; }
@@ -134,7 +137,7 @@ struct ExtFunction : public ExtPredicate {
 
 class EsPredicate {
 public:
-    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, RuntimeState* runtime_state, ObjectPool* pool);
+    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, const std::string& timezone, ObjectPool* pool);
     ~EsPredicate();
     const std::vector<ExtPredicate*>& get_predicate_list();
     Status build_disjuncts_list(bool use_vectorized = true);
@@ -160,7 +163,7 @@ private:
     const TupleDescriptor* _tuple_desc = nullptr;
     std::vector<ExtPredicate*> _disjuncts;
     Status _es_query_status;
-    RuntimeState* _runtime_state;
+    const std::string _timezone;
     ObjectPool* _pool = nullptr;
     std::map<std::string, std::string> _field_context;
 };

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -47,7 +47,7 @@ public:
 // for vectorized call
 class VExtLiteral : public ExtLiteral {
 public:
-    VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column);
+    VExtLiteral(PrimitiveType type, vectorized::ColumnPtr column, RuntimeState* runtime_state);
 
     VExtLiteral() = default;
     const std::string& to_string() const override { return _value; }
@@ -134,7 +134,7 @@ struct ExtFunction : public ExtPredicate {
 
 class EsPredicate {
 public:
-    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, ObjectPool* pool);
+    EsPredicate(ExprContext* context, const TupleDescriptor* tuple_desc, RuntimeState* runtime_state, ObjectPool* pool);
     ~EsPredicate();
     const std::vector<ExtPredicate*>& get_predicate_list();
     Status build_disjuncts_list(bool use_vectorized = true);
@@ -160,6 +160,7 @@ private:
     const TupleDescriptor* _tuple_desc = nullptr;
     std::vector<ExtPredicate*> _disjuncts;
     Status _es_query_status;
+    RuntimeState* _runtime_state;
     ObjectPool* _pool = nullptr;
     std::map<std::string, std::string> _field_context;
 };

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -26,13 +26,13 @@
 #include <vector>
 
 #include "cctz/time_zone.h"
-#include "util/timezone_utils.h"
 #include "column/vectorized_fwd.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Opcodes_types.h"
 #include "runtime/descriptors.h"
 #include "runtime/primitive_type.h"
 #include "types/date_value.h"
+#include "util/timezone_utils.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Original ES will only use the default timezone(+8:00) to convert `datetime` type to UNIX time(UTC+0:00) for the search, but if the user saves `date` type in (UTC+0:00), the search result will be inaccurate. 

So we support using a custom timezone in ES.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
