### PR TITLE
[BugFix][Cherry-pick][Branch-2.4] data error after reload persistent index (#12620)

### DIFF
--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -360,22 +360,36 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         values.emplace_back(i * 2);
         key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
+
+    const int second_n = 50000;
+    vector<Key> second_keys;
+    vector<Slice> second_key_slices;
+    vector<IndexValue> second_values;
+    second_keys.reserve(second_n);
+    second_key_slices.reserve(second_n);
+    for (int i = 0; i < second_n; i++) {
+        second_keys.emplace_back(i);
+        second_values.emplace_back(i * 3);
+        second_key_slices.emplace_back((uint8_t*)(&second_keys[i]), sizeof(Key));
+    }
+
     // erase
     vector<Key> erase_keys;
     vector<Slice> erase_key_slices;
-    erase_keys.reserve(N / 2);
-    erase_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    erase_keys.reserve(second_n);
+    erase_key_slices.reserve(second_n);
+    for (int i = 0; i < second_n; i++) {
         erase_keys.emplace_back(i);
         erase_key_slices.emplace_back((uint8_t*)(&erase_keys[i]), sizeof(Key));
     }
+
     // append invalid wal
     std::vector<Key> invalid_keys;
     std::vector<Slice> invalid_key_slices;
     std::vector<IndexValue> invalid_values;
-    invalid_keys.reserve(N / 2);
-    invalid_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    invalid_keys.reserve(second_n);
+    invalid_key_slices.reserve(second_n);
+    for (int i = 0; i < second_n; i++) {
         invalid_keys.emplace_back(i);
         invalid_values.emplace_back(i * 2);
         invalid_key_slices.emplace_back((uint8_t*)(&invalid_keys[i]), sizeof(Key));
@@ -395,20 +409,30 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
         version.to_pb(snapshot_meta->mutable_version());
 
+        std::vector<IndexValue> old_values(N);
         PersistentIndex index(kPersistentIndexDir);
-        //ASSERT_TRUE(index.create(sizeof(Key), version).ok());
-
+        // flush l0 first
         ASSERT_OK(index.load(index_meta));
         ASSERT_OK(index.prepare(EditVersion(1, 0)));
-        ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
+        ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
-        std::vector<IndexValue> old_values(keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
-        ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
-        ASSERT_TRUE(index.commit(&index_meta).ok());
-        ASSERT_TRUE(index.on_commited().ok());
+        //std::vector<IndexValue> old_values(second_keys.size());
+        ASSERT_OK(index.prepare(EditVersion(2, 0)));
+        ASSERT_OK(index.upsert(second_n, second_key_slices.data(), second_values.data(), old_values.data()));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < second_n; i++) {
+            ASSERT_EQ(second_values[i], get_values[i]);
+        }
+        for (int i = second_n; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
 
         vector<IndexValue> erase_old_values(erase_keys.size());
         ASSERT_TRUE(index.prepare(EditVersion(3, 0)).ok());
@@ -417,14 +441,14 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
-        std::vector<IndexValue> get_values(keys.size());
-        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
-        ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
-            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
+        std::vector<IndexValue> new_get_values(keys.size());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), new_get_values.data()).ok());
+        ASSERT_EQ(keys.size(), new_get_values.size());
+        for (int i = 0; i < second_n; i++) {
+            ASSERT_EQ(NullIndexValue, new_get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
-            ASSERT_EQ(values[i], get_values[i]);
+        for (int i = second_n; i < values.size(); i++) {
+            ASSERT_EQ(values[i], new_get_values[i]);
         }
     }
 
@@ -437,10 +461,10 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
 
         ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
+        for (int i = 0; i < second_n; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
+        for (int i = second_n; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
 
@@ -467,6 +491,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }
+
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
@@ -545,7 +570,8 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
 
     using Key = std::string;
     PersistentIndexMetaPB index_meta;
-    const int N = 100000;
+    const int N = 1000000;
+    const int wal_n = 50000;
     // insert
     vector<Key> keys(N);
     vector<Slice> key_slices;
@@ -557,19 +583,19 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         key_slices.emplace_back(keys[i]);
     }
     // erase
-    vector<Key> erase_keys(N / 2);
+    vector<Key> erase_keys(wal_n);
     vector<Slice> erase_key_slices;
-    erase_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    erase_key_slices.reserve(wal_n);
+    for (int i = 0; i < wal_n; i++) {
         erase_keys[i] = "test_varlen_" + std::to_string(i);
         erase_key_slices.emplace_back(erase_keys[i]);
     }
     // append invalid wal
-    std::vector<Key> invalid_keys(N / 2);
+    std::vector<Key> invalid_keys(wal_n);
     std::vector<Slice> invalid_key_slices;
     std::vector<IndexValue> invalid_values;
-    invalid_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    invalid_key_slices.reserve(wal_n);
+    for (int i = 0; i < wal_n; i++) {
         invalid_keys[i] = "test_varlen_" + std::to_string(i);
         invalid_values.emplace_back(i);
         invalid_key_slices.emplace_back(invalid_keys[i]);
@@ -613,10 +639,10 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         std::vector<IndexValue> get_values(keys.size());
         ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
+        for (int i = 0; i < wal_n; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
+        for (int i = wal_n; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }
@@ -629,10 +655,10 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         std::vector<IndexValue> get_values(keys.size());
         ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
+        for (int i = 0; i < wal_n; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
+        for (int i = wal_n; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
 
@@ -669,7 +695,8 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
     ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
     using Key = std::string;
     PersistentIndexMetaPB index_meta;
-    const int N = 10000;
+    const int N = 300000;
+    const int wal_n = 15000;
     // insert
     vector<Key> keys(N);
     vector<Slice> key_slices;
@@ -681,19 +708,19 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         key_slices.emplace_back(keys[i]);
     }
     // erase
-    vector<Key> erase_keys(N / 2);
+    vector<Key> erase_keys(wal_n);
     vector<Slice> erase_key_slices;
-    erase_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    erase_key_slices.reserve(wal_n);
+    for (int i = 0; i < wal_n; i++) {
         erase_keys[i] = keys[i];
         erase_key_slices.emplace_back(erase_keys[i]);
     }
     // append invalid wal
-    std::vector<Key> invalid_keys(N / 2);
+    std::vector<Key> invalid_keys(wal_n);
     std::vector<Slice> invalid_key_slices;
     std::vector<IndexValue> invalid_values;
-    invalid_key_slices.reserve(N / 2);
-    for (int i = 0; i < N / 2; i++) {
+    invalid_key_slices.reserve(wal_n);
+    for (int i = 0; i < wal_n; i++) {
         invalid_keys[i] = keys[i];
         invalid_values.emplace_back(i);
         invalid_key_slices.emplace_back(invalid_keys[i]);
@@ -737,10 +764,10 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         std::vector<IndexValue> get_values(keys.size());
         ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
+        for (int i = 0; i < wal_n; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
+        for (int i = wal_n; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }
@@ -753,10 +780,10 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         std::vector<IndexValue> get_values(keys.size());
         ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < N / 2; i++) {
+        for (int i = 0; i < wal_n; i++) {
             ASSERT_EQ(NullIndexValue, get_values[i].get_value());
         }
-        for (int i = N / 2; i < values.size(); i++) {
+        for (int i = wal_n; i < values.size(); i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
 


### PR DESCRIPTION
We should take care of calling emplace_back after initializing the capacity of the vector because this may not be your expected behavior. And the first n elements are null but not the data we want, that is why cause the inconsistent of persistent index.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/12513

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
