### PR TITLE
[BugFix] orc scanner should be case sensitive

### DIFF
--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -74,6 +74,7 @@ Status ORCScanner::open() {
     _orc_reader->set_timezone(_state->timezone());
     _orc_reader->drop_nanoseconds_in_datetime();
     _orc_reader->set_runtime_state(_state);
+    _orc_reader->set_case_sensitive(true);
     RETURN_IF_ERROR(_open_next_orc_reader());
 
     return Status::OK();

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1248,7 +1248,12 @@ Status OrcChunkReader::_init_position_in_orc() {
 
         if (slot_desc == nullptr) continue;
         auto it = _name_to_column_id.find(slot_desc->col_name());
-        DCHECK(it != _name_to_column_id.end());
+        if (it == _name_to_column_id.end()) {
+            auto s = strings::Substitute(
+                    "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1",
+                    slot_desc->col_name(), _current_file_name);
+            return Status::NotFound(s);
+        }
         int col_id = it->second;
         auto it2 = column_id_to_pos.find(col_id);
         if (it2 == column_id_to_pos.end()) {

--- a/be/test/exprs/vectorized/map_functions_test.cpp
+++ b/be/test/exprs/vectorized/map_functions_test.cpp
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
-#include "column/map_column.h"
 #include "column/column_helper.h"
+#include "column/map_column.h"
 #include "testutil/parallel_test.h"
 
 namespace starrocks::vectorized {

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -450,36 +450,36 @@ HdfsScannerContext* FileReaderTest::_create_file6_base_context() {
 }
 
 HdfsScannerContext* FileReaderTest::_create_file_map_base_context() {
-        auto ctx = _create_scan_context();
+    auto ctx = _create_scan_context();
 
-        TypeDescriptor type_map(PrimitiveType::TYPE_MAP);
-        type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
-        type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+    TypeDescriptor type_map(PrimitiveType::TYPE_MAP);
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
 
-        TypeDescriptor type_map_map(PrimitiveType::TYPE_MAP);
-        type_map_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
-        type_map_map.children.emplace_back(type_map);
+    TypeDescriptor type_map_map(PrimitiveType::TYPE_MAP);
+    type_map_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_map.children.emplace_back(type_map);
 
-        TypeDescriptor type_array(PrimitiveType::TYPE_ARRAY);
-        type_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
-        TypeDescriptor type_map_array(PrimitiveType::TYPE_MAP);
-        type_map_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
-        type_map_array.children.emplace_back(type_array);
+    TypeDescriptor type_array(PrimitiveType::TYPE_ARRAY);
+    type_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+    TypeDescriptor type_map_array(PrimitiveType::TYPE_MAP);
+    type_map_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_array.children.emplace_back(type_array);
 
-        // tuple desc
-        SlotDesc slot_descs[] = {
-                {"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
-                {"c2", type_map},
-                {"c3", type_map_map},
-                {"c4", type_map_array},
-                {""},
-        };
-        ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-        make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
-        ctx->scan_ranges.emplace_back(_create_scan_range(_file_map_path));
+    // tuple desc
+    SlotDesc slot_descs[] = {
+            {"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
+            {"c2", type_map},
+            {"c3", type_map_map},
+            {"c4", type_map_array},
+            {""},
+    };
+    ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+    make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+    ctx->scan_ranges.emplace_back(_create_scan_range(_file_map_path));
 
-        return ctx;
-    }
+    return ctx;
+}
 
 void FileReaderTest::_create_int_conjunct_ctxs(TExprOpcode::type opcode, SlotId slot_id, int value,
                                                std::vector<ExprContext*>* conjunct_ctxs) {
@@ -945,7 +945,6 @@ TEST_F(FileReaderTest, TestReadArray2dColumn) {
     EXPECT_EQ(chunk->debug_row(4), "[5, [[1, 2, 3], [4, 5]]]");
 }
 
-
 TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
     auto file = _create_file(_file6_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
@@ -1016,7 +1015,8 @@ TEST_F(FileReaderTest, TestReadMapColumn) {
     }
     EXPECT_EQ(chunk->debug_row(0), "[1, ['k1'->0, 'k2'->1], ['e1'->['f1'->1, 'f2'->2]], ['g1'->[1, 2]]]");
     EXPECT_EQ(chunk->debug_row(1),
-              "[2, ['k1'->1, 'k3'->2, 'k4'->3], ['e1'->['f1'->1, 'f2'->2], 'e2'->['f1'->1, 'f2'->2]], ['g1'->[1], 'g3'->[2]]]");
+              "[2, ['k1'->1, 'k3'->2, 'k4'->3], ['e1'->['f1'->1, 'f2'->2], 'e2'->['f1'->1, 'f2'->2]], ['g1'->[1], "
+              "'g3'->[2]]]");
     EXPECT_EQ(chunk->debug_row(2),
               "[3, ['k2'->2, 'k3'->3, 'k5'->4], ['e1'->['f1'->1, 'f2'->2, 'f3'->3]], ['g1'->[1, 2, 3]]]");
     EXPECT_EQ(chunk->debug_row(3), "[4, ['k1'->3, 'k2'->4, 'k3'->5], ['e2'->['f2'->2]], ['g1'->[1]]]");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12711 #12587

it's introduced in this PR: https://github.com/StarRocks/starrocks/pull/9744. 

For orc broker load, we don't need to consider case-sensitive or not. It has been always case-sensitive before, so we have to  keep backward-compatiblity.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

TODO: will add it later.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
