### PR TITLE
[Enhancement] Add hashJoin execution cost model

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -95,10 +95,6 @@ public class ExpressionContext {
         return childrenProperty.get(index).getOutputColumns();
     }
 
-    public int getChildLeftMostScanTabletsNum(int index) {
-        return childrenProperty.get(index).getLeftMostScanTabletsNum();
-    }
-
     public boolean isExecuteInOneTablet(int index) {
         return childrenProperty.get(index).isExecuteInOneTablet();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -29,7 +29,6 @@ import java.util.Set;
  * which came from the initial query tree.
  */
 public class Group {
-
     private final int id;
 
     private final List<GroupExpression> logicalExpressions;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -29,6 +29,7 @@ import java.util.Set;
  * which came from the initial query tree.
  */
 public class Group {
+
     private final int id;
 
     private final List<GroupExpression> logicalExpressions;
@@ -42,7 +43,7 @@ public class Group {
     private final Map<PhysicalPropertySet, Statistics> confidenceStatistics;
     private final Map<PhysicalPropertySet, Pair<Double, GroupExpression>> lowestCostExpressions;
     // GroupExpressions in this Group which could satisfy the required property.
-    private final Map<PhysicalPropertySet, Set<GroupExpression>> satisfyOutputPropertyGroupExpressions;
+    private final Map<PhysicalPropertySet, Set<GroupExpression>> satisfyRequiredPropertyGroupExpressions;
 
     // All expressions in one group have same logical property.
     private LogicalProperty logicalProperty;
@@ -52,7 +53,7 @@ public class Group {
         logicalExpressions = Lists.newArrayList();
         physicalExpressions = Lists.newArrayList();
         lowestCostExpressions = Maps.newHashMap();
-        satisfyOutputPropertyGroupExpressions = Maps.newHashMap();
+        satisfyRequiredPropertyGroupExpressions = Maps.newHashMap();
         confidenceStatistics = Maps.newHashMap();
         isExplored = false;
     }
@@ -141,35 +142,26 @@ public class Group {
         }
     }
 
-    public List<PhysicalPropertySet> getSatisfyRequiredPropertyGroupExpressions(PhysicalPropertySet requiredProperty) {
-        List<PhysicalPropertySet> outputProperties = Lists.newArrayList();
-        for (Map.Entry<PhysicalPropertySet, Set<GroupExpression>> entry : satisfyOutputPropertyGroupExpressions.entrySet()) {
-            if (entry.getKey().isSatisfy(requiredProperty)) {
-                outputProperties.add(entry.getKey());
-            }
-        }
-        return outputProperties;
-    }
-
-    public Set<GroupExpression> getSatisfyOutputPropertyGroupExpressions(PhysicalPropertySet outputProperty) {
-        Set<GroupExpression> groupExpressions = Sets.newLinkedHashSet();
-        Preconditions.checkState(satisfyOutputPropertyGroupExpressions.containsKey(outputProperty));
-        groupExpressions.addAll(satisfyOutputPropertyGroupExpressions.get(outputProperty));
+    public Set<GroupExpression> getSatisfyRequiredGroupExpressions(PhysicalPropertySet requiredProperty) {
+        Set<GroupExpression> groupExpressions = satisfyRequiredPropertyGroupExpressions.get(requiredProperty);
+        Preconditions.checkState(groupExpressions != null);
         return groupExpressions;
     }
 
-    public void addSatisfyOutputPropertyGroupExpression(PhysicalPropertySet outputProperty,
-                                                        GroupExpression groupExpression) {
-        if (!satisfyOutputPropertyGroupExpressions.containsKey(outputProperty)) {
-            satisfyOutputPropertyGroupExpressions.put(outputProperty, Sets.newLinkedHashSet());
+    public void addSatisfyRequiredPropertyGroupExpression(PhysicalPropertySet outputProperty,
+                                                          GroupExpression groupExpression) {
+        if (!satisfyRequiredPropertyGroupExpressions.containsKey(outputProperty)) {
+            satisfyRequiredPropertyGroupExpressions.put(outputProperty, Sets.newLinkedHashSet());
         }
-        satisfyOutputPropertyGroupExpressions.get(outputProperty).add(groupExpression);
+        satisfyRequiredPropertyGroupExpressions.get(outputProperty).add(groupExpression);
     }
 
-    public void addSatisfyOutputPropertyGroupExpressions(PhysicalPropertySet outputProperty,
-                                                         Set<GroupExpression> groupExpressions) {
-        groupExpressions.forEach(
-                groupExpression -> addSatisfyOutputPropertyGroupExpression(outputProperty, groupExpression));
+    public void addSatisfyRequiredPropertyGroupExpressions(PhysicalPropertySet outputProperty,
+                                                           Set<GroupExpression> groupExpressions) {
+        if (!satisfyRequiredPropertyGroupExpressions.containsKey(outputProperty)) {
+            satisfyRequiredPropertyGroupExpressions.put(outputProperty, Sets.newLinkedHashSet());
+        }
+        satisfyRequiredPropertyGroupExpressions.get(outputProperty).addAll(groupExpressions);
     }
 
     public void replaceBestExpressionProperty(PhysicalPropertySet oldProperty, PhysicalPropertySet newProperty,
@@ -266,7 +258,7 @@ public class Group {
         if (statistics == null) {
             statistics = other.statistics;
         }
-        other.satisfyOutputPropertyGroupExpressions.forEach(this::addSatisfyOutputPropertyGroupExpressions);
+        other.satisfyRequiredPropertyGroupExpressions.forEach(this::addSatisfyRequiredPropertyGroupExpressions);
     }
 
     public void removeGroupExpression(GroupExpression groupExpression) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostEstimate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostEstimate.java
@@ -37,6 +37,12 @@ public class CostEstimate {
                 left.networkCost + right.networkCost);
     }
 
+    public CostEstimate multiplyBy(double factor) {
+        return new CostEstimate(cpuCost * factor,
+                memoryCost * factor,
+                networkCost * factor);
+    }
+
     public static boolean isZero(CostEstimate costEstimate) {
         return costEstimate.cpuCost == 0 && costEstimate.memoryCost == 0 && costEstimate.networkCost == 0;
     }
@@ -59,5 +65,10 @@ public class CostEstimate {
 
     public static CostEstimate of(double cpuCost, double memoryCost, double networkCost) {
         return new CostEstimate(cpuCost, memoryCost, networkCost);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[cpuCost: %f. memoryCost: %f. networkCost: %f.]", cpuCost, memoryCost, networkCost);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.optimizer.cost;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -52,7 +53,7 @@ public class CostModel {
     }
 
     private static double calculateCost(ExpressionContext expressionContext) {
-        CostEstimator costEstimator = new CostEstimator(null);
+        CostEstimator costEstimator = new CostEstimator(ImmutableList.of());
         CostEstimate costEstimate = expressionContext.getOp().accept(costEstimator, expressionContext);
         double realCost = getRealCost(costEstimate);
         LOG.debug("operator: {}, outputRowCount: {}, outPutSize: {}, costEstimate: {}, realCost: {}",
@@ -64,7 +65,7 @@ public class CostModel {
     }
 
     public static CostEstimate calculateCostEstimate(ExpressionContext expressionContext) {
-        CostEstimator costEstimator = new CostEstimator(null);
+        CostEstimator costEstimator = new CostEstimator(ImmutableList.of());
         return expressionContext.getOp().accept(costEstimator, expressionContext);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -69,17 +69,17 @@ public class CostModel {
         return expressionContext.getOp().accept(costEstimator, expressionContext);
     }
 
-    public static double calculateCostWithInputProperty(GroupExpression expression,
-                                                              List<PhysicalPropertySet> inputProperties) {
+    public static double calculateCostWithChildrenOutProperty(GroupExpression expression,
+                                                              List<PhysicalPropertySet> childrenOutputProperties) {
         ExpressionContext expressionContext = new ExpressionContext(expression);
-        CostEstimator costEstimator = new CostEstimator(inputProperties);
+        CostEstimator costEstimator = new CostEstimator(childrenOutputProperties);
         CostEstimate costEstimate = expressionContext.getOp().accept(costEstimator, expressionContext);
         double realCost = getRealCost(costEstimate);
 
         LOG.debug("operator: {}, group id: {}, child group id: {}, " +
                         "inputProperties: {}, outputRowCount: {}, outPutSize: {}, costEstimate: {}, realCost: {}",
                 expressionContext.getOp(), expression.getGroup().getId(),
-                expression.getInputs().stream().map(Group::getId).collect(Collectors.toList()), inputProperties,
+                expression.getInputs().stream().map(Group::getId).collect(Collectors.toList()), childrenOutputProperties,
                 expressionContext.getStatistics().getOutputRowCount(),
                 expressionContext.getStatistics().getComputeSize(),
                 costEstimate, realCost);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
@@ -31,8 +31,8 @@ import java.util.List;
  * parallelism, and left and right table size. The most important thing in the model is the evaluation of the
  * probe cost for each row. When the size of the right table is greater than bottom_number, the average probe
  * cost needs to be expanded by multiply a penalty factor. The parallel computing characteristics of shuffle
- * join can offset part of the probe cost. We also set an upper limit on the probe cost to avoid cost distortion
- * caused by huge table.
+ * join can offset part of the probe cost by subtract a  parallel factor. We also set an upper limit on the
+ * penalty factor to avoid cost distortion caused by huge table.
  */
 public class HashJoinCostModel {
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
@@ -1,0 +1,121 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.cost;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class HashJoinCostModel {
+
+    private static final Logger LOG = LogManager.getLogger(HashJoinCostModel.class);
+    private static final String EMPTY = "EMPTY";
+
+    private static final String BROADCAST = "BROADCAST";
+
+    private static final String SHUFFLE = "SHUFFLE";
+
+    private static final int BOTTOM_NUMBER = 100000;
+
+    private final Statistics leftStatistics;
+
+    private final Statistics rightStatistics;
+
+    private final ExpressionContext context;
+
+    private final List<PhysicalPropertySet> inputProperties;
+
+    private final List<BinaryPredicateOperator> eqOnPredicates;
+
+    public HashJoinCostModel(ExpressionContext context, List<PhysicalPropertySet> inputProperties,
+                             List<BinaryPredicateOperator> eqOnPredicates) {
+        this.context = context;
+        this.leftStatistics = context.getChildStatistics(0);
+        this.rightStatistics = context.getChildStatistics(1);
+        this.inputProperties = inputProperties;
+        this.eqOnPredicates = eqOnPredicates;
+    }
+
+    public double getCpuCost() {
+        String execMode = deriveJoinExecMode();
+        double buildCost;
+        double probeCost;
+        double leftOutput = leftStatistics.getOutputSize(context.getChildOutputColumns(0));
+        double rightOutput = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
+        int beNum = Math.max(1, ConnectContext.get().getAliveBackendNumber());
+        switch (execMode) {
+            case BROADCAST:
+                buildCost = rightOutput;
+                probeCost = leftOutput * getAvgProbeCost();
+                break;
+            case SHUFFLE:
+                buildCost = rightOutput / beNum;
+                probeCost = leftOutput * getAvgProbeCost();
+                break;
+            default:
+                buildCost = rightOutput;
+                probeCost = leftOutput;
+        }
+        return buildCost + probeCost;
+    }
+
+    public double getMemCost() {
+        String execMode = deriveJoinExecMode();
+        double rightOutput = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
+        double memCost;
+        int beNum = Math.max(1, ConnectContext.get().getAliveBackendNumber());
+        switch (execMode) {
+            case BROADCAST:
+                memCost = rightOutput * beNum;
+                break;
+            default:
+                memCost = rightOutput;
+        }
+        return memCost;
+    }
+
+    private double getAvgProbeCost() {
+        String execMode = deriveJoinExecMode();
+        double keySize = 0;
+        for (BinaryPredicateOperator predicateOperator : eqOnPredicates) {
+            ColumnRefOperator leftCol = (ColumnRefOperator) predicateOperator.getChild(0);
+            ColumnRefOperator rightCol = (ColumnRefOperator) predicateOperator.getChild(1);
+            if (context.getChildStatistics(1).getColumnStatistics().containsKey(leftCol)) {
+                keySize += context.getChildStatistics(1).getColumnStatistic(leftCol).getAverageRowSize();
+            } else if (context.getChildStatistics(1).getColumnStatistics().containsKey(rightCol)) {
+                keySize += context.getChildStatistics(1).getColumnStatistic(rightCol).getAverageRowSize();
+            }
+        }
+        double degradeRatio;
+        int parallelFactor = Math.max(ConnectContext.get().getAliveBackendNumber(),
+                ConnectContext.get().getSessionVariable().getDegreeOfParallelism()) * 2;
+        double mapSize = Math.min(1, keySize) * rightStatistics.getOutputRowCount();
+        switch (execMode) {
+            case BROADCAST:
+                degradeRatio = Math.max(1, Math.log(mapSize / BOTTOM_NUMBER));
+                break;
+            default:
+                degradeRatio = Math.max(1, (Math.log(mapSize / BOTTOM_NUMBER) -
+                        Math.log(parallelFactor) / Math.log(2)));
+        }
+        LOG.debug("execMode: {}, degradeRatio: {}", execMode, degradeRatio);
+        return degradeRatio;
+    }
+
+    private String deriveJoinExecMode() {
+        if (inputProperties == null) {
+            return EMPTY;
+        } else if (inputProperties.get(1).getDistributionProperty().isBroadcast()) {
+            return BROADCAST;
+        } else {
+            return SHUFFLE;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDistributionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDistributionOperator.java
@@ -48,4 +48,9 @@ public class PhysicalDistributionOperator extends PhysicalOperator {
     public boolean couldApplyStringDict(Set<Integer> childDictColumns) {
         return true;
     }
+
+    @Override
+    public String toString() {
+        return String.format("[optType: %s, distributionSpec: %s]", opType, distributionSpec);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -283,11 +283,8 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         double leftOutputSize = leftChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex - 1));
         double rightOutputSize = rightChildStats.getOutputSize(groupExpression.getChildOutputColumns(curChildIndex));
 
-        int parallelExecInstance = CostModel.getParallelExecInstanceNum(
-                groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum());
-        if (leftOutputSize < rightOutputSize * parallelExecInstance * beNum * sv.getBroadcastRightTableScaleFactor()
-                && rightChildStats.getOutputRowCount() >
-                sv.getBroadcastRowCountLimit()) {
+        if (leftOutputSize < rightOutputSize * beNum * sv.getBroadcastRightTableScaleFactor()
+                && rightChildStats.getOutputRowCount() > sv.getBroadcastRowCountLimit()) {
             return false;
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -307,7 +307,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
                                        List<PhysicalPropertySet> childrenOutputProperties) {
         // re-calculate local cost and update total cost
         curTotalCost -= localCost;
-        localCost = CostModel.calculateCost(groupExpression);
+        localCost = CostModel.calculateCostWithInputProperty(groupExpression, inputProperties);
         curTotalCost += localCost;
 
         setSatisfiedPropertyWithCost(outputProperty, childrenOutputProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -304,7 +304,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
                                        List<PhysicalPropertySet> childrenOutputProperties) {
         // re-calculate local cost and update total cost
         curTotalCost -= localCost;
-        localCost = CostModel.calculateCostWithInputProperty(groupExpression, inputProperties);
+        localCost = CostModel.calculateCostWithChildrenOutProperty(groupExpression, childrenOutputProperties);
         curTotalCost += localCost;
 
         setSatisfiedPropertyWithCost(outputProperty, childrenOutputProperties);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -483,11 +483,11 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     public void testCountPruneJoinByProject() throws Exception {
         String sql = "select count(*) from customer join orders on C_CUSTKEY = O_CUSTKEY";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "5:AGGREGATE (update serialize)\n" +
+        assertContains(plan, "6:AGGREGATE (update serialize)\n" +
                 "  |  output: count(*)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
-                "  4:Project\n" +
+                "  5:Project\n" +
                 "  |  <slot 1> : 1: C_CUSTKEY");
         checkTwoPhaseAgg(plan);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -48,7 +48,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testTPCHQ5EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q5", true);
+        runFileUnitTest("enumerate-plan/tpch-q5");
     }
 
     @Test
@@ -68,12 +68,12 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testTPCHQ9EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q9", true);
+        runFileUnitTest("enumerate-plan/tpch-q9");
     }
 
     @Test
     public void testTPCHQ10EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q10", true);
+        runFileUnitTest("enumerate-plan/tpch-q10");
     }
 
     @Test
@@ -113,7 +113,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testTPCHQ18EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q18", true);
+        runFileUnitTest("enumerate-plan/tpch-q18");
     }
 
     @Test
@@ -128,7 +128,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testTPCHQ21EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q21", true);
+        runFileUnitTest("enumerate-plan/tpch-q21");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -79,7 +79,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    p_partkey limit 100;\n" +
                 "\n";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(39, planCount);
+        Assert.assertEquals(45, planCount);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "order by\n" +
                 "    o_year ;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(49, planCount);
+        Assert.assertEquals(51, planCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -4,7 +4,6 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -23,7 +22,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testThreeTableJoinEnumPlan() throws Exception {
+    public void testThreeTableJoinEnumPlan() {
         runFileUnitTest("enumerate-plan/three-join");
     }
 
@@ -33,53 +32,8 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ2EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    s_acctbal,\n" +
-                "    s_name,\n" +
-                "    n_name,\n" +
-                "    p_partkey,\n" +
-                "    p_mfgr,\n" +
-                "    s_address,\n" +
-                "    s_phone,\n" +
-                "    s_comment\n" +
-                "from\n" +
-                "    part,\n" +
-                "    supplier,\n" +
-                "    partsupp,\n" +
-                "    nation,\n" +
-                "    region\n" +
-                "where\n" +
-                "        p_partkey = ps_partkey\n" +
-                "  and s_suppkey = ps_suppkey\n" +
-                "  and p_size = 12\n" +
-                "  and p_type like '%COPPER'\n" +
-                "  and s_nationkey = n_nationkey\n" +
-                "  and n_regionkey = r_regionkey\n" +
-                "  and r_name = 'AMERICA'\n" +
-                "  and ps_supplycost = (\n" +
-                "    select\n" +
-                "        min(ps_supplycost)\n" +
-                "    from\n" +
-                "        partsupp,\n" +
-                "        supplier,\n" +
-                "        nation,\n" +
-                "        region\n" +
-                "    where\n" +
-                "            p_partkey = ps_partkey\n" +
-                "      and s_suppkey = ps_suppkey\n" +
-                "      and s_nationkey = n_nationkey\n" +
-                "      and n_regionkey = r_regionkey\n" +
-                "      and r_name = 'AMERICA'\n" +
-                ")\n" +
-                "order by\n" +
-                "    s_acctbal desc,\n" +
-                "    n_name,\n" +
-                "    s_name,\n" +
-                "    p_partkey limit 100;\n" +
-                "\n";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(45, planCount);
+    public void testTPCHQ2EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q2");
     }
 
     @Test
@@ -93,33 +47,8 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ5EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    n_name,\n" +
-                "    sum(l_extendedprice * (1 - l_discount)) as revenue\n" +
-                "from\n" +
-                "    customer,\n" +
-                "    orders,\n" +
-                "    lineitem,\n" +
-                "    supplier,\n" +
-                "    nation,\n" +
-                "    region\n" +
-                "where\n" +
-                "        c_custkey = o_custkey\n" +
-                "  and l_orderkey = o_orderkey\n" +
-                "  and l_suppkey = s_suppkey\n" +
-                "  and c_nationkey = s_nationkey\n" +
-                "  and s_nationkey = n_nationkey\n" +
-                "  and n_regionkey = r_regionkey\n" +
-                "  and r_name = 'AFRICA'\n" +
-                "  and o_orderdate >= date '1995-01-01'\n" +
-                "  and o_orderdate < date '1996-01-01'\n" +
-                "group by\n" +
-                "    n_name\n" +
-                "order by\n" +
-                "    revenue desc ;";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(77, planCount);
+    public void testTPCHQ5EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q5", true);
     }
 
     @Test
@@ -128,101 +57,23 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ7EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    supp_nation,\n" +
-                "    cust_nation,\n" +
-                "    l_year,\n" +
-                "    sum(volume) as revenue\n" +
-                "from\n" +
-                "    (\n" +
-                "        select\n" +
-                "            n1.n_name as supp_nation,\n" +
-                "            n2.n_name as cust_nation,\n" +
-                "            extract(year from l_shipdate) as l_year,\n" +
-                "            l_extendedprice * (1 - l_discount) as volume\n" +
-                "        from\n" +
-                "            supplier,\n" +
-                "            lineitem,\n" +
-                "            orders,\n" +
-                "            customer,\n" +
-                "            nation n1,\n" +
-                "            nation n2\n" +
-                "        where\n" +
-                "                s_suppkey = l_suppkey\n" +
-                "          and o_orderkey = l_orderkey\n" +
-                "          and c_custkey = o_custkey\n" +
-                "          and s_nationkey = n1.n_nationkey\n" +
-                "          and c_nationkey = n2.n_nationkey\n" +
-                "          and (\n" +
-                "                (n1.n_name = 'CANADA' and n2.n_name = 'IRAN')\n" +
-                "                or (n1.n_name = 'IRAN' and n2.n_name = 'CANADA')\n" +
-                "            )\n" +
-                "          and l_shipdate between date '1995-01-01' and date '1996-12-31'\n" +
-                "    ) as shipping\n" +
-                "group by\n" +
-                "    supp_nation,\n" +
-                "    cust_nation,\n" +
-                "    l_year\n" +
-                "order by\n" +
-                "    supp_nation,\n" +
-                "    cust_nation,\n" +
-                "    l_year ;";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(9, planCount);
+    public void testTPCHQ7EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q7");
     }
 
     @Test
-    public void testTPCHQ8EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    o_year,\n" +
-                "    sum(case\n" +
-                "            when nation = 'IRAN' then volume\n" +
-                "            else 0\n" +
-                "        end) / sum(volume) as mkt_share\n" +
-                "from\n" +
-                "    (\n" +
-                "        select\n" +
-                "            extract(year from o_orderdate) as o_year,\n" +
-                "            l_extendedprice * (1 - l_discount) as volume,\n" +
-                "            n2.n_name as nation\n" +
-                "        from\n" +
-                "            part,\n" +
-                "            supplier,\n" +
-                "            lineitem,\n" +
-                "            orders,\n" +
-                "            customer,\n" +
-                "            nation n1,\n" +
-                "            nation n2,\n" +
-                "            region\n" +
-                "        where\n" +
-                "                p_partkey = l_partkey\n" +
-                "          and s_suppkey = l_suppkey\n" +
-                "          and l_orderkey = o_orderkey\n" +
-                "          and o_custkey = c_custkey\n" +
-                "          and c_nationkey = n1.n_nationkey\n" +
-                "          and n1.n_regionkey = r_regionkey\n" +
-                "          and r_name = 'MIDDLE EAST'\n" +
-                "          and s_nationkey = n2.n_nationkey\n" +
-                "          and o_orderdate between date '1995-01-01' and date '1996-12-31'\n" +
-                "          and p_type = 'ECONOMY ANODIZED STEEL'\n" +
-                "    ) as all_nations\n" +
-                "group by\n" +
-                "    o_year\n" +
-                "order by\n" +
-                "    o_year ;";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(51, planCount);
+    public void testTPCHQ8EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q8");
     }
 
     @Test
     public void testTPCHQ9EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q9");
+        runFileUnitTest("enumerate-plan/tpch-q9", true);
     }
 
     @Test
     public void testTPCHQ10EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q10");
+        runFileUnitTest("enumerate-plan/tpch-q10", true);
     }
 
     @Test
@@ -261,41 +112,8 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ18EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    c_name,\n" +
-                "    c_custkey,\n" +
-                "    o_orderkey,\n" +
-                "    o_orderdate,\n" +
-                "    o_totalprice,\n" +
-                "    sum(l_quantity)\n" +
-                "from\n" +
-                "    customer,\n" +
-                "    orders,\n" +
-                "    lineitem\n" +
-                "where\n" +
-                "        o_orderkey in (\n" +
-                "        select\n" +
-                "            l_orderkey\n" +
-                "        from\n" +
-                "            lineitem\n" +
-                "        group by\n" +
-                "            l_orderkey having\n" +
-                "                sum(l_quantity) > 315\n" +
-                "    )\n" +
-                "  and c_custkey = o_custkey\n" +
-                "  and o_orderkey = l_orderkey\n" +
-                "group by\n" +
-                "    c_name,\n" +
-                "    c_custkey,\n" +
-                "    o_orderkey,\n" +
-                "    o_orderdate,\n" +
-                "    o_totalprice\n" +
-                "order by\n" +
-                "    o_totalprice desc,\n" +
-                "    o_orderdate limit 100;";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(40, planCount);
+    public void testTPCHQ18EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q18", true);
     }
 
     @Test
@@ -304,93 +122,13 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ20EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    s_name,\n" +
-                "    s_address\n" +
-                "from\n" +
-                "    supplier,\n" +
-                "    nation\n" +
-                "where\n" +
-                "        s_suppkey in (\n" +
-                "        select\n" +
-                "            ps_suppkey\n" +
-                "        from\n" +
-                "            partsupp\n" +
-                "        where\n" +
-                "                ps_partkey in (\n" +
-                "                select\n" +
-                "                    p_partkey\n" +
-                "                from\n" +
-                "                    part\n" +
-                "                where\n" +
-                "                        p_name like 'sienna%'\n" +
-                "            )\n" +
-                "          and ps_availqty > (\n" +
-                "            select\n" +
-                "                    0.5 * sum(l_quantity)\n" +
-                "            from\n" +
-                "                lineitem\n" +
-                "            where\n" +
-                "                    l_partkey = ps_partkey\n" +
-                "              and l_suppkey = ps_suppkey\n" +
-                "              and l_shipdate >= date '1993-01-01'\n" +
-                "              and l_shipdate < date '1994-01-01'\n" +
-                "        )\n" +
-                "    )\n" +
-                "  and s_nationkey = n_nationkey\n" +
-                "  and n_name = 'ARGENTINA'\n" +
-                "order by\n" +
-                "    s_name ;";
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals(12, planCount);
+    public void testTPCHQ20EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q20");
     }
 
     @Test
-    public void testTPCHQ21EnumPlan() throws Exception {
-        String sql = "select\n" +
-                "    s_name,\n" +
-                "    count(*) as numwait\n" +
-                "from\n" +
-                "    supplier,\n" +
-                "    lineitem l1,\n" +
-                "    orders,\n" +
-                "    nation\n" +
-                "where\n" +
-                "        s_suppkey = l1.l_suppkey\n" +
-                "  and o_orderkey = l1.l_orderkey\n" +
-                "  and o_orderstatus = 'F'\n" +
-                "  and l1.l_receiptdate > l1.l_commitdate\n" +
-                "  and exists (\n" +
-                "        select\n" +
-                "            *\n" +
-                "        from\n" +
-                "            lineitem l2\n" +
-                "        where\n" +
-                "                l2.l_orderkey = l1.l_orderkey\n" +
-                "          and l2.l_suppkey <> l1.l_suppkey\n" +
-                "    )\n" +
-                "  and not exists (\n" +
-                "        select\n" +
-                "            *\n" +
-                "        from\n" +
-                "            lineitem l3\n" +
-                "        where\n" +
-                "                l3.l_orderkey = l1.l_orderkey\n" +
-                "          and l3.l_suppkey <> l1.l_suppkey\n" +
-                "          and l3.l_receiptdate > l3.l_commitdate\n" +
-                "    )\n" +
-                "  and s_nationkey = n_nationkey\n" +
-                "  and n_name = 'CANADA'\n" +
-                "group by\n" +
-                "    s_name\n" +
-                "order by\n" +
-                "    numwait desc,\n" +
-                "    s_name limit 100;";
-        connectContext.getSessionVariable().setJoinImplementationMode("hash");
-        int planCount = getPlanCount(sql);
-        Assert.assertEquals("planCount is " + planCount, 21, planCount);
-        connectContext.getSessionVariable().setJoinImplementationMode("auto");
+    public void testTPCHQ21EnumPlan() {
+        runFileUnitTest("enumerate-plan/tpch-q21", true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -22,7 +23,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testThreeTableJoinEnumPlan() {
+    public void testThreeTableJoinEnumPlan() throws Exception {
         runFileUnitTest("enumerate-plan/three-join");
     }
 
@@ -32,8 +33,53 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ2EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q2");
+    public void testTPCHQ2EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    s_acctbal,\n" +
+                "    s_name,\n" +
+                "    n_name,\n" +
+                "    p_partkey,\n" +
+                "    p_mfgr,\n" +
+                "    s_address,\n" +
+                "    s_phone,\n" +
+                "    s_comment\n" +
+                "from\n" +
+                "    part,\n" +
+                "    supplier,\n" +
+                "    partsupp,\n" +
+                "    nation,\n" +
+                "    region\n" +
+                "where\n" +
+                "        p_partkey = ps_partkey\n" +
+                "  and s_suppkey = ps_suppkey\n" +
+                "  and p_size = 12\n" +
+                "  and p_type like '%COPPER'\n" +
+                "  and s_nationkey = n_nationkey\n" +
+                "  and n_regionkey = r_regionkey\n" +
+                "  and r_name = 'AMERICA'\n" +
+                "  and ps_supplycost = (\n" +
+                "    select\n" +
+                "        min(ps_supplycost)\n" +
+                "    from\n" +
+                "        partsupp,\n" +
+                "        supplier,\n" +
+                "        nation,\n" +
+                "        region\n" +
+                "    where\n" +
+                "            p_partkey = ps_partkey\n" +
+                "      and s_suppkey = ps_suppkey\n" +
+                "      and s_nationkey = n_nationkey\n" +
+                "      and n_regionkey = r_regionkey\n" +
+                "      and r_name = 'AMERICA'\n" +
+                ")\n" +
+                "order by\n" +
+                "    s_acctbal desc,\n" +
+                "    n_name,\n" +
+                "    s_name,\n" +
+                "    p_partkey limit 100;\n" +
+                "\n";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(39, planCount);
     }
 
     @Test
@@ -47,8 +93,33 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ5EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q5");
+    public void testTPCHQ5EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    n_name,\n" +
+                "    sum(l_extendedprice * (1 - l_discount)) as revenue\n" +
+                "from\n" +
+                "    customer,\n" +
+                "    orders,\n" +
+                "    lineitem,\n" +
+                "    supplier,\n" +
+                "    nation,\n" +
+                "    region\n" +
+                "where\n" +
+                "        c_custkey = o_custkey\n" +
+                "  and l_orderkey = o_orderkey\n" +
+                "  and l_suppkey = s_suppkey\n" +
+                "  and c_nationkey = s_nationkey\n" +
+                "  and s_nationkey = n_nationkey\n" +
+                "  and n_regionkey = r_regionkey\n" +
+                "  and r_name = 'AFRICA'\n" +
+                "  and o_orderdate >= date '1995-01-01'\n" +
+                "  and o_orderdate < date '1996-01-01'\n" +
+                "group by\n" +
+                "    n_name\n" +
+                "order by\n" +
+                "    revenue desc ;";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(77, planCount);
     }
 
     @Test
@@ -57,13 +128,91 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ7EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q7");
+    public void testTPCHQ7EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    supp_nation,\n" +
+                "    cust_nation,\n" +
+                "    l_year,\n" +
+                "    sum(volume) as revenue\n" +
+                "from\n" +
+                "    (\n" +
+                "        select\n" +
+                "            n1.n_name as supp_nation,\n" +
+                "            n2.n_name as cust_nation,\n" +
+                "            extract(year from l_shipdate) as l_year,\n" +
+                "            l_extendedprice * (1 - l_discount) as volume\n" +
+                "        from\n" +
+                "            supplier,\n" +
+                "            lineitem,\n" +
+                "            orders,\n" +
+                "            customer,\n" +
+                "            nation n1,\n" +
+                "            nation n2\n" +
+                "        where\n" +
+                "                s_suppkey = l_suppkey\n" +
+                "          and o_orderkey = l_orderkey\n" +
+                "          and c_custkey = o_custkey\n" +
+                "          and s_nationkey = n1.n_nationkey\n" +
+                "          and c_nationkey = n2.n_nationkey\n" +
+                "          and (\n" +
+                "                (n1.n_name = 'CANADA' and n2.n_name = 'IRAN')\n" +
+                "                or (n1.n_name = 'IRAN' and n2.n_name = 'CANADA')\n" +
+                "            )\n" +
+                "          and l_shipdate between date '1995-01-01' and date '1996-12-31'\n" +
+                "    ) as shipping\n" +
+                "group by\n" +
+                "    supp_nation,\n" +
+                "    cust_nation,\n" +
+                "    l_year\n" +
+                "order by\n" +
+                "    supp_nation,\n" +
+                "    cust_nation,\n" +
+                "    l_year ;";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(9, planCount);
     }
 
     @Test
-    public void testTPCHQ8EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q8");
+    public void testTPCHQ8EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    o_year,\n" +
+                "    sum(case\n" +
+                "            when nation = 'IRAN' then volume\n" +
+                "            else 0\n" +
+                "        end) / sum(volume) as mkt_share\n" +
+                "from\n" +
+                "    (\n" +
+                "        select\n" +
+                "            extract(year from o_orderdate) as o_year,\n" +
+                "            l_extendedprice * (1 - l_discount) as volume,\n" +
+                "            n2.n_name as nation\n" +
+                "        from\n" +
+                "            part,\n" +
+                "            supplier,\n" +
+                "            lineitem,\n" +
+                "            orders,\n" +
+                "            customer,\n" +
+                "            nation n1,\n" +
+                "            nation n2,\n" +
+                "            region\n" +
+                "        where\n" +
+                "                p_partkey = l_partkey\n" +
+                "          and s_suppkey = l_suppkey\n" +
+                "          and l_orderkey = o_orderkey\n" +
+                "          and o_custkey = c_custkey\n" +
+                "          and c_nationkey = n1.n_nationkey\n" +
+                "          and n1.n_regionkey = r_regionkey\n" +
+                "          and r_name = 'MIDDLE EAST'\n" +
+                "          and s_nationkey = n2.n_nationkey\n" +
+                "          and o_orderdate between date '1995-01-01' and date '1996-12-31'\n" +
+                "          and p_type = 'ECONOMY ANODIZED STEEL'\n" +
+                "    ) as all_nations\n" +
+                "group by\n" +
+                "    o_year\n" +
+                "order by\n" +
+                "    o_year ;";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(49, planCount);
     }
 
     @Test
@@ -112,8 +261,41 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ18EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q18");
+    public void testTPCHQ18EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    c_name,\n" +
+                "    c_custkey,\n" +
+                "    o_orderkey,\n" +
+                "    o_orderdate,\n" +
+                "    o_totalprice,\n" +
+                "    sum(l_quantity)\n" +
+                "from\n" +
+                "    customer,\n" +
+                "    orders,\n" +
+                "    lineitem\n" +
+                "where\n" +
+                "        o_orderkey in (\n" +
+                "        select\n" +
+                "            l_orderkey\n" +
+                "        from\n" +
+                "            lineitem\n" +
+                "        group by\n" +
+                "            l_orderkey having\n" +
+                "                sum(l_quantity) > 315\n" +
+                "    )\n" +
+                "  and c_custkey = o_custkey\n" +
+                "  and o_orderkey = l_orderkey\n" +
+                "group by\n" +
+                "    c_name,\n" +
+                "    c_custkey,\n" +
+                "    o_orderkey,\n" +
+                "    o_orderdate,\n" +
+                "    o_totalprice\n" +
+                "order by\n" +
+                "    o_totalprice desc,\n" +
+                "    o_orderdate limit 100;";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(40, planCount);
     }
 
     @Test
@@ -122,13 +304,93 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
-    public void testTPCHQ20EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q20");
+    public void testTPCHQ20EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    s_name,\n" +
+                "    s_address\n" +
+                "from\n" +
+                "    supplier,\n" +
+                "    nation\n" +
+                "where\n" +
+                "        s_suppkey in (\n" +
+                "        select\n" +
+                "            ps_suppkey\n" +
+                "        from\n" +
+                "            partsupp\n" +
+                "        where\n" +
+                "                ps_partkey in (\n" +
+                "                select\n" +
+                "                    p_partkey\n" +
+                "                from\n" +
+                "                    part\n" +
+                "                where\n" +
+                "                        p_name like 'sienna%'\n" +
+                "            )\n" +
+                "          and ps_availqty > (\n" +
+                "            select\n" +
+                "                    0.5 * sum(l_quantity)\n" +
+                "            from\n" +
+                "                lineitem\n" +
+                "            where\n" +
+                "                    l_partkey = ps_partkey\n" +
+                "              and l_suppkey = ps_suppkey\n" +
+                "              and l_shipdate >= date '1993-01-01'\n" +
+                "              and l_shipdate < date '1994-01-01'\n" +
+                "        )\n" +
+                "    )\n" +
+                "  and s_nationkey = n_nationkey\n" +
+                "  and n_name = 'ARGENTINA'\n" +
+                "order by\n" +
+                "    s_name ;";
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals(12, planCount);
     }
 
     @Test
-    public void testTPCHQ21EnumPlan() {
-        runFileUnitTest("enumerate-plan/tpch-q21");
+    public void testTPCHQ21EnumPlan() throws Exception {
+        String sql = "select\n" +
+                "    s_name,\n" +
+                "    count(*) as numwait\n" +
+                "from\n" +
+                "    supplier,\n" +
+                "    lineitem l1,\n" +
+                "    orders,\n" +
+                "    nation\n" +
+                "where\n" +
+                "        s_suppkey = l1.l_suppkey\n" +
+                "  and o_orderkey = l1.l_orderkey\n" +
+                "  and o_orderstatus = 'F'\n" +
+                "  and l1.l_receiptdate > l1.l_commitdate\n" +
+                "  and exists (\n" +
+                "        select\n" +
+                "            *\n" +
+                "        from\n" +
+                "            lineitem l2\n" +
+                "        where\n" +
+                "                l2.l_orderkey = l1.l_orderkey\n" +
+                "          and l2.l_suppkey <> l1.l_suppkey\n" +
+                "    )\n" +
+                "  and not exists (\n" +
+                "        select\n" +
+                "            *\n" +
+                "        from\n" +
+                "            lineitem l3\n" +
+                "        where\n" +
+                "                l3.l_orderkey = l1.l_orderkey\n" +
+                "          and l3.l_suppkey <> l1.l_suppkey\n" +
+                "          and l3.l_receiptdate > l3.l_commitdate\n" +
+                "    )\n" +
+                "  and s_nationkey = n_nationkey\n" +
+                "  and n_name = 'CANADA'\n" +
+                "group by\n" +
+                "    s_name\n" +
+                "order by\n" +
+                "    numwait desc,\n" +
+                "    s_name limit 100;";
+        connectContext.getSessionVariable().setJoinImplementationMode("hash");
+        int planCount = getPlanCount(sql);
+        Assert.assertEquals("planCount is " + planCount, 21, planCount);
+        connectContext.getSessionVariable().setJoinImplementationMode("auto");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -443,8 +443,8 @@ public class ReplayFromDumpTest {
     public void testJoinWithPipelineDop() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/join_pipeline_dop"), null, TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("24:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("25:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 5: ss_customer_sk = 52: c_customer_sk"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -619,11 +619,9 @@ public class ReplayFromDumpTest {
     public void testHiveTPCH05UsingResource() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch05_resource"), null, TExplainLevel.COSTS);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("5:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("20:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  equal join conjunct: [10: o_custkey, INT, true] = [1: c_custkey, INT, true]\n" +
-                "  |  build runtime filters:\n" +
-                "  |  - filter_id = 0, build_expr = (1: c_custkey), remote = false\n" +
                 "  |  output columns: 4, 9\n" +
                 "  |  cardinality: 22765073"));
     }
@@ -632,7 +630,7 @@ public class ReplayFromDumpTest {
     public void testHiveTPCH08UsingResource() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch08_resource"), null, TExplainLevel.COSTS);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("6:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("5:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [52: n_regionkey, INT, true] = [58: r_regionkey, INT, true]\n" +
                 "  |  build runtime filters:\n" +

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -50,39 +50,38 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
-            INNER JOIN (join-predicate [36: cast = 37: cast] post-join-predicate [null])
-                EXCHANGE SHUFFLE[36]
-                    SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                EXCHANGE SHUFFLE[37]
-                    INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-                        SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                        EXCHANGE SHUFFLE[18]
-                            EXCHANGE SHUFFLE[37, 19, 18]
-                                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+            INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
+                CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                    SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                EXCHANGE BROADCAST
+                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-5]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
-            INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
-                    EXCHANGE SHUFFLE[18]
+            INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
+                CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                    SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                EXCHANGE SHUFFLE[18]
+                    EXCHANGE SHUFFLE[37, 19, 18]
                         SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
-                    EXCHANGE SHUFFLE[11]
-                        SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                EXCHANGE BROADCAST
-                    SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
 [plan-6]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
-            INNER JOIN (join-predicate [19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
+            INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
+                SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE SHUFFLE[18]
-                    INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
-                        EXCHANGE BROADCAST
-                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                EXCHANGE SHUFFLE[11]
-                    SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
+                    EXCHANGE SHUFFLE[19, 18]
+                        INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
+                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q10.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q10.sql
@@ -31,7 +31,7 @@ group by
 order by
     revenue desc limit 20;
 [planCount]
-3
+5
 [plan-1]
 TOP-N (order by [[43: sum DESC NULLS LAST]])
     TOP-N (order by [[43: sum DESC NULLS LAST]])
@@ -78,4 +78,36 @@ TOP-N (order by [[43: sum DESC NULLS LAST]])
                                     SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1994-05-01 AND 14: O_ORDERDATE < 1994-08-01])
                 EXCHANGE BROADCAST
                     SCAN (columns[37: N_NATIONKEY, 38: N_NAME] predicate[null])
+[end]
+[plan-4]
+TOP-N (order by [[43: sum DESC NULLS LAST]])
+    TOP-N (order by [[43: sum DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{43: sum=sum(42: expr)}] group by [[1: C_CUSTKEY, 2: C_NAME, 6: C_ACCTBAL, 5: C_PHONE, 38: N_NAME, 3: C_ADDRESS, 8: C_COMMENT]] having [null]
+            INNER JOIN (join-predicate [1: C_CUSTKEY = 11: O_CUSTKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [4: C_NATIONKEY = 37: N_NATIONKEY] post-join-predicate [null])
+                    SCAN (columns[1: C_CUSTKEY, 2: C_NAME, 3: C_ADDRESS, 4: C_NATIONKEY, 5: C_PHONE, 6: C_ACCTBAL, 8: C_COMMENT] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[37: N_NATIONKEY, 38: N_NAME] predicate[null])
+                EXCHANGE SHUFFLE[11]
+                    EXCHANGE SHUFFLE[11]
+                        INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                            SCAN (columns[20: L_ORDERKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT, 28: L_RETURNFLAG] predicate[28: L_RETURNFLAG = R])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1994-05-01 AND 14: O_ORDERDATE < 1994-08-01])
+[end]
+[plan-5]
+TOP-N (order by [[43: sum DESC NULLS LAST]])
+    TOP-N (order by [[43: sum DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{43: sum=sum(42: expr)}] group by [[1: C_CUSTKEY, 2: C_NAME, 6: C_ACCTBAL, 5: C_PHONE, 38: N_NAME, 3: C_ADDRESS, 8: C_COMMENT]] having [null]
+            INNER JOIN (join-predicate [1: C_CUSTKEY = 11: O_CUSTKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [4: C_NATIONKEY = 37: N_NATIONKEY] post-join-predicate [null])
+                    SCAN (columns[1: C_CUSTKEY, 2: C_NAME, 3: C_ADDRESS, 4: C_NATIONKEY, 5: C_PHONE, 6: C_ACCTBAL, 8: C_COMMENT] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[37: N_NATIONKEY, 38: N_NAME] predicate[null])
+                EXCHANGE SHUFFLE[11]
+                    EXCHANGE SHUFFLE[11]
+                        INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                            SCAN (columns[20: L_ORDERKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT, 28: L_RETURNFLAG] predicate[28: L_RETURNFLAG = R])
+                            EXCHANGE SHUFFLE[10]
+                                SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1994-05-01 AND 14: O_ORDERDATE < 1994-08-01])
 [end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q18.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q18.sql
@@ -32,7 +32,7 @@ order by
     o_totalprice desc,
     o_orderdate limit 100;
 [planCount]
-8
+16
 [plan-1]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
@@ -54,6 +54,22 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
             LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                    SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                    EXCHANGE SHUFFLE[10]
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                EXCHANGE BROADCAST
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-3]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
                 INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
                     INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                         SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
@@ -66,7 +82,24 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                         AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
                             SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
-[plan-3]
+[plan-4]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                    SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                    EXCHANGE SHUFFLE[10]
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                EXCHANGE BROADCAST
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                        AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
+                            SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-5]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -82,7 +115,23 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                     AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
                         SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
-[plan-4]
+[plan-6]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                    SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                    EXCHANGE SHUFFLE[10]
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                EXCHANGE SHUFFLE[37]
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-7]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -99,7 +148,24 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                         AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
                             SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
 [end]
-[plan-5]
+[plan-8]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                    SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                    EXCHANGE SHUFFLE[10]
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                EXCHANGE SHUFFLE[37]
+                    AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                        AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
+                            SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-9]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -115,7 +181,7 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
-[plan-6]
+[plan-10]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -132,7 +198,7 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
-[plan-7]
+[plan-11]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -148,7 +214,7 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]
-[plan-8]
+[plan-12]
 TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
     TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
@@ -164,4 +230,70 @@ TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FI
                                         SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+[end]
+[plan-13]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                EXCHANGE SHUFFLE[10]
+                    LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                        EXCHANGE SHUFFLE[37]
+                            AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                                SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-14]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                EXCHANGE SHUFFLE[10]
+                    LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE BROADCAST
+                                SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+                        EXCHANGE SHUFFLE[37]
+                            AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                                AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
+                                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+[end]
+[plan-15]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                EXCHANGE SHUFFLE[10]
+                    INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                        LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE SHUFFLE[37]
+                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                                    SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
+[end]
+[plan-16]
+TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+    TOP-N (order by [[13: O_TOTALPRICE DESC NULLS LAST, 14: O_ORDERDATE ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{56: sum=sum(24: L_QUANTITY)}] group by [[2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE]] having [null]
+            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
+                SCAN (columns[20: L_ORDERKEY, 24: L_QUANTITY] predicate[null])
+                EXCHANGE SHUFFLE[10]
+                    INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                        LEFT SEMI JOIN (join-predicate [10: O_ORDERKEY = 37: L_ORDERKEY] post-join-predicate [null])
+                            SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 13: O_TOTALPRICE, 14: O_ORDERDATE] predicate[null])
+                            EXCHANGE SHUFFLE[37]
+                                AGGREGATE ([GLOBAL] aggregate [{54: sum=sum(54: sum)}] group by [[37: L_ORDERKEY]] having [54: sum > 315.0]
+                                    AGGREGATE ([LOCAL] aggregate [{54: sum=sum(41: L_QUANTITY)}] group by [[37: L_ORDERKEY]] having [null]
+                                        SCAN (columns[37: L_ORDERKEY, 41: L_QUANTITY] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[1: C_CUSTKEY, 2: C_NAME] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q21.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q21.sql
@@ -39,8 +39,30 @@ order by
     numwait desc,
     s_name limit 100;
 [planCount]
-4
+6
 [plan-1]
+TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
+    TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{77: count=count()}] group by [[2: S_NAME]] having [null]
+            EXCHANGE SHUFFLE[2]
+                LEFT ANTI JOIN (join-predicate [9: L_ORDERKEY = 59: L_ORDERKEY AND 61: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                    LEFT SEMI JOIN (join-predicate [9: L_ORDERKEY = 41: L_ORDERKEY AND 43: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [26: O_ORDERKEY = 9: L_ORDERKEY] post-join-predicate [null])
+                            SCAN (columns[26: O_ORDERKEY, 28: O_ORDERSTATUS] predicate[28: O_ORDERSTATUS = F])
+                            EXCHANGE SHUFFLE[9]
+                                INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
+                                    SCAN (columns[20: L_COMMITDATE, 21: L_RECEIPTDATE, 9: L_ORDERKEY, 11: L_SUPPKEY] predicate[21: L_RECEIPTDATE > 20: L_COMMITDATE])
+                                    EXCHANGE BROADCAST
+                                        INNER JOIN (join-predicate [4: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
+                                            SCAN (columns[1: S_SUPPKEY, 2: S_NAME, 4: S_NATIONKEY] predicate[null])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[36: N_NATIONKEY, 37: N_NAME] predicate[37: N_NAME = CANADA])
+                        EXCHANGE SHUFFLE[41]
+                            SCAN (columns[41: L_ORDERKEY, 43: L_SUPPKEY] predicate[null])
+                    EXCHANGE SHUFFLE[59]
+                        SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
+[end]
+[plan-2]
 TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
     TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{77: count=count()}] group by [[2: S_NAME]] having [null]
@@ -62,7 +84,7 @@ TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
                     EXCHANGE SHUFFLE[59]
                         SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
 [end]
-[plan-2]
+[plan-3]
 TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
     TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{77: count=count()}] group by [[2: S_NAME]] having [null]
@@ -85,7 +107,30 @@ TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
                                                         EXCHANGE BROADCAST
                                                             SCAN (columns[36: N_NATIONKEY, 37: N_NAME] predicate[37: N_NAME = CANADA])
 [end]
-[plan-3]
+[plan-4]
+TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
+    TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{77: count=count(77: count)}] group by [[2: S_NAME]] having [null]
+            EXCHANGE SHUFFLE[2]
+                AGGREGATE ([LOCAL] aggregate [{77: count=count()}] group by [[2: S_NAME]] having [null]
+                    LEFT ANTI JOIN (join-predicate [9: L_ORDERKEY = 59: L_ORDERKEY AND 61: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                        LEFT SEMI JOIN (join-predicate [9: L_ORDERKEY = 41: L_ORDERKEY AND 43: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [26: O_ORDERKEY = 9: L_ORDERKEY] post-join-predicate [null])
+                                SCAN (columns[26: O_ORDERKEY, 28: O_ORDERSTATUS] predicate[28: O_ORDERSTATUS = F])
+                                EXCHANGE SHUFFLE[9]
+                                    INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
+                                        SCAN (columns[20: L_COMMITDATE, 21: L_RECEIPTDATE, 9: L_ORDERKEY, 11: L_SUPPKEY] predicate[21: L_RECEIPTDATE > 20: L_COMMITDATE])
+                                        EXCHANGE BROADCAST
+                                            INNER JOIN (join-predicate [4: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
+                                                SCAN (columns[1: S_SUPPKEY, 2: S_NAME, 4: S_NATIONKEY] predicate[null])
+                                                EXCHANGE BROADCAST
+                                                    SCAN (columns[36: N_NATIONKEY, 37: N_NAME] predicate[37: N_NAME = CANADA])
+                            EXCHANGE SHUFFLE[41]
+                                SCAN (columns[41: L_ORDERKEY, 43: L_SUPPKEY] predicate[null])
+                        EXCHANGE SHUFFLE[59]
+                            SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
+[end]
+[plan-5]
 TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
     TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{77: count=count(77: count)}] group by [[2: S_NAME]] having [null]
@@ -108,7 +153,7 @@ TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[59]
                             SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
 [end]
-[plan-4]
+[plan-6]
 TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
     TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{77: count=count(77: count)}] group by [[2: S_NAME]] having [null]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q5.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q5.sql
@@ -24,7 +24,7 @@ group by
 order by
     revenue desc ;
 [planCount]
-9
+8
 [plan-1]
 TOP-N (order by [[55: sum DESC NULLS LAST]])
     TOP-N (order by [[55: sum DESC NULLS LAST]])
@@ -52,48 +52,50 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
 [plan-2]
 TOP-N (order by [[55: sum DESC NULLS LAST]])
     TOP-N (order by [[55: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(55: sum)}] group by [[46: N_NAME]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
-                AGGREGATE ([LOCAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
-                    INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
-                            INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
-                                INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
+                    INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                                EXCHANGE SHUFFLE[11]
                                     INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                         SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
                                         EXCHANGE BROADCAST
                                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                                    EXCHANGE BROADCAST
-                                        SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
+                                EXCHANGE SHUFFLE[1]
+                                    SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
                             EXCHANGE BROADCAST
-                                SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
+                                SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
                         EXCHANGE BROADCAST
-                            SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
+                            SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
 [end]
+
+
 [plan-3]
 TOP-N (order by [[55: sum DESC NULLS LAST]])
     TOP-N (order by [[55: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(55: sum)}] group by [[46: N_NAME]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
-                AGGREGATE ([LOCAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
-                    INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
-                            INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
-                                INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
+                    INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                                EXCHANGE SHUFFLE[11]
                                     INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
                                         SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
                                         EXCHANGE SHUFFLE[10]
                                             SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                                    EXCHANGE BROADCAST
-                                        SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
+                                EXCHANGE SHUFFLE[1]
+                                    SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
                             EXCHANGE BROADCAST
-                                SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
+                                SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
                         EXCHANGE BROADCAST
-                            SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
+                            SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
 [end]
 [plan-4]
 TOP-N (order by [[55: sum DESC NULLS LAST]])
@@ -195,45 +197,22 @@ TOP-N (order by [[55: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(55: sum)}] group by [[46: N_NAME]] having [null]
             EXCHANGE SHUFFLE[46]
                 AGGREGATE ([LOCAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
-                    INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
-                            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
-                                SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
-                                EXCHANGE BROADCAST
-                                    INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                    INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY AND 40: S_NATIONKEY = 4: C_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY] post-join-predicate [null])
+                            SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
+                            EXCHANGE BROADCAST
+                                INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
+                                    SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
+                                    EXCHANGE BROADCAST
+                                        INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
+                                            SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
+                        EXCHANGE SHUFFLE[10]
+                            EXCHANGE SHUFFLE[10]
+                                INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
+                                    EXCHANGE SHUFFLE[11]
                                         SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                                        EXCHANGE BROADCAST
-                                            SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
-                        EXCHANGE BROADCAST
-                            INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
-                                SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
-[end]
-[plan-9]
-TOP-N (order by [[55: sum DESC NULLS LAST]])
-    TOP-N (order by [[55: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{55: sum=sum(55: sum)}] group by [[46: N_NAME]] having [null]
-            EXCHANGE SHUFFLE[46]
-                AGGREGATE ([LOCAL] aggregate [{55: sum=sum(54: expr)}] group by [[46: N_NAME]] having [null]
-                    INNER JOIN (join-predicate [40: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
-                        INNER JOIN (join-predicate [22: L_SUPPKEY = 37: S_SUPPKEY AND 4: C_NATIONKEY = 40: S_NATIONKEY] post-join-predicate [null])
-                            INNER JOIN (join-predicate [20: L_ORDERKEY = 10: O_ORDERKEY] post-join-predicate [null])
-                                SCAN (columns[20: L_ORDERKEY, 22: L_SUPPKEY, 25: L_EXTENDEDPRICE, 26: L_DISCOUNT] predicate[null])
-                                EXCHANGE SHUFFLE[10]
-                                    EXCHANGE SHUFFLE[10]
-                                        INNER JOIN (join-predicate [11: O_CUSTKEY = 1: C_CUSTKEY] post-join-predicate [null])
-                                            EXCHANGE SHUFFLE[11]
-                                                SCAN (columns[10: O_ORDERKEY, 11: O_CUSTKEY, 14: O_ORDERDATE] predicate[14: O_ORDERDATE >= 1995-01-01 AND 14: O_ORDERDATE < 1996-01-01])
-                                            EXCHANGE SHUFFLE[1]
-                                                SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
-                            EXCHANGE BROADCAST
-                                SCAN (columns[37: S_SUPPKEY, 40: S_NATIONKEY] predicate[null])
-                        EXCHANGE BROADCAST
-                            INNER JOIN (join-predicate [47: N_REGIONKEY = 50: R_REGIONKEY] post-join-predicate [null])
-                                SCAN (columns[45: N_NATIONKEY, 46: N_NAME, 47: N_REGIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    SCAN (columns[50: R_REGIONKEY, 51: R_NAME] predicate[51: R_NAME = AFRICA])
+                                    EXCHANGE SHUFFLE[1]
+                                        SCAN (columns[1: C_CUSTKEY, 4: C_NATIONKEY] predicate[null])
 [end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q7.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q7.sql
@@ -39,7 +39,7 @@ order by
     cust_nation,
     l_year ;
 [planCount]
-2
+3
 [plan-1]
 TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
     TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
@@ -64,6 +64,29 @@ TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: ye
                             SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])
 [end]
 [plan-2]
+TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
+    TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{57: sum=sum(57: sum)}] group by [[46: N_NAME, 51: N_NAME, 55: year]] having [null]
+            EXCHANGE SHUFFLE[46, 51, 55]
+                AGGREGATE ([LOCAL] aggregate [{57: sum=sum(56: expr)}] group by [[46: N_NAME, 51: N_NAME, 55: year]] having [null]
+                    INNER JOIN (join-predicate [27: O_CUSTKEY = 36: C_CUSTKEY] post-join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA])
+                        INNER JOIN (join-predicate [9: L_ORDERKEY = 26: O_ORDERKEY] post-join-predicate [null])
+                            INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
+                                SCAN (columns[19: L_SHIPDATE, 9: L_ORDERKEY, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-01-01 AND 19: L_SHIPDATE <= 1996-12-31])
+                                EXCHANGE BROADCAST
+                                    INNER JOIN (join-predicate [4: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
+                                        SCAN (columns[1: S_SUPPKEY, 4: S_NATIONKEY] predicate[null])
+                                        EXCHANGE BROADCAST
+                                            SCAN (columns[45: N_NATIONKEY, 46: N_NAME] predicate[46: N_NAME IN (CANADA, IRAN)])
+                            EXCHANGE SHUFFLE[26]
+                                SCAN (columns[26: O_ORDERKEY, 27: O_CUSTKEY] predicate[null])
+                        EXCHANGE BROADCAST
+                            INNER JOIN (join-predicate [39: C_NATIONKEY = 50: N_NATIONKEY] post-join-predicate [null])
+                                SCAN (columns[36: C_CUSTKEY, 39: C_NATIONKEY] predicate[null])
+                                EXCHANGE BROADCAST
+                                    SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])
+[end]
+[plan-3]
 TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
     TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{57: sum=sum(57: sum)}] group by [[46: N_NAME, 51: N_NAME, 55: year]] having [null]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q9.sql
@@ -32,8 +32,106 @@ order by
     nation,
     o_year desc ;
 [planCount]
-3
+7
 [plan-1]
+TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+    TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
+            EXCHANGE SHUFFLE[53, 57]
+                AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
+                    INNER JOIN (join-predicate [14: S_NATIONKEY = 52: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[19]
+                                INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [11: S_SUPPKEY = 21: L_SUPPKEY AND 1: P_PARTKEY = 20: L_PARTKEY] post-join-predicate [null])
+                                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
+                                        EXCHANGE BROADCAST
+                                            SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
+                                    EXCHANGE BROADCAST
+                                        SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
+                            EXCHANGE SHUFFLE[42]
+                                SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
+[end]
+[plan-2]
+TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+    TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
+            EXCHANGE SHUFFLE[53, 57]
+                AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
+                    INNER JOIN (join-predicate [14: S_NATIONKEY = 52: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[19]
+                                INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [11: S_SUPPKEY = 21: L_SUPPKEY AND 1: P_PARTKEY = 20: L_PARTKEY] post-join-predicate [null])
+                                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
+                                        EXCHANGE SHUFFLE[20]
+                                            EXCHANGE SHUFFLE[21, 20]
+                                                SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
+                                    EXCHANGE BROADCAST
+                                        SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
+                            EXCHANGE SHUFFLE[42]
+                                SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
+[end]
+[plan-3]
+TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+    TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
+            EXCHANGE SHUFFLE[53, 57]
+                AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
+                    INNER JOIN (join-predicate [14: S_NATIONKEY = 52: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[19]
+                                INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [11: S_SUPPKEY = 21: L_SUPPKEY AND 1: P_PARTKEY = 20: L_PARTKEY] post-join-predicate [null])
+                                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
+                                        EXCHANGE BROADCAST
+                                            SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
+                                    EXCHANGE SHUFFLE[36]
+                                        SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
+                            EXCHANGE SHUFFLE[42]
+                                SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
+[end]
+[plan-4]
+TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+    TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
+            EXCHANGE SHUFFLE[53, 57]
+                AGGREGATE ([LOCAL] aggregate [{59: sum=sum(58: expr)}] group by [[53: N_NAME, 57: year]] having [null]
+                    INNER JOIN (join-predicate [14: S_NATIONKEY = 52: N_NATIONKEY] post-join-predicate [null])
+                        INNER JOIN (join-predicate [19: L_ORDERKEY = 42: O_ORDERKEY] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[19]
+                                INNER JOIN (join-predicate [21: L_SUPPKEY = 37: PS_SUPPKEY AND 20: L_PARTKEY = 36: PS_PARTKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [11: S_SUPPKEY = 21: L_SUPPKEY AND 1: P_PARTKEY = 20: L_PARTKEY] post-join-predicate [null])
+                                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
+                                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                                            EXCHANGE BROADCAST
+                                                SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
+                                        EXCHANGE SHUFFLE[20]
+                                            EXCHANGE SHUFFLE[21, 20]
+                                                SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 23: L_QUANTITY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
+                                    EXCHANGE SHUFFLE[36]
+                                        SCAN (columns[36: PS_PARTKEY, 37: PS_SUPPKEY, 39: PS_SUPPLYCOST] predicate[null])
+                            EXCHANGE SHUFFLE[42]
+                                SCAN (columns[42: O_ORDERKEY, 46: O_ORDERDATE] predicate[null])
+                        EXCHANGE BROADCAST
+                            SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
+[end]
+[plan-5]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -57,7 +155,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                         EXCHANGE BROADCAST
                             SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
 [end]
-[plan-2]
+[plan-6]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]
@@ -81,7 +179,7 @@ TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
                                 EXCHANGE BROADCAST
                                     SCAN (columns[52: N_NATIONKEY, 53: N_NAME] predicate[null])
 [end]
-[plan-3]
+[plan-7]
 TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
     TOP-N (order by [[53: N_NAME ASC NULLS FIRST, 57: year DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{59: sum=sum(59: sum)}] group by [[53: N_NAME, 57: year]] having [null]

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -31,12 +31,12 @@ group by
 order by
     revenue desc limit 20;
 [fragment statistics]
-PLAN FRAGMENT 0(F08)
+PLAN FRAGMENT 0(F09)
 Output Exprs:1: c_custkey | 2: c_name | 39: sum | 6: c_acctbal | 35: n_name | 3: c_address | 5: c_phone | 8: c_comment
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-19:MERGING-EXCHANGE
+18:MERGING-EXCHANGE
 limit: 20
 cardinality: 20
 column statistics:
@@ -47,15 +47,15 @@ column statistics:
 * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
 * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* sum-->[810.9, 440054.13183940493, 0.0, 16.0, 3736520.0] ESTIMATE
+* sum-->[810.9, 214903.376217033, 0.0, 16.0, 3736520.0] ESTIMATE
 
-PLAN FRAGMENT 1(F07)
+PLAN FRAGMENT 1(F08)
 
-Input Partition: HASH_PARTITIONED: 1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment
+Input Partition: HASH_PARTITIONED: 1: c_custkey
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 19
+OutPut Exchange Id: 18
 
-18:TOP-N
+17:TOP-N
 |  order by: [39, DECIMAL128(38,4), true] DESC
 |  offset: 0
 |  limit: 20
@@ -68,33 +68,9 @@ OutPut Exchange Id: 19
 |  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
 |  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-|  * sum-->[810.9, 440054.13183940493, 0.0, 16.0, 3736520.0] ESTIMATE
+|  * sum-->[810.9, 214903.376217033, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-17:AGGREGATE (merge finalize)
-|  aggregate: sum[([39: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
-|  group by: [1: c_custkey, INT, true], [2: c_name, VARCHAR, true], [6: c_acctbal, DECIMAL64(15,2), true], [5: c_phone, VARCHAR, true], [35: n_name, VARCHAR, true], [3: c_address, VARCHAR, true], [8: c_comment, VARCHAR, true]
-|  cardinality: 7651211
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 7651210.947193347] ESTIMATE
-|  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 7651210.947193347] ESTIMATE
-|  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 7651210.947193347] ESTIMATE
-|  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
-|  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-|  * sum-->[810.9, 440054.13183940493, 0.0, 16.0, 3736520.0] ESTIMATE
-|
-16:EXCHANGE
-cardinality: 7651211
-
-PLAN FRAGMENT 2(F00)
-
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment
-OutPut Exchange Id: 16
-
-15:AGGREGATE (update serialize)
-|  STREAMING
+16:AGGREGATE (update finalize)
 |  aggregate: sum[([38: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  group by: [1: c_custkey, INT, true], [2: c_name, VARCHAR, true], [6: c_acctbal, DECIMAL64(15,2), true], [5: c_phone, VARCHAR, true], [35: n_name, VARCHAR, true], [3: c_address, VARCHAR, true], [8: c_comment, VARCHAR, true]
 |  cardinality: 7651211
@@ -108,7 +84,7 @@ OutPut Exchange Id: 16
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |  * sum-->[810.9, 214903.376217033, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-14:Project
+15:Project
 |  output columns:
 |  1 <-> [1: c_custkey, INT, true]
 |  2 <-> [2: c_name, VARCHAR, true]
@@ -129,118 +105,37 @@ OutPut Exchange Id: 16
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-13:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [4: c_nationkey, INT, true] = [34: n_nationkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (34: n_nationkey), remote = false
+14:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [1: c_custkey, INT, true] = [10: o_custkey, INT, true]
 |  output columns: 1, 2, 3, 5, 6, 8, 23, 24, 35
 |  cardinality: 7651211
 |  column statistics:
 |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
 |  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 7651210.947193347] ESTIMATE
 |  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 7651210.947193347] ESTIMATE
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 7651210.947193347] ESTIMATE
-|  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
-|  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
-|
-|----12:EXCHANGE
-|       cardinality: 25
-|
-10:Project
-|  output columns:
-|  1 <-> [1: c_custkey, INT, true]
-|  2 <-> [2: c_name, VARCHAR, true]
-|  3 <-> [3: c_address, VARCHAR, true]
-|  4 <-> [4: c_nationkey, INT, true]
-|  5 <-> [5: c_phone, VARCHAR, true]
-|  6 <-> [6: c_acctbal, DECIMAL64(15,2), true]
-|  8 <-> [8: c_comment, VARCHAR, true]
-|  23 <-> [23: l_extendedprice, DECIMAL64(15,2), true]
-|  24 <-> [24: l_discount, DECIMAL64(15,2), true]
-|  cardinality: 7651211
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 7651210.947193347] ESTIMATE
-|  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 7651210.947193347] ESTIMATE
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 7651210.947193347] ESTIMATE
-|  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
-|  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-9:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [1: c_custkey, INT, true] = [10: o_custkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (10: o_custkey), remote = false
-|  output columns: 1, 2, 3, 4, 5, 6, 8, 23, 24
-|  cardinality: 7651211
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 7651210.947193347] ESTIMATE
-|  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 7651210.947193347] ESTIMATE
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 7651210.947193347] ESTIMATE
 |  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
 |  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
 |  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-|----8:EXCHANGE
+|----13:EXCHANGE
 |       cardinality: 7651211
 |
-0:HdfsScanNode
-TABLE: customer
-NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
-partitions=1/1
-avgRowSize=217.0
-numNodes=0
+5:EXCHANGE
 cardinality: 15000000
-probe runtime filters:
-- filter_id = 1, probe_expr = (1: c_custkey)
-- filter_id = 2, probe_expr = (4: c_nationkey)
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-* c_address-->[-Infinity, Infinity, 0.0, 40.0, 1.5E7] ESTIMATE
-* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* c_phone-->[-Infinity, Infinity, 0.0, 15.0, 1.5E7] ESTIMATE
-* c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
-* c_comment-->[-Infinity, Infinity, 0.0, 117.0, 1.4788744E7] ESTIMATE
 
-PLAN FRAGMENT 3(F05)
+PLAN FRAGMENT 2(F04)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 12
+OutPut Partition: HASH_PARTITIONED: 10: o_custkey
+OutPut Exchange Id: 13
 
-11:HdfsScanNode
-TABLE: nation
-NON-PARTITION PREDICATES: 34: n_nationkey IS NOT NULL
-partitions=1/1
-avgRowSize=29.0
-numNodes=0
-cardinality: 25
-column statistics:
-* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 4(F01)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 08
-
-7:Project
+12:Project
 |  output columns:
 |  10 <-> [10: o_custkey, INT, true]
 |  23 <-> [23: l_extendedprice, DECIMAL64(15,2), true]
@@ -251,11 +146,11 @@ OutPut Exchange Id: 08
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-6:HASH JOIN
+11:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [18: l_orderkey, INT, true] = [9: o_orderkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (9: o_orderkey), remote = false
+|  - filter_id = 1, build_expr = (9: o_orderkey), remote = false
 |  output columns: 10, 23, 24
 |  cardinality: 7651211
 |  column statistics:
@@ -265,10 +160,10 @@ OutPut Exchange Id: 08
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-|----5:EXCHANGE
+|----10:EXCHANGE
 |       cardinality: 5738046
 |
-2:Project
+7:Project
 |  output columns:
 |  18 <-> [18: l_orderkey, INT, true]
 |  23 <-> [23: l_extendedprice, DECIMAL64(15,2), true]
@@ -279,7 +174,7 @@ OutPut Exchange Id: 08
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-1:HdfsScanNode
+6:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 26: l_returnflag = 'R'
 MIN/MAX PREDICATES: 40: l_returnflag <= 'R', 41: l_returnflag >= 'R'
@@ -288,20 +183,20 @@ avgRowSize=25.0
 numNodes=0
 cardinality: 200012634
 probe runtime filters:
-- filter_id = 0, probe_expr = (18: l_orderkey)
+- filter_id = 1, probe_expr = (18: l_orderkey)
 column statistics:
 * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 * l_returnflag-->[-Infinity, Infinity, 0.0, 1.0, 3.0] ESTIMATE
 
-PLAN FRAGMENT 5(F02)
+PLAN FRAGMENT 3(F05)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 05
+OutPut Exchange Id: 10
 
-4:Project
+9:Project
 |  output columns:
 |  9 <-> [9: o_orderkey, INT, true]
 |  10 <-> [10: o_custkey, INT, true]
@@ -310,7 +205,7 @@ OutPut Exchange Id: 05
 |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
 |  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
 |
-3:HdfsScanNode
+8:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 MIN/MAX PREDICATES: 42: o_orderdate >= '1994-05-01', 43: o_orderdate < '1994-08-01'
@@ -322,5 +217,86 @@ column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
 * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
 * o_orderdate-->[7.677216E8, 7.756704E8, 0.0, 4.0, 2412.0] ESTIMATE
+
+PLAN FRAGMENT 4(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 1: c_custkey
+OutPut Exchange Id: 05
+
+4:Project
+|  output columns:
+|  1 <-> [1: c_custkey, INT, true]
+|  2 <-> [2: c_name, VARCHAR, true]
+|  3 <-> [3: c_address, VARCHAR, true]
+|  5 <-> [5: c_phone, VARCHAR, true]
+|  6 <-> [6: c_acctbal, DECIMAL64(15,2), true]
+|  8 <-> [8: c_comment, VARCHAR, true]
+|  35 <-> [35: n_name, VARCHAR, true]
+|  cardinality: 15000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 1.5E7] ESTIMATE
+|  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 1.5E7] ESTIMATE
+|  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
+|  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 1.4788744E7] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+|
+3:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [4: c_nationkey, INT, true] = [34: n_nationkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 0, build_expr = (34: n_nationkey), remote = false
+|  output columns: 1, 2, 3, 5, 6, 8, 35
+|  cardinality: 15000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * c_address-->[-Infinity, Infinity, 0.0, 40.0, 1.5E7] ESTIMATE
+|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 1.5E7] ESTIMATE
+|  * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
+|  * c_comment-->[-Infinity, Infinity, 0.0, 117.0, 1.4788744E7] ESTIMATE
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+|
+|----2:EXCHANGE
+|       cardinality: 25
+|
+0:HdfsScanNode
+TABLE: customer
+NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
+partitions=1/1
+avgRowSize=217.0
+numNodes=0
+cardinality: 15000000
+probe runtime filters:
+- filter_id = 0, probe_expr = (4: c_nationkey)
+column statistics:
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+* c_address-->[-Infinity, Infinity, 0.0, 40.0, 1.5E7] ESTIMATE
+* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* c_phone-->[-Infinity, Infinity, 0.0, 15.0, 1.5E7] ESTIMATE
+* c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
+* c_comment-->[-Infinity, Infinity, 0.0, 117.0, 1.4788744E7] ESTIMATE
+
+PLAN FRAGMENT 5(F01)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 02
+
+1:HdfsScanNode
+TABLE: nation
+NON-PARTITION PREDICATES: 34: n_nationkey IS NOT NULL
+partitions=1/1
+avgRowSize=29.0
+numNodes=0
+cardinality: 25
+column statistics:
+* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
@@ -30,12 +30,12 @@ order by
     p_type,
     p_size ;
 [fragment statistics]
-PLAN FRAGMENT 0(F06)
+PLAN FRAGMENT 0(F08)
 Output Exprs:9: p_brand | 10: p_type | 11: p_size | 23: count
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-15:MERGING-EXCHANGE
+16:MERGING-EXCHANGE
 cardinality: 7119
 column statistics:
 * p_brand-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -43,13 +43,13 @@ column statistics:
 * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 * count-->[0.0, 6912000.0, 0.0, 8.0, 7119.140625] ESTIMATE
 
-PLAN FRAGMENT 1(F05)
+PLAN FRAGMENT 1(F07)
 
 Input Partition: HASH_PARTITIONED: 9: p_brand, 10: p_type, 11: p_size
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 15
+OutPut Exchange Id: 16
 
-14:SORT
+15:SORT
 |  order by: [23, BIGINT, false] DESC, [9, VARCHAR, true] ASC, [10, VARCHAR, true] ASC, [11, INT, true] ASC
 |  offset: 0
 |  cardinality: 7119
@@ -59,7 +59,7 @@ OutPut Exchange Id: 15
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |  * count-->[0.0, 6912000.0, 0.0, 8.0, 7119.140625] ESTIMATE
 |
-13:AGGREGATE (update finalize)
+14:AGGREGATE (update finalize)
 |  aggregate: count[([2: ps_suppkey, INT, true]); args: INT; result: BIGINT; args nullable: true; result nullable: false]
 |  group by: [9: p_brand, VARCHAR, true], [10: p_type, VARCHAR, true], [11: p_size, INT, true]
 |  cardinality: 7119
@@ -69,7 +69,7 @@ OutPut Exchange Id: 15
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |  * count-->[0.0, 6912000.0, 0.0, 8.0, 7119.140625] ESTIMATE
 |
-12:AGGREGATE (merge serialize)
+13:AGGREGATE (merge serialize)
 |  group by: [2: ps_suppkey, INT, true], [9: p_brand, VARCHAR, true], [10: p_type, VARCHAR, true], [11: p_size, INT, true]
 |  cardinality: 6912000
 |  column statistics:
@@ -78,16 +78,16 @@ OutPut Exchange Id: 15
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |
-11:EXCHANGE
+12:EXCHANGE
 cardinality: 6912000
 
-PLAN FRAGMENT 2(F00)
+PLAN FRAGMENT 2(F04)
 
-Input Partition: RANDOM
+Input Partition: HASH_PARTITIONED: 1: ps_partkey
 OutPut Partition: HASH_PARTITIONED: 9: p_brand, 10: p_type, 11: p_size
-OutPut Exchange Id: 11
+OutPut Exchange Id: 12
 
-10:AGGREGATE (update serialize)
+11:AGGREGATE (update serialize)
 |  STREAMING
 |  group by: [2: ps_suppkey, INT, true], [9: p_brand, VARCHAR, true], [10: p_type, VARCHAR, true], [11: p_size, INT, true]
 |  cardinality: 6912000
@@ -97,7 +97,7 @@ OutPut Exchange Id: 11
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |
-9:Project
+10:Project
 |  output columns:
 |  2 <-> [2: ps_suppkey, INT, true]
 |  9 <-> [9: p_brand, VARCHAR, true]
@@ -110,7 +110,7 @@ OutPut Exchange Id: 11
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |
-8:HASH JOIN
+9:HASH JOIN
 |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)
 |  equal join conjunct: [2: ps_suppkey, INT, true] = [15: s_suppkey, INT, true]
 |  output columns: 2, 9, 10, 11
@@ -122,10 +122,10 @@ OutPut Exchange Id: 11
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 250000.0] ESTIMATE
 |
-|----7:EXCHANGE
+|----8:EXCHANGE
 |       cardinality: 250000
 |
-4:Project
+5:Project
 |  output columns:
 |  2 <-> [2: ps_suppkey, INT, true]
 |  9 <-> [9: p_brand, VARCHAR, true]
@@ -138,11 +138,11 @@ OutPut Exchange Id: 11
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |
-3:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+4:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  equal join conjunct: [1: ps_partkey, INT, true] = [6: p_partkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (6: p_partkey), remote = false
+|  - filter_id = 0, build_expr = (6: p_partkey), remote = true
 |  output columns: 2, 9, 10, 11
 |  cardinality: 9216000
 |  column statistics:
@@ -153,36 +153,26 @@ OutPut Exchange Id: 11
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
 |
-|----2:EXCHANGE
+|----3:EXCHANGE
 |       cardinality: 2304000
 |
-0:HdfsScanNode
-TABLE: partsupp
-NON-PARTITION PREDICATES: 1: ps_partkey IS NOT NULL
-partitions=1/1
-avgRowSize=16.0
-numNodes=0
+1:EXCHANGE
 cardinality: 80000000
-probe runtime filters:
-- filter_id = 0, probe_expr = (1: ps_partkey)
-column statistics:
-* ps_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0E7] ESTIMATE
-* ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 
-PLAN FRAGMENT 3(F03)
+PLAN FRAGMENT 3(F05)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 07
+OutPut Exchange Id: 08
 
-6:Project
+7:Project
 |  output columns:
 |  15 <-> [15: s_suppkey, INT, true]
 |  cardinality: 250000
 |  column statistics:
 |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 250000.0] ESTIMATE
 |
-5:HdfsScanNode
+6:HdfsScanNode
 TABLE: supplier
 NON-PARTITION PREDICATES: 21: s_comment LIKE '%Customer%Complaints%'
 partitions=1/1
@@ -193,13 +183,13 @@ column statistics:
 * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 250000.0] ESTIMATE
 * s_comment-->[-Infinity, Infinity, 0.0, 101.0, 250000.0] ESTIMATE
 
-PLAN FRAGMENT 4(F01)
+PLAN FRAGMENT 4(F02)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 02
+OutPut Partition: HASH_PARTITIONED: 6: p_partkey
+OutPut Exchange Id: 03
 
-1:HdfsScanNode
+2:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 9: p_brand != 'Brand#43', NOT (10: p_type LIKE 'PROMO BURNISHED%'), 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)
 MIN/MAX PREDICATES: 24: p_size >= 1, 25: p_size <= 43
@@ -212,5 +202,24 @@ column statistics:
 * p_brand-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
 * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 * p_size-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
+
+PLAN FRAGMENT 5(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 1: ps_partkey
+OutPut Exchange Id: 01
+
+0:HdfsScanNode
+TABLE: partsupp
+NON-PARTITION PREDICATES: 1: ps_partkey IS NOT NULL
+partitions=1/1
+avgRowSize=16.0
+numNodes=0
+cardinality: 80000000
+probe runtime filters:
+- filter_id = 0, probe_expr = (1: ps_partkey)
+column statistics:
+* ps_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0E7] ESTIMATE
+* ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
@@ -32,144 +32,268 @@ order by
     o_totalprice desc,
     o_orderdate limit 100;
 [fragment statistics]
-PLAN FRAGMENT 0
-OUTPUT EXPRS:2: C_NAME | 1: C_CUSTKEY | 10: O_ORDERKEY | 14: O_ORDERDATE | 13: O_TOTALPRICE | 56: sum
-PARTITION: UNPARTITIONED
-
+PLAN FRAGMENT 0(F10)
+Output Exprs:2: c_name | 1: c_custkey | 9: o_orderkey | 13: o_orderdate | 12: o_totalprice | 52: sum
+Input Partition: UNPARTITIONED
 RESULT SINK
 
-17:MERGING-EXCHANGE
+20:MERGING-EXCHANGE
 limit: 100
+cardinality: 100
+column statistics:
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+* o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+* o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+* sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
 
-PLAN FRAGMENT 1
-OUTPUT EXPRS:
-PARTITION: RANDOM
+PLAN FRAGMENT 1(F09)
 
-STREAM DATA SINK
-EXCHANGE ID: 17
-UNPARTITIONED
+Input Partition: HASH_PARTITIONED: 34: l_orderkey
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 20
 
-16:TOP-N
-|  order by: <slot 13> 13: O_TOTALPRICE DESC, <slot 14> 14: O_ORDERDATE ASC
+19:TOP-N
+|  order by: [12, DECIMAL64(15,2), true] DESC, [13, DATE, true] ASC
 |  offset: 0
 |  limit: 100
+|  cardinality: 100
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  * sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
 |
-15:AGGREGATE (update finalize)
-|  output: sum(24: L_QUANTITY)
-|  group by: 2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE
+18:AGGREGATE (update finalize)
+|  aggregate: sum[([22: l_quantity, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
+|  group by: [2: c_name, VARCHAR, true], [1: c_custkey, INT, true], [9: o_orderkey, INT, true], [13: o_orderdate, DATE, true], [12: o_totalprice, DECIMAL64(15,2), true]
+|  cardinality: 600037902
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  * sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
 |
-14:Project
-|  <slot 1> : 1: C_CUSTKEY
-|  <slot 2> : 2: C_NAME
-|  <slot 10> : 10: O_ORDERKEY
-|  <slot 13> : 13: O_TOTALPRICE
-|  <slot 14> : 14: O_ORDERDATE
-|  <slot 24> : 24: L_QUANTITY
+17:Project
+|  output columns:
+|  1 <-> [1: c_custkey, INT, true]
+|  2 <-> [2: c_name, VARCHAR, true]
+|  9 <-> [9: o_orderkey, INT, true]
+|  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
+|  13 <-> [13: o_orderdate, DATE, true]
+|  22 <-> [22: l_quantity, DECIMAL64(15,2), true]
+|  cardinality: 600037902
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 |
-13:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  colocate: false, reason:
-|  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
+16:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE(S))
+|  equal join conjunct: [18: l_orderkey, INT, true] = [9: o_orderkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (9: o_orderkey), remote = true
+|  output columns: 1, 2, 9, 12, 13, 22
+|  cardinality: 600037902
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 |
-|----12:EXCHANGE
+|----15:Project
+|    |  output columns:
+|    |  1 <-> [1: c_custkey, INT, true]
+|    |  2 <-> [2: c_name, VARCHAR, true]
+|    |  9 <-> [9: o_orderkey, INT, true]
+|    |  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
+|    |  13 <-> [13: o_orderdate, DATE, true]
+|    |  cardinality: 150000000
+|    |  column statistics:
+|    |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|    |  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|    |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|    |  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|    |  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|    |
+|    14:HASH JOIN
+|    |  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE(S))
+|    |  equal join conjunct: [9: o_orderkey, INT, true] = [34: l_orderkey, INT, true]
+|    |  build runtime filters:
+|    |  - filter_id = 1, build_expr = (34: l_orderkey), remote = false
+|    |  output columns: 1, 2, 9, 12, 13
+|    |  cardinality: 150000000
+|    |  column statistics:
+|    |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|    |  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|    |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|    |  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|    |  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|    |
+|    |----13:Project
+|    |    |  output columns:
+|    |    |  34 <-> [34: l_orderkey, INT, true]
+|    |    |  cardinality: 150000000
+|    |    |  column statistics:
+|    |    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|    |    |
+|    |    12:AGGREGATE (merge finalize)
+|    |    |  aggregate: sum[([50: sum, DECIMAL128(38,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
+|    |    |  group by: [34: l_orderkey, INT, true]
+|    |    |  having: [50: sum, DECIMAL128(38,2), true] > 315
+|    |    |  cardinality: 150000000
+|    |    |  column statistics:
+|    |    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
+|    |    |  * sum-->[315.0, 4.5E14, 0.0, 8.0, 50.0] ESTIMATE
+|    |    |
+|    |    11:EXCHANGE
+|    |       cardinality: 150000000
+|    |
+|    8:EXCHANGE
+|       cardinality: 150000000
+|       probe runtime filters:
+|       - filter_id = 1, probe_expr = (9: o_orderkey)
 |
-0:OlapScanNode
+1:EXCHANGE
+cardinality: 600037902
+probe runtime filters:
+- filter_id = 2, probe_expr = (18: l_orderkey)
+
+PLAN FRAGMENT 2(F08)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 34: l_orderkey
+OutPut Exchange Id: 11
+
+10:AGGREGATE (update serialize)
+|  STREAMING
+|  aggregate: sum[([38: l_quantity, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
+|  group by: [34: l_orderkey, INT, true]
+|  cardinality: 150000000
+|  column statistics:
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+|  * sum-->[1.0, 1.5E8, 0.0, 8.0, 50.0] ESTIMATE
+|
+9:HdfsScanNode
 TABLE: lineitem
-PREAGGREGATION: ON
+NON-PARTITION PREDICATES: 34: l_orderkey IS NOT NULL
 partitions=1/1
-rollup: lineitem
-tabletRatio=20/20
-cardinality=600000000
 avgRowSize=16.0
 numNodes=0
+cardinality: 600037902
+column statistics:
+* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+* l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 
-PLAN FRAGMENT 2
-OUTPUT EXPRS:
-PARTITION: RANDOM
+PLAN FRAGMENT 3(F06)
 
-STREAM DATA SINK
-EXCHANGE ID: 12
-BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
+Input Partition: HASH_PARTITIONED: 10: o_custkey
+OutPut Partition: HASH_PARTITIONED: 9: o_orderkey
+OutPut Exchange Id: 08
 
-11:Project
-|  <slot 1> : 1: C_CUSTKEY
-|  <slot 2> : 2: C_NAME
-|  <slot 10> : 10: O_ORDERKEY
-|  <slot 13> : 13: O_TOTALPRICE
-|  <slot 14> : 14: O_ORDERDATE
-|
-10:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  colocate: false, reason:
-|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
-|
-|----9:EXCHANGE
-|
 7:Project
-|  <slot 10> : 10: O_ORDERKEY
-|  <slot 11> : 11: O_CUSTKEY
-|  <slot 13> : 13: O_TOTALPRICE
-|  <slot 14> : 14: O_ORDERDATE
+|  output columns:
+|  1 <-> [1: c_custkey, INT, true]
+|  2 <-> [2: c_name, VARCHAR, true]
+|  9 <-> [9: o_orderkey, INT, true]
+|  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
+|  13 <-> [13: o_orderdate, DATE, true]
+|  cardinality: 150000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
 |
 6:HASH JOIN
-|  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE)
-|  colocate: false, reason:
-|  equal join conjunct: 10: O_ORDERKEY = 37: L_ORDERKEY
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [10: o_custkey, INT, true] = [1: c_custkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 0, build_expr = (1: c_custkey), remote = true
+|  output columns: 1, 2, 9, 12, 13
+|  cardinality: 150000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
 |
 |----5:EXCHANGE
+|       cardinality: 15000000
 |
-1:OlapScanNode
-TABLE: orders
-PREAGGREGATION: ON
-partitions=1/1
-rollup: orders
-tabletRatio=10/10
-cardinality=150000000
-avgRowSize=28.0
-numNodes=0
+3:EXCHANGE
+cardinality: 150000000
 
-PLAN FRAGMENT 3
-OUTPUT EXPRS:
-PARTITION: RANDOM
+PLAN FRAGMENT 4(F04)
 
-STREAM DATA SINK
-EXCHANGE ID: 09
-UNPARTITIONED
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 1: c_custkey
+OutPut Exchange Id: 05
 
-8:OlapScanNode
+4:HdfsScanNode
 TABLE: customer
-PREAGGREGATION: ON
+NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
-rollup: customer
-tabletRatio=10/10
-cardinality=15000000
 avgRowSize=33.0
 numNodes=0
+cardinality: 15000000
+column statistics:
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
 
-PLAN FRAGMENT 4
-OUTPUT EXPRS:
-PARTITION: RANDOM
+PLAN FRAGMENT 5(F02)
 
-STREAM DATA SINK
-EXCHANGE ID: 05
-BUCKET_SHUFFLE_HASH_PARTITIONED: 37: L_ORDERKEY
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 10: o_custkey
+OutPut Exchange Id: 03
 
-4:Project
-|  <slot 37> : 37: L_ORDERKEY
-|
-3:AGGREGATE (update finalize)
-|  output: sum(41: L_QUANTITY)
-|  group by: 37: L_ORDERKEY
-|  having: 54: sum > 315.0
-|
-2:OlapScanNode
-TABLE: lineitem
-PREAGGREGATION: ON
+2:HdfsScanNode
+TABLE: orders
+NON-PARTITION PREDICATES: 10: o_custkey IS NOT NULL
 partitions=1/1
-rollup: lineitem
-tabletRatio=20/20
-cardinality=600000000
+avgRowSize=28.0
+numNodes=0
+cardinality: 150000000
+probe runtime filters:
+- filter_id = 0, probe_expr = (10: o_custkey)
+column statistics:
+* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+* o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
+* o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
+* o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+
+PLAN FRAGMENT 6(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 18: l_orderkey
+OutPut Exchange Id: 01
+
+0:HdfsScanNode
+TABLE: lineitem
+NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
+partitions=1/1
 avgRowSize=16.0
 numNodes=0
+cardinality: 600037902
+probe runtime filters:
+- filter_id = 2, probe_expr = (18: l_orderkey)
+column statistics:
+* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+* l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
@@ -32,259 +32,144 @@ order by
     o_totalprice desc,
     o_orderdate limit 100;
 [fragment statistics]
-PLAN FRAGMENT 0(F08)
-Output Exprs:2: c_name | 1: c_custkey | 9: o_orderkey | 13: o_orderdate | 12: o_totalprice | 52: sum
-Input Partition: UNPARTITIONED
+PLAN FRAGMENT 0
+OUTPUT EXPRS:2: C_NAME | 1: C_CUSTKEY | 10: O_ORDERKEY | 14: O_ORDERDATE | 13: O_TOTALPRICE | 56: sum
+PARTITION: UNPARTITIONED
+
 RESULT SINK
 
-19:MERGING-EXCHANGE
+17:MERGING-EXCHANGE
 limit: 100
-cardinality: 100
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-* o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-* o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-* sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
 
-PLAN FRAGMENT 1(F07)
+PLAN FRAGMENT 1
+OUTPUT EXPRS:
+PARTITION: RANDOM
 
-Input Partition: HASH_PARTITIONED: 34: l_orderkey
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 19
+STREAM DATA SINK
+EXCHANGE ID: 17
+UNPARTITIONED
 
-18:TOP-N
-|  order by: [12, DECIMAL64(15,2), true] DESC, [13, DATE, true] ASC
+16:TOP-N
+|  order by: <slot 13> 13: O_TOTALPRICE DESC, <slot 14> 14: O_ORDERDATE ASC
 |  offset: 0
 |  limit: 100
-|  cardinality: 100
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|  * sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
 |
-17:AGGREGATE (update finalize)
-|  aggregate: sum[([22: l_quantity, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
-|  group by: [2: c_name, VARCHAR, true], [1: c_custkey, INT, true], [9: o_orderkey, INT, true], [13: o_orderdate, DATE, true], [12: o_totalprice, DECIMAL64(15,2), true]
-|  cardinality: 600037902
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|  * sum-->[1.0, 6.000379019995813E8, 0.0, 8.0, 50.0] ESTIMATE
+15:AGGREGATE (update finalize)
+|  output: sum(24: L_QUANTITY)
+|  group by: 2: C_NAME, 1: C_CUSTKEY, 10: O_ORDERKEY, 14: O_ORDERDATE, 13: O_TOTALPRICE
 |
-16:Project
-|  output columns:
-|  1 <-> [1: c_custkey, INT, true]
-|  2 <-> [2: c_name, VARCHAR, true]
-|  9 <-> [9: o_orderkey, INT, true]
-|  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
-|  13 <-> [13: o_orderdate, DATE, true]
-|  22 <-> [22: l_quantity, DECIMAL64(15,2), true]
-|  cardinality: 600037902
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
+14:Project
+|  <slot 1> : 1: C_CUSTKEY
+|  <slot 2> : 2: C_NAME
+|  <slot 10> : 10: O_ORDERKEY
+|  <slot 13> : 13: O_TOTALPRICE
+|  <slot 14> : 14: O_ORDERDATE
+|  <slot 24> : 24: L_QUANTITY
 |
-15:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE(S))
-|  equal join conjunct: [18: l_orderkey, INT, true] = [9: o_orderkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (9: o_orderkey), remote = true
-|  output columns: 1, 2, 9, 12, 13, 22
-|  cardinality: 600037902
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
+13:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  colocate: false, reason:
+|  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
 |
-|----14:Project
-|    |  output columns:
-|    |  1 <-> [1: c_custkey, INT, true]
-|    |  2 <-> [2: c_name, VARCHAR, true]
-|    |  9 <-> [9: o_orderkey, INT, true]
-|    |  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
-|    |  13 <-> [13: o_orderdate, DATE, true]
-|    |  cardinality: 150000000
-|    |  column statistics:
-|    |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|    |  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|    |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|    |  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|    |  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|    |
-|    13:HASH JOIN
-|    |  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE(S))
-|    |  equal join conjunct: [9: o_orderkey, INT, true] = [34: l_orderkey, INT, true]
-|    |  build runtime filters:
-|    |  - filter_id = 1, build_expr = (34: l_orderkey), remote = false
-|    |  output columns: 1, 2, 9, 12, 13
-|    |  cardinality: 150000000
-|    |  column statistics:
-|    |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|    |  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|    |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|    |  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|    |  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
-|    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|    |
-|    |----12:Project
-|    |    |  output columns:
-|    |    |  34 <-> [34: l_orderkey, INT, true]
-|    |    |  cardinality: 150000000
-|    |    |  column statistics:
-|    |    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|    |    |
-|    |    11:AGGREGATE (merge finalize)
-|    |    |  aggregate: sum[([50: sum, DECIMAL128(38,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
-|    |    |  group by: [34: l_orderkey, INT, true]
-|    |    |  having: [50: sum, DECIMAL128(38,2), true] > 315
-|    |    |  cardinality: 150000000
-|    |    |  column statistics:
-|    |    |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.4999999999989533E8] ESTIMATE
-|    |    |  * sum-->[315.0, 4.5E14, 0.0, 8.0, 50.0] ESTIMATE
-|    |    |
-|    |    10:EXCHANGE
-|    |       cardinality: 150000000
-|    |
-|    7:EXCHANGE
-|       cardinality: 150000000
-|       probe runtime filters:
-|       - filter_id = 1, probe_expr = (9: o_orderkey)
+|----12:EXCHANGE
 |
-1:EXCHANGE
-cardinality: 600037902
-probe runtime filters:
-- filter_id = 2, probe_expr = (18: l_orderkey)
-
-PLAN FRAGMENT 2(F06)
-
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 34: l_orderkey
-OutPut Exchange Id: 10
-
-9:AGGREGATE (update serialize)
-|  STREAMING
-|  aggregate: sum[([38: l_quantity, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
-|  group by: [34: l_orderkey, INT, true]
-|  cardinality: 150000000
-|  column statistics:
-|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-|  * sum-->[1.0, 1.5E8, 0.0, 8.0, 50.0] ESTIMATE
-|
-8:HdfsScanNode
+0:OlapScanNode
 TABLE: lineitem
-NON-PARTITION PREDICATES: 34: l_orderkey IS NOT NULL
+PREAGGREGATION: ON
 partitions=1/1
+rollup: lineitem
+tabletRatio=20/20
+cardinality=600000000
 avgRowSize=16.0
 numNodes=0
-cardinality: 600037902
-column statistics:
-* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 
-PLAN FRAGMENT 3(F02)
+PLAN FRAGMENT 2
+OUTPUT EXPRS:
+PARTITION: RANDOM
 
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 9: o_orderkey
-OutPut Exchange Id: 07
+STREAM DATA SINK
+EXCHANGE ID: 12
+BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
 
-6:Project
-|  output columns:
-|  1 <-> [1: c_custkey, INT, true]
-|  2 <-> [2: c_name, VARCHAR, true]
-|  9 <-> [9: o_orderkey, INT, true]
-|  12 <-> [12: o_totalprice, DECIMAL64(15,2), true]
-|  13 <-> [13: o_orderdate, DATE, true]
-|  cardinality: 150000000
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+11:Project
+|  <slot 1> : 1: C_CUSTKEY
+|  <slot 2> : 2: C_NAME
+|  <slot 10> : 10: O_ORDERKEY
+|  <slot 13> : 13: O_TOTALPRICE
+|  <slot 14> : 14: O_ORDERDATE
 |
-5:HASH JOIN
+10:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [10: o_custkey, INT, true] = [1: c_custkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 0, build_expr = (1: c_custkey), remote = false
-|  output columns: 1, 2, 9, 12, 13
-|  cardinality: 150000000
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-|  * o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  colocate: false, reason:
+|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
 |
-|----4:EXCHANGE
-|       cardinality: 15000000
+|----9:EXCHANGE
 |
-2:HdfsScanNode
+7:Project
+|  <slot 10> : 10: O_ORDERKEY
+|  <slot 11> : 11: O_CUSTKEY
+|  <slot 13> : 13: O_TOTALPRICE
+|  <slot 14> : 14: O_ORDERDATE
+|
+6:HASH JOIN
+|  join op: LEFT SEMI JOIN (BUCKET_SHUFFLE)
+|  colocate: false, reason:
+|  equal join conjunct: 10: O_ORDERKEY = 37: L_ORDERKEY
+|
+|----5:EXCHANGE
+|
+1:OlapScanNode
 TABLE: orders
-NON-PARTITION PREDICATES: 10: o_custkey IS NOT NULL
+PREAGGREGATION: ON
 partitions=1/1
+rollup: orders
+tabletRatio=10/10
+cardinality=150000000
 avgRowSize=28.0
 numNodes=0
-cardinality: 150000000
-probe runtime filters:
-- filter_id = 0, probe_expr = (10: o_custkey)
-column statistics:
-* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
-* o_totalprice-->[811.73, 591036.15, 0.0, 8.0, 3.469658E7] ESTIMATE
-* o_orderdate-->[6.941952E8, 9.019872E8, 0.0, 4.0, 2412.0] ESTIMATE
 
-PLAN FRAGMENT 4(F03)
+PLAN FRAGMENT 3
+OUTPUT EXPRS:
+PARTITION: RANDOM
 
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 04
+STREAM DATA SINK
+EXCHANGE ID: 09
+UNPARTITIONED
 
-3:HdfsScanNode
+8:OlapScanNode
 TABLE: customer
-NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
+PREAGGREGATION: ON
 partitions=1/1
+rollup: customer
+tabletRatio=10/10
+cardinality=15000000
 avgRowSize=33.0
 numNodes=0
-cardinality: 15000000
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* c_name-->[-Infinity, Infinity, 0.0, 25.0, 1.5E7] ESTIMATE
 
-PLAN FRAGMENT 5(F00)
+PLAN FRAGMENT 4
+OUTPUT EXPRS:
+PARTITION: RANDOM
 
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 18: l_orderkey
-OutPut Exchange Id: 01
+STREAM DATA SINK
+EXCHANGE ID: 05
+BUCKET_SHUFFLE_HASH_PARTITIONED: 37: L_ORDERKEY
 
-0:HdfsScanNode
+4:Project
+|  <slot 37> : 37: L_ORDERKEY
+|
+3:AGGREGATE (update finalize)
+|  output: sum(41: L_QUANTITY)
+|  group by: 37: L_ORDERKEY
+|  having: 54: sum > 315.0
+|
+2:OlapScanNode
 TABLE: lineitem
-NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
+PREAGGREGATION: ON
 partitions=1/1
+rollup: lineitem
+tabletRatio=20/20
+cardinality=600000000
 avgRowSize=16.0
 numNodes=0
-cardinality: 600037902
-probe runtime filters:
-- filter_id = 2, probe_expr = (18: l_orderkey)
-column statistics:
-* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -112,24 +112,24 @@ OutPut Exchange Id: 26
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
 |
 23:SELECT
-       |  predicates: 20: ps_supplycost = 50: min
-       |  cardinality: 2
-       |  column statistics:
-       |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0027237042377637] ESTIMATE
-       |  * p_mfgr-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
-       |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 2.0027237042377637] ESTIMATE
-       |  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
-       |  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 2.0027237042377637] ESTIMATE
-       |  * s_phone-->[-Infinity, Infinity, 0.0, 15.0, 2.0027237042377637] ESTIMATE
-       |  * s_acctbal-->[-998.22, 9999.72, 0.0, 8.0, 2.0027237042377637] ESTIMATE
-       |  * s_comment-->[-Infinity, Infinity, 0.0, 101.0, 2.0027237042377637] ESTIMATE
-       |  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
-       |  * ps_supplycost-->[1.0, 1000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
-       |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
-       |  * min-->[1.0, 1000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
-       |
-       22:ANALYTIC
-       |  functions: [, min[([20: ps_supplycost, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL64(15,2); args nullable: true; result nullable: true], ]
+|  predicates: 20: ps_supplycost = 50: min
+|  cardinality: 2
+|  column statistics:
+|  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0027237042377637] ESTIMATE
+|  * p_mfgr-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
+|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 2.0027237042377637] ESTIMATE
+|  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
+|  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 2.0027237042377637] ESTIMATE
+|  * s_phone-->[-Infinity, Infinity, 0.0, 15.0, 2.0027237042377637] ESTIMATE
+|  * s_acctbal-->[-998.22, 9999.72, 0.0, 8.0, 2.0027237042377637] ESTIMATE
+|  * s_comment-->[-Infinity, Infinity, 0.0, 101.0, 2.0027237042377637] ESTIMATE
+|  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
+|  * ps_supplycost-->[1.0, 1000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 2.0027237042377637] ESTIMATE
+|  * min-->[1.0, 1000.0, 0.0, 8.0, 2.0027237042377637] ESTIMATE
+|
+22:ANALYTIC
+|  functions: [, min[([20: ps_supplycost, DECIMAL64(15,2), true]); args: DECIMAL64; result: DECIMAL64(15,2); args nullable: true; result nullable: true], ]
 |  partition by: [1: p_partkey, INT, true]
 |  cardinality: 200000
 |  column statistics:
@@ -149,18 +149,18 @@ OutPut Exchange Id: 26
 21:SORT
 |  order by: [1, INT, true] ASC
 |  offset: 0
-|  cardinality: 80000
+|  cardinality: 200000
 |  column statistics:
-|  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 80000.0] ESTIMATE
+|  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 100000.0] ESTIMATE
 |  * p_mfgr-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 80000.0] ESTIMATE
-|  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 80000.0] ESTIMATE
-|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * s_phone-->[-Infinity, Infinity, 0.0, 15.0, 80000.0] ESTIMATE
-|  * s_acctbal-->[-998.22, 9999.72, 0.0, 8.0, 80000.0] ESTIMATE
-|  * s_comment-->[-Infinity, Infinity, 0.0, 101.0, 80000.0] ESTIMATE
-|  * ps_supplycost-->[1.0, 1000.0, 0.0, 8.0, 80000.0] ESTIMATE
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 200000.0] ESTIMATE
+|  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 200000.0] ESTIMATE
+|  * s_phone-->[-Infinity, Infinity, 0.0, 15.0, 200000.0] ESTIMATE
+|  * s_acctbal-->[-998.22, 9999.72, 0.0, 8.0, 200000.0] ESTIMATE
+|  * s_comment-->[-Infinity, Infinity, 0.0, 101.0, 200000.0] ESTIMATE
+|  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 200000.0] ESTIMATE
+|  * ps_supplycost-->[1.0, 1000.0, 0.0, 8.0, 99864.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 20:EXCHANGE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
@@ -37,12 +37,12 @@ where
 order by
     s_name ;
 [fragment statistics]
-PLAN FRAGMENT 0(F12)
+PLAN FRAGMENT 0(F14)
 Output Exprs:2: s_name | 3: s_address
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-25:MERGING-EXCHANGE
+26:MERGING-EXCHANGE
 cardinality: 40000
 column statistics:
 * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
@@ -50,13 +50,13 @@ column statistics:
 * s_address-->[-Infinity, Infinity, 0.0, 40.0, 40000.0] ESTIMATE
 * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 40000.0] ESTIMATE
 
-PLAN FRAGMENT 1(F11)
+PLAN FRAGMENT 1(F13)
 
 Input Partition: HASH_PARTITIONED: 13: ps_suppkey
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 25
+OutPut Exchange Id: 26
 
-24:SORT
+25:SORT
 |  order by: [2, VARCHAR, true] ASC
 |  offset: 0
 |  cardinality: 40000
@@ -66,7 +66,7 @@ OutPut Exchange Id: 25
 |  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 40000.0] ESTIMATE
 |  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 40000.0] ESTIMATE
 |
-23:Project
+24:Project
 |  output columns:
 |  2 <-> [2: s_name, VARCHAR, true]
 |  3 <-> [3: s_address, VARCHAR, true]
@@ -75,7 +75,7 @@ OutPut Exchange Id: 25
 |  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 40000.0] ESTIMATE
 |
-22:HASH JOIN
+23:HASH JOIN
 |  join op: RIGHT SEMI JOIN (PARTITIONED)
 |  equal join conjunct: [13: ps_suppkey, INT, true] = [1: s_suppkey, INT, true]
 |  build runtime filters:
@@ -88,19 +88,19 @@ OutPut Exchange Id: 25
 |  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 40000.0] ESTIMATE
 |  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 40000.0] ESTIMATE
 |
-|----21:EXCHANGE
+|----22:EXCHANGE
 |       cardinality: 40000
 |
-14:EXCHANGE
+15:EXCHANGE
 cardinality: 39032168
 
-PLAN FRAGMENT 2(F07)
+PLAN FRAGMENT 2(F09)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 1: s_suppkey
-OutPut Exchange Id: 21
+OutPut Exchange Id: 22
 
-20:Project
+21:Project
 |  output columns:
 |  1 <-> [1: s_suppkey, INT, true]
 |  2 <-> [2: s_name, VARCHAR, true]
@@ -111,7 +111,7 @@ OutPut Exchange Id: 21
 |  * s_name-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * s_address-->[-Infinity, Infinity, 0.0, 40.0, 40000.0] ESTIMATE
 |
-19:HASH JOIN
+20:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [4: s_nationkey, INT, true] = [8: n_nationkey, INT, true]
 |  build runtime filters:
@@ -125,10 +125,10 @@ OutPut Exchange Id: 21
 |  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
-|----18:EXCHANGE
+|----19:EXCHANGE
 |       cardinality: 1
 |
-15:HdfsScanNode
+16:HdfsScanNode
 TABLE: supplier
 NON-PARTITION PREDICATES: 4: s_nationkey IS NOT NULL
 partitions=1/1
@@ -143,20 +143,20 @@ column statistics:
 * s_address-->[-Infinity, Infinity, 0.0, 40.0, 1000000.0] ESTIMATE
 * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 3(F08)
+PLAN FRAGMENT 3(F10)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 18
+OutPut Exchange Id: 19
 
-17:Project
+18:Project
 |  output columns:
 |  8 <-> [8: n_nationkey, INT, true]
 |  cardinality: 1
 |  column statistics:
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
-16:HdfsScanNode
+17:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 9: n_name = 'ARGENTINA'
 MIN/MAX PREDICATES: 49: n_name <= 'ARGENTINA', 50: n_name >= 'ARGENTINA'
@@ -172,16 +172,16 @@ PLAN FRAGMENT 4(F01)
 
 Input Partition: HASH_PARTITIONED: 28: l_partkey
 OutPut Partition: HASH_PARTITIONED: 13: ps_suppkey
-OutPut Exchange Id: 14
+OutPut Exchange Id: 15
 
-13:Project
+14:Project
 |  output columns:
 |  13 <-> [13: ps_suppkey, INT, true]
 |  cardinality: 39032168
 |  column statistics:
 |  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 |
-12:HASH JOIN
+13:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE(S))
 |  equal join conjunct: [28: l_partkey, INT, true] = [12: ps_partkey, INT, true]
 |  equal join conjunct: [29: l_suppkey, INT, true] = [13: ps_suppkey, INT, true]
@@ -199,7 +199,7 @@ OutPut Exchange Id: 14
 |  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |  * sum-->[1.0, 1.5047014083835206E14, 0.0, 8.0, 50.0] ESTIMATE
 |
-|----11:EXCHANGE
+|----12:EXCHANGE
 |       cardinality: 20000000
 |
 4:AGGREGATE (merge finalize)
@@ -217,13 +217,13 @@ probe runtime filters:
 - filter_id = 1, probe_expr = (28: l_partkey)
 - filter_id = 2, probe_expr = (29: l_suppkey)
 
-PLAN FRAGMENT 5(F02)
+PLAN FRAGMENT 5(F06)
 
-Input Partition: RANDOM
+Input Partition: HASH_PARTITIONED: 12: ps_partkey
 OutPut Partition: HASH_PARTITIONED: 12: ps_partkey
-OutPut Exchange Id: 11
+OutPut Exchange Id: 12
 
-10:Project
+11:Project
 |  output columns:
 |  12 <-> [12: ps_partkey, INT, true]
 |  13 <-> [13: ps_suppkey, INT, true]
@@ -234,11 +234,11 @@ OutPut Exchange Id: 11
 |  * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 |  * ps_availqty-->[1.0, 9999.0, 0.0, 4.0, 9999.0] ESTIMATE
 |
-9:HASH JOIN
-|  join op: LEFT SEMI JOIN (BROADCAST)
+10:HASH JOIN
+|  join op: LEFT SEMI JOIN (PARTITIONED)
 |  equal join conjunct: [12: ps_partkey, INT, true] = [17: p_partkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (17: p_partkey), remote = false
+|  - filter_id = 0, build_expr = (17: p_partkey), remote = true
 |  output columns: 12, 13, 14
 |  cardinality: 20000000
 |  column statistics:
@@ -247,9 +247,42 @@ OutPut Exchange Id: 11
 |  * ps_availqty-->[1.0, 9999.0, 0.0, 4.0, 9999.0] ESTIMATE
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
 |
-|----8:EXCHANGE
+|----9:EXCHANGE
 |       cardinality: 5000000
 |
+6:EXCHANGE
+cardinality: 80000000
+
+PLAN FRAGMENT 6(F04)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 17: p_partkey
+OutPut Exchange Id: 09
+
+8:Project
+|  output columns:
+|  17 <-> [17: p_partkey, INT, true]
+|  cardinality: 5000000
+|  column statistics:
+|  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
+|
+7:HdfsScanNode
+TABLE: part
+NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL, 18: p_name LIKE 'sienna%'
+partitions=1/1
+avgRowSize=63.0
+numNodes=0
+cardinality: 5000000
+column statistics:
+* p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
+* p_name-->[-Infinity, Infinity, 0.0, 55.0, 5000000.0] ESTIMATE
+
+PLAN FRAGMENT 7(F02)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 12: ps_partkey
+OutPut Exchange Id: 06
+
 5:HdfsScanNode
 TABLE: partsupp
 NON-PARTITION PREDICATES: 13: ps_suppkey IS NOT NULL
@@ -265,31 +298,7 @@ column statistics:
 * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 * ps_availqty-->[1.0, 9999.0, 0.0, 4.0, 9999.0] ESTIMATE
 
-PLAN FRAGMENT 6(F03)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 08
-
-7:Project
-|  output columns:
-|  17 <-> [17: p_partkey, INT, true]
-|  cardinality: 5000000
-|  column statistics:
-|  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
-|
-6:HdfsScanNode
-TABLE: part
-NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL, 18: p_name LIKE 'sienna%'
-partitions=1/1
-avgRowSize=63.0
-numNodes=0
-cardinality: 5000000
-column statistics:
-* p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
-* p_name-->[-Infinity, Infinity, 0.0, 55.0, 5000000.0] ESTIMATE
-
-PLAN FRAGMENT 7(F00)
+PLAN FRAGMENT 8(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 28: l_partkey

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -24,329 +24,319 @@ group by
 order by
     revenue desc ;
 [fragment statistics]
-PLAN FRAGMENT 0(F14)
-Output Exprs:42: n_name | 49: sum
+PLAN FRAGMENT 0(F12)
+Output Exprs:46: N_NAME | 55: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-28:MERGING-EXCHANGE
+27:MERGING-EXCHANGE
 cardinality: 5
 column statistics:
-* n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-* sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
+* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+* sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 
-PLAN FRAGMENT 1(F13)
+PLAN FRAGMENT 1(F11)
 
-Input Partition: HASH_PARTITIONED: 42: n_name
+Input Partition: HASH_PARTITIONED: 46: N_NAME
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 28
+OutPut Exchange Id: 27
 
-27:SORT
-|  order by: [49, DECIMAL128(38,4), true] DESC
+26:SORT
+|  order by: [55, DOUBLE, true] DESC
 |  offset: 0
 |  cardinality: 5
 |  column statistics:
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-26:AGGREGATE (merge finalize)
-|  aggregate: sum[([49: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
-|  group by: [42: n_name, VARCHAR, true]
+25:AGGREGATE (merge finalize)
+|  aggregate: sum[([55: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  group by: [46: N_NAME, VARCHAR, false]
 |  cardinality: 5
 |  column statistics:
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-25:EXCHANGE
+24:EXCHANGE
 cardinality: 5
 
 PLAN FRAGMENT 2(F00)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 42: n_name
-OutPut Exchange Id: 25
+OutPut Partition: HASH_PARTITIONED: 46: N_NAME
+OutPut Exchange Id: 24
 
-24:AGGREGATE (update serialize)
+23:AGGREGATE (update serialize)
 |  STREAMING
-|  aggregate: sum[([48: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
-|  group by: [42: n_name, VARCHAR, true]
+|  aggregate: sum[([54: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
+|  group by: [46: N_NAME, VARCHAR, false]
 |  cardinality: 5
 |  column statistics:
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-23:Project
+22:Project
 |  output columns:
-|  42 <-> [42: n_name, VARCHAR, true]
-|  48 <-> cast([23: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [24: l_discount, DECIMAL64(15,2), true] as DECIMAL128(18,2))
-|  cardinality: 16391888
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  54 <-> [25: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [26: L_DISCOUNT, DOUBLE, false]
+|  cardinality: 20488565
 |  column statistics:
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-22:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [20: l_suppkey, INT, true] = [34: s_suppkey, INT, true]
-|  equal join conjunct: [4: c_nationkey, INT, true] = [37: s_nationkey, INT, true]
+21:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [4: C_NATIONKEY, INT, false]
+|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (34: s_suppkey), remote = false
-|  - filter_id = 5, build_expr = (37: s_nationkey), remote = true
-|  output columns: 23, 24, 42
-|  cardinality: 16391888
+|  - filter_id = 4, build_expr = (4: C_NATIONKEY), remote = false
+|  - filter_id = 5, build_expr = (10: O_ORDERKEY), remote = false
+|  output columns: 25, 26, 46
+|  cardinality: 20488565
 |  column statistics:
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
+|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-|----21:EXCHANGE
-|       cardinality: 200000
-|
-10:Project
-|  output columns:
-|  4 <-> [4: c_nationkey, INT, true]
-|  20 <-> [20: l_suppkey, INT, true]
-|  23 <-> [23: l_extendedprice, DECIMAL64(15,2), true]
-|  24 <-> [24: l_discount, DECIMAL64(15,2), true]
-|  cardinality: 91066043
-|  column statistics:
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-9:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [18: l_orderkey, INT, true] = [9: o_orderkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (9: o_orderkey), remote = false
-|  output columns: 4, 20, 23, 24
-|  cardinality: 91066043
-|  column statistics:
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-|----8:EXCHANGE
+|----20:EXCHANGE
 |       cardinality: 22765073
-|       probe runtime filters:
-|       - filter_id = 5, probe_expr = (4: c_nationkey)
 |
-0:HdfsScanNode
-TABLE: lineitem
-NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
-partitions=1/1
-avgRowSize=28.0
-numNodes=0
-cardinality: 600037902
+13:Project
+|  output columns:
+|  20 <-> [20: L_ORDERKEY, INT, false]
+|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
+|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+12:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (37: S_SUPPKEY), remote = false
+|  output columns: 20, 25, 26, 40, 46
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
+|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+|----11:EXCHANGE
+|       cardinality: 200000
+|       probe runtime filters:
+|       - filter_id = 4, probe_expr = (40: S_NATIONKEY)
+|
+0:OlapScanNode
+table: lineitem, rollup: lineitem
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=20/20
+actualRows=0, avgRowSize=28.0
+cardinality: 600000000
 probe runtime filters:
-- filter_id = 1, probe_expr = (18: l_orderkey)
-- filter_id = 4, probe_expr = (20: l_suppkey)
+- filter_id = 2, probe_expr = (22: L_SUPPKEY)
+- filter_id = 5, probe_expr = (20: L_ORDERKEY)
 column statistics:
-* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-* l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+* L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+* L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+* L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 
 PLAN FRAGMENT 3(F07)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 21
+OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
+OutPut Exchange Id: 20
 
-20:Project
+19:Project
 |  output columns:
-|  34 <-> [34: s_suppkey, INT, true]
-|  37 <-> [37: s_nationkey, INT, true]
-|  42 <-> [42: n_name, VARCHAR, true]
-|  cardinality: 200000
+|  4 <-> [4: C_NATIONKEY, INT, false]
+|  10 <-> [10: O_ORDERKEY, INT, false]
+|  cardinality: 22765073
 |  column statistics:
-|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
 |
-19:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [37: s_nationkey, INT, true] = [41: n_nationkey, INT, true]
+18:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [1: C_CUSTKEY, INT, false] = [11: O_CUSTKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 3, build_expr = (41: n_nationkey), remote = false
-|  output columns: 34, 37, 42
-|  cardinality: 200000
+|  - filter_id = 3, build_expr = (11: O_CUSTKEY), remote = false
+|  output columns: 4, 10
+|  cardinality: 22765073
 |  column statistics:
-|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * C_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
+|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-|----18:EXCHANGE
-|       cardinality: 5
+|----17:EXCHANGE
+|       cardinality: 22765073
 |
-11:HdfsScanNode
-TABLE: supplier
-NON-PARTITION PREDICATES: 34: s_suppkey IS NOT NULL, 37: s_nationkey IS NOT NULL
-partitions=1/1
-avgRowSize=8.0
-numNodes=0
-cardinality: 1000000
+14:OlapScanNode
+table: customer, rollup: customer
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=10/10
+actualRows=0, avgRowSize=12.0
+cardinality: 15000000
 probe runtime filters:
-- filter_id = 3, probe_expr = (37: s_nationkey)
+- filter_id = 3, probe_expr = (1: C_CUSTKEY)
 column statistics:
-* s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* s_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
 PLAN FRAGMENT 4(F08)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 18
+OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 11: O_CUSTKEY
+OutPut Exchange Id: 17
 
-17:Project
+16:Project
 |  output columns:
-|  41 <-> [41: n_nationkey, INT, true]
-|  42 <-> [42: n_name, VARCHAR, true]
-|  cardinality: 5
+|  10 <-> [10: O_ORDERKEY, INT, false]
+|  11 <-> [11: O_CUSTKEY, INT, false]
+|  cardinality: 22765073
 |  column statistics:
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-16:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [43: n_regionkey, INT, true] = [45: r_regionkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (45: r_regionkey), remote = false
-|  output columns: 41, 42
-|  cardinality: 5
-|  column statistics:
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * n_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-|----15:EXCHANGE
-|       cardinality: 1
-|
-12:HdfsScanNode
-TABLE: nation
-NON-PARTITION PREDICATES: 41: n_nationkey IS NOT NULL
-partitions=1/1
-avgRowSize=33.0
-numNodes=0
-cardinality: 25
-probe runtime filters:
-- filter_id = 2, probe_expr = (43: n_regionkey)
+15:OlapScanNode
+table: orders, rollup: orders
+preAggregation: on
+Predicates: [14: O_ORDERDATE, DATE, false] >= '1995-01-01', [14: O_ORDERDATE, DATE, false] < '1996-01-01'
+partitionsRatio=1/1, tabletsRatio=10/10
+actualRows=0, avgRowSize=20.0
+cardinality: 22765073
 column statistics:
-* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* n_regionkey-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+* O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+* O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
+* O_ORDERDATE-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2406.0] ESTIMATE
 
-PLAN FRAGMENT 5(F09)
+PLAN FRAGMENT 5(F01)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 15
+OutPut Exchange Id: 11
 
-14:Project
+10:Project
 |  output columns:
-|  45 <-> [45: r_regionkey, INT, true]
-|  cardinality: 1
+|  37 <-> [37: S_SUPPKEY, INT, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 200000
 |  column statistics:
-|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
-13:HdfsScanNode
-TABLE: region
-NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
-MIN/MAX PREDICATES: 50: r_name <= 'AFRICA', 51: r_name >= 'AFRICA'
-partitions=1/1
-avgRowSize=10.8
-numNodes=0
-cardinality: 1
+9:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 1, build_expr = (45: N_NATIONKEY), remote = false
+|  output columns: 37, 40, 46
+|  cardinality: 200000
+|  column statistics:
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+|----8:EXCHANGE
+|       cardinality: 5
+|
+1:OlapScanNode
+table: supplier, rollup: supplier
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=8.0
+cardinality: 1000000
+probe runtime filters:
+- filter_id = 1, probe_expr = (40: S_NATIONKEY)
 column statistics:
-* r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* r_name-->[-Infinity, Infinity, 0.0, 6.8, 1.0] ESTIMATE
+* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 6(F05)
+PLAN FRAGMENT 6(F02)
 
-Input Partition: HASH_PARTITIONED: 10: o_custkey
+Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 08
 
 7:Project
 |  output columns:
-|  4 <-> [4: c_nationkey, INT, true]
-|  9 <-> [9: o_orderkey, INT, true]
-|  cardinality: 22765073
+|  45 <-> [45: N_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, CHAR, false]
+|  cardinality: 5
 |  column statistics:
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 6:HASH JOIN
-|  join op: INNER JOIN (PARTITIONED)
-|  equal join conjunct: [10: o_custkey, INT, true] = [1: c_custkey, INT, true]
-|  output columns: 4, 9
-|  cardinality: 22765073
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 0, build_expr = (50: R_REGIONKEY), remote = false
+|  output columns: 45, 46
+|  cardinality: 5
 |  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 |----5:EXCHANGE
-|       cardinality: 15000000
+|       cardinality: 1
 |
-3:EXCHANGE
-cardinality: 22765073
+2:OlapScanNode
+table: nation, rollup: nation
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=33.0
+cardinality: 25
+probe runtime filters:
+- filter_id = 0, probe_expr = (47: N_REGIONKEY)
+column statistics:
+* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
 
 PLAN FRAGMENT 7(F03)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 1: c_custkey
+OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 05
 
-4:HdfsScanNode
-TABLE: customer
-NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
-partitions=1/1
-avgRowSize=12.0
-numNodes=0
-cardinality: 15000000
-probe runtime filters:
-- filter_id = 5, probe_expr = (4: c_nationkey)
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 8(F01)
-
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 10: o_custkey
-OutPut Exchange Id: 03
-
-2:Project
+4:Project
 |  output columns:
-|  9 <-> [9: o_orderkey, INT, true]
-|  10 <-> [10: o_custkey, INT, true]
-|  cardinality: 22765073
+|  50 <-> [50: R_REGIONKEY, INT, false]
+|  cardinality: 1
 |  column statistics:
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
-1:HdfsScanNode
-TABLE: orders
-NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
-MIN/MAX PREDICATES: 52: o_orderdate >= '1995-01-01', 53: o_orderdate < '1996-01-01'
-partitions=1/1
-avgRowSize=20.0
-numNodes=0
-cardinality: 22765073
+3:OlapScanNode
+table: region, rollup: region
+preAggregation: on
+Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=29.0
+cardinality: 1
 column statistics:
-* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-* o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
-* o_orderdate-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2412.0] ESTIMATE
+* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
 [end]

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -24,210 +24,224 @@ group by
 order by
     revenue desc ;
 [fragment statistics]
-PLAN FRAGMENT 0(F12)
-Output Exprs:46: N_NAME | 55: sum
+PLAN FRAGMENT 0(F16)
+Output Exprs:42: n_name | 49: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-27:MERGING-EXCHANGE
+29:MERGING-EXCHANGE
 cardinality: 5
 column statistics:
-* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-* sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
+* n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+* sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
 
-PLAN FRAGMENT 1(F11)
+PLAN FRAGMENT 1(F15)
 
-Input Partition: HASH_PARTITIONED: 46: N_NAME
+Input Partition: HASH_PARTITIONED: 42: n_name
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 27
+OutPut Exchange Id: 29
 
-26:SORT
-|  order by: [55, DOUBLE, true] DESC
+28:SORT
+|  order by: [49, DECIMAL128(38,4), true] DESC
 |  offset: 0
 |  cardinality: 5
 |  column statistics:
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
 |
-25:AGGREGATE (merge finalize)
-|  aggregate: sum[([55: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
-|  group by: [46: N_NAME, VARCHAR, false]
+27:AGGREGATE (merge finalize)
+|  aggregate: sum[([49: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  group by: [42: n_name, VARCHAR, true]
 |  cardinality: 5
 |  column statistics:
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
 |
-24:EXCHANGE
+26:EXCHANGE
 cardinality: 5
 
-PLAN FRAGMENT 2(F00)
+PLAN FRAGMENT 2(F14)
 
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 46: N_NAME
-OutPut Exchange Id: 24
+Input Partition: HASH_PARTITIONED: 18: l_orderkey
+OutPut Partition: HASH_PARTITIONED: 42: n_name
+OutPut Exchange Id: 26
 
-23:AGGREGATE (update serialize)
+25:AGGREGATE (update serialize)
 |  STREAMING
-|  aggregate: sum[([54: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
-|  group by: [46: N_NAME, VARCHAR, false]
+|  aggregate: sum[([48: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  group by: [42: n_name, VARCHAR, true]
 |  cardinality: 5
 |  column statistics:
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 16.0, 5.0] ESTIMATE
 |
-22:Project
+24:Project
 |  output columns:
-|  46 <-> [46: N_NAME, VARCHAR, false]
-|  54 <-> [25: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [26: L_DISCOUNT, DOUBLE, false]
+|  42 <-> [42: n_name, VARCHAR, true]
+|  48 <-> cast([23: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [24: l_discount, DECIMAL64(15,2), true] as DECIMAL128(18,2))
 |  cardinality: 20488565
 |  column statistics:
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-21:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [4: C_NATIONKEY, INT, false]
-|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
+23:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [37: s_nationkey, INT, true] = [4: c_nationkey, INT, true]
+|  equal join conjunct: [18: l_orderkey, INT, true] = [9: o_orderkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (4: C_NATIONKEY), remote = false
-|  - filter_id = 5, build_expr = (10: O_ORDERKEY), remote = false
-|  output columns: 25, 26, 46
+|  - filter_id = 5, build_expr = (9: o_orderkey), remote = true
+|  output columns: 23, 24, 42
 |  cardinality: 20488565
 |  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.276507276507276E7] ESTIMATE
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.276507276507276E7] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
-|----20:EXCHANGE
+|----22:EXCHANGE
 |       cardinality: 22765073
 |
-13:Project
-|  output columns:
-|  20 <-> [20: L_ORDERKEY, INT, false]
-|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
-|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
-|  40 <-> [40: S_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, VARCHAR, false]
-|  cardinality: 120000000
-|  column statistics:
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-12:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (37: S_SUPPKEY), remote = false
-|  output columns: 20, 25, 26, 40, 46
-|  cardinality: 120000000
-|  column statistics:
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-|----11:EXCHANGE
-|       cardinality: 200000
-|       probe runtime filters:
-|       - filter_id = 4, probe_expr = (40: S_NATIONKEY)
-|
-0:OlapScanNode
-table: lineitem, rollup: lineitem
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=20/20
-actualRows=0, avgRowSize=28.0
-cardinality: 600000000
-probe runtime filters:
-- filter_id = 2, probe_expr = (22: L_SUPPKEY)
-- filter_id = 5, probe_expr = (20: L_ORDERKEY)
-column statistics:
-* L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-* L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+14:EXCHANGE
+cardinality: 120007580
 
-PLAN FRAGMENT 3(F07)
+PLAN FRAGMENT 3(F12)
+
+Input Partition: HASH_PARTITIONED: 10: o_custkey
+OutPut Partition: HASH_PARTITIONED: 9: o_orderkey
+OutPut Exchange Id: 22
+
+21:Project
+|  output columns:
+|  4 <-> [4: c_nationkey, INT, true]
+|  9 <-> [9: o_orderkey, INT, true]
+|  cardinality: 22765073
+|  column statistics:
+|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|
+20:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [10: o_custkey, INT, true] = [1: c_custkey, INT, true]
+|  output columns: 4, 9
+|  cardinality: 22765073
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
+|
+|----19:EXCHANGE
+|       cardinality: 15000000
+|
+17:EXCHANGE
+cardinality: 22765073
+
+PLAN FRAGMENT 4(F10)
 
 Input Partition: RANDOM
-OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
-OutPut Exchange Id: 20
+OutPut Partition: HASH_PARTITIONED: 1: c_custkey
+OutPut Exchange Id: 19
 
-19:Project
-|  output columns:
-|  4 <-> [4: C_NATIONKEY, INT, false]
-|  10 <-> [10: O_ORDERKEY, INT, false]
-|  cardinality: 22765073
-|  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|
-18:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [1: C_CUSTKEY, INT, false] = [11: O_CUSTKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 3, build_expr = (11: O_CUSTKEY), remote = false
-|  output columns: 4, 10
-|  cardinality: 22765073
-|  column statistics:
-|  * C_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
-|
-|----17:EXCHANGE
-|       cardinality: 22765073
-|
-14:OlapScanNode
-table: customer, rollup: customer
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=10/10
-actualRows=0, avgRowSize=12.0
+18:HdfsScanNode
+TABLE: customer
+NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
+partitions=1/1
+avgRowSize=12.0
+numNodes=0
 cardinality: 15000000
-probe runtime filters:
-- filter_id = 3, probe_expr = (1: C_CUSTKEY)
 column statistics:
-* C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 4(F08)
+PLAN FRAGMENT 5(F08)
 
 Input Partition: RANDOM
-OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 11: O_CUSTKEY
+OutPut Partition: HASH_PARTITIONED: 10: o_custkey
 OutPut Exchange Id: 17
 
 16:Project
 |  output columns:
-|  10 <-> [10: O_ORDERKEY, INT, false]
-|  11 <-> [11: O_CUSTKEY, INT, false]
+|  9 <-> [9: o_orderkey, INT, true]
+|  10 <-> [10: o_custkey, INT, true]
 |  cardinality: 22765073
 |  column statistics:
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
 |
-15:OlapScanNode
-table: orders, rollup: orders
-preAggregation: on
-Predicates: [14: O_ORDERDATE, DATE, false] >= '1995-01-01', [14: O_ORDERDATE, DATE, false] < '1996-01-01'
-partitionsRatio=1/1, tabletsRatio=10/10
-actualRows=0, avgRowSize=20.0
+15:HdfsScanNode
+TABLE: orders
+NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
+MIN/MAX PREDICATES: 52: o_orderdate >= '1995-01-01', 53: o_orderdate < '1996-01-01'
+partitions=1/1
+avgRowSize=20.0
+numNodes=0
 cardinality: 22765073
 column statistics:
-* O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-* O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
-* O_ORDERDATE-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2406.0] ESTIMATE
+* o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+* o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
+* o_orderdate-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2412.0] ESTIMATE
 
-PLAN FRAGMENT 5(F01)
+PLAN FRAGMENT 6(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 18: l_orderkey
+OutPut Exchange Id: 14
+
+13:Project
+|  output columns:
+|  18 <-> [18: l_orderkey, INT, true]
+|  23 <-> [23: l_extendedprice, DECIMAL64(15,2), true]
+|  24 <-> [24: l_discount, DECIMAL64(15,2), true]
+|  37 <-> [37: s_nationkey, INT, true]
+|  42 <-> [42: n_name, VARCHAR, true]
+|  cardinality: 120007580
+|  column statistics:
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.2000758039999999E8] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+12:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [20: l_suppkey, INT, true] = [34: s_suppkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (34: s_suppkey), remote = false
+|  output columns: 18, 23, 24, 37, 42
+|  cardinality: 120007580
+|  column statistics:
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.2000758039999999E8] ESTIMATE
+|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+|----11:EXCHANGE
+|       cardinality: 200000
+|
+0:HdfsScanNode
+TABLE: lineitem
+NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
+partitions=1/1
+avgRowSize=28.0
+numNodes=0
+cardinality: 600037902
+probe runtime filters:
+- filter_id = 2, probe_expr = (20: l_suppkey)
+- filter_id = 5, probe_expr = (18: l_orderkey)
+column statistics:
+* l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+* l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+* l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+
+PLAN FRAGMENT 7(F01)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
@@ -235,44 +249,45 @@ OutPut Exchange Id: 11
 
 10:Project
 |  output columns:
-|  37 <-> [37: S_SUPPKEY, INT, false]
-|  40 <-> [40: S_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, VARCHAR, false]
+|  34 <-> [34: s_suppkey, INT, true]
+|  37 <-> [37: s_nationkey, INT, true]
+|  42 <-> [42: n_name, VARCHAR, true]
 |  cardinality: 200000
 |  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 9:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
+|  equal join conjunct: [37: s_nationkey, INT, true] = [41: n_nationkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 1, build_expr = (45: N_NATIONKEY), remote = false
-|  output columns: 37, 40, 46
+|  - filter_id = 1, build_expr = (41: n_nationkey), remote = false
+|  output columns: 34, 37, 42
 |  cardinality: 200000
 |  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 |----8:EXCHANGE
 |       cardinality: 5
 |
-1:OlapScanNode
-table: supplier, rollup: supplier
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=8.0
+1:HdfsScanNode
+TABLE: supplier
+NON-PARTITION PREDICATES: 34: s_suppkey IS NOT NULL, 37: s_nationkey IS NOT NULL
+partitions=1/1
+avgRowSize=8.0
+numNodes=0
 cardinality: 1000000
 probe runtime filters:
-- filter_id = 1, probe_expr = (40: S_NATIONKEY)
+- filter_id = 1, probe_expr = (37: s_nationkey)
 column statistics:
-* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* s_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 6(F02)
+PLAN FRAGMENT 8(F02)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
@@ -280,43 +295,44 @@ OutPut Exchange Id: 08
 
 7:Project
 |  output columns:
-|  45 <-> [45: N_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, CHAR, false]
+|  41 <-> [41: n_nationkey, INT, true]
+|  42 <-> [42: n_name, VARCHAR, true]
 |  cardinality: 5
 |  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 6:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
+|  equal join conjunct: [43: n_regionkey, INT, true] = [45: r_regionkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (50: R_REGIONKEY), remote = false
-|  output columns: 45, 46
+|  - filter_id = 0, build_expr = (45: r_regionkey), remote = false
+|  output columns: 41, 42
 |  cardinality: 5
 |  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * n_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 |----5:EXCHANGE
 |       cardinality: 1
 |
-2:OlapScanNode
-table: nation, rollup: nation
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=33.0
+2:HdfsScanNode
+TABLE: nation
+NON-PARTITION PREDICATES: 41: n_nationkey IS NOT NULL
+partitions=1/1
+avgRowSize=33.0
+numNodes=0
 cardinality: 25
 probe runtime filters:
-- filter_id = 0, probe_expr = (47: N_REGIONKEY)
+- filter_id = 0, probe_expr = (43: n_regionkey)
 column statistics:
-* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+* n_regionkey-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
 
-PLAN FRAGMENT 7(F03)
+PLAN FRAGMENT 9(F03)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
@@ -324,19 +340,20 @@ OutPut Exchange Id: 05
 
 4:Project
 |  output columns:
-|  50 <-> [50: R_REGIONKEY, INT, false]
+|  45 <-> [45: r_regionkey, INT, true]
 |  cardinality: 1
 |  column statistics:
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
-3:OlapScanNode
-table: region, rollup: region
-preAggregation: on
-Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=29.0
+3:HdfsScanNode
+TABLE: region
+NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
+MIN/MAX PREDICATES: 50: r_name <= 'AFRICA', 51: r_name >= 'AFRICA'
+partitions=1/1
+avgRowSize=10.8
+numNodes=0
 cardinality: 1
 column statistics:
-* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
+* r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* r_name-->[-Infinity, Infinity, 0.0, 6.8, 1.0] ESTIMATE
 [end]

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
@@ -39,12 +39,12 @@ order by
     cust_nation,
     l_year ;
 [fragment statistics]
-PLAN FRAGMENT 0(F14)
+PLAN FRAGMENT 0(F16)
 Output Exprs:42: n_name | 46: n_name | 49: year | 51: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-26:MERGING-EXCHANGE
+27:MERGING-EXCHANGE
 cardinality: 250
 column statistics:
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
@@ -52,13 +52,13 @@ column statistics:
 * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 * sum-->[810.9, 104949.5, 0.0, 16.0, 250.28228759765625] ESTIMATE
 
-PLAN FRAGMENT 1(F13)
+PLAN FRAGMENT 1(F15)
 
 Input Partition: HASH_PARTITIONED: 42: n_name, 46: n_name, 49: year
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 26
+OutPut Exchange Id: 27
 
-25:SORT
+26:SORT
 |  order by: [42, VARCHAR, true] ASC, [46, VARCHAR, true] ASC, [49, SMALLINT, true] ASC
 |  offset: 0
 |  cardinality: 250
@@ -68,7 +68,7 @@ OutPut Exchange Id: 26
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 250.28228759765625] ESTIMATE
 |
-24:AGGREGATE (merge finalize)
+25:AGGREGATE (merge finalize)
 |  aggregate: sum[([51: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  group by: [42: n_name, VARCHAR, true], [46: n_name, VARCHAR, true], [49: year, SMALLINT, true]
 |  cardinality: 250
@@ -78,16 +78,16 @@ OutPut Exchange Id: 26
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 250.28228759765625] ESTIMATE
 |
-23:EXCHANGE
+24:EXCHANGE
 cardinality: 297
 
-PLAN FRAGMENT 2(F06)
+PLAN FRAGMENT 2(F08)
 
 Input Partition: HASH_PARTITIONED: 8: l_orderkey
 OutPut Partition: HASH_PARTITIONED: 42: n_name, 46: n_name, 49: year
-OutPut Exchange Id: 23
+OutPut Exchange Id: 24
 
-22:AGGREGATE (update serialize)
+23:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: sum[([50: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  group by: [42: n_name, VARCHAR, true], [46: n_name, VARCHAR, true], [49: year, SMALLINT, true]
@@ -98,7 +98,7 @@ OutPut Exchange Id: 23
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 296.630859375] ESTIMATE
 |
-21:Project
+22:Project
 |  output columns:
 |  42 <-> [42: n_name, VARCHAR, true]
 |  46 <-> [46: n_name, VARCHAR, true]
@@ -111,7 +111,7 @@ OutPut Exchange Id: 23
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 277562.0869449505] ESTIMATE
 |
-20:HASH JOIN
+21:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [36: c_nationkey, INT, true] = [45: n_nationkey, INT, true]
 |  other join predicates: ((42: n_name = 'CANADA') AND (46: n_name = 'IRAN')) OR ((42: n_name = 'IRAN') AND (46: n_name = 'CANADA'))
@@ -130,10 +130,10 @@ OutPut Exchange Id: 23
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 277562.0869449505] ESTIMATE
 |
-|----19:EXCHANGE
+|----20:EXCHANGE
 |       cardinality: 25
 |
-17:Project
+18:Project
 |  output columns:
 |  13 <-> [13: l_extendedprice, DECIMAL64(15,2), true]
 |  14 <-> [14: l_discount, DECIMAL64(15,2), true]
@@ -148,7 +148,7 @@ OutPut Exchange Id: 23
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-16:HASH JOIN
+17:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [10: l_suppkey, INT, true] = [1: s_suppkey, INT, true]
 |  build runtime filters:
@@ -164,10 +164,10 @@ OutPut Exchange Id: 23
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-|----15:EXCHANGE
+|----16:EXCHANGE
 |       cardinality: 1000000
 |
-9:Project
+10:Project
 |  output columns:
 |  10 <-> [10: l_suppkey, INT, true]
 |  13 <-> [13: l_extendedprice, DECIMAL64(15,2), true]
@@ -182,7 +182,7 @@ OutPut Exchange Id: 23
 |  * l_shipdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2526.0] ESTIMATE
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |
-8:HASH JOIN
+9:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)
 |  equal join conjunct: [8: l_orderkey, INT, true] = [24: o_orderkey, INT, true]
 |  output columns: 10, 13, 14, 18, 36
@@ -196,7 +196,7 @@ OutPut Exchange Id: 23
 |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |
-|----7:EXCHANGE
+|----8:EXCHANGE
 |       cardinality: 150000000
 |       probe runtime filters:
 |       - filter_id = 3, probe_expr = (36: c_nationkey)
@@ -206,13 +206,13 @@ cardinality: 173476304
 probe runtime filters:
 - filter_id = 2, probe_expr = (10: l_suppkey)
 
-PLAN FRAGMENT 3(F11)
+PLAN FRAGMENT 3(F13)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 19
+OutPut Exchange Id: 20
 
-18:HdfsScanNode
+19:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 46: n_name IN ('IRAN', 'CANADA')
 MIN/MAX PREDICATES: 52: n_name >= 'CANADA', 53: n_name <= 'IRAN'
@@ -224,13 +224,13 @@ column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 4(F07)
+PLAN FRAGMENT 4(F09)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 15
+OutPut Exchange Id: 16
 
-14:Project
+15:Project
 |  output columns:
 |  1 <-> [1: s_suppkey, INT, true]
 |  42 <-> [42: n_name, VARCHAR, true]
@@ -239,7 +239,7 @@ OutPut Exchange Id: 15
 |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-13:HASH JOIN
+14:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [4: s_nationkey, INT, true] = [41: n_nationkey, INT, true]
 |  build runtime filters:
@@ -252,10 +252,10 @@ OutPut Exchange Id: 15
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-|----12:EXCHANGE
+|----13:EXCHANGE
 |       cardinality: 25
 |
-10:HdfsScanNode
+11:HdfsScanNode
 TABLE: supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
@@ -268,13 +268,13 @@ column statistics:
 * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 5(F08)
+PLAN FRAGMENT 5(F10)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 12
+OutPut Exchange Id: 13
 
-11:HdfsScanNode
+12:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 42: n_name IN ('CANADA', 'IRAN')
 MIN/MAX PREDICATES: 54: n_name >= 'CANADA', 55: n_name <= 'IRAN'
@@ -286,13 +286,13 @@ column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 6(F02)
+PLAN FRAGMENT 6(F06)
 
-Input Partition: RANDOM
+Input Partition: HASH_PARTITIONED: 25: o_custkey
 OutPut Partition: HASH_PARTITIONED: 24: o_orderkey
-OutPut Exchange Id: 07
+OutPut Exchange Id: 08
 
-6:Project
+7:Project
 |  output columns:
 |  24 <-> [24: o_orderkey, INT, true]
 |  36 <-> [36: c_nationkey, INT, true]
@@ -301,11 +301,11 @@ OutPut Exchange Id: 07
 |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |
-5:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+6:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  equal join conjunct: [25: o_custkey, INT, true] = [33: c_custkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (33: c_custkey), remote = false
+|  - filter_id = 0, build_expr = (33: c_custkey), remote = true
 |  output columns: 24, 36
 |  cardinality: 150000000
 |  column statistics:
@@ -314,9 +314,37 @@ OutPut Exchange Id: 07
 |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.0031873E7] ESTIMATE
 |  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |
-|----4:EXCHANGE
+|----5:EXCHANGE
 |       cardinality: 15000000
 |
+3:EXCHANGE
+cardinality: 150000000
+
+PLAN FRAGMENT 7(F04)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 33: c_custkey
+OutPut Exchange Id: 05
+
+4:HdfsScanNode
+TABLE: customer
+NON-PARTITION PREDICATES: 33: c_custkey IS NOT NULL
+partitions=1/1
+avgRowSize=12.0
+numNodes=0
+cardinality: 15000000
+probe runtime filters:
+- filter_id = 3, probe_expr = (36: c_nationkey)
+column statistics:
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 8(F02)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 25: o_custkey
+OutPut Exchange Id: 03
+
 2:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 24: o_orderkey IS NOT NULL
@@ -330,26 +358,7 @@ column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
 
-PLAN FRAGMENT 7(F03)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 04
-
-3:HdfsScanNode
-TABLE: customer
-NON-PARTITION PREDICATES: 33: c_custkey IS NOT NULL
-partitions=1/1
-avgRowSize=12.0
-numNodes=0
-cardinality: 15000000
-probe runtime filters:
-- filter_id = 3, probe_expr = (36: c_nationkey)
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 8(F00)
+PLAN FRAGMENT 9(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 8: l_orderkey

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q18.sql
@@ -67,25 +67,11 @@ UNPARTITIONED
 |  <slot 24> : 24: L_QUANTITY
 |
 13:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  colocate: false, reason:
-|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
-|
-|----12:EXCHANGE
-|
-10:Project
-|  <slot 10> : 10: O_ORDERKEY
-|  <slot 11> : 11: O_CUSTKEY
-|  <slot 13> : 13: O_TOTALPRICE
-|  <slot 14> : 14: O_ORDERDATE
-|  <slot 24> : 24: L_QUANTITY
-|
-9:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
 |
-|----8:EXCHANGE
+|----12:EXCHANGE
 |
 0:OlapScanNode
 TABLE: lineitem
@@ -103,26 +89,22 @@ PARTITION: RANDOM
 
 STREAM DATA SINK
 EXCHANGE ID: 12
-UNPARTITIONED
-
-11:OlapScanNode
-TABLE: customer
-PREAGGREGATION: ON
-partitions=1/1
-rollup: customer
-tabletRatio=10/10
-cardinality=15000000
-avgRowSize=33.0
-numNodes=0
-
-PLAN FRAGMENT 3
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 08
 BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
 
+11:Project
+|  <slot 1> : 1: C_CUSTKEY
+|  <slot 2> : 2: C_NAME
+|  <slot 10> : 10: O_ORDERKEY
+|  <slot 13> : 13: O_TOTALPRICE
+|  <slot 14> : 14: O_ORDERDATE
+|
+10:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  colocate: false, reason:
+|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
+|
+|----9:EXCHANGE
+|
 7:Project
 |  <slot 10> : 10: O_ORDERKEY
 |  <slot 11> : 11: O_CUSTKEY
@@ -144,6 +126,24 @@ rollup: orders
 tabletRatio=10/10
 cardinality=150000000
 avgRowSize=28.0
+numNodes=0
+
+PLAN FRAGMENT 3
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 09
+UNPARTITIONED
+
+8:OlapScanNode
+TABLE: customer
+PREAGGREGATION: ON
+partitions=1/1
+rollup: customer
+tabletRatio=10/10
+cardinality=15000000
+avgRowSize=33.0
 numNodes=0
 
 PLAN FRAGMENT 4

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q5.sql
@@ -24,7 +24,7 @@ group by
 order by
     revenue desc ;
 [fragment statistics]
-PLAN FRAGMENT 0(F14)
+PLAN FRAGMENT 0(F12)
 Output Exprs:46: N_NAME | 55: sum
 Input Partition: UNPARTITIONED
 RESULT SINK

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q5.sql
@@ -29,19 +29,19 @@ Output Exprs:46: N_NAME | 55: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-28:MERGING-EXCHANGE
+27:MERGING-EXCHANGE
 cardinality: 5
 column statistics:
 * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 
-PLAN FRAGMENT 1(F13)
+PLAN FRAGMENT 1(F11)
 
 Input Partition: HASH_PARTITIONED: 46: N_NAME
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 28
+OutPut Exchange Id: 27
 
-27:SORT
+26:SORT
 |  order by: [55, DOUBLE, true] DESC
 |  offset: 0
 |  cardinality: 5
@@ -49,7 +49,7 @@ OutPut Exchange Id: 28
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-26:AGGREGATE (merge finalize)
+25:AGGREGATE (merge finalize)
 |  aggregate: sum[([55: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  group by: [46: N_NAME, VARCHAR, false]
 |  cardinality: 5
@@ -57,16 +57,16 @@ OutPut Exchange Id: 28
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-25:EXCHANGE
+24:EXCHANGE
 cardinality: 5
 
 PLAN FRAGMENT 2(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 46: N_NAME
-OutPut Exchange Id: 25
+OutPut Exchange Id: 24
 
-24:AGGREGATE (update serialize)
+23:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: sum[([54: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  group by: [46: N_NAME, VARCHAR, false]
@@ -75,69 +75,72 @@ OutPut Exchange Id: 25
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-23:Project
+22:Project
 |  output columns:
 |  46 <-> [46: N_NAME, VARCHAR, false]
 |  54 <-> [25: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [26: L_DISCOUNT, DOUBLE, false]
-|  cardinality: 16381891
+|  cardinality: 20477364
 |  column statistics:
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-22:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
-|  equal join conjunct: [4: C_NATIONKEY, INT, false] = [40: S_NATIONKEY, INT, false]
+21:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [4: C_NATIONKEY, INT, false]
+|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (37: S_SUPPKEY), remote = false
-|  - filter_id = 5, build_expr = (40: S_NATIONKEY), remote = true
+|  - filter_id = 4, build_expr = (4: C_NATIONKEY), remote = false
+|  - filter_id = 5, build_expr = (10: O_ORDERKEY), remote = false
 |  output columns: 25, 26, 46
-|  cardinality: 16381891
+|  cardinality: 20477364
 |  column statistics:
 |  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|
+|----20:EXCHANGE
+|       cardinality: 22752627
+|
+13:Project
+|  output columns:
+|  20 <-> [20: L_ORDERKEY, INT, false]
+|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
+|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+12:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (37: S_SUPPKEY), remote = false
+|  output columns: 20, 25, 26, 40, 46
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
 |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
 |  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-|----21:EXCHANGE
+|----11:EXCHANGE
 |       cardinality: 200000
-|
-10:Project
-|  output columns:
-|  4 <-> [4: C_NATIONKEY, INT, false]
-|  22 <-> [22: L_SUPPKEY, INT, false]
-|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
-|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
-|  cardinality: 91010508
-|  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-9:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (10: O_ORDERKEY), remote = false
-|  output columns: 4, 22, 25, 26
-|  cardinality: 91010508
-|  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-|----8:EXCHANGE
-|       cardinality: 22752627
 |       probe runtime filters:
-|       - filter_id = 5, probe_expr = (4: C_NATIONKEY)
+|       - filter_id = 4, probe_expr = (40: S_NATIONKEY)
 |
 0:OlapScanNode
 table: lineitem, rollup: lineitem
@@ -146,8 +149,8 @@ partitionsRatio=1/1, tabletsRatio=20/20
 actualRows=0, avgRowSize=28.0
 cardinality: 600000000
 probe runtime filters:
-- filter_id = 1, probe_expr = (20: L_ORDERKEY)
-- filter_id = 4, probe_expr = (22: L_SUPPKEY)
+- filter_id = 2, probe_expr = (22: L_SUPPKEY)
+- filter_id = 5, probe_expr = (20: L_ORDERKEY)
 column statistics:
 * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
@@ -157,123 +160,10 @@ column statistics:
 PLAN FRAGMENT 3(F07)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 21
-
-20:Project
-|  output columns:
-|  37 <-> [37: S_SUPPKEY, INT, false]
-|  40 <-> [40: S_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, VARCHAR, false]
-|  cardinality: 200000
-|  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-19:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 3, build_expr = (45: N_NATIONKEY), remote = false
-|  output columns: 37, 40, 46
-|  cardinality: 200000
-|  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-|----18:EXCHANGE
-|       cardinality: 5
-|
-11:OlapScanNode
-table: supplier, rollup: supplier
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=8.0
-cardinality: 1000000
-probe runtime filters:
-- filter_id = 3, probe_expr = (40: S_NATIONKEY)
-column statistics:
-* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 4(F08)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 18
-
-17:Project
-|  output columns:
-|  45 <-> [45: N_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, CHAR, false]
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-16:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (50: R_REGIONKEY), remote = false
-|  output columns: 45, 46
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-|----15:EXCHANGE
-|       cardinality: 1
-|
-12:OlapScanNode
-table: nation, rollup: nation
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=33.0
-cardinality: 25
-probe runtime filters:
-- filter_id = 2, probe_expr = (47: N_REGIONKEY)
-column statistics:
-* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
-
-PLAN FRAGMENT 5(F09)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 15
-
-14:Project
-|  output columns:
-|  50 <-> [50: R_REGIONKEY, INT, false]
-|  cardinality: 1
-|  column statistics:
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-13:OlapScanNode
-table: region, rollup: region
-preAggregation: on
-Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=29.0
-cardinality: 1
-column statistics:
-* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
-
-PLAN FRAGMENT 6(F05)
-
-Input Partition: HASH_PARTITIONED: 11: O_CUSTKEY
 OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
-OutPut Exchange Id: 08
+OutPut Exchange Id: 20
 
-7:Project
+19:Project
 |  output columns:
 |  4 <-> [4: C_NATIONKEY, INT, false]
 |  10 <-> [10: O_ORDERKEY, INT, false]
@@ -282,9 +172,11 @@ OutPut Exchange Id: 08
 |  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
 |
-6:HASH JOIN
-|  join op: INNER JOIN (PARTITIONED)
-|  equal join conjunct: [11: O_CUSTKEY, INT, false] = [1: C_CUSTKEY, INT, false]
+18:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [1: C_CUSTKEY, INT, false] = [11: O_CUSTKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 3, build_expr = (11: O_CUSTKEY), remote = false
 |  output columns: 4, 10
 |  cardinality: 22752627
 |  column statistics:
@@ -293,37 +185,28 @@ OutPut Exchange Id: 08
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
 |  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-|----5:EXCHANGE
-|       cardinality: 15000000
+|----17:EXCHANGE
+|       cardinality: 22752627
 |
-3:EXCHANGE
-cardinality: 22752627
-
-PLAN FRAGMENT 7(F03)
-
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 1: C_CUSTKEY
-OutPut Exchange Id: 05
-
-4:OlapScanNode
+14:OlapScanNode
 table: customer, rollup: customer
 preAggregation: on
 partitionsRatio=1/1, tabletsRatio=10/10
 actualRows=0, avgRowSize=12.0
 cardinality: 15000000
 probe runtime filters:
-- filter_id = 5, probe_expr = (4: C_NATIONKEY)
+- filter_id = 3, probe_expr = (1: C_CUSTKEY)
 column statistics:
 * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
 * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 8(F01)
+PLAN FRAGMENT 4(F08)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 11: O_CUSTKEY
-OutPut Exchange Id: 03
+OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 11: O_CUSTKEY
+OutPut Exchange Id: 17
 
-2:Project
+16:Project
 |  output columns:
 |  10 <-> [10: O_ORDERKEY, INT, false]
 |  11 <-> [11: O_CUSTKEY, INT, false]
@@ -332,7 +215,7 @@ OutPut Exchange Id: 03
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
 |  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-1:OlapScanNode
+15:OlapScanNode
 table: orders, rollup: orders
 preAggregation: on
 Predicates: [14: O_ORDERDATE, DATE, false] >= '1995-01-01', [14: O_ORDERDATE, DATE, false] < '1996-01-01'
@@ -343,4 +226,117 @@ column statistics:
 * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2752627E7] ESTIMATE
 * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 * O_ORDERDATE-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2406.0] ESTIMATE
+
+PLAN FRAGMENT 5(F01)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 11
+
+10:Project
+|  output columns:
+|  37 <-> [37: S_SUPPKEY, INT, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 200000
+|  column statistics:
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+9:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 1, build_expr = (45: N_NATIONKEY), remote = false
+|  output columns: 37, 40, 46
+|  cardinality: 200000
+|  column statistics:
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+|----8:EXCHANGE
+|       cardinality: 5
+|
+1:OlapScanNode
+table: supplier, rollup: supplier
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=8.0
+cardinality: 1000000
+probe runtime filters:
+- filter_id = 1, probe_expr = (40: S_NATIONKEY)
+column statistics:
+* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 6(F02)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 08
+
+7:Project
+|  output columns:
+|  45 <-> [45: N_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, CHAR, false]
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+6:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 0, build_expr = (50: R_REGIONKEY), remote = false
+|  output columns: 45, 46
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+|----5:EXCHANGE
+|       cardinality: 1
+|
+2:OlapScanNode
+table: nation, rollup: nation
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=33.0
+cardinality: 25
+probe runtime filters:
+- filter_id = 0, probe_expr = (47: N_REGIONKEY)
+column statistics:
+* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+
+PLAN FRAGMENT 7(F03)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 05
+
+4:Project
+|  output columns:
+|  50 <-> [50: R_REGIONKEY, INT, false]
+|  cardinality: 1
+|  column statistics:
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+3:OlapScanNode
+table: region, rollup: region
+preAggregation: on
+Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=29.0
+cardinality: 1
+column statistics:
+* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
 [end]

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q8.sql
@@ -37,12 +37,12 @@ group by
 order by
     o_year ;
 [fragment statistics]
-PLAN FRAGMENT 0(F16)
+PLAN FRAGMENT 0(F20)
 Output Exprs:69: year | 74: expr
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-36:MERGING-EXCHANGE
+38:MERGING-EXCHANGE
 cardinality: 2
 column statistics:
 * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
@@ -50,13 +50,13 @@ column statistics:
 * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
 
-PLAN FRAGMENT 1(F15)
+PLAN FRAGMENT 1(F19)
 
 Input Partition: HASH_PARTITIONED: 69: year
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 36
+OutPut Exchange Id: 38
 
-35:SORT
+37:SORT
 |  order by: [69, SMALLINT, false] ASC
 |  offset: 0
 |  cardinality: 2
@@ -66,7 +66,7 @@ OutPut Exchange Id: 36
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
 |
-34:Project
+36:Project
 |  output columns:
 |  69 <-> [69: year, SMALLINT, false]
 |  74 <-> [72: sum, DOUBLE, true] / [73: sum, DOUBLE, true]
@@ -75,7 +75,7 @@ OutPut Exchange Id: 36
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
 |
-33:AGGREGATE (merge finalize)
+35:AGGREGATE (merge finalize)
 |  aggregate: sum[([72: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([73: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  group by: [69: year, SMALLINT, false]
 |  cardinality: 2
@@ -85,16 +85,16 @@ OutPut Exchange Id: 36
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
 |
-32:EXCHANGE
+34:EXCHANGE
 cardinality: 2
 
-PLAN FRAGMENT 2(F00)
+PLAN FRAGMENT 2(F16)
 
-Input Partition: RANDOM
+Input Partition: HASH_PARTITIONED: 21: L_SUPPKEY
 OutPut Partition: HASH_PARTITIONED: 69: year
-OutPut Exchange Id: 32
+OutPut Exchange Id: 34
 
-31:AGGREGATE (update serialize)
+33:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: sum[([71: case, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([70: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  group by: [69: year, SMALLINT, false]
@@ -104,7 +104,7 @@ OutPut Exchange Id: 32
 |  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |
-30:Project
+32:Project
 |  output columns:
 |  69 <-> year[([40: O_ORDERDATE, DATE, false]); args: DATE; result: SMALLINT; args nullable: false; result nullable: false]
 |  70 <-> [76: multiply, DOUBLE, false]
@@ -112,19 +112,19 @@ OutPut Exchange Id: 32
 |  common expressions:
 |  75 <-> 1.0 - [25: L_DISCOUNT, DOUBLE, false]
 |  76 <-> [24: L_EXTENDEDPRICE, DOUBLE, false] * [75: subtract, DOUBLE, false]
-|  cardinality: 6425045
+|  cardinality: 3000000
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * case-->[-Infinity, Infinity, 0.0, 8.0, 932378.0] ESTIMATE
 |
-29:HASH JOIN
+31:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [14: S_NATIONKEY, INT, false] = [60: N_NATIONKEY, INT, false]
 |  build runtime filters:
 |  - filter_id = 6, build_expr = (60: N_NATIONKEY), remote = true
 |  output columns: 24, 25, 40, 61
-|  cardinality: 6425045
+|  cardinality: 3000000
 |  column statistics:
 |  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
@@ -136,29 +136,29 @@ OutPut Exchange Id: 32
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * case-->[-Infinity, Infinity, 0.0, 8.0, 932378.0] ESTIMATE
 |
-|----28:EXCHANGE
+|----30:EXCHANGE
 |       cardinality: 25
 |
-26:Project
+28:Project
 |  output columns:
 |  14 <-> [14: S_NATIONKEY, INT, false]
 |  24 <-> [24: L_EXTENDEDPRICE, DOUBLE, false]
 |  25 <-> [25: L_DISCOUNT, DOUBLE, false]
 |  40 <-> [40: O_ORDERDATE, DATE, false]
-|  cardinality: 6425045
+|  cardinality: 3000000
 |  column statistics:
 |  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
 |
-25:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+27:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  equal join conjunct: [21: L_SUPPKEY, INT, false] = [11: S_SUPPKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 5, build_expr = (11: S_SUPPKEY), remote = false
+|  - filter_id = 5, build_expr = (11: S_SUPPKEY), remote = true
 |  output columns: 14, 24, 25, 40
-|  cardinality: 6425045
+|  cardinality: 3000000
 |  column statistics:
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -167,30 +167,219 @@ OutPut Exchange Id: 32
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
 |
-|----24:EXCHANGE
+|----26:EXCHANGE
 |       cardinality: 1000000
 |       probe runtime filters:
 |       - filter_id = 6, probe_expr = (14: S_NATIONKEY)
 |
-22:Project
+24:EXCHANGE
+cardinality: 3000000
+
+PLAN FRAGMENT 3(F17)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 30
+
+29:OlapScanNode
+table: nation, rollup: nation
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=29.0
+cardinality: 25
+column statistics:
+* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 4(F14)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 11: S_SUPPKEY
+OutPut Exchange Id: 26
+
+25:OlapScanNode
+table: supplier, rollup: supplier
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=8.0
+cardinality: 1000000
+probe runtime filters:
+- filter_id = 6, probe_expr = (14: S_NATIONKEY)
+column statistics:
+* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 5(F12)
+
+Input Partition: HASH_PARTITIONED: 37: O_CUSTKEY
+OutPut Partition: HASH_PARTITIONED: 21: L_SUPPKEY
+OutPut Exchange Id: 24
+
+23:Project
 |  output columns:
 |  21 <-> [21: L_SUPPKEY, INT, false]
 |  24 <-> [24: L_EXTENDEDPRICE, DOUBLE, false]
 |  25 <-> [25: L_DISCOUNT, DOUBLE, false]
 |  40 <-> [40: O_ORDERDATE, DATE, false]
-|  cardinality: 6425045
+|  cardinality: 3000000
 |  column statistics:
 |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
 |
-21:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [19: L_ORDERKEY, INT, false] = [36: O_ORDERKEY, INT, false]
+22:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [37: O_CUSTKEY, INT, false] = [46: C_CUSTKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (36: O_ORDERKEY), remote = false
+|  - filter_id = 4, build_expr = (46: C_CUSTKEY), remote = true
 |  output columns: 21, 24, 25, 40
+|  cardinality: 3000000
+|  column statistics:
+|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
+|  * C_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|
+|----21:EXCHANGE
+|       cardinality: 3000000
+|
+10:EXCHANGE
+cardinality: 6425045
+
+PLAN FRAGMENT 6(F06)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 46: C_CUSTKEY
+OutPut Exchange Id: 21
+
+20:Project
+|  output columns:
+|  46 <-> [46: C_CUSTKEY, INT, false]
+|  cardinality: 3000000
+|  column statistics:
+|  * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|
+19:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [49: C_NATIONKEY, INT, false] = [55: N_NATIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 3, build_expr = (55: N_NATIONKEY), remote = false
+|  output columns: 46
+|  cardinality: 3000000
+|  column statistics:
+|  * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|
+|----18:EXCHANGE
+|       cardinality: 5
+|
+11:OlapScanNode
+table: customer, rollup: customer
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=10/10
+actualRows=0, avgRowSize=12.0
+cardinality: 15000000
+probe runtime filters:
+- filter_id = 3, probe_expr = (49: C_NATIONKEY)
+column statistics:
+* C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 7(F07)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 18
+
+17:Project
+|  output columns:
+|  55 <-> [55: N_NATIONKEY, INT, false]
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|
+16:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [57: N_REGIONKEY, INT, false] = [65: R_REGIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (65: R_REGIONKEY), remote = false
+|  output columns: 55
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+|----15:EXCHANGE
+|       cardinality: 1
+|
+12:OlapScanNode
+table: nation, rollup: nation
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=8.0
+cardinality: 25
+probe runtime filters:
+- filter_id = 2, probe_expr = (57: N_REGIONKEY)
+column statistics:
+* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+
+PLAN FRAGMENT 8(F08)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 15
+
+14:Project
+|  output columns:
+|  65 <-> [65: R_REGIONKEY, INT, false]
+|  cardinality: 1
+|  column statistics:
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+13:OlapScanNode
+table: region, rollup: region
+preAggregation: on
+Predicates: [66: R_NAME, CHAR, false] = 'MIDDLE EAST'
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=29.0
+cardinality: 1
+column statistics:
+* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
+
+PLAN FRAGMENT 9(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 37: O_CUSTKEY
+OutPut Exchange Id: 10
+
+9:Project
+|  output columns:
+|  21 <-> [21: L_SUPPKEY, INT, false]
+|  24 <-> [24: L_EXTENDEDPRICE, DOUBLE, false]
+|  25 <-> [25: L_DISCOUNT, DOUBLE, false]
+|  37 <-> [37: O_CUSTKEY, INT, false]
+|  40 <-> [40: O_ORDERDATE, DATE, false]
+|  cardinality: 6425045
+|  column statistics:
+|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 6425044.833617465] ESTIMATE
+|  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
+|
+8:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [36: O_ORDERKEY, INT, false] = [19: L_ORDERKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 1, build_expr = (19: L_ORDERKEY), remote = false
+|  output columns: 21, 24, 25, 37, 40
 |  cardinality: 6425045
 |  column statistics:
 |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 6425044.833617464] ESTIMATE
@@ -198,12 +387,34 @@ OutPut Exchange Id: 32
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 6425044.833617464] ESTIMATE
+|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 6425044.833617465] ESTIMATE
 |  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
 |
-|----20:EXCHANGE
-|       cardinality: 13687215
+|----7:EXCHANGE
+|       cardinality: 6425045
 |
-5:Project
+0:OlapScanNode
+table: orders, rollup: orders
+preAggregation: on
+Predicates: [40: O_ORDERDATE, DATE, false] >= '1995-01-01', [40: O_ORDERDATE, DATE, false] <= '1996-12-31'
+partitionsRatio=1/1, tabletsRatio=10/10
+actualRows=0, avgRowSize=20.0
+cardinality: 45622224
+probe runtime filters:
+- filter_id = 1, probe_expr = (36: O_ORDERKEY)
+- filter_id = 4, probe_expr = (37: O_CUSTKEY)
+column statistics:
+* O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4.5622224E7] ESTIMATE
+* O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
+* O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
+
+PLAN FRAGMENT 10(F01)
+
+Input Partition: RANDOM
+OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 19: L_ORDERKEY
+OutPut Exchange Id: 07
+
+6:Project
 |  output columns:
 |  19 <-> [19: L_ORDERKEY, INT, false]
 |  21 <-> [21: L_SUPPKEY, INT, false]
@@ -216,7 +427,7 @@ OutPut Exchange Id: 32
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-4:HASH JOIN
+5:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [20: L_PARTKEY, INT, false] = [1: P_PARTKEY, INT, false]
 |  build runtime filters:
@@ -231,10 +442,10 @@ OutPut Exchange Id: 32
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-|----3:EXCHANGE
+|----4:EXCHANGE
 |       cardinality: 214168
 |
-0:OlapScanNode
+1:OlapScanNode
 table: lineitem, rollup: lineitem
 preAggregation: on
 partitionsRatio=1/1, tabletsRatio=20/20
@@ -242,7 +453,6 @@ actualRows=0, avgRowSize=36.0
 cardinality: 600000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (20: L_PARTKEY)
-- filter_id = 4, probe_expr = (19: L_ORDERKEY)
 - filter_id = 5, probe_expr = (21: L_SUPPKEY)
 column statistics:
 * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
@@ -251,203 +461,20 @@ column statistics:
 * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 
-PLAN FRAGMENT 3(F13)
+PLAN FRAGMENT 11(F02)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 28
+OutPut Exchange Id: 04
 
-27:OlapScanNode
-table: nation, rollup: nation
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=29.0
-cardinality: 25
-column statistics:
-* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 4(F11)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 24
-
-23:OlapScanNode
-table: supplier, rollup: supplier
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=8.0
-cardinality: 1000000
-probe runtime filters:
-- filter_id = 6, probe_expr = (14: S_NATIONKEY)
-column statistics:
-* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 5(F03)
-
-Input Partition: RANDOM
-OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 36: O_ORDERKEY
-OutPut Exchange Id: 20
-
-19:Project
-|  output columns:
-|  36 <-> [36: O_ORDERKEY, INT, false]
-|  40 <-> [40: O_ORDERDATE, DATE, false]
-|  cardinality: 13687215
-|  column statistics:
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.3687214688587544E7] ESTIMATE
-|  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
-|
-18:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [37: O_CUSTKEY, INT, false] = [46: C_CUSTKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 3, build_expr = (46: C_CUSTKEY), remote = false
-|  output columns: 36, 40
-|  cardinality: 13687215
-|  column statistics:
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.3687214688587544E7] ESTIMATE
-|  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|  * O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
-|  * C_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|
-|----17:EXCHANGE
-|       cardinality: 3000000
-|
-6:OlapScanNode
-table: orders, rollup: orders
-preAggregation: on
-Predicates: [40: O_ORDERDATE, DATE, false] >= '1995-01-01', [40: O_ORDERDATE, DATE, false] <= '1996-12-31'
-partitionsRatio=1/1, tabletsRatio=10/10
-actualRows=0, avgRowSize=20.0
-cardinality: 45622224
-probe runtime filters:
-- filter_id = 3, probe_expr = (37: O_CUSTKEY)
-column statistics:
-* O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4.5622224E7] ESTIMATE
-* O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
-* O_ORDERDATE-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2406.0] ESTIMATE
-
-PLAN FRAGMENT 6(F04)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 17
-
-16:Project
-|  output columns:
-|  46 <-> [46: C_CUSTKEY, INT, false]
-|  cardinality: 3000000
-|  column statistics:
-|  * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|
-15:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [49: C_NATIONKEY, INT, false] = [55: N_NATIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (55: N_NATIONKEY), remote = false
-|  output columns: 46
-|  cardinality: 3000000
-|  column statistics:
-|  * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|
-|----14:EXCHANGE
-|       cardinality: 5
-|
-7:OlapScanNode
-table: customer, rollup: customer
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=10/10
-actualRows=0, avgRowSize=12.0
-cardinality: 15000000
-probe runtime filters:
-- filter_id = 2, probe_expr = (49: C_NATIONKEY)
-column statistics:
-* C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 7(F05)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 14
-
-13:Project
-|  output columns:
-|  55 <-> [55: N_NATIONKEY, INT, false]
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|
-12:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [57: N_REGIONKEY, INT, false] = [65: R_REGIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (65: R_REGIONKEY), remote = false
-|  output columns: 55
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-|----11:EXCHANGE
-|       cardinality: 1
-|
-8:OlapScanNode
-table: nation, rollup: nation
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=8.0
-cardinality: 25
-probe runtime filters:
-- filter_id = 1, probe_expr = (57: N_REGIONKEY)
-column statistics:
-* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
-
-PLAN FRAGMENT 8(F06)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 11
-
-10:Project
-|  output columns:
-|  65 <-> [65: R_REGIONKEY, INT, false]
-|  cardinality: 1
-|  column statistics:
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-9:OlapScanNode
-table: region, rollup: region
-preAggregation: on
-Predicates: [66: R_NAME, CHAR, false] = 'MIDDLE EAST'
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=29.0
-cardinality: 1
-column statistics:
-* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
-
-PLAN FRAGMENT 9(F01)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 03
-
-2:Project
+3:Project
 |  output columns:
 |  1 <-> [1: P_PARTKEY, INT, false]
 |  cardinality: 214168
 |  column statistics:
 |  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 214168.16112058214] ESTIMATE
 |
-1:OlapScanNode
+2:OlapScanNode
 table: part, rollup: part
 preAggregation: on
 Predicates: [5: P_TYPE, VARCHAR, false] = 'ECONOMY ANODIZED STEEL'

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q18.sql
@@ -67,25 +67,11 @@ UNPARTITIONED
 |  <slot 24> : 24: L_QUANTITY
 |
 13:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  colocate: false, reason:
-|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
-|
-|----12:EXCHANGE
-|
-10:Project
-|  <slot 10> : 10: O_ORDERKEY
-|  <slot 11> : 11: O_CUSTKEY
-|  <slot 13> : 13: O_TOTALPRICE
-|  <slot 14> : 14: O_ORDERDATE
-|  <slot 24> : 24: L_QUANTITY
-|
-9:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
 |  colocate: false, reason:
 |  equal join conjunct: 20: L_ORDERKEY = 10: O_ORDERKEY
 |
-|----8:EXCHANGE
+|----12:EXCHANGE
 |
 0:OlapScanNode
 TABLE: lineitem
@@ -103,26 +89,22 @@ PARTITION: RANDOM
 
 STREAM DATA SINK
 EXCHANGE ID: 12
-UNPARTITIONED
-
-11:OlapScanNode
-TABLE: customer
-PREAGGREGATION: ON
-partitions=1/1
-rollup: customer
-tabletRatio=10/10
-cardinality=15000000
-avgRowSize=33.0
-numNodes=0
-
-PLAN FRAGMENT 3
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 08
 BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
 
+11:Project
+|  <slot 1> : 1: C_CUSTKEY
+|  <slot 2> : 2: C_NAME
+|  <slot 10> : 10: O_ORDERKEY
+|  <slot 13> : 13: O_TOTALPRICE
+|  <slot 14> : 14: O_ORDERDATE
+|
+10:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  colocate: false, reason:
+|  equal join conjunct: 11: O_CUSTKEY = 1: C_CUSTKEY
+|
+|----9:EXCHANGE
+|
 7:Project
 |  <slot 10> : 10: O_ORDERKEY
 |  <slot 11> : 11: O_CUSTKEY
@@ -144,6 +126,24 @@ rollup: orders
 tabletRatio=10/10
 cardinality=150000000
 avgRowSize=28.0
+numNodes=0
+
+PLAN FRAGMENT 3
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 09
+UNPARTITIONED
+
+8:OlapScanNode
+TABLE: customer
+PREAGGREGATION: ON
+partitions=1/1
+rollup: customer
+tabletRatio=10/10
+cardinality=15000000
+avgRowSize=33.0
 numNodes=0
 
 PLAN FRAGMENT 4

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
@@ -24,24 +24,24 @@ group by
 order by
     revenue desc ;
 [fragment statistics]
-PLAN FRAGMENT 0(F14)
+PLAN FRAGMENT 0(F12)
 Output Exprs:46: N_NAME | 55: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-28:MERGING-EXCHANGE
+27:MERGING-EXCHANGE
 cardinality: 5
 column statistics:
 * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 
-PLAN FRAGMENT 1(F13)
+PLAN FRAGMENT 1(F11)
 
 Input Partition: HASH_PARTITIONED: 46: N_NAME
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 28
+OutPut Exchange Id: 27
 
-27:SORT
+26:SORT
 |  order by: [55, DOUBLE, true] DESC
 |  offset: 0
 |  cardinality: 5
@@ -49,7 +49,7 @@ OutPut Exchange Id: 28
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-26:AGGREGATE (merge finalize)
+25:AGGREGATE (merge finalize)
 |  aggregate: sum[([55: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  group by: [46: N_NAME, VARCHAR, false]
 |  cardinality: 5
@@ -57,16 +57,16 @@ OutPut Exchange Id: 28
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-25:EXCHANGE
+24:EXCHANGE
 cardinality: 5
 
 PLAN FRAGMENT 2(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 46: N_NAME
-OutPut Exchange Id: 25
+OutPut Exchange Id: 24
 
-24:AGGREGATE (update serialize)
+23:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: sum[([54: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  group by: [46: N_NAME, VARCHAR, false]
@@ -75,69 +75,72 @@ OutPut Exchange Id: 25
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 5.0] ESTIMATE
 |
-23:Project
+22:Project
 |  output columns:
 |  46 <-> [46: N_NAME, VARCHAR, false]
 |  54 <-> [25: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [26: L_DISCOUNT, DOUBLE, false]
-|  cardinality: 16390852
+|  cardinality: 20488565
 |  column statistics:
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-22:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
-|  equal join conjunct: [4: C_NATIONKEY, INT, false] = [40: S_NATIONKEY, INT, false]
+21:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [4: C_NATIONKEY, INT, false]
+|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (37: S_SUPPKEY), remote = false
-|  - filter_id = 5, build_expr = (40: S_NATIONKEY), remote = true
+|  - filter_id = 4, build_expr = (4: C_NATIONKEY), remote = false
+|  - filter_id = 5, build_expr = (10: O_ORDERKEY), remote = false
 |  output columns: 25, 26, 46
-|  cardinality: 16390852
+|  cardinality: 20488565
 |  column statistics:
 |  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|
+|----20:EXCHANGE
+|       cardinality: 22765073
+|
+13:Project
+|  output columns:
+|  20 <-> [20: L_ORDERKEY, INT, false]
+|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
+|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+12:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [22: L_SUPPKEY, INT, false] = [37: S_SUPPKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (37: S_SUPPKEY), remote = false
+|  output columns: 20, 25, 26, 40, 46
+|  cardinality: 120000000
+|  column statistics:
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E8] ESTIMATE
 |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
 |  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
 |  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
 |  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
-|----21:EXCHANGE
+|----11:EXCHANGE
 |       cardinality: 200000
-|
-10:Project
-|  output columns:
-|  4 <-> [4: C_NATIONKEY, INT, false]
-|  22 <-> [22: L_SUPPKEY, INT, false]
-|  25 <-> [25: L_EXTENDEDPRICE, DOUBLE, false]
-|  26 <-> [26: L_DISCOUNT, DOUBLE, false]
-|  cardinality: 91060291
-|  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-9:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [20: L_ORDERKEY, INT, false] = [10: O_ORDERKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (10: O_ORDERKEY), remote = false
-|  output columns: 4, 22, 25, 26
-|  cardinality: 91060291
-|  column statistics:
-|  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-|  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
-|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|
-|----8:EXCHANGE
-|       cardinality: 22765073
 |       probe runtime filters:
-|       - filter_id = 5, probe_expr = (4: C_NATIONKEY)
+|       - filter_id = 4, probe_expr = (40: S_NATIONKEY)
 |
 0:OlapScanNode
 table: lineitem, rollup: lineitem
@@ -146,8 +149,8 @@ partitionsRatio=1/1, tabletsRatio=20/20
 actualRows=0, avgRowSize=28.0
 cardinality: 600000000
 probe runtime filters:
-- filter_id = 1, probe_expr = (20: L_ORDERKEY)
-- filter_id = 4, probe_expr = (22: L_SUPPKEY)
+- filter_id = 2, probe_expr = (22: L_SUPPKEY)
+- filter_id = 5, probe_expr = (20: L_ORDERKEY)
 column statistics:
 * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
@@ -157,123 +160,10 @@ column statistics:
 PLAN FRAGMENT 3(F07)
 
 Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 21
-
-20:Project
-|  output columns:
-|  37 <-> [37: S_SUPPKEY, INT, false]
-|  40 <-> [40: S_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, VARCHAR, false]
-|  cardinality: 200000
-|  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-19:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 3, build_expr = (45: N_NATIONKEY), remote = false
-|  output columns: 37, 40, 46
-|  cardinality: 200000
-|  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
-|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-|----18:EXCHANGE
-|       cardinality: 5
-|
-11:OlapScanNode
-table: supplier, rollup: supplier
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=8.0
-cardinality: 1000000
-probe runtime filters:
-- filter_id = 3, probe_expr = (40: S_NATIONKEY)
-column statistics:
-* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 4(F08)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 18
-
-17:Project
-|  output columns:
-|  45 <-> [45: N_NATIONKEY, INT, false]
-|  46 <-> [46: N_NAME, CHAR, false]
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|
-16:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (50: R_REGIONKEY), remote = false
-|  output columns: 45, 46
-|  cardinality: 5
-|  column statistics:
-|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
-|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-|----15:EXCHANGE
-|       cardinality: 1
-|
-12:OlapScanNode
-table: nation, rollup: nation
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=33.0
-cardinality: 25
-probe runtime filters:
-- filter_id = 2, probe_expr = (47: N_REGIONKEY)
-column statistics:
-* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
-
-PLAN FRAGMENT 5(F09)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 15
-
-14:Project
-|  output columns:
-|  50 <-> [50: R_REGIONKEY, INT, false]
-|  cardinality: 1
-|  column statistics:
-|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-13:OlapScanNode
-table: region, rollup: region
-preAggregation: on
-Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
-partitionsRatio=1/1, tabletsRatio=1/1
-actualRows=0, avgRowSize=29.0
-cardinality: 1
-column statistics:
-* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
-
-PLAN FRAGMENT 6(F05)
-
-Input Partition: HASH_PARTITIONED: 11: O_CUSTKEY
 OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 10: O_ORDERKEY
-OutPut Exchange Id: 08
+OutPut Exchange Id: 20
 
-7:Project
+19:Project
 |  output columns:
 |  4 <-> [4: C_NATIONKEY, INT, false]
 |  10 <-> [10: O_ORDERKEY, INT, false]
@@ -282,9 +172,11 @@ OutPut Exchange Id: 08
 |  * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
 |
-6:HASH JOIN
-|  join op: INNER JOIN (PARTITIONED)
-|  equal join conjunct: [11: O_CUSTKEY, INT, false] = [1: C_CUSTKEY, INT, false]
+18:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [1: C_CUSTKEY, INT, false] = [11: O_CUSTKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 3, build_expr = (11: O_CUSTKEY), remote = false
 |  output columns: 4, 10
 |  cardinality: 22765073
 |  column statistics:
@@ -293,37 +185,28 @@ OutPut Exchange Id: 08
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
 |  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-|----5:EXCHANGE
-|       cardinality: 15000000
+|----17:EXCHANGE
+|       cardinality: 22765073
 |
-3:EXCHANGE
-cardinality: 22765073
-
-PLAN FRAGMENT 7(F03)
-
-Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 1: C_CUSTKEY
-OutPut Exchange Id: 05
-
-4:OlapScanNode
+14:OlapScanNode
 table: customer, rollup: customer
 preAggregation: on
 partitionsRatio=1/1, tabletsRatio=10/10
 actualRows=0, avgRowSize=12.0
 cardinality: 15000000
 probe runtime filters:
-- filter_id = 5, probe_expr = (4: C_NATIONKEY)
+- filter_id = 3, probe_expr = (1: C_CUSTKEY)
 column statistics:
 * C_CUSTKEY-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
 * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 8(F01)
+PLAN FRAGMENT 4(F08)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 11: O_CUSTKEY
-OutPut Exchange Id: 03
+OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 11: O_CUSTKEY
+OutPut Exchange Id: 17
 
-2:Project
+16:Project
 |  output columns:
 |  10 <-> [10: O_ORDERKEY, INT, false]
 |  11 <-> [11: O_CUSTKEY, INT, false]
@@ -332,7 +215,7 @@ OutPut Exchange Id: 03
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
 |  * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 |
-1:OlapScanNode
+15:OlapScanNode
 table: orders, rollup: orders
 preAggregation: on
 Predicates: [14: O_ORDERDATE, DATE, false] >= '1995-01-01', [14: O_ORDERDATE, DATE, false] < '1996-01-01'
@@ -343,6 +226,119 @@ column statistics:
 * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
 * O_CUSTKEY-->[1.0, 1.49999E7, 0.0, 8.0, 9999600.0] ESTIMATE
 * O_ORDERDATE-->[7.888896E8, 8.204256E8, 0.0, 4.0, 2406.0] ESTIMATE
+
+PLAN FRAGMENT 5(F01)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 11
+
+10:Project
+|  output columns:
+|  37 <-> [37: S_SUPPKEY, INT, false]
+|  40 <-> [40: S_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, VARCHAR, false]
+|  cardinality: 200000
+|  column statistics:
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+9:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [40: S_NATIONKEY, INT, false] = [45: N_NATIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 1, build_expr = (45: N_NATIONKEY), remote = false
+|  output columns: 37, 40, 46
+|  cardinality: 200000
+|  column statistics:
+|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 200000.0] ESTIMATE
+|  * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+|----8:EXCHANGE
+|       cardinality: 5
+|
+1:OlapScanNode
+table: supplier, rollup: supplier
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=8.0
+cardinality: 1000000
+probe runtime filters:
+- filter_id = 1, probe_expr = (40: S_NATIONKEY)
+column statistics:
+* S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+* S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 6(F02)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 08
+
+7:Project
+|  output columns:
+|  45 <-> [45: N_NATIONKEY, INT, false]
+|  46 <-> [46: N_NAME, CHAR, false]
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|
+6:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [47: N_REGIONKEY, INT, false] = [50: R_REGIONKEY, INT, false]
+|  build runtime filters:
+|  - filter_id = 0, build_expr = (50: R_REGIONKEY), remote = false
+|  output columns: 45, 46
+|  cardinality: 5
+|  column statistics:
+|  * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
+|  * N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+|----5:EXCHANGE
+|       cardinality: 1
+|
+2:OlapScanNode
+table: nation, rollup: nation
+preAggregation: on
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=33.0
+cardinality: 25
+probe runtime filters:
+- filter_id = 0, probe_expr = (47: N_REGIONKEY)
+column statistics:
+* N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
+* N_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+
+PLAN FRAGMENT 7(F03)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 05
+
+4:Project
+|  output columns:
+|  50 <-> [50: R_REGIONKEY, INT, false]
+|  cardinality: 1
+|  column statistics:
+|  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+3:OlapScanNode
+table: region, rollup: region
+preAggregation: on
+Predicates: [51: R_NAME, CHAR, false] = 'AFRICA'
+partitionsRatio=1/1, tabletsRatio=1/1
+actualRows=0, avgRowSize=29.0
+cardinality: 1
+column statistics:
+* R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* R_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
 [dump]
 {
   "statement": "select\n    n_name,\n    sum(l_extendedprice * (1 - l_discount)) as revenue\nfrom\n    customer,\n    orders,\n    lineitem,\n    supplier,\n    nation,\n    region\nwhere\n        c_custkey \u003d o_custkey\n  and l_orderkey \u003d o_orderkey\n  and l_suppkey \u003d s_suppkey\n  and c_nationkey \u003d s_nationkey\n  and s_nationkey \u003d n_nationkey\n  and n_regionkey \u003d r_regionkey\n  and r_name \u003d \u0027AFRICA\u0027\n  and o_orderdate \u003e\u003d date \u00271995-01-01\u0027\n  and o_orderdate \u003c date \u00271996-01-01\u0027\ngroup by\n    n_name\norder by\n    revenue desc ;\n",

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q8.sql
@@ -43,44 +43,44 @@ PARTITION: UNPARTITIONED
 
 RESULT SINK
 
-36:MERGING-EXCHANGE
+38:MERGING-EXCHANGE
 
 PLAN FRAGMENT 1
 OUTPUT EXPRS:
 PARTITION: HASH_PARTITIONED: 69: year
 
 STREAM DATA SINK
-EXCHANGE ID: 36
+EXCHANGE ID: 38
 UNPARTITIONED
 
-35:SORT
+37:SORT
 |  order by: <slot 69> 69: year ASC
 |  offset: 0
 |
-34:Project
+36:Project
 |  <slot 69> : 69: year
 |  <slot 74> : 72: sum / 73: sum
 |
-33:AGGREGATE (merge finalize)
+35:AGGREGATE (merge finalize)
 |  output: sum(72: sum), sum(73: sum)
 |  group by: 69: year
 |
-32:EXCHANGE
+34:EXCHANGE
 
 PLAN FRAGMENT 2
 OUTPUT EXPRS:
-PARTITION: RANDOM
+PARTITION: HASH_PARTITIONED: 21: L_SUPPKEY
 
 STREAM DATA SINK
-EXCHANGE ID: 32
+EXCHANGE ID: 34
 HASH_PARTITIONED: 69: year
 
-31:AGGREGATE (update serialize)
+33:AGGREGATE (update serialize)
 |  STREAMING
 |  output: sum(71: case), sum(70: expr)
 |  group by: 69: year
 |
-30:Project
+32:Project
 |  <slot 69> : year(40: O_ORDERDATE)
 |  <slot 70> : 76: multiply
 |  <slot 71> : if(61: N_NAME = 'IRAN', 76: multiply, 0.0)
@@ -88,39 +88,173 @@ HASH_PARTITIONED: 69: year
 |  <slot 75> : 1.0 - 25: L_DISCOUNT
 |  <slot 76> : 24: L_EXTENDEDPRICE * 75: subtract
 |
-29:HASH JOIN
+31:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  colocate: false, reason:
 |  equal join conjunct: 14: S_NATIONKEY = 60: N_NATIONKEY
 |
-|----28:EXCHANGE
+|----30:EXCHANGE
 |
-26:Project
+28:Project
 |  <slot 14> : 14: S_NATIONKEY
 |  <slot 24> : 24: L_EXTENDEDPRICE
 |  <slot 25> : 25: L_DISCOUNT
 |  <slot 40> : 40: O_ORDERDATE
 |
-25:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+27:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  colocate: false, reason:
 |  equal join conjunct: 21: L_SUPPKEY = 11: S_SUPPKEY
 |
-|----24:EXCHANGE
+|----26:EXCHANGE
 |
-22:Project
+24:EXCHANGE
+
+PLAN FRAGMENT 3
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 30
+UNPARTITIONED
+
+29:OlapScanNode
+TABLE: nation
+PREAGGREGATION: ON
+partitions=1/1
+rollup: nation
+tabletRatio=1/1
+cardinality=25
+avgRowSize=29.0
+numNodes=0
+
+PLAN FRAGMENT 4
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 26
+HASH_PARTITIONED: 11: S_SUPPKEY
+
+25:OlapScanNode
+TABLE: supplier
+PREAGGREGATION: ON
+partitions=1/1
+rollup: supplier
+tabletRatio=1/1
+cardinality=1000000
+avgRowSize=8.0
+numNodes=0
+
+PLAN FRAGMENT 5
+OUTPUT EXPRS:
+PARTITION: HASH_PARTITIONED: 37: O_CUSTKEY
+
+STREAM DATA SINK
+EXCHANGE ID: 24
+HASH_PARTITIONED: 21: L_SUPPKEY
+
+23:Project
 |  <slot 21> : 21: L_SUPPKEY
 |  <slot 24> : 24: L_EXTENDEDPRICE
 |  <slot 25> : 25: L_DISCOUNT
 |  <slot 40> : 40: O_ORDERDATE
 |
-21:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+22:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  colocate: false, reason:
 |  equal join conjunct: 37: O_CUSTKEY = 46: C_CUSTKEY
 |
-|----20:EXCHANGE
+|----21:EXCHANGE
 |
+10:EXCHANGE
+
+PLAN FRAGMENT 6
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 21
+HASH_PARTITIONED: 46: C_CUSTKEY
+
+20:Project
+|  <slot 46> : 46: C_CUSTKEY
+|
+19:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  colocate: false, reason:
+|  equal join conjunct: 49: C_NATIONKEY = 55: N_NATIONKEY
+|
+|----18:EXCHANGE
+|
+11:OlapScanNode
+TABLE: customer
+PREAGGREGATION: ON
+partitions=1/1
+rollup: customer
+tabletRatio=10/10
+cardinality=15000000
+avgRowSize=12.0
+numNodes=0
+
+PLAN FRAGMENT 7
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 18
+UNPARTITIONED
+
+17:Project
+|  <slot 55> : 55: N_NATIONKEY
+|
+16:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  colocate: false, reason:
+|  equal join conjunct: 57: N_REGIONKEY = 65: R_REGIONKEY
+|
+|----15:EXCHANGE
+|
+12:OlapScanNode
+TABLE: nation
+PREAGGREGATION: ON
+partitions=1/1
+rollup: nation
+tabletRatio=1/1
+cardinality=25
+avgRowSize=8.0
+numNodes=0
+
+PLAN FRAGMENT 8
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 15
+UNPARTITIONED
+
+14:Project
+|  <slot 65> : 65: R_REGIONKEY
+|
+13:OlapScanNode
+TABLE: region
+PREAGGREGATION: ON
+PREDICATES: 66: R_NAME = 'MIDDLE EAST'
+partitions=1/1
+rollup: region
+tabletRatio=1/1
+cardinality=1
+avgRowSize=29.0
+numNodes=0
+
+PLAN FRAGMENT 9
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 10
+HASH_PARTITIONED: 37: O_CUSTKEY
+
 9:Project
 |  <slot 21> : 21: L_SUPPKEY
 |  <slot 24> : 24: L_EXTENDEDPRICE
@@ -142,131 +276,11 @@ PREDICATES: 40: O_ORDERDATE >= '1995-01-01', 40: O_ORDERDATE <= '1996-12-31'
 partitions=1/1
 rollup: orders
 tabletRatio=10/10
-tabletList=10139,10141,10143,10145,10147,10149,10151,10153,10155,10157
 cardinality=45530146
 avgRowSize=20.0
 numNodes=0
 
-PLAN FRAGMENT 3
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 28
-UNPARTITIONED
-
-27:OlapScanNode
-TABLE: nation
-PREAGGREGATION: ON
-partitions=1/1
-rollup: nation
-tabletRatio=1/1
-tabletList=10185
-cardinality=25
-avgRowSize=29.0
-numNodes=0
-
-PLAN FRAGMENT 4
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 24
-UNPARTITIONED
-
-23:OlapScanNode
-TABLE: supplier
-PREAGGREGATION: ON
-partitions=1/1
-rollup: supplier
-tabletRatio=1/1
-tabletList=10111
-cardinality=1000000
-avgRowSize=8.0
-numNodes=0
-
-PLAN FRAGMENT 5
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 20
-UNPARTITIONED
-
-19:Project
-|  <slot 46> : 46: C_CUSTKEY
-|
-18:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  colocate: false, reason:
-|  equal join conjunct: 49: C_NATIONKEY = 55: N_NATIONKEY
-|
-|----17:EXCHANGE
-|
-10:OlapScanNode
-TABLE: customer
-PREAGGREGATION: ON
-partitions=1/1
-rollup: customer
-tabletRatio=10/10
-tabletList=10162,10164,10166,10168,10170,10172,10174,10176,10178,10180
-cardinality=15000000
-avgRowSize=12.0
-numNodes=0
-
-PLAN FRAGMENT 6
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 17
-UNPARTITIONED
-
-16:Project
-|  <slot 55> : 55: N_NATIONKEY
-|
-15:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  colocate: false, reason:
-|  equal join conjunct: 57: N_REGIONKEY = 65: R_REGIONKEY
-|
-|----14:EXCHANGE
-|
-11:OlapScanNode
-TABLE: nation
-PREAGGREGATION: ON
-partitions=1/1
-rollup: nation
-tabletRatio=1/1
-tabletList=10185
-cardinality=25
-avgRowSize=8.0
-numNodes=0
-
-PLAN FRAGMENT 7
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 14
-UNPARTITIONED
-
-13:Project
-|  <slot 65> : 65: R_REGIONKEY
-|
-12:OlapScanNode
-TABLE: region
-PREAGGREGATION: ON
-PREDICATES: 66: R_NAME = 'MIDDLE EAST'
-partitions=1/1
-rollup: region
-tabletRatio=1/1
-tabletList=10106
-cardinality=1
-avgRowSize=29.0
-numNodes=0
-
-PLAN FRAGMENT 8
+PLAN FRAGMENT 10
 OUTPUT EXPRS:
 PARTITION: RANDOM
 
@@ -293,12 +307,11 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: lineitem
 tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
 cardinality=600000000
 avgRowSize=36.0
 numNodes=0
 
-PLAN FRAGMENT 9
+PLAN FRAGMENT 11
 OUTPUT EXPRS:
 PARTITION: RANDOM
 
@@ -316,7 +329,6 @@ PREDICATES: 5: P_TYPE = 'ECONOMY ANODIZED STEEL'
 partitions=1/1
 rollup: part
 tabletRatio=10/10
-tabletList=10190,10192,10194,10196,10198,10200,10202,10204,10206,10208
 cardinality=133333
 avgRowSize=33.0
 numNodes=0


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For different distributed join execution methods, due to their different execution characteristics, they should have different cost. We currently have four execution modes: broadcast join, bucket_shuffle join, shuffle join, and colocate join. The latter three are essentially shuffle joins, so their execution efficiency can be approximately regarded as consistent. The implementation of broadcast join is a little different from the other three.
1. In the build hash table stage of broadcast join, the parallelism is 1 while it can be parallized in shuffle join.
2. Broadcast join consumes more memory for redundant data in multiple BEs.
3. The data size in each hash table of shuffle join is 1/parallelism of right table_size while it is full size in broadcast join. A small hash table can improve probe efficiency.
4. The process of redistributing data by shuffle operation makes the tasks of each processing thread are more balanced, and it is more conducive to parallel computing.
Therefore, our join execution cost calculation model should comprehensively consider parameters such as join execution mode, parallelism, and left and right table size. The most important thing in the model is the evaluation of the probe cost for each row. When the size of the right table is greater than bottom_number, the average probe cost needs to be expanded. The parallel computing characteristics of shuffle join can offset part of the probe cost. We also set an upper limit on the probe cost to avoid cost distortion caused by too large table data.

## Performance Test
Environment benchmark07.
TPCDS-1t from 806s to 637s.
TPCH-1t from 254s to 250s.

## UT changes
 - hive sql plan chanages. New join execution cost model inclined to shuffle join when the right table is larger than a million level. Cases with a 10M level table join with a 1M level table use shuffle join now. The changes of q2.sql reflects a bug. When the child's best plan was updated, his father's confidence statistics were not updated because of oldChildcost + oldEnforcerCost < newChildCost(smaller than old) + newEnforcerCost(bigger than old).
  
 - enumerate paln numbers changes. Join cost number has different from before which may lead to different prune operations.
 - Sqls in testCountPruneJoinByProject, testJoinWithPipelineDop use broadcast join before is very slow.  This pr optimizes them.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
