### PR TITLE
[WIP][Enhancement] optimize shuffle efficiency

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -600,6 +600,23 @@ static void BM_selective_int64(benchmark::State& state) {
 BENCHMARK(BM_selective_int64);
 
 // Benchmark shuffle string
+// Run on (104 X 3199.92 MHz CPU s)
+// CPU Caches:
+//   L1 Data 32 KiB (x52)
+//   L1 Instruction 32 KiB (x52)
+//   L2 Unified 1024 KiB (x52)
+//   L3 Unified 36608 KiB (x2)
+// Load Average: 40.86, 21.31, 19.16
+// -----------------------------------------------------------------------------------
+// Benchmark                         Time             CPU   Iterations UserCounters...
+// -----------------------------------------------------------------------------------
+// BM_selective_int64             3608 ns         3607 ns       188512 payload_size=32.768k
+// BM_selective_string/1         12989 ns        12988 ns        53864 payload_size=36.864k
+// BM_selective_string/4         13323 ns        13320 ns        52922 payload_size=49.152k
+// BM_selective_string/16        14101 ns        14099 ns        49830 payload_size=98.304k
+// BM_selective_string/64        25019 ns        24999 ns        28125 payload_size=294.912k
+// BM_selective_string/256       92448 ns        92436 ns         7573 payload_size=1081.34k
+// BM_selective_string/1024     342813 ns       342721 ns         1995 payload_size=4.22707M
 static void BM_selective_string(benchmark::State& state) {
     constexpr size_t kChunkSize = 4096;
     auto column = BinaryColumn::create();

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -67,10 +67,10 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
 
     auto* dest_bytes = _bytes.data();
     for (size_t i = 0; i < size; i++) {
-        uint32_t row_idx = indexes[from + i];
-        T str_size = src_offsets[row_idx + 1] - src_offsets[row_idx];
-        strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i], src_bytes.data() + src_offsets[row_idx],
-                                str_size);
+        T src_offset = src_offsets[from + i];
+        T src_length = src_offsets[from + i + 1] - src_offset;
+        T dst_offset = _offsets[cur_row_count + i];
+        strings::memcpy_inlined(dest_bytes + dst_offset, src_bytes.data() + src_offset, src_length);
     }
 
     _slices_cache = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Env:
```
Run on (104 X 3199.92 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x52)
  L1 Instruction 32 KiB (x52)
  L2 Unified 1024 KiB (x52)
  L3 Unified 36608 KiB (x2)
```

Before: 
```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
BM_selective_int64             3624 ns         3623 ns       188037 payload_size=32.768k
BM_selective_string/1         13929 ns        13928 ns        50389 payload_size=36.864k
BM_selective_string/4         14781 ns        14779 ns        47580 payload_size=49.152k
BM_selective_string/16        15525 ns        15523 ns        45177 payload_size=98.304k
BM_selective_string/64        37310 ns        37307 ns        18632 payload_size=294.912k
BM_selective_string/256      100471 ns       100462 ns         6962 payload_size=1081.34k
BM_selective_string/1024     388610 ns       388574 ns         1789 payload_size=4.22707M
```


After: 
```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
BM_selective_int64             3679 ns         3679 ns       191441 payload_size=32.768k
BM_selective_string/1         16530 ns        16529 ns        42370 payload_size=36.864k
BM_selective_string/4         16536 ns        16532 ns        42349 payload_size=49.152k
BM_selective_string/16        16691 ns        16690 ns        41947 payload_size=98.304k
BM_selective_string/64        26827 ns        26824 ns        23507 payload_size=294.912k
BM_selective_string/256       93103 ns        93094 ns         7517 payload_size=1081.34k
BM_selective_string/1024     345926 ns       345881 ns         2028 payload_size=4.22707M
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
