### PR TITLE
[Enhancement] optimize finalize stage for nullable aggregator

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -115,7 +115,7 @@ public:
     static auto MakeSumAggregateFunction();
 
     template <PrimitiveType PT>
-    static AggregateFunctionPtr MakeDecimalSumAggregateFunction();
+    static auto MakeDecimalSumAggregateFunction();
 
     template <PrimitiveType PT, bool is_sample>
     static AggregateFunctionPtr MakeVarianceAggregateFunction();
@@ -124,11 +124,11 @@ public:
     static AggregateFunctionPtr MakeStddevAggregateFunction();
 
     template <PrimitiveType PT>
-    static AggregateFunctionPtr MakeSumDistinctAggregateFunction();
+    static auto MakeSumDistinctAggregateFunction();
     template <PrimitiveType PT>
-    static AggregateFunctionPtr MakeSumDistinctAggregateFunctionV2();
+    static auto MakeSumDistinctAggregateFunctionV2();
     template <PrimitiveType PT>
-    static AggregateFunctionPtr MakeDecimalSumDistinctAggregateFunction();
+    static auto MakeDecimalSumDistinctAggregateFunction();
 
     static AggregateFunctionPtr MakeDictMergeAggregateFunction();
     static AggregateFunctionPtr MakeRetentionAggregateFunction();
@@ -263,7 +263,7 @@ auto AggregateFactory::MakeSumAggregateFunction() {
 }
 
 template <PrimitiveType PT>
-AggregateFunctionPtr AggregateFactory::MakeDecimalSumAggregateFunction() {
+auto AggregateFactory::MakeDecimalSumAggregateFunction() {
     return std::make_shared<DecimalSumAggregateFunction<PT>>();
 }
 
@@ -278,17 +278,17 @@ AggregateFunctionPtr AggregateFactory::MakeStddevAggregateFunction() {
 }
 
 template <PrimitiveType PT>
-AggregateFunctionPtr AggregateFactory::MakeSumDistinctAggregateFunction() {
+auto AggregateFactory::MakeSumDistinctAggregateFunction() {
     return std::make_shared<DistinctAggregateFunction<PT, AggDistinctType::SUM>>();
 }
 
 template <PrimitiveType PT>
-AggregateFunctionPtr AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
+auto AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
     return std::make_shared<DistinctAggregateFunctionV2<PT, AggDistinctType::SUM>>();
 }
 
 template <PrimitiveType PT>
-AggregateFunctionPtr AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
+auto AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
     return std::make_shared<DecimalDistinctAggregateFunction<PT, AggDistinctType::SUM>>();
 }
 

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -62,8 +62,8 @@ public:
         return pair->second.get();
     }
 
-    template <PrimitiveType ArgType, PrimitiveType RetType>
-    void add_aggregate_mapping_notnull(const std::string& name, bool is_window, AggregateFunctionPtr fun) {
+    template <PrimitiveType ArgType, PrimitiveType RetType, typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_aggregate_mapping_notnull(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), fun);
         if (is_window) {
@@ -72,8 +72,9 @@ public:
         }
     }
 
-    template <PrimitiveType ArgType, PrimitiveType RetType, class StateType>
-    void add_aggregate_mapping(const std::string& name, bool is_window, AggregateFunctionPtr fun) {
+    template <PrimitiveType ArgType, PrimitiveType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_aggregate_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
         auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, false>(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), nullable_agg);
@@ -85,8 +86,9 @@ public:
         }
     }
 
-    template <PrimitiveType ArgType, PrimitiveType RetType, class StateType>
-    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, AggregateFunctionPtr fun) {
+    template <PrimitiveType ArgType, PrimitiveType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
         auto variadic_agg = AggregateFactory::MakeNullableAggregateFunctionVariadic<StateType>(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), variadic_agg);
@@ -183,10 +185,11 @@ public:
         return nullptr;
     }
 
-private:
-    std::unordered_map<AggregateFuncKey, AggregateFunctionPtr, AggregateFuncMapHash> _infos_mapping;
     AggregateFuncResolver(const AggregateFuncResolver&) = delete;
     const AggregateFuncResolver& operator=(const AggregateFuncResolver&) = delete;
+
+private:
+    std::unordered_map<AggregateFuncKey, AggregateFunctionPtr, AggregateFuncMapHash> _infos_mapping;
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#9118

## Problem Summary(Required) ：
baseline: 1e65105c6f30ee2644b74cbae16d9f6e7a98bb8b
TPCDS-SF1000 4BE 16C
```sql
set new_planner_agg_stage=2;
set streaming_preaggregation_mode=force_streaming;
with max_store_sales as (
    select max(csales) tpcds_cmax
    from (
            select c_customer_sk,
                sum(cast(ss_quantity * ss_sales_price as float)) csales
            from store_sales,
                customer,
                date_dim
            where ss_customer_sk = c_customer_sk
                and ss_sold_date_sk = d_date_sk
                and d_year in (2000, 2000 + 1, 2000 + 2, 2000 + 3)
            group by c_customer_sk
        ) t1
)
select count(*)
from (
        select *
        from max_store_sales
    ) t
```

AggFunctionComputeTime:
```
baseline:
- AggFuncComputeTime: 1s312ms
 - __MAX_OF_AggFuncComputeTime: 1s453ms
 - __MIN_OF_AggFuncComputeTime: 1s169ms
contributed by inline:
 - AggFuncComputeTime: 1s282ms
 - __MAX_OF_AggFuncComputeTime: 1s427ms
 - __MIN_OF_AggFuncComputeTime: 1s166ms
patched:
 - AggFuncComputeTime: 683.401ms
 - __MAX_OF_AggFuncComputeTime: 758.184ms
 - __MIN_OF_AggFuncComputeTime: 614.961ms
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
