### PR TITLE
[Enhancement] partial materialize for mapType

### DIFF
--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -68,16 +68,16 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx) {
     case TTypeNodeType::ARRAY:
         DCHECK(!node.__isset.scalar_type);
         DCHECK_LT(*idx, types.size() - 1);
-        ++(*idx);
         type = TYPE_ARRAY;
+        ++(*idx);
         children.push_back(TypeDescriptor(types, idx));
         break;
     case TTypeNodeType::MAP:
         DCHECK(!node.__isset.scalar_type);
         DCHECK_LT(*idx, types.size() - 2);
         type = TYPE_MAP;
+        DCHECK_EQ(2, node.selected_fields.size());
         selected_fields = node.selected_fields;
-        DCHECK_EQ(2, selected_fields.size());
         ++(*idx);
         children.push_back(TypeDescriptor(types, idx));
         children.push_back(TypeDescriptor(types, idx));
@@ -95,6 +95,7 @@ void TypeDescriptor::to_thrift(TTypeDesc* thrift_type) const {
         children[0].to_thrift(thrift_type);
     } else if (type == TYPE_MAP) {
         curr_node.__set_type(TTypeNodeType::MAP);
+        DCHECK_EQ(2, selected_fields.size());
         curr_node.__set_selected_fields(selected_fields);
         DCHECK_EQ(2, children.size());
         children[0].to_thrift(thrift_type);

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -63,6 +63,7 @@ struct TypeDescriptor {
 
     /// Only set if type == TYPE_STRUCT. The field name of each child.
     std::vector<std::string> field_names;
+
     // Only set if type == TYPE_MAP || type == TYPE_STRUCT.
     std::vector<bool> selected_fields;
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -57,6 +57,7 @@ private:
     HdfsScannerContext* _create_file6_base_context();
     HdfsScannerContext* _create_file_map_char_key_context();
     HdfsScannerContext* _create_file_map_base_context();
+    HdfsScannerContext* _create_file_map_partial_materialize_context();
 
     void _create_int_conjunct_ctxs(TExprOpcode::type opcode, SlotId slot_id, int value,
                                    std::vector<ExprContext*>* conjunct_ctxs);
@@ -534,6 +535,47 @@ HdfsScannerContext* FileReaderTest::_create_file_map_base_context() {
             {"c4", type_map_array},
             {""},
     };
+    ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+    make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+    ctx->scan_ranges.emplace_back(_create_scan_range(_file_map_path));
+
+    return ctx;
+}
+
+HdfsScannerContext* FileReaderTest::_create_file_map_partial_materialize_context() {
+    auto ctx = _create_scan_context();
+
+    TypeDescriptor type_map(PrimitiveType::TYPE_MAP);
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+    // only key will be materialized
+    type_map.selected_fields.emplace_back(true);
+    type_map.selected_fields.emplace_back(false);
+
+    TypeDescriptor type_map_map(PrimitiveType::TYPE_MAP);
+    type_map_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_map.children.emplace_back(type_map);
+    // the first level value will be materialized, and the second level key will be materialized
+    type_map_map.selected_fields.emplace_back(false);
+    type_map_map.selected_fields.emplace_back(true);
+
+    TypeDescriptor type_array(PrimitiveType::TYPE_ARRAY);
+    type_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+    TypeDescriptor type_map_array(PrimitiveType::TYPE_MAP);
+    type_map_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_array.children.emplace_back(type_array);
+    // only value will be materialized
+    type_map_array.selected_fields.emplace_back(false);
+    type_map_array.selected_fields.emplace_back(true);
+
+    // tuple desc
+    SlotDesc slot_descs[] = {
+            {"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
+            {"c2", type_map},
+            {"c3", type_map_map},
+            {"c4", type_map_array},
+            {""},
+        };
     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
     ctx->scan_ranges.emplace_back(_create_scan_range(_file_map_path));
@@ -1500,6 +1542,69 @@ TEST_F(FileReaderTest, TestReadStructNull) {
     //    for (int i = 0; i < 4; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
     //    }
+}
+
+TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
+    auto file = _create_file(_file_map_path);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(_file_map_path));
+
+    //init
+    auto* ctx = _create_file_map_partial_materialize_context();
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+
+    std::vector<SharedBufferedInputStream::IORange> ranges;
+    int64_t end_offset = 0;
+    file_reader->_row_group_readers[0]->collect_io_ranges(&ranges, &end_offset);
+
+    // c1, c2.key, c2.value, c3.key, c3.value.key, c3.value.value, c4.key. c4.value
+    EXPECT_EQ(ranges.size(), 8);
+
+    EXPECT_EQ(file_reader->_file_metadata->num_rows(), 8);
+    TypeDescriptor type_map(PrimitiveType::TYPE_MAP);
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+
+    TypeDescriptor type_map_map(PrimitiveType::TYPE_MAP);
+    type_map_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_map.children.emplace_back(type_map);
+
+    TypeDescriptor type_array(PrimitiveType::TYPE_ARRAY);
+    type_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
+    TypeDescriptor type_map_array(PrimitiveType::TYPE_MAP);
+    type_map_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
+    type_map_array.children.emplace_back(type_array);
+
+    vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+    _append_column_for_chunk(PrimitiveType::TYPE_INT, &chunk);
+    auto c = vectorized::ColumnHelper::create_column(type_map, true);
+    chunk->append_column(c, chunk->num_columns());
+    auto c_map_map = vectorized::ColumnHelper::create_column(type_map_map, true);
+    chunk->append_column(c_map_map, chunk->num_columns());
+    auto c_map_array = vectorized::ColumnHelper::create_column(type_map_array, true);
+    chunk->append_column(c_map_array, chunk->num_columns());
+
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(chunk->num_rows(), 8);
+    for (int i = 0; i < chunk->num_rows(); ++i) {
+        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
+    }
+    EXPECT_EQ(chunk->debug_row(0),
+              "[1, ['k1'->NULL, 'k2'->NULL], [NULL->['f1'->NULL, 'f2'->NULL]], [NULL->[1, 2]]]");
+    EXPECT_EQ(chunk->debug_row(1),
+              "[2, ['k1'->NULL, 'k3'->NULL, 'k4'->NULL], [NULL->['f1'->NULL, 'f2'->NULL], NULL->['f1'->NULL, 'f2'->NULL]], [NULL->[1], NULL->[2]]]");
+    EXPECT_EQ(chunk->debug_row(2),
+              "[3, ['k2'->NULL, 'k3'->NULL, 'k5'->NULL], [NULL->['f1'->NULL, 'f2'->NULL, 'f3'->NULL]], [NULL->[1, 2, 3]]]");
+    EXPECT_EQ(chunk->debug_row(3), "[4, ['k1'->NULL, 'k2'->NULL, 'k3'->NULL], [NULL->['f2'->NULL]], [NULL->[1]]]");
+    EXPECT_EQ(chunk->debug_row(4), "[5, ['k3'->NULL], [NULL->['f2'->NULL]], [NULL->[NULL]]]");
+    EXPECT_EQ(chunk->debug_row(5), "[6, ['k1'->NULL], [NULL->['f2'->NULL]], [NULL->[1]]]");
+    EXPECT_EQ(chunk->debug_row(6), "[7, ['k1'->NULL, 'k2'->NULL], [NULL->['f2'->NULL]], [NULL->[1, 2, 3]]]");
+    EXPECT_EQ(chunk->debug_row(7), "[8, ['k3'->NULL], [NULL->['f1'->NULL, 'f2'->NULL, 'f3'->NULL]], [NULL->[1], NULL->[2]]]");
 }
 
 } // namespace starrocks::parquet

--- a/be/test/runtime/type_descriptor_test.cpp
+++ b/be/test/runtime/type_descriptor_test.cpp
@@ -282,6 +282,8 @@ TEST_F(TypeDescriptorTest, test_to_thrift) {
     {
         TypeDescriptor t;
         t.type = PrimitiveType::TYPE_MAP;
+        t.selected_fields.emplace_back(true);
+        t.selected_fields.emplace_back(true);
         t.children.resize(2);
         t.children[0].type = PrimitiveType::TYPE_INT;
         t.children[1].type = PrimitiveType::TYPE_STRUCT;
@@ -574,6 +576,8 @@ TEST_F(TypeDescriptorTest, test_to_protobuf) {
         TypeDescriptor t;
         t.children.resize(2);
         t.type = PrimitiveType::TYPE_MAP;
+        t.selected_fields.emplace_back(true);
+        t.selected_fields.emplace_back(true);
         t.children[0].type = PrimitiveType::TYPE_INT;
         t.children[1].type = PrimitiveType::TYPE_STRUCT;
         t.children[1].field_names = {"a", "b", "c"};
@@ -667,6 +671,8 @@ TEST_F(TypeDescriptorTest, test_debug_string) {
     {
         TypeDescriptor t;
         t.type = PrimitiveType::TYPE_MAP;
+        t.selected_fields.emplace_back(true);
+        t.selected_fields.emplace_back(true);
         t.children.resize(2);
         t.children[0].type = PrimitiveType::TYPE_INT;
         t.children[1].type = PrimitiveType::TYPE_VARCHAR;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotDescriptor.java
@@ -24,8 +24,10 @@ package com.starrocks.analysis;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnStats;
+import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -126,6 +128,41 @@ public class SlotDescriptor {
             throw new SemanticException("slot type shouldn't be invalid");
         }
         this.type = type;
+    }
+
+    public void setUsedSubfieldPosGroup(List<List<Integer>> usedSubfieldPosGroup) {
+        Preconditions.checkArgument(type.isComplexType());
+        // type should be cloned from originType!
+        if (usedSubfieldPosGroup.isEmpty()) {
+            type.selectAll();
+            return;
+        }
+
+        for (List<Integer> usedSubfieldPos : usedSubfieldPosGroup) {
+            if (usedSubfieldPos.isEmpty()) {
+                type.selectAll();
+                return;
+            }
+            Type tmpType = type;
+            for (int i = 0; i < usedSubfieldPos.size(); i++) {
+                // we will always select the ItemType of ArrayType, so we don't mark it and skip it.
+                while (tmpType.isArrayType()) {
+                    tmpType = ((ArrayType)tmpType).getItemType();
+                }
+                int pos = usedSubfieldPos.get(i);
+                if (i == usedSubfieldPos.size() -1) {
+                    // last one, select children
+                    tmpType.setSelectedField(pos, true);
+                } else {
+                    tmpType.setSelectedField(pos, false);
+                    if (tmpType.isStructType()) {
+                        // wait to be done
+                    } else if (tmpType.isMapType()) {
+                        tmpType = pos == 0 ? ((MapType)tmpType).getKeyType() : ((MapType)tmpType).getValueType();
+                    }
+                }
+            }
+        }
     }
 
     public Type getOriginType() {
@@ -241,7 +278,7 @@ public class SlotDescriptor {
 
     // TODO
     public TSlotDescriptor toThrift() {
-        if (originType != null) {
+        if (originType != null && !originType.isComplexType()) {
             return new TSlotDescriptor(id.asInt(), parent.getId().asInt(), originType.toThrift(), -1,
                     byteOffset, nullIndicatorByte,
                     nullIndicatorBit, ((column != null) ? column.getName() : ""),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -103,6 +103,13 @@ public class ArrayType extends Type {
         return clone;
     }
 
+    @Override
+    public void selectAll() {
+        if (itemType.isComplexType()) {
+            itemType.selectAll();
+        }
+    }
+
     /**
      * @return 33 (utf8_general_ci) if type is array
      * https://dev.mysql.com/doc/internals/en/com-query-response.html#column-definition

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -27,16 +27,19 @@ import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
 
+import java.util.Arrays;
+
 /**
  * Describes a MAP type. MAP types have a scalar key and an arbitrarily-typed value.
  */
 public class MapType extends Type {
-    private final Type keyType;
-    private final Type valueType;
+    private Type keyType;
+    private Type valueType;
 
     public MapType(Type keyType, Type valueType) {
         Preconditions.checkNotNull(keyType);
         Preconditions.checkNotNull(valueType);
+        selectedFields = new Boolean[] { false, false };
         this.keyType = keyType;
         this.valueType = valueType;
     }
@@ -47,6 +50,26 @@ public class MapType extends Type {
 
     public Type getValueType() {
         return valueType;
+    }
+
+    @Override
+    public void setSelectedField(int pos, boolean needSetChildren) {
+        if (pos == -1) {
+            Arrays.fill(selectedFields, true);
+        } else {
+            selectedFields[pos] = true;
+        }
+        if (needSetChildren && (pos == 1 || pos == -1) && valueType.isComplexType()) {
+            valueType.selectAll();
+        }
+    }
+
+    @Override
+    public void selectAll() {
+        Arrays.fill(selectedFields, true);
+        if (valueType.isComplexType()) {
+            valueType.selectAll();
+        }
     }
 
     @Override
@@ -97,8 +120,18 @@ public class MapType extends Type {
         Preconditions.checkNotNull(keyType);
         Preconditions.checkNotNull(valueType);
         node.setType(TTypeNodeType.MAP);
+        node.setSelected_fields(Arrays.asList(selectedFields));
         keyType.toThrift(container);
         valueType.toThrift(container);
+    }
+
+    @Override
+    public MapType clone() {
+        MapType clone = (MapType) super.clone();
+        clone.keyType = this.keyType.clone();
+        clone.valueType = this.valueType.clone();
+        clone.selectedFields = this.selectedFields.clone();
+        return clone;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
  * as abstract methods that subclasses must implement.
  */
 public abstract class Type implements Cloneable {
+    // used for nested type such as map and struct
+    protected Boolean[] selectedFields;
 
     public static final int BINARY = 63;
     public static final int CHARSET_UTF8 = 33;
@@ -536,6 +538,27 @@ public abstract class Type implements Cloneable {
      * prettyPrint() with space-indented nested types.
      */
     protected abstract String prettyPrint(int lpad);
+
+    /**
+     * Used for Nest Type
+     */
+    public void setSelectedField(int pos, boolean needSetChildren) {
+        throw new IllegalStateException("setSelectedField() is not implemented for type " + toSql());
+    }
+
+    /**
+     * Used for Nest Type
+     */
+    public void selectAll() {
+        throw new IllegalStateException("selectAll() is not implemented for type " + toSql());
+    }
+
+    /**
+     * used for test
+     */
+    public Boolean[] getSelectedFields() {
+        return selectedFields;
+    }
 
     public boolean isInvalid() {
         return isScalarType(PrimitiveType.INVALID_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -5,6 +5,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,12 +22,24 @@ public final class ColumnRefOperator extends ScalarOperator {
 
     private boolean isLambdaArgument;
 
+    // Empty list for default
+    // If it's empty, means select all
+    private final List<List<Integer>> usedSubfieldPosGroup = new ArrayList<>();
+
     public ColumnRefOperator(int id, Type type, String name, boolean nullable) {
         super(OperatorType.VARIABLE, type);
         this.id = id;
         this.name = requireNonNull(name, "name is null");
         this.nullable = nullable;
         this.isLambdaArgument = false;
+    }
+
+    public void addUsedSubfieldPos(List<Integer> usedNestFieldPos) {
+        this.usedSubfieldPosGroup.add(usedNestFieldPos);
+    }
+
+    public List<List<Integer>> getUsedSubfieldPosGroup() {
+        return this.usedSubfieldPosGroup;
     }
 
     public ColumnRefOperator(int id, Type type, String name, boolean nullable, boolean isLambdaArgument) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -664,6 +664,9 @@ public class PlanFragmentBuilder {
                 slotDescriptor.setColumn(entry.getValue());
                 slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
                 slotDescriptor.setIsMaterialized(true);
+                if (slotDescriptor.getType().isComplexType()) {
+                    slotDescriptor.setUsedSubfieldPosGroup(entry.getKey().getUsedSubfieldPosGroup());
+                }
                 context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SlotDescriptorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SlotDescriptorTest.java
@@ -1,0 +1,128 @@
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.ArrayType;
+import com.starrocks.catalog.MapType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SlotDescriptorTest {
+
+    private Type mapType;
+    private Type typeMapArrayMap;
+    private SlotDescriptor slot;
+    private ColumnRefOperator colRef;
+
+    @Before
+    public void setup() {
+        Type keyType = ScalarType.createType(PrimitiveType.INT);
+        Type valueType = ScalarType.createCharType(10);
+        mapType = new MapType(keyType, valueType);
+        Type arrayType = new ArrayType(mapType);
+        Type keyTypeOuter = ScalarType.createType(PrimitiveType.INT);
+        typeMapArrayMap = new MapType(keyTypeOuter, arrayType);
+        slot = new SlotDescriptor(SlotId.createGenerator().getNextId(), "type_map_array_map", typeMapArrayMap, true);
+        colRef = new ColumnRefOperator(0, typeMapArrayMap, "type_map_array_map", true);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupEmpty() {
+        // if the usedSubfieldPosGroup is null, all subfields are selected
+        slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+        Assert.assertEquals(2, mapType.getSelectedFields().length);
+        Assert.assertEquals(true, mapType.getSelectedFields()[0]);
+        Assert.assertEquals(true, mapType.getSelectedFields()[1]);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupNotLeaf() {
+        // if the last one is complextype, select all child
+        List<Integer> usedSubfieldPos = new ArrayList<>();
+        usedSubfieldPos.add(1);
+        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
+        Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+        Assert.assertEquals(2, mapType.getSelectedFields().length);
+        Assert.assertEquals(true, mapType.getSelectedFields()[0]);
+        Assert.assertEquals(true, mapType.getSelectedFields()[1]);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupLeaf() {
+        // if the last one is a leaf
+        List<Integer> usedSubfieldPos = Arrays.asList(1, 1);
+        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
+        Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+        Assert.assertEquals(2, mapType.getSelectedFields().length);
+        Assert.assertEquals(false, mapType.getSelectedFields()[0]);
+        Assert.assertEquals(true, mapType.getSelectedFields()[1]);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupTwoPos() {
+        List<Integer> usedSubfieldPos1 = Arrays.asList(1, 1);
+        colRef.addUsedSubfieldPos(usedSubfieldPos1);
+        List<Integer> usedSubfieldPos2 = Arrays.asList(1, 0);
+        colRef.addUsedSubfieldPos(usedSubfieldPos2);
+        slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
+        Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+        Assert.assertEquals(2, mapType.getSelectedFields().length);
+        Assert.assertEquals(true, mapType.getSelectedFields()[0]);
+        Assert.assertEquals(true, mapType.getSelectedFields()[1]);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupMapAllField() {
+        // if the last one is a leaf
+        List<Integer> usedSubfieldPos = Arrays.asList(1, -1);
+        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
+        Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+        Assert.assertEquals(2, mapType.getSelectedFields().length);
+        Assert.assertEquals(true, mapType.getSelectedFields()[0]);
+        Assert.assertEquals(true, mapType.getSelectedFields()[1]);
+
+        Type map_new = typeMapArrayMap.clone();
+        SlotDescriptor slot_new = new SlotDescriptor(SlotId.createGenerator().getNextId(), "clone_map", map_new, true);
+        ColumnRefOperator colRef_new = new ColumnRefOperator(0, map_new, "clone_map", true);
+        List<Integer> usedSubfield = Arrays.asList(-1);
+        colRef_new.addUsedSubfieldPos(usedSubfield);
+        slot_new.setUsedSubfieldPosGroup(colRef_new.getUsedSubfieldPosGroup());
+        Assert.assertEquals(2, map_new.getSelectedFields().length);
+        // the cloned map selected 1, 1
+        Assert.assertEquals(true, map_new.getSelectedFields()[0]);
+        Assert.assertEquals(true, map_new.getSelectedFields()[1]);
+        // the origin map selected 0, 1
+        Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
+        Assert.assertEquals(true, typeMapArrayMap.getSelectedFields()[1]);
+    }
+
+    @Test
+    public void testSetUsedSubfieldPosGroupMapWrongField() {
+        // if the last one is a leaf
+        List<Integer> usedSubfieldPos = Arrays.asList(0, 0, 0);
+        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        Assert.assertThrows(IllegalStateException.class, ()->slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup()));
+    }
+
+}


### PR DESCRIPTION
such as, map_keys() will only materialize keycolumn of mapcolumn, and valuecolumn for map_values()

Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
when translate an expr to operator, we mark the expr use a stack, mark the used subfield, such as map_keys use subfield0, map_values use subfield1, map[] use all of two subfields.  when we finally arrive the slotRef, add the used field to the ColumnOperator. 
When build planfragment, we merge the used subfields, and mark the type's selected_field, then transfer to be.
Be will use the selected field init the reader and scan the file.
The type may be nested. such as map<int, map<*, *>>.

give an example
![UML 图-2](https://user-images.githubusercontent.com/28446271/199899147-46874198-1988-42fc-8d5a-cb41307eea50.jpg)


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
