### PR TITLE
[Refactor] Refactor pt_is_binary to pt_is_string

### DIFF
--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -342,7 +342,7 @@ struct RunTimeTypeLimits<TYPE_LARGEINT> {
 };
 
 template <PrimitiveType ptype>
-struct RunTimeTypeLimits<ptype, BinaryPTGuard<ptype>> {
+struct RunTimeTypeLimits<ptype, StringPTGuard<ptype>> {
     using value_type = RunTimeCppType<ptype>;
 
     static constexpr value_type min_value() { return Slice(&_min, 0); }

--- a/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
@@ -178,12 +178,12 @@ void offsets_copy(const T* arrow_offsets_data, T arrow_base_offset, size_t num_e
     }
 }
 
-template <PrimitiveType PT, typename = BinaryPTGuard<PT>>
+template <PrimitiveType PT, typename = StringPTGuard<PT>>
 static inline constexpr uint32_t binary_max_length = (PT == TYPE_VARCHAR) ? TypeDescriptor::MAX_VARCHAR_LENGTH
                                                                           : TypeDescriptor::MAX_CHAR_LENGTH;
 
 template <ArrowTypeId AT, PrimitiveType PT, bool is_nullable, bool is_strict>
-struct ArrowConverter<AT, PT, is_nullable, is_strict, BinaryATGuard<AT>, BinaryPTGuard<PT>> {
+struct ArrowConverter<AT, PT, is_nullable, is_strict, BinaryATGuard<AT>, StringPTGuard<PT>> {
     using ArrowArrayType = ArrowTypeIdToArrayType<AT>;
     using ArrowCppType = ArrowTypeIdToCppType<AT>;
     using CppType = RunTimeCppType<PT>;

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -21,7 +21,7 @@ const Buffer<typename JoinBuildFunc<PT>::CppType>& JoinBuildFunc<PT>::get_key_da
         data_column = table_items.key_columns[0];
     }
 
-    if constexpr (pt_is_binary<PT>) {
+    if constexpr (pt_is_string<PT>) {
         if (UNLIKELY(data_column->is_large_binary())) {
             return ColumnHelper::as_raw_column<LargeBinaryColumn>(data_column)->get_data();
         } else {

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -85,7 +85,7 @@ struct AnyValueAggregateData<TYPE_DATE, guard::Guard> {
 };
 
 template <PrimitiveType PT>
-struct AnyValueAggregateData<PT, BinaryPTGuard<PT>> {
+struct AnyValueAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
     Buffer<uint8_t> buffer;
 
@@ -124,7 +124,7 @@ struct AnyValueElement {
 };
 
 template <PrimitiveType PT>
-struct AnyValueElement<PT, AnyValueAggregateData<PT>, BinaryPTGuard<PT>> {
+struct AnyValueElement<PT, AnyValueAggregateData<PT>, StringPTGuard<PT>> {
     void operator()(AnyValueAggregateData<PT>& state, const Slice& right) const {
         if (UNLIKELY(!state.has_value())) {
             state.buffer.resize(right.size);
@@ -202,7 +202,7 @@ public:
 };
 
 template <PrimitiveType PT, typename State, class OP>
-class AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>, BinaryPTGuard<PT>> final
+class AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>, StringPTGuard<PT>> final
         : public AggregateFunctionBatchHelper<State, AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -23,7 +23,7 @@ struct ArrayAggAggregateState<PT, FixedLengthPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-struct ArrayAggAggregateState<PT, BinaryPTGuard<PT>> {
+struct ArrayAggAggregateState<PT, StringPTGuard<PT>> {
     using CppType = RunTimeCppType<PT>;
 
     void update(MemPool* mem_pool, Slice key) {

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -41,7 +41,7 @@ inline constexpr PrimitiveType ImmediateAvgResultPT<PT, AvgDecimal64PTGuard<PT>>
 
 // Only for compile
 template <PrimitiveType PT>
-inline constexpr PrimitiveType ImmediateAvgResultPT<PT, BinaryPTGuard<PT>> = TYPE_DOUBLE;
+inline constexpr PrimitiveType ImmediateAvgResultPT<PT, StringPTGuard<PT>> = TYPE_DOUBLE;
 
 template <typename T>
 struct AvgAggregateState {

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -97,7 +97,7 @@ struct DistinctAggregateState<PT, SumPT, FixedLengthPTGuard<PT>> {
 };
 
 template <PrimitiveType PT, PrimitiveType SumPT>
-struct DistinctAggregateState<PT, SumPT, BinaryPTGuard<PT>> {
+struct DistinctAggregateState<PT, SumPT, StringPTGuard<PT>> {
     DistinctAggregateState() = default;
     using KeyType = typename SliceHashSet::key_type;
 
@@ -258,7 +258,7 @@ struct DistinctAggregateStateV2<PT, SumPT, FixedLengthPTGuard<PT>> {
 };
 
 template <PrimitiveType PT, PrimitiveType SumPT>
-struct DistinctAggregateStateV2<PT, SumPT, BinaryPTGuard<PT>> : public DistinctAggregateState<PT, SumPT> {};
+struct DistinctAggregateStateV2<PT, SumPT, StringPTGuard<PT>> : public DistinctAggregateState<PT, SumPT> {};
 
 // Dear god this template class as template parameter kills me!
 template <PrimitiveType PT, PrimitiveType SumPT,

--- a/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
@@ -12,7 +12,7 @@ namespace starrocks::vectorized {
 struct HLLUnionBuilder {
     template <PrimitiveType pt>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr (pt_is_fixedlength<pt> || pt_is_binary<pt>) {
+        if constexpr (pt_is_fixedlength<pt> || pt_is_string<pt>) {
             resolver->add_aggregate_mapping<pt, TYPE_HLL, HyperLogLog>(
                     "hll_raw", false, AggregateFactory::MakeHllRawAggregateFunction<pt>());
 

--- a/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
@@ -24,7 +24,7 @@ struct AvgDispatcher {
 struct ArrayAggDispatcher {
     template <PrimitiveType pt>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr (pt_is_aggregate<pt> || pt_is_binary<pt>) {
+        if constexpr (pt_is_aggregate<pt> || pt_is_string<pt>) {
             auto func = AggregateFactory::MakeArrayAggAggregateFunction<pt>();
             using AggState = ArrayAggAggregateState<pt>;
             resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState>("array_agg", false, func);

--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -34,7 +34,7 @@ void AggregateFuncResolver::register_bitmap() {
 struct MinMaxAnyDispatcher {
     template <PrimitiveType pt>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr (pt_is_aggregate<pt> || pt_is_binary<pt>) {
+        if constexpr (pt_is_aggregate<pt> || pt_is_string<pt>) {
             resolver->add_aggregate_mapping<pt, pt, MinAggregateData<pt>>(
                     "min", true, AggregateFactory::MakeMinAggregateFunction<pt>());
             resolver->add_aggregate_mapping<pt, pt, MaxAggregateData<pt>>(
@@ -53,8 +53,8 @@ template <PrimitiveType ret_type>
 struct MaxByDispatcherInner {
     template <PrimitiveType arg_type>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr ((pt_is_aggregate<arg_type> || pt_is_binary<arg_type>)&&(pt_is_aggregate<ret_type> ||
-                                                                              pt_is_binary<ret_type>)) {
+        if constexpr ((pt_is_aggregate<arg_type> || pt_is_string<arg_type>)&&(pt_is_aggregate<ret_type> ||
+                                                                              pt_is_string<ret_type>)) {
             resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
                     "max_by", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type>());
         }

--- a/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
@@ -25,7 +25,7 @@ struct SumDispatcher {
 struct DistinctDispatcher {
     template <PrimitiveType pt>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr (pt_is_aggregate<pt> || pt_is_binary<pt>) {
+        if constexpr (pt_is_aggregate<pt> || pt_is_string<pt>) {
             using DistinctState = DistinctAggregateState<pt, SumResultPT<pt>>;
             using DistinctState2 = DistinctAggregateStateV2<pt, SumResultPT<pt>>;
             resolver->add_aggregate_mapping<pt, TYPE_BIGINT, DistinctState>(

--- a/be/src/exprs/agg/histogram.h
+++ b/be/src/exprs/agg/histogram.h
@@ -156,7 +156,7 @@ public:
                                                 buckets[i].count, buckets[i].upper_repeats, sample_ratio) +
                                    ",";
                 }
-            } else if constexpr (pt_is_binary<PT>) {
+            } else if constexpr (pt_is_string<PT>) {
                 for (int i = 0; i < buckets.size(); ++i) {
                     bucket_json += toBucketJson(buckets[i].lower.to_string(), buckets[i].upper.to_string(),
                                                 buckets[i].count, buckets[i].upper_repeats, sample_ratio) +

--- a/be/src/exprs/agg/hll_ndv.h
+++ b/be/src/exprs/agg/hll_ndv.h
@@ -32,7 +32,7 @@ public:
         uint64_t value = 0;
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (pt_is_binary<PT>) {
+        if constexpr (pt_is_string<PT>) {
             Slice s = column->get_slice(row_num);
             value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
         } else {
@@ -50,7 +50,7 @@ public:
                                               int64_t frame_end) const override {
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (pt_is_binary<PT>) {
+        if constexpr (pt_is_string<PT>) {
             uint64_t value = 0;
             for (size_t i = frame_start; i < frame_end; ++i) {
                 Slice s = column->get_slice(i);
@@ -117,7 +117,7 @@ public:
         uint64_t value = 0;
         for (size_t i = 0; i < chunk_size; ++i) {
             HyperLogLog hll;
-            if constexpr (pt_is_binary<PT>) {
+            if constexpr (pt_is_string<PT>) {
                 Slice s = column->get_slice(i);
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
             } else {

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -60,7 +60,7 @@ struct MaxAggregateData<TYPE_DATE, guard::Guard> {
 };
 
 template <PrimitiveType PT>
-struct MaxAggregateData<PT, BinaryPTGuard<PT>> {
+struct MaxAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
     raw::RawVector<uint8_t> buffer;
 
@@ -121,7 +121,7 @@ struct MinAggregateData<TYPE_DATE, guard::Guard> {
 };
 
 template <PrimitiveType PT>
-struct MinAggregateData<PT, BinaryPTGuard<PT>> {
+struct MinAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
     Buffer<uint8_t> buffer;
 
@@ -148,7 +148,7 @@ struct MinElement {
 };
 
 template <PrimitiveType PT>
-struct MaxElement<PT, MaxAggregateData<PT>, BinaryPTGuard<PT>> {
+struct MaxElement<PT, MaxAggregateData<PT>, StringPTGuard<PT>> {
     void operator()(MaxAggregateData<PT>& state, const Slice& right) const {
         if (!state.has_value() || state.slice().compare(right) < 0) {
             state.buffer.resize(right.size);
@@ -159,7 +159,7 @@ struct MaxElement<PT, MaxAggregateData<PT>, BinaryPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-struct MinElement<PT, MinAggregateData<PT>, BinaryPTGuard<PT>> {
+struct MinElement<PT, MinAggregateData<PT>, StringPTGuard<PT>> {
     void operator()(MinAggregateData<PT>& state, const Slice& right) const {
         if (!state.has_value() || state.slice().compare(right) > 0) {
             state.buffer.resize(right.size);
@@ -230,7 +230,7 @@ public:
 };
 
 template <PrimitiveType PT, typename State, class OP>
-class MaxMinAggregateFunction<PT, State, OP, RunTimeCppType<PT>, BinaryPTGuard<PT>> final
+class MaxMinAggregateFunction<PT, State, OP, RunTimeCppType<PT>, StringPTGuard<PT>> final
         : public AggregateFunctionBatchHelper<State, MaxMinAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {

--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -98,7 +98,7 @@ struct MaxByElement {
 };
 
 template <PrimitiveType PT>
-struct MaxByAggregateData<PT, BinaryPTGuard<PT>> {
+struct MaxByAggregateData<PT, StringPTGuard<PT>> {
     raw::RawVector<uint8_t> buffer_result;
     raw::RawVector<uint8_t> buffer_max;
     int32_t size = -1;
@@ -112,7 +112,7 @@ struct MaxByAggregateData<PT, BinaryPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-struct MaxByElement<PT, MaxByAggregateData<PT>, BinaryPTGuard<PT>> {
+struct MaxByElement<PT, MaxByAggregateData<PT>, StringPTGuard<PT>> {
     void operator()(MaxByAggregateData<PT>& state, Column* col, size_t row_num, const Slice& right) const {
         if (!state.has_value() || state.slice_max().compare(right) < 0) {
             state.buffer_result.resize(col->serialize_size(row_num));
@@ -263,7 +263,7 @@ public:
 };
 
 template <PrimitiveType PT, typename State, class OP>
-class MaxByAggregateFunction<PT, State, OP, RunTimeCppType<PT>, BinaryPTGuard<PT>> final
+class MaxByAggregateFunction<PT, State, OP, RunTimeCppType<PT>, StringPTGuard<PT>> final
         : public AggregateFunctionBatchHelper<State, MaxByAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -438,7 +438,7 @@ class LeadLagWindowFunction final : public ValueWindowFunction<PT, LeadLagState<
 };
 
 template <PrimitiveType PT>
-struct FirstValueState<PT, BinaryPTGuard<PT>> {
+struct FirstValueState<PT, StringPTGuard<PT>> {
     Buffer<uint8_t> buffer;
     bool has_value = false;
     bool is_null = false;
@@ -447,7 +447,7 @@ struct FirstValueState<PT, BinaryPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-class FirstValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<FirstValueState<PT>> {
+class FirstValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public WindowFunction<FirstValueState<PT>> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
         this->data(state).has_value = false;
@@ -484,7 +484,7 @@ class FirstValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public Wind
 };
 
 template <PrimitiveType PT>
-struct LastValueState<PT, BinaryPTGuard<PT>> {
+struct LastValueState<PT, StringPTGuard<PT>> {
     Buffer<uint8_t> buffer;
     bool is_null = false;
 
@@ -492,7 +492,7 @@ struct LastValueState<PT, BinaryPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-class LastValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<LastValueState<PT>> {
+class LastValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public WindowFunction<LastValueState<PT>> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
         this->data(state).is_null = false;
@@ -524,7 +524,7 @@ class LastValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public Windo
 };
 
 template <PrimitiveType PT>
-struct LeadLagState<PT, BinaryPTGuard<PT>> {
+struct LeadLagState<PT, StringPTGuard<PT>> {
     Buffer<uint8_t> value;
     Buffer<uint8_t> default_value;
     bool is_null = false;
@@ -534,7 +534,7 @@ struct LeadLagState<PT, BinaryPTGuard<PT>> {
 };
 
 template <PrimitiveType PT>
-class LeadLagWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<LeadLagState<PT>> {
+class LeadLagWindowFunction<PT, Slice, StringPTGuard<PT>> final : public WindowFunction<LeadLagState<PT>> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value.clear();
         this->data(state).is_null = false;

--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -1079,7 +1079,7 @@ public:
                 ResultType result;
 
                 size_t index;
-                if constexpr (!pt_is_binary<value_type>) {
+                if constexpr (!pt_is_string<value_type>) {
                     if constexpr (is_min) {
                         result = RunTimeTypeLimits<value_type>::max_value();
                     } else {
@@ -1121,7 +1121,7 @@ public:
                     }
                 }
 
-                if constexpr (!pt_is_binary<value_type>) {
+                if constexpr (!pt_is_string<value_type>) {
                     if (has_data) {
                         result_column->append(result);
                     } else {

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -21,7 +21,7 @@ public:
             return _array_distinct<phmap::flat_hash_set<CppType, Hash128WithSeed<PhmapSeed1>>>(columns);
         } else if constexpr (pt_is_fixedlength<PT>) {
             return _array_distinct<phmap::flat_hash_set<CppType, StdHash<CppType>>>(columns);
-        } else if constexpr (pt_is_binary<PT>) {
+        } else if constexpr (pt_is_string<PT>) {
             return _array_distinct<phmap::flat_hash_set<CppType, SliceHash>>(columns);
         } else {
             assert(false);
@@ -463,7 +463,7 @@ public:
             return _array_overlap<phmap::flat_hash_set<CppType, Hash128WithSeed<PhmapSeed1>>>(columns);
         } else if constexpr (pt_is_fixedlength<PT>) {
             return _array_overlap<phmap::flat_hash_set<CppType, StdHash<CppType>>>(columns);
-        } else if constexpr (pt_is_binary<PT>) {
+        } else if constexpr (pt_is_string<PT>) {
             return _array_overlap<phmap::flat_hash_set<CppType, SliceHash>>(columns);
         } else {
             assert(false);
@@ -569,7 +569,7 @@ public:
                 return phmap_mix_with_seed<sizeof(size_t), PhmapSeed1>()(hash_128(PhmapSeed1, cpp_type_value.value));
             } else if constexpr (pt_is_fixedlength<PT>) {
                 return phmap_mix<sizeof(size_t)>()(std::hash<CppType>()(cpp_type_value.value));
-            } else if constexpr (pt_is_binary<PT>) {
+            } else if constexpr (pt_is_string<PT>) {
                 return crc_hash_64(cpp_type_value.value.data, static_cast<int32_t>(cpp_type_value.value.size),
                                    CRC_HASH_SEED1);
             } else {
@@ -591,7 +591,7 @@ public:
         } else if constexpr (pt_is_fixedlength<PT>) {
             return _array_intersect<phmap::flat_hash_set<CppTypeWithOverlapTimes, CppTypeWithOverlapTimesHash<PT>,
                                                          CppTypeWithOverlapTimesEqual>>(columns);
-        } else if constexpr (pt_is_binary<PT>) {
+        } else if constexpr (pt_is_string<PT>) {
             return _array_intersect<phmap::flat_hash_set<CppTypeWithOverlapTimes, CppTypeWithOverlapTimesHash<PT>,
                                                          CppTypeWithOverlapTimesEqual>>(columns);
         } else {
@@ -903,7 +903,7 @@ private:
     static void _reverse_data_column(Column* column, const Buffer<uint32_t>& offsets, size_t chunk_size) {
         if constexpr (pt_is_fixedlength<PT>) {
             _reverse_fixed_column(column, offsets, chunk_size);
-        } else if constexpr (pt_is_binary<PT>) {
+        } else if constexpr (pt_is_string<PT>) {
             _reverse_binary_column(column, offsets, chunk_size);
         } else {
             assert(false);

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -144,7 +144,7 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
             value = JsonValue::from_double(viewer.value(row));
         } else if constexpr (pt_is_boolean<FromType>) {
             value = JsonValue::from_bool(viewer.value(row));
-        } else if constexpr (pt_is_binary<FromType>) {
+        } else if constexpr (pt_is_string<FromType>) {
             auto maybe = JsonValue::parse_json_or_string(viewer.value(row));
             if (maybe.ok()) {
                 value = maybe.value();
@@ -219,7 +219,7 @@ static ColumnPtr cast_from_json_fn(ColumnPtr& column) {
                 }
                 builder.append_null();
             }
-        } else if constexpr (pt_is_binary<ToType>) {
+        } else if constexpr (pt_is_string<ToType>) {
             // if the json already a string value, get the string directly
             // else cast it to string representation
             if (json->get_type() == JsonType::JSON_STRING) {

--- a/be/src/exprs/vectorized/decimal_cast_expr.h
+++ b/be/src/exprs/vectorized/decimal_cast_expr.h
@@ -288,13 +288,13 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
 };
 
 // cast: char/varchar <-> decimal
-template <bool check_overflow, PrimitiveType DecimalType, PrimitiveType BinaryType>
-struct DecimalNonDecimalCast<check_overflow, DecimalType, BinaryType, DecimalPTGuard<DecimalType>,
-                             BinaryPTGuard<BinaryType>> {
+template <bool check_overflow, PrimitiveType DecimalType, PrimitiveType StringType>
+struct DecimalNonDecimalCast<check_overflow, DecimalType, StringType, DecimalPTGuard<DecimalType>,
+                             StringPTGuard<StringType>> {
     using DecimalCppType = RunTimeCppType<DecimalType>;
     using DecimalColumnType = RunTimeColumnType<DecimalType>;
-    using BinaryCppType = RunTimeCppType<BinaryType>;
-    using BinaryColumnType = RunTimeColumnType<BinaryType>;
+    using StringCppType = RunTimeCppType<StringType>;
+    using StringColumnType = RunTimeColumnType<StringType>;
 
     static inline ColumnPtr decimal_from(const ColumnPtr& column, int precision, int scale) {
         const auto num_rows = column->size();
@@ -308,7 +308,7 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, BinaryType, DecimalPTG
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
         }
-        const auto binary_data = ColumnHelper::cast_to_raw<BinaryType>(column);
+        const auto binary_data = ColumnHelper::cast_to_raw<StringType>(column);
         for (auto i = 0; i < num_rows; ++i) {
             auto slice = binary_data->get_slice(i);
             auto overflow = DecimalV3Cast::from_string<DecimalCppType>(

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -152,7 +152,7 @@ Status MysqlTableWriter::_build_insert_sql(int from, int to, std::string_view* s
                             fmt::format_to(_stmt_buffer, "'{}'", vectorized::date::to_string(y, m, d));
                         } else if constexpr (pt_is_datetime<type>) {
                             fmt::format_to(_stmt_buffer, "'{}'", viewer.value(i).to_string());
-                        } else if constexpr (pt_is_binary<type>) {
+                        } else if constexpr (pt_is_string<type>) {
                             auto slice = viewer.value(i);
                             _escape_buffer.resize(slice.size * 2 + 1);
 

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -145,7 +145,7 @@ VALUE_GUARD(PrimitiveType, DecimalPTGuard, pt_is_decimal, TYPE_DECIMAL32, TYPE_D
 VALUE_GUARD(PrimitiveType, SumDecimal64PTGuard, pt_is_sum_decimal64, TYPE_DECIMAL32, TYPE_DECIMAL64)
 VALUE_GUARD(PrimitiveType, HllPTGuard, pt_is_hll, TYPE_HLL)
 VALUE_GUARD(PrimitiveType, ObjectPTGuard, pt_is_object, TYPE_OBJECT)
-VALUE_GUARD(PrimitiveType, BinaryPTGuard, pt_is_binary, TYPE_CHAR, TYPE_VARCHAR)
+VALUE_GUARD(PrimitiveType, StringPTGuard, pt_is_string, TYPE_CHAR, TYPE_VARCHAR)
 VALUE_GUARD(PrimitiveType, JsonGuard, pt_is_json, TYPE_JSON)
 VALUE_GUARD(PrimitiveType, FunctionGuard, pt_is_function, TYPE_FUNCTION)
 

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -154,7 +154,7 @@ struct ColumnToArrowConverter<PT, AT, is_nullable, ConvBinaryGuard<PT, AT>> {
 
     static inline std::string convert_datum(const StarRocksCppType& datum, [[maybe_unused]] int precision,
                                             [[maybe_unused]] int scale) {
-        if constexpr (pt_is_binary<PT> || pt_is_decimalv2<PT> || pt_is_date_or_datetime<PT>) {
+        if constexpr (pt_is_string<PT> || pt_is_decimalv2<PT> || pt_is_date_or_datetime<PT>) {
             return datum.to_string();
         } else if constexpr (pt_is_hll<PT>) {
             std::string s;

--- a/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
+++ b/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
@@ -147,7 +147,7 @@ struct CastParamCppTypeTrait {
     using type = RunTimeCppType<Type>;
 };
 template <PrimitiveType Type>
-struct CastParamCppTypeTrait<Type, BinaryPTGuard<Type>> {
+struct CastParamCppTypeTrait<Type, StringPTGuard<Type>> {
     using type = std::string;
 };
 
@@ -167,7 +167,7 @@ CastParamCppType<ToType> cast_value(CastParamCppType<FromType> const& value, int
     ColumnPtr column = cast<FromType, ToType, CONST>(RunTimeCppType<FromType>(value), from_type, to_type, 0, 0);
     DCHECK(column->is_constant() && !column->only_null());
     RunTimeCppType<ToType> result = ColumnHelper::get_const_value<ToType>(column);
-    if constexpr (pt_is_binary<ToType>) {
+    if constexpr (pt_is_string<ToType>) {
         return result.to_string();
     } else if constexpr (pt_is_decimalv2<ToType>) {
         return result.value();

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -253,7 +253,7 @@ struct MockConstExprBuilder {
 
             using CppType = RunTimeCppType<ptype>;
             CppType literal_value;
-            if constexpr (pt_is_binary<ptype>) {
+            if constexpr (pt_is_string<ptype>) {
                 literal_value = "123";
             } else if constexpr (pt_is_integer<ptype>) {
                 literal_value = 123;

--- a/be/test/util/arrow/starrocks_column_to_arrow_test.cpp
+++ b/be/test/util/arrow/starrocks_column_to_arrow_test.cpp
@@ -48,7 +48,7 @@ void compare_arrow_value(const RunTimeCppType<PT>& datum, const ArrowTypeIdToArr
         ASSERT_EQ(data_array->Value(i), datum);
     } else if constexpr (pt_is_largeint<PT>) {
         ASSERT_EQ(data_array->GetString(i), LargeIntValue::to_string(datum));
-    } else if constexpr (pt_is_binary<PT> || pt_is_date_or_datetime<PT>) {
+    } else if constexpr (pt_is_string<PT> || pt_is_date_or_datetime<PT>) {
         ASSERT_EQ(data_array->GetString(i), datum.to_string());
     } else if constexpr (pt_is_hll<PT>) {
         std::string s;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Original `pt_is_binary` is not exactly correct because:
1. pt_is_binary only represents `TYPE_VARCHAR` and `TYPE_CHAR` which really are string types;
2. multi places use it as just string types, eg, max_by/min_by or runtime_filter.

So correct it to `pt_is_string` so later add a real binary type which is called `pt_is_binary`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
